### PR TITLE
Handle scopes properly

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -124,17 +124,17 @@ namespace clad {
     }
 
     /// Get a current scope.
-    clang::Scope* currentScope() {
+    clang::Scope* getCurrentScope() {
       return m_CurScope;
     }
     /// Enters a new scope.
-    void enterScope(unsigned ScopeFlags) {
+    void beginScope(unsigned ScopeFlags) {
       // FIXME: since Sema::CurScope is private, we cannot access it and have
       // to use separate member variable m_CurScope. The only options to set
       // CurScope of Sema seemt to be through Parser or ContextAndScopeRAII.
-      m_CurScope = new clang::Scope(currentScope(), ScopeFlags, m_Sema.Diags);
+      m_CurScope = new clang::Scope(getCurrentScope(), ScopeFlags, m_Sema.Diags);
     }
-    void exitScope() {
+    void endScope() {
       // This will remove all the decls in the scope from the IdResolver. 
       m_Sema.ActOnPopScope(noLoc, m_CurScope);
       auto oldScope = m_CurScope;

--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -123,6 +123,25 @@ namespace clad {
       getCurrentBlock().push_back(S);
     }
 
+    /// Get a current scope.
+    clang::Scope* currentScope() {
+      return m_CurScope;
+    }
+    /// Enters a new scope.
+    void enterScope(unsigned ScopeFlags) {
+      // FIXME: since Sema::CurScope is private, we cannot access it and have
+      // to use separate member variable m_CurScope. The only options to set
+      // CurScope of Sema seemt to be through Parser or ContextAndScopeRAII.
+      m_CurScope = new clang::Scope(currentScope(), ScopeFlags, m_Sema.Diags);
+    }
+    void exitScope() {
+      // This will remove all the decls in the scope from the IdResolver. 
+      m_Sema.ActOnPopScope(noLoc, m_CurScope);
+      auto oldScope = m_CurScope;
+      m_CurScope = oldScope->getParent();
+      delete oldScope;
+    }
+
     /// A shorthand to simplify syntax for creation of new expressions.
     /// Uses m_Sema.BuildUnOp internally.
     clang::Expr* BuildOp(clang::UnaryOperatorKind OpCode, clang::Expr* E);


### PR DESCRIPTION
Handle scopes properly

Previously, scopes were not handled properly and varibable declarations
were not removed from IdResolver on scope exit. This could lead to errors,
in particular with shadowing declarations, e.g.:
```
double f(double x) {
  { double x = 0; return x; }
}
```
would cause an error: reference to 'x' is ambiguous. IdResolver was not
cleared properly, which also causes errors, for example, on
```
double f(double x) {
  { double y = ...; // inside block scope }
  // y is no longer visible here, but was not removed from IdResolver
  double y = ...; // error: reference to 'y' is ambiguous
}
```

This commit introduces proper handling of scopes and declarations in
IdResolver.