### PR TITLE
Reimplement runtime check.

### DIFF
--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -47,7 +47,7 @@ namespace clad {
       clang::CompilerInstance& m_CI;
       DifferentiationOptions m_DO;
       std::unique_ptr<DerivativeBuilder> m_DerivativeBuilder;
-      bool m_CheckRuntime;
+      bool m_HasRuntime;
     public:
       CladPlugin(clang::CompilerInstance& CI, DifferentiationOptions& DO);
       ~CladPlugin();


### PR DESCRIPTION
Reimplement runtime check.

When clad works as a clang plugin usually we see the runtime quite early
because #includes usually go first. In the case of interpreters such as
cling the clad runtime can come at any point in time.

This patch activates the plugin only when we include
clad/Differentiator/Differentiator.h'. We speed up cases where we do not
have code to be processed by the plugin.