### PR TITLE
[for discussion] RooFit Gaussian gradient

### DIFF
--- a/demos/Gradient_RooFit.cpp
+++ b/demos/Gradient_RooFit.cpp
@@ -5,42 +5,43 @@
 // implicit function.
 //
 // author:  Alexander Penev <alexander_penev-at-yahoo.com>
+// author:  Patrick Bos <p.bos-at-esciencecenter.nl>
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
 // path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
-// path/to/libclad.so  -I../include/ -x c++ -std=c++11 Gradient.cpp
+// path/to/libclad.so  -I../include/ -I $ROOTSYS/include -x c++ -std=c++11 \
+// Gradient_RooFit.cpp -o Gradient_RooFit
 //
 // A typical invocation would be:
 // ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
-// -I../include/ -x c++ -std=c++11 Gradient.cpp
+// -I../include/ -I $ROOTSYS/include -x c++ -std=c++11 Gradient_RooFit.cpp \
+// -o Gradient_RooFit
 
 // Necessary for clad to work include
 #include "clad/Differentiator/Differentiator.h"
 
+#include "RooRealVar.h"
+#include "RooConstVar.h"
+#include "RooGaussian.h"
+
 // Implicit function for sphere
-float sphere_implicit_func(float x, float y, float z, float xc, float yc, float zc, float r) {
-  return (x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc) - r*r;
+float roofit_gauss(float _x) {
+  RooRealVar x("x", "x", _x);
+  RooConstVar mean("mean", "Mean of Gaussian", 0) ;
+  RooConstVar sigma("sigma","Width of Gaussian",3) ;
+  RooGaussian gauss("gauss","gauss(x,mean,sigma)", x, mean, sigma) ;
+
+  return gauss.GetVal();
 }
 
 int main() {
-  // Differentiate implicit sphere function. Clad will produce the three partial derivatives
-  // of function sphere_implicit_func
-  auto sphere_implicit_func_dx = clad::differentiate(sphere_implicit_func, 0);
-  auto sphere_implicit_func_dy = clad::differentiate(sphere_implicit_func, 1);
-  auto sphere_implicit_func_dz = clad::differentiate(sphere_implicit_func, 2);
-
-  // Point P=(x,y,z) on surface
-  float x = 5.0f;
-  float y = 0;
-  float z = 0;
+  // Differentiate implicit sphere function. Clad will produce the three derivatives
+  // of function roofit_gauss
+  auto roofit_gauss_dx = clad::differentiate(roofit_gauss, 0);
 
   // Calculate gradient in point P (Normal vector)
-  float Nx = sphere_implicit_func_dx.execute(x, y, z, 0, 0, 0, 5.0f);
-  float Ny = sphere_implicit_func_dy.execute(x, y, z, 0, 0, 0, 5.0f);
-  float Nz = sphere_implicit_func_dz.execute(x, y, z, 0, 0, 0, 5.0f);
-  printf("Result is N=(%f,%f,%f)\n", Nx, Ny, Nz);
-
-  return 0;
+  float grad_0 = roofit_gauss_dx.execute(0);
+  printf("Results are %f, \n", grad_0);
 }

--- a/demos/Gradient_RooFit.cpp
+++ b/demos/Gradient_RooFit.cpp
@@ -1,0 +1,46 @@
+//--------------------------------------------------------------------*- C++ -*-
+// clad - The C++ Clang-based Automatic Differentiator
+//
+// A demo, describing how to calculate gradient/normal vector of
+// implicit function.
+//
+// author:  Alexander Penev <alexander_penev-at-yahoo.com>
+//----------------------------------------------------------------------------//
+
+// To run the demo please type:
+// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/libclad.so  -I../include/ -x c++ -std=c++11 Gradient.cpp
+//
+// A typical invocation would be:
+// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
+// -I../include/ -x c++ -std=c++11 Gradient.cpp
+
+// Necessary for clad to work include
+#include "clad/Differentiator/Differentiator.h"
+
+// Implicit function for sphere
+float sphere_implicit_func(float x, float y, float z, float xc, float yc, float zc, float r) {
+  return (x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc) - r*r;
+}
+
+int main() {
+  // Differentiate implicit sphere function. Clad will produce the three partial derivatives
+  // of function sphere_implicit_func
+  auto sphere_implicit_func_dx = clad::differentiate(sphere_implicit_func, 0);
+  auto sphere_implicit_func_dy = clad::differentiate(sphere_implicit_func, 1);
+  auto sphere_implicit_func_dz = clad::differentiate(sphere_implicit_func, 2);
+
+  // Point P=(x,y,z) on surface
+  float x = 5.0f;
+  float y = 0;
+  float z = 0;
+
+  // Calculate gradient in point P (Normal vector)
+  float Nx = sphere_implicit_func_dx.execute(x, y, z, 0, 0, 0, 5.0f);
+  float Ny = sphere_implicit_func_dy.execute(x, y, z, 0, 0, 0, 5.0f);
+  float Nz = sphere_implicit_func_dz.execute(x, y, z, 0, 0, 0, 5.0f);
+  printf("Result is N=(%f,%f,%f)\n", Nx, Ny, Nz);
+
+  return 0;
+}


### PR DESCRIPTION
@vincecr0ft and I were wondering how easy it is to apply Clad in its current form on RooFit classes. This is just a very naive first try towards that goal, meant in the first place to open up discussion. Of course, if it turns out to be very easy, then feel free to merge.

I currently cannot get this Gradient_RooFit.cpp to compile. I based this file off the Gradient.cpp demo, which did compile and run perfectly. I'm using the command I put in the comment header of the file, i.e. on my system (inside the demos directory):
```sh
clang -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang ../install/lib/clad.dylib -I../include/ -I $ROOTSYS/include -x c++ -std=c++11 Gradient_RooFit.cpp -o Gradient_RooFit
```

This is using clang 5.0 from the clangdev=5.0 conda-forge package. That's also what I used to build clad (aside: this may be interesting to add to your README.md build instructions; it's simply `conda install clangdev=5.0 -c conda-forge` and then build/install clad using `git clone git@github.com:vgvassilev/clad.git; cd clad; mkdir build install; cd build; cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install; make; make install`). I'm running on macOS High Sierra, latest version, also Xcode newest, if that's relevant.

