### PR TITLE
Do not link against clang or llvm libraries.

### DIFF
--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -90,11 +90,3 @@ add_llvm_library(cladDifferentiator
   Version.cpp
   ${version_inc}
   )
-
-if((TARGET clangAST) AND (TARGET clangBasic) AND (TARGET clangSema))
-   target_link_libraries(cladDifferentiator PRIVATE
-      clangAST
-      clangBasic
-      clangSema
-   )
-endif()


### PR DESCRIPTION
In in-source builds we have all clang and llvm libraries as targets. We should not link against them because this causes double initialization of statics when the plugin is dlopened by clang.

Depending on what clang initializes we can get:
"CommandLine Error: Option 'pass-remarks' registered more than once!
fatal error: error in backend: inconsistency in registered CommandLine options"