### PR TITLE
Fix ForStmt issue in reverse mode

### DIFF
--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -2221,7 +2221,7 @@ namespace clad {
     beginBlock(forward);
     beginBlock(reverse);
     const Stmt* init = FS->getInit();
-    StmtDiff initResult = init ? Visit(init) : StmtDiff{};
+    StmtDiff initResult = init ? DifferentiateSingleStmt(init) : StmtDiff{};
 
     VarDecl* condVarDecl = FS->getConditionVariable();
     VarDecl* condVarClone = nullptr;
@@ -2324,6 +2324,8 @@ namespace clad {
     CompoundStmt* ReverseBody = endBlock(reverse);
     std::reverse(ReverseBody->body_begin(), ReverseBody->body_end());
     Stmt* ReverseResult = unwrapIfSingleStmt(ReverseBody);
+    if (!ReverseResult) 
+      ReverseResult = new (m_Context) NullStmt(noLoc);
     Stmt* Reverse = new (m_Context) ForStmt(m_Context, nullptr,
                                             CounterCondition, condVarClone,
                                             CounterDecrement, ReverseResult,

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -164,6 +164,28 @@ double f4(double x) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
+double f5(double x){
+  for (int i = 0; i < 10; i++)
+    x++;
+  return x;
+} // == x + 10
+
+//CHECK:   void f5_grad(double x, double *_result) {
+//CHECK-NEXT:       unsigned long _t0;
+//CHECK-NEXT:       int _d_i = 0;
+//CHECK-NEXT:       _t0 = 0;
+//CHECK-NEXT:       for (int i = 0; i < 10; i++) {
+//CHECK-NEXT:           _t0++;
+//CHECK-NEXT:           x++;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       double f5_return = x;
+//CHECK-NEXT:       goto _label0;
+//CHECK-NEXT:     _label0:
+//CHECK-NEXT:       _result[0UL] += 1;
+//CHECK-NEXT:       for (; _t0; _t0--)
+//CHECK-NEXT:           ;
+//CHECK-NEXT:   }
+
 double f_sum(double *p, int n) {
   double s = 0;
   for (int i = 0; i < n; i++)
@@ -358,6 +380,7 @@ int main() {
   TEST(f2, 3); // CHECK-EXEC: {59049.00} 
   TEST(f3, 3); // CHECK-EXEC: {6.00} 
   TEST(f4, 3); // CHECK-EXEC: {27.00}
+  TEST(f5, 3); // CHECK-EXEC: {1.00}
 
   double p[] = { 1, 2, 3, 4, 5 };
 


### PR DESCRIPTION
This commit fixes the following issues with the reverse mode visitor for ForStmt

1) Initialization of the loop variable outside the ForStmt resulted in a crash
2) Single statement loop bodies would result in failed assertions