### PR TITLE
Support member functions with qualifiers in differentiation calls

### DIFF
--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -1,0 +1,349 @@
+#ifndef FUNCTION_TRAITS
+#define FUNCTION_TRAITS
+
+namespace clad {
+
+  // Trait class to deduce return type of function(both member and non-member) at commpile time
+  // Only function pointer types are supported by this trait class
+  template <class F> 
+  struct return_type {};
+  template <class F> 
+  using return_type_t = typename return_type<F>::type;
+
+  // specializations for non-member functions pointer types
+  template <class ReturnType, class... Args> 
+  struct return_type<ReturnType (*)(Args...)> {
+    using type = ReturnType;
+  };
+  template <class ReturnType, class... Args> 
+  struct return_type<ReturnType (*)(Args..., ...)> {
+    using type = ReturnType;
+  };
+
+  // specializations for member functions pointer types with no qualifiers
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...)> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...)> { 
+    using type = ReturnType; 
+  };
+
+  // specializations for member functions pointer type with only cv-qualifiers
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) const> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) const> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) volatile> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) volatile> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) const volatile> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) const volatile> { 
+    using type = ReturnType; 
+  };
+
+  // specializations for member functions pointer types with 
+  // reference qualifiers and with and without cv-qualifiers
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) &> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) &> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) const &> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) const &> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) volatile &> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) volatile &> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) const volatile &> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) const volatile &> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) &&> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) &&> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) const &&> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) const &&> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) volatile &&> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) volatile &&> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) const volatile &&> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) const volatile &&> { 
+    using type = ReturnType; 
+  };
+
+  // specializations for noexcept member functions
+  #if __cpp_noexcept_function_type > 0
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) const noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) const noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) volatile noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) volatile noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) const volatile noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) const volatile noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) & noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) & noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) const & noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) const & noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) volatile & noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) volatile & noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) const volatile & noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) const volatile & noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) && noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) && noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) const && noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) const && noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) volatile && noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) volatile && noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args...) const volatile && noexcept> { 
+    using type = ReturnType; 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct return_type<ReturnType (C::*)(Args..., ...) const volatile && noexcept> { 
+    using type = ReturnType; 
+  };
+  #endif
+
+  // ExtractDerivedFnTraits is used to deduce type of the derived functions 
+  // derived using reverse, hessian and jacobian differentiation modes
+  // It SHOULD NOT be used to get traits of derived functions derived using
+  // forward differentiation mode
+  template<class ReturnType>
+  struct ExtractDerivedFnTraits {};
+  template<class T>
+  using ExtractDerivedFnTraits_t = typename ExtractDerivedFnTraits<T>::type;
+
+  // specializations for non-member functions pointer types
+  template <class ReturnType,class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (*)(Args...)> {
+    using type = void (*)(Args..., ReturnType*);
+  };
+
+  // specializations for member functions pointer types with no cv-qualifiers
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  
+  // specializations for member functions pointer types with only cv-qualifiers
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+
+  // specializations for member functions pointer types with 
+  // reference qualifiers and with and without cv-qualifiers
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &&> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &&> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &&> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &&> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+
+  // specializations for noexcept member functions
+  #if __cpp_noexcept_function_type > 0
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) noexcept> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const noexcept> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile noexcept> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile noexcept> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) & noexcept> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const & noexcept> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile & noexcept> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile & noexcept> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) && noexcept> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const && noexcept> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile && noexcept> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile && noexcept> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+  #endif
+} // namespace clad
+
+#endif // FUNCTION_TRAITS

