### PR TITLE
Replace Travis CI with Github Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,750 @@
+name: Clad-CI
+on:
+  push:
+    branches:
+      - master
+      - coverity_scan
+  pull_request:
+    branches:
+      - master
+      - coverity_scan
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+
+        include:
+          - name: macos-clang-runtime5
+            os: macos-latest
+            compiler: clang
+            clang-runtime: '5.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc5-runtime5
+            os: ubuntu-16.04
+            compiler: gcc-5
+            clang-runtime: '5.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc6-runtime5-coverity
+            os: ubuntu-16.04
+            compiler: gcc-6
+            clang-runtime: '5.0'
+            coverage: false
+            coverity: true
+
+          - name: ubuntu-gcc6-runtime5
+            os: ubuntu-16.04
+            compiler: gcc-6
+            clang-runtime: '5.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc8-runtime5
+            os: ubuntu-16.04
+            compiler: gcc-8
+            clang-runtime: '5.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc9-runtime5
+            os: ubuntu-16.04
+            compiler: gcc-9
+            clang-runtime: '5.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang4-runtime5
+            os: ubuntu-16.04
+            compiler: 'clang-4.0'
+            clang-runtime: '5.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang8-runtime5
+            os: ubuntu-16.04
+            compiler: clang-8
+            clang-runtime: '5.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang9-runtime5
+            os: ubuntu-16.04
+            compiler: clang-9
+            clang-runtime: '5.0'
+            coverage: false
+            coverity: false
+
+          - name: macos-clang-runtime6
+            os: macos-latest
+            compiler: clang
+            clang-runtime: '6.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc5-runtime6
+            os: ubuntu-16.04
+            compiler: gcc-5
+            clang-runtime: '6.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc8-runtime6
+            os: ubuntu-16.04
+            compiler: gcc-8
+            clang-runtime: '6.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc9-runtime6
+            os: ubuntu-16.04
+            compiler: gcc-9
+            clang-runtime: '6.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang4-runtime6
+            os: ubuntu-16.04
+            compiler: 'clang-4.0'
+            clang-runtime: '6.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang8-runtime6
+            os: ubuntu-16.04
+            compiler: clang-8
+            clang-runtime: '6.0'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang9-runtime6
+            os: ubuntu-16.04
+            compiler: clang-9
+            clang-runtime: '6.0'
+            coverage: false
+            coverity: false
+
+          - name: macos-clang-runtime7
+            os: macos-latest
+            compiler: clang
+            clang-runtime: '7'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc5-runtime7
+            os: ubuntu-16.04
+            compiler: gcc-5
+            clang-runtime: '7'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc8-runtime7
+            os: ubuntu-16.04
+            compiler: gcc-8
+            clang-runtime: '7'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc9-runtime7
+            os: ubuntu-16.04
+            compiler: gcc-9
+            clang-runtime: '7'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang4-runtime7
+            os: ubuntu-16.04
+            compiler: 'clang-4.0'
+            clang-runtime: '7'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang8-runtime7
+            os: ubuntu-16.04
+            compiler: clang-8
+            clang-runtime: '7'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang9-runtime7
+            os: ubuntu-16.04
+            compiler: clang-9
+            clang-runtime: '7'
+            coverage: false
+            coverity: false
+
+          - name: macos-clang-runtime8
+            os: macos-latest
+            compiler: clang
+            clang-runtime: '8'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc5-runtime8
+            os: ubuntu-18.04
+            compiler: gcc-5
+            clang-runtime: '8'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc8-runtime8
+            os: ubuntu-18.04
+            compiler: gcc-8
+            clang-runtime: '8'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc9-runtime8
+            os: ubuntu-18.04
+            compiler: gcc-9
+            clang-runtime: '8'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang4-runtime8
+            os: ubuntu-18.04
+            compiler: 'clang-4.0'
+            clang-runtime: '8'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang8-runtime8
+            os: ubuntu-18.04
+            compiler: clang-8
+            clang-runtime: '8'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang9-runtime8
+            os: ubuntu-18.04
+            compiler: clang-9
+            clang-runtime: '8'
+            coverage: false
+            coverity: false
+
+          - name: macos-clang-runtime9
+            os: macos-latest
+            compiler: clang
+            clang-runtime: '9'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc5-runtime9
+            os: ubuntu-18.04
+            compiler: gcc-5
+            clang-runtime: '9'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc6-runtime9-coverage
+            os: ubuntu-18.04
+            compiler: gcc-6
+            clang-runtime: '9'
+            coverage: true
+            coverity: false
+
+          - name: ubuntu-gcc8-runtime9
+            os: ubuntu-18.04
+            compiler: gcc-8
+            clang-runtime: '9'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc9-runtime9
+            os: ubuntu-18.04
+            compiler: gcc-9
+            clang-runtime: '9'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang4-runtime9
+            os: ubuntu-18.04
+            compiler: 'clang-4.0'
+            clang-runtime: '9'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang8-runtime9
+            os: ubuntu-18.04
+            compiler: clang-8
+            clang-runtime: '9'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang9-runtime9
+            os: ubuntu-18.04
+            compiler: clang-9
+            clang-runtime: '9'
+            coverage: false
+            coverity: false
+
+          - name: macos-clang-runtime10
+            os: macos-latest
+            compiler: clang
+            clang-runtime: '10'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc5-runtime10
+            os: ubuntu-18.04
+            compiler: gcc-5
+            clang-runtime: '10'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc6-runtime10-coverage
+            os: ubuntu-18.04
+            compiler: gcc-6
+            clang-runtime: '10'
+            coverage: true
+            coverity: false
+
+          - name: ubuntu-gcc8-runtime10
+            os: ubuntu-18.04
+            compiler: gcc-8
+            clang-runtime: '10'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc9-runtime10
+            os: ubuntu-18.04
+            compiler: gcc-9
+            clang-runtime: '10'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang4-runtime10
+            os: ubuntu-18.04
+            compiler: 'clang-4.0'
+            clang-runtime: '10'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang8-runtime10
+            os: ubuntu-18.04
+            compiler: clang-8
+            clang-runtime: '10'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang9-runtime10
+            os: ubuntu-18.04
+            compiler: clang-9
+            clang-runtime: '10'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang10-runtime10
+            os: ubuntu-18.04
+            compiler: clang-10
+            clang-runtime: '10'
+            coverage: false
+            coverity: false
+
+          - name: macos-clang-runtime11
+            os: macos-latest
+            compiler: clang
+            clang-runtime: '11'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc5-runtime11
+            os: ubuntu-18.04
+            compiler: gcc-5
+            clang-runtime: '11'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc6-runtime11-coverage
+            os: ubuntu-18.04
+            compiler: gcc-6
+            clang-runtime: '11'
+            coverage: true
+            coverity: false
+
+          - name: ubuntu-gcc8-runtime11
+            os: ubuntu-18.04
+            compiler: gcc-8
+            clang-runtime: '11'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-gcc9-runtime11
+            os: ubuntu-18.04
+            compiler: gcc-9
+            clang-runtime: '11'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang4-runtime11
+            os: ubuntu-18.04
+            compiler: 'clang-4.0'
+            clang-runtime: '11'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang8-runtime11
+            os: ubuntu-18.04
+            compiler: clang-8
+            clang-runtime: '11'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang9-runtime11
+            os: ubuntu-18.04
+            compiler: clang-9
+            clang-runtime: '11'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang10-runtime11
+            os: ubuntu-18.04
+            compiler: clang-10
+            clang-runtime: '11'
+            coverage: false
+            coverity: false
+
+          - name: ubuntu-clang11-runtime11
+            os: ubuntu-18.04
+            compiler: clang-11
+            clang-runtime: '11'
+            coverage: false
+            coverity: false
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: nelonoel/branch-name@v1.0.1
+    - name: Setup default Build Type
+      run: |
+        echo "BUILD_TYPE=Release" >> $GITHUB_ENV
+        echo "CODE_COVERAGE=0" >> $GITHUB_ENV
+    - name: Download Coverity Build Tool - Linux
+      if: ${{ (matrix.coverity == true) && (runner.os == 'Linux') }}
+      run: |
+        # FIXME: Ideally the check should be in the if: block of the action
+        if [ $BRANCH_NAME == "coverity_scan" ]; then
+          # wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=$TOKEN&project=vgvassilev/clad" -O cov-analysis-linux64.tar.gz
+          mkdir cov-analysis-linux64
+          # tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
+          echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/cov-analysis-linux64/bin" >> $GITHUB_PATH
+        fi
+      # env:
+      #  TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+    - name: Download Coverity Build Tool - macOS
+      if: ${{ (matrix.coverity == true) && (runner.os == 'macOS') }}
+      run: |
+        # FIXME: Ideally the check should be in the if: block of the action
+        if [ $BRANCH_NAME == "coverity_scan" ]; then
+          # wget -q https://scan.coverity.com/download/cxx/<macOS> --post-data "token=$TOKEN&project=vgvassilev/clad" -O cov-analysis-<macOS>.tar.gz
+          mkdir cov-analysis-macOS
+          # tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-macOS
+          echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/cov-analysis-macOS/bin" >> $GITHUB_PATH
+        else
+          echo "This action only runs on branch coverity_scan"
+        fi
+      # env:
+      #  TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+    - name: Setup Ubuntu apt sources
+      if: runner.os == 'Linux'
+      run: |
+        curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        if [[ ${{ matrix.clang-runtime }} == '7' ]]; then
+          echo "deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" | sudo tee -a /etc/apt/sources.list
+          sudo apt update
+          sudo apt install llvm-${{ matrix.clang-runtime }}-dev llvm-${{ matrix.clang-runtime }}-tools clang-${{ matrix.clang-runtime }} libclang-${{ matrix.clang-runtime }}-dev
+        fi
+        if [[ ${{ matrix.clang-runtime }} == '8' ]]; then
+          echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" | sudo tee -a /etc/apt/sources.list
+          sudo apt update
+          sudo apt install llvm-${{ matrix.clang-runtime }}-dev clang-${{ matrix.clang-runtime }} libclang-${{ matrix.clang-runtime }}-dev
+        fi
+        if [[ ${{ matrix.clang-runtime }} == '9' ]]; then
+          echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" | sudo tee -a /etc/apt/sources.list
+          sudo apt update
+          sudo apt install llvm-${{ matrix.clang-runtime }}-dev llvm-${{ matrix.clang-runtime }}-tools clang-${{ matrix.clang-runtime }} libclang-${{ matrix.clang-runtime }}-dev
+        fi
+        if [[ ${{ matrix.clang-runtime }} == '10' ]]; then
+          echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" | sudo tee -a /etc/apt/sources.list
+          sudo apt update
+          sudo apt install llvm-${{ matrix.clang-runtime }}-dev llvm-${{ matrix.clang-runtime }}-tools clang-${{ matrix.clang-runtime }} libclang-${{ matrix.clang-runtime }}-dev
+        fi
+        if [[ ${{ matrix.clang-runtime }} == '11' ]]; then
+          echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main" | sudo tee -a /etc/apt/sources.list
+          sudo apt update
+          sudo apt install llvm-${{ matrix.clang-runtime }}-dev llvm-${{ matrix.clang-runtime }}-tools clang-${{ matrix.clang-runtime }} libclang-${{ matrix.clang-runtime }}-dev
+        fi
+    - name: Setup compiler on Linux
+      if: runner.os == 'Linux'
+      run: |
+        # https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
+        vers="${compiler#*-}"
+        sudo apt update
+        if [[ ${{ matrix.compiler }} == *"gcc"* ]]; then
+          sudo apt install -y gcc-${vers} g++-${vers}
+          echo "CC=gcc-${vers}" >> $GITHUB_ENV
+          echo "CXX=g++-${vers}" >> $GITHUB_ENV
+        else
+          sudo apt install -y clang-${vers}
+          echo "CC=clang-${vers}" >> $GITHUB_ENV
+          echo "CXX=clang++-${vers}" >> $GITHUB_ENV
+        fi
+      env:
+        compiler: ${{ matrix.compiler }}
+    - name: Setup compiler on macOS
+      if: runner.os == 'macOS'
+      run: |
+        if [[ "${{ matrix.compiler }}" == *"clang"* ]]; then
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+        else
+          echo "Unsupported compiler - fix YAML file"
+        fi
+    - name: Setup LLVM/Clang on macOS
+      if: runner.os == 'macOS'
+      run: |
+        # Update openssl on osx because the current one is deprecated by python.
+        curl -L https://bootstrap.pypa.io/get-pip.py | sudo python
+        echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
+        PATH_TO_LLVM_BUILD=/usr/local/opt/llvm@${{ matrix.clang-runtime }}/
+        # Package llvm@5 is not supported on brew. We must install it from binary build.
+        if [[ ${{ matrix.clang-runtime }} == '5.0' ]]; then
+          PATH_TO_LLVM_BUILD=/usr/local/opt/llvm@5/
+          pushd /usr/local/opt
+          sudo curl -L https://releases.llvm.org/5.0.2/clang+llvm-5.0.2-x86_64-apple-darwin.tar.xz | sudo xz -d -c | sudo tar -x
+          sudo rm -fr /usr/local/clang*
+          sudo mv clang+llvm-5.0.2-x86_64-apple-darwin/ llvm@5/
+          # Use llvm/llvm@10/llvm@6 Filecheck
+          if [[ ! -f $PATH_TO_LLVM_BUILD/bin/FileCheck ]]; then
+            if [[ -f /usr/local/opt/llvm/bin/FileCheck ]]; then
+              sudo ln -s /usr/local/opt/llvm/bin/FileCheck $PATH_TO_LLVM_BUILD/bin/FileCheck
+            elif [[ -f /usr/local/opt/llvm\@10/bin/FileCheck ]]; then
+              sudo ln -s /usr/local/opt/llvm\@10/bin/FileCheck $PATH_TO_LLVM_BUILD/bin/FileCheck
+            elif [[ -f /usr/local/opt/llvm\@6/bin/FileCheck ]]; then
+              sudo ln -s /usr/local/opt/llvm\@6/bin/FileCheck $PATH_TO_LLVM_BUILD/bin/FileCheck
+            fi
+          fi
+          popd
+        fi
+        # Package llvm@6
+        if [[ ${{ matrix.clang-runtime }} == '6.0' ]]; then
+          PATH_TO_LLVM_BUILD=/usr/local/opt/llvm@6/
+          pushd /usr/local/opt
+          sudo curl -L https://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz | sudo xz -d -c | sudo tar -x
+          sudo rm -fr /usr/local/clang*
+          sudo mv clang+llvm-6.0.0-x86_64-apple-darwin/ llvm@6/
+          # Use llvm/llvm@10/llvm@6 Filecheck
+          if [[ ! -f $PATH_TO_LLVM_BUILD/bin/FileCheck ]]; then
+            if [[ -f /usr/local/opt/llvm/bin/FileCheck ]]; then
+              sudo ln -s /usr/local/opt/llvm/bin/FileCheck $PATH_TO_LLVM_BUILD/bin/FileCheck
+            elif [[ -f /usr/local/opt/llvm\@10/bin/FileCheck ]]; then
+              sudo ln -s /usr/local/opt/llvm\@10/bin/FileCheck $PATH_TO_LLVM_BUILD/bin/FileCheck
+            elif [[ -f /usr/local/opt/llvm\@6/bin/FileCheck ]]; then
+              sudo ln -s /usr/local/opt/llvm\@6/bin/FileCheck $PATH_TO_LLVM_BUILD/bin/FileCheck
+            fi
+          fi
+          popd
+        fi
+        if [[ ${{ matrix.clang-runtime }} == '7' || ${{ matrix.clang-runtime }} == '8' || ${{ matrix.clang-runtime }} == '9' ]]; then
+          brew install llvm@${{ matrix.clang-runtime }}
+        fi
+        # Package llvm@10 == llvm. FIXME: Remove when official brew package llvm@10 is released.
+        if [[ ${{ matrix.clang-runtime }} == '10' ]]; then
+          export PATH_TO_LLVM_BUILD=/usr/local/opt/llvm@10/
+          sudo ln -s /usr/local/opt/llvm /usr/local/opt/llvm@10
+        fi
+        # Package llvm@11 is not supported (yet) on brew. FIXME: Remove when official brew package is released.
+        if [[ ${{ matrix.clang-runtime }} == '11' ]]; then
+          PATH_TO_LLVM_BUILD=/usr/local/opt/llvm@11/
+          pushd /usr/local/opt
+          sudo curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0-rc2/clang+llvm-11.0.0-rc2-x86_64-apple-darwin.tar.xz | sudo xz -d -c | sudo tar -x
+          sudo rm -fr /usr/local/clang*
+          sudo mv clang+llvm-11.0.0-rc2-x86_64-apple-darwin/ llvm@11/
+          # Use llvm/llvm@10/llvm@6 Filecheck
+          if [[ ! -f $PATH_TO_LLVM_BUILD/bin/FileCheck ]]; then
+            if [[ -f /usr/local/opt/llvm/bin/FileCheck ]]; then
+              sudo ln -s /usr/local/opt/llvm/bin/FileCheck $PATH_TO_LLVM_BUILD/bin/FileCheck
+            elif [[ -f /usr/local/opt/llvm\@10/bin/FileCheck ]]; then
+              sudo ln -s /usr/local/opt/llvm\@10/bin/FileCheck $PATH_TO_LLVM_BUILD/bin/FileCheck
+            elif [[ -f /usr/local/opt/llvm\@6/bin/FileCheck ]]; then
+              sudo ln -s /usr/local/opt/llvm\@6/bin/FileCheck $PATH_TO_LLVM_BUILD/bin/FileCheck
+            fi
+          fi
+          popd
+        fi
+        # Add -H to silence 'The directory '/home/..../pip/http' or its parent
+        # directory is not owned by the current user and the cache has been disabled.
+        pyver=$(python -c"import sys; print(sys.version_info.major)")
+        if [ $pyver -eq 2 ]; then
+          echo "/Library/Frameworks/Python.framework/Versions/2.7/bin" >> $GITHUB_PATH
+        fi
+        sudo -H pip install lit # LLVM lit is not part of the llvm releases...
+        # We need headers in correct place
+        for file in $(xcrun --show-sdk-path)/usr/include/*
+        do
+          if [ ! -f /usr/local/include/$(basename $file) ]; then
+            ln -s $file /usr/local/include/$(basename $file)
+          fi
+        done
+        # We need PATH_TO_LLVM_BUILD later
+        echo "PATH_TO_LLVM_BUILD=$PATH_TO_LLVM_BUILD" >> $GITHUB_ENV
+    - name: Setup LLVM/Clang on Linux
+      if: runner.os == 'Linux'
+      run: |
+        UNIX_DISTRO=$(lsb_release -rs)
+        PATH_TO_LLVM_BUILD=/usr/lib/llvm-${{ matrix.clang-runtime }}/
+        # Ubuntu 16.04 & 18.04 llvm/clang-5.0 package is broken - install it from binary build.
+        if [[ ${{ matrix.clang-runtime }} == '5.0' ]]; then
+          # Install clang-5.0 to run the plugin with.
+          PATH_TO_LLVM_BUILD=/usr/lib/opt/llvm-${{ matrix.clang-runtime }}/
+          sudo mkdir -p /usr/lib/opt
+          pushd /usr/lib/opt
+          sudo curl -L https://releases.llvm.org/5.0.2/clang+llvm-5.0.2-x86_64-linux-gnu-ubuntu-${UNIX_DISTRO}.tar.xz | sudo xz -d -c | sudo tar -x
+          sudo rm -fr /usr/lib/clang*
+          sudo mv clang+llvm-5.0.2-x86_64-linux-gnu-ubuntu-${UNIX_DISTRO}/ llvm-5.0/
+          if [[ ! -f $PATH_TO_LLVM_BUILD/bin/FileCheck ]]; then
+            sudo apt install llvm-5.0-dev llvm-5.0-tools
+            sudo ln -s /usr/lib/llvm-5.0/bin/FileCheck $PATH_TO_LLVM_BUILD/bin/FileCheck
+          fi
+          popd
+        fi
+        # Ubuntu 16.04 & 18.04 llvm/clang-6.0 package is broken - install it from binary build.
+        if [[ ${{ matrix.clang-runtime }} == '6.0' ]]; then
+          # Install clang-6.0 to run the plugin with.
+          PATH_TO_LLVM_BUILD=/usr/lib/opt/llvm-${{ matrix.clang-runtime }}/
+          sudo mkdir -p /usr/lib/opt
+          pushd /usr/lib/opt
+          sudo curl -L https://releases.llvm.org/6.0.1/clang+llvm-6.0.1-x86_64-linux-gnu-ubuntu-${UNIX_DISTRO}.tar.xz | sudo xz -d -c | sudo tar -x
+          sudo rm -fr /usr/lib/clang*
+          sudo mv clang+llvm-6.0.1-x86_64-linux-gnu-ubuntu-${UNIX_DISTRO}/ llvm-6.0/
+          if [[ ! -f $PATH_TO_LLVM_BUILD/bin/FileCheck ]]; then
+            sudo apt install llvm-6.0-dev llvm-6.0-tools
+            sudo ln -s /usr/lib/llvm-6.0/bin/FileCheck $PATH_TO_LLVM_BUILD/bin/FileCheck
+          fi
+          popd
+        fi
+        # llvm-8-tools is broken as it depends on python2.7 we use FileCheck from llvm-7-tools
+        if [[ ${{ matrix.clang-runtime }} == '8' ]]; then
+          if [[ ! -f $PATH_TO_LLVM_BUILD/bin/FileCheck ]]; then
+            sudo apt install llvm-7-dev llvm-7-tools
+            sudo ln -s /usr/lib/llvm-7/bin/FileCheck $PATH_TO_LLVM_BUILD/bin/FileCheck
+          fi
+        fi
+        # Add -H to silence 'The directory '/home/..../pip/http' or its parent
+        # directory is not owned by the current user and the cache has been disabled.
+        sudo -H pip install lit # LLVM lit is not part of the llvm releases...
+        # We need PATH_TO_LLVM_BUILD later
+        echo "PATH_TO_LLVM_BUILD=$PATH_TO_LLVM_BUILD" >> $GITHUB_ENV
+    - name: Setup code coverage on Linux
+      if: ${{ (matrix.coverage == true) && (runner.os == 'Linux') }}
+      run: |
+        sudo apt install lcov
+        echo "CODE_COVERAGE=1" >> $GITHUB_ENV
+        echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
+    - name: Setup code coverage on macOS
+      if: ${{ (matrix.coverage == true) && (runner.os == 'macOS') }}
+      run: |
+        brew install lcov
+        echo "CODE_COVERAGE=1" >> $GITHUB_ENV
+        echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
+    - name: Display config
+      run: |
+        cmake --version
+        $CC --version
+        $CXX --version
+        xz --version
+        tar --version
+        echo "Use Clang/LLVM in $PATH_TO_LLVM_BUILD"
+        echo "Building clad in `[[ -z "$BUILD_TYPE" ]] && echo RelWithDebInfo || echo $BUILD_TYPE`"
+        python --version
+    - name: Build Clad
+      if: ${{ matrix.coverity == false }}
+      run: |
+        mkdir obj && cd obj
+        cmake -DClang_DIR="$PATH_TO_LLVM_BUILD" \
+          -DLLVM_DIR="$PATH_TO_LLVM_BUILD" \
+          -DCMAKE_BUILD_TYPE=$([[ -z "$BUILD_TYPE" ]] && echo RelWithDebInfo || echo $BUILD_TYPE) \
+          -DCODE_COVERAGE=${CODE_COVERAGE}  \
+          -DLLVM_EXTERNAL_LIT="`which lit`" \
+          $GITHUB_WORKSPACE
+        cmake --build . --target check-clad -- -j4
+    - name: Build Clad for Coverity Scan
+      if: ${{ matrix.coverity == true }}
+      run: |
+        # FIXME: Ideally the check should be in the if: block of the action
+        if [ $BRANCH_NAME == "coverity_scan" ]; then
+          if [[ ${{ matrix.compiler }} == "gcc-6" ]]; then
+            mkdir obj && cd obj
+            cmake -DClang_DIR="$PATH_TO_LLVM_BUILD" \
+              -DLLVM_DIR="$PATH_TO_LLVM_BUILD" \
+              -DCMAKE_BUILD_TYPE=$([[ -z "$BUILD_TYPE" ]] && echo RelWithDebInfo || echo $BUILD_TYPE) \
+              $GITHUB_WORKSPACE
+            cov-build --dir cov-out cmake --build .  -- -j4
+          else
+            echo "Coverity Scan can only be triggered for GCC 6. Fix Github Actions YAML"
+            exit 1
+          fi
+        else
+          echo "This action only runs on branch coverity_scan"
+        fi
+    - name: Failed job config
+      if: ${{ failure() }}
+      run: |
+        export
+        if [[ runner.os == "Linux" ]]; then
+          apt-mark showhold
+          dpkg-query -L libclang-${{ matrix.clang-runtime }}-dev
+          dpkg-query -L clang-${{ matrix.clang-runtime }}
+          dpkg-query -L llvm-${{ matrix.clang-runtime }}-dev
+          find /usr/lib/llvm-${{ matrix.clang-runtime }}/
+          find /usr/local/opt/llvm@*/
+        fi
+        if [[ runner.os == "macOS" ]]; then
+          brew search llvm
+        fi
+        pip show lit
+        cat obj/CMakeCache.txt
+        cat obj/CMakeFiles/*.log
+    - name: Code coverage report
+      if: ${{ success() && (matrix.coverage == true) }}
+      run: |
+        # Create lcov report
+        # capture coverage info
+        lcov --directory . --capture --output-file coverage.info
+        # filter out system and extra files.
+        # To also not include test code in coverage add them with full path to the patterns: '*/tests/*'
+        lcov --remove coverage.info '/usr/*' "${HOME}"'/.cache/*' "$GITHUB_WORKSPACE"'/test/*' --output-file coverage.info
+        # output coverage data for debugging (optional)
+        lcov --list coverage.info
+        # Uploading to CodeCov
+        # '-f' specifies file(s) to use and disables manual coverage gathering and file search which has already been done above
+        bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
+    - name: Upload report to coverity_scan
+      if: ${{ success() && (matrix.coverity == true) }}
+      run: |
+        # FIXME: Ideally the check should be in the if: block of the action
+        if [ $BRANCH_NAME == "coverity_scan" ]; then
+          # Upload to coverity
+          tar czvf clad.tgz cov-out
+          # curl \
+          #   --form project=vgvassilev/clad \
+          #   --form token=$TOKEN \
+          #   --form email=v.g.vassilev@gmail.com \
+          #   --form file=@clad.tgz \
+          #   --form version=trunk \
+          #   --form description=""Clad build submitted via Travis CI"" \
+          #   https://scan.coverity.com/builds?project=vgvassilev/clad
+        else
+          echo "This action only runs on branch coverity_scan"
+        fi
+      # env:
+      #  TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -967,7 +967,6 @@ script:
 
 branches:
   only:
-    - master
     - coverity_scan
 
 notifications:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,9 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   ## Define clad supported version of clang and llvm
 
   set(CLANG_MIN_SUPPORTED 5.0)
-  set(CLANG_MAX_SUPPORTED 11.0.1)
+  set(CLANG_MAX_SUPPORTED 11.1.0)
   set(LLVM_MIN_SUPPORTED 5.0)
-  set(LLVM_MAX_SUPPORTED 11.0.1)
+  set(LLVM_MAX_SUPPORTED 11.1.0)
 
   if (NOT DEFINED Clang_DIR)
     set(Clang_DIR ${LLVM_DIR})

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Clad is a plugin for the Clang compiler. It relies on the Clang to build the AST
 * Finally, derivative's AST is [passed](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/tools/ClangPlugin.cpp#L145) for further processing by Clang compiler (LLVM IR generation, optimizations, machine code generation, etc.).
 
 ## How to install
-At the moment, LLVM/Clang 5.0.x - 11.0.x are supported.
+At the moment, LLVM/Clang 5.0.x - 11.1.0 are supported.
 
 ###  Building from source (example was tested on Ubuntu 18.04 LTS)
   ```


### PR DESCRIPTION
2 tests are failing on the test instances with Clang 10 and Clang 11. I am unable to debug the issue myself and would really appreciate any help with that.

I updated the maximum supported version of LLVM/Clang to 11.1.0 from 11.0.1 since the default LLVM/Clang 11 installed by apt from https://apt.llvm.org/ is version 11.1.0.

Coverity scan hasn't properly been integrated into the new Github Actions CI yet, therefore I have kept the .travis.yml but edited it to make sure that it only gets triggered on the "coverity_scan" branch. We could also remove travis completely in this PR if that would be cleaner.

@vgvassilev 