### PR TITLE
Find independent variables based on pointer comparison instead of string comparisons

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -223,10 +223,8 @@ namespace clad {
         clang::ConstStmtVisitor<ReverseModeVisitor, void>::Visit(stmt);
         m_Stack.pop();
     }
-    /// A map that contains the names and positions of all function parameters,
-    /// e.g for f(x, y, z) we have
-    /// m_VariableIdx = {{"x", 0}, {"y", 1}, {"z", 2}}.
-    std::unordered_map<std::string, unsigned> m_VariableIdx;
+    /// The function that is currently differentiated.
+    clang::FunctionDecl* m_Function;
  
     /// A stack of all the blocks where the statements of the gradient function
     /// are stored (e.g., function body, if statement blocks).


### PR DESCRIPTION
Currently, we identify independent variables if their name (a string obtained by getNameAsString()) is equal to that of one of the function parameters.

This is inefficient and can be incorrect (i.e. when a local variable with the same name shadows the parameter declaration).

Each DeclRefExpr (reference to a declaration) contains a pointer to its declaration (getDecl()). This pointer is unique for each declaration, therefore we can check if DeclRefExpr references a parameter declaration by comparing the pointers.

Additionally, I removed some unnecessary calls to Clone(); this is relevant as one needs to be careful and distinguish if DeclRefExpr references to parameters of old function or newly generated derivative.