### PR TITLE
Fix program crash on differentiating member functions in reverse mode

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -143,33 +143,33 @@ namespace clad {
   /// A function for gradient computation.
   /// Given a function f, clad::gradient generates its gradient f_grad and
   /// returns a CladFunction for it.
-  template<bool isDerived=false, typename ArgSpec = const char *, typename F>
-  CladFunction<ExtractDerivedFnTraits_t<F, isDerived>> __attribute__((annotate("G")))
+  template<bool isDerivedFn=false, typename ArgSpec = const char *, typename F>
+  CladFunction<ExtractDerivedFnTraits_t<F, isDerivedFn>> __attribute__((annotate("G")))
   gradient(F f, ArgSpec args = "", const char* code = "") {
     assert(f && "Must pass in a non-0 argument");
-    return CladFunction<ExtractDerivedFnTraits_t<F, isDerived>>(
-      reinterpret_cast<ExtractDerivedFnTraits_t<F, isDerived>>(f) /* will be replaced by gradient*/,
+    return CladFunction<ExtractDerivedFnTraits_t<F, isDerivedFn>>(
+      reinterpret_cast<ExtractDerivedFnTraits_t<F, isDerivedFn>>(f) /* will be replaced by gradient*/,
       code);
   }
 
   /// Function for Hessian matrix computation
   /// Given  a function f, clad::hessian generates all the second derivatives
   /// of the original function, (they are also columns of a Hessian matrix)
-  template<bool isDerived=false, typename ArgSpec = const char *, typename F>
-  CladFunction<ExtractDerivedFnTraits_t<F, isDerived>> __attribute__((annotate("H")))
+  template<bool isDerivedFn=false, typename ArgSpec = const char *, typename F>
+  CladFunction<ExtractDerivedFnTraits_t<F, isDerivedFn>> __attribute__((annotate("H")))
   hessian(F f, ArgSpec args = "", const char* code = "") {
     assert(f && "Must pass in a non-0 argument");
-    return CladFunction<ExtractDerivedFnTraits_t<F, isDerived>>(
-      reinterpret_cast<ExtractDerivedFnTraits_t<F, isDerived>>(f) /* will be replaced by Hessian*/,
+    return CladFunction<ExtractDerivedFnTraits_t<F, isDerivedFn>>(
+      reinterpret_cast<ExtractDerivedFnTraits_t<F, isDerivedFn>>(f) /* will be replaced by Hessian*/,
       code);
   }
 
-  template<bool isDerived=false, typename ArgSpec = const char *, typename F>
-  CladFunction<ExtractDerivedFnTraits_t<F, isDerived>> __attribute__((annotate("J")))
+  template<bool isDerivedFn=false, typename ArgSpec = const char *, typename F>
+  CladFunction<ExtractDerivedFnTraits_t<F, isDerivedFn>> __attribute__((annotate("J")))
   jacobian(F f, ArgSpec args = "", const char* code = "") {
     assert(f && "Must pass in a non-0 argument");
-    return CladFunction<ExtractDerivedFnTraits_t<F, isDerived>>(
-        reinterpret_cast<ExtractDerivedFnTraits_t<F, isDerived>>(f) /* will be replaced by Jacobian*/,
+    return CladFunction<ExtractDerivedFnTraits_t<F, isDerivedFn>>(
+        reinterpret_cast<ExtractDerivedFnTraits_t<F, isDerivedFn>>(f) /* will be replaced by Jacobian*/,
         code);
   }
 }

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -143,33 +143,33 @@ namespace clad {
   /// A function for gradient computation.
   /// Given a function f, clad::gradient generates its gradient f_grad and
   /// returns a CladFunction for it.
-  template<typename ArgSpec = const char *, typename F>
-  CladFunction<ExtractDerivedFnTraits_t<F>> __attribute__((annotate("G")))
+  template<bool isDerived=false, typename ArgSpec = const char *, typename F>
+  CladFunction<ExtractDerivedFnTraits_t<F, isDerived>> __attribute__((annotate("G")))
   gradient(F f, ArgSpec args = "", const char* code = "") {
     assert(f && "Must pass in a non-0 argument");
-    return CladFunction<ExtractDerivedFnTraits_t<F>>(
-      reinterpret_cast<ExtractDerivedFnTraits_t<F>>(f) /* will be replaced by gradient*/,
+    return CladFunction<ExtractDerivedFnTraits_t<F, isDerived>>(
+      reinterpret_cast<ExtractDerivedFnTraits_t<F, isDerived>>(f) /* will be replaced by gradient*/,
       code);
   }
 
   /// Function for Hessian matrix computation
   /// Given  a function f, clad::hessian generates all the second derivatives
   /// of the original function, (they are also columns of a Hessian matrix)
-  template<typename ArgSpec = const char *, typename F>
-  CladFunction<ExtractDerivedFnTraits_t<F>> __attribute__((annotate("H")))
+  template<bool isDerived=false, typename ArgSpec = const char *, typename F>
+  CladFunction<ExtractDerivedFnTraits_t<F, isDerived>> __attribute__((annotate("H")))
   hessian(F f, ArgSpec args = "", const char* code = "") {
     assert(f && "Must pass in a non-0 argument");
-    return CladFunction<ExtractDerivedFnTraits_t<F>>(
-      reinterpret_cast<ExtractDerivedFnTraits_t<F>>(f) /* will be replaced by Hessian*/,
+    return CladFunction<ExtractDerivedFnTraits_t<F, isDerived>>(
+      reinterpret_cast<ExtractDerivedFnTraits_t<F, isDerived>>(f) /* will be replaced by Hessian*/,
       code);
   }
 
-  template<typename ArgSpec = const char *, typename F>
-  CladFunction<ExtractDerivedFnTraits_t<F>> __attribute__((annotate("J")))
+  template<bool isDerived=false, typename ArgSpec = const char *, typename F>
+  CladFunction<ExtractDerivedFnTraits_t<F, isDerived>> __attribute__((annotate("J")))
   jacobian(F f, ArgSpec args = "", const char* code = "") {
     assert(f && "Must pass in a non-0 argument");
-    return CladFunction<ExtractDerivedFnTraits_t<F>>(
-        reinterpret_cast<ExtractDerivedFnTraits_t<F>>(f) /* will be replaced by Jacobian*/,
+    return CladFunction<ExtractDerivedFnTraits_t<F, isDerived>>(
+        reinterpret_cast<ExtractDerivedFnTraits_t<F, isDerived>>(f) /* will be replaced by Jacobian*/,
         code);
   }
 }

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -227,10 +227,10 @@ namespace clad {
   // derived using reverse, hessian and jacobian differentiation modes
   // It SHOULD NOT be used to get traits of derived functions derived using
   // forward differentiation mode
-  template<class ReturnType, bool isDerived>
+  template<class ReturnType, bool isDerivedFn>
   struct ExtractDerivedFnTraits {};
-  template<class T, bool isDerived>
-  using ExtractDerivedFnTraits_t = typename ExtractDerivedFnTraits<T, isDerived>::type;
+  template<class T, bool isDerivedFn>
+  using ExtractDerivedFnTraits_t = typename ExtractDerivedFnTraits<T, isDerivedFn>::type;
 
   // specializations for non-member functions pointer types
   template <class ReturnType, class... Args>

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -239,11 +239,15 @@ namespace clad {
   };
 
   // specializations for member functions pointer types with no cv-qualifiers
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...)> { 
+    using type = void (C::*)(Args...); 
+  };
+  
   template <class ReturnType, class C, class... Args> 
   struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
-  
   // specializations for member functions pointer types with only cv-qualifiers
   template <class ReturnType, class C, class... Args> 
   struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const> { 

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -227,224 +227,227 @@ namespace clad {
   // derived using reverse, hessian and jacobian differentiation modes
   // It SHOULD NOT be used to get traits of derived functions derived using
   // forward differentiation mode
-  template<class ReturnType>
+  template<class ReturnType, bool isDerived>
   struct ExtractDerivedFnTraits {};
-  template<class T>
-  using ExtractDerivedFnTraits_t = typename ExtractDerivedFnTraits<T>::type;
+  template<class T, bool isDerived>
+  using ExtractDerivedFnTraits_t = typename ExtractDerivedFnTraits<T, isDerived>::type;
 
   // specializations for non-member functions pointer types
-  template <class... Args>
-  struct ExtractDerivedFnTraits<void (*)(Args...)> {
-    using type = void (*)(Args...);
-  };
-  template <class ReturnType,class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (*)(Args...)> {
+  template <class ReturnType, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (*)(Args...), false> {
     using type = void (*)(Args..., ReturnType*);
   };
 
+  template <class ReturnType, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (*)(Args...), true> {
+    using type = ReturnType (*)(Args...);
+  };
+
   // specializations for member functions pointer types with no cv-qualifiers
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...)> { 
-    using type = void (C::*)(Args...); 
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...), false> { 
+    using type = void (C::*)(Args..., ReturnType*); 
+  };
+
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...), true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  
+  // specializations for member functions pointer types with only cv-qualifiers
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile, true> { 
+    using type = ReturnType (C::*)(Args...); 
   };
   
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)> { 
-    using type = void (C::*)(Args..., ReturnType*); 
-  };
-
-  // specializations for member functions pointer types with only cv-qualifiers
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) const> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) volatile> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) const volatile> { 
-    using type = void (C::*)(Args...); 
-  };
-
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
 
   // specializations for member functions pointer types with 
   // reference qualifiers and with and without cv-qualifiers
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) &> { 
-    using type = void (C::*)(Args...); 
+
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &, true> { 
+    using type = ReturnType (C::*)(Args...); 
   };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) const &> { 
-    using type = void (C::*)(Args...); 
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &, true> { 
+    using type = ReturnType (C::*)(Args...); 
   };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) volatile &> { 
-    using type = void (C::*)(Args...); 
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &, true> { 
+    using type = ReturnType (C::*)(Args...); 
   };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) const volatile &> { 
-    using type = void (C::*)(Args...); 
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &, true> { 
+    using type = ReturnType (C::*)(Args...); 
   };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) &&> { 
-    using type = void (C::*)(Args...); 
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &&, true> { 
+    using type = ReturnType (C::*)(Args...); 
   };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) const &&> { 
-    using type = void (C::*)(Args...); 
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &&, true> { 
+    using type = ReturnType (C::*)(Args...); 
   };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) volatile &&> { 
-    using type = void (C::*)(Args...); 
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &&, true> { 
+    using type = ReturnType (C::*)(Args...); 
   };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) const volatile &&> { 
-    using type = void (C::*)(Args...); 
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &&, true> { 
+    using type = ReturnType (C::*)(Args...); 
   };
 
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &&> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &&, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &&> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &&, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &&> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &&, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &&> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &&, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
 
   // specializations for noexcept member functions
   #if __cpp_noexcept_function_type > 0
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) noexcept> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) const noexcept> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) volatile noexcept> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) const volatile noexcept> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) & noexcept> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) const & noexcept> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) volatile & noexcept> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) const volatile & noexcept> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) && noexcept> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) const && noexcept> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) volatile && noexcept> { 
-    using type = void (C::*)(Args...); 
-  };
-  template <class C, class... Args> 
-  struct ExtractDerivedFnTraits<void (C::*)(Args...) const volatile && noexcept> { 
-    using type = void (C::*)(Args...); 
-  };
 
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) noexcept> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) noexcept, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const noexcept, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile noexcept, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile noexcept, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) & noexcept, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const & noexcept, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile & noexcept, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile & noexcept, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) && noexcept, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const && noexcept, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile && noexcept, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile && noexcept, true> { 
+    using type = ReturnType (C::*)(Args...); 
+  };
+  
+  template <class ReturnType, class C, class... Args> 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) noexcept, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const noexcept> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const noexcept, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile noexcept> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile noexcept, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile noexcept> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile noexcept, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) & noexcept> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) & noexcept, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const & noexcept> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const & noexcept, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile & noexcept> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile & noexcept, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile & noexcept> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile & noexcept, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) && noexcept> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) && noexcept, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const && noexcept> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const && noexcept, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile && noexcept> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile && noexcept, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile && noexcept> { 
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile && noexcept, false> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
   #endif

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -233,6 +233,10 @@ namespace clad {
   using ExtractDerivedFnTraits_t = typename ExtractDerivedFnTraits<T>::type;
 
   // specializations for non-member functions pointer types
+  template <class... Args>
+  struct ExtractDerivedFnTraits<void (*)(Args...)> {
+    using type = void (*)(Args...);
+  };
   template <class ReturnType,class... Args>
   struct ExtractDerivedFnTraits<ReturnType (*)(Args...)> {
     using type = void (*)(Args..., ReturnType*);
@@ -248,7 +252,21 @@ namespace clad {
   struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)> { 
     using type = void (C::*)(Args..., ReturnType*); 
   };
+
   // specializations for member functions pointer types with only cv-qualifiers
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) const> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) volatile> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) const volatile> { 
+    using type = void (C::*)(Args...); 
+  };
+
   template <class ReturnType, class C, class... Args> 
   struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const> { 
     using type = void (C::*)(Args..., ReturnType*); 
@@ -264,6 +282,39 @@ namespace clad {
 
   // specializations for member functions pointer types with 
   // reference qualifiers and with and without cv-qualifiers
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) &> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) const &> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) volatile &> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) const volatile &> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) &&> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) const &&> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) volatile &&> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) const volatile &&> { 
+    using type = void (C::*)(Args...); 
+  };
+
   template <class ReturnType, class C, class... Args> 
   struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &> { 
     using type = void (C::*)(Args..., ReturnType*); 
@@ -299,6 +350,55 @@ namespace clad {
 
   // specializations for noexcept member functions
   #if __cpp_noexcept_function_type > 0
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) noexcept> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) const noexcept> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) volatile noexcept> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) const volatile noexcept> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) & noexcept> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) const & noexcept> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) volatile & noexcept> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) const volatile & noexcept> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) && noexcept> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) const && noexcept> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) volatile && noexcept> { 
+    using type = void (C::*)(Args...); 
+  };
+  template <class C, class... Args> 
+  struct ExtractDerivedFnTraits<void (C::*)(Args...) const volatile && noexcept> { 
+    using type = void (C::*)(Args...); 
+  };
+
   template <class ReturnType, class C, class... Args> 
   struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) noexcept> { 
     using type = void (C::*)(Args..., ReturnType*); 

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -166,7 +166,6 @@ namespace clad {
                                     [] (llvm::ArrayRef<QualType>) {
                                       return false;
                                     });
-
     // DeclRefExpr for new specialization.
     Expr* CladGradientExprNew = clad_compat::GetResult<Expr*>(
       SemaRef.BuildDeclRefExpr(CladGradientFDeclNew,

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -149,9 +149,9 @@ namespace clad {
 
     FunctionDecl* CladGradientFDeclNew = nullptr;
     sema::TemplateDeductionInfo Info(noLoc);
-    auto isDerivedTempArg = TemplateArgument(C, llvm::APSInt::getMaxValue(1, 1), C.BoolTy);
+    auto isDerivedFnTempArg = TemplateArgument(C, llvm::APSInt::getMaxValue(/* numBits */ 1, /* isUnsigned */ 1), C.BoolTy);
     TemplateArgumentListInfo TempArgListInfoNew;
-    TempArgListInfoNew.addArgument(TemplateArgumentLoc(isDerivedTempArg, TemplateArgumentLocInfo()));
+    TempArgListInfoNew.addArgument(TemplateArgumentLoc(isDerivedFnTempArg, TemplateArgumentLocInfo()));
     // Create/get template specialization of clad::gradient that matches
     // argument types. Result is stored to CladGradientFDeclNew.
     SemaRef.DeduceTemplateArguments(CladGradientFTemplate,


### PR DESCRIPTION
This PR fixes program crash on differentiating member functions using `clad::gradient`. For more details, see #139 

The root cause of the issue was incorrect return type of updated call expressions of clad reverse mode differentiation functions (`gradient`, `hessian` and `jacobian`).

To compute correct return type for a given function, `ExtractDerivedFnTrait` also needs to know at compile time if the function passed to it, is already a derived function, or needs to be derived. 

To solve this issue I have modified `ExtractDerivedFnTraits` such that, 
`ExtractDerivedFnTraits<F, isDerivedFn>` now takes an extra argument, `bool isDerivedFn`, this should be `false` when `F` is the type of original function to be differentiated, and true if `F` is the derived function type (this is the case when we rebuild the calling function in `clad::DiffRequest::updateCall`), and I have also modified clad reverse mode differentiation functions accordingly. `ExtractDerivedFnTraits` now behaves as following:

- `ExtractDerivedFnTraits<F, false>::type` is derived function type, computed using `F`
- `ExtractDerivedFnTraits<F, true>::type` is `F`, since `F` is already the required derived function type.

Now, while rebuilding the calling function in `clang::DiffRequest::updateCall`, we can specify `isDerivedFn` to true, so that `ExtractDerivedFn` give correct type on updated call too. 

I would like to know opinion of this solution and how can we improve it further.

Closes #139 