### PR TITLE
Store intermediate results in temporary variables

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -154,12 +154,26 @@ namespace clad {
       return m_Builder.BuildOp(OpCode, E);
     }
 
-    clang::Expr* BuildOp(
-      clang::BinaryOperatorKind OpCode,
-      clang::Expr* L,
-      clang::Expr* R) {
+    clang::Expr* BuildOp(clang::BinaryOperatorKind OpCode,
+                         clang::Expr* L,
+                         clang::Expr* R) {
       return m_Builder.BuildOp(OpCode, L, R);
     }
+    /// Builds variable declaration to be used inside the derivative body
+    clang::VarDecl* BuildVarDecl(clang::QualType Type,
+                                 clang::IdentifierInfo* Identifier,
+                                 clang::Expr* Init = nullptr);
+
+    /// Wraps variable declaration in DeclStmt
+    clang::Stmt* BuildDeclStmt(clang::VarDecl* VD);
+
+    /// Conuter used to create unique identifiers for temporaries
+    std::size_t m_tmpId = 0;
+    
+    /// Creates unique identifier of the form "_t<number>" that is guaranteed
+    /// not to collide with anything in the current scope
+    clang::IdentifierInfo* CreateUniqueIdentifier(const char * name_base,
+                                                  std::size_t id);
 
     clang::CompoundStmt* MakeCompoundStmt(
       const llvm::SmallVector<clang::Stmt*, 16> & Stmts);
@@ -246,6 +260,9 @@ namespace clad {
       m_Blocks.pop();
       return CS;
     }
+    /// Stores the result of an expression in a temporary variable and
+    /// returns a reference to it.
+    clang::Expr* StoreAndRef(clang::Expr* E, const char* prefix = "_t");
  
     //// A reference to the output parameter of the gradient function.
     clang::Expr* m_Result;

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -64,9 +64,8 @@ namespace clad {
 
   }
 
-  FunctionDecl* DerivativeBuilder::Derive(
-    FunctionDeclInfo& FDI,
-    const DiffPlan& plan) {
+  FunctionDecl* DerivativeBuilder::Derive(FunctionDeclInfo& FDI,
+                                          const DiffPlan& plan) {
     FunctionDecl* result = nullptr;
     if (plan.getMode() == DiffMode::forward) {
       ForwardModeVisitor V(*this);
@@ -80,6 +79,47 @@ namespace clad {
     if (result)
       registerDerivative(result, m_Sema);
     return result;
+  }
+
+  VarDecl* VisitorBase::BuildVarDecl(QualType Type,
+                                     IdentifierInfo* Identifier,
+                                     Expr* Init) {
+
+    auto VD = VarDecl::Create(m_Context,
+                              m_Derivative,
+                              noLoc,
+                              noLoc,
+                              Identifier,
+                              Type,
+                              nullptr, // FIXME: Should there be any TypeInfo?
+                              SC_None);
+    VD->setInit(Init);
+    return VD;
+  }
+
+  Stmt* VisitorBase::BuildDeclStmt(VarDecl* VD) {
+    return m_Sema.ActOnDeclStmt(m_Sema.ConvertDeclToDeclGroup(VD),
+                                noLoc,
+                                noLoc).get();
+  }
+
+  IdentifierInfo* VisitorBase::CreateUniqueIdentifier(const char * name_base,
+                                                      std::size_t id) {
+  
+    for (;;) {
+      auto name = &m_Context.Idents.get(name_base + std::to_string(id));
+      LookupResult R(m_Sema,
+                     DeclarationName(name),
+                     noLoc,
+                     Sema::LookupOrdinaryName);
+      m_Sema.LookupName(R, m_CurScope.get(), false);
+      if (R.empty()) {
+        m_tmpId = id + 1;
+        return name;
+      }
+      else
+        id += 1;
+    }
   }
 
   CompoundStmt* VisitorBase::MakeCompoundStmt(
@@ -227,7 +267,10 @@ namespace clad {
   }
 
   Expr* DerivativeBuilder::BuildOp(UnaryOperatorKind OpCode, Expr* E) {
-    return m_Sema.BuildUnaryOp(nullptr, noLoc, OpCode, E).get();
+    return m_Sema.BuildUnaryOp(m_CurScope.get(),
+                               noLoc,
+                               OpCode,
+                               E).get();
   }
   Expr* DerivativeBuilder::BuildOp(clang::BinaryOperatorKind OpCode,
                                    Expr* L, Expr* R) {
@@ -637,6 +680,24 @@ namespace clad {
     return m_Builder.Clone(e);
   }
 
+  Expr* ReverseModeVisitor::StoreAndRef(clang::Expr* E, const char * prefix) {
+    // Creates temporary variable and stores the result of the expression in it.
+
+    // Create variable declaration.
+    auto Var = BuildVarDecl(E->getType(),
+                            CreateUniqueIdentifier(prefix, m_tmpId),
+                            E);
+    
+    // Add the declaration to the body of the gradient function.
+    currentBlock().push_back(BuildDeclStmt(Var));
+
+    // Return reference to the declaration instead of original expression.
+    return m_Sema.BuildDeclRefExpr(Var,
+                                   E->getType(),
+                                   VK_LValue,
+                                   noLoc).get();
+  }
+
   ReverseModeVisitor::ReverseModeVisitor(DerivativeBuilder& builder):
     VisitorBase(builder) {}
 
@@ -733,12 +794,12 @@ namespace clad {
                                            (PVD->hasDefaultArg() ?  
                                              Clone(PVD->getDefaultArg()) :
                                              nullptr));
-        if (VD->getIdentifier()) {
-          m_CurScope->AddDecl(VD);
-          m_Sema.IdResolver.AddDecl(VD);
-        }
-        return VD;
-      });
+                     if (VD->getIdentifier()) {
+                       m_CurScope->AddDecl(VD);
+                       m_Sema.IdResolver.AddDecl(VD);
+                     }
+                     return VD;
+                   });
     // The output paremeter "_result".
     params.back() =
       ParmVarDecl::Create(m_Context,
@@ -837,7 +898,7 @@ namespace clad {
 
   void ReverseModeVisitor::VisitConditionalOperator(
     const clang::ConditionalOperator* CO) {
-    auto cond = Clone(CO->getCond());
+    auto cond = StoreAndRef(Clone(CO->getCond()));
     auto ifTrue = CO->getTrueExpr();
     auto ifFalse = CO->getFalseExpr();
 
@@ -976,11 +1037,13 @@ namespace clad {
       //dxi/xl = xr
       //df/dxl += df/dxi * dxi/xl = df/dxi * xr
       auto dl = BuildOp(BO_Mul, dfdx(), Clone(R));
-      Visit(L, dl);
+      auto dlTmp = StoreAndRef(dl);
+      Visit(L, dlTmp);
       //dxi/xr = xl
       //df/dxr += df/dxi * dxi/xr = df/dxi * xl
       auto dr = BuildOp(BO_Mul, Clone(L), dfdx());
-      Visit(R, dr);
+      auto drTmp = StoreAndRef(dr);
+      Visit(R, drTmp);
     }
     else if (opCode == BO_Div) {
       //xi = xl / xr
@@ -991,7 +1054,8 @@ namespace clad {
                                                    1.0);
       auto clonedR = Clone(R);
       auto dl = BuildOp(BO_Div, one, clonedR);
-      Visit(L, dl);
+      auto dlTmp = StoreAndRef(dl);
+      Visit(L, dlTmp);
       //dxi/xr = -xl / (xr * xr)
       //df/dxl += df/dxi * dxi/xr = df/dxi * (-xl /(xr * xr))
       auto RxR = BuildOp(BO_Mul, clonedR, clonedR);

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -13,6 +13,7 @@ double f_add1(double x, double y) {
 // CHECK-NEXT:   _result[0UL] += 1.;
 // CHECK-NEXT:   _result[1UL] += 1.;
 // CHECK-NEXT: }
+
 void f_add1_grad(double x, double y, double *_result);
 
 double f_add2(double x, double y) {
@@ -20,9 +21,14 @@ double f_add2(double x, double y) {
 }
 
 // CHECK: void f_add2_grad(double x, double y, double *_result) {
-// CHECK-NEXT:   _result[0UL] += 3 * 1.;
-// CHECK-NEXT:   _result[1UL] += 4 * 1.;
+// CHECK-NEXT:     double _t0 = 1. * x;
+// CHECK-NEXT:     double _t1 = 3 * 1.;
+// CHECK-NEXT:     _result[0UL] += _t1;
+// CHECK-NEXT:     double _t2 = 1. * y;
+// CHECK-NEXT:     double _t3 = 4 * 1.;
+// CHECK-NEXT:     _result[1UL] += _t3;
 // CHECK-NEXT: }
+
 void f_add2_grad(double x, double y, double *_result);
 
 double f_add3(double x, double y) {
@@ -30,9 +36,16 @@ double f_add3(double x, double y) {
 }
 
 // CHECK: void f_add3_grad(double x, double y, double *_result) {
-// CHECK-NEXT:   _result[0UL] += 3 * 1.;
-// CHECK-NEXT:   _result[1UL] += 4 * 1. * 4;
+// CHECK-NEXT:     double _t0 = 1. * x;
+// CHECK-NEXT:     double _t1 = 3 * 1.;
+// CHECK-NEXT:     _result[0UL] += _t1;
+// CHECK-NEXT:     double _t2 = 1. * 4;
+// CHECK-NEXT:     double _t3 = _t2 * y;
+// CHECK-NEXT:     double _t4 = 4 * _t2;
+// CHECK-NEXT:     _result[1UL] += _t4;
+// CHECK-NEXT:     double _t5 = 4 * y * 1.;
 // CHECK-NEXT: }
+
 void f_add3_grad(double x, double y, double *_result);
 
 double f_sub1(double x, double y) {
@@ -50,9 +63,14 @@ double f_sub2(double x, double y) {
 }
 
 // CHECK: void f_sub2_grad(double x, double y, double *_result) {
-// CHECK-NEXT:   _result[0UL] += 3 * 1.;
-// CHECK-NEXT:   _result[1UL] += 4 * -1.;
+// CHECK-NEXT:     double _t0 = 1. * x;
+// CHECK-NEXT:     double _t1 = 3 * 1.;
+// CHECK-NEXT:     _result[0UL] += _t1;
+// CHECK-NEXT:     double _t2 = -1. * y;
+// CHECK-NEXT:     double _t3 = 4 * -1.;
+// CHECK-NEXT:     _result[1UL] += _t3;
 // CHECK-NEXT: }
+
 void f_sub2_grad(double x, double y, double *_result);
 
 double f_mult1(double x, double y) {
@@ -60,9 +78,12 @@ double f_mult1(double x, double y) {
 }
 
 // CHECK: void f_mult1_grad(double x, double y, double *_result) {
-// CHECK-NEXT:   _result[0UL] += 1. * y;
-// CHECK-NEXT:   _result[1UL] += x * 1.;
+// CHECK-NEXT:    double _t0 = 1. * y;
+// CHECK-NEXT:    _result[0UL] += _t0;
+// CHECK-NEXT:    double _t1 = x * 1.;
+// CHECK-NEXT:    _result[1UL] += _t1;
 // CHECK-NEXT: }
+
 void f_mult1_grad(double x, double y, double *_result);
 
 double f_mult2(double x, double y) {
@@ -70,9 +91,16 @@ double f_mult2(double x, double y) {
 }
 
 // CHECK: void f_mult2_grad(double x, double y, double *_result) {
-// CHECK-NEXT:   _result[0UL] += 3 * 1. * y * 4;
-// CHECK-NEXT:   _result[1UL] += 3 * x * 4 * 1.;
+// CHECK-NEXT:    double _t0 = 1. * y;
+// CHECK-NEXT:    double _t1 = _t0 * 4;
+// CHECK-NEXT:    double _t2 = _t1 * x;
+// CHECK-NEXT:    double _t3 = 3 * _t1;
+// CHECK-NEXT:    _result[0UL] += _t3;
+// CHECK-NEXT:    double _t4 = 3 * x * _t0;
+// CHECK-NEXT:    double _t5 = 3 * x * 4 * 1.;
+// CHECK-NEXT:    _result[1UL] += _t5;
 // CHECK-NEXT: }
+
 void f_mult2_grad(double x, double y, double *_result);
 
 double f_div1(double x, double y) {
@@ -80,9 +108,11 @@ double f_div1(double x, double y) {
 }
 
 // CHECK: void f_div1_grad(double x, double y, double *_result) {
-// CHECK-NEXT:   _result[0UL] += 1. / y;
-// CHECK-NEXT:   _result[1UL] += -x / y * y;
+// CHECK-NEXT:    double _t0 = 1. / y;
+// CHECK-NEXT:    _result[0UL] += _t0;
+// CHECK-NEXT:    _result[1UL] += -x / y * y;
 // CHECK-NEXT: }
+
 void f_div1_grad(double x, double y, double *_result);
 
 double f_div2(double x, double y) {
@@ -90,9 +120,15 @@ double f_div2(double x, double y) {
 }
 
 // CHECK: void f_div2_grad(double x, double y, double *_result) {
-// CHECK-NEXT:   _result[0UL] += 3 * 1. / (4 * y);
-// CHECK-NEXT:   _result[1UL] += 4 * -3 * x / (4 * y) * (4 * y);
+// CHECK-NEXT:    double _t0 = 1. / (4 * y);
+// CHECK-NEXT:    double _t1 = _t0 * x;
+// CHECK-NEXT:    double _t2 = 3 * _t0;
+// CHECK-NEXT:    _result[0UL] += _t2;
+// CHECK-NEXT:    double _t3 = -3 * x / (4 * y) * (4 * y) * y;
+// CHECK-NEXT:    double _t4 = 4 * -3 * x / (4 * y) * (4 * y);
+// CHECK-NEXT:    _result[1UL] += _t4;
 // CHECK-NEXT: }
+
 void f_div2_grad(double x, double y, double *_result);
 
 double f_c(double x, double y) {
@@ -100,15 +136,23 @@ double f_c(double x, double y) {
 }
 
 // CHECK: void f_c_grad(double x, double y, double *_result) {
-// CHECK-NEXT:   _result[0UL] += -1. * y;
-// CHECK-NEXT:   _result[1UL] += -x * 1.;
-// CHECK-NEXT:   _result[0UL] += 1. * (x / y);
-// CHECK-NEXT:   _result[1UL] += 1. * (x / y);
-// CHECK-NEXT:   _result[0UL] += 1. / y;
-// CHECK-NEXT:   _result[1UL] += -x / y * y;
-// CHECK-NEXT:   _result[0UL] += -1. * x;
-// CHECK-NEXT:   _result[0UL] += x * -1.;
+// CHECK-NEXT:    double _t0 = 1. * y;
+// CHECK-NEXT:    _result[0UL] += -_t0;
+// CHECK-NEXT:    double _t1 = -x * 1.;
+// CHECK-NEXT:    _result[1UL] += _t1;
+// CHECK-NEXT:    double _t2 = 1. * (x / y);
+// CHECK-NEXT:    _result[0UL] += _t2;
+// CHECK-NEXT:    _result[1UL] += _t2;
+// CHECK-NEXT:    double _t3 = (x + y) * 1.;
+// CHECK-NEXT:    double _t4 = 1. / y;
+// CHECK-NEXT:    _result[0UL] += _t4;
+// CHECK-NEXT:    _result[1UL] += -x / y * y;
+// CHECK-NEXT:    double _t5 = -1. * x;
+// CHECK-NEXT:    _result[0UL] += _t5;
+// CHECK-NEXT:    double _t6 = x * -1.;
+// CHECK-NEXT:    _result[0UL] += _t6;
 // CHECK-NEXT: }
+
 void f_c_grad(double x, double y, double *_result);
 
 double f_rosenbrock(double x, double y) {
@@ -116,15 +160,26 @@ double f_rosenbrock(double x, double y) {
 }
 
 // CHECK: void f_rosenbrock_grad(double x, double y, double *_result) {
-// CHECK-NEXT:   _result[0UL] += 1. * (x - 1);
-// CHECK-NEXT:   _result[0UL] += (x - 1) * 1.;
-// CHECK-NEXT:   _result[1UL] += 100 * 1. * (y - x * x);
-// CHECK-NEXT:   _result[0UL] += -100 * 1. * (y - x * x) * x;
-// CHECK-NEXT:   _result[0UL] += x * -100 * 1. * (y - x * x);
-// CHECK-NEXT:   _result[1UL] += 100 * (y - x * x) * 1.;
-// CHECK-NEXT:   _result[0UL] += -100 * (y - x * x) * 1. * x;
-// CHECK-NEXT:   _result[0UL] += x * -100 * (y - x * x) * 1.;
+// CHECK-NEXT:     double _t0 = 1. * (x - 1);
+// CHECK-NEXT:     _result[0UL] += _t0;
+// CHECK-NEXT:     double _t1 = (x - 1) * 1.;
+// CHECK-NEXT:     _result[0UL] += _t1;
+// CHECK-NEXT:     double _t2 = 1. * (y - x * x);
+// CHECK-NEXT:     double _t3 = _t2 * (y - x * x);
+// CHECK-NEXT:     double _t4 = 100 * _t2;
+// CHECK-NEXT:     _result[1UL] += _t4;
+// CHECK-NEXT:     double _t5 = -_t4 * x;
+// CHECK-NEXT:     _result[0UL] += _t5;
+// CHECK-NEXT:     double _t6 = x * -_t4;
+// CHECK-NEXT:     _result[0UL] += _t6;
+// CHECK-NEXT:     double _t7 = 100 * (y - x * x) * 1.;
+// CHECK-NEXT:     _result[1UL] += _t7;
+// CHECK-NEXT:     double _t8 = -_t7 * x;
+// CHECK-NEXT:     _result[0UL] += _t8;
+// CHECK-NEXT:     double _t9 = x * -_t7;
+// CHECK-NEXT:     _result[0UL] += _t9;
 // CHECK-NEXT: }
+
 void f_rosenbrock_grad(double x, double y, double *_result);
 
 double f_cond1(double x, double y) {
@@ -132,8 +187,9 @@ double f_cond1(double x, double y) {
 }
 
 // CHECK: void f_cond1_grad(double x, double y, double *_result) {
-// CHECK-NEXT:     _result[0UL] += (x > y ? 1. : 0.);
-// CHECK-NEXT:     _result[1UL] += (x > y ? 0. : 1.);
+// CHECK-NEXT:     _Bool _t0 = x > y;
+// CHECK-NEXT:     _result[0UL] += (_t0 ? 1. : 0.);
+// CHECK-NEXT:     _result[1UL] += (_t0 ? 0. : 1.);
 // CHECK-NEXT: }
 
 void f_cond1_grad(double x, double y, double *_result);
@@ -143,10 +199,12 @@ double f_cond2(double x, double y) {
 }
 
 // CHECK: void f_cond2_grad(double x, double y, double *_result) {
-// CHECK-NEXT:    _result[0UL] += (x > y ? 1. : 0.);
-// CHECK-NEXT:    _result[1UL] += (y > 0 ? (x > y ? 0. : 1.) : 0.);
-// CHECK-NEXT:    _result[1UL] += -(y > 0 ? 0. : (x > y ? 0. : 1.));
-// CHECK-NEXT:}
+// CHECK-NEXT:     _Bool _t0 = x > y;
+// CHECK-NEXT:     _result[0UL] += (_t0 ? 1. : 0.);
+// CHECK-NEXT:     _Bool _t1 = y > 0;
+// CHECK-NEXT:     _result[1UL] += (_t1 ? (_t0 ? 0. : 1.) : 0.);
+// CHECK-NEXT:     _result[1UL] += -(_t1 ? 0. : (_t0 ? 0. : 1.));
+// CHECK-NEXT: }
 
 void f_cond2_grad(double x, double y, double *_result);
 
@@ -155,11 +213,12 @@ double f_cond3(double x, double c) {
 }
 
 // CHECK: void f_cond3_grad(double x, double c, double *_result) {
-// CHECK-NEXT:    _result[0UL] += (c > 0 ? 1. : 0.);
-// CHECK-NEXT:    _result[1UL] += (c > 0 ? 1. : 0.);
-// CHECK-NEXT:    _result[0UL] += (c > 0 ? 0. : 1.);
-// CHECK-NEXT:    _result[1UL] += -(c > 0 ? 0. : 1.);
-// CHECK-NEXT:}
+// CHECK-NEXT:     _Bool _t0 = c > 0;
+// CHECK-NEXT:     _result[0UL] += (_t0 ? 1. : 0.);
+// CHECK-NEXT:     _result[1UL] += (_t0 ? 1. : 0.);
+// CHECK-NEXT:     _result[0UL] += (_t0 ? 0. : 1.);
+// CHECK-NEXT:     _result[1UL] += -(_t0 ? 0. : 1.);
+// CHECK-NEXT: }
 
 double f_cond3_grad(double x, double c, double *_result);
 
@@ -211,10 +270,15 @@ struct S {
   }
    
   // CHECK: void f_grad(double x, double y, double *_result) {
-  // CHECK-NEXT:  _result[0UL] += this->c1 * 1.;
-  // CHECK-NEXT:  _result[1UL] += this->c2 * 1.;
+  // CHECK-NEXT:   double _t0 = 1. * x;
+  // CHECK-NEXT:   double _t1 = this->c1 * 1.;
+  // CHECK-NEXT:   _result[0UL] += _t1;
+  // CHECK-NEXT:   double _t2 = 1. * y;
+  // CHECK-NEXT:   double _t3 = this->c2 * 1.;
+  // CHECK-NEXT:  _result[1UL] += _t3;
   // CHECK-NEXT: }
 
+  void f_grad(double x, double y, double *_result);
 };
 
 unsigned f_types(int x, float y, double z) {


### PR DESCRIPTION
This commit adds functionality to store intermediate derivatives in variables, so that the same expressions are not evaluated multiple times.

Currently, output of both differentiation modes is equivalent of that of symbolic differentiation. Resulting formulas often require to evaluate same expressions multiple times and can be exponentially longer than the original function.

Implemented functionality allows to (for now partially) reduce the size of the formula by storing intermediate results in variables. 

For example:
```
double f(double x, double y, double z) {
  return 2*(x + y + z)*x*y*z;
}
...
clad::gradient(f)
```

Old result would be:
```
void f_grad(double x, double y, double z, double *_result) {
    _result[0UL] += 2 * 1. * z * y * x;
    _result[1UL] += 2 * 1. * z * y * x;
    _result[2UL] += 2 * 1. * z * y * x;
    _result[0UL] += 2 * (x + y + z) * 1. * z * y;
    _result[1UL] += 2 * (x + y + z) * x * 1. * z;
    _result[2UL] += 2 * (x + y + z) * x * y * 1.;
}
```
Note that, e.g., expression `2 * 1. * (z * y * x)` has to be evaluated three times.

After this commit, the output is:
```
void f_grad(double x, double y, double z, double *_result) {
    double _t1 = 1. * z;
    double _t2 = _t1 * y;
    double _t3 = _t2 * x;
    double _t4 = _t3 * (x + y + z);
    double _t5 = 2 * _t3;
    _result[0UL] += _t5;
    _result[1UL] += _t5;
    _result[2UL] += _t5;
    double _t6 = 2 * (x + y + z) * _t2;
    _result[0UL] += _t6;
    double _t7 = 2 * (x + y + z) * x * _t1;
    _result[1UL] += _t7;
    double _t8 = 2 * (x + y + z) * x * y * 1.;
    _result[2UL] += _t8;
}
```

Now the result of the same expression is stored in the variable `_t5` and needs not to be recomputed multiple times.

There are ways to optimize it further. For example, the variable `_t4` is unused (it is the derivative of f w.r.t. constant 2 and it does not end up in the result). It is possible to eliminate such variables.

Additionally, we sometimes still recompute subexpressions of original function, e.g., `2 * (x + y + z)` multiple times. This too can be optimized by preprocessing the function and storing results of its subexpressions in variables.

