### PR TITLE
Support variable assignments in forward mode

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -269,6 +269,12 @@ namespace clad {
     /// Map used to keep track of variable declarations and match them
     /// with their derivatives.
     std::unordered_map<clang::VarDecl*, clang::Expr*> m_Variables;
+    /// Map contains variable declarations replacements. If the original
+    /// function contains a declaration which name collides with something
+    /// already created inside derivative's body, the declaration is replaced
+    /// with a new one.
+    /// See the example inside ForwardModeVisitor::VisitDeclStmt.
+    std::unordered_map<const clang::VarDecl*, clang::VarDecl*> m_DeclReplacements;
     unsigned m_DerivativeOrder;
     unsigned m_ArgIndex;
 

--- a/test/FirstDerivative/Assignments.C
+++ b/test/FirstDerivative/Assignments.C
@@ -1,0 +1,108 @@
+// RUN: %cladclang %s -lm -I%S/../../include -oAssignments.out 2>&1 | FileCheck %s
+// RUN: ./Assignments.out
+//CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cmath>
+
+double f1(double x, double y) {
+  x = y;
+  return y;
+}
+
+// CHECK: double f1_darg0(double x, double y) {
+// CHECK-NEXT:   double _d_x = 1;
+// CHECK-NEXT:   double _d_y = 0;
+// CHECK-NEXT:   _d_x = _d_y;
+// CHECK-NEXT:   x = y;
+// CHECK-NEXT:   return _d_y;
+// CHECK-NEXT: }
+
+double f2(double x, double y) {
+  if (x < y)
+    x = y;
+  return x;
+}
+
+// CHECK: double f2_darg0(double x, double y) {
+// CHECK-NEXT:   double _d_x = 1;
+// CHECK-NEXT:   double _d_y = 0;
+// CHECK-NEXT:   if (x < y) {
+// CHECK-NEXT:     _d_x = _d_y;
+// CHECK-NEXT:     x = y;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return _d_x;
+// CHECK-NEXT: }
+
+// CHECK: double f2_darg1(double x, double y) {
+// CHECK-NEXT:   double _d_x = 0;
+// CHECK-NEXT:   double _d_y = 1;
+// CHECK-NEXT:   if (x < y) {
+// CHECK-NEXT:     _d_x = _d_y;
+// CHECK-NEXT:     x = y;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return _d_x;
+// CHECK-NEXT: }
+
+double f3(double x, double y) {
+  x = x;
+  x = x * x;
+  y = x * x;
+  x = y;
+  return y;
+}
+
+// CHECK: double f3_darg0(double x, double y) {
+// CHECK-NEXT:   double _d_x = 1;
+// CHECK-NEXT:   double _d_y = 0;
+// CHECK-NEXT:   _d_x = _d_x;
+// CHECK-NEXT:   x = x;
+// CHECK-NEXT:   _d_x = _d_x * x + x * _d_x;
+// CHECK-NEXT:   x = x * x;
+// CHECK-NEXT:   _d_y = _d_x * x + x * _d_x;
+// CHECK-NEXT:   y = x * x;
+// CHECK-NEXT:   _d_x = _d_y;
+// CHECK-NEXT:   x = y;
+// CHECK-NEXT:   return _d_y;
+// CHECK-NEXT: }
+
+// CHECK: double f3_darg1(double x, double y) {
+// CHECK-NEXT:   double _d_x = 0;
+// CHECK-NEXT:   double _d_y = 1;
+// CHECK-NEXT:   _d_x = _d_x;
+// CHECK-NEXT:   x = x;
+// CHECK-NEXT:   _d_x = _d_x * x + x * _d_x;
+// CHECK-NEXT:   x = x * x;
+// CHECK-NEXT:   _d_y = _d_x * x + x * _d_x;
+// CHECK-NEXT:   y = x * x;
+// CHECK-NEXT:   _d_x = _d_y;
+// CHECK-NEXT:   x = y;
+// CHECK-NEXT:   return _d_y;
+// CHECK-NEXT: }
+
+double f4(double x, double y) {
+   y = x;
+   x = 0;
+   return y;
+}
+
+// CHECK: double f4_darg0(double x, double y) {
+// CHECK-NEXT:   double _d_x = 1;
+// CHECK-NEXT:   double _d_y = 0;
+// CHECK-NEXT:   _d_y = _d_x;
+// CHECK-NEXT:   y = x;
+// CHECK-NEXT:   _d_x = 0;
+// CHECK-NEXT:   x = 0;
+// CHECK-NEXT:   return _d_y;
+// CHECK-NEXT: }
+
+int main() {
+  clad::differentiate(f1, 0);
+  clad::differentiate(f2, 0);
+  clad::differentiate(f2, 1);
+  clad::differentiate(f3, 0);
+  clad::differentiate(f3, 1);
+  clad::differentiate(f4, 0);
+}
+
+

--- a/test/FirstDerivative/BasicArithmeticAddSub.C
+++ b/test/FirstDerivative/BasicArithmeticAddSub.C
@@ -12,6 +12,7 @@ int a_1(int x) {
   return y + y; // == 0
 }
 // CHECK: int a_1_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
 // CHECK-NEXT: return _d_y + _d_y;
@@ -21,6 +22,7 @@ int a_2(int x) {
   return 1 + 1; // == 0
 }
 // CHECK: int a_2_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: return 0 + 0;
 // CHECK-NEXT: }
 
@@ -28,7 +30,8 @@ int a_3(int x) {
   return x + x; // == 2
 }
 // CHECK: int a_3_darg0(int x) {
-// CHECK-NEXT: return 1 + 1;
+// CHECK-NEXT: int _d_x = 1;
+// CHECK-NEXT: return _d_x + _d_x;
 // CHECK-NEXT: }
 
 int a_4(int x) {
@@ -36,9 +39,10 @@ int a_4(int x) {
   return x + y + x + 3 + x; // == 3x
 }
 // CHECK: int a_4_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
-// CHECK-NEXT: return 1 + _d_y + 1 + 0 + 1;
+// CHECK-NEXT: return _d_x + _d_y + _d_x + 0 + _d_x;
 // CHECK-NEXT: }
 
 int s_1(int x) {
@@ -46,6 +50,7 @@ int s_1(int x) {
   return y - y; // == 0
 }
 // CHECK: int s_1_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
 // CHECK-NEXT: return _d_y - _d_y;
@@ -55,6 +60,7 @@ int s_2(int x) {
   return 1 - 1; // == 0
 }
 // CHECK: int s_2_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: return 0 - 0;
 // CHECK-NEXT: }
 
@@ -62,7 +68,8 @@ int s_3(int x) {
   return x - x; // == 0
 }
 // CHECK: int s_3_darg0(int x) {
-// CHECK-NEXT: return 1 - 1;
+// CHECK-NEXT: int _d_x = 1;
+// CHECK-NEXT: return _d_x - _d_x;
 // CHECK-NEXT: }
 
 int s_4(int x) {
@@ -70,9 +77,10 @@ int s_4(int x) {
   return x - y - x - 3 - x; // == -1
 }
 // CHECK: int s_4_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
-// CHECK-NEXT: return 1 - _d_y - 1 - 0 - 1;
+// CHECK-NEXT: return _d_x - _d_y - _d_x - 0 - _d_x;
 // CHECK-NEXT: }
 
 int as_1(int x) {
@@ -80,16 +88,19 @@ int as_1(int x) {
   return x + x - x + y - y + 3 - 3; // == 1
 }
 // CHECK: int as_1_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
-// CHECK-NEXT: return 1 + 1 - 1 + _d_y - _d_y + 0 - 0;
+// CHECK-NEXT: return _d_x + _d_x - _d_x + _d_y - _d_y + 0 - 0;
 // CHECK-NEXT: }
 
 float IntegerLiteralToFloatLiteral(float x, float y) {
   return x * x - y;
 }
 // CHECK: float IntegerLiteralToFloatLiteral_darg0(float x, float y) {
-// CHECK-NEXT: return 1.F * x + x * 1.F - 0.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: return _d_x * x + x * _d_x - _d_y;
 // CHECK-NEXT: }
 
 int a_1_darg0(int x);

--- a/test/FirstDerivative/BasicArithmeticAll.C
+++ b/test/FirstDerivative/BasicArithmeticAll.C
@@ -13,6 +13,7 @@ float basic_1(int x) {
   return (y + x) / (x - z) * ((x * y * z) / 5); // == y * z * (x * x - 2 * x * z - y * z) / (5 * (x - z) * (x - z))
 }
 // CHECK: float basic_1_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
 // CHECK-NEXT: int _d_z = 0;
@@ -23,7 +24,7 @@ float basic_1(int x) {
 // CHECK-NEXT: int _t3 = (_t2 * z);
 // CHECK-NEXT: int _t4 = _t0 / _t1;
 // CHECK-NEXT: int _t5 = (_t3 / 5);
-// CHECK-NEXT: return (((_d_y + 1) * _t1 - _t0 * (1 - _d_z)) / (_t1 * _t1)) * _t5 + _t4 * ((((1 * y + x * _d_y) * z + _t2 * _d_z) * 5 - _t3 * 0) / (5 * 5));
+// CHECK-NEXT: return (((_d_y + _d_x) * _t1 - _t0 * (_d_x - _d_z)) / (_t1 * _t1)) * _t5 + _t4 * ((((_d_x * y + x * _d_y) * z + _t2 * _d_z) * 5 - _t3 * 0) / (5 * 5));
 // CHECK-NEXT: }
 
 float basic_1_darg0(int x);

--- a/test/FirstDerivative/BasicArithmeticMulDiv.C
+++ b/test/FirstDerivative/BasicArithmeticMulDiv.C
@@ -12,6 +12,7 @@ int m_1(int x) {
   return y * y; // == 0
 }
 // CHECK: int m_1_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
 // CHECK-NEXT: return _d_y * y + y * _d_y;
@@ -21,6 +22,7 @@ int m_2(int x) {
   return 1 * 1; // == 0
 }
 // CHECK: int m_2_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: return 0 * 1 + 1 * 0;
 // CHECK-NEXT: }
 
@@ -28,7 +30,8 @@ int m_3(int x) {
   return x * x; // == 2 * x
 }
 // CHECK: int m_3_darg0(int x) {
-// CHECK-NEXT: return 1 * x + x * 1;
+// CHECK-NEXT: int _d_x = 1;
+// CHECK-NEXT: return _d_x * x + x * _d_x;
 // CHECK-NEXT: }
 
 int m_4(int x) {
@@ -36,26 +39,29 @@ int m_4(int x) {
   return x * y * x * 3 * x; // == 9 * x * x * y
 }
 // CHECK: int m_4_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
 // CHECK-NEXT: int _t0 = x * y;
 // CHECK-NEXT: int _t1 = _t0 * x;
 // CHECK-NEXT: int _t2 = _t1 * 3;
-// CHECK-NEXT: return (((1 * y + x * _d_y) * x + _t0 * 1) * 3 + _t1 * 0) * x + _t2 * 1;
+// CHECK-NEXT: return (((_d_x * y + x * _d_y) * x + _t0 * _d_x) * 3 + _t1 * 0) * x + _t2 * _d_x;
 // CHECK-NEXT: }
 
 double m_5(int x) {
   return 3.14 * x;
 }
 // CHECK: double m_5_darg0(int x) {
-// CHECK-NEXT: return 0. * x + 3.1400000000000001 * 1;
+// CHECK-NEXT: int _d_x = 1;
+// CHECK-NEXT: return 0. * x + 3.1400000000000001 * _d_x;
 // CHECK-NEXT: }
 
 float m_6(int x) {
   return 3.f * x;
 }
 // CHECK: float m_6_darg0(int x) {
-// CHECK-NEXT: return 0.F * x + 3.F * 1;
+// CHECK-NEXT: int _d_x = 1;
+// CHECK-NEXT: return 0.F * x + 3.F * _d_x;
 // CHECK-NEXT: }
 
 int d_1(int x) {
@@ -63,6 +69,7 @@ int d_1(int x) {
   return y / y; // == 0
 }
 // CHECK: int d_1_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
 // CHECK-NEXT: return (_d_y * y - y * _d_y) / (y * y);
@@ -72,6 +79,7 @@ int d_2(int x) {
   return 1 / 1; // == 0
 }
 // CHECK: int d_2_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: return (0 * 1 - 1 * 0) / (1 * 1);
 // CHECK-NEXT: }
 
@@ -79,7 +87,8 @@ int d_3(int x) {
   return x / x; // == 0
 }
 // CHECK: int d_3_darg0(int x) {
-// CHECK-NEXT: return (1 * x - x * 1) / (x * x);
+// CHECK-NEXT: int _d_x = 1;
+// CHECK-NEXT: return (_d_x * x - x * _d_x) / (x * x);
 // CHECK-NEXT: }
 
 int d_4(int x) {
@@ -87,12 +96,13 @@ int d_4(int x) {
   return x / y / x / 3 / x; // == -1 / 3 / x / x / y
 }
 // CHECK: int d_4_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
 // CHECK-NEXT: int _t0 = x / y;
 // CHECK-NEXT: int _t1 = _t0 / x;
 // CHECK-NEXT: int _t2 = _t1 / 3;
-// CHECK-NEXT: return (((((((1 * y - x * _d_y) / (y * y)) * x - _t0 * 1) / (x * x)) * 3 - _t1 * 0) / (3 * 3)) * x - _t2 * 1) / (x * x);
+// CHECK-NEXT: return (((((((_d_x * y - x * _d_y) / (y * y)) * x - _t0 * _d_x) / (x * x)) * 3 - _t1 * 0) / (3 * 3)) * x - _t2 * _d_x) / (x * x);
 // CHECK-NEXT: }
 
 double issue25(double x, double y) {
@@ -118,6 +128,7 @@ int md_1(int x) {
   return x * x / x * y / y * 3 / 3; // == 1
 }
 // CHECK: int md_1_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
 // CHECK-NEXT: int _t0 = x * x;
@@ -125,7 +136,7 @@ int md_1(int x) {
 // CHECK-NEXT: int _t2 = _t1 * y;
 // CHECK-NEXT: int _t3 = _t2 / y;
 // CHECK-NEXT: int _t4 = _t3 * 3;
-// CHECK-NEXT: return ((((((((1 * x + x * 1) * x - _t0 * 1) / (x * x)) * y + _t1 * _d_y) * y - _t2 * _d_y) / (y * y)) * 3 + _t3 * 0) * 3 - _t4 * 0) / (3 * 3);
+// CHECK-NEXT: return ((((((((_d_x * x + x * _d_x) * x - _t0 * _d_x) / (x * x)) * y + _t1 * _d_y) * y - _t2 * _d_y) / (y * y)) * 3 + _t3 * 0) * 3 - _t4 * 0) / (3 * 3);
 // CHECK-NEXT: }
 
 

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -12,7 +12,8 @@ float f1(float x) {
 }
 
 // CHECK: float f1_darg0(float x) {
-// CHECK-NEXT: return custom_derivatives::sin_darg0(x) * 1.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: return custom_derivatives::sin_darg0(x) * _d_x;
 // CHECK-NEXT: }
 
 float f2(float x) {
@@ -20,7 +21,8 @@ float f2(float x) {
 }
 
 // CHECK: float f2_darg0(float x) {
-// CHECK-NEXT: custom_derivatives::cos_darg0(x) * 1.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: custom_derivatives::cos_darg0(x) * _d_x;
 // CHECK-NEXT: }
 
 float f3(float x, float y) {
@@ -28,11 +30,15 @@ float f3(float x, float y) {
 }
 
 // CHECK: float f3_darg0(float x, float y) {
-// CHECK-NEXT: return custom_derivatives::sin_darg0(x) * 1.F + custom_derivatives::sin_darg0(y) * 0.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: return custom_derivatives::sin_darg0(x) * _d_x + custom_derivatives::sin_darg0(y) * _d_y;
 // CHECK-NEXT: }
 
 // CHECK: float f3_darg1(float x, float y) {
-// CHECK-NEXT: return custom_derivatives::sin_darg0(x) * 0.F + custom_derivatives::sin_darg0(y) * 1.F;
+// CHECK-NEXT: float _d_x = 0;
+// CHECK-NEXT: float _d_y = 1;
+// CHECK-NEXT: return custom_derivatives::sin_darg0(x) * _d_x + custom_derivatives::sin_darg0(y) * _d_y;
 // CHECK-NEXT: }
 
 float f4(float x, float y) {
@@ -40,11 +46,15 @@ float f4(float x, float y) {
 }
 
 // CHECK: float f4_darg0(float x, float y) {
-// CHECK-NEXT: return custom_derivatives::sin_darg0(x * x) * (1.F * x + x * 1.F) + custom_derivatives::sin_darg0(y * y) * (0.F * y + y * 0.F);
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: return custom_derivatives::sin_darg0(x * x) * (_d_x * x + x * _d_x) + custom_derivatives::sin_darg0(y * y) * (_d_y * y + y * _d_y);
 // CHECK-NEXT: }
 
 // CHECK: float f4_darg1(float x, float y) {
-// CHECK-NEXT: return custom_derivatives::sin_darg0(x * x) * (0.F * x + x * 0.F) + custom_derivatives::sin_darg0(y * y) * (1.F * y + y * 1.F);
+// CHECK-NEXT: float _d_x = 0;
+// CHECK-NEXT: float _d_y = 1;
+// CHECK-NEXT: return custom_derivatives::sin_darg0(x * x) * (_d_x * x + x * _d_x) + custom_derivatives::sin_darg0(y * y) * (_d_y * y + y * _d_y);
 // CHECK-NEXT: }
 
 float f5(float x) {
@@ -52,7 +62,8 @@ float f5(float x) {
 }
 
 // CHECK: float f5_darg0(float x) {
-// CHECK-NEXT: return custom_derivatives::exp_darg0(x) * 1.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: return custom_derivatives::exp_darg0(x) * _d_x;
 // CHECK-NEXT: }
 
 float f6(float x) {
@@ -60,7 +71,8 @@ float f6(float x) {
 }
 
 // CHECK: float f6_darg0(float x) {
-// CHECK-NEXT: return custom_derivatives::exp_darg0(x * x) * (1.F * x + x * 1.F);
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: return custom_derivatives::exp_darg0(x * x) * (_d_x * x + x * _d_x);
 // CHECK-NEXT: }
 
 

--- a/test/FirstDerivative/CallArguments.C
+++ b/test/FirstDerivative/CallArguments.C
@@ -18,8 +18,9 @@ float g(float x) {
 }
 
 // CHECK: float g_darg0(float x) {
+// CHECK-NEXT: float _d_x = 1;
 // CHECK: float _t0 = x * x;
-// CHECK-NEXT: custom_derivatives::f_darg0(_t0 * x) * ((1.F * x + x * 1.F) * x + _t0 * 1.F);
+// CHECK-NEXT: custom_derivatives::f_darg0(_t0 * x) * ((_d_x * x + x * _d_x) * x + _t0 * _d_x);
 // CHECK-NEXT: }
 
 float sqrt_func(float x, float y) {
@@ -27,7 +28,9 @@ float sqrt_func(float x, float y) {
 }
 
 // CHECK: float sqrt_func_darg0(float x, float y) {
-// CHECK-NEXT: return custom_derivatives::sqrt_darg0(x * x + y * y) * (1.F * x + x * 1.F + 0.F * y + y * 0.F) - 0.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: return custom_derivatives::sqrt_darg0(x * x + y * y) * (_d_x * x + x * _d_x + _d_y * y + y * _d_y) - _d_y;
 // CHECK-NEXT: }
 
 float f_const_args_func_1(const float x, const float y) {
@@ -35,7 +38,9 @@ float f_const_args_func_1(const float x, const float y) {
 }
 
 // CHECK: float f_const_args_func_1_darg0(const float x, const float y) {
-// CHECK-NEXT: return 1.F * x + x * 1.F + 0.F * y + y * 0.F - 0.F;
+// CHECK-NEXT: const float _d_x = 1;
+// CHECK-NEXT: const float _d_y = 0;
+// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
 // CHECK-NEXT: }
 
 float f_const_args_func_2(float x, const float y) {
@@ -43,7 +48,9 @@ float f_const_args_func_2(float x, const float y) {
 }
 
 // CHECK: float f_const_args_func_2_darg0(float x, const float y) {
-// CHECK-NEXT: return 1.F * x + x * 1.F + 0.F * y + y * 0.F - 0.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: const float _d_y = 0;
+// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
 // CHECK-NEXT: }
 
 float f_const_args_func_3(const float x, float y) {
@@ -51,7 +58,9 @@ float f_const_args_func_3(const float x, float y) {
 }
 
 // CHECK: float f_const_args_func_3_darg0(const float x, float y) {
-// CHECK-NEXT: return 1.F * x + x * 1.F + 0.F * y + y * 0.F - 0.F;
+// CHECK-NEXT: const float _d_x = 1;
+// CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
 // CHECK-NEXT: }
 
 struct Vec { float x,y,z; };
@@ -60,7 +69,9 @@ float f_const_args_func_4(float x, float y, const Vec v) {
 }
 
 // CHECK: float f_const_args_func_4_darg0(float x, float y, const Vec v) {
-// CHECK-NEXT: return 1.F * x + x * 1.F + 0.F * y + y * 0.F - 0.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
 // CHECK-NEXT: }
 
 float f_const_args_func_5(float x, float y, const Vec &v) {
@@ -68,7 +79,9 @@ float f_const_args_func_5(float x, float y, const Vec &v) {
 }
 
 // CHECK: float f_const_args_func_5_darg0(float x, float y, const Vec &v) {
-// CHECK-NEXT: return 1.F * x + x * 1.F + 0.F * y + y * 0.F - 0.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
 // CHECK-NEXT: }
 
 float f_const_args_func_6(const float x, const float y, const Vec &v) {
@@ -76,7 +89,9 @@ float f_const_args_func_6(const float x, const float y, const Vec &v) {
 }
 
 // CHECK: float f_const_args_func_6_darg0(const float x, const float y, const Vec &v) {
-// CHECK-NEXT: return 1.F * x + x * 1.F + 0.F * y + y * 0.F - 0.F;
+// CHECK-NEXT: const float _d_x = 1;
+// CHECK-NEXT: const float _d_y = 0;
+// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
 // CHECK-NEXT: }
 
 float f_const_helper(const float x) {
@@ -88,7 +103,9 @@ float f_const_args_func_7(const float x, const float y) {
 }
 
 // CHECKTODO: float f_const_args_func_7_darg0(const float x, const float y) {
-// CHECKTODO-NEXT: f_const_helper_darg0(x) + (f_const_helper_darg0(y)) - (0.F)
+// CHECKTODO-NEXT: const float _d_x = 1;
+// CHECKTODO-NEXT: const float _d_y = 0;
+// CHECKTODO-NEXT: f_const_helper_darg0(x) + (f_const_helper_darg0(y)) - (_d_y)
 // CHECKTODO-NEXT: }
 
 float f_const_args_func_8(const float x, float y) {
@@ -96,7 +113,9 @@ float f_const_args_func_8(const float x, float y) {
 }
 
 // CHECKTODO: float f_const_args_func_8_darg0(const float x, float y) {
-// CHECKTODO-NEXT: f_const_helper_darg0(x) + (f_const_helper_darg0(y)) - (0.F)
+// CHECKTODO-NEXT: const float _d_x = 1;
+// CHECKTODO-NEXT: float _d_y = 0;
+// CHECKTODO-NEXT: f_const_helper_darg0(x) + (f_const_helper_darg0(y)) - (_d_y)
 // CHECKTODO-NEXT: }
 
 extern "C" int printf(const char* fmt, ...);

--- a/test/FirstDerivative/CodeGenSimple.C
+++ b/test/FirstDerivative/CodeGenSimple.C
@@ -10,9 +10,10 @@ int f_1(int x) {
    return x * x;
 }
 // CHECK: int f_1_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: 0;
 // CHECK-NEXT: printf("I am being run!\n");
-// CHECK-NEXT: return 1 * x + x * 1;
+// CHECK-NEXT: return _d_x * x + x * _d_x;
 // CHECK-NEXT: }
 
 

--- a/test/FirstDerivative/DiffInterface.C
+++ b/test/FirstDerivative/DiffInterface.C
@@ -12,10 +12,11 @@ int f_1(float y) {
 }
 
 // CHECK: int f_1_darg0(float y) {
+// CHECK-NEXT: float _d_y = 1;
 // CHECK-NEXT: int _d_x = 0, _d_z = 0;
 // CHECK-NEXT: int x = 1, z = 3;
 // CHECK-NEXT: float _t0 = x * y;
-// CHECK-NEXT: return (_d_x * y + x * 1.F) * z + _t0 * _d_z;
+// CHECK-NEXT: return (_d_x * y + x * _d_y) * z + _t0 * _d_z;
 // CHECK-NEXT: }
 
 int f_2(int x, float y, int z) {
@@ -23,20 +24,29 @@ int f_2(int x, float y, int z) {
 }
 
 // CHECK: int f_2_darg0(int x, float y, int z) {
+// CHECK-NEXT: int _d_x = 1;
+// CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: int _d_z = 0;
 // CHECK-NEXT: float _t0 = x * y;
-// CHECK-NEXT: return (1 * y + x * 0.F) * z + _t0 * 0;
+// CHECK-NEXT: return (_d_x * y + x * _d_y) * z + _t0 * _d_z;
 // CHECK-NEXT: }
 
 // x * z
 // CHECK: int f_2_darg1(int x, float y, int z) {
+// CHECK-NEXT: int _d_x = 0;
+// CHECK-NEXT: float _d_y = 1;
+// CHECK-NEXT: int _d_z = 0;
 // CHECK-NEXT: float _t0 = x * y;
-// CHECK-NEXT: return (0 * y + x * 1.F) * z + _t0 * 0;
+// CHECK-NEXT: return (_d_x * y + x * _d_y) * z + _t0 * _d_z;
 // CHECK-NEXT: }
 
 // x * y
 // CHECK: int f_2_darg2(int x, float y, int z) {
+// CHECK-NEXT: int _d_x = 0;
+// CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: int _d_z = 1;
 // CHECK-NEXT: float _t0 = x * y;
-// CHECK-NEXT: return (0 * y + x * 0.F) * z + _t0 * 1;
+// CHECK-NEXT: return (_d_x * y + x * _d_y) * z + _t0 * _d_z;
 // CHECK-NEXT: }
 
 int f_3() {
@@ -54,7 +64,8 @@ int f_redeclared(int x) {
 int f_redeclared(int x);
 
 // CHECK: int f_redeclared_darg0(int x) {
-// CHECK-NEXT:  return 1;
+// CHECK-NEXT:   int _d_x = 1;
+// CHECK-NEXT:   return _d_x;
 // CHECK: }
 
 int f_try_catch(int x)
@@ -66,6 +77,7 @@ int f_try_catch(int x)
   } // expected-warning {{attempted to differentiate unsupported statement, no changes applied}}
 
 // CHECK: int f_try_catch_darg0(int x) {
+// CHECK-NEXT:    int _d_x = 1;
 // CHECK-NEXT:    try {
 // CHECK-NEXT:        return x;
 // CHECK-NEXT:    } catch (int) {

--- a/test/FirstDerivative/FunctionCalls.C
+++ b/test/FirstDerivative/FunctionCalls.C
@@ -54,7 +54,8 @@ float test_1(float x) {
 }
 
 // CHECK: float test_1_darg0(float x) {
-// CHECK-NEXT: return custom_derivatives::overloaded_darg0(x) * 1.F + custom_derivatives::custom_fn_darg0(x) * 1.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: return custom_derivatives::overloaded_darg0(x) * _d_x + custom_derivatives::custom_fn_darg0(x) * _d_x;
 // CHECK-NEXT: }
 
 float test_2(float x) {
@@ -62,7 +63,8 @@ float test_2(float x) {
 }
 
 // CHECK: float test_2_darg0(float x) {
-// CHECK-NEXT: return custom_derivatives::overloaded_darg0(x) * 1.F + custom_derivatives::custom_fn_darg0(x) * 1.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: return custom_derivatives::overloaded_darg0(x) * _d_x + custom_derivatives::custom_fn_darg0(x) * _d_x;
 // CHECK-NEXT: }
 
 float test_3() {
@@ -76,6 +78,7 @@ float test_4(int x) {
 }
 
 // CHECK: float test_4_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: return 0;
 // CHECK-NEXT: }
 
@@ -84,7 +87,8 @@ float test_5(int x) {
 }
 
 // CHECK: float test_5_darg0(int x) {
-// CHECK-NEXT: return custom_derivatives::no_body_darg0(x) * 1;
+// CHECK-NEXT: int _d_x = 1;
+// CHECK-NEXT: return custom_derivatives::no_body_darg0(x) * _d_x;
 // CHECK-NEXT: }
 
 int main () {

--- a/test/FirstDerivative/FunctionCallsWithResults.C
+++ b/test/FirstDerivative/FunctionCallsWithResults.C
@@ -51,7 +51,8 @@ float test_1(float x) {
 }
 
 // CHECK: float test_1_darg0(float x) {
-// CHECK-NEXT: return custom_derivatives::overloaded_darg0(x) * 1.F + custom_derivatives::custom_fn_darg0(x) * 1.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: return custom_derivatives::overloaded_darg0(x) * _d_x + custom_derivatives::custom_fn_darg0(x) * _d_x;
 // CHECK-NEXT: }
 
 float test_2(float x) {
@@ -59,7 +60,8 @@ float test_2(float x) {
 }
 
 // CHECK: float test_2_darg0(float x) {
-// CHECK-NEXT: return custom_derivatives::overloaded_darg0(x) * 1.F + custom_derivatives::custom_fn_darg0(x) * 1.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: return custom_derivatives::overloaded_darg0(x) * _d_x + custom_derivatives::custom_fn_darg0(x) * _d_x;
 // CHECK-NEXT: }
 
 float test_4(float x) {
@@ -67,6 +69,7 @@ float test_4(float x) {
 }
 
 // CHECK: float test_4_darg0(float x) {
+// CHECK-NEXT: float _d_x = 1;
 // CHECK-NEXT: return custom_derivatives::overloaded_darg0();
 // CHECK-NEXT: }
 

--- a/test/FirstDerivative/FunctionsOneVariable.C
+++ b/test/FirstDerivative/FunctionsOneVariable.C
@@ -12,24 +12,36 @@ float f_simple(float x) {
 }
 
 //CHECK:float f_simple_darg0(float x) {
-//CHECK-NEXT:    return 1.F * x + x * 1.F;
+//CHECK-NEXT:    float _d_x = 1;
+//CHECK-NEXT:    return _d_x * x + x * _d_x;
 //CHECK-NEXT:}
 
-//CHECK:float f_simple_d2arg0(float x) {
-//CHECK-NEXT:    return 0.F * x + 1.F * 1.F + 1.F * 1.F + x * 0.F;
-//CHECK-NEXT:}
+//CHECK: float f_simple_d2arg0(float x) {
+//CHECK-NEXT:    float _d_x = 1;
+//CHECK-NEXT:    float _d__d_x = 0;
+//CHECK-NEXT:    float _d_x0 = 1;
+//CHECK-NEXT:    return _d__d_x * x + _d_x0 * _d_x + _d_x * _d_x0 + x * _d__d_x;
+//CHECK-NEXT: }
 
-//CHECK:float f_simple_d3arg0(float x) {
-//CHECK-NEXT:    return 0.F * x + 0.F * 1.F + 0.F * 1.F + 1.F * 0.F + 0.F * 1.F + 1.F * 0.F + 1.F * 0.F + x * 0.F;
-//CHECK-NEXT:}
+//CHECK: float f_simple_d3arg0(float x) {
+//CHECK-NEXT:    float _d_x = 1;
+//CHECK-NEXT:    float _d__d_x = 0;
+//CHECK-NEXT:    float _d_x0 = 1;
+//CHECK-NEXT:    float _d__d__d_x = 0;
+//CHECK-NEXT:    float _d__d_x1 = 0;
+//CHECK-NEXT:    float _d__d_x0 = 0;
+//CHECK-NEXT:    float _d_x02 = 1;
+//CHECK-NEXT:    return _d__d__d_x * x + _d__d_x1 * _d_x + _d__d_x0 * _d_x0 + _d_x02 * _d__d_x + _d__d_x * _d_x02 + _d_x0 * _d__d_x0 + _d_x * _d__d_x1 + x * _d__d__d_x;
+//CHECK-NEXT: }
 
 int f_simple_negative(int x) {
   //  printf("This is f(x).\n");
   return -x*x;
 }
 // CHECK: int f_simple_negative_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _t0 = -x;
-// CHECK-NEXT: return -1 * x + _t0 * 1;
+// CHECK-NEXT: return -_d_x * x + _t0 * _d_x;
 // CHECK-NEXT: }
 
 int main () {

--- a/test/FirstDerivative/NonContinuous.C
+++ b/test/FirstDerivative/NonContinuous.C
@@ -16,11 +16,12 @@ int f(int x) {
   return x*x;
 }
 // CHECK: int f_darg0(int x) {
+// CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: if (x < 0) {
 // CHECK-NEXT:   int _t0 = -x;
-// CHECK-NEXT:   return -1 * x + _t0 * 1;
+// CHECK-NEXT:   return -_d_x * x + _t0 * _d_x;
 // CHECK-NEXT: }
-// CHECK-NEXT: return 1 * x + x * 1;
+// CHECK-NEXT: return _d_x * x + x * _d_x;
 // CHECK-NEXT: }
 
 // Semantically equivallent to f(x), but implemented differently.
@@ -31,11 +32,12 @@ int f1(int x) {
     return x*x;
 }
 // CHECK: int f1_darg0(int x) {
+// CHECK-NEXT:  int _d_x = 1;
 // CHECK-NEXT:  if (x < 0) {
 // CHECK-NEXT:    int _t0 = -x;
-// CHECK-NEXT:    return -1 * x + _t0 * 1;
+// CHECK-NEXT:    return -_d_x * x + _t0 * _d_x;
 // CHECK-NEXT:  } else
-// CHECK-NEXT:    return 1 * x + x * 1;
+// CHECK-NEXT:    return _d_x * x + x * _d_x;
 // CHECK-NEXT: }
 
 // g(y) = | 1, y >= 0
@@ -50,6 +52,7 @@ int g(long y) {
     return 2;
 }
 // CHECK: int g_darg0(long y) {
+// CHECK-NEXT: long _d_y = 1;
 // CHECK-NEXT: if (y)
 // CHECK-NEXT:   return 0;
 // CHECK-NEXT: else

--- a/test/FirstDerivative/Recursive.C
+++ b/test/FirstDerivative/Recursive.C
@@ -15,12 +15,14 @@ int f_pow(int arg, int p) {
 }
 
 // CHECK: int f_pow_darg0(int arg, int p) {
-// CHECK-NEXT:  if (p == 0)
-// CHECK-NEXT:    return 0;
-// CHECK-NEXT:  else {
-// CHECK-NEXT:    int _t0 = f_pow(arg, p - 1);
-// CHECK-NEXT:    return 1 * _t0 + arg * (f_pow_darg0(arg, p - 1) * (1 + 0 - 0));
-// CHECK-NEXT:  }
+// CHECK-NEXT:   int _d_arg = 1;
+// CHECK-NEXT:   int _d_p = 0;
+// CHECK-NEXT:   if (p == 0)
+// CHECK-NEXT:     return 0;
+// CHECK-NEXT:   else {
+// CHECK-NEXT:     int _t0 = f_pow(arg, p - 1);
+// CHECK-NEXT:     return _d_arg * _t0 + arg * (f_pow_darg0(arg, p - 1) * (_d_arg + _d_p - 0));
+// CHECK-NEXT:   }
 // CHECK-NEXT: }
 
 int f_pow_darg0(int arg, int p);

--- a/test/FirstDerivative/StructMethodCall.C
+++ b/test/FirstDerivative/StructMethodCall.C
@@ -12,7 +12,8 @@ public:
   }
 
   // CHECK: int f_darg0(int x) {
-  // CHECK-NEXT: return 1;
+  // CHECK-NEXT: int _d_x = 1;
+  // CHECK-NEXT: return _d_x;
   // CHECK-NEXT: }
 
   int g_1(int x, int y) {
@@ -20,11 +21,15 @@ public:
   }
 
   // CHECK: int g_1_darg0(int x, int y) {
-  // CHECK-NEXT: return 1 * x + x * 1 + 0;
+  // CHECK-NEXT: int _d_x = 1;
+  // CHECK-NEXT: int _d_y = 0;
+  // CHECK-NEXT: return _d_x * x + x * _d_x + _d_y;
   // CHECK-NEXT: }
 
   // CHECK: int g_1_darg1(int x, int y) {
-  // CHECK-NEXT: return 0 * x + x * 0 + 1;
+  // CHECK-NEXT: int _d_x = 0;
+  // CHECK-NEXT: int _d_y = 1;
+  // CHECK-NEXT: return _d_x * x + x * _d_x + _d_y;
   // CHECK-NEXT: }
 
   int g_2(int x, int y) {
@@ -32,11 +37,15 @@ public:
   }
 
   // CHECK: int g_2_darg0(int x, int y) {
-  // CHECK-NEXT: return 1 + 0 * y + y * 0;
+  // CHECK-NEXT: int _d_x = 1;
+  // CHECK-NEXT: int _d_y = 0;
+  // CHECK-NEXT: return _d_x + _d_y * y + y * _d_y;
   // CHECK-NEXT: }
 
   // CHECK: int g_2_darg1(int x, int y) {
-  // CHECK-NEXT: return 0 + 1 * y + y * 1;
+  // CHECK-NEXT: int _d_x = 0;
+  // CHECK-NEXT: int _d_y = 1;
+  // CHECK-NEXT: return _d_x + _d_y * y + y * _d_y;
   // CHECK-NEXT: }
 
 

--- a/test/FirstDerivative/TemplateFunction.C
+++ b/test/FirstDerivative/TemplateFunction.C
@@ -23,47 +23,56 @@ int main () {
 
   clad::differentiate(simple_return<int>, 0);
   // CHECK: int simple_return_darg0(int x) {
-  // CHECK-NEXT: return 1;
+  // CHECK-NEXT: int _d_x = 1;
+  // CHECK-NEXT: return _d_x;
   // CHECK-NEXT: }
 
   clad::differentiate(simple_return<float>, 0);
   // CHECK: float simple_return_darg0(float x) {
-  // CHECK-NEXT: return 1.F;
+  // CHECK-NEXT: float _d_x = 1;
+  // CHECK-NEXT: return _d_x;
   // CHECK-NEXT: }
 
   clad::differentiate(simple_return<double>, 0);
   // CHECK: double simple_return_darg0(double x) {
-  // CHECK-NEXT: return 1.;
+  // CHECK-NEXT: double _d_x = 1;
+  // CHECK-NEXT: return _d_x;
   // CHECK-NEXT: }
 
   clad::differentiate(addition<int>, 0);
   // CHECK: int addition_darg0(int x) {
-  // CHECK-NEXT: return 1 + 1;
+  // CHECK-NEXT: int _d_x = 1;
+  // CHECK-NEXT: return _d_x + _d_x;
   // CHECK-NEXT: }
 
   clad::differentiate(addition<float>, 0);
   // CHECK: float addition_darg0(float x) {
-  // CHECK-NEXT: return 1.F + 1.F;
+  // CHECK-NEXT: float _d_x = 1;
+  // CHECK-NEXT: return _d_x + _d_x;
   // CHECK-NEXT: }
 
   clad::differentiate(addition<double>, 0);
   // CHECK: double addition_darg0(double x) {
-  // CHECK-NEXT: return 1. + 1.;
+  // CHECK-NEXT: double _d_x = 1;
+  // CHECK-NEXT: return _d_x + _d_x;
   // CHECK-NEXT: }
 
   clad::differentiate(multiplication<int>, 0);
   // CHECK: int multiplication_darg0(int x) {
-  // CHECK-NEXT: return 1 * x + x * 1;
+  // CHECK-NEXT: int _d_x = 1;
+  // CHECK-NEXT: return _d_x * x + x * _d_x;
   // CHECK-NEXT: }
 
   clad::differentiate(multiplication<float>, 0);
   // CHECK: float multiplication_darg0(float x) {
-  // CHECK-NEXT: return 1.F * x + x * 1.F;
+  // CHECK-NEXT: float _d_x = 1;
+  // CHECK-NEXT: return _d_x * x + x * _d_x;
   // CHECK-NEXT: }
 
   clad::differentiate(multiplication<double>, 0);
   // CHECK: double multiplication_darg0(double x) {
-  // CHECK-NEXT: return 1. * x + x * 1.;
+  // CHECK: double _d_x = 1;
+  // CHECK-NEXT: return _d_x * x + x * _d_x;
   // CHECK-NEXT: }
 
   return 0;

--- a/test/FirstDerivative/Variables.C
+++ b/test/FirstDerivative/Variables.C
@@ -12,7 +12,8 @@ double f_x(double x) {
 }
 
 // CHECK: double f_x_darg0(double x) {
-// CHECK-NEXT:    double _d_t0 = 1.;
+// CHECK-NEXT:    double _d_x = 1;
+// CHECK-NEXT:    double _d_t0 = _d_x;
 // CHECK-NEXT:    double t0 = x;
 // CHECK-NEXT:    double _d_t1 = _d_t0;
 // CHECK-NEXT:    double t1 = t0;
@@ -28,9 +29,10 @@ double f_ops1(double x) {
 }
 
 // CHECK: double f_ops1_darg0(double x) {
-// CHECK-NEXT:    double _d_t0 = 1.;
+// CHECK-NEXT:    double _d_x = 1;
+// CHECK-NEXT:    double _d_t0 = _d_x;
 // CHECK-NEXT:    double t0 = x;
-// CHECK-NEXT:    double _d_t1 = 0 * x + 2 * 1.;
+// CHECK-NEXT:    double _d_t1 = 0 * x + 2 * _d_x;
 // CHECK-NEXT:    double t1 = 2 * x;
 // CHECK-NEXT:    double _d_t2 = 0;
 // CHECK-NEXT:    double t2 = 0;
@@ -48,13 +50,14 @@ double f_ops2(double x) {
 }
 
 // CHECK: double f_ops2_darg0(double x) {
-// CHECK-NEXT:    double _d_t0 = 1.;
+// CHECK-NEXT:    double _d_x = 1;
+// CHECK-NEXT:    double _d_t0 = _d_x;
 // CHECK-NEXT:    double t0 = x;
-// CHECK-NEXT:    double _d_t1 = 0 * x + 2 * 1.;
+// CHECK-NEXT:    double _d_t1 = 0 * x + 2 * _d_x;
 // CHECK-NEXT:    double t1 = 2 * x;
 // CHECK-NEXT:    double _d_t2 = 0;
 // CHECK-NEXT:    double t2 = 5;
-// CHECK-NEXT:    double _d_t3 = _d_t1 * x + t1 * 1. + _d_t2;
+// CHECK-NEXT:    double _d_t3 = _d_t1 * x + t1 * _d_x + _d_t2;
 // CHECK-NEXT:    double t3 = t1 * x + t2;
 // CHECK-NEXT:    return _d_t3;
 // CHECK-NEXT: }
@@ -68,9 +71,11 @@ double f_sin(double x, double y) {
 }
 
 // CHECK: double f_sin_darg0(double x, double y) {
-// CHECK-NEXT:     double _d_xsin = custom_derivatives::sin_darg0(x) * 1.;
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     double _d_y = 0;
+// CHECK-NEXT:     double _d_xsin = custom_derivatives::sin_darg0(x) * _d_x;
 // CHECK-NEXT:     double xsin = std::sin(x);
-// CHECK-NEXT:     double _d_ysin = custom_derivatives::sin_darg0(y) * 0.;
+// CHECK-NEXT:     double _d_ysin = custom_derivatives::sin_darg0(y) * _d_y;
 // CHECK-NEXT:     double ysin = std::sin(y);
 // CHECK-NEXT:     double _d_xt = _d_xsin * xsin + xsin * _d_xsin;
 // CHECK-NEXT:     double xt = xsin * xsin;

--- a/test/Functors/Simple.C
+++ b/test/Functors/Simple.C
@@ -34,11 +34,15 @@ public:
 };
 
 // CHECK: float operator_call_darg0(float x, float y) {
-// CHECK-NEXT: return 1.F * x + x * 1.F + 0.F * y + y * 0.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
 // CHECK-NEXT: }
 
 // CHECK: float operator_call_darg1(float x, float y) {
-// CHECK-NEXT: return 0.F * x + x * 0.F + 1.F * y + y * 1.F;
+// CHECK-NEXT: float _d_x = 0;
+// CHECK-NEXT: float _d_y = 1;
+// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
 // CHECK-NEXT: }
 
 float f(float x) {

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -11,8 +11,8 @@ double f_add1(double x, double y) {
 }
 
 // CHECK: void f_add1_grad(double x, double y, double *_result) {
-// CHECK-NEXT:   _result[0UL] += 1.;
-// CHECK-NEXT:   _result[1UL] += 1.;
+// CHECK-NEXT:   _result[0UL] += 1;
+// CHECK-NEXT:   _result[1UL] += 1;
 // CHECK-NEXT: }
 
 void f_add1_grad(double x, double y, double *_result);
@@ -22,11 +22,11 @@ double f_add2(double x, double y) {
 }
 
 // CHECK: void f_add2_grad(double x, double y, double *_result) {
-// CHECK-NEXT:     double _t0 = 1. * x;
-// CHECK-NEXT:     double _t1 = 3 * 1.;
+// CHECK-NEXT:     double _t0 = 1 * x;
+// CHECK-NEXT:     double _t1 = 3 * 1;
 // CHECK-NEXT:     _result[0UL] += _t1;
-// CHECK-NEXT:     double _t2 = 1. * y;
-// CHECK-NEXT:     double _t3 = 4 * 1.;
+// CHECK-NEXT:     double _t2 = 1 * y;
+// CHECK-NEXT:     double _t3 = 4 * 1;
 // CHECK-NEXT:     _result[1UL] += _t3;
 // CHECK-NEXT: }
 
@@ -37,14 +37,14 @@ double f_add3(double x, double y) {
 }
 
 // CHECK: void f_add3_grad(double x, double y, double *_result) {
-// CHECK-NEXT:     double _t0 = 1. * x;
-// CHECK-NEXT:     double _t1 = 3 * 1.;
+// CHECK-NEXT:     double _t0 = 1 * x;
+// CHECK-NEXT:     double _t1 = 3 * 1;
 // CHECK-NEXT:     _result[0UL] += _t1;
-// CHECK-NEXT:     double _t2 = 1. * 4;
+// CHECK-NEXT:     double _t2 = 1 * 4;
 // CHECK-NEXT:     double _t3 = _t2 * y;
 // CHECK-NEXT:     double _t4 = 4 * _t2;
 // CHECK-NEXT:     _result[1UL] += _t4;
-// CHECK-NEXT:     double _t5 = 4 * y * 1.;
+// CHECK-NEXT:     double _t5 = 4 * y * 1;
 // CHECK-NEXT: }
 
 void f_add3_grad(double x, double y, double *_result);
@@ -54,8 +54,8 @@ double f_sub1(double x, double y) {
 }
 
 // CHECK: void f_sub1_grad(double x, double y, double *_result) {
-// CHECK-NEXT:   _result[0UL] += 1.;
-// CHECK-NEXT:   _result[1UL] += -1.;
+// CHECK-NEXT:   _result[0UL] += 1;
+// CHECK-NEXT:   _result[1UL] += -1;
 // CHECK-NEXT: }
 void f_sub1_grad(double x, double y, double *_result);
 
@@ -64,11 +64,11 @@ double f_sub2(double x, double y) {
 }
 
 // CHECK: void f_sub2_grad(double x, double y, double *_result) {
-// CHECK-NEXT:     double _t0 = 1. * x;
-// CHECK-NEXT:     double _t1 = 3 * 1.;
+// CHECK-NEXT:     double _t0 = 1 * x;
+// CHECK-NEXT:     double _t1 = 3 * 1;
 // CHECK-NEXT:     _result[0UL] += _t1;
-// CHECK-NEXT:     double _t2 = -1. * y;
-// CHECK-NEXT:     double _t3 = 4 * -1.;
+// CHECK-NEXT:     double _t2 = -1 * y;
+// CHECK-NEXT:     double _t3 = 4 * -1;
 // CHECK-NEXT:     _result[1UL] += _t3;
 // CHECK-NEXT: }
 
@@ -79,9 +79,9 @@ double f_mult1(double x, double y) {
 }
 
 // CHECK: void f_mult1_grad(double x, double y, double *_result) {
-// CHECK-NEXT:    double _t0 = 1. * y;
+// CHECK-NEXT:    double _t0 = 1 * y;
 // CHECK-NEXT:    _result[0UL] += _t0;
-// CHECK-NEXT:    double _t1 = x * 1.;
+// CHECK-NEXT:    double _t1 = x * 1;
 // CHECK-NEXT:    _result[1UL] += _t1;
 // CHECK-NEXT: }
 
@@ -92,13 +92,13 @@ double f_mult2(double x, double y) {
 }
 
 // CHECK: void f_mult2_grad(double x, double y, double *_result) {
-// CHECK-NEXT:    double _t0 = 1. * y;
+// CHECK-NEXT:    double _t0 = 1 * y;
 // CHECK-NEXT:    double _t1 = _t0 * 4;
 // CHECK-NEXT:    double _t2 = _t1 * x;
 // CHECK-NEXT:    double _t3 = 3 * _t1;
 // CHECK-NEXT:    _result[0UL] += _t3;
 // CHECK-NEXT:    double _t4 = 3 * x * _t0;
-// CHECK-NEXT:    double _t5 = 3 * x * 4 * 1.;
+// CHECK-NEXT:    double _t5 = 3 * x * 4 * 1;
 // CHECK-NEXT:    _result[1UL] += _t5;
 // CHECK-NEXT: }
 
@@ -109,9 +109,9 @@ double f_div1(double x, double y) {
 }
 
 // CHECK: void f_div1_grad(double x, double y, double *_result) {
-// CHECK-NEXT:    double _t0 = 1. / y;
+// CHECK-NEXT:    double _t0 = 1 / y;
 // CHECK-NEXT:    _result[0UL] += _t0;
-// CHECK-NEXT:    double _t1 = 1. * -x / (y * y);
+// CHECK-NEXT:    double _t1 = 1 * -x / (y * y);
 // CHECK-NEXT:    _result[1UL] += _t1;
 // CHECK-NEXT: }
 
@@ -122,11 +122,11 @@ double f_div2(double x, double y) {
 }
 
 // CHECK: void f_div2_grad(double x, double y, double *_result) {
-// CHECK-NEXT:    double _t0 = 1. / (4 * y);
+// CHECK-NEXT:    double _t0 = 1 / (4 * y);
 // CHECK-NEXT:    double _t1 = _t0 * x;
 // CHECK-NEXT:    double _t2 = 3 * _t0;
 // CHECK-NEXT:    _result[0UL] += _t2;
-// CHECK-NEXT:    double _t3 = 1. * -3 * x / ((4 * y) * (4 * y));
+// CHECK-NEXT:    double _t3 = 1 * -3 * x / ((4 * y) * (4 * y));
 // CHECK-NEXT:    double _t4 = _t3 * y;
 // CHECK-NEXT:    double _t5 = 4 * _t3;
 // CHECK-NEXT:    _result[1UL] += _t5;
@@ -139,21 +139,21 @@ double f_c(double x, double y) {
 }
 
 // CHECK: void f_c_grad(double x, double y, double *_result) {
-// CHECK-NEXT:    double _t0 = 1. * y;
+// CHECK-NEXT:    double _t0 = 1 * y;
 // CHECK-NEXT:    _result[0UL] += -_t0;
-// CHECK-NEXT:    double _t1 = -x * 1.;
+// CHECK-NEXT:    double _t1 = -x * 1;
 // CHECK-NEXT:    _result[1UL] += _t1;
-// CHECK-NEXT:    double _t2 = 1. * (x / y);
+// CHECK-NEXT:    double _t2 = 1 * (x / y);
 // CHECK-NEXT:    _result[0UL] += _t2;
 // CHECK-NEXT:    _result[1UL] += _t2;
-// CHECK-NEXT:    double _t3 = (x + y) * 1.;
+// CHECK-NEXT:    double _t3 = (x + y) * 1;
 // CHECK-NEXT:    double _t4 = _t3 / y;
 // CHECK-NEXT:    _result[0UL] += _t4;
 // CHECK-NEXT:    double _t5 = _t3 * -x / (y * y);
 // CHECK-NEXT:    _result[1UL] += _t5;
-// CHECK-NEXT:    double _t6 = -1. * x;
+// CHECK-NEXT:    double _t6 = -1 * x;
 // CHECK-NEXT:    _result[0UL] += _t6;
-// CHECK-NEXT:    double _t7 = x * -1.;
+// CHECK-NEXT:    double _t7 = x * -1;
 // CHECK-NEXT:    _result[0UL] += _t7;
 // CHECK-NEXT: }
 
@@ -164,11 +164,11 @@ double f_rosenbrock(double x, double y) {
 }
 
 // CHECK: void f_rosenbrock_grad(double x, double y, double *_result) {
-// CHECK-NEXT:     double _t0 = 1. * (x - 1);
+// CHECK-NEXT:     double _t0 = 1 * (x - 1);
 // CHECK-NEXT:     _result[0UL] += _t0;
-// CHECK-NEXT:     double _t1 = (x - 1) * 1.;
+// CHECK-NEXT:     double _t1 = (x - 1) * 1;
 // CHECK-NEXT:     _result[0UL] += _t1;
-// CHECK-NEXT:     double _t2 = 1. * (y - x * x);
+// CHECK-NEXT:     double _t2 = 1 * (y - x * x);
 // CHECK-NEXT:     double _t3 = _t2 * (y - x * x);
 // CHECK-NEXT:     double _t4 = 100 * _t2;
 // CHECK-NEXT:     _result[1UL] += _t4;
@@ -176,7 +176,7 @@ double f_rosenbrock(double x, double y) {
 // CHECK-NEXT:     _result[0UL] += _t5;
 // CHECK-NEXT:     double _t6 = x * -_t4;
 // CHECK-NEXT:     _result[0UL] += _t6;
-// CHECK-NEXT:     double _t7 = 100 * (y - x * x) * 1.;
+// CHECK-NEXT:     double _t7 = 100 * (y - x * x) * 1;
 // CHECK-NEXT:     _result[1UL] += _t7;
 // CHECK-NEXT:     double _t8 = -_t7 * x;
 // CHECK-NEXT:     _result[0UL] += _t8;
@@ -192,8 +192,8 @@ double f_cond1(double x, double y) {
 
 // CHECK: void f_cond1_grad(double x, double y, double *_result) {
 // CHECK-NEXT:     _Bool _t0 = x > y;
-// CHECK-NEXT:     _result[0UL] += (_t0 ? 1. : 0.);
-// CHECK-NEXT:     _result[1UL] += (_t0 ? 0. : 1.);
+// CHECK-NEXT:     _result[0UL] += (_t0 ? 1 : 0);
+// CHECK-NEXT:     _result[1UL] += (_t0 ? 0 : 1);
 // CHECK-NEXT: }
 
 void f_cond1_grad(double x, double y, double *_result);
@@ -204,10 +204,10 @@ double f_cond2(double x, double y) {
 
 // CHECK: void f_cond2_grad(double x, double y, double *_result) {
 // CHECK-NEXT:     _Bool _t0 = x > y;
-// CHECK-NEXT:     _result[0UL] += (_t0 ? 1. : 0.);
+// CHECK-NEXT:     _result[0UL] += (_t0 ? 1 : 0);
 // CHECK-NEXT:     _Bool _t1 = y > 0;
-// CHECK-NEXT:     _result[1UL] += (_t1 ? (_t0 ? 0. : 1.) : 0.);
-// CHECK-NEXT:     _result[1UL] += -(_t1 ? 0. : (_t0 ? 0. : 1.));
+// CHECK-NEXT:     _result[1UL] += (_t1 ? (_t0 ? 0 : 1) : 0);
+// CHECK-NEXT:     _result[1UL] += -(_t1 ? 0 : (_t0 ? 0 : 1));
 // CHECK-NEXT: }
 
 void f_cond2_grad(double x, double y, double *_result);
@@ -218,10 +218,10 @@ double f_cond3(double x, double c) {
 
 // CHECK: void f_cond3_grad(double x, double c, double *_result) {
 // CHECK-NEXT:     _Bool _t0 = c > 0;
-// CHECK-NEXT:     _result[0UL] += (_t0 ? 1. : 0.);
-// CHECK-NEXT:     _result[1UL] += (_t0 ? 1. : 0.);
-// CHECK-NEXT:     _result[0UL] += (_t0 ? 0. : 1.);
-// CHECK-NEXT:     _result[1UL] += -(_t0 ? 0. : 1.);
+// CHECK-NEXT:     _result[0UL] += (_t0 ? 1 : 0);
+// CHECK-NEXT:     _result[1UL] += (_t0 ? 1 : 0);
+// CHECK-NEXT:     _result[0UL] += (_t0 ? 0 : 1);
+// CHECK-NEXT:     _result[1UL] += -(_t0 ? 0 : 1);
 // CHECK-NEXT: }
 
 double f_cond3_grad(double x, double c, double *_result);
@@ -235,9 +235,9 @@ double f_if1(double x, double y) {
 
 // CHECK: void f_if1_grad(double x, double y, double *_result) {
 // CHECK-NEXT:     if (x > y) {
-// CHECK-NEXT:         _result[0UL] += 1.;
+// CHECK-NEXT:         _result[0UL] += 1;
 // CHECK-NEXT:     } else {
-// CHECK-NEXT:         _result[1UL] += 1.;
+// CHECK-NEXT:         _result[1UL] += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -254,12 +254,12 @@ double f_if2(double x, double y) {
 
 // CHECK: void f_if2_grad(double x, double y, double *_result) {
 // CHECK-NEXT:     if (x > y) {
-// CHECK-NEXT:         _result[0UL] += 1.;
+// CHECK-NEXT:         _result[0UL] += 1;
 // CHECK-NEXT:     } else {
 // CHECK-NEXT:         if (y > 0) {
-// CHECK-NEXT:             _result[1UL] += 1.;
+// CHECK-NEXT:             _result[1UL] += 1;
 // CHECK-NEXT:         } else {
-// CHECK-NEXT:             _result[1UL] += -1.;
+// CHECK-NEXT:             _result[1UL] += -1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -274,11 +274,11 @@ struct S {
   }
    
   // CHECK: void f_grad(double x, double y, double *_result) {
-  // CHECK-NEXT:   double _t0 = 1. * x;
-  // CHECK-NEXT:   double _t1 = this->c1 * 1.;
+  // CHECK-NEXT:   double _t0 = 1 * x;
+  // CHECK-NEXT:   double _t1 = this->c1 * 1;
   // CHECK-NEXT:   _result[0UL] += _t1;
-  // CHECK-NEXT:   double _t2 = 1. * y;
-  // CHECK-NEXT:   double _t3 = this->c2 * 1.;
+  // CHECK-NEXT:   double _t2 = 1 * y;
+  // CHECK-NEXT:   double _t3 = this->c2 * 1;
   // CHECK-NEXT:  _result[1UL] += _t3;
   // CHECK-NEXT: }
 
@@ -308,7 +308,7 @@ void f_norm_grad(double x, double y, double z, double d, double* _result);
 // CHECK: void f_norm_grad(double x, double y, double z, double d, double *_result) {
 // CHECK-NEXT:     double _grad[2] = {};
 // CHECK-NEXT:     pow_grad(sum_of_powers(x, y, z, d), 1 / d, _grad);
-// CHECK-NEXT:     double _t0 = 1. * _grad[0UL];
+// CHECK-NEXT:     double _t0 = 1 * _grad[0UL];
 // CHECK-NEXT:     double _grad1[4] = {};
 // CHECK-NEXT:     custom_derivatives::sum_of_powers_grad(x, y, z, d, _grad1);
 // CHECK-NEXT:     double _t2 = _t0 * _grad1[0UL];
@@ -319,7 +319,7 @@ void f_norm_grad(double x, double y, double z, double d, double* _result);
 // CHECK-NEXT:     _result[2UL] += _t4;
 // CHECK-NEXT:     double _t5 = _t0 * _grad1[3UL];
 // CHECK-NEXT:     _result[3UL] += _t5;
-// CHECK-NEXT:     double _t6 = 1. * _grad[1UL];
+// CHECK-NEXT:     double _t6 = 1 * _grad[1UL];
 // CHECK-NEXT:     double _t7 = _t6 / d;
 // CHECK-NEXT:     double _t8 = _t6 * -1 / (d * d);
 // CHECK-NEXT:     _result[3UL] += _t8;
@@ -331,14 +331,14 @@ double f_sin(double x, double y) {
 
 void f_sin_grad(double x, double y, double* _result);
 // CHECK: void f_sin_grad(double x, double y, double *_result) {
-// CHECK-NEXT:     double _t0 = 1. * (x + y);
+// CHECK-NEXT:     double _t0 = 1 * (x + y);
 // CHECK-NEXT:     double _t1 = custom_derivatives::sin_darg0(x);
 // CHECK-NEXT:     double _t2 = _t0 * _t1;
 // CHECK-NEXT:     _result[0UL] += _t2;
 // CHECK-NEXT:     double _t3 = custom_derivatives::sin_darg0(y);
 // CHECK-NEXT:     double _t4 = _t0 * _t3;
 // CHECK-NEXT:     _result[1UL] += _t4;
-// CHECK-NEXT:     double _t5 = (std::sin(x) + std::sin(y)) * 1.;
+// CHECK-NEXT:     double _t5 = (std::sin(x) + std::sin(y)) * 1;
 // CHECK-NEXT:     _result[0UL] += _t5;
 // CHECK-NEXT:     _result[1UL] += _t5;
 // CHECK-NEXT: }
@@ -348,9 +348,9 @@ unsigned f_types(int x, float y, double z) {
 }
 
 // CHECK: void f_types_grad(int x, float y, double z, unsigned int *_result) {
-// CHECK-NEXT:   _result[0UL] += 1U;
-// CHECK-NEXT:   _result[1UL] += 1U;
-// CHECK-NEXT:   _result[2UL] += 1U;
+// CHECK-NEXT:   _result[0UL] += 1;
+// CHECK-NEXT:   _result[1UL] += 1;
+// CHECK-NEXT:   _result[2UL] += 1;
 // CHECK-NEXT: }
 void f_types_grad(int x, float y, double z, unsigned int *_result);
 

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -11,33 +11,54 @@
 // RUN: %cladclang %S/../../demos/Gradient.cpp -I%S/../../include -oGradient.out 2>&1 | FileCheck -check-prefix CHECK_GRADIENT %s 
 // CHECK_GRADIENT-NOT:{{.*error|warning|note:.*}}
 // CHECK_GRADIENT:float sphere_implicit_func_darg0(float x, float y, float z, float xc, float yc, float zc, float r) {
+// CHECK_GRADIENT: float _d_x = 1;
+// CHECK_GRADIENT: float _d_y = 0;
+// CHECK_GRADIENT: float _d_z = 0;
+// CHECK_GRADIENT: float _d_xc = 0;
+// CHECK_GRADIENT: float _d_yc = 0;
+// CHECK_GRADIENT: float _d_zc = 0;
+// CHECK_GRADIENT: float _d_r = 0;
 // CHECK_GRADIENT: float _t0 = (x - xc);
 // CHECK_GRADIENT: float _t1 = (x - xc);
 // CHECK_GRADIENT: float _t2 = (y - yc);
 // CHECK_GRADIENT: float _t3 = (y - yc);
 // CHECK_GRADIENT: float _t4 = (z - zc);
 // CHECK_GRADIENT: float _t5 = (z - zc);
-// CHECK_GRADIENT: return (1.F - 0.F) * _t1 + _t0 * (1.F - 0.F) + (0.F - 0.F) * _t3 + _t2 * (0.F - 0.F) + (0.F - 0.F) * _t5 + _t4 * (0.F - 0.F) - (0.F * r + r * 0.F);
+// CHECK_GRADIENT: return (_d_x - _d_xc) * _t1 + _t0 * (_d_x - _d_xc) + (_d_y - _d_yc) * _t3 + _t2 * (_d_y - _d_yc) + (_d_z - _d_zc) * _t5 + _t4 * (_d_z - _d_zc) - (_d_r * r + r * _d_r);
 // CHECK_GRADIENT:}
 
 // CHECK_GRADIENT:float sphere_implicit_func_darg1(float x, float y, float z, float xc, float yc, float zc, float r) {
-// CHECK_GRADIENT: float _t0 = (x - xc);
-// CHECK_GRADIENT: float _t1 = (x - xc);
-// CHECK_GRADIENT: float _t2 = (y - yc);
-// CHECK_GRADIENT: float _t3 = (y - yc);
-// CHECK_GRADIENT: float _t4 = (z - zc);
- // CHECK_GRADIENT: float _t5 = (z - zc);
-// CHECK_GRADIENT:  return (0.F - 0.F) * _t1 + _t0 * (0.F - 0.F) + (1.F - 0.F) * _t3 + _t2 * (1.F - 0.F) + (0.F - 0.F) * _t5 + _t4 * (0.F - 0.F) - (0.F * r + r * 0.F);
-// CHECK_GRADIENT:}
-
-// CHECK_GRADIENT:float sphere_implicit_func_darg2(float x, float y, float z, float xc, float yc, float zc, float r) {
+// CHECK_GRADIENT: float _d_x = 0;
+// CHECK_GRADIENT: float _d_y = 1;
+// CHECK_GRADIENT: float _d_z = 0;
+// CHECK_GRADIENT: float _d_xc = 0;
+// CHECK_GRADIENT: float _d_yc = 0;
+// CHECK_GRADIENT: float _d_zc = 0;
+// CHECK_GRADIENT: float _d_r = 0;
 // CHECK_GRADIENT: float _t0 = (x - xc);
 // CHECK_GRADIENT: float _t1 = (x - xc);
 // CHECK_GRADIENT: float _t2 = (y - yc);
 // CHECK_GRADIENT: float _t3 = (y - yc);
 // CHECK_GRADIENT: float _t4 = (z - zc);
 // CHECK_GRADIENT: float _t5 = (z - zc);
-// CHECK_GRADIENT: return (0.F - 0.F) * _t1 + _t0 * (0.F - 0.F) + (0.F - 0.F) * _t3 + _t2 * (0.F - 0.F) + (1.F - 0.F) * _t5 + _t4 * (1.F - 0.F) - (0.F * r + r * 0.F);
+// CHECK_GRADIENT: return (_d_x - _d_xc) * _t1 + _t0 * (_d_x - _d_xc) + (_d_y - _d_yc) * _t3 + _t2 * (_d_y - _d_yc) + (_d_z - _d_zc) * _t5 + _t4 * (_d_z - _d_zc) - (_d_r * r + r * _d_r);
+// CHECK_GRADIENT:}
+
+// CHECK_GRADIENT:float sphere_implicit_func_darg2(float x, float y, float z, float xc, float yc, float zc, float r) {
+// CHECK_GRADIENT: float _d_x = 0;
+// CHECK_GRADIENT: float _d_y = 0;
+// CHECK_GRADIENT: float _d_z = 1;
+// CHECK_GRADIENT: float _d_xc = 0;
+// CHECK_GRADIENT: float _d_yc = 0;
+// CHECK_GRADIENT: float _d_zc = 0;
+// CHECK_GRADIENT: float _d_r = 0;
+// CHECK_GRADIENT: float _t0 = (x - xc);
+// CHECK_GRADIENT: float _t1 = (x - xc);
+// CHECK_GRADIENT: float _t2 = (y - yc);
+// CHECK_GRADIENT: float _t3 = (y - yc);
+// CHECK_GRADIENT: float _t4 = (z - zc);
+// CHECK_GRADIENT: float _t5 = (z - zc);
+// CHECK_GRADIENT: return (_d_x - _d_xc) * _t1 + _t0 * (_d_x - _d_xc) + (_d_y - _d_yc) * _t3 + _t2 * (_d_y - _d_yc) + (_d_z - _d_zc) * _t5 + _t4 * (_d_z - _d_zc) - (_d_r * r + r * _d_r);
 // CHECK_GRADIENT:}
 
 // RUN: ./Gradient.out | FileCheck -check-prefix CHECK_GRADIENT_EXEC %s
@@ -49,20 +70,24 @@
 // RUN: %cladclang %S/../../demos/RosenbrockFunction.cpp -I%S/../../include -oRosenbrockFunction.out 2>&1 | FileCheck -check-prefix CHECK_ROSENBROCK %s
 // CHECK_ROSENBROCK-NOT:{{.*error|warning|note:.*}}
 // CHECK_ROSENBROCK:double rosenbrock_func_darg0(double x, double y) {
+// CHECK_ROSENBROCK: double _d_x = 1;
+// CHECK_ROSENBROCK: double _d_y = 0;
 // CHECK_ROSENBROCK: double _t0 = (x - 1);
 // CHECK_ROSENBROCK: double _t1 = (x - 1);
 // CHECK_ROSENBROCK: double _t2 = (y - x * x);
 // CHECK_ROSENBROCK: double _t3 = 100 * _t2;
 // CHECK_ROSENBROCK: double _t4 = (y - x * x);
-// CHECK_ROSENBROCK: return (1. - 0) * _t1 + _t0 * (1. - 0) + (0 * _t2 + 100 * (0. - (1. * x + x * 1.))) * _t4 + _t3 * (0. - (1. * x + x * 1.));
+// CHECK_ROSENBROCK: return (_d_x - 0) * _t1 + _t0 * (_d_x - 0) + (0 * _t2 + 100 * (_d_y - (_d_x * x + x * _d_x))) * _t4 + _t3 * (_d_y - (_d_x * x + x * _d_x));
 // CHECK_ROSENBROCK:}
 // CHECK_ROSENBROCK:double rosenbrock_func_darg1(double x, double y) {
+// CHECK_ROSENBROCK: double _d_x = 0;
+// CHECK_ROSENBROCK: double _d_y = 1;
 // CHECK_ROSENBROCK: double _t0 = (x - 1);
 // CHECK_ROSENBROCK: double _t1 = (x - 1);
 // CHECK_ROSENBROCK: double _t2 = (y - x * x);
 // CHECK_ROSENBROCK: double _t3 = 100 * _t2;
 // CHECK_ROSENBROCK: double _t4 = (y - x * x);
-// CHECK_ROSENBROCK: return (0. - 0) * _t1 + _t0 * (0. - 0) + (0 * _t2 + 100 * (1. - (0. * x + x * 0.))) * _t4 + _t3 * (1. - (0. * x + x * 0.));
+// CHECK_ROSENBROCK: return (_d_x - 0) * _t1 + _t0 * (_d_x - 0) + (0 * _t2 + 100 * (_d_y - (_d_x * x + x * _d_x))) * _t4 + _t3 * (_d_y - (_d_x * x + x * _d_x));
 // CHECK_ROSENBROCK:}
 // RUN: ./RosenbrockFunction.out | FileCheck -check-prefix CHECK_ROSENBROCK_EXEC %s
 // CHECK_ROSENBROCK_EXEC: The result is -899.000000.

--- a/test/MixedDerivatives/Simple.C
+++ b/test/MixedDerivatives/Simple.C
@@ -10,12 +10,21 @@ extern "C" int printf(const char* fmt, ...);
 float f1(float x, float y) {
   return x * x + y * y;
 }
+
 // CHECK: float f1_darg0(float x, float y) {
-// CHECK-NEXT: return 1.F * x + x * 1.F + 0.F * y + y * 0.F;
+// CHECK-NEXT:    float _d_x = 1;
+// CHECK-NEXT:    float _d_y = 0;
+// CHECK-NEXT:    return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
 // CHECK-NEXT: }
 
 // CHECK: float f1_darg0_darg1(float x, float y) {
-// CHECK-NEXT: return 0.F * x + 1.F * 0.F + 0.F * 1.F + x * 0.F + 0.F * y + 0.F * 1.F + 1.F * 0.F + y * 0.F;
+// CHECK-NEXT:    float _d_x = 0;
+// CHECK-NEXT:    float _d_y = 1;
+// CHECK-NEXT:    float _d__d_x = 0;
+// CHECK-NEXT:    float _d_x0 = 1;
+// CHECK-NEXT:    float _d__d_y = 0;
+// CHECK-NEXT:    float _d_y1 = 0;
+// CHECK-NEXT:    return _d__d_x * x + _d_x0 * _d_x + _d_x * _d_x0 + x * _d__d_x + _d__d_y * y + _d_y1 * _d_y + _d_y * _d_y1 + y * _d__d_y;
 // CHECK-NEXT: }
 
 float f1_darg0(float x, float y);

--- a/test/NthDerivative/BasicArithmeticMul.C
+++ b/test/NthDerivative/BasicArithmeticMul.C
@@ -11,24 +11,55 @@ float test_2(float x, float y) {
 }
 
 // CHECK: float test_2_darg0(float x, float y) {
-// CHECK-NEXT: return 1.F * x + x * 1.F + 0.F * y + y * 0.F;
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
 // CHECK-NEXT: }
 
 // CHECK: float test_2_d2arg0(float x, float y) {
-// CHECK-NEXT: return 0.F * x + 1.F * 1.F + 1.F * 1.F + x * 0.F + 0.F * y + 0.F * 0.F + 0.F * 0.F + y * 0.F;
-// CHECK-NEXT: }
+// CHECK-NEXT:    float _d_x = 1;
+// CHECK-NEXT:    float _d_y = 0;
+// CHECK-NEXT:    float _d__d_x = 0;
+// CHECK-NEXT:    float _d_x0 = 1;
+// CHECK-NEXT:    float _d__d_y = 0;
+// CHECK-NEXT:    float _d_y1 = 0;
+// CHECK-NEXT:    return _d__d_x * x + _d_x0 * _d_x + _d_x * _d_x0 + x * _d__d_x + _d__d_y * y + _d_y1 * _d_y + _d_y * _d_y1 + y * _d__d_y;
+// CHECK-NEXT:}
 
 // CHECK: float test_2_darg1(float x, float y) {
-// CHECK-NEXT: return 0.F * x + x * 0.F + 1.F * y + y * 1.F;
+// CHECK-NEXT: float _d_x = 0;
+// CHECK-NEXT: float _d_y = 1;
+// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
 // CHECK-NEXT: }
 
 // CHECK: float test_2_d2arg1(float x, float y) {
-// CHECK-NEXT: return 0.F * x + 0.F * 0.F + 0.F * 0.F + x * 0.F + 0.F * y + 1.F * 1.F + 1.F * 1.F + y * 0.F;
-// CHECK-NEXT: }
+// CHECK-NEXT:    float _d_x = 0;
+// CHECK-NEXT:    float _d_y = 1;
+// CHECK-NEXT:    float _d__d_x = 0;
+// CHECK-NEXT:    float _d_x0 = 0;
+// CHECK-NEXT:    float _d__d_y = 0;
+// CHECK-NEXT:    float _d_y1 = 1;
+// CHECK-NEXT:    return _d__d_x * x + _d_x0 * _d_x + _d_x * _d_x0 + x * _d__d_x + _d__d_y * y + _d_y1 * _d_y + _d_y * _d_y1 + y * _d__d_y;
+// CHECK-NEXT:}
 
 // CHECK: float test_2_d3arg1(float x, float y) {
-// CHECK-NEXT: return 0.F * x + 0.F * 0.F + 0.F * 0.F + 0.F * 0.F + 0.F * 0.F + 0.F * 0.F + 0.F * 0.F + x * 0.F + 0.F * y + 0.F * 1.F + 0.F * 1.F + 1.F * 0.F + 0.F * 1.F + 1.F * 0.F + 1.F * 0.F + y * 0.F;
-// CHECK-NEXT: }
+// CHECK-NEXT:    float _d_x = 0;
+// CHECK-NEXT:    float _d_y = 1;
+// CHECK-NEXT:    float _d__d_x = 0;
+// CHECK-NEXT:    float _d_x0 = 0;
+// CHECK-NEXT:    float _d__d_y = 0;
+// CHECK-NEXT:    float _d_y1 = 1;
+// CHECK-NEXT:    float _d__d__d_x = 0;
+// CHECK-NEXT:    float _d__d_x2 = 0;
+// CHECK-NEXT:    float _d__d_x0 = 0;
+// CHECK-NEXT:    float _d_x03 = 0;
+// CHECK-NEXT:    float _d__d__d_y = 0;
+// CHECK-NEXT:    float _d__d_y4 = 0;
+// CHECK-NEXT:    float _d__d_y1 = 0;
+// CHECK-NEXT:    float _d_y15 = 1;
+// CHECK-NEXT:    return _d__d__d_x * x + _d__d_x2 * _d_x + _d__d_x0 * _d_x0 + _d_x03 * _d__d_x + _d__d_x * _d_x03 + _d_x0 * _d__d_x0 + _d_x * _d__d_x2 + x * _d__d__d_x + _d__d__d_y * y + _d__d_y4 * _d_y + _d__d_y1 * _d_y1 + _d_y15 * _d__d_y + _d__d_y * _d_y15 + _d_y1 * _d__d_y1 + _d_y * _d__d_y4 + y * _d__d__d_y;
+// CHECK-NEXT:  }
+
 
 float test_1_darg0(float x);
 float test_1_d2arg0(float x);


### PR DESCRIPTION
This commit allows to keep track of variable reassignments in forward mode.
Example:
```
double f(double x, double y) {
  y = x;
  return y;
}
->
double f_darg0(double x, double y) {
  double _d_x = 1;
  double _d_y = 0;
  _d_y = _d_x;
  y = x;
  return _d_y;
}
```

Currently assigmnents are only supported for function parameters and
variables declared inside the function body (i.e. assignments to global
variables and struct members are not tracked).