### PR TITLE
Fix const type error in reverse mode

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -60,6 +60,23 @@ namespace clad {
         return "_result";
     }
 
+    /// Removes the local as well as non-local const qualifiers from a QualType
+    /// and returns a new type.
+    static clang::QualType
+    getNonConstType(clang::QualType T, clang::ASTContext& C, clang::Sema& S) {
+      if (T->isPointerType()) {
+        clang::Qualifiers quals(T->getPointeeType().getQualifiers());
+        quals.removeConst();
+        clang::QualType newType = S.BuildQualifiedType(
+            T->getPointeeType().getUnqualifiedType(), noLoc, quals);
+        return C.getPointerType(newType);
+      } else {
+        clang::Qualifiers quals(T.getQualifiers());
+        quals.removeConst();
+        return S.BuildQualifiedType(T.getUnqualifiedType(), noLoc, quals);
+      }
+    }
+
   public:
     clang::Expr* dfdx() {
       if (m_Stack.empty())
@@ -125,7 +142,11 @@ namespace clad {
                              llvm::StringRef prefix = "_t",
                              bool forceDeclCreation = false) {
       assert(E && "cannot infer type from null expression");
-      return StoreAndRef(E, E->getType(), d, prefix, forceDeclCreation);
+      return StoreAndRef(E,
+                         getNonConstType(E->getType(), m_Context, m_Sema),
+                         d,
+                         prefix,
+                         forceDeclCreation);
     }
 
     /// An overload allowing to specify the type for the variable.

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -49,7 +49,8 @@ namespace clad {
   ReverseModeVisitor::CladTapeResult
   ReverseModeVisitor::MakeCladTapeFor(Expr* E) {
     assert(E && "must be provided");
-    QualType TapeType = GetCladTapeOfType(E->getType());
+    QualType TapeType =
+        GetCladTapeOfType(getNonConstType(E->getType(), m_Context, m_Sema));
     LookupResult& Push = GetCladTapePush();
     LookupResult& Pop = GetCladTapePop();
     Expr* TapeRef = BuildDeclRef(GlobalStoreImpl(TapeType, "_t"));
@@ -936,7 +937,7 @@ namespace clad {
     std::size_t insertionPoint = getCurrentBlock(reverse).size();
     // Store the type to reduce call overhead that would occur if used in the
     // loop
-    auto CEType = CE->getType();
+    auto CEType = getNonConstType(CE->getType(), m_Context, m_Sema);
     for (const Expr* Arg : CE->arguments()) {
       // Create temporary variables corresponding to derivative of each
       // argument, so that they can be referred to when arguments is visited.
@@ -1382,7 +1383,8 @@ namespace clad {
           //   _t0 = _ref0;
           //   double r = _ref0 *= z;
           if (LCloned->HasSideEffects(m_Context)) {
-            QualType RefType = m_Context.getLValueReferenceType(L->getType());
+            QualType RefType = m_Context.getLValueReferenceType(
+                getNonConstType(L->getType(), m_Context, m_Sema));
             LRef =
                 StoreAndRef(LCloned, RefType, forward, "_ref", /*force*/ true);
           }
@@ -1406,7 +1408,8 @@ namespace clad {
         Expr* LRef = LCloned;
         if (!RDelayed.isConstant) {
           if (LCloned->HasSideEffects(m_Context)) {
-            QualType RefType = m_Context.getLValueReferenceType(L->getType());
+            QualType RefType = m_Context.getLValueReferenceType(
+                getNonConstType(L->getType(), m_Context, m_Sema));
             LRef =
                 StoreAndRef(LCloned, RefType, forward, "_ref", /*force*/ true);
           }
@@ -1463,7 +1466,9 @@ namespace clad {
   VarDeclDiff ReverseModeVisitor::DifferentiateVarDecl(const VarDecl* VD) {
     auto zero = getZeroInit(VD->getType());
     VarDecl* VDDerived =
-        BuildVarDecl(VD->getType(), "_d_" + VD->getNameAsString(), zero);
+        BuildVarDecl(getNonConstType(VD->getType(), m_Context, m_Sema),
+                     "_d_" + VD->getNameAsString(),
+                     zero);
     StmtDiff initDiff = VD->getInit()
                             ? Visit(VD->getInit(), BuildDeclRef(VDDerived))
                             : StmtDiff{};
@@ -1627,7 +1632,8 @@ namespace clad {
                                                  llvm::StringRef prefix,
                                                  bool force) {
     assert(E && "cannot infer type");
-    return GlobalStoreAndRef(E, E->getType(), prefix, force);
+    return GlobalStoreAndRef(
+        E, getNonConstType(E->getType(), m_Context, m_Sema), prefix, force);
   }
 
   void ReverseModeVisitor::DelayedStoreResult::Finalize(Expr* New) {
@@ -1664,7 +1670,8 @@ namespace clad {
                                 /*isConstant*/ false,
                                 /*isInsideLoop*/ true};
     } else {
-      Expr* Ref = BuildDeclRef(GlobalStoreImpl(E->getType(), prefix));
+      Expr* Ref = BuildDeclRef(GlobalStoreImpl(
+          getNonConstType(E->getType(), m_Context, m_Sema), prefix));
       // Return reference to the declaration instead of original expression.
       return DelayedStoreResult{*this,
                                 StmtDiff{Ref, Ref},

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -818,6 +818,27 @@ void f_issue138_grad(double x, double y, double *_result);
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
+double f_const(const double a, const double b) {
+  return a * b;
+}
+
+void f_const_grad(const double a, const double b, double *_result);
+//CHECK: void f_const_grad(const double a, const double b, double *_result) {
+//CHECK-NEXT:       double _t0;
+//CHECK-NEXT:       double _t1;
+//CHECK-NEXT:       _t1 = a;
+//CHECK-NEXT:       _t0 = b;
+//CHECK-NEXT:       double f_const_return = _t1 * _t0;
+//CHECK-NEXT:       goto _label0;
+//CHECK-NEXT:     _label0:
+//CHECK-NEXT:       {
+//CHECK-NEXT:           double _r0 = 1 * _t0;
+//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           double _r1 = _t1 * 1;
+//CHECK-NEXT:           _result[1UL] += _r1;
+//CHECK-NEXT:       }
+//CHECK-NEXT:   }
+
 #define TEST(F, x, y) { \
   result[0] = 0; result[1] = 0;\
   clad::gradient(F);\
@@ -855,5 +876,7 @@ int main() { // expected-no-diagnostics
   TEST(f_decls3, 0.5, 0); // CHECK-EXEC: Result is = {9.00, 0.00}
   TEST(f_decls3, 0, 100); // CHECK-EXEC: Result is = {0.00, 0.00}
   TEST(f_issue138, 1, 2); // CHECK-EXEC: Result is = {4.00, 32.00}
+  TEST(f_const, 2, 3); // CHECK-EXEC: Result is = {3.00, 2.00}
+
 }
 

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -367,6 +367,50 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
+double f_const(const double a, const double b) {
+  int r = 0;
+  for (int i = 0; i < a; i++) {
+    int sq = b * b;
+    r += sq;
+  }
+  return r;
+}
+
+void f_const_grad(const double, const double, double *);
+//CHECK: void f_const_grad(const double a, const double b, double *_result) {
+//CHECK-NEXT:       int _d_r = 0;
+//CHECK-NEXT:       unsigned long _t0;
+//CHECK-NEXT:       int _d_i = 0;
+//CHECK-NEXT:       clad::tape<double> _t1 = {};
+//CHECK-NEXT:       clad::tape<double> _t2 = {};
+//CHECK-NEXT:       int _d_sq = 0;
+//CHECK-NEXT:       int r = 0;
+//CHECK-NEXT:       _t0 = 0;
+//CHECK-NEXT:       for (int i = 0; i < a; i++) {
+//CHECK-NEXT:           _t0++;
+//CHECK-NEXT:           int sq0 = clad::push(_t2, b) * clad::push(_t1, b);
+//CHECK-NEXT:           r += sq0;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       int f_const_return = r;
+//CHECK-NEXT:       goto _label0;
+//CHECK-NEXT:     _label0:
+//CHECK-NEXT:       _d_r += 1;
+//CHECK-NEXT:       for (; _t0; _t0--) {
+//CHECK-NEXT:           {
+//CHECK-NEXT:               int _r_d0 = _d_r;
+//CHECK-NEXT:               _d_r += _r_d0;
+//CHECK-NEXT:               _d_sq += _r_d0;
+//CHECK-NEXT:               _d_r -= _r_d0;
+//CHECK-NEXT:           }
+//CHECK-NEXT:           {
+//CHECK-NEXT:               double _r0 = _d_sq * clad::pop(_t1);
+//CHECK-NEXT:               _result[1UL] += _r0;
+//CHECK-NEXT:               double _r1 = clad::pop(_t2) * _d_sq;
+//CHECK-NEXT:               _result[1UL] += _r1;
+//CHECK-NEXT:           }
+//CHECK-NEXT:       }
+//CHECK-NEXT:   }
+
 #define TEST(F, x) { \
   result[0] = 0; \
   auto F##grad = clad::gradient(F);\
@@ -399,4 +443,10 @@ int main() {
   double x[] = { 1, 1, 1, 1, 1 };
   f_log_gaus_d_means.execute(x, p, 5, 2.0, result);
   printf("{%.2f, %.2f, %.2f, %.2f, %.2f}\n", result[0], result[1], result[2], result[3], result[4]); // CHECK-EXEC: {0.00, -0.25, -0.50, -0.75, -1.00}
+
+  result[0] = 0;
+  result[1] = 0;
+  auto f_const_d = clad::gradient(f_const);
+  f_const_d.execute(2, 3, result);
+  printf("{%.2f, %.2f}\n", result[0], result[1]); // CHECK-EXEC: {0.00, 18.00}
 }


### PR DESCRIPTION
This PR fixes the error that arises due to const type parameters or variables being used in the input function. The const type was being carried forward when declaring clad tape, diff variables and temporary variables. Since these variables are modified later it gave an error during code generation.