### PR TITLE
Add the pluing as a static lib.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,6 +2,10 @@ if( NOT CLAD_BUILT_STANDALONE AND NOT LLVM_BUILD_TOOLS )
   set(EXCLUDE_FROM_ALL ON)
 endif()
 
+add_llvm_library(cladPlugin
+  ClangPlugin.cpp
+  RequiredSymbols.cpp
+  )
 add_llvm_loadable_module(clad
   ClangPlugin.cpp
   RequiredSymbols.cpp


### PR DESCRIPTION
This allows frameworks to link the plugin against a clang library.
The static initialization will trigger as usual and the plugin should
attach itself as if it were dlopen-ed.