### PR TITLE
 Differentiate boolean conditions

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -392,6 +392,13 @@ namespace clad {
     StmtDiff VisitUnaryOperator(const clang::UnaryOperator* UnOp);
     // Decl is not Stmt, so it cannot be visited directly.
     VarDeclDiff DifferentiateVarDecl(const clang::VarDecl* VD);
+    /// Shorthand for warning on differentiation of unsupported operators
+    void unsupportedOpWarn(clang::SourceLocation loc,
+                           llvm::ArrayRef<llvm::StringRef> args = {}) {
+        diag(clang::DiagnosticsEngine::Warning, loc,
+             "attempt to differentiate unsupported operator,  derivative \
+                         set to 0", args);
+    }
   };
 
   /// A visitor for processing the function code in reverse mode.
@@ -633,6 +640,12 @@ namespace clad {
     /// additionally created Stmts, second is a direct result of call to Visit.
     std::pair<StmtDiff, StmtDiff> 
     DifferentiateSingleExpr(const clang::Expr* E, clang::Expr* dfdE = nullptr);
+    /// Shorthand for warning on differentiation of unsupported operators
+    void unsupportedOpWarn(clang::SourceLocation loc,
+            llvm::ArrayRef<llvm::StringRef> args = {}) {
+        diag(clang::DiagnosticsEngine::Warning, loc,
+             "attempt to differentiate unsupported operator, ignored.", args);
+    }
 
   };
   

--- a/test/FirstDerivative/UnsupportedOpsWarn.C
+++ b/test/FirstDerivative/UnsupportedOpsWarn.C
@@ -1,0 +1,58 @@
+// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1 | FileCheck %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+//CHECK-NOT: {{.*error|warning|note:.*}}
+
+int binOpWarn_0(int x){
+    return x << 1;  // expected-warning {{attempt to differentiate unsupported operator,  derivative                          set to 0}}
+}
+
+// CHECK: int binOpWarn_0_darg0(int x) {
+// CHECK-NEXT:    int _d_x = 1;
+// CHECK-NEXT:    return 0;
+// CHECK-NEXT: }
+
+
+int binOpWarn_1(int x){
+    return x ^ 1;   // expected-warning {{attempt to differentiate unsupported operator, ignored.}}
+}
+
+// CHECK: void binOpWarn_1_grad(int x, int *_result) {
+// CHECK-NEXT:   int binOpWarn_1_return = x ^ 1;
+// CHECK-NEXT:   goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:   ;
+// CHECK-NEXT: }
+
+int unOpWarn_0(int x){
+    return ~x;  // expected-warning {{attempt to differentiate unsupported operator,  derivative                          set to 0}}
+}
+
+// CHECK: int unOpWarn_0_darg0(int x) {
+// CHECK-NEXT:   int _d_x = 1;
+// CHECK-NEXT:   return 0;
+// CHECK-NEXT: }
+
+int unOpWarn_1(int x){
+    auto pnt = &x;  // expected-warning {{attempt to differentiate unsupported operator, ignored.}}
+    return x;
+}
+
+// CHECK: void unOpWarn_1_grad(int x, int *_result) {
+// CHECK-NEXT:   int *_d_pnt = 0;
+// CHECK-NEXT:   int *pnt = &x;
+// CHECK-NEXT:   int unOpWarn_1_return = x;
+// CHECK-NEXT:   goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:   _result[0UL] += 1;
+// CHECK-NEXT: }
+
+int main(){
+
+    clad::differentiate(binOpWarn_0, 0);
+    clad::gradient(binOpWarn_1);
+    clad::differentiate(unOpWarn_0, 0);
+    clad::gradient(unOpWarn_1);
+}
+


### PR DESCRIPTION
Differentiate boolean conditions to account for differentiable side effects. 

Fixes  #132