### PR TITLE
Derive if condition stmts in forward differentiation

### DIFF
--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -1035,7 +1035,8 @@ namespace clad {
     // }
     // This is done to avoid variable names clashes.
     addToCurrentBlock(initResult.getStmt_dx());
-
+    auto condExpr = Visit(If->getCond());
+    addToCurrentBlock(condExpr.getStmt_dx());
     VarDecl* condVarClone = nullptr;
     if (const VarDecl* condVarDecl = If->getConditionVariable()) {
       VarDeclDiff condVarDeclDiff = DifferentiateVarDecl(condVarDecl);


### PR DESCRIPTION
This PR aims to enable differentiation of conditions in `if` statements if it is changing any variable. This issue is mentioned in `FIXME` [here](https://github.com/vgvassilev/clad/blob/4851107d558f129d04f64e379059168aff6706f5/lib/Differentiator/DerivativeBuilder.cpp#L1048)
This will give correct differentiation output for functions like these:

```c++
double fn(double i, double j) {
  double a, b, c;
  if (a=i, 0) {
  }
  else if(b=i, c=i) {

  }
  return a*b*c;
}
```