--- a/test/ForwardMode/MemberFunctions.C
+++ b/test/ForwardMode/MemberFunctions.C
@@ -1,0 +1,755 @@
+// RUN: %cladclang %s -I%S/../../include -oMemberFunctions.out 2>&1 | FileCheck %s
+// RUN: ./MemberFunctions.out | FileCheck -check-prefix=CHECK-EXEC %s
+// RUN: %cladclang -std=c++14 %s -I%S/../../include -oMemberFunctions-cpp14.out 2>&1 | FileCheck %s
+// RUN: ./MemberFunctions-cpp14.out | FileCheck -check-prefix=CHECK-EXEC %s
+// RUN: %cladclang -std=c++17 %s -I%S/../../include -oMemberFunctions-cpp17.out 2>&1 | FileCheck %s
+// RUN: ./MemberFunctions-cpp17.out | FileCheck -check-prefix=CHECK-EXEC %s
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+extern "C" int printf(const char *fmt, ...);
+class SimpleFunctions {
+public:
+  SimpleFunctions(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
+  double x, y;
+  double mem_fn(double i, double j)  { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double mem_fn_darg0(double i, double j) {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double mem_fn_with_var_arg_list(double i, double j, ...)  { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double mem_fn_with_var_arg_list_darg0(double i, double j, ...) {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_mem_fn(double i, double j) const { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_mem_fn_darg0(double i, double j) const {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_mem_fn_with_var_arg_list(double i, double j, ...) const { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double volatile_mem_fn(double i, double j) volatile { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double volatile_mem_fn_darg0(double i, double j) volatile {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double volatile_mem_fn_with_var_arg_list(double i, double j, ...) volatile { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double volatile_mem_fn_with_var_arg_list_darg0(double i, double j, ...) volatile {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_volatile_mem_fn(double i, double j) const volatile { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_volatile_mem_fn_darg0(double i, double j) const volatile {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_volatile_mem_fn_with_var_arg_list(double i, double j, ...) const volatile { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_volatile_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const volatile {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double lval_ref_mem_fn(double i, double j) & { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double lval_ref_mem_fn_darg0(double i, double j) & {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double lval_ref_mem_fn_with_var_arg_list(double i, double j, ...) & { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double lval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) & {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_lval_ref_mem_fn(double i, double j) const & { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_lval_ref_mem_fn_darg0(double i, double j) const & {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_lval_ref_mem_fn_with_var_arg_list(double i, double j, ...) const & { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_lval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const & {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double volatile_lval_ref_mem_fn(double i, double j) volatile & { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double volatile_lval_ref_mem_fn_darg0(double i, double j) volatile & {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double volatile_lval_ref_mem_fn_with_var_arg_list(double i, double j, ...) volatile & { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double volatile_lval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) volatile & {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_volatile_lval_ref_mem_fn(double i, double j) const volatile & { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_volatile_lval_ref_mem_fn_darg0(double i, double j) const volatile & {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_volatile_lval_ref_mem_fn_with_var_arg_list(double i, double j, ...) const volatile & { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_volatile_lval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const volatile & {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double rval_ref_mem_fn(double i, double j) && { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double rval_ref_mem_fn_darg0(double i, double j) && {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double rval_ref_mem_fn_with_var_arg_list(double i, double j, ...) && { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double rval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) && {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_rval_ref_mem_fn(double i, double j) const && { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_rval_ref_mem_fn_darg0(double i, double j) const && {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_rval_ref_mem_fn_with_var_arg_list(double i, double j, ...) const && { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_rval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const && {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double volatile_rval_ref_mem_fn(double i, double j) volatile && { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double volatile_rval_ref_mem_fn_darg0(double i, double j) volatile && {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double volatile_rval_ref_mem_fn_with_var_arg_list(double i, double j, ...) volatile && { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double volatile_rval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) volatile && {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_volatile_rval_ref_mem_fn(double i, double j) const volatile && { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_volatile_rval_ref_mem_fn_darg0(double i, double j) const volatile && {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_volatile_rval_ref_mem_fn_with_var_arg_list(double i, double j, ...) const volatile && { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_volatile_rval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const volatile && {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double noexcept_mem_fn(double i, double j) noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double noexcept_mem_fn_darg0(double i, double j) noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double noexcept_mem_fn_with_var_arg_list(double i, double j, ...) noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_noexcept_mem_fn(double i, double j) const noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_noexcept_mem_fn_darg0(double i, double j) const noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) const noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double volatile_noexcept_mem_fn(double i, double j) volatile noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double volatile_noexcept_mem_fn_darg0(double i, double j) volatile noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double volatile_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) volatile noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double volatile_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) volatile noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_volatile_noexcept_mem_fn(double i, double j) const volatile noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_volatile_noexcept_mem_fn_darg0(double i, double j) const volatile noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_volatile_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) const volatile noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_volatile_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const volatile noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double lval_ref_noexcept_mem_fn(double i, double j) & noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double lval_ref_noexcept_mem_fn_darg0(double i, double j) & noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double lval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) & noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double lval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) & noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_lval_ref_noexcept_mem_fn(double i, double j) const & noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_lval_ref_noexcept_mem_fn_darg0(double i, double j) const & noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_lval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) const & noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_lval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const & noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double volatile_lval_ref_noexcept_mem_fn(double i, double j) volatile & noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double volatile_lval_ref_noexcept_mem_fn_darg0(double i, double j) volatile & noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double volatile_lval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) volatile & noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double volatile_lval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) volatile & noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_volatile_lval_ref_noexcept_mem_fn(double i, double j) const volatile & noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_volatile_lval_ref_noexcept_mem_fn_darg0(double i, double j) const volatile & noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_volatile_lval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) const volatile & noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_volatile_lval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const volatile & noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double rval_ref_noexcept_mem_fn(double i, double j) && noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double rval_ref_noexcept_mem_fn_darg0(double i, double j) && noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double rval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) && noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double rval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) && noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_rval_ref_noexcept_mem_fn(double i, double j) const && noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_rval_ref_noexcept_mem_fn_darg0(double i, double j) const && noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_rval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) const && noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_rval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const && noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double volatile_rval_ref_noexcept_mem_fn(double i, double j) volatile && noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double volatile_rval_ref_noexcept_mem_fn_darg0(double i, double j) volatile && noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double volatile_rval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) volatile && noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double volatile_rval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) volatile && noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_volatile_rval_ref_noexcept_mem_fn(double i, double j) const volatile && noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_volatile_rval_ref_noexcept_mem_fn_darg0(double i, double j) const volatile && noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+  double const_volatile_rval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) const volatile && noexcept { 
+    return (x+y)*i + i*j*j; 
+  } 
+
+  // CHECK: double const_volatile_rval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const volatile && noexcept {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t1 = i * j;
+  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+
+};
+
+#define TEST(name,i,j) \
+  auto d_##name = clad::differentiate(&SimpleFunctions::name,"i");\
+  printf("%.2f\n", d_##name.execute(expr_1, 3, 5));\
+  printf("%.2f\n", d_##name.execute(expr_2, 3, 5));\
+  printf("\n");\
+
+#define RVAL_REF_TEST(name, i, j) \
+  auto d_##name = clad::differentiate(&SimpleFunctions::name,"i");\
+  printf("%.2f\n", d_##name.execute(std::move(expr_1), 3, 5));\
+  printf("%.2f\n", d_##name.execute(std::move(expr_2), 3, 5));\
+  printf("\n");\
+
+int main() {
+
+  SimpleFunctions expr_1(2, 3);
+  SimpleFunctions expr_2(3, 5);
+
+  TEST(mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                      // CHECK-EXEC: 33.00 
+
+  TEST(mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                        // CHECK-EXEC: 33.00 
+
+  TEST(const_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                            // CHECK-EXEC: 33.00 
+
+  TEST(const_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                              // CHECK-EXEC: 33.00 
+
+  TEST(volatile_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                               // CHECK-EXEC: 33.00 
+
+  TEST(volatile_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                 // CHECK-EXEC: 33.00 
+
+  TEST(const_volatile_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                     // CHECK-EXEC: 33.00 
+
+  TEST(const_volatile_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                       // CHECK-EXEC: 33.00 
+
+  TEST(lval_ref_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                               // CHECK-EXEC: 33.00 
+
+  TEST(lval_ref_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                 // CHECK-EXEC: 33.00 
+
+  TEST(const_lval_ref_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                     // CHECK-EXEC: 33.00 
+
+  TEST(const_lval_ref_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                       // CHECK-EXEC: 33.00 
+
+  TEST(volatile_lval_ref_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                        // CHECK-EXEC: 33.00 
+
+  TEST(volatile_lval_ref_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                          // CHECK-EXEC: 33.00 
+
+  TEST(const_volatile_lval_ref_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                              // CHECK-EXEC: 33.00 
+
+  TEST(const_volatile_lval_ref_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(rval_ref_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                        // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(rval_ref_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                          // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(const_rval_ref_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                              // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(const_rval_ref_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(volatile_rval_ref_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                                 // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(volatile_rval_ref_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                   // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(const_volatile_rval_ref_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                                       // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(const_volatile_rval_ref_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                         // CHECK-EXEC: 33.00 
+
+  TEST(noexcept_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                               // CHECK-EXEC: 33.00 
+
+  TEST(noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                 // CHECK-EXEC: 33.00 
+
+  TEST(const_noexcept_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                     // CHECK-EXEC: 33.00 
+
+  TEST(const_noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                       // CHECK-EXEC: 33.00 
+
+  TEST(volatile_noexcept_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                        // CHECK-EXEC: 33.00 
+
+  TEST(volatile_noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                          // CHECK-EXEC: 33.00 
+
+  TEST(const_volatile_noexcept_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                              // CHECK-EXEC: 33.00 
+
+  TEST(const_volatile_noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                // CHECK-EXEC: 33.00 
+
+  TEST(lval_ref_noexcept_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                        // CHECK-EXEC: 33.00 
+
+  TEST(lval_ref_noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                          // CHECK-EXEC: 33.00 
+
+  TEST(const_lval_ref_noexcept_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                              // CHECK-EXEC: 33.00 
+
+  TEST(const_lval_ref_noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                // CHECK-EXEC: 33.00 
+
+  TEST(volatile_lval_ref_noexcept_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                                 // CHECK-EXEC: 33.00 
+
+  TEST(volatile_lval_ref_noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                   // CHECK-EXEC: 33.00 
+
+  TEST(const_volatile_lval_ref_noexcept_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                                       // CHECK-EXEC: 33.00 
+
+  TEST(const_volatile_lval_ref_noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                         // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(rval_ref_noexcept_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                                 // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(rval_ref_noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                   // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(const_rval_ref_noexcept_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                                       // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(const_rval_ref_noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                         // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(volatile_rval_ref_noexcept_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                                          // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(volatile_rval_ref_noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                            // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(const_volatile_rval_ref_noexcept_mem_fn, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                // CHECK-EXEC: 33.00 
+
+  RVAL_REF_TEST(const_volatile_rval_ref_noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
+                                                                                  // CHECK-EXEC: 33.00 
+
+}

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -1,0 +1,749 @@
+// RUN: %cladclang %s -lm -I%S/../../include -oMemberFunctions.out 2>&1 | FileCheck %s
+// RUN: ./MemberFunctions.out | FileCheck -check-prefix=CHECK-EXEC %s
+// RUN: %cladclang -std=c++14 %s -lm -I%S/../../include -oMemberFunctions-cpp14.out 2>&1 | FileCheck %s
+// RUN: ./MemberFunctions-cpp14.out | FileCheck -check-prefix=CHECK-EXEC %s
+// RUN: %cladclang -std=c++17 %s -lm -I%S/../../include -oMemberFunctions-cpp17.out 2>&1 | FileCheck %s
+// RUN: ./MemberFunctions-cpp17.out | FileCheck -check-prefix=CHECK-EXEC %s
+
+//CHECK-NOT: {{.*error|warning|note:.*}}
+#include "clad/Differentiator/Differentiator.h"
+
+class SimpleFunctions {
+public:
+  SimpleFunctions(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
+  double x, y;
+  double mem_fn(double i, double j)  { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double const_mem_fn(double i, double j) const { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void const_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double volatile_mem_fn(double i, double j) volatile { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void volatile_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double volatile_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double const_volatile_mem_fn(double i, double j) const volatile { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void const_volatile_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_volatile_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double lval_ref_mem_fn(double i, double j) & { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void lval_ref_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double const_lval_ref_mem_fn(double i, double j) const & { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double volatile_lval_ref_mem_fn(double i, double j) volatile & { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double const_volatile_lval_ref_mem_fn(double i, double j) const volatile & { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double rval_ref_mem_fn(double i, double j) && { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void rval_ref_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double const_rval_ref_mem_fn(double i, double j) const && { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double volatile_rval_ref_mem_fn(double i, double j) volatile && { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double volatile_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double const_volatile_rval_ref_mem_fn(double i, double j) const volatile && { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_volatile_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double noexcept_mem_fn(double i, double j) noexcept { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void noexcept_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double const_noexcept_mem_fn(double i, double j) const noexcept { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void const_noexcept_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double volatile_noexcept_mem_fn(double i, double j) volatile noexcept { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double volatile_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double const_volatile_noexcept_mem_fn(double i, double j) const volatile noexcept { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_volatile_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double lval_ref_noexcept_mem_fn(double i, double j) & noexcept { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double const_lval_ref_noexcept_mem_fn(double i, double j) const & noexcept { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double volatile_lval_ref_noexcept_mem_fn(double i, double j) volatile & noexcept { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double volatile_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double const_volatile_lval_ref_noexcept_mem_fn(double i, double j) const volatile & noexcept { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_volatile_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double rval_ref_noexcept_mem_fn(double i, double j) && noexcept { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double const_rval_ref_noexcept_mem_fn(double i, double j) const && noexcept { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double volatile_rval_ref_noexcept_mem_fn(double i, double j) volatile && noexcept { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double volatile_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  double const_volatile_rval_ref_noexcept_mem_fn(double i, double j) const volatile && noexcept { 
+    return (x+y)*i + i*j; 
+  } 
+
+  // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_volatile_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  void mem_fn_grad(double i, double j, double *_result) ; 
+  void const_mem_fn_grad(double i, double j, double *_result) ; 
+  void volatile_mem_fn_grad(double i, double j, double *_result) ; 
+  void const_volatile_mem_fn_grad(double i, double j, double *_result) ; 
+  void lval_ref_mem_fn_grad(double i, double j, double *_result) ; 
+  void const_lval_ref_mem_fn_grad(double i, double j, double *_result) ; 
+  void volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) ; 
+  void const_volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) ; 
+  void rval_ref_mem_fn_grad(double i, double j, double *_result) ; 
+  void const_rval_ref_mem_fn_grad(double i, double j, double *_result) ; 
+  void volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) ; 
+  void const_volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) ; 
+  void noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+  void const_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+  void volatile_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+  void const_volatile_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+  void lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+  void const_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+  void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+  void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+  void rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+  void const_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+  void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+  void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+
+};
+
+double fn(double i,double j) {
+  return i*i*j;
+}
+
+// CHECK: void fn_grad(double i, double j, double *_result) {
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     double _t3;
+// CHECK-NEXT:     _t2 = i;
+// CHECK-NEXT:     _t1 = i;
+// CHECK-NEXT:     _t3 = _t2 * _t1;
+// CHECK-NEXT:     _t0 = j;
+// CHECK-NEXT:     double fn_return = _t3 * _t0;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 1 * _t0;
+// CHECK-NEXT:         double _r1 = _r0 * _t1;
+// CHECK-NEXT:         _result[0UL] += _r1;
+// CHECK-NEXT:         double _r2 = _t2 * _r0;
+// CHECK-NEXT:         _result[0UL] += _r2;
+// CHECK-NEXT:         double _r3 = _t3 * 1;
+// CHECK-NEXT:         _result[1UL] += _r3;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+int main() {
+  auto d_mem_fn = clad::gradient(&SimpleFunctions::mem_fn);
+  auto d_const_mem_fn = clad::gradient(&SimpleFunctions::const_mem_fn);
+  auto d_volatile_mem_fn = clad::gradient(&SimpleFunctions::volatile_mem_fn);
+  auto d_const_volatile_mem_fn = clad::gradient(&SimpleFunctions::const_volatile_mem_fn);
+  auto d_lval_ref_mem_fn = clad::gradient(&SimpleFunctions::lval_ref_mem_fn);
+  auto d_const_lval_ref_mem_fn = clad::gradient(&SimpleFunctions::const_lval_ref_mem_fn);
+  auto d_volatile_lval_ref_mem_fn = clad::gradient(&SimpleFunctions::volatile_lval_ref_mem_fn);
+  auto d_const_volatile_lval_ref_mem_fn = clad::gradient(&SimpleFunctions::const_volatile_lval_ref_mem_fn);
+  auto d_rval_ref_mem_fn = clad::gradient(&SimpleFunctions::rval_ref_mem_fn);
+  auto d_const_rval_ref_mem_fn = clad::gradient(&SimpleFunctions::const_rval_ref_mem_fn);
+  auto d_volatile_rval_ref_mem_fn = clad::gradient(&SimpleFunctions::volatile_rval_ref_mem_fn);
+  auto d_const_volatile_rval_ref_mem_fn = clad::gradient(&SimpleFunctions::const_volatile_rval_ref_mem_fn);
+  auto d_noexcept_mem_fn = clad::gradient(&SimpleFunctions::noexcept_mem_fn);
+  auto d_const_noexcept_mem_fn = clad::gradient(&SimpleFunctions::const_noexcept_mem_fn);
+  auto d_volatile_noexcept_mem_fn = clad::gradient(&SimpleFunctions::volatile_noexcept_mem_fn);
+  auto d_const_volatile_noexcept_mem_fn = clad::gradient(&SimpleFunctions::const_volatile_noexcept_mem_fn);
+  auto d_lval_ref_noexcept_mem_fn = clad::gradient(&SimpleFunctions::lval_ref_noexcept_mem_fn);
+  auto d_const_lval_ref_noexcept_mem_fn = clad::gradient(&SimpleFunctions::const_lval_ref_noexcept_mem_fn);
+  auto d_volatile_lval_ref_noexcept_mem_fn = clad::gradient(&SimpleFunctions::volatile_lval_ref_noexcept_mem_fn);
+  auto d_const_volatile_lval_ref_noexcept_mem_fn = clad::gradient(&SimpleFunctions::const_volatile_lval_ref_noexcept_mem_fn);
+  auto d_rval_ref_noexcept_mem_fn = clad::gradient(&SimpleFunctions::rval_ref_noexcept_mem_fn);
+  auto d_const_rval_ref_noexcept_mem_fn = clad::gradient(&SimpleFunctions::const_rval_ref_noexcept_mem_fn);
+  auto d_volatile_rval_ref_noexcept_mem_fn = clad::gradient(&SimpleFunctions::volatile_rval_ref_noexcept_mem_fn);
+  auto d_const_volatile_rval_ref_noexcept_mem_fn = clad::gradient(&SimpleFunctions::const_volatile_rval_ref_noexcept_mem_fn);
+
+  auto d_fn = clad::gradient(fn);
+  double result[2];
+  d_fn.execute(4,5,result);
+  for(unsigned i=0;i<2;++i) {
+    printf("%.2f ",result[i]);  //CHECK-EXEC: 40.00 16.00
+  }
+}


### PR DESCRIPTION
This pull request :
-  Add support of functions with qualifiers (`const`, `volatile`,`reference qualifiers` and `noexcept`)
    in differentiation calls using:
   - `clad::differentiate`
   - `clad::gradient`
   - `clad::hessian`
   - `clad::jacobian`
- Add support of vardiac functions for forward differentiation mode (`clad::differentiation`)
  
Consequently, it fix differentiation of member functions with qualifiers in forward differentiation mode .

Main idea used in this PR is suggested by @vgvassilev and @pdimov

Fixes #199 

