### PR TITLE
Add gradient computations in reverse mode

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -10,6 +10,9 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
 
+#include <stack>
+#include <unordered_map>
+
 namespace clang {
   class ASTContext;
   class CXXOperatorCallExpr;
@@ -79,20 +82,35 @@ namespace clad {
   };
 
   class DiffPlan;
-  class DerivativeBuilder
-    : public clang::ConstStmtVisitor<DerivativeBuilder, NodeContext> {
+  /// The main builder class which then uses either ForwardModeVisitor or 
+  /// ReverseModeVisitor based on the required mode.
+  class DerivativeBuilder {
   private:
+    friend class VisitorBase;
+    friend class ForwardModeVisitor;
+    friend class ReverseModeVisitor;
+
     clang::Sema& m_Sema;
     clang::ASTContext& m_Context;
-    clang::ValueDecl* m_IndependentVar;
     std::unique_ptr<clang::Scope> m_CurScope;
     std::unique_ptr<utils::StmtClone> m_NodeCloner;
     clang::NamespaceDecl* m_BuiltinDerivativesNSD;
-    bool m_DerivativeInFlight;
-    unsigned m_DerivativeOrder;
-    unsigned m_ArgIndex;
 
+    /// Updates references in newly cloned statements.
     void updateReferencesOf(clang::Stmt* InSubtree);
+    /// Clones a statement
+    clang::Stmt* Clone(const clang::Stmt* S);
+    /// A shorthand to simplify cloning of expressions.
+    clang::Expr* Clone(const clang::Expr* E);
+    /// A shorthand to simplify syntax for creation of new expressions.
+    /// Uses m_Sema.BuildUnOp internally.
+    clang::Expr* BuildOp(clang::UnaryOperatorKind OpCode, clang::Expr* E);
+    /// Uses m_Sema.BuildBin internally.
+    clang::Expr* BuildOp(
+      clang::BinaryOperatorKind OpCode,
+      clang::Expr* L,
+      clang::Expr* R);
+
     clang::Expr* findOverloadedDefinition(clang::DeclarationNameInfo DNI,
                             llvm::SmallVector<clang::Expr*, 4> CallArgs);
     bool overloadExists(clang::Expr* UnresolvedLookup,
@@ -102,20 +120,75 @@ namespace clad {
     DerivativeBuilder(clang::Sema& S);
     ~DerivativeBuilder();
 
+    ///\brief Produces the derivative of a given function
+    /// according to a given plan.
+    ///
+    ///\param[in] FD - the function that will be differentiated.
+    ///
+    ///\returns The differentiated function.
+    ///
+    clang::FunctionDecl* Derive(FunctionDeclInfo& FDI, const DiffPlan & plan);
+  };
+
+  /// A base class for all common functionality for visitors
+  class VisitorBase {
+  protected:
+    VisitorBase(DerivativeBuilder& builder) :
+      m_Builder(builder),
+      m_Sema(builder.m_Sema),
+      m_Context(builder.m_Context),
+      m_CurScope(builder.m_CurScope),
+      m_DerivativeInFlight(false) {}
+
+    DerivativeBuilder& m_Builder;
+    clang::Sema& m_Sema;
+    clang::ASTContext& m_Context;
+    std::unique_ptr<clang::Scope> & m_CurScope;
+    bool m_DerivativeInFlight;
+
+    clang::Expr* BuildOp(clang::UnaryOperatorKind OpCode, clang::Expr* E) {
+      return m_Builder.BuildOp(OpCode, E);
+    }
+
+    clang::Expr* BuildOp(
+      clang::BinaryOperatorKind OpCode,
+      clang::Expr* L,
+      clang::Expr* R) {
+      return m_Builder.BuildOp(OpCode, L, R);
+    }
+  };
+    
+  /// A visitor for processing the function code in forward mode.
+  /// Used to compute derivatives by clad::differentiate.
+  class ForwardModeVisitor
+    : public clang::ConstStmtVisitor<ForwardModeVisitor, NodeContext>,
+      public VisitorBase {
+  private:
+    clang::ValueDecl* m_IndependentVar;
+    unsigned m_DerivativeOrder;
+    unsigned m_ArgIndex;
+
+  public:
+    ForwardModeVisitor(DerivativeBuilder& builder);
+    ~ForwardModeVisitor();
+
     ///\brief Produces the first derivative of a given function.
     ///
     ///\param[in] FD - the function that will be differentiated.
     ///
     ///\returns The differentiated function.
     ///
-    clang::FunctionDecl* Derive(FunctionDeclInfo& FDI, DiffPlan* plan);
+    clang::FunctionDecl* Derive(FunctionDeclInfo& FDI, const DiffPlan& plan);
+
+    NodeContext Clone(const clang::Stmt* S);
     NodeContext VisitStmt(const clang::Stmt* S);
     NodeContext VisitCompoundStmt(const clang::CompoundStmt* CS);
     NodeContext VisitIfStmt(const clang::IfStmt* If);
     NodeContext VisitReturnStmt(const clang::ReturnStmt* RS);
     NodeContext VisitUnaryOperator(const clang::UnaryOperator* UnOp);
     NodeContext VisitBinaryOperator(const clang::BinaryOperator* BinOp);
-    NodeContext VisitCXXOperatorCallExpr(const clang::CXXOperatorCallExpr* OpCall);
+    NodeContext VisitCXXOperatorCallExpr(
+      const clang::CXXOperatorCallExpr* OpCall);
     NodeContext VisitDeclRefExpr(const clang::DeclRefExpr* DRE);
     NodeContext VisitParenExpr(const clang::ParenExpr* PE);
     NodeContext VisitMemberExpr(const clang::MemberExpr* ME);
@@ -124,6 +197,66 @@ namespace clad {
     NodeContext VisitCallExpr(const clang::CallExpr* CE);
     NodeContext VisitDeclStmt(const clang::DeclStmt* DS);
     NodeContext VisitImplicitCastExpr(const clang::ImplicitCastExpr* ICE);
+  };
+
+  /// A visitor for processing the function code in reverse mode.
+  /// Used to compute derivatives by clad::gradient.
+  class ReverseModeVisitor
+    : public clang::ConstStmtVisitor<ReverseModeVisitor, void>,
+      public VisitorBase {
+  private:
+
+    /// Stack is used to pass the arguments (dfdx) to further nodes
+    /// in the Visit method.
+    std::stack<clang::Expr*> m_Stack;
+    clang::Expr* dfdx () {
+        return m_Stack.top ();
+    }
+    void Visit(const clang::Stmt* stmt, clang::Expr* expr) {
+        m_Stack.push(expr);
+        clang::ConstStmtVisitor<ReverseModeVisitor, void>::Visit(stmt);
+        m_Stack.pop();
+    }
+    /// A map that contains the names and positions of all function parameters,
+    /// e.g for f(x, y, z) we have
+    /// m_VariableIdx = {{"x", 0}, {"y", 1}, {"z", 2}}.
+    std::unordered_map<std::string, unsigned> m_VariableIdx;
+ 
+    /// A vector that is used to store all the statements
+    /// for the gradient function body.
+    llvm::SmallVector<clang::Stmt*, 16> m_BodyStmts;
+    //// A reference to the output parameter of the gradient function.
+    clang::Expr* m_Result;
+    // Shorthands that delegate their functionality to DerviativeBuilder.
+    // Used to simplify the code.
+    clang::Stmt* Clone(const clang::Stmt* S);
+    clang::Expr* Clone(const clang::Expr* E);
+
+  public:
+    ReverseModeVisitor(DerivativeBuilder& builder);
+    ~ReverseModeVisitor();
+
+    ///\brief Produces the gradient of a given function.
+    ///
+    ///\param[in] FD - the function that will be differentiated.
+    ///
+    ///\returns The gradient of the function
+    ///
+    clang::FunctionDecl* Derive(FunctionDeclInfo & FDI, const DiffPlan& plan);
+    void VisitCompoundStmt(const clang::CompoundStmt* CS);
+    void VisitIfStmt(const clang::IfStmt* If);
+    void VisitReturnStmt(const clang::ReturnStmt* RS);
+    void VisitUnaryOperator(const clang::UnaryOperator* UnOp);
+    void VisitBinaryOperator(const clang::BinaryOperator* BinOp);
+    void VisitDeclStmt(const clang::DeclStmt* DS);
+    void VisitStmt(const clang::Stmt* S);
+    void VisitMemberExpr(const clang::MemberExpr* ME);
+    void VisitDeclRefExpr(const clang::DeclRefExpr* DRE);
+    void VisitParenExpr(const clang::ParenExpr* PE);
+    void VisitIntegerLiteral(const clang::IntegerLiteral* IL);
+    void VisitFloatingLiteral(const clang::FloatingLiteral* FL);
+    void VisitCallExpr(const clang::CallExpr* CE);
+    void VisitImplicitCastExpr(const clang::ImplicitCastExpr* ICE);
   };
 } // end namespace clad
 

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -105,5 +105,31 @@ namespace clad {
     assert(f && "Must pass in a non-0 argument");
     return CladFunction<true, R, C, Args...>(f, code);
   }
+
+  template <typename R, typename ... Args>
+  using grad_ptr_t = void (*)(Args..., R*);
+
+  /// A function used to detect the placeholder f and replace it with generated code.
+  template <typename Ptr, typename R, typename ... Args>
+  CladFunction<false, void, Args..., R*> __attribute__((annotate("GR")))
+  make_gradient(Ptr f, const char * code = "") {
+    return CladFunction<false, void, Args..., R*>(f, code);
+  }
+  /// A placeholder that will be replaced by a new code.
+  template <typename ... Args>
+  void result_placeholder(Args ...) {}
+  
+  /// A function for gradient computation.
+  /// Given a function f, clad::gradient generates its gradient f_grad and
+  /// returns a CladFunction for it.
+  template<typename R, typename... Args>
+  CladFunction<false, void, Args..., R*> __attribute__((annotate("G")))
+  gradient(R (*f)(Args...), const char* code = "") {
+    assert(f && "Must pass in a non-0 argument");
+    return
+      make_gradient<grad_ptr_t<R, Args...>, R, Args...>(
+       result_placeholder<Args..., R*>,
+       code);
+  }
 }
 #endif // CLAD_DIFFERENTIATOR

--- a/include/clad/Differentiator/StmtClone.h
+++ b/include/clad/Differentiator/StmtClone.h
@@ -10,6 +10,10 @@
 #define CLAD_UTILS_STMTCLONE_H
 
 #include "clang/AST/StmtVisitor.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+
+#include "clang/Sema/Sema.h"
+#include "clang/Sema/Scope.h"
 
 #include "llvm/ADT/DenseMap.h"
 
@@ -131,7 +135,17 @@ namespace utils {
     return static_cast<StmtTy*>(clonedStmt);
   }
 
-} // namespace ASTProcessing
-} // namespace clang
+  class ReferencesUpdater :
+    public clang::RecursiveASTVisitor<ReferencesUpdater> {
+  private:
+    clang::Sema& m_Sema; // We don't own.
+    StmtClone* m_NodeCloner; // We don't own.
+    clang::Scope* m_CurScope; // We don't own.
+  public:
+    ReferencesUpdater(clang::Sema& SemaRef, StmtClone* C, clang::Scope* S);
+    bool VisitDeclRefExpr(clang::DeclRefExpr* DRE);
+  };
+} // namespace utils
+} // namespace clad
 
 #endif  //CLAD_UTILS_STMTCLONE_H

