### PR TITLE
Fix naming collisions in reverse mode

### DIFF
--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -2707,7 +2707,7 @@ namespace clad {
     else {
       diag(DiagnosticsEngine::Warning, UnOp->getEndLoc(),
            "attempt to differentiate unsupported unary operator, ignored");
-      return Clone(UnOp);
+      diff = Visit(UnOp->getSubExpr());
     }
     Expr* op = BuildOp(opCode, diff.getExpr());
     return StmtDiff(op, ResultRef);
@@ -2817,7 +2817,7 @@ namespace clad {
         diag(DiagnosticsEngine::Warning, BinOp->getEndLoc(),
              "derivative of an assignment attempts to assign to unassignable "
              "expr, assignment ignored");
-        return Clone(BinOp);
+        return BuildOp(opCode, Visit(L).getExpr(), Visit(R).getExpr());
       }
 
       if (auto ASE = dyn_cast<ArraySubscriptExpr>(L)) {
@@ -2868,7 +2868,7 @@ namespace clad {
       // like (x = y) it propagates recursively, so _d_x is also returned.
       Expr* AssignedDiff = Ldiff.getExpr_dx();
       if (!AssignedDiff)
-        return Clone(BinOp);
+        return BuildOp(opCode, LCloned, Visit(R).getExpr());
       ResultRef = AssignedDiff;
       // If assigned expr is dependent, first update its derivative;
       auto Lblock_begin = Lblock->body_rbegin();
@@ -2968,7 +2968,8 @@ namespace clad {
     else {
       diag(DiagnosticsEngine::Warning, BinOp->getEndLoc(),
            "attempt to differentiate unsupported binary operator, ignored");
-      return Clone(BinOp);
+      Ldiff = Visit(L);
+      Rdiff = Visit(R);
     }
     Expr* op = BuildOp(opCode, Ldiff.getExpr(), Rdiff.getExpr());
     return StmtDiff(op, ResultRef);


### PR DESCRIPTION
Fixed naming collision in reverse mode for the following statements:

- *Expression statements*: Called `Visit` on expressions unconditionally even if they are not differentiable. Directly cloning non-differentiable expressions generates only a warning, however, due to naming collisions, it may result in clad crashing. Hence, for now, I have visited all expressions unconditionally.

- *Selection, Iteration statements, and conditional operator*: Called `Visit` on the condition before storing it via `*StoreAndRef`, it does generate warnings when the condition is boolean or is not supported. I suppose there might be a better way to do this or suppress the warnings for now.

 This PR fixes #166 and maybe #132  