### PR TITLE
Find LLVM before Clang. Fix ROOT-10886

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,46 +26,6 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
     set(LLVM_DIR ${Clang_DIR})
   endif()
 
-  ## Find supported Clang
-
-  set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
-  set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
-
-  if (DEFINED CLANG_VERSION)
-    if (CLANG_VERSION VERSION_GREATER CLANG_MAX_SUPPORTED)
-      set(CLANG_VERSION ${CLANG_MAX_SUPPORTED})
-    endif()
-    if (CLANG_VERSION VERSION_LESS CLANG_MIN_SUPPORTED)
-      set(CLANG_VERSION ${CLANG_MIN_SUPPORTED})
-    endif()
-
-    find_package(Clang ${CLANG_VERSION} REQUIRED CONFIG)
-  endif()
-
-  if (NOT Clang_FOUND AND DEFINED Clang_DIR)
-    find_package(Clang REQUIRED CONFIG PATHS ${Clang_DIR} "${Clang_DIR}/lib/cmake/clang" "${Clang_DIR}/cmake" NO_DEFAULT_PATH)
-  endif()
-
-  if (NOT Clang_FOUND)
-    find_package(Clang REQUIRED CONFIG)
-    endif()
-
-  if (NOT Clang_FOUND)
-    message(FATAL_ERROR "Please set Clang_DIR pointing to the clang build or installation folder")
-  endif()
-
-  set(CLANG_VERSION_MAJOR ${LLVM_VERSION_MAJOR})
-  set(CLANG_VERSION_MINOR ${LLVM_VERSION_MINOR})
-  set(CLANG_VERSION_PATCH ${LLVM_VERSION_PATCH})
-  set(CLANG_PACKAGE_VERSION ${LLVM_PACKAGE_VERSION})
-
-  if (CLANG_PACKAGE_VERSION VERSION_LESS CLANG_MIN_SUPPORTED OR CLANG_PACKAGE_VERSION VERSION_GREATER CLANG_MAX_SUPPORTED)
-    message(FATAL_ERROR "Found unsupported version: Clang ${CLANG_PACKAGE_VERSION};\nPlease set Clang_DIR pointing to the clang version ${CLANG_MIN_SUPPORTED} to ${CLANG_MAX_SUPPORTED} build or installation folder")
-  endif()
-
-  message(STATUS "Found supported version: Clang ${CLANG_PACKAGE_VERSION}")
-  message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
-
   ## Find supported LLVM
 
   if (LLVM_FOUND)
@@ -111,6 +71,46 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
 
   message(STATUS "Found supported version: LLVM ${LLVM_PACKAGE_VERSION}")
   message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+  ## Find supported Clang
+
+  set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
+  set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
+
+  if (DEFINED CLANG_VERSION)
+    if (CLANG_VERSION VERSION_GREATER CLANG_MAX_SUPPORTED)
+      set(CLANG_VERSION ${CLANG_MAX_SUPPORTED})
+    endif()
+    if (CLANG_VERSION VERSION_LESS CLANG_MIN_SUPPORTED)
+      set(CLANG_VERSION ${CLANG_MIN_SUPPORTED})
+    endif()
+
+    find_package(Clang ${CLANG_VERSION} REQUIRED CONFIG)
+  endif()
+
+  if (NOT Clang_FOUND AND DEFINED Clang_DIR)
+    find_package(Clang REQUIRED CONFIG PATHS ${Clang_DIR} "${Clang_DIR}/lib/cmake/clang" "${Clang_DIR}/cmake" NO_DEFAULT_PATH)
+  endif()
+
+  if (NOT Clang_FOUND)
+    find_package(Clang REQUIRED CONFIG)
+  endif()
+
+  if (NOT Clang_FOUND)
+    message(FATAL_ERROR "Please set Clang_DIR pointing to the clang build or installation folder")
+  endif()
+
+  set(CLANG_VERSION_MAJOR ${LLVM_VERSION_MAJOR})
+  set(CLANG_VERSION_MINOR ${LLVM_VERSION_MINOR})
+  set(CLANG_VERSION_PATCH ${LLVM_VERSION_PATCH})
+  set(CLANG_PACKAGE_VERSION ${LLVM_PACKAGE_VERSION})
+
+  if (CLANG_PACKAGE_VERSION VERSION_LESS CLANG_MIN_SUPPORTED OR CLANG_PACKAGE_VERSION VERSION_GREATER CLANG_MAX_SUPPORTED)
+    message(FATAL_ERROR "Found unsupported version: Clang ${CLANG_PACKAGE_VERSION};\nPlease set Clang_DIR pointing to the clang version ${CLANG_MIN_SUPPORTED} to ${CLANG_MAX_SUPPORTED} build or installation folder")
+  endif()
+
+  message(STATUS "Found supported version: Clang ${CLANG_PACKAGE_VERSION}")
+  message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
 
   # When clad is in debug mode the llvm package thinks it is built with -frtti.
   # For consistency we should set it to the correct value.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,11 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
       set(LLVM_VERSION ${LLVM_MIN_SUPPORTED})
     endif()
 
-    find_package(LLVM ${LLVM_VERSION} REQUIRED CONFIG)
+    if (DEFINED LLVM_DIR)
+       set(search_hints HINTS ${LLVM_DIR} "${LLVM_DIR}/lib/cmake/llvm" "${LLVM_DIR}/cmake")
+    endif()
+
+    find_package(LLVM ${LLVM_VERSION} REQUIRED CONFIG ${search_hints})
   endif()
 
   if (NOT LLVM_FOUND AND DEFINED LLVM_DIR)
@@ -85,7 +89,11 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
       set(CLANG_VERSION ${CLANG_MIN_SUPPORTED})
     endif()
 
-    find_package(Clang ${CLANG_VERSION} REQUIRED CONFIG)
+    if (DEFINED Clang_DIR)
+       set(extra_hints HINTS ${Clang_DIR} "${Clang_DIR}/lib/cmake/clang" "${Clang_DIR}/cmake")
+    endif()
+
+    find_package(Clang ${CLANG_VERSION} REQUIRED CONFIGi ${extra_hints})
   endif()
 
   if (NOT Clang_FOUND AND DEFINED Clang_DIR)


### PR DESCRIPTION
    Find LLVM before Clang.
    
    This fixes ROOT-10886.
    
    In the environment described in ROOT-10886, CMAKE_PREFIX_PATH is set to point
    to the clang (compiler) installation with includes an installation of the
    LLVM and Clang libraries.
    
    When finding Clang, the find_package for Clang will (in the ROOT environment)
    execute interpreter/llvm/src/tools/clang/lib/cmake/clang/ClangConfig.cmake
    which contains the line:
    
      find_package(LLVM REQUIRED CONFIG
                   HINTS path_where_ROOT_found_LLVM)
    
    However, CMAKE_PREFIX_PATH has search priority of the HINTS and circunvents
    Clad's CMakeLists.txt to constrain the search first to a version then
    to paths when they are supplied.
    
    This result in Cling and Clad using 2 distincts (and incompatible) version
    of LLVM/Clang.
    
    The solution is to search for LLVM first and then for Clang.