### PR TITLE
Fix assert failures in clang codegen.

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -51,6 +51,8 @@ namespace clad {
     typedef llvm::SmallVector<FunctionDeclInfo, 16> Functions;
     Functions m_Functions;
     clang::CallExpr* m_CallToUpdate;
+    clang::DeclRefExpr* m_OldDRE;
+    clang::Expr* m_OldArg;
     unsigned m_RequestedDerivativeOrder;
     unsigned m_CurrentDerivativeOrder;
     unsigned m_ArgIndex;

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -105,6 +105,24 @@ namespace clad {
     assert(f && "Must pass in a non-0 argument");
     return CladFunction<true, R, C, Args...>(f, code);
   }
+
+  template <typename R, typename ... Args>
+  using grad_fn_ptr_t = void (*)(Args..., R*);
+
+  template <typename C, typename R, typename ... Args>
+  using grad_mem_ptr_t = void (C::*) (Args..., R*);
+
+  template <typename Ptr, typename R, typename ... Args>
+  CladFunction<false, void, Args..., R*> __attribute__((annotate("GR")))
+  make_gradient_fn(Ptr f, const char* code = "") {
+    return CladFunction<false, void, Args..., R*> (f, code);
+  }
+
+  template <typename Ptr, typename R, typename C, typename ... Args>
+  CladFunction<true, void, C, Args..., R*> __attribute__((annotate("GR")))
+  make_gradient_mem_fn(Ptr f, const char* code = "") {
+    return CladFunction<true, void, C, Args..., R*> (f, code);
+  }
   
   /// A function for gradient computation.
   /// Given a function f, clad::gradient generates its gradient f_grad and
@@ -113,18 +131,22 @@ namespace clad {
   CladFunction<false, void, Args..., R*> __attribute__((annotate("G")))
   gradient(R (*f)(Args...), const char* code = "") {
     assert(f && "Must pass in a non-0 argument");
-    return CladFunction<false, void, Args..., R*>(
-      reinterpret_cast<void (*) (Args..., R*)>(f) /* will be replaced by gradient*/,
-      code);
+    using ptr_type = grad_fn_ptr_t<R, Args...>;
+    return
+      make_gradient_fn<ptr_type, R, Args...>(
+       static_cast<ptr_type>(nullptr), // will be replaced by gradient
+       code);
   }
 
   template<typename R, typename C, typename... Args>
   CladFunction<true, void, C, Args..., R*> __attribute__((annotate("G")))
   gradient(R (C::*f)(Args...), const char* code = "") {
     assert(f && "Must pass in a non-0 argument");
-    return CladFunction<true, void, C, Args..., R*>(
-      reinterpret_cast<void (C::*) (Args..., R*)>(f) /* will be replaced by gradient*/,
-      code);
+    using ptr_type = grad_mem_ptr_t<C, R, Args...>;
+    return
+      make_gradient_mem_fn<ptr_type, R, C, Args...>(
+       static_cast<ptr_type>(nullptr), // will be replaced by gradient
+       code);
   }
 }
 #endif // CLAD_DIFFERENTIATOR

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -904,7 +904,12 @@ namespace clad {
 
   void ReverseModeVisitor::VisitConditionalOperator(
     const clang::ConditionalOperator* CO) {
-    auto cond = StoreAndRef(Clone(CO->getCond()));
+    auto condVar = StoreAndRef(Clone(CO->getCond()));
+    auto cond =
+      m_Sema.ActOnCondition(m_CurScope.get(),
+                            noLoc,
+                            condVar,
+                            Sema::ConditionKind::Boolean).get().second;
     auto ifTrue = CO->getTrueExpr();
     auto ifFalse = CO->getFalseExpr();
 

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -7,6 +7,14 @@ using namespace clang;
 
 namespace clad {
   static SourceLocation noLoc;
+  // FIXME:
+  // Currently, the global variable is used to store the pointer to the last
+  // call which requires update.
+  // This is needed to share this information between different invocations of
+  // CladPlugin::HandleTopLevelDecl in which clad::gradient and make_gradient
+  // are processed (see Differentiator.h).
+  clang::CallExpr* g_LastGradientToUpdate = nullptr;
+
   FunctionDeclInfo::FunctionDeclInfo(FunctionDecl* FD, ParmVarDecl* PVD)
     : m_FD(FD), m_PVD(PVD) {
 #ifndef NDEBUG
@@ -35,42 +43,34 @@ namespace clad {
   }
 
   void DiffPlan::updateCall(FunctionDecl* FD, Sema& SemaRef) {
-    auto call = m_CallToUpdate;
+    auto call =
+      (getMode() == DiffMode::forward) ?
+        m_CallToUpdate :
+        g_LastGradientToUpdate;
+
+    assert(call && "Must be set");
+
     // Index of "code" parameter:
     // 2 for clad::differentiate, 1 for clad::gradient.
     auto codeArgIdx = static_cast<int>(call->getNumArgs()) - 1;
-    assert(call && "Must be set");
-
-    DeclRefExpr* oldDRE = nullptr;
-    // Handle the case of function pointer.
-    if (auto ICE = dyn_cast<ImplicitCastExpr>(call->getArg(0))){
-      oldDRE = dyn_cast<DeclRefExpr>(ICE->getSubExpr());
-    }
-    // Handle the case of member function.
-    else if (auto UnOp = dyn_cast<UnaryOperator>(call->getArg(0))){
-      oldDRE = dyn_cast<DeclRefExpr>(UnOp->getSubExpr());
-    }
-    else 
-      llvm_unreachable("Trying to differentiate something unsupported");
     
     ASTContext& C = SemaRef.getASTContext();
     // Create ref to generated FD.
     auto DRE = DeclRefExpr::Create(C,
                                    // same namespace qualifier
-                                   oldDRE->getQualifierLoc(),
+                                   m_OldDRE->getQualifierLoc(),
                                    noLoc,
                                    FD,
                                    false,
                                    FD->getNameInfo(),
                                    FD->getType(),
-                                   oldDRE->getValueKind());
+                                   m_OldDRE->getValueKind());
    
     // FIXME: I am not sure if the following part is necessary:
     // using call->setArg(0, DRE) seems to be sufficient,
     // though the real AST allways contains the ImplicitCastExpr (function -> 
     // function ptr cast) or UnaryOp (method ptr call).
-    auto oldArg = call->getArg(0);
-    if (auto oldCast = dyn_cast<ImplicitCastExpr>(oldArg)) {
+    if (auto oldCast = dyn_cast<ImplicitCastExpr>(m_OldArg)) {
       // Cast function to function pointer.
       auto newCast = ImplicitCastExpr::Create(C,
                                               C.getPointerType(FD->getType()),
@@ -80,7 +80,7 @@ namespace clad {
                                               oldCast->getValueKind());
       call->setArg(0, newCast);
     }
-    else if (auto oldUnOp = dyn_cast<UnaryOperator>(oldArg)) {
+    else if (auto oldUnOp = dyn_cast<UnaryOperator>(m_OldArg)) {
       // Add the "&" operator
       auto newUnOp = SemaRef.BuildUnaryOp(nullptr,
                                           noLoc,
@@ -230,39 +230,48 @@ namespace clad {
         else if (UnaryOperator* UnOp = dyn_cast<UnaryOperator>(E->getArg(0))){
           DRE = dyn_cast<DeclRefExpr>(UnOp->getSubExpr());
         }
-        if (DRE) {          
-          auto && label = A->getAnnotation();
-          if (label.equals("D")) {
-            // A call to clad::differentiate was found.
 
-            m_DiffPlans.push_back(DiffPlan());
-            getCurrentPlan().setMode(DiffMode::forward);
+        auto && label = A->getAnnotation();
+        if (label.equals("D")) {
+          // A call to clad::differentiate was found.
 
-            llvm::APSInt derivativeOrderAPSInt
-              = FD->getTemplateSpecializationArgs()->get(0).getAsIntegral();
-            // We know the first template spec argument is of unsigned type
-            assert(derivativeOrderAPSInt.isUnsigned() && "Must be unsigned");
-            unsigned derivativeOrder = derivativeOrderAPSInt.getZExtValue();
-            getCurrentPlan().m_RequestedDerivativeOrder = derivativeOrder;
+          m_DiffPlans.push_back(DiffPlan());
+          getCurrentPlan().setMode(DiffMode::forward);
 
-            getCurrentPlan().setCallToUpdate(E);
-            FunctionDecl* cand = cast<FunctionDecl>(DRE->getDecl());
-            ParmVarDecl* candPVD = getIndependentArg(E->getArg(1), cand);
-            FunctionDeclInfo FDI(cand, candPVD);
-            m_TopMostFDI = &FDI;
-            TraverseDecl(cand);
-            m_TopMostFDI = 0;
-            getCurrentPlan().push_back(FDI);
-          }
-          else if (label.equals("G")) {
-            // A call to clad::gradient was found.
+          llvm::APSInt derivativeOrderAPSInt
+            = FD->getTemplateSpecializationArgs()->get(0).getAsIntegral();
+          // We know the first template spec argument is of unsigned type
+          assert(derivativeOrderAPSInt.isUnsigned() && "Must be unsigned");
+          unsigned derivativeOrder = derivativeOrderAPSInt.getZExtValue();
+          getCurrentPlan().m_RequestedDerivativeOrder = derivativeOrder;
 
-            m_DiffPlans.push_back(DiffPlan());
-            getCurrentPlan().setMode(DiffMode::reverse);
-            getCurrentPlan().setCallToUpdate(E);
-            FunctionDeclInfo FDI(cast<FunctionDecl>(DRE->getDecl()), nullptr);
-            getCurrentPlan().push_back(FDI);
-          }
+          getCurrentPlan().setCallToUpdate(E);
+          assert(DRE && "clad::differentiate is called on something that is not"
+                        " a function pointer");
+          FunctionDecl* cand = cast<FunctionDecl>(DRE->getDecl());
+          ParmVarDecl* candPVD = getIndependentArg(E->getArg(1), cand);
+          FunctionDeclInfo FDI(cand, candPVD);
+          m_TopMostFDI = &FDI;
+          TraverseDecl(cand);
+          m_TopMostFDI = 0;
+          getCurrentPlan().push_back(FDI);
+          getCurrentPlan().m_OldDRE = DRE;
+          getCurrentPlan().m_OldArg = E->getArg(0);
+        }
+        else if (label.equals("G")) {
+          // A call to clad::gradient was found.
+
+          m_DiffPlans.push_back(DiffPlan());
+          getCurrentPlan().setMode(DiffMode::reverse);
+          assert(DRE && "clad::gradient is called on something that is not a "
+                        "function pointer");
+          FunctionDeclInfo FDI(cast<FunctionDecl>(DRE->getDecl()), nullptr);
+          getCurrentPlan().push_back(FDI);
+          getCurrentPlan().m_OldDRE = DRE;
+          getCurrentPlan().m_OldArg = E->getArg(0);
+        }
+        else if (label.equals("GR")) {
+          g_LastGradientToUpdate = E;
         }
       }  
     }


### PR DESCRIPTION
Two problems were: 

* Mismatch of clad::gradient function type and type of generated gradient function that is passed as an argument.

* Lvalue to Rvalue casts where missing, which caused assert failures in cases like:
```
bool _t0 = x < y;
return (_t0 ? x : y );
```
Second `_t0` must be cast to Rvalue.

NOTE: This is PR #65 rebased + trailing whitespaces removed.