### PR TITLE
Visit only regions annotated with #pragma clad ON.

### DIFF
--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -6,13 +6,14 @@
 #ifndef CLAD_COMPATIBILITY
 #define CLAD_COMPATIBILITY
 
-#include "clang/Basic/Version.h"
 #include "llvm/Config/llvm-config.h"
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/Stmt.h"
+#include "clang/Basic/Version.h"
+#include "clang/Basic/SourceManager.h"
 #include "clang/Sema/Sema.h"
 
 namespace clad_compat {
@@ -21,6 +22,18 @@ using namespace clang;
 using namespace llvm;
 
 // Compatibility helper function for creation CompoundStmt. Clang 6 and above use Create.
+
+static inline bool SourceManager_isPointWithin(const SourceManager& SM,
+                                               SourceLocation Loc,
+                                               SourceLocation B,
+                                               SourceLocation E) {
+#if CLANG_VERSION_MAJOR == 5
+  return Loc == B || Loc == E || (SM.isBeforeInTranslationUnit(B, Loc) &&
+                                  SM.isBeforeInTranslationUnit(Loc, E));
+#elif CLANG_VERSION_MAJOR >= 6
+  return SM.isPointWithin(Loc, B, E);
+#endif
+}
 
 static inline CompoundStmt* CompoundStmt_Create(
         const ASTContext &Ctx, ArrayRef<Stmt *> Stmts,

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -94,6 +94,7 @@ namespace clad {
         // clad did not place the derivative in this object. This can happen
         // upon error of if clad was disabled. Diagnose.
         printf("clad failed to place the generated derivative in the object\n");
+        printf("Make sure calls to clad are within a #pragma clad ON region\n");
 
         // Invalidate the placeholders.
         m_Function = nullptr;
@@ -201,3 +202,7 @@ namespace clad {
   }
 }
 #endif // CLAD_DIFFERENTIATOR
+
+// Enable clad after the header was included.
+// FIXME: The header inclusion should be made automatic if the pragma is seen.
+#pragma clad ON

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -9,6 +9,7 @@
 
 #include "clad/Differentiator/Version.h"
 #include "clad/Differentiator/DerivativeBuilder.h"
+#include "clad/Differentiator/DiffPlanner.h"
 
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/RecursiveASTVisitor.h"
@@ -23,7 +24,7 @@ namespace clang {
   class CompilerInstance;
   class DeclGroupRef;
   class Expr;
-//class FunctionDecl;
+  class FunctionDecl;
   class ParmVarDecl;
   class Sema;
 }
@@ -46,20 +47,19 @@ namespace clad {
     };
 
     class CladPlugin : public clang::ASTConsumer {
-    private:
       clang::CompilerInstance& m_CI;
       DifferentiationOptions m_DO;
       std::unique_ptr<DerivativeBuilder> m_DerivativeBuilder;
+      DerivativesSet m_Derivatives;
       bool m_HasRuntime = false;
       bool m_PendingInstantiationsInFlight = false;
     public:
       CladPlugin(clang::CompilerInstance& CI, DifferentiationOptions& DO);
       ~CladPlugin();
-
-      virtual bool HandleTopLevelDecl(clang::DeclGroupRef DGR);
+      bool HandleTopLevelDecl(clang::DeclGroupRef DGR) override;
       clang::FunctionDecl* ProcessDiffRequest(DiffRequest& request);
     private:
-      bool ShouldProcessDecl(clang::DeclGroupRef DGR);
+      bool CheckBuiltins();
     };
 
     clang::FunctionDecl* ProcessDiffRequest(CladPlugin& P,


### PR DESCRIPTION
This PR implements more sophisticated handling of #pragma clad ON/OFF/DEFAULT
and tracks the regions where it was enabled/disabled.

Later, we only collect the calls to `clad::*` within that region without
descending into the clad-produced derivatives/gradients.