--- a/lib/Differentiator/ConstantFolder.h
+++ b/lib/Differentiator/ConstantFolder.h
@@ -19,7 +19,8 @@ namespace clang {
 }
 
 namespace clad {
-  class ConstantFolder: public clang::StmtVisitor<ConstantFolder, clang::Expr*> {
+  class ConstantFolder:
+    public clang::StmtVisitor<ConstantFolder, clang::Expr*> {
   private:
     clang::ASTContext& m_Context;
     bool m_Enabled;

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -1,0 +1,164 @@
+// RUN: %cladclang %s -I%S/../../include -oGradients.out 2>&1 | FileCheck %s
+// RUN: ./Gradients.out | FileCheck -check-prefix=CHECK-EXEC %s
+
+//CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+double f_add1(double x, double y) {
+  return x + y;
+}
+
+// CHECK: void f_add1_grad(double x, double y, double *_result) {
+// CHECK-NEXT:   _result[0UL] += 1.;
+// CHECK-NEXT:   _result[1UL] += 1.;
+// CHECK-NEXT: }
+void f_add1_grad(double x, double y, double *_result);
+
+double f_add2(double x, double y) {
+  return 3*x + 4*y;
+}
+
+// CHECK: void f_add2_grad(double x, double y, double *_result) {
+// CHECK-NEXT:   _result[0UL] += 3 * 1.;
+// CHECK-NEXT:   _result[1UL] += 4 * 1.;
+// CHECK-NEXT: }
+void f_add2_grad(double x, double y, double *_result);
+
+double f_add3(double x, double y) {
+  return 3*x + 4*y*4;
+}
+
+// CHECK: void f_add3_grad(double x, double y, double *_result) {
+// CHECK-NEXT:   _result[0UL] += 3 * 1.;
+// CHECK-NEXT:   _result[1UL] += 4 * 1. * 4;
+// CHECK-NEXT: }
+void f_add3_grad(double x, double y, double *_result);
+
+double f_sub1(double x, double y) {
+  return x - y;
+}
+
+// CHECK: void f_sub1_grad(double x, double y, double *_result) {
+// CHECK-NEXT:   _result[0UL] += 1.;
+// CHECK-NEXT:   _result[1UL] += -1.;
+// CHECK-NEXT: }
+void f_sub1_grad(double x, double y, double *_result);
+
+double f_sub2(double x, double y) {
+  return 3*x - 4*y;
+}
+
+// CHECK: void f_sub2_grad(double x, double y, double *_result) {
+// CHECK-NEXT:   _result[0UL] += 3 * 1.;
+// CHECK-NEXT:   _result[1UL] += 4 * -1.;
+// CHECK-NEXT: }
+void f_sub2_grad(double x, double y, double *_result);
+
+double f_mult1(double x, double y) {
+  return x*y;
+}
+
+// CHECK: void f_mult1_grad(double x, double y, double *_result) {
+// CHECK-NEXT:   _result[0UL] += 1. * y;
+// CHECK-NEXT:   _result[1UL] += x * 1.;
+// CHECK-NEXT: }
+void f_mult1_grad(double x, double y, double *_result);
+
+double f_mult2(double x, double y) {
+   return 3*x*4*y;
+}
+
+// CHECK: void f_mult2_grad(double x, double y, double *_result) {
+// CHECK-NEXT:   _result[0UL] += 3 * 1. * y * 4;
+// CHECK-NEXT:   _result[1UL] += 3 * x * 4 * 1.;
+// CHECK-NEXT: }
+void f_mult2_grad(double x, double y, double *_result);
+
+double f_div1(double x, double y) {
+  return x/y;
+}
+
+// CHECK: void f_div1_grad(double x, double y, double *_result) {
+// CHECK-NEXT:   _result[0UL] += 1. / y;
+// CHECK-NEXT:   _result[1UL] += -x / y * y;
+// CHECK-NEXT: }
+void f_div1_grad(double x, double y, double *_result);
+
+double f_div2(double x, double y) {
+  return 3*x/(4*y);
+}
+
+// CHECK: void f_div2_grad(double x, double y, double *_result) {
+// CHECK-NEXT:   _result[0UL] += 3 * 1. / (4 * y);
+// CHECK-NEXT:   _result[1UL] += 4 * -3 * x / (4 * y) * (4 * y);
+// CHECK-NEXT: }
+void f_div2_grad(double x, double y, double *_result);
+
+double f_c(double x, double y) {
+  return -x*y + (x + y)*(x/y) - x*x; 
+}
+
+// CHECK: void f_c_grad(double x, double y, double *_result) {
+// CHECK-NEXT:   _result[0UL] += -1. * y;
+// CHECK-NEXT:   _result[1UL] += -x * 1.;
+// CHECK-NEXT:   _result[0UL] += 1. * (x / y);
+// CHECK-NEXT:   _result[1UL] += 1. * (x / y);
+// CHECK-NEXT:   _result[0UL] += 1. / y;
+// CHECK-NEXT:   _result[1UL] += -x / y * y;
+// CHECK-NEXT:   _result[0UL] += -1. * x;
+// CHECK-NEXT:   _result[0UL] += x * -1.;
+// CHECK-NEXT: }
+void f_c_grad(double x, double y, double *_result);
+
+double f_rosenbrock(double x, double y) {
+  return (x - 1) * (x - 1) + 100 * (y - x * x) * (y - x * x);
+}
+
+// CHECK: void f_rosenbrock_grad(double x, double y, double *_result) {
+// CHECK-NEXT:   _result[0UL] += 1. * (x - 1);
+// CHECK-NEXT:   _result[0UL] += (x - 1) * 1.;
+// CHECK-NEXT:   _result[1UL] += 100 * 1. * (y - x * x);
+// CHECK-NEXT:   _result[0UL] += -100 * 1. * (y - x * x) * x;
+// CHECK-NEXT:   _result[0UL] += x * -100 * 1. * (y - x * x);
+// CHECK-NEXT:   _result[1UL] += 100 * (y - x * x) * 1.;
+// CHECK-NEXT:   _result[0UL] += -100 * (y - x * x) * 1. * x;
+// CHECK-NEXT:   _result[0UL] += x * -100 * (y - x * x) * 1.;
+// CHECK-NEXT: }
+void f_rosenbrock_grad(double x, double y, double *_result);
+
+unsigned f_types(int x, float y, double z) {
+  return x + y + z;
+}
+
+// CHECK: void f_types_grad(int x, float y, double z, unsigned int *_result) {
+// CHECK-NEXT:   _result[0UL] += 1U;
+// CHECK-NEXT:   _result[1UL] += 1U;
+// CHECK-NEXT:   _result[2UL] += 1U;
+// CHECK-NEXT: }
+void f_types_grad(int x, float y, double z, unsigned int *_result);
+
+#define TEST(F, x, y) { \
+  result[0] = 0; result[1] = 0;\
+  clad::gradient(F);\
+  F##_grad(x, y, result);\
+  printf("Result is = {%.2f, %.2f}\n", result[0], result[1]); \
+}
+ 
+int main() { // expected-no-diagnostics
+  double result[2];
+
+  TEST(f_add1, 1, 1); // CHECK-EXEC: Result is = {1.00, 1.00}
+  TEST(f_add2, 1, 1); // CHECK-EXEC: Result is = {3.00, 4.00}
+  TEST(f_add3, 1, 1); // CHECK-EXEC: Result is = {3.00, 16.00}
+  TEST(f_sub1, 1, 1); // CHECK-EXEC: Result is = {1.00, -1.00}
+  TEST(f_sub2, 1, 1); // CHECK-EXEC: Result is = {3.00, -4.00}
+  TEST(f_mult1, 1, 1); // CHECK-EXEC: Result is = {1.00, 1.00}
+  TEST(f_mult2, 1, 1); // CHECK-EXEC: Result is = {12.00, 12.00}
+  TEST(f_div1, 1, 1); // CHECK-EXEC: Result is = {1.00, -1.00}
+  TEST(f_div2, 1, 1); // CHECK-EXEC: Result is = {0.75, -0.75}
+  TEST(f_c, 1, 1); // CHECK-EXEC: Result is = {-1.00, -1.00}
+  TEST(f_rosenbrock, 1, 1); // CHECK-EXEC: Result is = {0.00, 0.00}
+  clad::gradient(f_types);
+}
+

--- a/test/Gradient/TestAgainstDiff.C
+++ b/test/Gradient/TestAgainstDiff.C
@@ -1,0 +1,43 @@
+// RUN: %cladclang %s -I%S/../../include -oGradients.out 2>&1 | FileCheck %s
+// RUN: ./Gradients.out | FileCheck -check-prefix=CHECK-EXEC %s
+
+//CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+double f(double x, double y) {
+  return (x - 1) * (x - 1) + 100 * (y - x * x) * (y - x * x);
+}
+void f_grad(double x, double y, double * _result);
+
+void f_grad_old(double x, double y, double * _result) {
+  auto dx = clad::differentiate(f, 0);
+  auto dy = clad::differentiate(f, 1);
+
+  _result[0] = dx.execute(x, y);
+  _result[1] = dy.execute(x, y);
+}
+
+int main() {
+  clad::gradient(f);
+  
+  auto test = [&] (double x, double y) { // expected-no-diagnostics
+    double result_old[2] = {};
+    double result_new[2] = {};
+
+    f_grad_old(x, y, result_old);
+    f_grad(x, y, result_new);
+
+    for (int i = 0; i < 2; i++)
+      if (result_old[i] != result_new[i])
+        return false;
+    return true;
+  };
+
+  printf("Equal? %s\n", test(1, 1) ? "true" : "false"); // CHECK-EXEC: Equal? true
+  printf("Equal? %s\n", test(3, 3) ? "true" : "false"); // CHECK-EXEC: Equal? true
+  printf("Equal? %s\n", test(5, 5) ? "true" : "false"); // CHECK-EXEC: Equal? true
+  
+}
+
+

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -47,7 +47,7 @@ namespace clad {
       clang::CompilerInstance& m_CI;
       DifferentiationOptions m_DO;
       std::unique_ptr<DerivativeBuilder> m_DerivativeBuilder;
-       bool m_CheckRuntime;
+      bool m_CheckRuntime;
     public:
       CladPlugin(clang::CompilerInstance& CI, DifferentiationOptions& DO);
       ~CladPlugin();
@@ -60,8 +60,9 @@ namespace clad {
     private:
       DifferentiationOptions m_DO;
     protected:
-      std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance& CI,
-                                            llvm::StringRef InFile) {
+      std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
+        clang::CompilerInstance& CI,
+        llvm::StringRef InFile) {
         return std::unique_ptr<clang::ASTConsumer>(new ConsumerType(CI, m_DO));
       }
 


### PR DESCRIPTION
For a function ```f```, its gradient can be computed by calling ```clad::gradient(f)```.

For example, calling ```clad::gradient``` on
```
double rosenbrock_func(double x, double y) {
  return (x - 1) * (x - 1) + 100 * (y - x * x) * (y - x * x);
}
```
should generate
```
void rosenbrock_func_grad(double x, double y, double *_result) {
    _result[0UL] += 1. * (x - 1);
    _result[0UL] += 1. * (x - 1);
    _result[1UL] += 1. * (y - x * x) * 100;
    _result[0UL] += -1. * (y - x * x) * 100 * x;
    _result[0UL] += -1. * (y - x * x) * 100 * x;
    _result[1UL] += 1. * 100 * (y - x * x);
    _result[0UL] += -1. * 100 * (y - x * x) * x;
    _result[0UL] += -1. * 100 * (y - x * x) * x;
}
```

The caller of the ```*_grad``` functions is responsible for allocating enough space for the ```_result``` array.
