### PR TITLE
Add support for using casts, * and & operators with fn argument

### DIFF
--- a/test/ForwardMode/Pointers.C
+++ b/test/ForwardMode/Pointers.C
@@ -1,0 +1,163 @@
+// RUN: %cladclang %s -I%S/../../include -oPointers.out 2>&1 | FileCheck %s
+// RUN: ./Pointers.out | FileCheck -check-prefix=CHECK-EXEC %s
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+class Expression {
+public:
+  Expression() {}
+  double memFn(double i) {
+    return i*i;
+  }
+
+  // CHECK: double memFn_darg0(double i) {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     return _d_i * i + i * _d_i;
+  // CHECK-NEXT: }
+
+};
+
+double nonMemFn(double i) {
+  return 5*i;
+}
+
+// CHECK: double nonMemFn_darg0(double i) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     return 0 * i + 5 * _d_i;
+// CHECK-NEXT: }
+
+#define MEM_FN_TEST(var)\
+printf("%.2f\n",var.execute(expr,7));
+
+#define NON_MEM_FN_TEST(var)\
+printf("%.2f\n",var.execute(3));
+
+int main() {
+  Expression expr;
+
+  auto memFnPtr = &Expression::memFn;
+  auto memFnPtrToPtr = &memFnPtr;
+  auto memFnPtrToPtrToPtr = &memFnPtrToPtr;
+  auto memFnIndirectPtr = memFnPtr;
+  auto memFnIndirectIndirectPtr = memFnIndirectPtr;
+
+  auto d_memFnPtr = clad::differentiate(memFnPtr, "i");
+  auto d_memFnPtrPar = clad::differentiate((memFnPtr), "i");
+  auto d_memFnPtrToPtr = clad::differentiate(*memFnPtrToPtr, "i");
+  auto d_memFnPtrToPtr_1 = clad::differentiate(**&memFnPtrToPtr, "i");
+  auto d_memFnPtrToPtr_1Par = clad::differentiate(**(&memFnPtrToPtr), "i");
+  auto d_memFnPtrToPtr_1ParPar = clad::differentiate(*(*(&memFnPtrToPtr)), "i");
+  auto d_memFnPtrToPtrToPtr = clad::differentiate(**memFnPtrToPtrToPtr, "i");
+  auto d_memFnPtrToPtrToPtrPar = clad::differentiate(*(*memFnPtrToPtrToPtr), "i");
+  auto d_memFnPtrToPtrToPtrParPar = clad::differentiate(((*(*memFnPtrToPtrToPtr))), "i");
+  auto d_memFnPtrToPtrToPtr_1 = clad::differentiate(***&memFnPtrToPtrToPtr, "i");
+  auto d_memFnPtrToPtrToPtr_1Par = clad::differentiate(***(&memFnPtrToPtrToPtr), "i");
+  auto d_memFnPtrToPtrToPtr_1ParPar = clad::differentiate(**(*(&memFnPtrToPtrToPtr)), "i");
+  auto d_memFnPtrToPtrToPtr_1ParParPar = clad::differentiate(*(*(*(&memFnPtrToPtrToPtr))), "i");
+  auto d_memFnIndirectPtr = clad::differentiate(memFnIndirectPtr, "i");
+  auto d_memFnIndirectIndirectPtr = clad::differentiate(memFnIndirectIndirectPtr, "i");
+  auto d_memFnStaticCast = clad::differentiate(static_cast<decltype(&Expression::memFn)>(&Expression::memFn), "i");
+  auto d_memFnReinterpretCast = clad::differentiate(reinterpret_cast<decltype(&Expression::memFn)>(&Expression::memFn), "i");
+  auto d_memFnCStyleCast = clad::differentiate((decltype(&Expression::memFn))(&Expression::memFn), "i");
+
+  MEM_FN_TEST(d_memFnPtr); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnPtrPar); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnPtrToPtr); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnPtrToPtr_1); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnPtrToPtr_1Par); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnPtrToPtr_1ParPar); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnPtrToPtrToPtr); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnPtrToPtrToPtrPar); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnPtrToPtrToPtrParPar); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnPtrToPtrToPtr_1); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnPtrToPtrToPtr_1Par); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnPtrToPtrToPtr_1ParPar); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnPtrToPtrToPtr_1ParParPar); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnIndirectPtr); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnIndirectIndirectPtr); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnStaticCast); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnReinterpretCast); // CHECK-EXEC: 14.00
+
+  MEM_FN_TEST(d_memFnCStyleCast); // CHECK-EXEC: 14.00
+
+  auto nonMemFnPtr = &nonMemFn;
+  auto nonMemFnPtrToPtr = &nonMemFnPtr;
+  auto nonMemFnPtrToPtrToPtr = &nonMemFnPtrToPtr;
+  auto nonMemFnIndirectPtr = nonMemFnPtr;
+  auto nonMemFnIndirectIndirectPtr = nonMemFnIndirectPtr;
+
+  auto d_nonMemFn = clad::differentiate(nonMemFn, "i");
+  auto d_nonMemFnPar = clad::differentiate((nonMemFn), "i");
+  auto d_nonMemFnPtr = clad::differentiate(nonMemFnPtr, "i");
+  auto d_nonMemFnPtrToPtr = clad::differentiate(*nonMemFnPtrToPtr, "i");
+  auto d_nonMemFnPtrToPtrPar = clad::differentiate((*(nonMemFnPtrToPtr)), "i");
+  auto d_nonMemFnPtrToPtr_1 = clad::differentiate(**&nonMemFnPtrToPtr, "i");
+  auto d_nonMemFnPtrToPtr_1Par = clad::differentiate(**(&nonMemFnPtrToPtr), "i");
+  auto d_nonMemFnPtrToPtr_1ParPar = clad::differentiate(*(*(&nonMemFnPtrToPtr)), "i");
+  auto d_nonMemFnPtrToPtrToPtr = clad::differentiate(**nonMemFnPtrToPtrToPtr, "i");
+  auto d_nonMemFnPtrToPtrToPtr_1 = clad::differentiate(***&nonMemFnPtrToPtrToPtr, "i");
+  auto d_nonMemFnPtrToPtrToPtr_1Par = clad::differentiate(***(&nonMemFnPtrToPtrToPtr), "i");
+  auto d_nonMemFnPtrToPtrToPtr_1ParPar = clad::differentiate(*(**(&nonMemFnPtrToPtrToPtr)), "i");
+  auto d_nonMemFnPtrToPtrToPtr_1ParParPar = clad::differentiate((*(**((&nonMemFnPtrToPtrToPtr)))), "i");
+  auto d_nonMemFnIndirectPtr = clad::differentiate(nonMemFnIndirectPtr, "i");
+  auto d_nonMemFnIndirectIndirectPtr = clad::differentiate(nonMemFnIndirectIndirectPtr, "i");
+  auto d_nonMemFnStaticCast = clad::differentiate(static_cast<decltype(&nonMemFn)>(nonMemFn), "i");
+  auto d_nonMemFnReinterpretCast = clad::differentiate(reinterpret_cast<decltype(&nonMemFn)>(nonMemFn), "i");
+  auto d_nonMemFnCStyleCast = clad::differentiate((decltype(&nonMemFn))(nonMemFn), "i");
+
+  NON_MEM_FN_TEST(d_nonMemFn); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPar); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtr); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrPar); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr_1); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr_1Par); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr_1ParPar); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr_1); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr_1Par); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr_1ParPar); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr_1ParParPar); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnIndirectPtr); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnIndirectIndirectPtr); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnStaticCast); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnReinterpretCast); // CHECK-EXEC: 5.00
+
+  NON_MEM_FN_TEST(d_nonMemFnCStyleCast); // CHECK-EXEC: 5.00
+
+
+
+}

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -1,0 +1,96 @@
+// RUN: %cladclang %s -I%S/../../include -oPointers.out 2>&1 | FileCheck %s
+// RUN: ./Pointers.out | FileCheck -check-prefix=CHECK-EXEC %s
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+double nonMemFn(double i) {
+  return i*i;
+}
+
+// CHECK: void nonMemFn_grad(double i, double *_result) {
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     _t1 = i;
+// CHECK-NEXT:     _t0 = i;
+// CHECK-NEXT:     double nonMemFn_return = _t1 * _t0;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 1 * _t0;
+// CHECK-NEXT:         _result[0UL] += _r0;
+// CHECK-NEXT:         double _r1 = _t1 * 1;
+// CHECK-NEXT:         _result[0UL] += _r1;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+#define NON_MEM_FN_TEST(var)\
+res[0]=0;\
+var.execute(5,res);\
+printf("%.2f\n", res[0]);
+
+int main() {
+  auto nonMemFnPtr = &nonMemFn;
+  auto nonMemFnPtrToPtr = &nonMemFnPtr;
+  auto nonMemFnPtrToPtrToPtr = &nonMemFnPtrToPtr;
+  auto nonMemFnIndirectPtr = nonMemFnPtr;
+  auto nonMemFnIndirectIndirectPtr = nonMemFnIndirectPtr;
+
+  double res[2];
+
+  auto d_nonMemFn = clad::gradient(nonMemFn, "i");
+  auto d_nonMemFnPar = clad::gradient((nonMemFn), "i");
+  auto d_nonMemFnPtr = clad::gradient(nonMemFnPtr, "i");
+  auto d_nonMemFnPtrToPtr = clad::gradient(*nonMemFnPtrToPtr, "i");
+  auto d_nonMemFnPtrToPtrPar = clad::gradient((*(nonMemFnPtrToPtr)), "i");
+  auto d_nonMemFnPtrToPtr_1 = clad::gradient(**&nonMemFnPtrToPtr, "i");
+  auto d_nonMemFnPtrToPtr_1Par = clad::gradient(**(&nonMemFnPtrToPtr), "i");
+  auto d_nonMemFnPtrToPtr_1ParPar = clad::gradient(*(*(&nonMemFnPtrToPtr)), "i");
+  auto d_nonMemFnPtrToPtrToPtr = clad::gradient(**nonMemFnPtrToPtrToPtr, "i");
+  auto d_nonMemFnPtrToPtrToPtr_1 = clad::gradient(***&nonMemFnPtrToPtrToPtr, "i");
+  auto d_nonMemFnPtrToPtrToPtr_1Par = clad::gradient(***(&nonMemFnPtrToPtrToPtr), "i");
+  auto d_nonMemFnPtrToPtrToPtr_1ParPar = clad::gradient(*(**(&nonMemFnPtrToPtrToPtr)), "i");
+  auto d_nonMemFnPtrToPtrToPtr_1ParParPar = clad::gradient((*(**((&nonMemFnPtrToPtrToPtr)))), "i");
+  auto d_nonMemFnIndirectPtr = clad::gradient(nonMemFnIndirectPtr, "i");
+  auto d_nonMemFnIndirectIndirectPtr = clad::gradient(nonMemFnIndirectIndirectPtr, "i");
+  auto d_nonMemFnStaticCast = clad::gradient(static_cast<decltype(&nonMemFn)>(nonMemFn), "i");
+  auto d_nonMemFnReinterpretCast = clad::gradient(reinterpret_cast<decltype(&nonMemFn)>(nonMemFn), "i");
+  auto d_nonMemFnCStyleCast = clad::gradient((decltype(&nonMemFn))(nonMemFn), "i");
+
+
+  NON_MEM_FN_TEST(d_nonMemFn); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPar); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtr); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrPar); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr_1); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr_1Par); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr_1ParPar); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr_1); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr_1Par); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr_1ParPar); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr_1ParParPar); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnIndirectPtr); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnIndirectIndirectPtr); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnStaticCast); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnReinterpretCast); // CHECK-EXEC: 10.00
+
+  NON_MEM_FN_TEST(d_nonMemFnCStyleCast); // CHECK-EXEC: 10.00
+}

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -1,0 +1,153 @@
+// RUN: %cladclang %s -I%S/../../include -oPointers.out 2>&1 | FileCheck %s
+// RUN: ./Pointers.out | FileCheck -check-prefix=CHECK-EXEC %s
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+double nonMemFn(double i, double j) {
+  return i*j;
+}
+
+// CHECK: double nonMemFn_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     return _d_i * j + i * _d_j;
+// CHECK-NEXT: }
+
+// CHECK: void nonMemFn_darg0_grad(double i, double j, double *_result) {
+// CHECK-NEXT:     double _d__d_i = 0;
+// CHECK-NEXT:     double _d__d_j = 0;
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     double _t3;
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     _t1 = _d_i;
+// CHECK-NEXT:     _t0 = j;
+// CHECK-NEXT:     _t3 = i;
+// CHECK-NEXT:     _t2 = _d_j;
+// CHECK-NEXT:     double nonMemFn_darg0_return = _t1 * _t0 + _t3 * _t2;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 1 * _t0;
+// CHECK-NEXT:         _d__d_i += _r0;
+// CHECK-NEXT:         double _r1 = _t1 * 1;
+// CHECK-NEXT:         _result[1UL] += _r1;
+// CHECK-NEXT:         double _r2 = 1 * _t2;
+// CHECK-NEXT:         _result[0UL] += _r2;
+// CHECK-NEXT:         double _r3 = _t3 * 1;
+// CHECK-NEXT:         _d__d_j += _r3;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: double nonMemFn_darg1(double i, double j) {
+// CHECK-NEXT:     double _d_i = 0;
+// CHECK-NEXT:     double _d_j = 1;
+// CHECK-NEXT:     return _d_i * j + i * _d_j;
+// CHECK-NEXT: }
+
+// CHECK: void nonMemFn_darg1_grad(double i, double j, double *_result) {
+// CHECK-NEXT:     double _d__d_i = 0;
+// CHECK-NEXT:     double _d__d_j = 0;
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     double _t3;
+// CHECK-NEXT:     double _d_i = 0;
+// CHECK-NEXT:     double _d_j = 1;
+// CHECK-NEXT:     _t1 = _d_i;
+// CHECK-NEXT:     _t0 = j;
+// CHECK-NEXT:     _t3 = i;
+// CHECK-NEXT:     _t2 = _d_j;
+// CHECK-NEXT:     double nonMemFn_darg1_return = _t1 * _t0 + _t3 * _t2;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 1 * _t0;
+// CHECK-NEXT:         _d__d_i += _r0;
+// CHECK-NEXT:         double _r1 = _t1 * 1;
+// CHECK-NEXT:         _result[1UL] += _r1;
+// CHECK-NEXT:         double _r2 = 1 * _t2;
+// CHECK-NEXT:         _result[0UL] += _r2;
+// CHECK-NEXT:         double _r3 = _t3 * 1;
+// CHECK-NEXT:         _d__d_j += _r3;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: void nonMemFn_hessian(double i, double j, double *hessianMatrix) {
+// CHECK-NEXT:     nonMemFn_darg0_grad(i, j, &hessianMatrix[0UL]);
+// CHECK-NEXT:     nonMemFn_darg1_grad(i, j, &hessianMatrix[2UL]);
+// CHECK-NEXT: }
+
+#define NON_MEM_FN_TEST(var)\
+res[0]=res[1]=res[2]=res[3]=0;\
+var.execute(3, 4, res);\
+printf("{%.2f %.2f %.2f %.2f}\n", res[0], res[1], res[2], res[3]);
+
+int main() {
+  auto nonMemFnPtr = &nonMemFn;
+  auto nonMemFnPtrToPtr = &nonMemFnPtr;
+  auto nonMemFnPtrToPtrToPtr = &nonMemFnPtrToPtr;
+  auto nonMemFnIndirectPtr = nonMemFnPtr;
+  auto nonMemFnIndirectIndirectPtr = nonMemFnIndirectPtr;
+
+  double res[4];
+
+  auto d_nonMemFn = clad::hessian(nonMemFn);
+  auto d_nonMemFnPar = clad::hessian((nonMemFn));
+  auto d_nonMemFnPtr = clad::hessian(nonMemFnPtr);
+  auto d_nonMemFnPtrToPtr = clad::hessian(*nonMemFnPtrToPtr);
+  auto d_nonMemFnPtrToPtrPar = clad::hessian((*(nonMemFnPtrToPtr)));
+  auto d_nonMemFnPtrToPtr_1 = clad::hessian(**&nonMemFnPtrToPtr);
+  auto d_nonMemFnPtrToPtr_1Par = clad::hessian(**(&nonMemFnPtrToPtr));
+  auto d_nonMemFnPtrToPtr_1ParPar = clad::hessian(*(*(&nonMemFnPtrToPtr)));
+  auto d_nonMemFnPtrToPtrToPtr = clad::hessian(**nonMemFnPtrToPtrToPtr);
+  auto d_nonMemFnPtrToPtrToPtr_1 = clad::hessian(***&nonMemFnPtrToPtrToPtr);
+  auto d_nonMemFnPtrToPtrToPtr_1Par = clad::hessian(***(&nonMemFnPtrToPtrToPtr));
+  auto d_nonMemFnPtrToPtrToPtr_1ParPar = clad::hessian(*(**(&nonMemFnPtrToPtrToPtr)));
+  auto d_nonMemFnPtrToPtrToPtr_1ParParPar = clad::hessian((*(**((&nonMemFnPtrToPtrToPtr)))));
+  auto d_nonMemFnIndirectPtr = clad::hessian(nonMemFnIndirectPtr);
+  auto d_nonMemFnIndirectIndirectPtr = clad::hessian(nonMemFnIndirectIndirectPtr);
+  auto d_nonMemFnStaticCast = clad::hessian(static_cast<decltype(&nonMemFn)>(nonMemFn));
+  auto d_nonMemFnReinterpretCast = clad::hessian(reinterpret_cast<decltype(&nonMemFn)>(nonMemFn));
+  auto d_nonMemFnCStyleCast = clad::hessian((decltype(&nonMemFn))(nonMemFn));
+
+  NON_MEM_FN_TEST(d_nonMemFn); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPar); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtr); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrPar); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr_1); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr_1Par); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr_1ParPar); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr_1); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr_1Par); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr_1ParPar); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrToPtr_1ParParPar); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnIndirectPtr); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnIndirectIndirectPtr); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnStaticCast); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnReinterpretCast); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnCStyleCast); // CHECK-EXEC: {0.00 1.00 1.00 0.00}
+
+}