I think one issue may be that the RooFit library either isn't found (which is possible, but a bit strange, since I sourced the `thisroot.sh` script), or that it's binary incompatible with clang 5, since it was built with the default Apple clang.

Any ideas? Below follows the actual crash output from clang using the above command.

```
In file included from Gradient_RooFit.cpp:24:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooRealVar.h:25:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsRealLValue.h:23:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsReal.h:19:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsArg.h:24:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooRefCountList.h:19:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooLinkedList.h:19:
In file included from /Users/pbos/sw/miniconda3/include/c++/v1/map:442:
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:756:23: error: field has incomplete type
      'std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, void *>::__node_value_type' (aka 'std::__1::__value_type<std::__1::pair<const RooArgSet *, const
      RooArgSet *>, unsigned long>')
    __node_value_type __value_;
                      ^
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:1064:17: note: in instantiation of template class
      'std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, void *>' requested here
        {return static_cast<__node_pointer>(__end_node()->__left_);}
                ^
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:1347:40: note: in instantiation of member function
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__root' requested here
            {return __lower_bound(__v, __root(), __end_node());}
                                       ^
/Users/pbos/sw/miniconda3/include/c++/v1/map:1245:25: note: in instantiation of function template specialization
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::lower_bound<std::__1::pair<const RooArgSet *, const RooArgSet *> >' requested here
        {return __tree_.lower_bound(__k);}
                        ^
/Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooNormSetCache.h:57:52: note: in
      instantiation of member function 'std::__1::map<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      unsigned long, std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >,
      std::__1::allocator<std::__1::pair<const std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::lower_bound' requested here
    PairIdxMapType::const_iterator it = _pairToIdx.lower_bound(pair);
                                                   ^
/Users/pbos/sw/miniconda3/include/c++/v1/utility:515:41: note: in instantiation of function template
      specialization 'std::__1::__check_tuple_constructor_fail::__enable_assign<const std::__1::pair<const
      RooArgSet *, const RooArgSet *> &>' requested here
            _CheckTLC<_Tuple>::template __enable_assign<_Tuple>()
                                        ^
/Users/pbos/sw/miniconda3/include/c++/v1/utility:518:11: note: (skipping 3 contexts in backtrace; use
      -ftemplate-backtrace-limit=0 to see all)
    pair& operator=(_Tuple&& __p) {
          ^
/Users/pbos/sw/miniconda3/include/c++/v1/type_traits:2075:14: note: in instantiation of template class
      'std::__1::__is_assignable_imp<const std::__1::pair<const RooArgSet *, const RooArgSet *> &, const
      std::__1::pair<const RooArgSet *, const RooArgSet *> &, false>' requested here
    : public __is_assignable_imp<_Tp, _Arg> {};
             ^
/Users/pbos/sw/miniconda3/include/c++/v1/type_traits:2085:14: note: in instantiation of template class
      'std::__1::is_assignable<const std::__1::pair<const RooArgSet *, const RooArgSet *> &, const
      std::__1::pair<const RooArgSet *, const RooArgSet *> &>' requested here
    : public is_assignable<typename add_lvalue_reference<_Tp>::type,
             ^
/Users/pbos/sw/miniconda3/include/c++/v1/utility:490:25: note: in instantiation of template class
      'std::__1::is_copy_assignable<const std::__1::pair<const RooArgSet *, const RooArgSet *> >' requested here
                        is_copy_assignable<first_type>::value &&
                        ^
/Users/pbos/sw/miniconda3/include/c++/v1/map:626:16: note: in instantiation of template class
      'std::__1::pair<const std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>' requested here
    value_type __cc;
               ^
/Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooNormSetCache.h:58:26: note: in
      instantiation of template class 'std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet
      *>, unsigned long>' requested here
    if (_pairToIdx.end() != it &&
                         ^
/Users/pbos/sw/miniconda3/include/c++/v1/map:619:7: note: definition of
      'std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>' is not
      complete until the closing '}'
union __value_type
      ^
In file included from Gradient_RooFit.cpp:24:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooRealVar.h:25:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsRealLValue.h:23:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsReal.h:19:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsArg.h:24:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooRefCountList.h:19:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooLinkedList.h:19:
In file included from /Users/pbos/sw/miniconda3/include/c++/v1/map:442:
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:1526:30: error: static_cast from
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__node_pointer' (aka 'std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet
      *, const RooArgSet *>, unsigned long>, void *> *') to
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__node_base_pointer' (aka 'std::__1::__tree_node_base<void *> *'), which are not related by
      inheritance, is not allowed
    if (__tree_is_left_child(static_cast<__node_base_pointer>(__cache)))
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:1621:41: note: in instantiation of member function
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__detach' requested here
                __node_pointer __next = __detach(__cache);
                                        ^
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:1550:9: note: in instantiation of function template specialization
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__assign_multi<std::__1::__tree_const_iterator<std::__1::__value_type<std::__1::pair<const
      RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, void *> *, long> >' requested here
        __assign_multi(__t.begin(), __t.end());
        ^
/Users/pbos/sw/miniconda3/include/c++/v1/map:914:21: note: in instantiation of member function
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::operator=' requested here
            __tree_ = __m.__tree_;
                    ^
/Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooNormSetCache.h:31:7: note: in
      instantiation of member function 'std::__1::map<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      unsigned long, std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >,
      std::__1::allocator<std::__1::pair<const std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::operator=' requested here
class RooNormSetCache {
      ^
In file included from Gradient_RooFit.cpp:24:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooRealVar.h:25:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsRealLValue.h:23:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsReal.h:19:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsArg.h:24:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooRefCountList.h:19:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooLinkedList.h:19:
In file included from /Users/pbos/sw/miniconda3/include/c++/v1/map:442:
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:1535:5: error: cannot initialize object parameter of type 'const
      std::__1::__tree_node_base<void *>' with an expression of type
      'std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, void *>'
    __cache->__parent_unsafe()->__right_ = nullptr;
    ^~~~~~~
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:860:62: error: cannot initialize a member subobject of type
      'std::__1::__tree_iterator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      unsigned long>, std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const
      RooArgSet *>, unsigned long>, void *> *, long>::__iter_pointer' (aka
      'std::__1::__tree_end_node<std::__1::__tree_node_base<void *> *> *') with an lvalue of type
      'std::__1::__tree_iterator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      unsigned long>, std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const
      RooArgSet *>, unsigned long>, void *> *, long>::__node_pointer' (aka
      'std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, void *> *')
    explicit __tree_iterator(__node_pointer __p) _NOEXCEPT : __ptr_(__p) {}
                                                             ^      ~~~
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:2312:12: note: in instantiation of member function
      'std::__1::__tree_iterator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      unsigned long>, std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const
      RooArgSet *>, unsigned long>, void *> *, long>::__tree_iterator' requested here
    return iterator(__nd);
           ^
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:1622:17: note: in instantiation of member function
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__node_insert_multi' requested here
                __node_insert_multi(__cache);
                ^
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:1550:9: note: in instantiation of function template specialization
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__assign_multi<std::__1::__tree_const_iterator<std::__1::__value_type<std::__1::pair<const
      RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, void *> *, long> >' requested here
        __assign_multi(__t.begin(), __t.end());
        ^
/Users/pbos/sw/miniconda3/include/c++/v1/map:914:21: note: in instantiation of member function
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::operator=' requested here
            __tree_ = __m.__tree_;
                    ^
/Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooNormSetCache.h:31:7: note: in
      instantiation of member function 'std::__1::map<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      unsigned long, std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >,
      std::__1::allocator<std::__1::pair<const std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::operator=' requested here
class RooNormSetCache {
      ^
In file included from Gradient_RooFit.cpp:24:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooRealVar.h:25:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsRealLValue.h:23:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsReal.h:19:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsArg.h:24:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooRefCountList.h:19:
In file included from /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooLinkedList.h:19:
In file included from /Users/pbos/sw/miniconda3/include/c++/v1/map:442:
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:2215:12: error: no matching conversion for functional-style cast
      from 'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__node_pointer' (aka 'std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet
      *, const RooArgSet *>, unsigned long>, void *> *') to
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::iterator' (aka '__tree_iterator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const
      RooArgSet *>, unsigned long>, std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *,
      const RooArgSet *>, unsigned long>, void *> *, long>')
    return iterator(static_cast<__node_pointer>(__h.release()));
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:1305:16: note: in instantiation of function template
      specialization 'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet
      *>, unsigned long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__emplace_multi<const std::__1::pair<const std::__1::pair<const RooArgSet *, const RooArgSet *>,
      unsigned long> &>' requested here
        return __emplace_multi(_VSTD::forward<_Vp>(__v));
               ^
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:1643:9: note: in instantiation of function template specialization
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__insert_multi<const std::__1::pair<const std::__1::pair<const RooArgSet *, const RooArgSet *>,
      unsigned long> &>' requested here
        __insert_multi(_NodeTypes::__get_value(*__first));
        ^
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:1550:9: note: in instantiation of function template specialization
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__assign_multi<std::__1::__tree_const_iterator<std::__1::__value_type<std::__1::pair<const
      RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, void *> *, long> >' requested here
        __assign_multi(__t.begin(), __t.end());
        ^
/Users/pbos/sw/miniconda3/include/c++/v1/map:914:21: note: in instantiation of member function
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::operator=' requested here
            __tree_ = __m.__tree_;
                    ^
/Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooNormSetCache.h:31:7: note: in
      instantiation of member function 'std::__1::map<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      unsigned long, std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >,
      std::__1::allocator<std::__1::pair<const std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::operator=' requested here
class RooNormSetCache {
      ^
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:802:28: note: candidate constructor
      (the implicit copy constructor) not viable: no known conversion from
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__node_pointer' (aka 'std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet
      *, const RooArgSet *>, unsigned long>, void *> *') to 'const
      std::__1::__tree_iterator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      unsigned long>, std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const
      RooArgSet *>, unsigned long>, void *> *, long>' for 1st argument
class _LIBCPP_TEMPLATE_VIS __tree_iterator
                           ^
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:802:28: note: candidate constructor
      (the implicit move constructor) not viable: no known conversion from
      'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__node_pointer' (aka 'std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet
      *, const RooArgSet *>, unsigned long>, void *> *') to
      'std::__1::__tree_iterator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      unsigned long>, std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const
      RooArgSet *>, unsigned long>, void *> *, long>' for 1st argument
class _LIBCPP_TEMPLATE_VIS __tree_iterator
                           ^
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:862:14: note: candidate constructor not viable: no known
      conversion from 'std::__1::__tree<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet
      *>, unsigned long>, std::__1::__map_value_compare<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned long>,
      std::__1::less<std::__1::pair<const RooArgSet *, const RooArgSet *> >, true>,
      std::__1::allocator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>, unsigned
      long> > >::__node_pointer' (aka 'std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet
      *, const RooArgSet *>, unsigned long>, void *> *') to
      'std::__1::__tree_iterator<std::__1::__value_type<std::__1::pair<const RooArgSet *, const RooArgSet *>,
      unsigned long>, std::__1::__tree_node<std::__1::__value_type<std::__1::pair<const RooArgSet *, const
      RooArgSet *>, unsigned long>, void *> *, long>::__end_node_pointer' (aka
      'std::__1::__tree_end_node<std::__1::__tree_node_base<void *> *> *') for 1st argument
    explicit __tree_iterator(__end_node_pointer __p) _NOEXCEPT : __ptr_(__p) {}
             ^
/Users/pbos/sw/miniconda3/include/c++/v1/__tree:820:31: note: candidate constructor not viable: requires 0
      arguments, but 1 was provided
    _LIBCPP_INLINE_VISIBILITY __tree_iterator() _NOEXCEPT
                              ^
Gradient_RooFit.cpp:35:16: error: no member named 'GetVal' in 'RooGaussian'; did you mean 'getValV'?
  return gauss.GetVal();
               ^~~~~~
               getValV
/Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include/RooAbsPdf.h:187:20: note: 'getValV'
      declared here
  virtual Double_t getValV(const RooArgSet* set=0) const ;
                   ^
0  clang-5.0                0x0000000110366c78 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 40
1  clang-5.0                0x00000001103672f6 SignalHandler(int) + 326
2  libsystem_platform.dylib 0x00007fff6be92f5a _sigtramp + 26
3  libdyld.dylib            0x00007fff6bb84149 dyldGlobalLockRelease() + 0
4  clang-5.0                0x0000000111c66fca clang::CallExpr::CallExpr(clang::ASTContext const&, clang::Stmt::StmtClass, clang::Expr*, llvm::ArrayRef<clang::Expr*>, clang::QualType, clang::ExprValueKind, clang::SourceLocation) + 74
5  clad.dylib               0x0000000112fae62d clang::CXXMemberCallExpr::CXXMemberCallExpr(clang::ASTContext&, clang::Expr*, llvm::ArrayRef<clang::Expr*>, clang::QualType, clang::ExprValueKind, clang::SourceLocation) + 157
6  clad.dylib               0x0000000112fa8c7a clang::CXXMemberCallExpr::CXXMemberCallExpr(clang::ASTContext&, clang::Expr*, llvm::ArrayRef<clang::Expr*>, clang::QualType, clang::ExprValueKind, clang::SourceLocation) + 90
7  clad.dylib               0x0000000112fa8b14 clad::utils::StmtClone::VisitCXXMemberCallExpr(clang::CXXMemberCallExpr*) + 212
8  clad.dylib               0x0000000112e8cd83 clang::StmtVisitorBase<clang::make_ptr, clad::utils::StmtClone, clang::Stmt*>::Visit(clang::Stmt*) + 2995
9  clad.dylib               0x0000000112e6c910 clang::Stmt* clad::utils::StmtClone::Clone<clang::Stmt>(clang::Stmt const*) + 64
10 clad.dylib               0x0000000112e6c8a6 clad::DerivativeBuilder::Clone(clang::Stmt const*) + 70
11 clad.dylib               0x0000000112e6a52e clad::ForwardModeVisitor::Clone(clang::Stmt const*) + 46
12 clad.dylib               0x0000000112e6d5d6 clad::ForwardModeVisitor::VisitReturnStmt(clang::ReturnStmt const*) + 102
13 clad.dylib               0x0000000112e6c235 clang::StmtVisitorBase<clang::make_const_ptr, clad::ForwardModeVisitor, clad::NodeContext>::Visit(clang::Stmt const*) + 6821
14 clad.dylib               0x0000000112e6cbfd clad::ForwardModeVisitor::VisitCompoundStmt(clang::CompoundStmt const*) + 189
15 clad.dylib               0x0000000112e6aea4 clang::StmtVisitorBase<clang::make_const_ptr, clad::ForwardModeVisitor, clad::NodeContext>::Visit(clang::Stmt const*) + 1812
16 clad.dylib               0x0000000112e688cc clad::ForwardModeVisitor::Derive(clad::FunctionDeclInfo&, clad::DiffPlan const&) + 6956
17 clad.dylib               0x0000000112e66cdd clad::DerivativeBuilder::Derive(clad::FunctionDeclInfo&, clad::DiffPlan const&) + 93
18 clad.dylib               0x0000000112e593d7 clad::plugin::CladPlugin::HandleTopLevelDecl(clang::DeclGroupRef) + 1527
19 clang-5.0                0x0000000110946340 clang::MultiplexConsumer::HandleTopLevelDecl(clang::DeclGroupRef) + 48
20 clang-5.0                0x0000000111004972 clang::ParseAST(clang::Sema&, bool, bool) + 370
  1 First rough implementation with RooGaussian
21 clang-5.0                0x000000011091dd15 clang::FrontendAction::Execute() + 69
22 clang-5.0                0x00000001108d41d8 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) + 1288
23 clang-5.0                0x0000000110963fe7 clang::ExecuteCompilerInvocation(clang::CompilerInstance*) + 2663
24 clang-5.0                0x000000010f725bbc cc1_main(llvm::ArrayRef<char const*>, char const*, void*) + 1212
25 clang-5.0                0x000000010f7248b2 main + 12274
26 libdyld.dylib            0x00007fff6bb84015 start + 1
Stack dump:
0.	Program arguments: /Users/pbos/sw/miniconda3/bin/clang-5.0 -cc1 -triple x86_64-apple-macosx10.13.0 -Wdeprecated-objc-isa-usage -Werror=deprecated-objc-isa-usage -emit-obj -mrelax-all -disable-free -disable-llvm-verifier -discard-value-names -main-file-name Gradient_RooFit.cpp -mrelocation-model pic -pic-level 2 -mthread-model posix -mdisable-fp-elim -masm-verbose -munwind-tables -target-cpu penryn -target-linker-version 242.2 -dwarf-column-info -debugger-tuning=lldb -resource-dir /Users/pbos/sw/miniconda3/lib/clang/5.0.0 -I ../include/ -I /Users/pbos/projects/apcocsm/root-roofit-dev/cmake-build-debug/include -stdlib=libc++ -std=c++11 -fdeprecated-macro -fdebug-compilation-dir /Users/pbos/src/git/clad/demos -ferror-limit 19 -fmessage-length 114 -stack-protector 1 -fblocks -fobjc-runtime=macosx-10.13.0 -fencode-extended-block-signature -fcxx-exceptions -fexceptions -fmax-type-align=16 -fdiagnostics-show-option -add-plugin clad -load ../install/lib/clad.dylib -o /var/folders/_k/2ysbjq6j6cz6ybqxl777795r0000gn/T/Gradient_RooFit-ae6d3e.o -x c++ Gradient_RooFit.cpp
1.	<eof> parser at end of file
clang-5.0: error: unable to execute command: Segmentation fault: 11
clang-5.0: error: clang frontend command failed due to signal (use -v to see invocation)
clang version 5.0.0 (tags/RELEASE_500/final)
Target: x86_64-apple-darwin17.6.0
Thread model: posix
InstalledDir: /Users/pbos/sw/miniconda3/bin
clang-5.0: note: diagnostic msg: PLEASE submit a bug report to  and include the crash backtrace, preprocessed source, and associated run script.
clang-5.0: note: diagnostic msg:
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang-5.0: note: diagnostic msg: /var/folders/_k/2ysbjq6j6cz6ybqxl777795r0000gn/T/Gradient_RooFit-0be816.cpp
clang-5.0: note: diagnostic msg: /var/folders/_k/2ysbjq6j6cz6ybqxl777795r0000gn/T/Gradient_RooFit-0be816.sh
clang-5.0: note: diagnostic msg: Crash backtrace is located in
clang-5.0: note: diagnostic msg: /Users/pbos/Library/Logs/DiagnosticReports/clang-5.0_<YYYY-MM-DD-HHMMSS>_<hostname>.crash
clang-5.0: note: diagnostic msg: (choose the .crash file that corresponds to your crash)
clang-5.0: note: diagnostic msg:

********************
```