### PR TITLE
Add missing operators to the reverse mode, improve assignments, add support for nested assignments, fix issues with storing expressions with side-effects, optimize visiting independent expressions

### DIFF
--- a/test/Arrays/Arrays.C
+++ b/test/Arrays/Arrays.C
@@ -215,7 +215,7 @@ double const_matmul_sum(double a, double b, double c, double d) {
 //CHECK-NEXT:       _t12 = B[0][1];
 //CHECK-NEXT:       _t15 = A[1][1];
 //CHECK-NEXT:       _t14 = B[1][1];
-//CHECK-NEXT:       double C[2][2] = {{[{][{]}}_t1 * B[0][0] + _t3 * B[1][0], _t5 * B[0][1] + _t7 * B[1][1]}, {_t9 * B[0][0] + _t11 * B[1][0], _t13 * B[0][1] + _t15 * B[1][1]}};
+//CHECK-NEXT:       double C[2][2] = {{[{][{]}}_t1 * _t0 + _t3 * _t2, _t5 * _t4 + _t7 * _t6}, {_t9 * _t8 + _t11 * _t10, _t13 * _t12 + _t15 * _t14}};
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
@@ -264,7 +264,7 @@ double const_matmul_sum(double a, double b, double c, double d) {
 //CHECK-NEXT:           _result[2UL] += _d_A[1][0];
 //CHECK-NEXT:           _result[3UL] += _d_A[1][1];
 //CHECK-NEXT:       }
-//CHECK-NEXT:   } 
+//CHECK-NEXT:   }
 
 int main () { // expected-no-diagnostics
   auto dsum = clad::differentiate(sum, 0);

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -17,9 +17,9 @@ double f1(double x, double y) {
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _result[1UL] += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d_x0 = 0;
-//CHECK-NEXT:           _result[1UL] += _result[0UL];
-//CHECK-NEXT:           _result[0UL] = _r_d_x0;
+//CHECK-NEXT:           double _r_d0 = _result[0UL];
+//CHECK-NEXT:          _result[1UL] += _r_d0;
+//CHECK-NEXT:          _result[0UL] -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -39,9 +39,9 @@ double f2(double x, double y) {
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _result[0UL] += 1;
 //CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:           double _r_d_x0 = 0;
-//CHECK-NEXT:           _result[1UL] += _result[0UL];
-//CHECK-NEXT:           _result[0UL] = _r_d_x0;
+//CHECK-NEXT:          double _r_d0 = _result[0UL];
+//CHECK-NEXT:         _result[1UL] += _r_d0;
+//CHECK-NEXT:         _result[0UL] -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -62,39 +62,39 @@ double f3(double x, double y) {
 //CHECK-NEXT:       x = x;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       x = _t1 * x;
+//CHECK-NEXT:       x = _t1 * _t0;
 //CHECK-NEXT:       _t3 = x;
 //CHECK-NEXT:       _t2 = x;
-//CHECK-NEXT:       y = _t3 * x;
+//CHECK-NEXT:       y = _t3 * _t2;
 //CHECK-NEXT:       x = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _result[1UL] += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d_x2 = 0;
-//CHECK-NEXT:           _result[1UL] += _result[0UL];
-//CHECK-NEXT:           _result[0UL] = _r_d_x2;
+//CHECK-NEXT:           double _r_d3 = _result[0UL];
+//CHECK-NEXT:           _result[1UL] += _r_d3;
+//CHECK-NEXT:           _result[0UL] -= _r_d3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d_y0 = 0;
-//CHECK-NEXT:           double _r2 = _result[1UL] * _t2;
+//CHECK-NEXT:           double _r_d2 = _result[1UL];
+//CHECK-NEXT:           double _r2 = _r_d2 * _t2;
 //CHECK-NEXT:           _result[0UL] += _r2;
-//CHECK-NEXT:           double _r3 = _t3 * _result[1UL];
+//CHECK-NEXT:           double _r3 = _t3 * _r_d2;
 //CHECK-NEXT:           _result[0UL] += _r3;
-//CHECK-NEXT:           _result[1UL] = _r_d_y0;
+//CHECK-NEXT:           _result[1UL] -= _r_d2;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d_x1 = 0;
-//CHECK-NEXT:           double _r0 = _result[0UL] * _t0;
-//CHECK-NEXT:           _r_d_x1 += _r0;
-//CHECK-NEXT:           double _r1 = _t1 * _result[0UL];
-//CHECK-NEXT:           _r_d_x1 += _r1;
-//CHECK-NEXT:           _result[0UL] = _r_d_x1;
+//CHECK-NEXT:           double _r_d1 = _result[0UL];
+//CHECK-NEXT:           double _r0 = _r_d1 * _t0;
+//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           double _r1 = _t1 * _r_d1;
+//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           _result[0UL] -= _r_d1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d_x0 = 0;
-//CHECK-NEXT:           _r_d_x0 += _result[0UL];
-//CHECK-NEXT:           _result[0UL] = _r_d_x0;
+//CHECK-NEXT:           double _r_d0 = _result[0UL];
+//CHECK-NEXT:           _result[0UL] += _r_d0;
+//CHECK-NEXT:           _result[0UL] -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -112,13 +112,13 @@ double f4(double x, double y) {
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _result[1UL] += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d_x0 = 0;
-//CHECK-NEXT:           _result[0UL] = _r_d_x0;
+//CHECK-NEXT:           double _r_d1 = _result[0UL];
+//CHECK-NEXT:           _result[0UL] -= _r_d1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d_y0 = 0;
-//CHECK-NEXT:           _result[0UL] += _result[1UL];
-//CHECK-NEXT:           _result[1UL] = _r_d_y0;
+//CHECK-NEXT:           double _r_d0 = _result[1UL];
+//CHECK-NEXT:           _result[0UL] += _r_d0;
+//CHECK-NEXT:           _result[1UL] -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -145,7 +145,7 @@ double f5(double x, double y) {
 //CHECK-NEXT:       double _d_z = 0;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       double t = _t1 * x;
+//CHECK-NEXT:       double t = _t1 * _t0;
 //CHECK-NEXT:       _cond0 = x < 0;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           t = -t;
@@ -161,9 +161,9 @@ double f5(double x, double y) {
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           {
-//CHECK-NEXT:               double _r_d_t1 = 0;
-//CHECK-NEXT:               _r_d_t1 += -_d_t;
-//CHECK-NEXT:               _d_t = _r_d_t1;
+//CHECK-NEXT:               double _r_d1 = _d_t;
+//CHECK-NEXT:               _d_t += -_r_d1;
+//CHECK-NEXT:               _d_t -= _r_d1;
 //CHECK-NEXT:           }
 //CHECK-NEXT:           _d_t += _d_z;
 //CHECK-NEXT:       }
@@ -171,9 +171,9 @@ double f5(double x, double y) {
 //CHECK-NEXT:         _label0:
 //CHECK-NEXT:           _d_t += 1;
 //CHECK-NEXT:           {
-//CHECK-NEXT:               double _r_d_t0 = 0;
-//CHECK-NEXT:               _r_d_t0 += -_d_t;
-//CHECK-NEXT:               _d_t = _r_d_t0;
+//CHECK-NEXT:               double _r_d0 = _d_t;
+//CHECK-NEXT:               _d_t += -_r_d0;
+//CHECK-NEXT:               _d_t -= _r_d0;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
@@ -207,7 +207,7 @@ double f6(double x, double y) {
 //CHECK-NEXT:       double _d_z = 0;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       double t = _t1 * x;
+//CHECK-NEXT:       double t = _t1 * _t0;
 //CHECK-NEXT:       _cond0 = x < 0;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           t = -t;
@@ -223,9 +223,9 @@ double f6(double x, double y) {
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           {
-//CHECK-NEXT:               double _r_d_t1 = 0;
-//CHECK-NEXT:               _r_d_t1 += -_d_t;
-//CHECK-NEXT:               _d_t = _r_d_t1;
+//CHECK-NEXT:               double _r_d1 = _d_t;
+//CHECK-NEXT:               _d_t += -_r_d1;
+//CHECK-NEXT:               _d_t -= _r_d1;
 //CHECK-NEXT:           }
 //CHECK-NEXT:           _d_t += _d_z;
 //CHECK-NEXT:       }
@@ -233,9 +233,9 @@ double f6(double x, double y) {
 //CHECK-NEXT:         _label0:
 //CHECK-NEXT:           _d_t += 1;
 //CHECK-NEXT:           {
-//CHECK-NEXT:               double _r_d_t0 = 0;
-//CHECK-NEXT:               _r_d_t0 += -_d_t;
-//CHECK-NEXT:               _d_t = _r_d_t0;
+//CHECK-NEXT:               double _r_d0 = _d_t;
+//CHECK-NEXT:               _d_t += -_r_d0;
+//CHECK-NEXT:               _d_t -= _r_d0;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
@@ -243,6 +243,143 @@ double f6(double x, double y) {
 //CHECK-NEXT:           _result[0UL] += _r0;
 //CHECK-NEXT:           double _r1 = _t1 * _d_t;
 //CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:       }
+//CHECK-NEXT:   }
+
+double f7(double x, double y) {
+  double t[] = {1, x, x * x};
+  t[0]++;
+  t[0]--;
+  ++t[0];
+  --t[0];
+  t[0] = x;
+  x = y;
+  t[0] += t[1];
+  t[0] *= t[1];
+  t[0] /= t[1];
+  t[0] -= t[1];
+  x = ++t[0];
+  return t[0]; // == x
+}
+
+//CHECK:   void f7_grad(double x, double y, double *_result) {
+//CHECK-NEXT:       double _t0;
+//CHECK-NEXT:       double _t1;
+//CHECK-NEXT:       double _d_t[3] = {};
+//CHECK-NEXT:       double _t2;
+//CHECK-NEXT:       double _t3;
+//CHECK-NEXT:       double _t4;
+//CHECK-NEXT:       double _t5;
+//CHECK-NEXT:       _t1 = x;
+//CHECK-NEXT:       _t0 = x;
+//CHECK-NEXT:       double t[3] = {1, x, _t1 * _t0};
+//CHECK-NEXT:       t[0]++;
+//CHECK-NEXT:       t[0]--;
+//CHECK-NEXT:       ++t[0];
+//CHECK-NEXT:       --t[0];
+//CHECK-NEXT:       t[0] = x;
+//CHECK-NEXT:       x = y;
+//CHECK-NEXT:       t[0] += t[1];
+//CHECK-NEXT:       double &_ref0 = t[0];
+//CHECK-NEXT:       _t3 = _ref0;
+//CHECK-NEXT:       _t2 = t[1];
+//CHECK-NEXT:       _ref0 *= _t2;
+//CHECK-NEXT:       double &_ref1 = t[0];
+//CHECK-NEXT:       _t5 = _ref1;
+//CHECK-NEXT:       _t4 = t[1];
+//CHECK-NEXT:       _ref1 /= _t4;
+//CHECK-NEXT:       t[0] -= t[1];
+//CHECK-NEXT:       x = ++t[0];
+//CHECK-NEXT:       goto _label0;
+//CHECK-NEXT:     _label0:
+//CHECK-NEXT:       _d_t[0] += 1;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           double _r_d6 = _result[0UL];
+//CHECK-NEXT:           _d_t[0] += _r_d6;
+//CHECK-NEXT:           _result[0UL] -= _r_d6;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       {
+//CHECK-NEXT:           double _r_d5 = _d_t[0];
+//CHECK-NEXT:           _d_t[0] += _r_d5;
+//CHECK-NEXT:           _d_t[1] += -_r_d5;
+//CHECK-NEXT:           _d_t[0] -= _r_d5;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       {
+//CHECK-NEXT:           double _r_d4 = _d_t[0];
+//CHECK-NEXT:           _d_t[0] += _r_d4 / _t4;
+//CHECK-NEXT:           double _r3 = _r_d4 * -_t5 / (_t4 * _t4);
+//CHECK-NEXT:           _d_t[1] += _r3;
+//CHECK-NEXT:           _d_t[0] -= _r_d4;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       {
+//CHECK-NEXT:           double _r_d3 = _d_t[0];
+//CHECK-NEXT:           _d_t[0] += _r_d3 * _t2;
+//CHECK-NEXT:           double _r2 = _t3 * _r_d3;
+//CHECK-NEXT:           _d_t[1] += _r2;
+//CHECK-NEXT:           _d_t[0] -= _r_d3;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       {
+//CHECK-NEXT:           double _r_d2 = _d_t[0];
+//CHECK-NEXT:           _d_t[0] += _r_d2;
+//CHECK-NEXT:           _d_t[1] += _r_d2;
+//CHECK-NEXT:           _d_t[0] -= _r_d2;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       {
+//CHECK-NEXT:           double _r_d1 = _result[0UL];
+//CHECK-NEXT:           _result[1UL] += _r_d1;
+//CHECK-NEXT:           _result[0UL] -= _r_d1;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       {
+//CHECK-NEXT:           double _r_d0 = _d_t[0];
+//CHECK-NEXT:           _result[0UL] += _r_d0;
+//CHECK-NEXT:           _d_t[0] -= _r_d0;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       {
+//CHECK-NEXT:           _result[0UL] += _d_t[1];
+//CHECK-NEXT:           double _r0 = _d_t[2] * _t0;
+//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           double _r1 = _t1 * _d_t[2];
+//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:       }
+//CHECK-NEXT:   }
+
+double f8(double x, double y) {
+  double t[] = {1, x, y, 1};
+  t[3] = (y *= (t[0] = t[1] = t[2]));
+  return t[3]; // == y * y
+}
+
+//CHECK:   void f8_grad(double x, double y, double *_result) {
+//CHECK-NEXT:       double _d_t[4] = {};
+//CHECK-NEXT:       double _t0;
+//CHECK-NEXT:       double _t1;
+//CHECK-NEXT:       double t[4] = {1, x, y, 1};
+//CHECK-NEXT:       double &_ref0 = y;
+//CHECK-NEXT:       _t1 = _ref0;
+//CHECK-NEXT:       _t0 = (t[0] = t[1] = t[2]);
+//CHECK-NEXT:       t[3] = (_ref0 *= _t0);
+//CHECK-NEXT:       goto _label0;
+//CHECK-NEXT:     _label0:
+//CHECK-NEXT:       _d_t[3] += 1;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           double _r_d0 = _d_t[3];
+//CHECK-NEXT:           _result[1UL] += _r_d0;
+//CHECK-NEXT:           double _r_d1 = _result[1UL];
+//CHECK-NEXT:           _result[1UL] += _r_d1 * _t0;
+//CHECK-NEXT:           double _r0 = _t1 * _r_d1;
+//CHECK-NEXT:           _d_t[0] += _r0;
+//CHECK-NEXT:           double _r_d2 = _d_t[0];
+//CHECK-NEXT:           _d_t[1] += _r_d2;
+//CHECK-NEXT:           double _r_d3 = _d_t[1];
+//CHECK-NEXT:           _d_t[2] += _r_d3;
+//CHECK-NEXT:           _d_t[1] -= _r_d3;
+//CHECK-NEXT:           _d_t[0] -= _r_d2;
+//CHECK-NEXT:           _result[1UL] -= _r_d1;
+//CHECK-NEXT:           _d_t[3] -= _r_d0;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       {
+//CHECK-NEXT:           _result[0UL] += _d_t[1];
+//CHECK-NEXT:           _result[1UL] += _d_t[2];
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -261,4 +398,6 @@ int main() {
   TEST(f4, 3, 4); // CHECK-EXEC: {1.00, 0.00} 
   TEST(f5, -3, 4); // NOT-CHECK-EXEC: {-6.00, 0.00} 
   TEST(f6, 3, -4); // CHECK-EXEC: {-6.00, 0.00} 
+  TEST(f7, 3, 4); // CHECK-EXEC: {1.00, 0.00}
+  TEST(f8, 3, 4); // CHECK-EXEC: {0.00, 8.00}
 }

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -63,7 +63,7 @@ double f_add3(double x, double y) {
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       _t4 = 4;
 //CHECK-NEXT:       _t3 = y;
-//CHECK-NEXT:       _t5 = _t4 * y;
+//CHECK-NEXT:       _t5 = _t4 * _t3;
 //CHECK-NEXT:       _t2 = 4;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
@@ -77,7 +77,7 @@ double f_add3(double x, double y) {
 //CHECK-NEXT:           _result[1UL] += _r4;
 //CHECK-NEXT:           double _r5 = _t5 * 1;
 //CHECK-NEXT:       }
-//CHECK-NEXT:   } 
+//CHECK-NEXT:   }
 
 void f_add3_grad(double x, double y, double *_result);
 
@@ -156,9 +156,9 @@ double f_mult2(double x, double y) {
 //CHECK-NEXT:       double _t5;
 //CHECK-NEXT:       _t3 = 3;
 //CHECK-NEXT:       _t2 = x;
-//CHECK-NEXT:       _t4 = _t3 * x;
+//CHECK-NEXT:       _t4 = _t3 * _t2;
 //CHECK-NEXT:       _t1 = 4;
-//CHECK-NEXT:       _t5 = _t4 * 4;
+//CHECK-NEXT:       _t5 = _t4 * _t1;
 //CHECK-NEXT:       _t0 = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
@@ -210,10 +210,10 @@ double f_div2(double x, double y) {
 //CHECK-NEXT:       int _t5;
 //CHECK-NEXT:       _t2 = 3;
 //CHECK-NEXT:       _t1 = x;
-//CHECK-NEXT:       _t3 = _t2 * x;
+//CHECK-NEXT:       _t3 = _t2 * _t1;
 //CHECK-NEXT:       _t5 = 4;
 //CHECK-NEXT:       _t4 = y;
-//CHECK-NEXT:       _t0 = (_t5 * y);
+//CHECK-NEXT:       _t0 = (_t5 * _t4);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
@@ -248,7 +248,7 @@ double f_c(double x, double y) {
 //CHECK-NEXT:       _t3 = (x + y);
 //CHECK-NEXT:       _t5 = x;
 //CHECK-NEXT:       _t4 = y;
-//CHECK-NEXT:       _t2 = (_t5 / y);
+//CHECK-NEXT:       _t2 = (_t5 / _t4);
 //CHECK-NEXT:       _t7 = x;
 //CHECK-NEXT:       _t6 = x;
 //CHECK-NEXT:       goto _label0;
@@ -271,7 +271,7 @@ double f_c(double x, double y) {
 //CHECK-NEXT:           double _r7 = _t7 * -1;
 //CHECK-NEXT:           _result[0UL] += _r7;
 //CHECK-NEXT:       }
-//CHECK-NEXT:   } 
+//CHECK-NEXT:   }
 
 void f_c_grad(double x, double y, double *_result);
 
@@ -295,11 +295,11 @@ double f_rosenbrock(double x, double y) {
 //CHECK-NEXT:       _t4 = 100;
 //CHECK-NEXT:       _t6 = x;
 //CHECK-NEXT:       _t5 = x;
-//CHECK-NEXT:       _t3 = (y - _t6 * x);
-//CHECK-NEXT:       _t7 = _t4 * (y - _t6 * x);
+//CHECK-NEXT:       _t3 = (y - _t6 * _t5);
+//CHECK-NEXT:       _t7 = _t4 * _t3;
 //CHECK-NEXT:       _t9 = x;
 //CHECK-NEXT:       _t8 = x;
-//CHECK-NEXT:       _t2 = (y - _t9 * x);
+//CHECK-NEXT:       _t2 = (y - _t9 * _t8);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
@@ -322,7 +322,7 @@ double f_rosenbrock(double x, double y) {
 //CHECK-NEXT:           double _r9 = _t9 * -_r7;
 //CHECK-NEXT:           _result[0UL] += _r9;
 //CHECK-NEXT:       }
-//CHECK-NEXT:   } 
+//CHECK-NEXT:   }
 
 void f_rosenbrock_grad(double x, double y, double *_result);
 
@@ -504,11 +504,10 @@ void f_norm_grad(double x, double y, double z, double d, double* _result);
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       _t2 = z;
 //CHECK-NEXT:       _t3 = d;
-//CHECK-NEXT:       _t4 = sum_of_powers(x, y, z, d);
+//CHECK-NEXT:       _t4 = sum_of_powers(_t0, _t1, _t2, _t3);
 //CHECK-NEXT:       _t6 = 1;
 //CHECK-NEXT:       _t5 = d;
-//CHECK-NEXT:       _t7 = _t6 / d;
-//NOT-CHECK-NEXT:       std::pow(sum_of_powers(x, y, z, d), _t6 / d);
+//CHECK-NEXT:       _t7 = _t6 / _t5;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
@@ -544,7 +543,7 @@ void f_sin_grad(double x, double y, double* _result);
 //CHECK-NEXT:       double _t3;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       _t3 = (std::sin(x) + std::sin(y));
+//CHECK-NEXT:       _t3 = (std::sin(_t1) + std::sin(_t2));
 //CHECK-NEXT:       _t0 = (x + y);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
@@ -595,10 +594,10 @@ void f_decls1_grad(double x, double y, double* _result);
 //CHECK-NEXT:       int _t5;
 //CHECK-NEXT:       _t1 = 3;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       double a = _t1 * x;
+//CHECK-NEXT:       double a = _t1 * _t0;
 //CHECK-NEXT:       _t3 = 5;
 //CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       double b = _t3 * y;
+//CHECK-NEXT:       double b = _t3 * _t2;
 //CHECK-NEXT:       double c = a + b;
 //CHECK-NEXT:       _t5 = 2;
 //CHECK-NEXT:       _t4 = c;
@@ -647,13 +646,13 @@ void f_decls2_grad(double x, double y, double* _result);
 //CHECK-NEXT:       int _t7;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       double a = _t1 * x;
+//CHECK-NEXT:       double a = _t1 * _t0;
 //CHECK-NEXT:       _t3 = x;
 //CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       double b = _t3 * y;
+//CHECK-NEXT:       double b = _t3 * _t2;
 //CHECK-NEXT:       _t5 = y;
 //CHECK-NEXT:       _t4 = y;
-//CHECK-NEXT:       double c = _t5 * y;
+//CHECK-NEXT:       double c = _t5 * _t4;
 //CHECK-NEXT:       _t7 = 2;
 //CHECK-NEXT:       _t6 = b;
 //CHECK-NEXT:       goto _label0;
@@ -715,10 +714,10 @@ void f_decls3_grad(double x, double y, double* _result);
 //CHECK-NEXT:       double _d_b = 0;
 //CHECK-NEXT:       _t1 = 3;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       double a = _t1 * x;
+//CHECK-NEXT:       double a = _t1 * _t0;
 //CHECK-NEXT:       _t3 = 333;
 //CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       double c = _t3 * y;
+//CHECK-NEXT:       double c = _t3 * _t2;
 //CHECK-NEXT:       _cond0 = x > 1;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           _t5 = 2;
@@ -734,7 +733,7 @@ void f_decls3_grad(double x, double y, double* _result);
 //CHECK-NEXT:       }
 //CHECK-NEXT:       _t9 = a;
 //CHECK-NEXT:       _t8 = a;
-//CHECK-NEXT:       double b = _t9 * a;
+//CHECK-NEXT:       double b = _t9 * _t8;
 //CHECK-NEXT:       goto _label2;
 //CHECK-NEXT:     _label2:
 //CHECK-NEXT:       _d_b += 1;

--- a/test/NestedCalls/NestedCalls.C
+++ b/test/NestedCalls/NestedCalls.C
@@ -73,9 +73,9 @@ double f(double x, double y) {
 //CHECK-NEXT:       double _t2;
 //CHECK-NEXT:       double _t3;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t1 = std::sin(x);
+//CHECK-NEXT:       _t1 = std::sin(_t0);
 //CHECK-NEXT:       _t2 = x;
-//CHECK-NEXT:       _t3 = std::cos(x);
+//CHECK-NEXT:       _t3 = std::cos(_t2);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
@@ -98,7 +98,7 @@ double f(double x, double y) {
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       double t = one(x);
+//CHECK-NEXT:       double t = one(_t0);
 //CHECK-NEXT:       _t2 = t;
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       goto _label0;


### PR DESCRIPTION
Now reverse mode supports operators `+=`, `-=`, `*=`, `/=`, `,`, `++`, `--`.

Assignments to array subscripts are now supported.

Now we also support nested assignments, even as parts of other expressions, like
`a = b * ((c ? d : e) = f = g);`

Storing expressions with side effects (e.g. assignments like `a *= b`) is fixed. The problem was that the expression was stored once and then reused
again in the forward pass, causing it to be executed twice, like:
```
...
_t0 = (x *= y)
...
t = (x *= y) * z
```
which lead to `x` being  updated twice and gave incorrect results in some cases. Now the stored temporary variable is used instead:
```
...
_t0 = (x *= y)
...
t = _t0 * z
```

Additionally, passing `dfdx()` as a parameter for `Visit` was optimized. It is no longer pushed on the stack repeatedly. Also, when `dfdx()` is zero,
derivatives are no longer updated with zero expressions, since it has no effect anyway. Thus we avoid creating useless expressions sometimes.