--- a/test/Jacobian/Pointers.C
+++ b/test/Jacobian/Pointers.C
@@ -1,0 +1,73 @@
+// RUN: %cladclang %s -I%S/../../include -oPointers.out 2>&1 | FileCheck %s
+// RUN: ./Pointers.out | FileCheck -check-prefix=CHECK-EXEC %s
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+void nonMemFn(double i, double j, double* out) {
+  out[0] = i;
+  out[1] = j;
+}
+
+// CHECK: void nonMemFn_jac(double i, double j, double *out, double *jacobianMatrix) {
+// CHECK-NEXT:     out[0] = i;
+// CHECK-NEXT:     out[1] = j;
+// CHECK-NEXT:     jacobianMatrix[3UL] += 1;
+// CHECK-NEXT:     jacobianMatrix[0UL] += 1;
+// CHECK-NEXT: }
+
+// CHECK: void nonMemFn_jac(double i, double j, double *out, double *jacobianMatrix) {
+// CHECK-NEXT:     out[0] = i;
+// CHECK-NEXT:     out[1] = j;
+// CHECK-NEXT:     jacobianMatrix[3UL] += 1;
+// CHECK-NEXT:     jacobianMatrix[0UL] += 1;
+// CHECK-NEXT: }
+
+// CHECK: void nonMemFn_jac(double i, double j, double *out, double *jacobianMatrix) {
+// CHECK-NEXT:     out[0] = i;
+// CHECK-NEXT:     out[1] = j;
+// CHECK-NEXT:     jacobianMatrix[3UL] += 1;
+// CHECK-NEXT:     jacobianMatrix[0UL] += 1;
+// CHECK-NEXT: }
+
+// CHECK: void nonMemFn_jac(double i, double j, double *out, double *jacobianMatrix) {
+// CHECK-NEXT:     out[0] = i;
+// CHECK-NEXT:     out[1] = j;
+// CHECK-NEXT:     jacobianMatrix[3UL] += 1;
+// CHECK-NEXT:     jacobianMatrix[0UL] += 1;
+// CHECK-NEXT: }
+
+// CHECK: void nonMemFn_jac(double i, double j, double *out, double *jacobianMatrix) {
+// CHECK-NEXT:     out[0] = i;
+// CHECK-NEXT:     out[1] = j;
+// CHECK-NEXT:     jacobianMatrix[3UL] += 1;
+// CHECK-NEXT:     jacobianMatrix[0UL] += 1;
+// CHECK-NEXT: }
+
+#define NON_MEM_FN_TEST(var)\
+res[0]=res[1]=res[2]=res[3]=0;\
+var.execute(5, 7, out, res);\
+printf("{%.2f %.2f %.2f %.2f}\n", res[0], res[1], res[2], res[3]);
+
+int main() {
+  auto nonMemFnPtr = &nonMemFn;
+  auto nonMemFnPtrToPtr = &nonMemFnPtr;
+
+  double res[4];
+  double out[2];
+  auto d_nonMemFn = clad::jacobian(nonMemFn);
+  auto d_nonMemFnPar = clad::jacobian((nonMemFn));
+  auto d_nonMemFnPtr = clad::jacobian(nonMemFnPtr);
+  auto d_nonMemFnPtrToPtr = clad::jacobian(*nonMemFnPtrToPtr);
+  auto d_nonMemFnPtrToPtrPar = clad::jacobian((*(nonMemFnPtrToPtr)));
+
+  NON_MEM_FN_TEST(d_nonMemFn); // CHECK-EXEC: {1.00 0.00 0.00 1.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPar); // CHECK-EXEC: {1.00 0.00 0.00 1.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtr); // CHECK-EXEC: {1.00 0.00 0.00 1.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtr); // CHECK-EXEC: {1.00 0.00 0.00 1.00}
+
+  NON_MEM_FN_TEST(d_nonMemFnPtrToPtrPar); // CHECK-EXEC: {1.00 0.00 0.00 1.00}
+}


### PR DESCRIPTION
Progress: 
- [x] Fix the issue
- [x] Add relevant regression tests

This PR aims to add support for differentiation calls with Unary operators(`&`, `*`), parantheses and casts (both C and C++ style) with the function argument.
For instance, with this PR, differentiation calls like these will work correctly: 

```c++
auto d_memFnPtrToPtr_1ParPar = clad::differentiate(*(*(&memFnPtrToPtr)),"i");
auto d_memFnPtrToPtrToPtr_1Par = clad::differentiate(***(&memFnPtrToPtrToPtr),"i");
auto d_memFnPtrToPtr_1 = clad::differentiate(**&memFnPtrToPtr,"i");
auto d_nonMemFnStaticCast = clad::differentiate(static_cast<decltype(&nonMemFn)>(nonMemFn),"i");
auto d_memFnCStyleCast = clad::differentiate((decltype(&Expression::memFn))(&Expression::memFn),"i");
```

Fixes #211 