### PR TITLE
The address of a member function pointer is a rvalue.

### DIFF
--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -63,7 +63,7 @@ namespace clad {
                                    false,
                                    FD->getNameInfo(),
                                    FD->getType(),
-                                   VK_LValue);
+                                   oldDRE->getValueKind());
    
     // FIXME: I am not sure if the following part is necessary:
     // using call->setArg(0, DRE) seems to be sufficient,


### PR DESCRIPTION
This caused an assert in Gradient.C when calling clad::gradient(&S::f);