### PR TITLE
Add checks if clad did not run.

### DIFF
--- a/test/FirstDerivative/DiffInterface.C
+++ b/test/FirstDerivative/DiffInterface.C
@@ -96,8 +96,8 @@ int main () {
   clad::differentiate(f_2, 2);
 
   clad::differentiate(f_2, -1); // expected-error {{Invalid argument index -1 among 3 argument(s)}}
-  // expected-note@clad/Differentiator/Differentiator.h:97 {{candidate function not viable: no known conversion from 'int (int, float, int)' to 'unsigned int' for 2nd argument}}
-  // expected-note@clad/Differentiator/Differentiator.h:104 {{candidate template ignored: could not match 'R (C::*)(Args...)' against 'int (*)(int, float, int)'}}
+  // expected-note@clad/Differentiator/Differentiator.h:114 {{candidate function not viable: no known conversion from 'int (int, float, int)' to 'unsigned int' for 2nd argument}}
+  // expected-note@clad/Differentiator/Differentiator.h:121 {{candidate template ignored: could not match 'R (C::*)(Args...)' against 'int (*)(int, float, int)'}}
 
   clad::differentiate(f_2, -1); // expected-error {{Invalid argument index -1 among 3 argument(s)}}
 


### PR DESCRIPTION
We expect clad to swap the template instantiation args with
the newly produced derivative calls. This patch detects if
this did not happen and give diagnostics at runtime.