### PR TITLE
Drop Python2 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,7 +513,7 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         # Update openssl on osx because the current one is deprecated by python.
-        curl -L https://bootstrap.pypa.io/get-pip.py | sudo python
+        curl -L https://bootstrap.pypa.io/get-pip.py | sudo python3
         echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
         PATH_TO_LLVM_BUILD=/usr/local/opt/llvm@${{ matrix.clang-runtime }}/
         # Package llvm@5 is not supported on brew. We must install it from binary build.
@@ -581,13 +581,7 @@ jobs:
           fi
           popd
         fi
-        # Add -H to silence 'The directory '/home/..../pip/http' or its parent
-        # directory is not owned by the current user and the cache has been disabled.
-        pyver=$(python -c"import sys; print(sys.version_info.major)")
-        if [ $pyver -eq 2 ]; then
-          echo "/Library/Frameworks/Python.framework/Versions/2.7/bin" >> $GITHUB_PATH
-        fi
-        sudo -H pip install lit # LLVM lit is not part of the llvm releases...
+        sudo -H python3 -m pip install lit # LLVM lit is not part of the llvm releases...
         # We need headers in correct place
         for file in $(xcrun --show-sdk-path)/usr/include/*
         do
@@ -641,7 +635,7 @@ jobs:
         fi
         # Add -H to silence 'The directory '/home/..../pip/http' or its parent
         # directory is not owned by the current user and the cache has been disabled.
-        sudo -H pip install lit # LLVM lit is not part of the llvm releases...
+        sudo -H python3 -m pip install lit # LLVM lit is not part of the llvm releases...
         # We need PATH_TO_LLVM_BUILD later
         echo "PATH_TO_LLVM_BUILD=$PATH_TO_LLVM_BUILD" >> $GITHUB_ENV
     - name: Setup code coverage on Linux
@@ -665,7 +659,7 @@ jobs:
         tar --version
         echo "Use Clang/LLVM in $PATH_TO_LLVM_BUILD"
         echo "Building clad in `[[ -z "$BUILD_TYPE" ]] && echo RelWithDebInfo || echo $BUILD_TYPE`"
-        python --version
+        python3 --version
     - name: Build Clad
       if: ${{ matrix.coverity == false }}
       run: |
@@ -711,7 +705,7 @@ jobs:
         if [[ runner.os == "macOS" ]]; then
           brew search llvm
         fi
-        pip show lit
+        python3 -m pip show lit
         cat obj/CMakeCache.txt
         cat obj/CMakeFiles/*.log
     - name: Setup tmate session


### PR DESCRIPTION
macOS CI was failing because libraries are slowly removing Python 2 support.