### PR TITLE
Support differentiation of recursive functions

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -145,6 +145,10 @@ namespace clad {
     clang::ASTContext& m_Context;
     std::unique_ptr<clang::Scope> & m_CurScope;
     bool m_DerivativeInFlight;
+    /// The Derivative function that is being generated.
+    clang::FunctionDecl* m_Derivative;
+    /// The function that is currently differentiated.
+    clang::FunctionDecl* m_Function;
 
     clang::Expr* BuildOp(clang::UnaryOperatorKind OpCode, clang::Expr* E) {
       return m_Builder.BuildOp(OpCode, E);
@@ -223,8 +227,6 @@ namespace clad {
         clang::ConstStmtVisitor<ReverseModeVisitor, void>::Visit(stmt);
         m_Stack.pop();
     }
-    /// The function that is currently differentiated.
-    clang::FunctionDecl* m_Function;
  
     /// A stack of all the blocks where the statements of the gradient function
     /// are stored (e.g., function body, if statement blocks).

--- a/test/FirstDerivative/Recursive.C
+++ b/test/FirstDerivative/Recursive.C
@@ -1,0 +1,30 @@
+// RUN: %cladclang %s -I%S/../../include -oBasicArithmeticAddSub.out 2>&1 | FileCheck %s
+// RUN: ./BasicArithmeticAddSub.out | FileCheck -check-prefix=CHECK-EXEC %s
+
+//CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+extern "C" int printf(const char* fmt, ...);
+
+int f_pow(int arg, int p) {
+  if (p == 0)
+    return 1;
+  else
+    return arg * f_pow(arg, p - 1);
+}
+
+// CHECK: int f_pow_darg0(int arg, int p) {
+// CHECK-NEXT:  if (p == 0)
+// CHECK-NEXT:    return 0;
+// CHECK-NEXT:  else
+// CHECK-NEXT:    return (1 * f_pow(arg, p - 1) + arg * f_pow_darg0(arg, p - 1) * (1 + 0 - (0)));
+// CHECK-NEXT: }
+
+int f_pow_darg0(int arg, int p);
+// == p * f_pow(arg, p - 1)
+
+int main() {
+  clad::differentiate(f_pow, 0);
+  printf("Result is = %d\n", f_pow_darg0(10, 2)); // CHECK-EXEC: Result is = 20
+}


### PR DESCRIPTION
Now clad::differentiate should produce correct results on recursive functions.
Any recursive call should be replaced by a call to a derivative.
