### PR TITLE
Fix assert failures in clang codegen.

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -105,7 +105,7 @@ namespace clad {
     assert(f && "Must pass in a non-0 argument");
     return CladFunction<true, R, C, Args...>(f, code);
   }
-  
+
   /// A function for gradient computation.
   /// Given a function f, clad::gradient generates its gradient f_grad and
   /// returns a CladFunction for it.

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -904,7 +904,12 @@ namespace clad {
 
   void ReverseModeVisitor::VisitConditionalOperator(
     const clang::ConditionalOperator* CO) {
-    auto cond = StoreAndRef(Clone(CO->getCond()));
+    auto condVar = StoreAndRef(Clone(CO->getCond()));
+    auto cond =
+      m_Sema.ActOnCondition(m_CurScope.get(),
+                            noLoc,
+                            condVar,
+                            Sema::ConditionKind::Boolean).get().second;
     auto ifTrue = CO->getTrueExpr();
     auto ifFalse = CO->getFalseExpr();
 

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -2,6 +2,7 @@
 
 #include "clang/AST/ASTContext.h"
 #include "clang/Sema/Sema.h"
+#include "clang/Sema/TemplateDeduction.h"
 
 using namespace clang;
 
@@ -27,7 +28,7 @@ namespace clad {
       m_FD->dump();
     else
       llvm::errs() << "<invalid> FD: " << m_FD << '\n';
-    
+
     if (m_PVD)
       m_PVD->dump();
     else
@@ -50,9 +51,9 @@ namespace clad {
     else if (auto UnOp = dyn_cast<UnaryOperator>(call->getArg(0))){
       oldDRE = dyn_cast<DeclRefExpr>(UnOp->getSubExpr());
     }
-    else 
+    else
       llvm_unreachable("Trying to differentiate something unsupported");
-    
+
     ASTContext& C = SemaRef.getASTContext();
     // Create ref to generated FD.
     auto DRE = DeclRefExpr::Create(C,
@@ -64,10 +65,10 @@ namespace clad {
                                    FD->getNameInfo(),
                                    FD->getType(),
                                    oldDRE->getValueKind());
-   
+
     // FIXME: I am not sure if the following part is necessary:
     // using call->setArg(0, DRE) seems to be sufficient,
-    // though the real AST allways contains the ImplicitCastExpr (function -> 
+    // though the real AST allways contains the ImplicitCastExpr (function ->
     // function ptr cast) or UnaryOp (method ptr call).
     auto oldArg = call->getArg(0);
     if (auto oldCast = dyn_cast<ImplicitCastExpr>(oldArg)) {
@@ -87,10 +88,10 @@ namespace clad {
                                           oldUnOp->getOpcode(),
                                           DRE).get();
       call->setArg(0, newUnOp);
-    } 
-    else 
+    }
+    else
       llvm_unreachable("Trying to differentiate something unsupported");
-    
+
     // Update the code parameter.
     if (CXXDefaultArgExpr* Arg
         = dyn_cast<CXXDefaultArgExpr>(call->getArg(codeArgIdx))) {
@@ -128,6 +129,45 @@ namespace clad {
                                   CK_ArrayToPointerDecay).get();
       call->setArg(codeArgIdx, newArg);
     }
+
+    // Replace old specialization of clad::gradient with a new one that matches
+    // the type of new argument.
+
+    auto CladGradientFDeclOld = call->getDirectCallee();
+    auto CladGradientExprOld = call->getCallee();
+    auto CladGradientFTemplate = CladGradientFDeclOld->getPrimaryTemplate();
+
+    FunctionDecl* CladGradientFDeclNew = nullptr;
+    sema::TemplateDeductionInfo info(noLoc);
+    // Create/get template specialization of clad::gradient that matches
+    // argument types. Result is stored to CladGradientFDeclNew.
+    SemaRef.DeduceTemplateArguments(CladGradientFTemplate,
+                                    nullptr,
+                                    llvm::ArrayRef<Expr*>(call->getArgs(),
+                                                          call->getNumArgs()),
+                                    CladGradientFDeclNew,
+                                    info,
+                                    false,
+                                    [] (llvm::ArrayRef<QualType>) {
+                                      return false;
+                                    });
+    // DeclRefExpr for new specialization.
+    auto CladGradientExprNew =
+      SemaRef.BuildDeclRefExpr(CladGradientFDeclNew,
+                               CladGradientFDeclNew->getType(),
+                               CladGradientExprOld->getValueKind(),
+                               CladGradientExprOld->getLocEnd()).get();
+    auto CastOld = dyn_cast<ImplicitCastExpr>(CladGradientExprOld);
+    // Function to pointer cast.
+    CladGradientExprNew =
+      ImplicitCastExpr::Create(C,
+                               C.getPointerType(CladGradientExprNew->getType()),
+                               CastOld->getCastKind(),
+                               CladGradientExprNew,
+                               nullptr,
+                               CastOld->getValueKind());
+    // Replace the old clad::gradient by the new one.
+    call->setCallee(CladGradientExprNew);
   }
 
   LLVM_DUMP_METHOD void DiffPlan::dump() {
@@ -189,7 +229,7 @@ namespace clad {
   }
 
   void DiffCollector::UpdatePlan(clang::FunctionDecl* FD, DiffPlan* plan) {
-    if (plan->getCurrentDerivativeOrder() == 
+    if (plan->getCurrentDerivativeOrder() ==
         plan->getRequestedDerivativeOrder())
       return;
     assert(plan->getRequestedDerivativeOrder() > 1
@@ -230,7 +270,7 @@ namespace clad {
         else if (UnaryOperator* UnOp = dyn_cast<UnaryOperator>(E->getArg(0))){
           DRE = dyn_cast<DeclRefExpr>(UnOp->getSubExpr());
         }
-        if (DRE) {          
+        if (DRE) {
           auto && label = A->getAnnotation();
           if (label.equals("D")) {
             // A call to clad::differentiate was found.
@@ -264,7 +304,7 @@ namespace clad {
             getCurrentPlan().push_back(FDI);
           }
         }
-      }  
+      }
     }
     return true;     // return false to abort visiting.
   }


### PR DESCRIPTION
Two problems were: 

* Mismatch of clad::gradient function type and type of generated gradient function that is passed as an argument.

* Lvalue to Rvalue casts where missing, which caused assert failures in cases like:
```
bool _t0 = x < y;
return (_t0 ? x : y );
```
Second `_t0` must be cast to Rvalue.

Some trailing whitespaces are removed.