### PR TITLE
[travis] Run clad with clang which has asserts enabled.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,14 @@ jobs:
             coverage: false
             coverity: false
 
+          - name: macos-clang-runtime9-llvmlab
+            os: macos-latest
+            compiler: clang
+            clang-runtime: '9'
+            coverage: false
+            coverity: false
+            llvmlab_id: clang-r354636-b54157
+
           - name: ubuntu-gcc5-runtime9
             os: ubuntu-18.04
             compiler: gcc-5
@@ -676,6 +684,17 @@ jobs:
           -DCODE_COVERAGE=${CODE_COVERAGE}  \
           -DLLVM_EXTERNAL_LIT="`which lit`" \
           $GITHUB_WORKSPACE
+
+        # Fetch clang with RelWithDebInfo which is useful as it has asserts on.
+        # This allows us to verify if clad produces correct AST.
+        if [ -n "${{ matrix.llvmlab_id }}" ]; then
+          git clone https://github.com/llvm-mirror/zorg.git zorg
+          cd zorg/llvmbisect
+          sudo python setup.py install
+          llvmlab fetch clang-stage1-configure-RA ${{ matrix.llvmlab_id }}
+          export CLANG=$(pwd)/${{ matrix.llvmlab_id }}/bin/clang
+        fi
+
         cmake --build . --target check-clad -- -j4
     - name: Build Clad for Coverity Scan
       if: ${{ matrix.coverity == true }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,7 +591,7 @@ jobs:
     - name: Setup tmate session
       if: ${{ failure() }}
       uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 1 # When debugging increase to a suitable value!
+      timeout-minutes: 50 # When debugging increase to a suitable value!
     - name: Code coverage report
       if: ${{ success() && (matrix.coverage == true) }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,11 +543,11 @@ jobs:
         # Fetch clang with RelWithDebInfo which is useful as it has asserts on.
         # This allows us to verify if clad produces correct AST.
         if [ -n "${{ matrix.llvmlab_id }}" ]; then
-          git clone https://github.com/llvm-mirror/zorg.git zorg
-          cd zorg/llvmbisect
-          sudo python setup.py install
-          llvmlab fetch clang-stage1-configure-RA ${{ matrix.llvmlab_id }}
-          export CLANG=$(pwd)/${{ matrix.llvmlab_id }}/bin/clang
+          #git clone https://github.com/llvm-mirror/zorg.git zorg
+          #cd zorg/llvmbisect
+          #sudo python setup.py install
+          #llvmlab fetch clang-stage1-configure-RA ${{ matrix.llvmlab_id }}
+          #export CLANG=$(pwd)/${{ matrix.llvmlab_id }}/bin/clang
         fi
 
         cmake --build . --target check-clad -- -j4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Clad-CI
+name: Main
 on:
   push:
     branches:
@@ -18,412 +18,288 @@ jobs:
       matrix:
 
         include:
-          - name: macos-clang-runtime5
+          - name: osx-clang-runtime5
             os: macos-latest
             compiler: clang
             clang-runtime: '5.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc5-runtime5
+          - name: ubu16-gcc5-runtime5
             os: ubuntu-16.04
             compiler: gcc-5
             clang-runtime: '5.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc6-runtime5-coverity
+          - name: ubu16-gcc6-runtime5-coverity
             os: ubuntu-16.04
             compiler: gcc-6
             clang-runtime: '5.0'
-            coverage: false
             coverity: true
 
-          - name: ubuntu-gcc6-runtime5
+          - name: ubu16-gcc6-runtime5
             os: ubuntu-16.04
             compiler: gcc-6
             clang-runtime: '5.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc8-runtime5
+          - name: ubu16-gcc8-runtime5
             os: ubuntu-16.04
             compiler: gcc-8
             clang-runtime: '5.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc9-runtime5
+          - name: ubu16-gcc9-runtime5
             os: ubuntu-16.04
             compiler: gcc-9
             clang-runtime: '5.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang4-runtime5
+          - name: ubu16-clang4-runtime5
             os: ubuntu-16.04
             compiler: 'clang-4.0'
             clang-runtime: '5.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang8-runtime5
+          - name: ubu16-clang8-runtime5
             os: ubuntu-16.04
             compiler: clang-8
             clang-runtime: '5.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang9-runtime5
+          - name: ubu16-clang9-runtime5
             os: ubuntu-16.04
             compiler: clang-9
             clang-runtime: '5.0'
-            coverage: false
-            coverity: false
 
-          - name: macos-clang-runtime6
+          - name: osx-clang-runtime6
             os: macos-latest
             compiler: clang
             clang-runtime: '6.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc5-runtime6
+          - name: ubu16-gcc5-runtime6
             os: ubuntu-16.04
             compiler: gcc-5
             clang-runtime: '6.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc8-runtime6
+          - name: ubu16-gcc8-runtime6
             os: ubuntu-16.04
             compiler: gcc-8
             clang-runtime: '6.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc9-runtime6
+          - name: ubu16-gcc9-runtime6
             os: ubuntu-16.04
             compiler: gcc-9
             clang-runtime: '6.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang4-runtime6
+          - name: ubu16-clang4-runtime6
             os: ubuntu-16.04
             compiler: 'clang-4.0'
             clang-runtime: '6.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang8-runtime6
+          - name: ubu16-clang8-runtime6
             os: ubuntu-16.04
             compiler: clang-8
             clang-runtime: '6.0'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang9-runtime6
+          - name: ubu16-clang9-runtime6
             os: ubuntu-16.04
             compiler: clang-9
             clang-runtime: '6.0'
-            coverage: false
-            coverity: false
 
-          - name: macos-clang-runtime7
+          - name: osx-clang-runtime7
             os: macos-latest
             compiler: clang
             clang-runtime: '7'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc5-runtime7
+          - name: ubu16-gcc5-runtime7
             os: ubuntu-16.04
             compiler: gcc-5
             clang-runtime: '7'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc8-runtime7
+          - name: ubu16-gcc8-runtime7
             os: ubuntu-16.04
             compiler: gcc-8
             clang-runtime: '7'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc9-runtime7
+          - name: ubu16-gcc9-runtime7
             os: ubuntu-16.04
             compiler: gcc-9
             clang-runtime: '7'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang4-runtime7
+          - name: ubu16-clang4-runtime7
             os: ubuntu-16.04
             compiler: 'clang-4.0'
             clang-runtime: '7'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang8-runtime7
+          - name: ubu16-clang8-runtime7
             os: ubuntu-16.04
             compiler: clang-8
             clang-runtime: '7'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang9-runtime7
+          - name: ubu16-clang9-runtime7
             os: ubuntu-16.04
             compiler: clang-9
             clang-runtime: '7'
-            coverage: false
-            coverity: false
 
-          - name: macos-clang-runtime8
+          - name: osx-clang-runtime8
             os: macos-latest
             compiler: clang
             clang-runtime: '8'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc5-runtime8
+          - name: ubu18-gcc5-runtime8
             os: ubuntu-18.04
             compiler: gcc-5
             clang-runtime: '8'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc8-runtime8
+          - name: ubu18-gcc8-runtime8
             os: ubuntu-18.04
             compiler: gcc-8
             clang-runtime: '8'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc9-runtime8
+          - name: ubu18-gcc9-runtime8
             os: ubuntu-18.04
             compiler: gcc-9
             clang-runtime: '8'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang4-runtime8
+          - name: ubu18-clang4-runtime8
             os: ubuntu-18.04
             compiler: 'clang-4.0'
             clang-runtime: '8'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang8-runtime8
+          - name: ubu18-clang8-runtime8
             os: ubuntu-18.04
             compiler: clang-8
             clang-runtime: '8'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang9-runtime8
+          - name: ubu18-clang9-runtime8
             os: ubuntu-18.04
             compiler: clang-9
             clang-runtime: '8'
-            coverage: false
-            coverity: false
 
-          - name: macos-clang-runtime9
+          - name: osx-clang-runtime9
             os: macos-latest
             compiler: clang
             clang-runtime: '9'
-            coverage: false
-            coverity: false
 
-          - name: macos-clang-runtime9-llvmlab
+          - name: osx-clang-runtime9-llvmlab
             os: macos-latest
             compiler: clang
             clang-runtime: '9'
-            coverage: false
-            coverity: false
             llvmlab_id: clang-r354636-b54157
 
-          - name: ubuntu-gcc5-runtime9
+          - name: ubu18-gcc5-runtime9
             os: ubuntu-18.04
             compiler: gcc-5
             clang-runtime: '9'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc6-runtime9-coverage
-            os: ubuntu-18.04
-            compiler: gcc-6
-            clang-runtime: '9'
-            coverage: true
-            coverity: false
-
-          - name: ubuntu-gcc8-runtime9
+          - name: ubu18-gcc8-runtime9
             os: ubuntu-18.04
             compiler: gcc-8
             clang-runtime: '9'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc9-runtime9
+          - name: ubu18-gcc9-runtime9
             os: ubuntu-18.04
             compiler: gcc-9
             clang-runtime: '9'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang4-runtime9
+          - name: ubu18-clang4-runtime9
             os: ubuntu-18.04
             compiler: 'clang-4.0'
             clang-runtime: '9'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang8-runtime9
+          - name: ubu18-clang8-runtime9
             os: ubuntu-18.04
             compiler: clang-8
             clang-runtime: '9'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang9-runtime9
+          - name: ubu18-clang9-runtime9
             os: ubuntu-18.04
             compiler: clang-9
             clang-runtime: '9'
-            coverage: false
-            coverity: false
 
-          - name: macos-clang-runtime10
+          - name: osx-clang-runtime10
             os: macos-latest
             compiler: clang
             clang-runtime: '10'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc5-runtime10
+          - name: ubu18-gcc5-runtime10
             os: ubuntu-18.04
             compiler: gcc-5
             clang-runtime: '10'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc6-runtime10-coverage
-            os: ubuntu-18.04
-            compiler: gcc-6
-            clang-runtime: '10'
-            coverage: true
-            coverity: false
-
-          - name: ubuntu-gcc8-runtime10
+          - name: ubu18-gcc8-runtime10
             os: ubuntu-18.04
             compiler: gcc-8
             clang-runtime: '10'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc9-runtime10
+          - name: ubu18-gcc9-runtime10
             os: ubuntu-18.04
             compiler: gcc-9
             clang-runtime: '10'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang4-runtime10
+          - name: ubu18-clang4-runtime10
             os: ubuntu-18.04
             compiler: 'clang-4.0'
             clang-runtime: '10'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang8-runtime10
+          - name: ubu18-clang8-runtime10
             os: ubuntu-18.04
             compiler: clang-8
             clang-runtime: '10'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang9-runtime10
+          - name: ubu18-clang9-runtime10
             os: ubuntu-18.04
             compiler: clang-9
             clang-runtime: '10'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang10-runtime10
+          - name: ubu18-clang10-runtime10
             os: ubuntu-18.04
             compiler: clang-10
             clang-runtime: '10'
-            coverage: false
-            coverity: false
 
-          - name: macos-clang-runtime11
+          - name: osx-clang-runtime11
             os: macos-latest
             compiler: clang
             clang-runtime: '11'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc5-runtime11
+          - name: ubu18-gcc5-runtime11
             os: ubuntu-18.04
             compiler: gcc-5
             clang-runtime: '11'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc6-runtime11-coverage
+          - name: ubu18-gcc6-runtime11-coverage
             os: ubuntu-18.04
             compiler: gcc-6
             clang-runtime: '11'
             coverage: true
-            coverity: false
 
-          - name: ubuntu-gcc8-runtime11
+          - name: ubu18-gcc8-runtime11
             os: ubuntu-18.04
             compiler: gcc-8
             clang-runtime: '11'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-gcc9-runtime11
+          - name: ubu18-gcc9-runtime11
             os: ubuntu-18.04
             compiler: gcc-9
             clang-runtime: '11'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang4-runtime11
+          - name: ubu18-clang4-runtime11
             os: ubuntu-18.04
             compiler: 'clang-4.0'
             clang-runtime: '11'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang8-runtime11
+          - name: ubu18-clang8-runtime11
             os: ubuntu-18.04
             compiler: clang-8
             clang-runtime: '11'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang9-runtime11
+          - name: ubu18-clang9-runtime11
             os: ubuntu-18.04
             compiler: clang-9
             clang-runtime: '11'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang10-runtime11
+          - name: ubu18-clang10-runtime11
             os: ubuntu-18.04
             compiler: clang-10
             clang-runtime: '11'
-            coverage: false
-            coverity: false
 
-          - name: ubuntu-clang11-runtime11
+          - name: ubu18-clang11-runtime11
             os: ubuntu-18.04
             compiler: clang-11
             clang-runtime: '11'
-            coverage: false
-            coverity: false
 
     steps:
     - uses: actions/checkout@v2
@@ -444,21 +320,6 @@ jobs:
           # tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
           echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
           echo "$GITHUB_WORKSPACE/cov-analysis-linux64/bin" >> $GITHUB_PATH
-        fi
-      # env:
-      #  TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
-    - name: Download Coverity Build Tool - macOS
-      if: ${{ (matrix.coverity == true) && (runner.os == 'macOS') }}
-      run: |
-        # FIXME: Ideally the check should be in the if: block of the action
-        if [ $BRANCH_NAME == "coverity_scan" ]; then
-          # wget -q https://scan.coverity.com/download/cxx/<macOS> --post-data "token=$TOKEN&project=vgvassilev/clad" -O cov-analysis-<macOS>.tar.gz
-          mkdir cov-analysis-macOS
-          # tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-macOS
-          echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
-          echo "$GITHUB_WORKSPACE/cov-analysis-macOS/bin" >> $GITHUB_PATH
-        else
-          echo "This action only runs on branch coverity_scan"
         fi
       # env:
       #  TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
@@ -652,16 +513,10 @@ jobs:
         sudo -H pip install lit # LLVM lit is not part of the llvm releases...
         # We need PATH_TO_LLVM_BUILD later
         echo "PATH_TO_LLVM_BUILD=$PATH_TO_LLVM_BUILD" >> $GITHUB_ENV
-    - name: Setup code coverage on Linux
-      if: ${{ (matrix.coverage == true) && (runner.os == 'Linux') }}
+    - name: Setup code coverage
+      if: ${{ (matrix.coverage == true) }}
       run: |
         sudo apt install lcov
-        echo "CODE_COVERAGE=1" >> $GITHUB_ENV
-        echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
-    - name: Setup code coverage on macOS
-      if: ${{ (matrix.coverage == true) && (runner.os == 'macOS') }}
-      run: |
-        brew install lcov
         echo "CODE_COVERAGE=1" >> $GITHUB_ENV
         echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
     - name: Display config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,10 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   # When clad is in debug mode the llvm package thinks it is built with -frtti.
   # For consistency we should set it to the correct value.
   set(LLVM_CONFIG_HAS_RTTI NO CACHE BOOL "" FORCE)
+  if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+  endif ()
+
 
   ## Init
 


### PR DESCRIPTION
This gives us a great deal of coverage. Clang has well-developed assert system
which often can detect malformed AST. This is very essential for clad as until
today I would need to run that by hand, locally on every pull request.