### PR TITLE
Run CI only if a ready to test label is added.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
     branches:
       - master
       - coverity_scan
-  pull_request:
+  pull_request_target:
+    types: [labeled]
     branches:
       - master
       - coverity_scan
@@ -13,6 +14,7 @@ jobs:
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    if: contains(github.event.pull_request.labels.*.name, 'ready to test')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This protects our token secrets from PR attackers. Exposing github secure tokens
as part of random PR build system is a security risk:
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

Instead, we should run the action after the lable was added.

Should fix #226.