### PR TITLE
Add string arguments for parameter specification

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -109,16 +109,16 @@ namespace clad {
 
   ///\brief N is the derivative order.
   ///
-  template<unsigned N = 1, typename R, typename... Args>
+  template<unsigned N = 1, typename ArgSpec = const char *, typename R, typename... Args>
   CladFunction <false, R, Args...> __attribute__((annotate("D")))
-  differentiate(R (*f)(Args...), unsigned independentArg, const char* code = "") {
+  differentiate(R (*f)(Args...), ArgSpec args = "", const char* code = "") {
     assert(f && "Must pass in a non-0 argument");
     return CladFunction<false, R, Args...>(f, code);
   }
 
-  template<unsigned N = 1, typename R, class C, typename... Args>
+  template<unsigned N = 1, typename ArgSpec = const char *, typename R, class C, typename... Args>
   CladFunction<true, R, C, Args...> __attribute__((annotate("D")))
-  differentiate(R (C::*f)(Args...), unsigned independentArg, const char* code = "") {
+  differentiate(R (C::*f)(Args...), ArgSpec args = "", const char* code = "") {
     assert(f && "Must pass in a non-0 argument");
     return CladFunction<true, R, C, Args...>(f, code);
   }
@@ -126,18 +126,18 @@ namespace clad {
   /// A function for gradient computation.
   /// Given a function f, clad::gradient generates its gradient f_grad and
   /// returns a CladFunction for it.
-  template<typename R, typename... Args>
+  template<typename ArgSpec = const char *, typename R, typename... Args>
   CladFunction<false, void, Args..., R*> __attribute__((annotate("G")))
-  gradient(R (*f)(Args...), const char* code = "") {
+  gradient(R (*f)(Args...), ArgSpec args = "", const char* code = "") {
     assert(f && "Must pass in a non-0 argument");
     return CladFunction<false, void, Args..., R*>(
       reinterpret_cast<void (*) (Args..., R*)>(f) /* will be replaced by gradient*/,
       code);
   }
 
-  template<typename R, typename C, typename... Args>
+  template<typename ArgSpec = const char *, typename R, typename C, typename... Args>
   CladFunction<true, void, C, Args..., R*> __attribute__((annotate("G")))
-  gradient(R (C::*f)(Args...), const char* code = "") {
+  gradient(R (C::*f)(Args...), ArgSpec args = "", const char* code = "") {
     assert(f && "Must pass in a non-0 argument");
     return CladFunction<true, void, C, Args..., R*>(
       reinterpret_cast<void (C::*) (Args..., R*)>(f) /* will be replaced by gradient*/,

--- a/test/FirstDerivative/DiffInterface.C
+++ b/test/FirstDerivative/DiffInterface.C
@@ -96,8 +96,6 @@ int main () {
   clad::differentiate(f_2, 2);
 
   clad::differentiate(f_2, -1); // expected-error {{Invalid argument index -1 among 3 argument(s)}}
-  // expected-note@clad/Differentiator/Differentiator.h:114 {{candidate function not viable: no known conversion from 'int (int, float, int)' to 'unsigned int' for 2nd argument}}
-  // expected-note@clad/Differentiator/Differentiator.h:121 {{candidate template ignored: could not match 'R (C::*)(Args...)' against 'int (*)(int, float, int)'}}
 
   clad::differentiate(f_2, -1); // expected-error {{Invalid argument index -1 among 3 argument(s)}}
 
@@ -105,20 +103,28 @@ int main () {
 
   clad::differentiate(f_2, 9); // expected-error {{Invalid argument index 9 among 3 argument(s)}}
 
-  clad::differentiate(f_2, x); // expected-error {{Must be an integral value}}
+  clad::differentiate(f_2, x); // expected-error {{Failed to parse the parameters, must be a string or numeric literal}}
 
-  clad::differentiate(f_2, f_2); // expected-error {{no matching function for call to 'differentiate'}}
+  clad::differentiate(f_2, f_2); // expected-error {{Failed to parse the parameters, must be a string or numeric literal}}
 
-  clad::differentiate(f_3, 0); // expected-error {{Trying to differentiate function 'f_3' taking no arguments}}
+  clad::differentiate(f_3, 0); // expected-error {{Invalid argument index 0 among 0 argument(s)}}
 
   float one = 1.0;
-  clad::differentiate(f_2, one); // expected-error {{Must be an integral value}}
+  clad::differentiate(f_2, one); // expected-error {{Failed to parse the parameters, must be a string or numeric literal}}
 
   clad::differentiate(f_no_definition, 0);
 
   clad::differentiate(f_redeclared, 0);
 
   clad::differentiate(f_try_catch, 0);
+
+  clad::differentiate(f_2, "x");
+  clad::differentiate(f_2, " y ");
+  clad::differentiate(f_2, "z");
+
+  clad::differentiate(f_2, "x, y"); // expected-error {{Forward mode differentiation w.r.t. several parameters at once is not supported, call 'clad::differentiate' for each parameter separately}}
+  clad::differentiate(f_2, "t"); // expected-error {{Requested parameter name 't' was not found among function parameters}}
+  clad::differentiate(f_2, "x, x"); // expected-error {{Requested parameter 'x' was specified multiple times}}
 
   return 0;
 }

--- a/test/FirstDerivative/FunctionCalls.C
+++ b/test/FirstDerivative/FunctionCalls.C
@@ -94,7 +94,7 @@ float test_5(int x) {
 int main () {
   clad::differentiate(test_1, 0);
   clad::differentiate(test_2, 0);
-  clad::differentiate(test_3, 0); //expected-error {{Trying to differentiate function 'test_3' taking no arguments}}
+  clad::differentiate(test_3, 0); //expected-error {{Invalid argument index 0 among 0 argument(s)}}
   clad::differentiate(test_4, 0);
   clad::differentiate(test_5, 0);
 

--- a/test/FirstDerivative/FunctionsOneVariable.C
+++ b/test/FirstDerivative/FunctionsOneVariable.C
@@ -46,7 +46,7 @@ int f_simple_negative(int x) {
 
 int main () {
   int x = 4;
-  clad::differentiate(f_simple, x); // expected-error {{Must be an integral value}}
+  clad::differentiate(f_simple, x); // expected-error {{Failed to parse the parameters, must be a string or numeric literal}}
   // Here the second arg denotes the differentiation of f with respect to the
   // given arg.
   //clad::differentiate(f_simple, 1);

--- a/test/Gradient/DiffInterface.C
+++ b/test/Gradient/DiffInterface.C
@@ -1,0 +1,143 @@
+// RUN: %cladclang %s -lm -I%S/../../include -oGradientDiffInterface.out 2>&1 | FileCheck %s
+// RUN: ./GradientDiffInterface.out | FileCheck -check-prefix=CHECK-EXEC %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+//CHECK-NOT: {{.*error|warning|note:.*}}
+
+extern "C" int printf(const char* fmt, ...);
+
+double f_1(double x, double y, double z) {
+  return 0 * x + 1 * y + 2 * z;
+}
+
+// all
+//CHECK:   void f_1_grad(double x, double y, double z, double *_result) {
+//CHECK-NEXT:       double _t0 = 1 * x;
+//CHECK-NEXT:       double _t1 = 0 * 1;
+//CHECK-NEXT:       _result[0UL] += _t1;
+//CHECK-NEXT:       double _t2 = 1 * y;
+//CHECK-NEXT:       double _t3 = 1 * 1;
+//CHECK-NEXT:       _result[1UL] += _t3;
+//CHECK-NEXT:       double _t4 = 1 * z;
+//CHECK-NEXT:       double _t5 = 2 * 1;
+//CHECK-NEXT:       _result[2UL] += _t5;
+//CHECK-NEXT:   }
+
+// x
+//CHECK:   void f_1_grad_0(double x, double y, double z, double *_result) {
+//CHECK-NEXT:       double _t0 = 1 * x;
+//CHECK-NEXT:       double _t1 = 0 * 1;
+//CHECK-NEXT:       _result[0UL] += _t1;
+//CHECK-NEXT:       double _t2 = 1 * y;
+//CHECK-NEXT:       double _t3 = 1 * 1;
+//CHECK-NEXT:       double _t4 = 1 * z;
+//CHECK-NEXT:       double _t5 = 2 * 1;
+//CHECK-NEXT:   }
+
+// y
+//CHECK:   void f_1_grad_1(double x, double y, double z, double *_result) {
+//CHECK-NEXT:       double _t0 = 1 * x;
+//CHECK-NEXT:       double _t1 = 0 * 1;
+//CHECK-NEXT:       double _t2 = 1 * y;
+//CHECK-NEXT:       double _t3 = 1 * 1;
+//CHECK-NEXT:       _result[0UL] += _t3;
+//CHECK-NEXT:       double _t4 = 1 * z;
+//CHECK-NEXT:       double _t5 = 2 * 1;
+//CHECK-NEXT:   }
+
+// z
+//CHECK:   void f_1_grad_2(double x, double y, double z, double *_result) {
+//CHECK-NEXT:       double _t0 = 1 * x;
+//CHECK-NEXT:       double _t1 = 0 * 1;
+//CHECK-NEXT:       double _t2 = 1 * y;
+//CHECK-NEXT:       double _t3 = 1 * 1;
+//CHECK-NEXT:       double _t4 = 1 * z;
+//CHECK-NEXT:       double _t5 = 2 * 1;
+//CHECK-NEXT:       _result[0UL] += _t5;
+//CHECK-NEXT:   }
+
+// x, y
+//CHECK:   void f_1_grad_0_1(double x, double y, double z, double *_result) {
+//CHECK-NEXT:       double _t0 = 1 * x;
+//CHECK-NEXT:       double _t1 = 0 * 1;
+//CHECK-NEXT:       _result[0UL] += _t1;
+//CHECK-NEXT:       double _t2 = 1 * y;
+//CHECK-NEXT:       double _t3 = 1 * 1;
+//CHECK-NEXT:       _result[1UL] += _t3;
+//CHECK-NEXT:       double _t4 = 1 * z;
+//CHECK-NEXT:       double _t5 = 2 * 1;
+//CHECK-NEXT:   }
+
+// y, x
+//CHECK:   void f_1_grad_1_0(double x, double y, double z, double *_result) {
+//CHECK-NEXT:       double _t0 = 1 * x;
+//CHECK-NEXT:       double _t1 = 0 * 1;
+//CHECK-NEXT:       _result[1UL] += _t1;
+//CHECK-NEXT:       double _t2 = 1 * y;
+//CHECK-NEXT:       double _t3 = 1 * 1;
+//CHECK-NEXT:       _result[0UL] += _t3;
+//CHECK-NEXT:       double _t4 = 1 * z;
+//CHECK-NEXT:       double _t5 = 2 * 1;
+//CHECK-NEXT:   }
+
+// x, y, z
+//CHECK:   void f_1_grad(double x, double y, double z, double *_result) {
+//CHECK-NEXT:       double _t0 = 1 * x;
+//CHECK-NEXT:       double _t1 = 0 * 1;
+//CHECK-NEXT:       _result[0UL] += _t1;
+//CHECK-NEXT:       double _t2 = 1 * y;
+//CHECK-NEXT:       double _t3 = 1 * 1;
+//CHECK-NEXT:       _result[1UL] += _t3;
+//CHECK-NEXT:       double _t4 = 1 * z;
+//CHECK-NEXT:       double _t5 = 2 * 1;
+//CHECK-NEXT:       _result[2UL] += _t5;
+//CHECK-NEXT:   }
+
+// z, y, z
+//CHECK:   void f_1_grad_2_1_0(double x, double y, double z, double *_result) {
+//CHECK-NEXT:       double _t0 = 1 * x;
+//CHECK-NEXT:       double _t1 = 0 * 1;
+//CHECK-NEXT:       _result[2UL] += _t1;
+//CHECK-NEXT:       double _t2 = 1 * y;
+//CHECK-NEXT:       double _t3 = 1 * 1;
+//CHECK-NEXT:       _result[1UL] += _t3;
+//CHECK-NEXT:       double _t4 = 1 * z;
+//CHECK-NEXT:       double _t5 = 2 * 1;
+//CHECK-NEXT:       _result[0UL] += _t5;
+//CHECK-NEXT:   }
+
+#define TEST(F) { \
+  result[0] = 0; result[1] = 0; result[2] = 0;\
+  F.execute(0, 0, 0, result);\
+  printf("{%.2f, %.2f, %.2f}\n", result[0], result[1], result[2]); \
+}
+
+int main () {
+  double result[3];
+
+  auto f1_grad_all = clad::gradient(f_1);
+  TEST(f1_grad_all); // CHECK-EXEC: {0.00, 1.00, 2.00}
+  
+  auto f1_grad_x = clad::gradient(f_1, "x");
+  TEST(f1_grad_x); // CHECK-EXEC: {0.00, 0.00, 0.00}
+
+  auto f1_grad_y = clad::gradient(f_1, "y");
+  TEST(f1_grad_y); // CHECK-EXEC: {1.00, 0.00, 0.00}
+  auto f1_grad_z = clad::gradient(f_1, "z");
+  TEST(f1_grad_z); // CHECK-EXEC: {2.00, 0.00, 0.00}
+
+  auto f1_grad_xy = clad::gradient(f_1, "x, y");
+  TEST(f1_grad_xy); // CHECK-EXEC: {0.00, 1.00, 0.00}
+
+  auto f1_grad_yz = clad::gradient(f_1, "y, x");
+  TEST(f1_grad_yz); // CHECK-EXEC: {1.00, 0.00, 0.00}
+
+  auto f1_grad_xyz = clad::gradient(f_1, "x, y, z");
+  TEST(f1_grad_xyz); // CHECK-EXEC: {0.00, 1.00, 2.00}
+
+  auto f1_grad_zyx = clad::gradient(f_1, "z,y,x");
+  TEST(f1_grad_zyx); // CHECK-EXEC: {2.00, 1.00, 0.00}
+
+  return 0;
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -257,7 +257,6 @@ if not lit_config.quiet:
 config.substitutions.append( ('%cladclang', config.clang + ' -x c++ -std=c++11' +
                               ' -Xclang -add-plugin -Xclang clad' +
                               ' -Xclang -plugin-arg-clad -Xclang -fdump-derived-fn' +
-                              ' -Xclang -plugin-arg-clad -Xclang -fvalidate-clang-version ' +
                               ' -Xclang -load -Xclang ' +
                               config.cladlib) )
 

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -85,16 +85,13 @@ namespace clad {
       for (DiffPlans::iterator plan = plans.begin(), planE = plans.end();
            plan != planE; ++plan)
          for (DiffPlan::iterator I = plan->begin(); I != plan->end(); ++I) {
-            if (!I->isValidInMode(plan->getMode()))
-                // Some error happened, ignore this plan.
-                continue;
             // if enabled, print source code of the original functions
             if (m_DO.DumpSourceFn) {
-               I->getFD()->print(llvm::outs(), Policy);
+               (*I)->print(llvm::outs(), Policy);
             }
             // if enabled, print ASTs of the original functions
             if (m_DO.DumpSourceFnAST) {
-               I->getFD()->dumpColor();
+               (*I)->dumpColor();
             }
 
             FunctionDecl* DerivativeDecl = nullptr;
@@ -106,7 +103,7 @@ namespace clad {
               bool WantTiming = getenv("LIBCLAD_TIMING");
               SimpleTimer Timer(WantTiming);
               Timer.setOutput("Generation time for "
-                              + plan->begin()->getFD()->getNameAsString());
+                              + (*plan->begin())->getNameAsString());
 
               std::tie(DerivativeDecl, DerivativeDeclContext) =
                 m_DerivativeBuilder->Derive(*I, *plan);


### PR DESCRIPTION
The commit introduces another option for the 2nd parameter of a call to
`clad::differentiate` and `clad::gradient`.
Now, there are 3 ways how to provide specific parameter(s), w.r.t. which the
differentiation will happen in `clad::differentiate` and `clad::gradient`:

1) Pass a string literal, containing comma-separated names of function's parameters,
as defined in function's defintion. The function will be differentiated w.r.t. all
the specified parameters. E.g., for a fucntion `double f(double x, double y, double
z) {...}`, calling `clad::gradient(f, "x, y")` will only differentiate it w.r.t. `x`
and `y` but not `z`.

2) Pass a numeric literal representing a single value. The function will be
differentiated w.r.t. to the parameter corresponding to literal's value index. For
now it only works for a single index/parameter.

3) Provide no argument, default argument will be used. The function will be
differentiated w.r.t. to its every parameter. E.g., `clad::gradient(f)`.

For now, gradient results are stored in the `_result` parameter in the same order as
they were provided in the argument string. E.g. on `clad::gradient(f, "y, x")`, `y`'s
derivative is stored in `_result[0]` and `x`'s in `_result[1]`. This will likely be
changed.