### PR TITLE
Fix assert failures in clang codegen

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -105,7 +105,7 @@ namespace clad {
     assert(f && "Must pass in a non-0 argument");
     return CladFunction<true, R, C, Args...>(f, code);
   }
-  
+
   /// A function for gradient computation.
   /// Given a function f, clad::gradient generates its gradient f_grad and
   /// returns a CladFunction for it.

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -904,7 +904,12 @@ namespace clad {
 
   void ReverseModeVisitor::VisitConditionalOperator(
     const clang::ConditionalOperator* CO) {
-    auto cond = StoreAndRef(Clone(CO->getCond()));
+    auto condVar = StoreAndRef(Clone(CO->getCond()));
+    auto cond =
+      m_Sema.ActOnCondition(m_CurScope.get(),
+                            noLoc,
+                            condVar,
+                            Sema::ConditionKind::Boolean).get().second;
     auto ifTrue = CO->getTrueExpr();
     auto ifFalse = CO->getFalseExpr();
 


### PR DESCRIPTION
Two problems were:

* Mismatch of clad::gradient function type and type of generated
gradient function that is passed as an argument.

* LValue to RValue casts where missing, which caused assert
failures in cases like the following example, where second 
`_t0` must be cast to RValue:
```
bool _t0 = x < y;
return (_t0 ? x : y );
```

Some trailing whitespaces are removed.

Close: #61 