### PR TITLE
Optimize stores, fix issues with compound statements in reverse mode

### DIFF
--- a/test/Arrays/Arrays.C
+++ b/test/Arrays/Arrays.C
@@ -56,10 +56,8 @@ double sum_squares(double x, double y, double z) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           int _d_i = 0;
 //CHECK-NEXT:           for (int i = 0; i < 3; i++) {
-//CHECK-NEXT:               double _t0 = vars[i];
-//CHECK-NEXT:               double _t1 = vars[i];
-//CHECK-NEXT:               _d_squares[i] = _d_vars[i] * _t1 + _t0 * _d_vars[i];
-//CHECK-NEXT:               squares[i] = _t0 * _t1;
+//CHECK-NEXT:               _d_squares[i] = _d_vars[i] * vars[i] + vars[i] * _d_vars[i];
+//CHECK-NEXT:               squares[i] = vars[i] * vars[i];
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       double _d_s = 0;
@@ -88,13 +86,7 @@ double const_dot_product(double x, double y, double z) {
 //CHECK-NEXT:       double vars[3] = {x, y, z};
 //CHECK-NEXT:       double _d_consts[3] = {0, 0, 0};
 //CHECK-NEXT:       double consts[3] = {1, 2, 3};
-//CHECK-NEXT:       double _t0 = vars[0];
-//CHECK-NEXT:       double _t1 = consts[0];
-//CHECK-NEXT:       double _t2 = vars[1];
-//CHECK-NEXT:       double _t3 = consts[1];
-//CHECK-NEXT:       double _t4 = vars[2];
-//CHECK-NEXT:       double _t5 = consts[2];
-//CHECK-NEXT:       return _d_vars[0] * _t1 + _t0 * _d_consts[0] + _d_vars[1] * _t3 + _t2 * _d_consts[1] + _d_vars[2] * _t5 + _t4 * _d_consts[2];
+//CHECK-NEXT:       return _d_vars[0] * consts[0] + vars[0] * _d_consts[0] + _d_vars[1] * consts[1] + vars[1] * _d_consts[1] + _d_vars[2] * consts[2] + vars[2] * _d_consts[2];
 //CHECK-NEXT:   }
 
 //CHECK:   void const_dot_product_grad(double x, double y, double z, double *_result) {
@@ -156,24 +148,8 @@ double const_matmul_sum(double a, double b, double c, double d) {
 //CHECK-NEXT:       double A[2][2] = {{[{][{]}}a, b}, {c, d}};
 //CHECK-NEXT:       double _d_B[2][2] = {{[{][{]}}0, 0}, {0, 0}};
 //CHECK-NEXT:       double B[2][2] = {{[{][{]}}1, 2}, {3, 4}};
-//CHECK-NEXT:       double _t0 = A[0][0];
-//CHECK-NEXT:       double _t1 = B[0][0];
-//CHECK-NEXT:       double _t2 = A[0][1];
-//CHECK-NEXT:       double _t3 = B[1][0];
-//CHECK-NEXT:       double _t4 = A[0][0];
-//CHECK-NEXT:       double _t5 = B[0][1];
-//CHECK-NEXT:       double _t6 = A[0][1];
-//CHECK-NEXT:       double _t7 = B[1][1];
-//CHECK-NEXT:       double _t8 = A[1][0];
-//CHECK-NEXT:       double _t9 = B[0][0];
-//CHECK-NEXT:       double _t10 = A[1][1];
-//CHECK-NEXT:       double _t11 = B[1][0];
-//CHECK-NEXT:       double _t12 = A[1][0];
-//CHECK-NEXT:       double _t13 = B[0][1];
-//CHECK-NEXT:       double _t14 = A[1][1];
-//CHECK-NEXT:       double _t15 = B[1][1];
-//CHECK-NEXT:       double _d_C[2][2] = {{[{][{]}}_d_A[0][0] * _t1 + _t0 * _d_B[0][0] + _d_A[0][1] * _t3 + _t2 * _d_B[1][0], _d_A[0][0] * _t5 + _t4 * _d_B[0][1] + _d_A[0][1] * _t7 + _t6 * _d_B[1][1]}, {_d_A[1][0] * _t9 + _t8 * _d_B[0][0] + _d_A[1][1] * _t11 + _t10 * _d_B[1][0], _d_A[1][0] * _t13 + _t12 * _d_B[0][1] + _d_A[1][1] * _t15 + _t14 * _d_B[1][1]}};
-//CHECK-NEXT:       double C[2][2] = {{[{][{]}}_t0 * _t1 + _t2 * _t3, _t4 * _t5 + _t6 * _t7}, {_t8 * _t9 + _t10 * _t11, _t12 * _t13 + _t14 * _t15}};
+//CHECK-NEXT:       double _d_C[2][2] = {{[{][{]}}_d_A[0][0] * B[0][0] + A[0][0] * _d_B[0][0] + _d_A[0][1] * B[1][0] + A[0][1] * _d_B[1][0], _d_A[0][0] * B[0][1] + A[0][0] * _d_B[0][1] + _d_A[0][1] * B[1][1] + A[0][1] * _d_B[1][1]}, {_d_A[1][0] * B[0][0] + A[1][0] * _d_B[0][0] + _d_A[1][1] * B[1][0] + A[1][1] * _d_B[1][0], _d_A[1][0] * B[0][1] + A[1][0] * _d_B[0][1] + _d_A[1][1] * B[1][1] + A[1][1] * _d_B[1][1]}};
+//CHECK-NEXT:       double C[2][2] = {{[{][{]}}A[0][0] * B[0][0] + A[0][1] * B[1][0], A[0][0] * B[0][1] + A[0][1] * B[1][1]}, {A[1][0] * B[0][0] + A[1][1] * B[1][0], A[1][0] * B[0][1] + A[1][1] * B[1][1]}};
 //CHECK-NEXT:       return _d_C[0][0] + _d_C[0][1] + _d_C[1][0] + _d_C[1][1];
 //CHECK-NEXT:   }
 

--- a/test/FirstDerivative/DependencyTracking.C
+++ b/test/FirstDerivative/DependencyTracking.C
@@ -23,9 +23,8 @@ double f(double x) {
 //CHECK-NEXT:       double _d_result = 0.;
 //CHECK-NEXT:       double result = 0.;
 //CHECK-NEXT:       if (x < 0) {
-//CHECK-NEXT:           double _t0 = -x;
-//CHECK-NEXT:           _d_result = -_d_x * x + _t0 * _d_x;
-//CHECK-NEXT:           result = _t0 * x;
+//CHECK-NEXT:           _d_result = -_d_x * x + -x * _d_x;
+//CHECK-NEXT:           result = -x * x;
 //CHECK-NEXT:       } else {
 //CHECK-NEXT:           _d_result = _d_x * x + x * _d_x;
 //CHECK-NEXT:           result = x * x;

--- a/test/FirstDerivative/FunctionsOneVariable.C
+++ b/test/FirstDerivative/FunctionsOneVariable.C
@@ -40,8 +40,7 @@ int f_simple_negative(int x) {
 }
 // CHECK: int f_simple_negative_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: int _t0 = -x;
-// CHECK-NEXT: return -_d_x * x + _t0 * _d_x;
+// CHECK-NEXT: return -_d_x * x + -x * _d_x;
 // CHECK-NEXT: }
 
 int main () {

--- a/test/FirstDerivative/NonContinuous.C
+++ b/test/FirstDerivative/NonContinuous.C
@@ -17,10 +17,8 @@ int f(int x) {
 }
 // CHECK: int f_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: if (x < 0) {
-// CHECK-NEXT:   int _t0 = -x;
-// CHECK-NEXT:   return -_d_x * x + _t0 * _d_x;
-// CHECK-NEXT: }
+// CHECK-NEXT: if (x < 0)
+// CHECK-NEXT:   return -_d_x * x + -x * _d_x;
 // CHECK-NEXT: return _d_x * x + x * _d_x;
 // CHECK-NEXT: }
 
@@ -33,10 +31,9 @@ int f1(int x) {
 }
 // CHECK: int f1_darg0(int x) {
 // CHECK-NEXT:  int _d_x = 1;
-// CHECK-NEXT:  if (x < 0) {
-// CHECK-NEXT:    int _t0 = -x;
-// CHECK-NEXT:    return -_d_x * x + _t0 * _d_x;
-// CHECK-NEXT:  } else
+// CHECK-NEXT:  if (x < 0)
+// CHECK-NEXT:    return -_d_x * x + -x * _d_x;
+// CHECK-NEXT:  else
 // CHECK-NEXT:    return _d_x * x + x * _d_x;
 // CHECK-NEXT: }
 

--- a/test/Gradient/DiffInterface.C
+++ b/test/Gradient/DiffInterface.C
@@ -14,28 +14,22 @@ double f_1(double x, double y, double z) {
 // all
 //CHECK:   void f_1_grad(double x, double y, double z, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       int _t5;
-//CHECK-NEXT:       _t1 = 0;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t3 = 1;
-//CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       _t5 = 2;
-//CHECK-NEXT:       _t4 = z;
+//CHECK-NEXT:       _t1 = y;
+//CHECK-NEXT:       _t2 = z;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
+//CHECK-NEXT:           double _r1 = 0 * 1;
 //CHECK-NEXT:           _result[0UL] += _r1;
-//CHECK-NEXT:           double _r2 = 1 * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * 1;
+//CHECK-NEXT:           double _r2 = 1 * _t1;
+//CHECK-NEXT:           double _r3 = 1 * 1;
 //CHECK-NEXT:           _result[1UL] += _r3;
-//CHECK-NEXT:           double _r4 = 1 * _t4;
-//CHECK-NEXT:           double _r5 = _t5 * 1;
+//CHECK-NEXT:           double _r4 = 1 * _t2;
+//CHECK-NEXT:           double _r5 = 2 * 1;
 //CHECK-NEXT:           _result[2UL] += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -43,165 +37,129 @@ double f_1(double x, double y, double z) {
 // x
 //CHECK:   void f_1_grad_0(double x, double y, double z, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       int _t5;
-//CHECK-NEXT:       _t1 = 0;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t3 = 1;
-//CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       _t5 = 2;
-//CHECK-NEXT:       _t4 = z;
+//CHECK-NEXT:       _t1 = y;
+//CHECK-NEXT:       _t2 = z;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
+//CHECK-NEXT:           double _r1 = 0 * 1;
 //CHECK-NEXT:           _result[0UL] += _r1;
-//CHECK-NEXT:           double _r2 = 1 * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * 1;
-//CHECK-NEXT:           double _r4 = 1 * _t4;
-//CHECK-NEXT:           double _r5 = _t5 * 1;
+//CHECK-NEXT:           double _r2 = 1 * _t1;
+//CHECK-NEXT:           double _r3 = 1 * 1;
+//CHECK-NEXT:           double _r4 = 1 * _t2;
+//CHECK-NEXT:           double _r5 = 2 * 1;
 //CHECK-NEXT:       }
-//CHECK-NEXT:   } 
+//CHECK-NEXT:   }
 
 // y
 //CHECK:   void f_1_grad_1(double x, double y, double z, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       int _t5;
-//CHECK-NEXT:       _t1 = 0;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t3 = 1;
-//CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       _t5 = 2;
-//CHECK-NEXT:       _t4 = z;
+//CHECK-NEXT:       _t1 = y;
+//CHECK-NEXT:       _t2 = z;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
-//CHECK-NEXT:           double _r2 = 1 * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * 1;
+//CHECK-NEXT:           double _r1 = 0 * 1;
+//CHECK-NEXT:           double _r2 = 1 * _t1;
+//CHECK-NEXT:           double _r3 = 1 * 1;
 //CHECK-NEXT:           _result[0UL] += _r3;
-//CHECK-NEXT:           double _r4 = 1 * _t4;
-//CHECK-NEXT:           double _r5 = _t5 * 1;
+//CHECK-NEXT:           double _r4 = 1 * _t2;
+//CHECK-NEXT:           double _r5 = 2 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // z
 //CHECK:   void f_1_grad_2(double x, double y, double z, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       int _t5;
-//CHECK-NEXT:       _t1 = 0;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t3 = 1;
-//CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       _t5 = 2;
-//CHECK-NEXT:       _t4 = z;
+//CHECK-NEXT:       _t1 = y;
+//CHECK-NEXT:       _t2 = z;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
-//CHECK-NEXT:           double _r2 = 1 * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * 1;
-//CHECK-NEXT:           double _r4 = 1 * _t4;
-//CHECK-NEXT:           double _r5 = _t5 * 1;
+//CHECK-NEXT:           double _r1 = 0 * 1;
+//CHECK-NEXT:           double _r2 = 1 * _t1;
+//CHECK-NEXT:           double _r3 = 1 * 1;
+//CHECK-NEXT:           double _r4 = 1 * _t2;
+//CHECK-NEXT:           double _r5 = 2 * 1;
 //CHECK-NEXT:           _result[0UL] += _r5;
 //CHECK-NEXT:       }
-//CHECK-NEXT:   } 
+//CHECK-NEXT:   }
 
 // x, y
 //CHECK:   void f_1_grad_0_1(double x, double y, double z, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       int _t5;
-//CHECK-NEXT:       _t1 = 0;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t3 = 1;
-//CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       _t5 = 2;
-//CHECK-NEXT:       _t4 = z;
+//CHECK-NEXT:       _t1 = y;
+//CHECK-NEXT:       _t2 = z;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
+//CHECK-NEXT:           double _r1 = 0 * 1;
 //CHECK-NEXT:           _result[0UL] += _r1;
-//CHECK-NEXT:           double _r2 = 1 * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * 1;
+//CHECK-NEXT:           double _r2 = 1 * _t1;
+//CHECK-NEXT:           double _r3 = 1 * 1;
 //CHECK-NEXT:           _result[1UL] += _r3;
-//CHECK-NEXT:           double _r4 = 1 * _t4;
-//CHECK-NEXT:           double _r5 = _t5 * 1;
+//CHECK-NEXT:           double _r4 = 1 * _t2;
+//CHECK-NEXT:           double _r5 = 2 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // y, x
 //CHECK:   void f_1_grad_1_0(double x, double y, double z, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       int _t5;
-//CHECK-NEXT:       _t1 = 0;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t3 = 1;
-//CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       _t5 = 2;
-//CHECK-NEXT:       _t4 = z;
+//CHECK-NEXT:       _t1 = y;
+//CHECK-NEXT:       _t2 = z;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
+//CHECK-NEXT:           double _r1 = 0 * 1;
 //CHECK-NEXT:           _result[1UL] += _r1;
-//CHECK-NEXT:           double _r2 = 1 * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * 1;
+//CHECK-NEXT:           double _r2 = 1 * _t1;
+//CHECK-NEXT:           double _r3 = 1 * 1;
 //CHECK-NEXT:           _result[0UL] += _r3;
-//CHECK-NEXT:           double _r4 = 1 * _t4;
-//CHECK-NEXT:           double _r5 = _t5 * 1;
+//CHECK-NEXT:           double _r4 = 1 * _t2;
+//CHECK-NEXT:           double _r5 = 2 * 1;
 //CHECK-NEXT:       }
-//CHECK-NEXT:   } 
+//CHECK-NEXT:   }
 
 // x, y, z
 //CHECK:   void f_1_grad(double x, double y, double z, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       int _t5;
-//CHECK-NEXT:       _t1 = 0;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t3 = 1;
-//CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       _t5 = 2;
-//CHECK-NEXT:       _t4 = z;
+//CHECK-NEXT:       _t1 = y;
+//CHECK-NEXT:       _t2 = z;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
+//CHECK-NEXT:           double _r1 = 0 * 1;
 //CHECK-NEXT:           _result[0UL] += _r1;
-//CHECK-NEXT:           double _r2 = 1 * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * 1;
+//CHECK-NEXT:           double _r2 = 1 * _t1;
+//CHECK-NEXT:           double _r3 = 1 * 1;
 //CHECK-NEXT:           _result[1UL] += _r3;
-//CHECK-NEXT:           double _r4 = 1 * _t4;
-//CHECK-NEXT:           double _r5 = _t5 * 1;
+//CHECK-NEXT:           double _r4 = 1 * _t2;
+//CHECK-NEXT:           double _r5 = 2 * 1;
 //CHECK-NEXT:           _result[2UL] += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -209,28 +167,22 @@ double f_1(double x, double y, double z) {
 // z, y, z
 //CHECK:   void f_1_grad_2_1_0(double x, double y, double z, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       int _t5;
-//CHECK-NEXT:       _t1 = 0;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t3 = 1;
-//CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       _t5 = 2;
-//CHECK-NEXT:       _t4 = z;
+//CHECK-NEXT:       _t1 = y;
+//CHECK-NEXT:       _t2 = z;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
+//CHECK-NEXT:           double _r1 = 0 * 1;
 //CHECK-NEXT:           _result[2UL] += _r1;
-//CHECK-NEXT:           double _r2 = 1 * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * 1;
+//CHECK-NEXT:           double _r2 = 1 * _t1;
+//CHECK-NEXT:           double _r3 = 1 * 1;
 //CHECK-NEXT:           _result[1UL] += _r3;
-//CHECK-NEXT:           double _r4 = 1 * _t4;
-//CHECK-NEXT:           double _r5 = _t5 * 1;
+//CHECK-NEXT:           double _r4 = 1 * _t2;
+//CHECK-NEXT:           double _r5 = 2 * 1;
 //CHECK-NEXT:           _result[0UL] += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -27,24 +27,20 @@ double f_add2(double x, double y) {
 
 //CHECK:   void f_add2_grad(double x, double y, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
-//CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
-//CHECK-NEXT:       _t1 = 3;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t3 = 4;
-//CHECK-NEXT:       _t2 = y;
+//CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
+//CHECK-NEXT:           double _r1 = 3 * 1;
 //CHECK-NEXT:           _result[0UL] += _r1;
-//CHECK-NEXT:           double _r2 = 1 * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * 1;
+//CHECK-NEXT:           double _r2 = 1 * _t1;
+//CHECK-NEXT:           double _r3 = 4 * 1;
 //CHECK-NEXT:           _result[1UL] += _r3;
 //CHECK-NEXT:       }
-//CHECK-NEXT:   } 
+//CHECK-NEXT:   }
 
 void f_add2_grad(double x, double y, double *_result);
 
@@ -54,28 +50,19 @@ double f_add3(double x, double y) {
 
 //CHECK:   void f_add3_grad(double x, double y, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
-//CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       double _t3;
-//CHECK-NEXT:       int _t4;
-//CHECK-NEXT:       double _t5;
-//CHECK-NEXT:       _t1 = 3;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t4 = 4;
-//CHECK-NEXT:       _t3 = y;
-//CHECK-NEXT:       _t5 = _t4 * _t3;
-//CHECK-NEXT:       _t2 = 4;
+//CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
+//CHECK-NEXT:           double _r1 = 3 * 1;
 //CHECK-NEXT:           _result[0UL] += _r1;
-//CHECK-NEXT:           double _r2 = 1 * _t2;
-//CHECK-NEXT:           double _r3 = _r2 * _t3;
-//CHECK-NEXT:           double _r4 = _t4 * _r2;
+//CHECK-NEXT:           double _r2 = 1 * 4;
+//CHECK-NEXT:           double _r3 = _r2 * _t1;
+//CHECK-NEXT:           double _r4 = 4 * _r2;
 //CHECK-NEXT:           _result[1UL] += _r4;
-//CHECK-NEXT:           double _r5 = _t5 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -101,21 +88,17 @@ double f_sub2(double x, double y) {
 
 //CHECK:   void f_sub2_grad(double x, double y, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
-//CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
-//CHECK-NEXT:       _t1 = 3;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t3 = 4;
-//CHECK-NEXT:       _t2 = y;
+//CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
+//CHECK-NEXT:           double _r1 = 3 * 1;
 //CHECK-NEXT:           _result[0UL] += _r1;
-//CHECK-NEXT:           double _r2 = -1 * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * -1;
+//CHECK-NEXT:           double _r2 = -1 * _t1;
+//CHECK-NEXT:           double _r3 = 4 * -1;
 //CHECK-NEXT:           _result[1UL] += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -151,26 +134,19 @@ double f_mult2(double x, double y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       double _t5;
-//CHECK-NEXT:       _t3 = 3;
-//CHECK-NEXT:       _t2 = x;
-//CHECK-NEXT:       _t4 = _t3 * _t2;
-//CHECK-NEXT:       _t1 = 4;
-//CHECK-NEXT:       _t5 = _t4 * _t1;
+//CHECK-NEXT:       _t1 = x;
+//CHECK-NEXT:       _t2 = 3 * _t1 * 4;
 //CHECK-NEXT:       _t0 = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _r0 * _t1;
-//CHECK-NEXT:           double _r2 = _r1 * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * _r1;
+//CHECK-NEXT:           double _r1 = _r0 * 4;
+//CHECK-NEXT:           double _r2 = _r1 * _t1;
+//CHECK-NEXT:           double _r3 = 3 * _r1;
 //CHECK-NEXT:           _result[0UL] += _r3;
-//CHECK-NEXT:           double _r4 = _t4 * _r0;
-//CHECK-NEXT:           double _r5 = _t5 * 1;
-//CHECK-NEXT:           _result[1UL] += _r5;
+//CHECK-NEXT:           double _r4 = _t2 * 1;
+//CHECK-NEXT:           _result[1UL] += _r4;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -204,26 +180,22 @@ double f_div2(double x, double y) {
 //CHECK:   void f_div2_grad(double x, double y, double *_result) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       int _t2;
+//CHECK-NEXT:       double _t2;
 //CHECK-NEXT:       double _t3;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       int _t5;
-//CHECK-NEXT:       _t2 = 3;
 //CHECK-NEXT:       _t1 = x;
-//CHECK-NEXT:       _t3 = _t2 * _t1;
-//CHECK-NEXT:       _t5 = 4;
-//CHECK-NEXT:       _t4 = y;
-//CHECK-NEXT:       _t0 = (_t5 * _t4);
+//CHECK-NEXT:       _t2 = 3 * _t1;
+//CHECK-NEXT:       _t3 = y;
+//CHECK-NEXT:       _t0 = (4 * _t3);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 / _t0;
 //CHECK-NEXT:           double _r1 = _r0 * _t1;
-//CHECK-NEXT:           double _r2 = _t2 * _r0;
+//CHECK-NEXT:           double _r2 = 3 * _r0;
 //CHECK-NEXT:           _result[0UL] += _r2;
-//CHECK-NEXT:           double _r3 = 1 * -_t3 / (_t0 * _t0);
-//CHECK-NEXT:           double _r4 = _r3 * _t4;
-//CHECK-NEXT:           double _r5 = _t5 * _r3;
+//CHECK-NEXT:           double _r3 = 1 * -_t2 / (_t0 * _t0);
+//CHECK-NEXT:           double _r4 = _r3 * _t3;
+//CHECK-NEXT:           double _r5 = 4 * _r3;
 //CHECK-NEXT:           _result[1UL] += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -284,22 +256,20 @@ double f_rosenbrock(double x, double y) {
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
 //CHECK-NEXT:       double _t3;
-//CHECK-NEXT:       int _t4;
+//CHECK-NEXT:       double _t4;
 //CHECK-NEXT:       double _t5;
 //CHECK-NEXT:       double _t6;
 //CHECK-NEXT:       double _t7;
 //CHECK-NEXT:       double _t8;
-//CHECK-NEXT:       double _t9;
 //CHECK-NEXT:       _t1 = (x - 1);
 //CHECK-NEXT:       _t0 = (x - 1);
-//CHECK-NEXT:       _t4 = 100;
-//CHECK-NEXT:       _t6 = x;
 //CHECK-NEXT:       _t5 = x;
-//CHECK-NEXT:       _t3 = (y - _t6 * _t5);
-//CHECK-NEXT:       _t7 = _t4 * _t3;
-//CHECK-NEXT:       _t9 = x;
+//CHECK-NEXT:       _t4 = x;
+//CHECK-NEXT:       _t3 = (y - _t5 * _t4);
+//CHECK-NEXT:       _t6 = 100 * _t3;
 //CHECK-NEXT:       _t8 = x;
-//CHECK-NEXT:       _t2 = (y - _t9 * _t8);
+//CHECK-NEXT:       _t7 = x;
+//CHECK-NEXT:       _t2 = (y - _t8 * _t7);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
@@ -309,17 +279,17 @@ double f_rosenbrock(double x, double y) {
 //CHECK-NEXT:           _result[0UL] += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t2;
 //CHECK-NEXT:           double _r3 = _r2 * _t3;
-//CHECK-NEXT:           double _r4 = _t4 * _r2;
+//CHECK-NEXT:           double _r4 = 100 * _r2;
 //CHECK-NEXT:           _result[1UL] += _r4;
-//CHECK-NEXT:           double _r5 = -_r4 * _t5;
+//CHECK-NEXT:           double _r5 = -_r4 * _t4;
 //CHECK-NEXT:           _result[0UL] += _r5;
-//CHECK-NEXT:           double _r6 = _t6 * -_r4;
+//CHECK-NEXT:           double _r6 = _t5 * -_r4;
 //CHECK-NEXT:           _result[0UL] += _r6;
-//CHECK-NEXT:           double _r7 = _t7 * 1;
+//CHECK-NEXT:           double _r7 = _t6 * 1;
 //CHECK-NEXT:           _result[1UL] += _r7;
-//CHECK-NEXT:           double _r8 = -_r7 * _t8;
+//CHECK-NEXT:           double _r8 = -_r7 * _t7;
 //CHECK-NEXT:           _result[0UL] += _r8;
-//CHECK-NEXT:           double _r9 = _t9 * -_r7;
+//CHECK-NEXT:           double _r9 = _t8 * -_r7;
 //CHECK-NEXT:           _result[0UL] += _r9;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -335,11 +305,11 @@ double f_cond1(double x, double y) {
 //CHECK-NEXT:       _cond0 = x > y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
-//CHECK-NEXT:       {
-//CHECK-NEXT:           _result[0UL] += (_cond0 ? 1 : 0);
-//CHECK-NEXT:           _result[1UL] += (_cond0 ? 0 : 1);
-//CHECK-NEXT:       }
-//CHECK-NEXT:   } 
+//CHECK-NEXT:       if (_cond0)
+//CHECK-NEXT:           _result[0UL] += 1;
+//CHECK-NEXT:       else
+//CHECK-NEXT:           _result[1UL] += 1;
+//CHECK-NEXT:   }
 
 void f_cond1_grad(double x, double y, double *_result);
 
@@ -351,14 +321,18 @@ double f_cond2(double x, double y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       _cond0 = x > y;
-//CHECK-NEXT:       _cond1 = y > 0;
+//CHECK-NEXT:       if (_cond0)
+//CHECK-NEXT:           ;
+//CHECK-NEXT:       else
+//CHECK-NEXT:           _cond1 = y > 0;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
-//CHECK-NEXT:       {
-//CHECK-NEXT:           _result[0UL] += (_cond0 ? 1 : 0);
-//CHECK-NEXT:           _result[1UL] += (_cond1 ? (_cond0 ? 0 : 1) : 0);
-//CHECK-NEXT:           _result[1UL] += -(_cond1 ? 0 : (_cond0 ? 0 : 1));
-//CHECK-NEXT:       }
+//CHECK-NEXT:       if (_cond0)
+//CHECK-NEXT:           _result[0UL] += 1;
+//CHECK-NEXT:       else if (_cond1)
+//CHECK-NEXT:           _result[1UL] += 1;
+//CHECK-NEXT:       else
+//CHECK-NEXT:           _result[1UL] += -1;
 //CHECK-NEXT:   }
 
 void f_cond2_grad(double x, double y, double *_result);
@@ -372,11 +346,12 @@ double f_cond3(double x, double c) {
 //CHECK-NEXT:       _cond0 = c > 0;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
-//CHECK-NEXT:       {
-//CHECK-NEXT:           _result[0UL] += (_cond0 ? 1 : 0);
-//CHECK-NEXT:           _result[1UL] += (_cond0 ? 1 : 0);
-//CHECK-NEXT:           _result[0UL] += (_cond0 ? 0 : 1);
-//CHECK-NEXT:           _result[1UL] += -(_cond0 ? 0 : 1);
+//CHECK-NEXT:       if (_cond0) {
+//CHECK-NEXT:           _result[0UL] += 1;
+//CHECK-NEXT:           _result[1UL] += 1;
+//CHECK-NEXT:       } else {
+//CHECK-NEXT:           _result[0UL] += 1;
+//CHECK-NEXT:           _result[1UL] += -1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   } 
 
@@ -498,21 +473,19 @@ void f_norm_grad(double x, double y, double z, double d, double* _result);
 //CHECK-NEXT:       double _t3;
 //CHECK-NEXT:       double _t4;
 //CHECK-NEXT:       double _t5;
-//CHECK-NEXT:       int _t6;
-//CHECK-NEXT:       double _t7;
+//CHECK-NEXT:       double _t6;
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       _t2 = z;
 //CHECK-NEXT:       _t3 = d;
 //CHECK-NEXT:       _t4 = sum_of_powers(_t0, _t1, _t2, _t3);
-//CHECK-NEXT:       _t6 = 1;
 //CHECK-NEXT:       _t5 = d;
-//CHECK-NEXT:       _t7 = _t6 / _t5;
+//CHECK-NEXT:       _t6 = 1 / _t5;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _grad1[2] = {};
-//CHECK-NEXT:           custom_derivatives::pow_grad(_t4, _t7, _grad1);
+//CHECK-NEXT:           custom_derivatives::pow_grad(_t4, _t6, _grad1);
 //CHECK-NEXT:           double _r0 = 1 * _grad1[0UL];
 //CHECK-NEXT:           double _grad0[4] = {};
 //CHECK-NEXT:           custom_derivatives::sum_of_powers_grad(_t0, _t1, _t2, _t3, _grad0);
@@ -526,7 +499,7 @@ void f_norm_grad(double x, double y, double z, double d, double* _result);
 //CHECK-NEXT:           _result[3UL] += _r4;
 //CHECK-NEXT:           double _r5 = 1 * _grad1[1UL];
 //CHECK-NEXT:           double _r6 = _r5 / _t5;
-//CHECK-NEXT:           double _r7 = _r5 * -_t6 / (_t5 * _t5);
+//CHECK-NEXT:           double _r7 = _r5 * -1 / (_t5 * _t5);
 //CHECK-NEXT:           _result[3UL] += _r7;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -584,28 +557,22 @@ double f_decls1(double x, double y) {
 void f_decls1_grad(double x, double y, double* _result);
 //CHECK:   void f_decls1_grad(double x, double y, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
 //CHECK-NEXT:       double _d_a = 0;
-//CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_b = 0;
 //CHECK-NEXT:       double _d_c = 0;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       int _t5;
-//CHECK-NEXT:       _t1 = 3;
+//CHECK-NEXT:       double _t2;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       double a = _t1 * _t0;
-//CHECK-NEXT:       _t3 = 5;
-//CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       double b = _t3 * _t2;
+//CHECK-NEXT:       double a = 3 * _t0;
+//CHECK-NEXT:       _t1 = y;
+//CHECK-NEXT:       double b = 5 * _t1;
 //CHECK-NEXT:       double c = a + b;
-//CHECK-NEXT:       _t5 = 2;
-//CHECK-NEXT:       _t4 = c;
+//CHECK-NEXT:       _t2 = c;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r4 = 1 * _t4;
-//CHECK-NEXT:           double _r5 = _t5 * 1;
+//CHECK-NEXT:           double _r4 = 1 * _t2;
+//CHECK-NEXT:           double _r5 = 2 * 1;
 //CHECK-NEXT:           _d_c += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
@@ -613,13 +580,13 @@ void f_decls1_grad(double x, double y, double* _result);
 //CHECK-NEXT:           _d_b += _d_c;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r2 = _d_b * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * _d_b;
+//CHECK-NEXT:           double _r2 = _d_b * _t1;
+//CHECK-NEXT:           double _r3 = 5 * _d_b;
 //CHECK-NEXT:           _result[1UL] += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = _d_a * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * _d_a;
+//CHECK-NEXT:           double _r1 = 3 * _d_a;
 //CHECK-NEXT:           _result[0UL] += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -643,7 +610,6 @@ void f_decls2_grad(double x, double y, double* _result);
 //CHECK-NEXT:       double _t5;
 //CHECK-NEXT:       double _d_c = 0;
 //CHECK-NEXT:       double _t6;
-//CHECK-NEXT:       int _t7;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       double a = _t1 * _t0;
@@ -653,14 +619,13 @@ void f_decls2_grad(double x, double y, double* _result);
 //CHECK-NEXT:       _t5 = y;
 //CHECK-NEXT:       _t4 = y;
 //CHECK-NEXT:       double c = _t5 * _t4;
-//CHECK-NEXT:       _t7 = 2;
 //CHECK-NEXT:       _t6 = b;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += 1;
 //CHECK-NEXT:           double _r6 = 1 * _t6;
-//CHECK-NEXT:           double _r7 = _t7 * 1;
+//CHECK-NEXT:           double _r7 = 2 * 1;
 //CHECK-NEXT:           _d_b += _r7;
 //CHECK-NEXT:           _d_c += 1;
 //CHECK-NEXT:       }
@@ -685,86 +650,78 @@ void f_decls2_grad(double x, double y, double* _result);
 //CHECK-NEXT:   }
 
 double f_decls3(double x, double y) {
- double a = 3 * x;
- double c = 333 * y;
- if (x > 1)
-   return 2 * a;
- else if (x < -1)
-   return -2 * a;
- double b = a * a;
- return b;
+  double a = 3 * x;
+  double c = 333 * y;
+  if (x > 1)
+    return 2 * a;
+  else if (x < -1)
+    return -2 * a;
+  double b = a * a;
+  return b;
 }
 
 void f_decls3_grad(double x, double y, double* _result);
 //CHECK:   void f_decls3_grad(double x, double y, double *_result) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       int _t1;
 //CHECK-NEXT:       double _d_a = 0;
-//CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       int _t3;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_c = 0;
 //CHECK-NEXT:       bool _cond0;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       int _t5;
+//CHECK-NEXT:       double _t2;
 //CHECK-NEXT:       bool _cond1;
-//CHECK-NEXT:       double _t6;
-//CHECK-NEXT:       int _t7;
-//CHECK-NEXT:       double _t8;
-//CHECK-NEXT:       double _t9;
+//CHECK-NEXT:       double _t3;
+//CHECK-NEXT:       double _t4;
+//CHECK-NEXT:       double _t5;
 //CHECK-NEXT:       double _d_b = 0;
-//CHECK-NEXT:       _t1 = 3;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       double a = _t1 * _t0;
-//CHECK-NEXT:       _t3 = 333;
-//CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       double c = _t3 * _t2;
+//CHECK-NEXT:       double a = 3 * _t0;
+//CHECK-NEXT:       _t1 = y;
+//CHECK-NEXT:       double c = 333 * _t1;
 //CHECK-NEXT:       _cond0 = x > 1;
 //CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:           _t5 = 2;
-//CHECK-NEXT:           _t4 = a;
+//CHECK-NEXT:           _t2 = a;
 //CHECK-NEXT:           goto _label0;
 //CHECK-NEXT:       } else {
 //CHECK-NEXT:           _cond1 = x < -1;
 //CHECK-NEXT:           if (_cond1) {
-//CHECK-NEXT:               _t7 = -2;
-//CHECK-NEXT:               _t6 = a;
+//CHECK-NEXT:               _t3 = a;
 //CHECK-NEXT:               goto _label1;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       _t9 = a;
-//CHECK-NEXT:       _t8 = a;
-//CHECK-NEXT:       double b = _t9 * _t8;
+//CHECK-NEXT:       _t5 = a;
+//CHECK-NEXT:       _t4 = a;
+//CHECK-NEXT:       double b = _t5 * _t4;
 //CHECK-NEXT:       goto _label2;
 //CHECK-NEXT:     _label2:
 //CHECK-NEXT:       _d_b += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r8 = _d_b * _t8;
+//CHECK-NEXT:           double _r8 = _d_b * _t4;
 //CHECK-NEXT:           _d_a += _r8;
-//CHECK-NEXT:           double _r9 = _t9 * _d_b;
+//CHECK-NEXT:           double _r9 = _t5 * _d_b;
 //CHECK-NEXT:           _d_a += _r9;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:         _label0:
 //CHECK-NEXT:           {
-//CHECK-NEXT:               double _r4 = 1 * _t4;
-//CHECK-NEXT:               double _r5 = _t5 * 1;
+//CHECK-NEXT:               double _r4 = 1 * _t2;
+//CHECK-NEXT:               double _r5 = 2 * 1;
 //CHECK-NEXT:               _d_a += _r5;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       else if (_cond1)
 //CHECK-NEXT:         _label1:
 //CHECK-NEXT:           {
-//CHECK-NEXT:               double _r6 = 1 * _t6;
-//CHECK-NEXT:               double _r7 = _t7 * 1;
+//CHECK-NEXT:               double _r6 = 1 * _t3;
+//CHECK-NEXT:               double _r7 = -2 * 1;
 //CHECK-NEXT:               _d_a += _r7;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r2 = _d_c * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * _d_c;
+//CHECK-NEXT:           double _r2 = _d_c * _t1;
+//CHECK-NEXT:           double _r3 = 333 * _d_c;
 //CHECK-NEXT:           _result[1UL] += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = _d_a * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * _d_a;
+//CHECK-NEXT:           double _r1 = 3 * _d_a;
 //CHECK-NEXT:           _result[0UL] += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }


### PR DESCRIPTION
Several optimizations for `StoreAndRef` and `GlobalStoreAndRef` are implemented.
In `StoreAndRef`, useless temporaries are no longer created for expressions like `+x`, `-x` and array subscripts. This fixed issue #89.
In `GlobalStoreAndRef`, constant literals are no longer stored. This will be useful when implementing for-loops to avoid stores into stack.

Additionally, in the reverse mode, an issue when visiting conditional operators is fixed:
In C++, in conditional operators like `(c ? a : b)` only `a` or `b` is executed, depending on `c`. We did not account for this when visiting, therefore
side effects of both `a` and `b` could be applied, independent of `c`. Now, an IfStmt is created and only one side will be evaluated. The issue is still present in forward mode: issue #128.
