### PR TITLE
Add array diff support to reverse mode and hessian mode

### DIFF
--- a/demos/Arrays.cpp
+++ b/demos/Arrays.cpp
@@ -1,0 +1,113 @@
+//--------------------------------------------------------------------*- C++ -*-
+// clad - The C++ Clang-based Automatic Differentiator
+//
+// A demo, describing how to differentiate functions w.r.t. to arrays in
+// forward, reverse and jacobian mode
+//
+// author:  Baidyanath Kundu <kundubaidya99-at-gmail.com>
+//----------------------------------------------------------------------------//
+
+// To run the demo please type:
+// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/libclad.so  -I../include/ -x c++ -std=c++11 Gradient.cpp
+//
+// A typical invocation would be:
+// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
+// -I../include/ -x c++ -std=c++11 Gradient.cpp
+
+// Necessary for clad to work include
+#include "clad/Differentiator/Differentiator.h"
+
+double weighted_avg(double* arr, double* weights) {
+  return (arr[0] * weights[0] + arr[1] * weights[1] + arr[2] * weights[2]) / 3;
+}
+
+int main() {
+  double arr[3] = {1, 2, 3};
+  double weights[3] = {.5, .6, .3};
+
+  // Forward Mode
+
+  // Differentiate weighted_avg w.r.t to each element in arr. For forward mode
+  // it is required to specify the array index along with the array to be
+  // differentiated w.r.t.
+  auto weighted_avg_darr0 = clad::differentiate(weighted_avg, "arr[0]");
+  auto weighted_avg_darr1 = clad::differentiate(weighted_avg, "arr[1]");
+  auto weighted_avg_darr2 = clad::differentiate(weighted_avg, "arr[2]");
+
+  double res_arr0 = weighted_avg_darr0.execute(arr, weights);
+  double res_arr1 = weighted_avg_darr1.execute(arr, weights);
+  double res_arr2 = weighted_avg_darr2.execute(arr, weights);
+
+  printf("Forward Mode w.r.t. arr:\n res_arr = %.2g, %.2g, %.2g\n", res_arr0,
+         res_arr1, res_arr2);
+
+  // Reverse Mode
+
+  // Differentiate weighted_avg w.r.t. to both arr and weights array.
+  auto weighted_avg_dall = clad::gradient(weighted_avg);
+  // Differentiate weighted_avg w.r.t. to arr.
+  auto weighted_avg_darr = clad::gradient(weighted_avg, "arr");
+
+  double darr[3] = {0, 0, 0};
+  double dweights[3] = {0, 0, 0};
+  // clad::array_ref is used by clad::gradient to keep track of the array size
+  // being sent into the generated gradient. Since clad::array_ref is a wrapper
+  // for the supplied array any changes to it will be reflected in the array and
+  // vice versa
+  clad::array_ref<double> darr_ref(darr, 3);
+  clad::array_ref<double> dweights_ref(dweights, 3);
+
+  weighted_avg_dall.execute(arr, weights, darr_ref, dweights_ref);
+  printf("Reverse Mode w.r.t. all:\n darr = {%.2g, %.2g, %.2g}\n dweights = "
+         "{%.2g, %.2g, %.2g}\n",
+         darr[0], darr[1], darr[2], dweights[0], dweights[1], dweights[2]);
+
+  darr[0] = darr[1] = darr[2] = 0;
+  weighted_avg_darr.execute(arr, weights, darr_ref);
+  printf("Reverse Mode w.r.t. arr:\n darr = {%.2g, %.2g, %.2g}\n", darr[0],
+         darr[1], darr[2]);
+
+  // Hessian mode
+
+  // Generates the Hessian matrix for weighted_avg w.r.t. to both arr and
+  // weights. When dealing with arrays hessian mode requires the user to specify
+  // the indexes of the array by using the format arr[0:<last index of arr>]
+  auto hessian_all = clad::hessian(weighted_avg, "arr[0:2], weights[0:2]");
+  // Generates the Hessian matrix for weighted_avg w.r.t. to arr.
+  auto hessian_arr = clad::hessian(weighted_avg, "arr[0:2]");
+
+  double matrix_all[36];
+  double matrix_arr[9];
+
+  clad::array_ref<double> matrix_all_ref(matrix_all, 36);
+  clad::array_ref<double> matrix_arr_ref(matrix_arr, 9);
+
+  hessian_all.execute(arr, weights, matrix_all_ref);
+  printf("Hessian Mode w.r.t. to all:\n matrix =\n"
+         "  {%.2g, %.2g, %.2g, %.2g, %.2g, %.2g}\n"
+         "  {%.2g, %.2g, %.2g, %.2g, %.2g, %.2g}\n"
+         "  {%.2g, %.2g, %.2g, %.2g, %.2g, %.2g}\n"
+         "  {%.2g, %.2g, %.2g, %.2g, %.2g, %.2g}\n"
+         "  {%.2g, %.2g, %.2g, %.2g, %.2g, %.2g}\n"
+         "  {%.2g, %.2g, %.2g, %.2g, %.2g, %.2g}\n",
+         matrix_all[0], matrix_all[1], matrix_all[2], matrix_all[3],
+         matrix_all[4], matrix_all[5], matrix_all[6], matrix_all[7],
+         matrix_all[8], matrix_all[9], matrix_all[10], matrix_all[11],
+         matrix_all[12], matrix_all[13], matrix_all[14], matrix_all[15],
+         matrix_all[16], matrix_all[17], matrix_all[18], matrix_all[19],
+         matrix_all[20], matrix_all[21], matrix_all[22], matrix_all[23],
+         matrix_all[24], matrix_all[25], matrix_all[26], matrix_all[27],
+         matrix_all[28], matrix_all[29], matrix_all[30], matrix_all[31],
+         matrix_all[32], matrix_all[33], matrix_all[34], matrix_all[35]);
+
+  hessian_arr.execute(arr, weights, matrix_arr_ref);
+  printf("Hessian Mode w.r.t. to arr:\n matrix =\n"
+         "  {%.2g, %.2g, %.2g}\n"
+         "  {%.2g, %.2g, %.2g}\n"
+         "  {%.2g, %.2g, %.2g}\n",
+         matrix_arr[0], matrix_arr[1], matrix_arr[2], matrix_arr[3],
+         matrix_arr[4], matrix_arr[5], matrix_arr[6], matrix_arr[7],
+         matrix_arr[8]);
+}

--- a/demos/ODESolverSensitivity.cpp
+++ b/demos/ODESolverSensitivity.cpp
@@ -68,7 +68,7 @@ double bSensitivity(double x) {
   auto h = clad::gradient(solution);
 
   double grad[4];
-  h.execute(1.0, 3.0, 3.0, x, grad);
+  h.execute(1.0, 3.0, 3.0, x, &grad[0], &grad[1], &grad[2], &grad[3]);
 
   return grad[1];
 }

--- a/include/clad/Differentiator/Array.h
+++ b/include/clad/Differentiator/Array.h
@@ -1,0 +1,66 @@
+#ifndef CLANG_ARRAY_H
+#define CLANG_ARRAY_H
+
+#include "clad/Differentiator/CladConfig.h"
+
+#include <type_traits>
+
+namespace clad {
+  /// This class is not meant to be used by user. It is used by clad internally
+  /// only
+  template <typename T> class array {
+  private:
+    /// The pointer to the underlying array
+    T* m_arr = nullptr;
+    /// The size of the array
+    std::size_t m_size = 0;
+
+  public:
+    /// Delete default constructor
+    array() = delete;
+    /// Constructor to create an array of the specified size
+    CUDA_HOST_DEVICE array(std::size_t size)
+        : m_arr(new T[size]{static_cast<T>(0)}), m_size(size) {}
+
+    /// Destructor to delete the array if it was created by array_ref
+    CUDA_HOST_DEVICE ~array() { delete[] m_arr; }
+
+    /// Returns the size of the underlying array
+    CUDA_HOST_DEVICE std::size_t size() { return m_size; }
+    /// Returns the ptr of the underlying array
+    CUDA_HOST_DEVICE T* ptr() { return m_arr; }
+    /// Returns the reference to the location at the index of the underlying
+    /// array
+    CUDA_HOST_DEVICE T& operator[](std::size_t i) { return m_arr[i]; }
+    /// Returns the reference to the underlying array
+    CUDA_HOST_DEVICE T& operator*() { return *m_arr; }
+
+    // Arithmetic overloads
+    /// Divides the number from every element in the array
+    CUDA_HOST_DEVICE array<T>& operator/=(T n) {
+      for (std::size_t i = 0; i < m_size; i++)
+        m_arr[i] /= n;
+      return *this;
+    }
+    /// Multiplies the number to every element in the array
+    CUDA_HOST_DEVICE array<T>& operator*=(T n) {
+      for (std::size_t i = 0; i < m_size; i++)
+        m_arr[i] *= n;
+      return *this;
+    }
+    /// Adds the number to every element in the array
+    CUDA_HOST_DEVICE array<T>& operator+=(T n) {
+      for (std::size_t i = 0; i < m_size; i++)
+        m_arr[i] += n;
+      return *this;
+    }
+    /// Subtracts the number from every element in the array
+    CUDA_HOST_DEVICE array<T>& operator-=(T n) {
+      for (std::size_t i = 0; i < m_size; i++)
+        m_arr[i] -= n;
+      return *this;
+    }
+  };
+} // namespace clad
+
+#endif // CLANG_ARRAY_H

--- a/include/clad/Differentiator/ArrayRef.h
+++ b/include/clad/Differentiator/ArrayRef.h
@@ -1,0 +1,79 @@
+#ifndef CLAD_ARRAY_REF_H
+#define CLAD_ARRAY_REF_H
+
+#include "clad/Differentiator/Array.h"
+#include "clad/Differentiator/CladConfig.h"
+
+#include <assert.h>
+#include <type_traits>
+
+namespace clad {
+  /// Stores the pointer to and the size of an array and provides some helper
+  /// functions for it. The array is supplied should have a life greater than
+  /// that of the array_ref
+  template <typename T> class array_ref {
+  private:
+    /// The pointer to the underlying array
+    T* m_arr = nullptr;
+    /// The size of the array
+    std::size_t m_size = 0;
+
+  public:
+    /// Delete default constructor
+    array_ref() = delete;
+    /// Constructor to store the pointer to and size of an array supplied by the
+    /// user
+    CUDA_HOST_DEVICE array_ref(T* arr, std::size_t size)
+        : m_arr(arr), m_size(size) {}
+    /// Constructor for arrays having size equal to 1 or non pointer types to
+    /// store their addresses
+    CUDA_HOST_DEVICE array_ref(T* a) : m_arr(a), m_size(1) {}
+    /// Constructor for clad::array types
+    CUDA_HOST_DEVICE array_ref(array<T>& a)
+        : m_arr(a.ptr()), m_size(a.size()) {}
+
+    /// Returns the size of the underlying array
+    CUDA_HOST_DEVICE std::size_t size() { return m_size; }
+    /// Returns the reference to the location at the index of the underlying
+    /// array
+    CUDA_HOST_DEVICE T& operator[](std::size_t i) { return m_arr[i]; }
+    /// Returns the reference to the underlying array
+    CUDA_HOST_DEVICE T& operator*() { return *m_arr; }
+
+    // Arithmetic overloads
+    /// Divides the arrays element wise
+    CUDA_HOST_DEVICE array_ref<T>& operator/=(array_ref<T>& Ar) {
+      assert(m_size == Ar.size() && "Size of both the array_refs must be equal "
+                                    "for carrying out addition assignment");
+      for (std::size_t i = 0; i < m_size; i++)
+        m_arr[i] /= Ar[i];
+      return *this;
+    }
+    /// Multiplies the arrays element wise
+    CUDA_HOST_DEVICE array_ref<T>& operator*=(array_ref<T>& Ar) {
+      assert(m_size == Ar.size() && "Size of both the array_refs must be equal "
+                                    "for carrying out addition assignment");
+      for (std::size_t i = 0; i < m_size; i++)
+        m_arr[i] *= Ar[i];
+      return *this;
+    }
+    /// Adds the arrays element wise
+    CUDA_HOST_DEVICE array_ref<T>& operator+=(array_ref<T>& Ar) {
+      assert(m_size == Ar.size() && "Size of both the array_refs must be equal "
+                                    "for carrying out addition assignment");
+      for (std::size_t i = 0; i < m_size; i++)
+        m_arr[i] += Ar[i];
+      return *this;
+    }
+    /// Subtracts the arrays element wise
+    CUDA_HOST_DEVICE array_ref<T>& operator-=(array_ref<T>& Ar) {
+      assert(m_size == Ar.size() && "Size of both the array_refs must be equal "
+                                    "for carrying out addition assignment");
+      for (std::size_t i = 0; i < m_size; i++)
+        m_arr[i] -= Ar[i];
+      return *this;
+    }
+  };
+} // namespace clad
+
+#endif // CLAD_ARRAY_REF_H

--- a/include/clad/Differentiator/ArrayRef.h
+++ b/include/clad/Differentiator/ArrayRef.h
@@ -34,6 +34,14 @@ namespace clad {
 
     /// Returns the size of the underlying array
     CUDA_HOST_DEVICE std::size_t size() { return m_size; }
+    /// Returns an array_ref to a part of the underlying array starting at
+    /// offset and having the specified size
+    CUDA_HOST_DEVICE array_ref<T> slice(std::size_t offset, std::size_t size) {
+      assert((offset >= 0) && (offset + size <= m_size) &&
+             "Window is outside array. Please provide an offset and size "
+             "inside the array size.");
+      return array_ref<T>(&m_arr[offset], size);
+    }
     /// Returns the reference to the location at the index of the underlying
     /// array
     CUDA_HOST_DEVICE T& operator[](std::size_t i) { return m_arr[i]; }

--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -11,6 +11,7 @@
 // should go.
 namespace custom_derivatives{}
 
+#include "clad/Differentiator/ArrayRef.h"
 #include "clad/Differentiator/CladConfig.h"
 
 #include <math.h>
@@ -93,10 +94,11 @@ namespace custom_derivatives {
   }
 
   template <typename T1, typename T2>
-  CUDA_HOST_DEVICE void 
-  pow_grad(T1 x, T2 exponent, decltype(pow(T1(), T2())) * result) {
-    result[0] += pow_darg0(x, exponent);
-    result[1] += pow_darg1(x, exponent);
+  CUDA_HOST_DEVICE void
+  pow_grad(T1 x, T2 exponent, clad::array_ref<decltype(pow(T1(), T2()))> _d_x,
+           clad::array_ref<decltype(pow(T1(), T2()))> _d_y) {
+    *_d_x += pow_darg0(x, exponent);
+    *_d_y += pow_darg1(x, exponent);
   }
 
   template <typename T>

--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -413,13 +413,22 @@ static inline QualType getConstantArrayType(const ASTContext &Ctx,
    #define CLAD_COMPAT_CLANG12_Declarator_LambdaExpr LambdaExpr
 #endif
 
-// Clang 12 add one extra param (FPO) in Create method of:
+// Clang 12 add one extra param (FPO) that we get from Node in Create method of:
 // ImplicitCastExpr, CStyleCastExpr, CXXStaticCastExpr and CXXFunctionalCastExpr
 
 #if CLANG_VERSION_MAJOR < 12
    #define CLAD_COMPAT_CLANG12_CastExpr_GetFPO(Node) /**/
 #elif CLANG_VERSION_MAJOR >= 12
    #define CLAD_COMPAT_CLANG12_CastExpr_GetFPO(Node) ,Node->getFPFeatures()
+#endif
+
+// Clang 12 adds one extra param (FPO) in Create method of:
+// ImplicitCastExpr, CStyleCastExpr, CXXStaticCastExpr and CXXFunctionalCastExpr
+
+#if CLANG_VERSION_MAJOR < 12
+#define CLAD_COMPAT_CLANG12_CastExpr_DefaultFPO /**/
+#elif CLANG_VERSION_MAJOR >= 12
+#define CLAD_COMPAT_CLANG12_CastExpr_DefaultFPO , FPOptionsOverride()
 #endif
 
 // Clang 12 add two extra param (Left and Right paren location) in Create method of:

--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -60,8 +60,15 @@ namespace clad {
 
 namespace clad {
   /// A pair of FunctionDecl and potential enclosing context, e.g. a function
-  // in nested namespaces
+  /// in nested namespaces.
+  // This is the type returned by cloneFunction. Using OverloadedDeclWithContext
+  // instead would lead to unnecessarily returning a nullptr in the overloaded
+  // FD
   using DeclWithContext = std::pair<clang::FunctionDecl*, clang::Decl*>;
+  /// A tuple which consists of a FunctionDecl, it's potential enclosing context
+  /// and optionally it's overload FunctionDecl
+  using OverloadedDeclWithContext =
+      std::tuple<clang::FunctionDecl*, clang::Decl*, clang::FunctionDecl*>;
   using DiffParams = llvm::SmallVector<const clang::VarDecl*, 16>;
   using IndexIntervalTable = llvm::SmallVector<IndexInterval, 16>;
   using DiffParamsWithIndices = std::pair<DiffParams, IndexIntervalTable>;
@@ -121,8 +128,8 @@ namespace clad {
     ///\returns The differentiated function and potentially created enclosing
     /// context.
     ///
-    DeclWithContext Derive(const clang::FunctionDecl* FD,
-                           const DiffRequest & request);
+    OverloadedDeclWithContext Derive(const clang::FunctionDecl* FD,
+                                     const DiffRequest& request);
   };
 
 } // end namespace clad

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -46,8 +46,9 @@ namespace clad {
     bool CallUpdateRequired = false;
     /// A flag to enable/disable diag warnings/errors during differentiation.
     bool VerboseDiags = false;
-
-    void updateCall(clang::FunctionDecl* FD, clang::Sema& SemaRef);
+    /// Puts the derived function and its code in the diff call
+    void updateCall(clang::FunctionDecl* FD, clang::FunctionDecl* OverloadedFD,
+                    clang::Sema& SemaRef);
   };
 
   using DiffSchedule = llvm::SmallVector<DiffRequest, 16>;

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -342,12 +342,10 @@ namespace clad {
   /// Function for Hessian matrix computation
   /// Given  a function f, clad::hessian generates all the second derivatives
   /// of the original function, (they are also columns of a Hessian matrix)
-  template <typename ArgSpec = const char*,
-            typename F,
-            typename DerivedFnType = ExtractDerivedFnTraits_t<F>>
+  template <typename ArgSpec = const char*, typename F,
+            typename DerivedFnType = HessianDerivedFnTraits_t<F>>
   CladFunction<DerivedFnType> __attribute__((annotate("H")))
-  hessian(F f,
-          ArgSpec args = "",
+  hessian(F f, ArgSpec args = "",
           DerivedFnType derivedFn = static_cast<DerivedFnType>(nullptr),
           const char* code = "") {
     assert(f && "Must pass in a non-0 argument");

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -7,8 +7,10 @@
 #ifndef CLAD_DIFFERENTIATOR
 #define CLAD_DIFFERENTIATOR
 
-#include "CladConfig.h"
+#include "Array.h"
+#include "ArrayRef.h"
 #include "BuiltinDerivatives.h"
+#include "CladConfig.h"
 #include "FunctionTraits.h"
 #include "Tape.h"
 

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -355,12 +355,10 @@ namespace clad {
                                        code);
   }
 
-  template <typename ArgSpec = const char*,
-            typename F,
-            typename DerivedFnType = ExtractDerivedFnTraits_t<F>>
+  template <typename ArgSpec = const char*, typename F,
+            typename DerivedFnType = JacobianDerivedFnTraits_t<F>>
   CladFunction<DerivedFnType> __attribute__((annotate("J")))
-  jacobian(F f,
-           ArgSpec args = "",
+  jacobian(F f, ArgSpec args = "",
            DerivedFnType derivedFn = static_cast<DerivedFnType>(nullptr),
            const char* code = "") {
     assert(f && "Must pass in a non-0 argument");

--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -40,8 +40,8 @@ namespace clad {
     ///\returns The differentiated and potentially created enclosing
     /// context.
     ///
-    DeclWithContext Derive(const clang::FunctionDecl* FD,
-                           const DiffRequest& request);
+    OverloadedDeclWithContext Derive(const clang::FunctionDecl* FD,
+                                     const DiffRequest& request);
     StmtDiff VisitArraySubscriptExpr(const clang::ArraySubscriptExpr* ASE);
     StmtDiff VisitBinaryOperator(const clang::BinaryOperator* BinOp);
     StmtDiff VisitCallExpr(const clang::CallExpr* CE);

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -449,12 +449,75 @@ namespace clad {
     using type = NoFunction*;
   };
 
+  template <class... Args> struct SelectLast;
+
+  template <class... Args>
+  using SelectLast_t = typename SelectLast<Args...>::type;
+
+  template <class T> struct SelectLast<T> { using type = T; };
+
+  template <class T, class... Args> struct SelectLast<T, Args...> {
+    using type = typename SelectLast<Args...>::type;
+  };
+
+  template <class T> struct JacobianDerivedFnTraits {};
+
+  // JacobianDerivedFnTraits is used to deduce type of the derived functions
+  // derived using jacobian mode
+  template <class T>
+  using JacobianDerivedFnTraits_t = typename JacobianDerivedFnTraits<T>::type;
+
+  // JacobianDerivedFnTraits specializations for pure function pointer types
+  template <class ReturnType, class... Args>
+  struct JacobianDerivedFnTraits<ReturnType (*)(Args...)> {
+    using type = void (*)(Args..., SelectLast_t<Args...>);
+  };
+
+  /// These macro expansions are used to cover all possible cases of
+  /// qualifiers in member functions when declaring JacobianDerivedFnTraits.
+  /// They need to be read from bottom to top. Starting from the use of AddCON,
+  /// the call to which is used to pass the cases with and without C-style
+  /// varargs, then as the macro name AddCON says it adds cases of const
+  /// qualifier. The AddVOL and AddREF macro similarly add cases for volatile
+  /// qualifier and reference respectively. The AddNOEX adds cases for noexcept
+  /// qualifier only if it is supported and finally AddSPECS declares the
+  /// function with all the cases
+#define JacobianDerivedFnTraits_AddSPECS(var, cv, vol, ref, noex)              \
+  template <typename R, typename C, typename... Args>                          \
+  struct JacobianDerivedFnTraits<R (C::*)(Args...) cv vol ref noex> {          \
+    using type = void (C::*)(Args..., SelectLast_t<Args...>) cv vol ref noex;  \
+  };
+
+#if __cpp_noexcept_function_type > 0
+#define JacobianDerivedFnTraits_AddNOEX(var, con, vol, ref)                    \
+  JacobianDerivedFnTraits_AddSPECS(var, con, vol, ref, )                       \
+      JacobianDerivedFnTraits_AddSPECS(var, con, vol, ref, noexcept)
+#else
+#define JacobianDerivedFnTraits_AddNOEX(var, con, vol, ref)                    \
+  JacobianDerivedFnTraits_AddSPECS(var, con, vol, ref, )
+#endif
+
+#define JacobianDerivedFnTraits_AddREF(var, con, vol)                          \
+  JacobianDerivedFnTraits_AddNOEX(var, con, vol, )                             \
+      JacobianDerivedFnTraits_AddNOEX(var, con, vol, &)                        \
+          JacobianDerivedFnTraits_AddNOEX(var, con, vol, &&)
+
+#define JacobianDerivedFnTraits_AddVOL(var, con)                               \
+  JacobianDerivedFnTraits_AddREF(var, con, )                                   \
+      JacobianDerivedFnTraits_AddREF(var, con, volatile)
+
+#define JacobianDerivedFnTraits_AddCON(var)                                    \
+  JacobianDerivedFnTraits_AddVOL(var, )                                        \
+      JacobianDerivedFnTraits_AddVOL(var, const)
+
+  JacobianDerivedFnTraits_AddCON(()); // Declares all the specializations
+
   // ExtractDerivedFnTraits is used to deduce type of the derived functions
   // derived using hessian and jacobian differentiation modes
   // It SHOULD NOT be used to get traits of derived functions derived using
   // forward or reverse differentiation mode
-  template<class ReturnType, class = void>
-  struct ExtractDerivedFnTraits {};
+  template <class ReturnType, class = void> struct ExtractDerivedFnTraits {};
+
   template<class T>
   using ExtractDerivedFnTraits_t = typename ExtractDerivedFnTraits<T>::type;
 

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -512,180 +512,83 @@ namespace clad {
 
   JacobianDerivedFnTraits_AddCON(()); // Declares all the specializations
 
-  // ExtractDerivedFnTraits is used to deduce type of the derived functions
-  // derived using hessian and jacobian differentiation modes
-  // It SHOULD NOT be used to get traits of derived functions derived using
-  // forward or reverse differentiation mode
-  template <class ReturnType, class = void> struct ExtractDerivedFnTraits {};
+  template <class T> struct HessianDerivedFnTraits {};
 
-  template<class T>
-  using ExtractDerivedFnTraits_t = typename ExtractDerivedFnTraits<T>::type;
+  // HessianDerivedFnTraits is used to deduce type of the derived functions
+  // derived using hessian mode
+  template <class T>
+  using HessianDerivedFnTraits_t = typename HessianDerivedFnTraits<T>::type;
 
-  // specializations for non-member functions pointer types
-  template <class ReturnType,class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (*)(Args...)> {
-    using type = void (*)(Args..., ReturnType*);
+  // HessianDerivedFnTraits specializations for pure function pointer types
+  template <class ReturnType, class... Args>
+  struct HessianDerivedFnTraits<ReturnType (*)(Args...)> {
+    using type = void (*)(Args..., array_ref<ReturnType>);
   };
 
-  // specializations for member functions pointer types with no cv-qualifiers
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)> {
-    using type = void (C::*)(Args..., ReturnType*);
+  /// These macro expansions are used to cover all possible cases of
+  /// qualifiers in member functions when declaring HessianDerivedFnTraits.
+  /// They need to be read from bottom to top. Starting from the use of AddCON,
+  /// the call to which is used to pass the cases with and without C-style
+  /// varargs, then as the macro name AddCON says it adds cases of const
+  /// qualifier. The AddVOL and AddREF macro similarly add cases for volatile
+  /// qualifier and reference respectively. The AddNOEX adds cases for noexcept
+  /// qualifier only if it is supported and finally AddSPECS declares the
+  /// function with all the cases
+#define HessianDerivedFnTraits_AddSPECS(var, cv, vol, ref, noex)               \
+  template <typename R, typename C, typename... Args>                          \
+  struct HessianDerivedFnTraits<R (C::*)(Args...) cv vol ref noex> {           \
+    using type = void (C::*)(Args..., array_ref<R>) cv vol ref noex;           \
   };
 
-  // specializations for member functions pointer types with only cv-qualifiers
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const> {
-    using type = void (C::*)(Args..., ReturnType*) const;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile> {
-    using type = void (C::*)(Args..., ReturnType*) volatile;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile> {
-    using type = void (C::*)(Args..., ReturnType*) const volatile;
-  };
-
-  // specializations for member functions pointer types with 
-  // reference qualifiers and with and without cv-qualifiers
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &> {
-    using type = void (C::*)(Args..., ReturnType*) &;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &> {
-    using type = void (C::*)(Args..., ReturnType*) const &;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &> {
-    using type = void (C::*)(Args..., ReturnType*) volatile &;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &> {
-    using type = void (C::*)(Args..., ReturnType*) const volatile &;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &&> {
-    using type = void (C::*)(Args..., ReturnType*) &&;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &&> {
-    using type = void (C::*)(Args..., ReturnType*) const &&;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &&> {
-    using type = void (C::*)(Args..., ReturnType*) volatile &&;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &&> {
-    using type = void (C::*)(Args..., ReturnType*) const volatile &&;
-  };
-
-  // specializations for noexcept member functions
-  #if __cpp_noexcept_function_type > 0
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) noexcept> {
-    using type = void (C::*)(Args..., ReturnType*) noexcept;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const noexcept> {
-    using type = void (C::*)(Args..., ReturnType*) const noexcept;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile noexcept> {
-    using type = void (C::*)(Args..., ReturnType*) volatile noexcept;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)
-                                    const volatile noexcept> {
-    using type = void (C::*)(Args..., ReturnType*) const volatile noexcept;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) & noexcept> {
-    using type = void (C::*)(Args..., ReturnType*) & noexcept;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const & noexcept> {
-    using type = void (C::*)(Args..., ReturnType*) const & noexcept;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile& noexcept> {
-    using type = void (C::*)(Args..., ReturnType*) volatile& noexcept;
-  };
-
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)
-                                    const volatile& noexcept> {
-    using type = void (C::*)(Args..., ReturnType*) const volatile& noexcept;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) && noexcept> {
-    using type = void (C::*)(Args..., ReturnType*) && noexcept;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const && noexcept> {
-    using type = void (C::*)(Args..., ReturnType*) const && noexcept;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(
-      Args...) volatile&& noexcept> {
-    using type = void (C::*)(Args..., ReturnType*) volatile&& noexcept;
-  };
-  template <class ReturnType, class C, class... Args>
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)
-                                    const volatile&& noexcept> {
-    using type = void (C::*)(Args..., ReturnType*) const volatile&& noexcept;
-  };
+#if __cpp_noexcept_function_type > 0
+#define HessianDerivedFnTraits_AddNOEX(var, con, vol, ref)                     \
+  HessianDerivedFnTraits_AddSPECS(var, con, vol, ref, )                        \
+      HessianDerivedFnTraits_AddSPECS(var, con, vol, ref, noexcept)
+#else
+#define HessianDerivedFnTraits_AddNOEX(var, con, vol, ref)                     \
+  HessianDerivedFnTraits_AddSPECS(var, con, vol, ref, )
 #endif
 
-  /// Specialization for class types
-  /// If class have exactly one user defined call operator, then defines
-  /// member typedef `type` same as the type of the derived function of the
-  /// call operator, otherwise defines member typedef `type` as the type of
-  /// `NoFunction*`.
-  template <class F>
-  struct ExtractDerivedFnTraits<
-      F,
-      typename std::enable_if<
-          std::is_class<remove_reference_and_pointer_t<F>>::value &&
-          has_call_operator<F>::value>::type> {
-    using ClassType =
-        typename std::decay<remove_reference_and_pointer_t<F>>::type;
-    using type = ExtractDerivedFnTraits_t<decltype(&ClassType::operator())>;
-  };
-  template <class F>
-  struct ExtractDerivedFnTraits<
-      F,
-      typename std::enable_if<
-          std::is_class<remove_reference_and_pointer_t<F>>::value &&
-          !has_call_operator<F>::value>::type> {
-    using type = NoFunction*;
-  };
+#define HessianDerivedFnTraits_AddREF(var, con, vol)                           \
+  HessianDerivedFnTraits_AddNOEX(var, con, vol, )                              \
+      HessianDerivedFnTraits_AddNOEX(var, con, vol, &)                         \
+          HessianDerivedFnTraits_AddNOEX(var, con, vol, &&)
+
+#define HessianDerivedFnTraits_AddVOL(var, con)                                \
+  HessianDerivedFnTraits_AddREF(var, con, )                                    \
+      HessianDerivedFnTraits_AddREF(var, con, volatile)
+
+#define HessianDerivedFnTraits_AddCON(var)                                     \
+  HessianDerivedFnTraits_AddVOL(var, ) HessianDerivedFnTraits_AddVOL(var, const)
+
+  HessianDerivedFnTraits_AddCON(()); // Declares all the specializations
 
   /// Compute type of derived function of function, method or functor when
-  /// differentiated using forward differentiation mode (`clad::differentiate`).
-  /// Computed type is provided as member typedef `type`.
+  /// differentiated using forward differentiation mode
+  /// (`clad::differentiate`). Computed type is provided as member typedef
+  /// `type`.
   ///
   /// More precisely, this type trait behaves as following:
   ///
   /// - If `F` is a function pointer type
-  ///   Defines member typedef `type` same as the type of the function pointer.
+  ///   Defines member typedef `type` same as the type of the function
+  ///   pointer.
   ///
   /// - If `F` is a member function pointer type
-  ///   Defines member typedef `type` same as the type of the member function
+  ///   Defines member typedef `type` same as the type of the member
+  ///   function
   /// pointer.
   ///
   /// - If `F` is class type, class reference type, class pointer type, or
   ///   reference to class pointer type.
-  ///   Defines member typedef `type` same as the type of the overloaded call
-  ///   operator member function of the class.
+  ///   Defines member typedef `type` same as the type of the overloaded
+  ///   call operator member function of the class.
   ///
   /// - For all other cases, no member typedef `type` is provided.
   ///
   /// This type trait is specific to forward mode differentiation since the
-  /// rules for computing the signature of derived functions are different for 
-  /// forward and reverse mode.
+  /// rules for computing the signature of derived functions are different
+  /// for forward and reverse mode.
   template <class F, class = void> struct ExtractDerivedFnTraitsForwMode {};
 
   /// Helper type for ExtractDerivedFnTraitsForwMode

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -1,5 +1,8 @@
 #ifndef FUNCTION_TRAITS
 #define FUNCTION_TRAITS
+
+#include "clad/Differentiator/ArrayRef.h"
+
 #include <type_traits>
 
 namespace clad {
@@ -167,108 +170,289 @@ namespace clad {
 
   // specializations for noexcept member functions
   #if __cpp_noexcept_function_type > 0
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args...) noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args...) noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args..., ...) noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args..., ...) noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args...) const noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args...) const noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args..., ...) const noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args..., ...) const noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args...) volatile noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args...) volatile noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args..., ...) volatile noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args..., ...) volatile noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args...) const volatile noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args...) const volatile noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args..., ...) const volatile noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args..., ...) const volatile noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args...) & noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args...)& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args..., ...) & noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args..., ...)& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args...) const & noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args...) const& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args..., ...) const & noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args..., ...) const& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args...) volatile & noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args...) volatile& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args..., ...) volatile & noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args..., ...) volatile& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args...) const volatile & noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args...) const volatile& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args..., ...) const volatile & noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args..., ...) const volatile& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args...) && noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args...)&& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args..., ...) && noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args..., ...)&& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args...) const && noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args...) const&& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args..., ...) const && noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args..., ...) const&& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args...) volatile && noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args...) volatile&& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args..., ...) volatile && noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args..., ...) volatile&& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args...) const volatile && noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args...) const volatile&& noexcept> {
+    using type = ReturnType;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct return_type<ReturnType (C::*)(Args..., ...) const volatile && noexcept> { 
-    using type = ReturnType; 
+  template <class ReturnType, class C, class... Args>
+  struct return_type<ReturnType (C::*)(Args..., ...)
+                         const volatile&& noexcept> {
+    using type = ReturnType;
   };
-  #endif
+#endif
 
-  // ExtractDerivedFnTraits is used to deduce type of the derived functions 
-  // derived using reverse, hessian and jacobian differentiation modes
+#define REM_CTOR(...) __VA_ARGS__
+
+  // Setup for DropArgs
+  template <typename... T> struct list {};
+
+  struct dummy {};
+
+  template <typename T> struct wrap {
+    constexpr operator dummy() const { return {}; }
+  };
+
+  template <std::size_t I> using placeholder = dummy;
+
+  template <size_t... Ints> struct IndexSequence {
+    using type = IndexSequence;
+    using value_type = size_t;
+    static constexpr std::size_t size() noexcept { return sizeof...(Ints); }
+  };
+
+  template <class Sequence1, class Sequence2> struct MergeAndRemember;
+
+  template <size_t... I1, size_t... I2>
+  struct MergeAndRemember<IndexSequence<I1...>, IndexSequence<I2...>>
+      : IndexSequence<I1..., (sizeof...(I1) + I2)...> {};
+
+  // Creates a sequence of numbers in the template in place of
+  template <size_t N>
+  struct MakeIndexSequence
+      : MergeAndRemember<typename MakeIndexSequence<N / 2>::type,
+                         typename MakeIndexSequence<N - N / 2>::type> {};
+
+  template <> struct MakeIndexSequence<0> : IndexSequence<> {};
+  template <> struct MakeIndexSequence<1> : IndexSequence<0> {};
+
+  template <std::size_t... Idx, typename... Rest>
+  auto wrapRest(placeholder<Idx>..., wrap<Rest>...) -> list<Rest...>;
+
+  template <typename... T, std::size_t... Idx>
+  auto dropUsingIndex(IndexSequence<Idx...>)
+      -> decltype(wrapRest<Idx...>(wrap<T>{}...)) {
+    return wrapRest<Idx...>(wrap<T>{}...);
+  }
+
+  template <std::size_t N, typename... T>
+  using Drop_t = decltype(dropUsingIndex<T...>(MakeIndexSequence<N>{}));
+
+  template <std::size_t, typename T> struct DropArgs;
+
+  // Returns the Args in the function F that come after the Nth arg
+  template <std::size_t N, typename F>
+  using DropArgs_t = typename DropArgs<N, F>::type;
+
+  template <std::size_t N, typename R, typename... Args>
+  struct DropArgs<N, R (*)(Args...)> {
+    using type = Drop_t<N, Args...>;
+  };
+
+  template <std::size_t N, typename R, typename... Args>
+  struct DropArgs<N, R (*)(Args..., ...)> {
+    using type = Drop_t<N, Args...>;
+  };
+
+  /// These macro expansions are used to cover all possible cases of
+  /// qualifiers in member functions when declaring DropArgs. They need to be
+  /// read from the bottom to the top. Starting from the use of AddCON,
+  /// the call to which is used to pass the cases with and without C-style
+  /// varargs, then as the macro name AddCON says it adds cases of const
+  /// qualifier. The AddVOL and AddREF macro similarly add cases for volatile
+  /// qualifier and reference respectively. The AddNOEX adds cases for noexcept
+  /// qualifier only if it is supported and finally AddSPECS declares the
+  /// function with all the cases
+#define DropArgs_AddSPECS(var, con, vol, ref, noex)                            \
+  template <std::size_t N, typename R, typename C, typename... Args>           \
+  struct DropArgs<N, R (C::*)(Args... REM_CTOR var) con vol ref noex> {        \
+    using type = Drop_t<N, Args...>;                                           \
+  };
+
+#if __cpp_noexcept_function_type > 0
+#define DropArgs_AddNOEX(var, con, vol, ref)                                   \
+  DropArgs_AddSPECS(var, con, vol, ref, )                                      \
+      DropArgs_AddSPECS(var, con, vol, ref, noexcept)
+#else
+#define DropArgs_AddNOEX(var, con, vol, ref)                                   \
+  DropArgs_AddSPECS(var, con, vol, ref, )
+#endif
+
+#define DropArgs_AddREF(var, con, vol)                                         \
+  DropArgs_AddNOEX(var, con, vol, ) DropArgs_AddNOEX(var, con, vol, &)         \
+      DropArgs_AddNOEX(var, con, vol, &&)
+
+#define DropArgs_AddVOL(var, con)                                              \
+  DropArgs_AddREF(var, con, ) DropArgs_AddREF(var, con, volatile)
+
+#define DropArgs_AddCON(var) DropArgs_AddVOL(var, ) DropArgs_AddVOL(var, const)
+
+  DropArgs_AddCON(())
+      DropArgs_AddCON((, ...)); // Declares all the specializations
+
+  template <class T, class R> struct OutputParamType {
+    using type = array_ref<R>;
+  };
+
+  template <class T, class R>
+  using OutputParamType_t = typename OutputParamType<T, R>::type;
+
+  template <class T, class = void> struct GradientDerivedFnTraits {};
+
+  // GradientDerivedFnTraits is used to deduce type of the derived functions
+  // derived using reverse modes
+  template <class T>
+  using GradientDerivedFnTraits_t = typename GradientDerivedFnTraits<T>::type;
+
+  // GradientDerivedFnTraits specializations for pure function pointer types
+  template <class ReturnType, class... Args>
+  struct GradientDerivedFnTraits<ReturnType (*)(Args...)> {
+    using type = void (*)(Args..., OutputParamType_t<Args, ReturnType>...);
+  };
+
+  /// These macro expansions are used to cover all possible cases of
+  /// qualifiers in member functions when declaring GradientDerivedFnTraits.
+  /// They need to be read from bottom to top. Starting from the use of AddCON,
+  /// the call to which is used to pass the cases with and without C-style
+  /// varargs, then as the macro name AddCON says it adds cases of const
+  /// qualifier. The AddVOL and AddREF macro similarly add cases for volatile
+  /// qualifier and reference respectively. The AddNOEX adds cases for noexcept
+  /// qualifier only if it is supported and finally AddSPECS declares the
+  /// function with all the cases
+#define GradientDerivedFnTraits_AddSPECS(var, cv, vol, ref, noex)              \
+  template <typename R, typename C, typename... Args>                          \
+  struct GradientDerivedFnTraits<R (C::*)(Args...) cv vol ref noex> {          \
+    using type = void (C::*)(Args...,                                          \
+                             OutputParamType_t<Args, R>...) cv vol ref noex;   \
+  };
+
+#if __cpp_noexcept_function_type > 0
+#define GradientDerivedFnTraits_AddNOEX(var, con, vol, ref)                    \
+  GradientDerivedFnTraits_AddSPECS(var, con, vol, ref, )                       \
+      GradientDerivedFnTraits_AddSPECS(var, con, vol, ref, noexcept)
+#else
+#define GradientDerivedFnTraits_AddNOEX(var, con, vol, ref)                    \
+  GradientDerivedFnTraits_AddSPECS(var, con, vol, ref, )
+#endif
+
+#define GradientDerivedFnTraits_AddREF(var, con, vol)                          \
+  GradientDerivedFnTraits_AddNOEX(var, con, vol, )                             \
+      GradientDerivedFnTraits_AddNOEX(var, con, vol, &)                        \
+          GradientDerivedFnTraits_AddNOEX(var, con, vol, &&)
+
+#define GradientDerivedFnTraits_AddVOL(var, con)                               \
+  GradientDerivedFnTraits_AddREF(var, con, )                                   \
+      GradientDerivedFnTraits_AddREF(var, con, volatile)
+
+#define GradientDerivedFnTraits_AddCON(var)                                    \
+  GradientDerivedFnTraits_AddVOL(var, )                                        \
+      GradientDerivedFnTraits_AddVOL(var, const)
+
+  GradientDerivedFnTraits_AddCON(()); // Declares all the specializations
+
+  /// Specialization for class types
+  /// If class have exactly one user defined call operator, then defines
+  /// member typedef `type` same as the type of the derived function of the
+  /// call operator, otherwise defines member typedef `type` as the type of
+  /// `NoFunction*`.
+  template <class F>
+  struct GradientDerivedFnTraits<
+      F, typename std::enable_if<
+             std::is_class<remove_reference_and_pointer_t<F>>::value &&
+             has_call_operator<F>::value>::type> {
+    using ClassType =
+        typename std::decay<remove_reference_and_pointer_t<F>>::type;
+    using type = GradientDerivedFnTraits_t<decltype(&ClassType::operator())>;
+  };
+  template <class F>
+  struct GradientDerivedFnTraits<
+      F, typename std::enable_if<
+             std::is_class<remove_reference_and_pointer_t<F>>::value &&
+             !has_call_operator<F>::value>::type> {
+    using type = NoFunction*;
+  };
+
+  // ExtractDerivedFnTraits is used to deduce type of the derived functions
+  // derived using hessian and jacobian differentiation modes
   // It SHOULD NOT be used to get traits of derived functions derived using
-  // forward differentiation mode
+  // forward or reverse differentiation mode
   template<class ReturnType, class = void>
   struct ExtractDerivedFnTraits {};
   template<class T>
@@ -281,11 +465,11 @@ namespace clad {
   };
 
   // specializations for member functions pointer types with no cv-qualifiers
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)> {
+    using type = void (C::*)(Args..., ReturnType*);
   };
-  
+
   // specializations for member functions pointer types with only cv-qualifiers
   template <class ReturnType, class C, class... Args>
   struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const> {

--- a/include/clad/Differentiator/HessianModeVisitor.h
+++ b/include/clad/Differentiator/HessianModeVisitor.h
@@ -27,8 +27,8 @@ namespace clad {
     /// A helper method that combines all the generated second derivatives
     /// (contained within a vector) obtained from Derive
     /// into a single FunctionDecl f_hessian
-    DeclWithContext Merge(std::vector<clang::FunctionDecl*> Functions,
-                          const DiffRequest& request);
+    OverloadedDeclWithContext Merge(std::vector<clang::FunctionDecl*> Functions,
+                                    const DiffRequest& request);
 
   public:
     HessianModeVisitor(DerivativeBuilder& builder);
@@ -40,15 +40,14 @@ namespace clad {
     ///\param[in] FD - the function that will be differentiated.
     ///
     ///\returns A function containing second derivatives (columns) of a hessian
-    /// matrix
-    /// and potentially created enclosing context.
+    /// matrix and potentially created enclosing context.
     ///
     /// We name the hessian of f as 'f_hessian'. Uses ForwardModeVisitor and
     /// ReverseModeVisitor to generate second derivatives that correspond to
     /// columns of the Hessian. uses Merge to return a FunctionDecl
     /// containing CallExprs to the generated second derivatives.
-    DeclWithContext Derive(const clang::FunctionDecl* FD,
-                           const DiffRequest& request);
+    OverloadedDeclWithContext Derive(const clang::FunctionDecl* FD,
+                                     const DiffRequest& request);
   };
 } // end namespace clad
 

--- a/include/clad/Differentiator/HessianModeVisitor.h
+++ b/include/clad/Differentiator/HessianModeVisitor.h
@@ -27,8 +27,10 @@ namespace clad {
     /// A helper method that combines all the generated second derivatives
     /// (contained within a vector) obtained from Derive
     /// into a single FunctionDecl f_hessian
-    OverloadedDeclWithContext Merge(std::vector<clang::FunctionDecl*> Functions,
-                                    const DiffRequest& request);
+    OverloadedDeclWithContext
+    Merge(std::vector<clang::FunctionDecl*> secDerivFuncs,
+          llvm::SmallVector<size_t, 16> IndependentArgsSize,
+          size_t TotalIndependentArgsSize, std::string hessianFuncName);
 
   public:
     HessianModeVisitor(DerivativeBuilder& builder);

--- a/include/clad/Differentiator/JacobianModeVisitor.h
+++ b/include/clad/Differentiator/JacobianModeVisitor.h
@@ -36,8 +36,8 @@ namespace clad {
     ///
     ///\returns A function containing jacobian matrix.
     ///
-    DeclWithContext Derive(const clang::FunctionDecl* FD,
-                           const DiffRequest& request);
+    OverloadedDeclWithContext Derive(const clang::FunctionDecl* FD,
+                                     const DiffRequest& request);
   };
 } // end namespace clad
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -264,6 +264,7 @@ namespace clad {
     StmtDiff VisitReturnStmt(const clang::ReturnStmt* RS);
     StmtDiff VisitStmt(const clang::Stmt* S);
     StmtDiff VisitUnaryOperator(const clang::UnaryOperator* UnOp);
+    StmtDiff VisitExprWithCleanups(const clang::ExprWithCleanups* EWC);
     /// Decl is not Stmt, so it cannot be visited directly.
     VarDeclDiff DifferentiateVarDecl(const clang::VarDecl* VD);
     /// A helper method to differentiate a single Stmt in the reverse mode.

--- a/include/clad/Differentiator/StmtClone.h
+++ b/include/clad/Differentiator/StmtClone.h
@@ -98,6 +98,7 @@ namespace utils {
     DECLARE_CLONE_FN(UnaryExprOrTypeTraitExpr)
     DECLARE_CLONE_FN(CallExpr)
     DECLARE_CLONE_FN(ShuffleVectorExpr)
+    DECLARE_CLONE_FN(ExprWithCleanups)
     DECLARE_CLONE_FN(CXXOperatorCallExpr)
     DECLARE_CLONE_FN(CXXMemberCallExpr)
     DECLARE_CLONE_FN(CXXStaticCastExpr)

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -381,6 +381,11 @@ namespace clad {
     /// Creates the expression Base.size() for the given Base expr. The Base
     /// expr must be of clad::array_ref<T> type
     clang::Expr* BuildArrayRefSizeExpr(clang::Expr* Base);
+    /// Creates the expression Base.slice(Args) for the given Base expr and Args
+    /// array. The Base expr must be of clad::array_ref<T> type
+    clang::Expr*
+    BuildArrayRefSliceExpr(clang::Expr* Base,
+                           llvm::MutableArrayRef<clang::Expr*> Args);
 
   public:
     /// Rebuild a sequence of nested namespaces ending with DC.

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -111,13 +111,15 @@ namespace clad {
     IdentifierInfo* II =
         &m_Context.Idents.get(derivativeBaseName + "_d" + s + "arg" +
                               std::to_string(m_ArgIndex) + derivativeSuffix);
-    DeclarationNameInfo name(II, noLoc);
+    SourceLocation loc{m_Function->getLocation()};
+    DeclarationNameInfo name(II, loc);
     llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
     llvm::SaveAndRestore<Scope*> SaveScope(m_CurScope);
     DeclContext* DC = const_cast<DeclContext*>(m_Function->getDeclContext());
     m_Sema.CurContext = DC;
-    DeclWithContext result = m_Builder.cloneFunction(
-        FD, *this, DC, m_Sema, m_Context, noLoc, name, FD->getType());
+    DeclWithContext result =
+        m_Builder.cloneFunction(FD, *this, DC, m_Sema, m_Context, loc, name,
+                                FD->getType());
     FunctionDecl* derivedFD = result.first;
     m_Derivative = derivedFD;
 

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -35,8 +35,9 @@ namespace clad {
 
   ForwardModeVisitor::~ForwardModeVisitor() {}
 
-  DeclWithContext ForwardModeVisitor::Derive(const FunctionDecl* FD,
-                                             const DiffRequest& request) {
+  OverloadedDeclWithContext
+  ForwardModeVisitor::Derive(const FunctionDecl* FD,
+                             const DiffRequest& request) {
     silenceDiags = !request.VerboseDiags;
     m_Function = FD;
     assert(!m_DerivativeInFlight &&
@@ -209,7 +210,9 @@ namespace clad {
     endScope(); // Function decl scope
 
     m_DerivativeInFlight = false;
-    return result;
+
+    return OverloadedDeclWithContext{result.first, result.second,
+                                     /*OverloadFunctionDecl=*/nullptr};
   }
 
   StmtDiff ForwardModeVisitor::VisitStmt(const Stmt* S) {

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -31,8 +31,9 @@ namespace clad {
 
   HessianModeVisitor::~HessianModeVisitor() {}
 
-  DeclWithContext HessianModeVisitor::Derive(const clang::FunctionDecl* FD,
-                                             const DiffRequest& request) {
+  OverloadedDeclWithContext
+  HessianModeVisitor::Derive(const clang::FunctionDecl* FD,
+                             const DiffRequest& request) {
     DiffParams args{};
     IndexIntervalTable indexIntervalTable{};
     if (request.Args)
@@ -88,7 +89,7 @@ namespace clad {
   // Combines all generated second derivative functions into a
   // single hessian function by creating CallExprs to each individual
   // secon derivative function in FunctionBody.
-  DeclWithContext
+  OverloadedDeclWithContext
   HessianModeVisitor::Merge(std::vector<FunctionDecl*> secDerivFuncs,
                             const DiffRequest& request) {
     DiffParams args;
@@ -239,6 +240,7 @@ namespace clad {
     m_Sema.PopDeclContext();
     endScope(); // Function decl scope
 
-    return result;
+    return OverloadedDeclWithContext{result.first, result.second,
+                                     /*OverloadFunctionDecl=*/nullptr};
   }
 } // end namespace clad

--- a/lib/Differentiator/JacobianModeVisitor.cpp
+++ b/lib/Differentiator/JacobianModeVisitor.cpp
@@ -31,10 +31,11 @@ namespace clad {
 
   JacobianModeVisitor::~JacobianModeVisitor() {}
 
-  DeclWithContext JacobianModeVisitor::Derive(const clang::FunctionDecl* FD,
-                                              const DiffRequest& request) {
+  OverloadedDeclWithContext
+  JacobianModeVisitor::Derive(const clang::FunctionDecl* FD,
+                              const DiffRequest& request) {
     FD = FD->getDefinition();
-    DeclWithContext result{};
+    OverloadedDeclWithContext result{};
 
     ReverseModeVisitor V(this->builder);
     result = V.Derive(FD, request);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1882,6 +1882,14 @@ namespace clad {
     return StmtDiff(Clone(ME));
   }
 
+  StmtDiff
+  ReverseModeVisitor::VisitExprWithCleanups(const ExprWithCleanups* EWC) {
+    StmtDiff subExprDiff = Visit(EWC->getSubExpr(), dfdx());
+    // FIXME: We are unable to create cleanup objects currently, this can be
+    // potentially problematic
+    return StmtDiff(subExprDiff.getExpr(), subExprDiff.getExpr_dx());
+  }
+
   bool ReverseModeVisitor::UsefulToStoreGlobal(Expr* E) {
     if (isInsideLoop)
       return !E->isEvaluatable(m_Context, Expr::SE_NoSideEffects);

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -108,6 +108,8 @@ DEFINE_CREATE_EXPR(CXXReinterpretCastExpr, (Ctx, Node->getType(), Node->getValue
 DEFINE_CREATE_EXPR(CXXConstCastExpr, (Ctx, Node->getType(), Node->getValueKind(), Clone(Node->getSubExpr()), Node->getTypeInfoAsWritten(), Node->getOperatorLoc(), Node->getRParenLoc(), Node->getAngleBrackets()))
 DEFINE_CREATE_EXPR(CXXConstructExpr, (Ctx, Node->getType(), Node->getLocation(), Node->getConstructor(), Node->isElidable(), llvm::makeArrayRef(Node->getArgs(), Node->getNumArgs()), Node->hadMultipleCandidates(), Node->isListInitialization(), Node->isStdInitListInitialization(), Node->requiresZeroInitialization(), Node->getConstructionKind(), Node->getParenOrBraceRange()))
 DEFINE_CREATE_EXPR(CXXFunctionalCastExpr, (Ctx, Node->getType(), Node->getValueKind(), Node->getTypeInfoAsWritten(), Node->getCastKind(), Clone(Node->getSubExpr()), 0 /*EP*/CLAD_COMPAT_CLANG12_CastExpr_GetFPO(Node), Node->getLParenLoc(), Node->getRParenLoc()))
+DEFINE_CREATE_EXPR(ExprWithCleanups, (Ctx, Node->getSubExpr(),
+                                      Node->cleanupsHaveSideEffects(), {}))
 
 DEFINE_CLONE_EXPR_CO(CXXTemporaryObjectExpr, (Ctx, Node->getConstructor(), Node->getType(), Node->getTypeSourceInfo(), llvm::makeArrayRef(Node->getArgs(), Node->getNumArgs()), Node->getSourceRange(), Node->hadMultipleCandidates(), Node->isListInitialization(), Node->isStdInitListInitialization(), Node->requiresZeroInitialization()))
 

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -647,6 +647,12 @@ namespace clad {
                                 /*MemberFunctionName=*/"size", {});
   }
 
+  Expr* VisitorBase::BuildArrayRefSliceExpr(Expr* Base,
+                                            MutableArrayRef<Expr*> Args) {
+    return BuildCallExprToMemFn(Base, /*isArrow=*/false,
+                                /*MemberFunctionName=*/"slice", Args);
+  }
+
   bool VisitorBase::isArrayRefType(QualType QT) {
     return QT.getAsString().find("clad::array_ref") != std::string::npos;
   }

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -1,0 +1,70 @@
+// RUN: %cladclang %s -lm -lstdc++ -I%S/../../include -oArrayInputsReverseMode.out 2>&1 | FileCheck %s
+// RUN: ./ArrayInputsReverseMode.out | FileCheck -check-prefix=CHECK-EXEC %s
+
+//CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+double addArr(double *arr, int n) {
+  double ret = 0;
+  for (int i = 0; i < n; i++) {
+    ret += arr[i];
+  }
+  return ret;
+}
+
+//CHECK:   void addArr_grad(double *arr, int n, clad::array_ref<double> _d_arr, clad::array_ref<double> _d_n) {
+//CHECK-NEXT:       double _d_ret = 0;
+//CHECK-NEXT:       unsigned long _t0;
+//CHECK-NEXT:       int _d_i = 0;
+//CHECK-NEXT:       clad::tape<int> _t1 = {};
+//CHECK-NEXT:       double ret = 0;
+//CHECK-NEXT:       _t0 = 0;
+//CHECK-NEXT:       for (int i = 0; i < n; i++) {
+//CHECK-NEXT:           _t0++;
+//CHECK-NEXT:           ret += arr[clad::push(_t1, i)];
+//CHECK-NEXT:       }
+//CHECK-NEXT:       double addArr_return = ret;
+//CHECK-NEXT:       goto _label0;
+//CHECK-NEXT:     _label0:
+//CHECK-NEXT:       _d_ret += 1;
+//CHECK-NEXT:       for (; _t0; _t0--) {
+//CHECK-NEXT:           {
+//CHECK-NEXT:               double _r_d0 = _d_ret;
+//CHECK-NEXT:               _d_ret += _r_d0;
+//CHECK-NEXT:               _d_arr[clad::pop(_t1)] += _r_d0;
+//CHECK-NEXT:               _d_ret -= _r_d0;
+//CHECK-NEXT:           }
+//CHECK-NEXT:       }
+//CHECK-NEXT:   }
+
+double f(double *arr) {
+  return addArr(arr, 3);
+}
+
+//CHECK:   void f_grad(double *arr, clad::array_ref<double> _d_arr) {
+//CHECK-NEXT:       double *_t0;
+//CHECK-NEXT:       _t0 = arr;
+//CHECK-NEXT:       double f_return = addArr(_t0, 3);
+//CHECK-NEXT:       goto _label0;
+//CHECK-NEXT:     _label0:
+//CHECK-NEXT:       {
+//CHECK-NEXT:           clad::array<double> _grad0(_d_arr.size());
+//CHECK-NEXT:           double _grad1 = 0.;
+//CHECK-NEXT:           addArr_grad(_t0, 3, _grad0, &_grad1);
+//CHECK-NEXT:           clad::array_ref<double> _r0(_grad0 *= 1);
+//CHECK-NEXT:           _d_arr += _r0;
+//CHECK-NEXT:           double _r1 = 1 * _grad1;
+//CHECK-NEXT:       }
+//CHECK-NEXT:   }
+
+int main() {
+  double arr[] = {1, 2, 3};
+  auto f_dx = clad::gradient(f);
+
+  double darr[3] = {};
+  clad::array_ref<double> darr_ref(darr, 3);
+  f_dx.execute(arr, darr_ref);
+
+  printf("Result = {%.2f, %.2f, %.2f}\n", darr[0], darr[1], darr[2]); // CHECK-EXEC: Result = {1.00, 1.00, 1.00}
+}

--- a/test/Arrays/Arrays.C
+++ b/test/Arrays/Arrays.C
@@ -89,7 +89,7 @@ double const_dot_product(double x, double y, double z) {
 //CHECK-NEXT:       return _d_vars[0] * consts[0] + vars[0] * _d_consts[0] + _d_vars[1] * consts[1] + vars[1] * _d_consts[1] + _d_vars[2] * consts[2] + vars[2] * _d_consts[2];
 //CHECK-NEXT:   }
 
-//CHECK:   void const_dot_product_grad(double x, double y, double z, double *_result) {
+//CHECK:   void const_dot_product_grad(double x, double y, double z, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y, clad::array_ref<double> _d_z) {
 //CHECK-NEXT:       double _d_vars[3] = {};
 //CHECK-NEXT:       double _d_consts[3] = {};
 //CHECK-NEXT:       double _t0;
@@ -124,9 +124,9 @@ double const_dot_product(double x, double y, double z) {
 //CHECK-NEXT:           _d_consts[2] += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _result[0UL] += _d_vars[0];
-//CHECK-NEXT:           _result[1UL] += _d_vars[1];
-//CHECK-NEXT:           _result[2UL] += _d_vars[2];
+//CHECK-NEXT:           * _d_x += _d_vars[0];
+//CHECK-NEXT:           * _d_y += _d_vars[1];
+//CHECK-NEXT:           * _d_z += _d_vars[2];
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -154,7 +154,7 @@ double const_matmul_sum(double a, double b, double c, double d) {
 //CHECK-NEXT:       return _d_C[0][0] + _d_C[0][1] + _d_C[1][0] + _d_C[1][1];
 //CHECK-NEXT:   }
 
-//CHECK:   void const_matmul_sum_grad(double a, double b, double c, double d, double *_result) {
+//CHECK:   void const_matmul_sum_grad(double a, double b, double c, double d, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b, clad::array_ref<double> _d_c, clad::array_ref<double> _d_d) {
 //CHECK-NEXT:       double _d_A[2][2] = {};
 //CHECK-NEXT:       double _d_B[2][2] = {};
 //CHECK-NEXT:       double _t0;
@@ -193,7 +193,7 @@ double const_matmul_sum(double a, double b, double c, double d) {
 //CHECK-NEXT:       _t15 = A[1][1];
 //CHECK-NEXT:       _t14 = B[1][1];
 //CHECK-NEXT:       double C[2][2] = {{[{][{]}}_t1 * _t0 + _t3 * _t2, _t5 * _t4 + _t7 * _t6}, {_t9 * _t8 + _t11 * _t10, _t13 * _t12 + _t15 * _t14}};
-//CHECK-NEXT:    double const_matmul_sum_return = C[0][0] + C[0][1] + C[1][0] + C[1][1];
+//CHECK-NEXT:       double const_matmul_sum_return = C[0][0] + C[0][1] + C[1][0] + C[1][1];
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
@@ -237,10 +237,10 @@ double const_matmul_sum(double a, double b, double c, double d) {
 //CHECK-NEXT:           _d_B[1][1] += _r15;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _result[0UL] += _d_A[0][0];
-//CHECK-NEXT:           _result[1UL] += _d_A[0][1];
-//CHECK-NEXT:           _result[2UL] += _d_A[1][0];
-//CHECK-NEXT:           _result[3UL] += _d_A[1][1];
+//CHECK-NEXT:           * _d_a += _d_A[0][0];
+//CHECK-NEXT:           * _d_b += _d_A[0][1];
+//CHECK-NEXT:           * _d_c += _d_A[1][0];
+//CHECK-NEXT:           * _d_d += _d_A[1][1];
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -255,7 +255,7 @@ int main () { // expected-no-diagnostics
 
   auto gradcdp = clad::gradient(const_dot_product);
   double result[3] = {};
-  gradcdp.execute(11, 12, 13, result);
+  gradcdp.execute(11, 12, 13, &result[0], &result[1], &result[2]);
   printf("{%.2f, %.2f, %.2f}\n", result[0], result[1], result[2]); // CHECK-EXEC: {1.00, 2.00, 3.00}
  
   auto dcms = clad::differentiate(const_matmul_sum, 0);
@@ -263,7 +263,8 @@ int main () { // expected-no-diagnostics
   
   auto grad = clad::gradient(const_matmul_sum);
   double result2[4] = {};
-  grad.execute(11, 12, 13, 14, result2);
+  grad.execute(
+      11, 12, 13, 14, &result2[0], &result2[1], &result2[2], &result2[3]);
   printf("{%.2f, %.2f, %.2f, %.2f}\n", result2[0], result2[1], result2[2], result2[3]); // CHECK-EXEC: {3.00, 7.00, 3.00, 7.00}
   return 0;
 }

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -20,103 +20,100 @@ __device__ __host__ double gaus(double* x, double* p, double sigma, int dim) {
 }
 
 __device__ __host__ void
-gaus_grad(double *x, double *p, double sigma, int dim, double *_result);
+gaus_grad_1(double* x, double* p, double sigma, int dim, clad::array_ref<double> _d_p);
 
-auto gaus_g = clad::gradient(gaus);
+auto gaus_g = clad::gradient(gaus, "p");
 
-//CHECK:    void gaus_grad(double *x, double *p, double sigma, int dim, double *_result) __attribute__((device)) __attribute__((host)) {
-//CHECK-NEXT:       double _d_t = 0;
-//CHECK-NEXT:       unsigned long _t0;
-//CHECK-NEXT:       int _d_i = 0;
-//CHECK-NEXT:       clad::tape<double> _t1 = {};
-//CHECK-NEXT:       clad::tape<int> _t2 = {};
-//CHECK-NEXT:       clad::tape<int> _t3 = {};
-//CHECK-NEXT:       clad::tape<double> _t4 = {};
-//CHECK-NEXT:       clad::tape<int> _t5 = {};
-//CHECK-NEXT:       clad::tape<int> _t6 = {};
-//CHECK-NEXT:       double _t7;
-//CHECK-NEXT:       double _t8;
-//CHECK-NEXT:       double _t9;
-//CHECK-NEXT:       double _t10;
-//CHECK-NEXT:       double _t11;
-//CHECK-NEXT:       double _t12;
-//CHECK-NEXT:       double _t13;
-//CHECK-NEXT:       double _t14;
-//CHECK-NEXT:       double _t15;
-//CHECK-NEXT:       double _t16;
-//CHECK-NEXT:       double _t17;
-//CHECK-NEXT:       double _t18;
-//CHECK-NEXT:       double _t19;
-//CHECK-NEXT:       double t = 0;
-//CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < dim; i++) {
-//CHECK-NEXT:           _t0++;
-//CHECK-NEXT:           t += clad::push(_t4, (x[clad::push(_t2, i)] - p[clad::push(_t3, i)])) * clad::push(_t1, (x[clad::push(_t5, i)] - p[clad::push(_t6, i)]));
-//CHECK-NEXT:       }
-//CHECK-NEXT:       _t8 = -t;
-//CHECK-NEXT:       _t10 = sigma;
-//CHECK-NEXT:       _t11 = 2 * _t10;
-//CHECK-NEXT:       _t9 = sigma;
-//CHECK-NEXT:       _t7 = (_t11 * _t9);
-//CHECK-NEXT:       t = _t8 / _t7;
-//CHECK-NEXT:       _t14 = 2 * 3.1415926535897931;
-//CHECK-NEXT:       _t15 = -dim / 2.;
-//CHECK-NEXT:       _t16 = std::pow(_t14, _t15);
-//CHECK-NEXT:       _t17 = sigma;
-//CHECK-NEXT:       _t13 = std::pow(_t17, -0.5);
-//CHECK-NEXT:       _t18 = _t16 * _t13;
-//CHECK-NEXT:       _t19 = t;
-//CHECK-NEXT:       _t12 = std::exp(_t19);
-//CHECK-NEXT:       double gaus_return = _t18 * _t12;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r8 = 1 * _t12;
-//CHECK-NEXT:           double _r9 = _r8 * _t13;
-//CHECK-NEXT:           double _grad0[2] = {};
-//CHECK-NEXT:           custom_derivatives::pow_grad(_t14, _t15, _grad0);
-//CHECK-NEXT:           double _r10 = _r9 * _grad0[0UL];
-//CHECK-NEXT:           double _r11 = _r10 * 3.1415926535897931;
-//CHECK-NEXT:           double _r12 = _r9 * _grad0[1UL];
-//CHECK-NEXT:           double _r13 = _r12 / 2.;
-//CHECK-NEXT:           _result[3UL] += -_r13;
-//CHECK-NEXT:           double _r14 = _t16 * _r8;
-//CHECK-NEXT:           double _grad1[2] = {};
-//CHECK-NEXT:           custom_derivatives::pow_grad(_t17, -0.5, _grad1);
-//CHECK-NEXT:           double _r15 = _r14 * _grad1[0UL];
-//CHECK-NEXT:           _result[2UL] += _r15;
-//CHECK-NEXT:           double _r16 = _r14 * _grad1[1UL];
-//CHECK-NEXT:           double _r17 = _t18 * 1;
-//CHECK-NEXT:           double _r18 = _r17 * custom_derivatives::exp_darg0(_t19);
-//CHECK-NEXT:           _d_t += _r18;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       {
-//CHECK-NEXT:          double _r_d1 = _d_t;
-//CHECK-NEXT:           double _r2 = _r_d1 / _t7;
-//CHECK-NEXT:           _d_t += -_r2;
-//CHECK-NEXT:           double _r3 = _r_d1 * -_t8 / (_t7 * _t7);
-//CHECK-NEXT:           double _r4 = _r3 * _t9;
-//CHECK-NEXT:           double _r5 = _r4 * _t10;
-//CHECK-NEXT:           double _r6 = 2 * _r4;
-//CHECK-NEXT:           _result[2UL] += _r6;
-//CHECK-NEXT:           double _r7 = _t11 * _r3;
-//CHECK-NEXT:           _result[2UL] += _r7;
-//CHECK-NEXT:           _d_t -= _r_d1;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       for (; _t0; _t0--) {
-//CHECK-NEXT:           double _r_d0 = _d_t;
-//CHECK-NEXT:           _d_t += _r_d0;
-//CHECK-NEXT:           double _r0 = _r_d0 * clad::pop(_t1);
-//CHECK-NEXT:           _result[clad::pop(_t3)] += -_r0;
-//CHECK-NEXT:           double _r1 = clad::pop(_t4) * _r_d0;
-//CHECK-NEXT:           _result[clad::pop(_t6)] += -_r1;
-//CHECK-NEXT:           _d_t -= _r_d0;
-//CHECK-NEXT:       }
-//CHECK-NEXT:   }
+// CHECK:    void gaus_grad_1(double *x, double *p, double sigma, int dim, clad::array_ref<double> _d_p) __attribute__((device)) __attribute__((host)) {
+// CHECK-NEXT:       double _d_t = 0;
+// CHECK-NEXT:       unsigned long _t0;
+// CHECK-NEXT:       int _d_i = 0;
+// CHECK-NEXT:       clad::tape<double> _t1 = {};
+// CHECK-NEXT:       clad::tape<int> _t2 = {};
+// CHECK-NEXT:       clad::tape<int> _t3 = {};
+// CHECK-NEXT:       clad::tape<double> _t4 = {};
+// CHECK-NEXT:       clad::tape<int> _t5 = {};
+// CHECK-NEXT:       clad::tape<int> _t6 = {};
+// CHECK-NEXT:       double _t7;
+// CHECK-NEXT:       double _t8;
+// CHECK-NEXT:       double _t9;
+// CHECK-NEXT:       double _t10;
+// CHECK-NEXT:       double _t11;
+// CHECK-NEXT:       double _t12;
+// CHECK-NEXT:       double _t13;
+// CHECK-NEXT:       double _t14;
+// CHECK-NEXT:       double _t15;
+// CHECK-NEXT:       double _t16;
+// CHECK-NEXT:       double _t17;
+// CHECK-NEXT:       double _t18;
+// CHECK-NEXT:       double _t19;
+// CHECK-NEXT:       double t = 0;
+// CHECK-NEXT:       _t0 = 0;
+// CHECK-NEXT:       for (int i = 0; i < dim; i++) {
+// CHECK-NEXT:           _t0++;
+// CHECK-NEXT:           t += clad::push(_t4, (x[clad::push(_t2, i)] - p[clad::push(_t3, i)])) * clad::push(_t1, (x[clad::push(_t5, i)] - p[clad::push(_t6, i)]));
+// CHECK-NEXT:       }
+// CHECK-NEXT:       _t8 = -t;
+// CHECK-NEXT:       _t10 = sigma;
+// CHECK-NEXT:       _t11 = 2 * _t10;
+// CHECK-NEXT:       _t9 = sigma;
+// CHECK-NEXT:       _t7 = (_t11 * _t9);
+// CHECK-NEXT:       t = _t8 / _t7;
+// CHECK-NEXT:       _t14 = 2 * 3.1415926535897931;
+// CHECK-NEXT:       _t15 = -dim / 2.;
+// CHECK-NEXT:       _t16 = std::pow(_t14, _t15);
+// CHECK-NEXT:       _t17 = sigma;
+// CHECK-NEXT:       _t13 = std::pow(_t17, -0.5);
+// CHECK-NEXT:       _t18 = _t16 * _t13;
+// CHECK-NEXT:       _t19 = t;
+// CHECK-NEXT:       _t12 = std::exp(_t19);
+// CHECK-NEXT:       double gaus_return = _t18 * _t12;
+// CHECK-NEXT:       goto _label0;
+// CHECK-NEXT:     _label0:
+// CHECK-NEXT:       {
+// CHECK-NEXT:           double _r8 = 1 * _t12;
+// CHECK-NEXT:           double _r9 = _r8 * _t13;
+// CHECK-NEXT:           double _grad0 = 0.;
+// CHECK-NEXT:           double _grad1 = 0.;
+// CHECK-NEXT:           custom_derivatives::pow_grad(_t14, _t15, &_grad0, &_grad1);
+// CHECK-NEXT:           double _r10 = _r9 * _grad0;
+// CHECK-NEXT:           double _r11 = _r10 * 3.1415926535897931;
+// CHECK-NEXT:           double _r12 = _r9 * _grad1;
+// CHECK-NEXT:           double _r13 = _r12 / 2.;
+// CHECK-NEXT:           double _r14 = _t16 * _r8;
+// CHECK-NEXT:           double _grad2 = 0.;
+// CHECK-NEXT:           double _grad3 = 0.;
+// CHECK-NEXT:           custom_derivatives::pow_grad(_t17, -0.5, &_grad2, &_grad3);
+// CHECK-NEXT:           double _r15 = _r14 * _grad2;
+// CHECK-NEXT:           double _r16 = _r14 * _grad3;
+// CHECK-NEXT:           double _r17 = _t18 * 1;
+// CHECK-NEXT:           double _r18 = _r17 * custom_derivatives::exp_darg0(_t19);
+// CHECK-NEXT:           _d_t += _r18;
+// CHECK-NEXT:       }
+// CHECK-NEXT:       {
+// CHECK-NEXT:           double _r_d1 = _d_t;
+// CHECK-NEXT:           double _r2 = _r_d1 / _t7;
+// CHECK-NEXT:           _d_t += -_r2;
+// CHECK-NEXT:           double _r3 = _r_d1 * -_t8 / (_t7 * _t7);
+// CHECK-NEXT:           double _r4 = _r3 * _t9;
+// CHECK-NEXT:           double _r5 = _r4 * _t10;
+// CHECK-NEXT:           double _r6 = 2 * _r4;
+// CHECK-NEXT:           double _r7 = _t11 * _r3;
+// CHECK-NEXT:           _d_t -= _r_d1;
+// CHECK-NEXT:       }
+// CHECK-NEXT:       for (; _t0; _t0--) {
+// CHECK-NEXT:           double _r_d0 = _d_t;
+// CHECK-NEXT:           _d_t += _r_d0;
+// CHECK-NEXT:           double _r0 = _r_d0 * clad::pop(_t1);
+// CHECK-NEXT:           _d_p[clad::pop(_t3)] += -_r0;
+// CHECK-NEXT:           double _r1 = clad::pop(_t4) * _r_d0;
+// CHECK-NEXT:           _d_p[clad::pop(_t6)] += -_r1;
+// CHECK-NEXT:           _d_t -= _r_d0;
+// CHECK-NEXT:       }
+// CHECK-NEXT:   }
 
-
-__global__ void compute(double* d_x, double* result, int n) {
-  gaus_grad(d_x, d_x, 2.0, n, result);
+__global__ void compute(double* d_x, double* d_p, int n) {
+  gaus_grad_1(d_x, d_x, 2.0, n, d_p);
 }
 
 int main(void) {

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -84,21 +84,22 @@ float f7(float x) {
 // CHECK-NEXT:   return custom_derivatives::pow_darg0(x, 2.) * (_d_x + 0.);
 // CHECK-NEXT: }
 
-void f7_grad(float x, float *result);
+void f7_grad(float x, clad::array_ref<float> _d_x);
 
-// CHECK: void f7_grad(float x, float *_result) {
-// CHECK-NEXT:   float _t0;
-// CHECK-NEXT:   _t0 = x;
-// CHECK-NEXT:   {{.*}} f7_return = pow(_t0, 2.);
-// CHECK-NEXT:   goto _label0;
+// CHECK: void f7_grad(float x, clad::array_ref<float> _d_x) {
+// CHECK-NEXT:     float _t0;
+// CHECK-NEXT:     _t0 = x;
+// CHECK-NEXT:     {{.*}} f7_return = pow(_t0, 2.);
+// CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
-// CHECK-NEXT:   {
-// CHECK-NEXT:     typename {{.*}} _grad0[2] = {};
-// CHECK-NEXT:     custom_derivatives::pow_grad(_t0, 2., _grad0);
-// CHECK-NEXT:     typename {{.*}} _r0 = 1 * _grad0[0UL];
-// CHECK-NEXT:     _result[0UL] += _r0;
-// CHECK-NEXT:     typename {{.*}} _r1 = 1 * _grad0[1UL];
-// CHECK-NEXT:   }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         typename {{.*}} _grad0 = 0.;
+// CHECK-NEXT:         typename {{.*}} _grad1 = 0.;
+// CHECK-NEXT:         custom_derivatives::pow_grad(_t0, 2., &_grad0, &_grad1);
+// CHECK-NEXT:         typename {{.*}} _r0 = 1 * _grad0;
+// CHECK-NEXT:         * _d_x += _r0;
+// CHECK-NEXT:         typename {{.*}} _r1 = 1 * _grad1;
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 double f8(float x) {
@@ -110,21 +111,22 @@ double f8(float x) {
 // CHECK-NEXT:   return custom_derivatives::pow_darg0(x, 2) * (_d_x + 0);
 // CHECK-NEXT: }
 
-void f8_grad(float x, double *result);
+void f8_grad(float x, double* _d_x);
 
-// CHECK: void f8_grad(float x, double *_result) {
-// CHECK-NEXT:   float _t0;
-// CHECK-NEXT:   _t0 = x;
-// CHECK-NEXT:   typename {{.*}} f8_return = pow(_t0, 2);
-// CHECK-NEXT:   goto _label0;
+// CHECK: void f8_grad(float x, clad::array_ref<double> _d_x) {
+// CHECK-NEXT:     float _t0;
+// CHECK-NEXT:     _t0 = x;
+// CHECK-NEXT:     typename {{.*}} f8_return = pow(_t0, 2);
+// CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
-// CHECK-NEXT:   {
-// CHECK-NEXT:     typename {{.*}} _grad0[2] = {};
-// CHECK-NEXT:     custom_derivatives::pow_grad(_t0, 2, _grad0);
-// CHECK-NEXT:     typename {{.*}} _r0 = 1 * _grad0[0UL];
-// CHECK-NEXT:     _result[0UL] += _r0;
-// CHECK-NEXT:     typename {{.*}} _r1 = 1 * _grad0[1UL];
-// CHECK-NEXT:   }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         typename {{.*}} _grad0 = 0.;
+// CHECK-NEXT:         typename {{.*}} _grad1 = 0.;
+// CHECK-NEXT:         custom_derivatives::pow_grad(_t0, 2, &_grad0, &_grad1);
+// CHECK-NEXT:         typename {{.*}} _r0 = 1 * _grad0;
+// CHECK-NEXT:         * _d_x += _r0;
+// CHECK-NEXT:         typename {{.*}} _r1 = 1 * _grad1;
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 float f9(float x, float y) {
@@ -137,24 +139,25 @@ float f9(float x, float y) {
 // CHECK-NEXT:     return custom_derivatives::pow_darg0(x, y) * (_d_x + _d_y);
 // CHECK-NEXT: }
 
-void f9_grad(float x, float y, float *result);
+void f9_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y);
 
-// CHECK: void f9_grad(float x, float y, float *_result) {
-// CHECK-NEXT:   float _t0;
-// CHECK-NEXT:   float _t1;
-// CHECK-NEXT:   _t0 = x;
-// CHECK-NEXT:   _t1 = y;
-// CHECK-NEXT:   float f9_return = pow(_t0, _t1);
-// CHECK-NEXT:   goto _label0;
+// CHECK: void f9_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y) {
+// CHECK-NEXT:     float _t0;
+// CHECK-NEXT:     float _t1;
+// CHECK-NEXT:     _t0 = x;
+// CHECK-NEXT:     _t1 = y;
+// CHECK-NEXT:     float f9_return = pow(_t0, _t1);
+// CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
-// CHECK-NEXT:   {
-// CHECK-NEXT:     float _grad0[2] = {};
-// CHECK-NEXT:     custom_derivatives::pow_grad(_t0, _t1, _grad0);
-// CHECK-NEXT:     float _r0 = 1 * _grad0[0UL];
-// CHECK-NEXT:     _result[0UL] += _r0;
-// CHECK-NEXT:     float _r1 = 1 * _grad0[1UL];
-// CHECK-NEXT:     _result[1UL] += _r1;
-// CHECK-NEXT:   }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         float _grad0 = 0.F;
+// CHECK-NEXT:         float _grad1 = 0.F;
+// CHECK-NEXT:         custom_derivatives::pow_grad(_t0, _t1, &_grad0, &_grad1);
+// CHECK-NEXT:         float _r0 = 1 * _grad0;
+// CHECK-NEXT:         * _d_x += _r0;
+// CHECK-NEXT:         float _r1 = 1 * _grad1;
+// CHECK-NEXT:         * _d_y += _r1;
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 double f10(float x, int y) {
@@ -167,24 +170,25 @@ double f10(float x, int y) {
 // CHECK-NEXT:   return custom_derivatives::pow_darg0(x, y) * (_d_x + _d_y);
 // CHECK-NEXT: }
 
-void f10_grad(float x, int y, double *result);
+void f10_grad(float x, int y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
-// CHECK: void f10_grad(float x, int y, double *_result) {
-// CHECK-NEXT:   float _t0;
-// CHECK-NEXT:   int _t1;
-// CHECK-NEXT:   _t0 = x;
-// CHECK-NEXT:   _t1 = y;
-// CHECK-NEXT:   typename {{.*}} f10_return = pow(_t0, _t1);
-// CHECK-NEXT:   goto _label0;
+// CHECK: void f10_grad(float x, int y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
+// CHECK-NEXT:     float _t0;
+// CHECK-NEXT:     int _t1;
+// CHECK-NEXT:     _t0 = x;
+// CHECK-NEXT:     _t1 = y;
+// CHECK-NEXT:     typename {{.*}} f10_return = pow(_t0, _t1);
+// CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
-// CHECK-NEXT:   {
-// CHECK-NEXT:     typename {{.*}} _grad0[2] = {};
-// CHECK-NEXT:     custom_derivatives::pow_grad(_t0, _t1, _grad0);
-// CHECK-NEXT:     typename {{.*}} _r0 = 1 * _grad0[0UL];
-// CHECK-NEXT:     _result[0UL] += _r0;
-// CHECK-NEXT:     typename {{.*}} _r1 = 1 * _grad0[1UL];
-// CHECK-NEXT:     _result[1UL] += _r1;
-// CHECK-NEXT:   }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         typename {{.*}} _grad0 = 0.;
+// CHECK-NEXT:         typename {{.*}} _grad1 = 0.;
+// CHECK-NEXT:         custom_derivatives::pow_grad(_t0, _t1, &_grad0, &_grad1);
+// CHECK-NEXT:         typename {{.*}} _r0 = 1 * _grad0;
+// CHECK-NEXT:         * _d_x += _r0;
+// CHECK-NEXT:         typename {{.*}} _r1 = 1 * _grad1;
+// CHECK-NEXT:         * _d_y += _r1;
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 int main () { //expected-no-diagnostics
@@ -236,7 +240,7 @@ int main () { //expected-no-diagnostics
 
   f_result[0] = f_result[1] = 0;
   clad::gradient(f9);
-  f9_grad(3, 4, f_result);
+  f9_grad(3, 4, &f_result[0], &f_result[1]);
   printf("Result is = {%f, %f}\n", f_result[0], f_result[1]); //CHECK-EXEC: Result is = {108.000000, 88.987595}
 
   auto f10_darg0 = clad::differentiate(f10, 0);
@@ -244,7 +248,7 @@ int main () { //expected-no-diagnostics
 
   d_result[0] = d_result[1] = 0;
   clad::gradient(f10);
-  f10_grad(3, 4, d_result);
+  f10_grad(3, 4, &d_result[0], &d_result[1]);
   printf("Result is = {%f, %f}\n", d_result[0], d_result[1]); //CHECK-EXEC: Result is = {108.000000, 88.987597}
 
   return 0;

--- a/test/FirstDerivative/UnsupportedOpsWarn.C
+++ b/test/FirstDerivative/UnsupportedOpsWarn.C
@@ -18,11 +18,11 @@ int binOpWarn_1(int x){
     return x ^ 1;   // expected-warning {{attempt to differentiate unsupported operator, ignored.}}
 }
 
-// CHECK: void binOpWarn_1_grad(int x, int *_result) {
-// CHECK-NEXT:   int binOpWarn_1_return = x ^ 1;
-// CHECK-NEXT:   goto _label0;
+// CHECK: void binOpWarn_1_grad(int x, clad::array_ref<int> _d_x) {
+// CHECK-NEXT:     int binOpWarn_1_return = x ^ 1;
+// CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
-// CHECK-NEXT:   ;
+// CHECK-NEXT:     ;
 // CHECK-NEXT: }
 
 int unOpWarn_0(int x){
@@ -39,13 +39,13 @@ int unOpWarn_1(int x){
     return x;
 }
 
-// CHECK: void unOpWarn_1_grad(int x, int *_result) {
-// CHECK-NEXT:   int *_d_pnt = 0;
-// CHECK-NEXT:   int *pnt = &x;
-// CHECK-NEXT:   int unOpWarn_1_return = x;
-// CHECK-NEXT:   goto _label0;
+// CHECK: void unOpWarn_1_grad(int x, clad::array_ref<int> _d_x) {
+// CHECK-NEXT:     int *_d_pnt = 0;
+// CHECK-NEXT:     int *pnt = &x;
+// CHECK-NEXT:     int unOpWarn_1_return = x;
+// CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
-// CHECK-NEXT:   _result[0UL] += 1;
+// CHECK-NEXT:     * _d_x += 1;
 // CHECK-NEXT: }
 
 int main(){

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -11,16 +11,17 @@ double f1(double x, double y) {
   return y;
 }
 
-//CHECK:   void f1_grad(double x, double y, double *_result) {
+//CHECK:   void f1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       x = y;
 //CHECK-NEXT:       double f1_return = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
-//CHECK-NEXT:       _result[1UL] += 1;
+//CHECK-NEXT:       * _d_y += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d0 = _result[0UL];
-//CHECK-NEXT:          _result[1UL] += _r_d0;
-//CHECK-NEXT:          _result[0UL] -= _r_d0;
+//CHECK-NEXT:           double _r_d0 = * _d_x;
+//CHECK-NEXT:           * _d_y += _r_d0;
+//CHECK-NEXT:           * _d_x -= _r_d0;
+//CHECK-NEXT:           * _d_x;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -31,7 +32,7 @@ double f2(double x, double y) {
   return x;
 }
 
-//CHECK:   void f2_grad(double x, double y, double *_result) {
+//CHECK:   void f2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       _cond0 = x < y;
 //CHECK-NEXT:       if (_cond0)
@@ -39,11 +40,12 @@ double f2(double x, double y) {
 //CHECK-NEXT:       double f2_return = x;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
-//CHECK-NEXT:       _result[0UL] += 1;
+//CHECK-NEXT:       * _d_x += 1;
 //CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:          double _r_d0 = _result[0UL];
-//CHECK-NEXT:         _result[1UL] += _r_d0;
-//CHECK-NEXT:         _result[0UL] -= _r_d0;
+//CHECK-NEXT:           double _r_d0 = * _d_x;
+//CHECK-NEXT:           * _d_y += _r_d0;
+//CHECK-NEXT:           * _d_x -= _r_d0;
+//CHECK-NEXT:           * _d_x;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -56,7 +58,7 @@ double f3(double x, double y) {
   return y;
 }
 
-//CHECK:   void f3_grad(double x, double y, double *_result) {
+//CHECK:   void f3_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -72,32 +74,36 @@ double f3(double x, double y) {
 //CHECK-NEXT:       double f3_return = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
-//CHECK-NEXT:       _result[1UL] += 1;
+//CHECK-NEXT:       * _d_y += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d3 = _result[0UL];
-//CHECK-NEXT:           _result[1UL] += _r_d3;
-//CHECK-NEXT:           _result[0UL] -= _r_d3;
+//CHECK-NEXT:           double _r_d3 = * _d_x;
+//CHECK-NEXT:           * _d_y += _r_d3;
+//CHECK-NEXT:           * _d_x -= _r_d3;
+//CHECK-NEXT:           * _d_x;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d2 = _result[1UL];
+//CHECK-NEXT:           double _r_d2 = * _d_y;
 //CHECK-NEXT:           double _r2 = _r_d2 * _t2;
-//CHECK-NEXT:           _result[0UL] += _r2;
+//CHECK-NEXT:           * _d_x += _r2;
 //CHECK-NEXT:           double _r3 = _t3 * _r_d2;
-//CHECK-NEXT:           _result[0UL] += _r3;
-//CHECK-NEXT:           _result[1UL] -= _r_d2;
+//CHECK-NEXT:           * _d_x += _r3;
+//CHECK-NEXT:           * _d_y -= _r_d2;
+//CHECK-NEXT:           * _d_y;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d1 = _result[0UL];
+//CHECK-NEXT:           double _r_d1 = * _d_x;
 //CHECK-NEXT:           double _r0 = _r_d1 * _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           double _r1 = _t1 * _r_d1;
-//CHECK-NEXT:           _result[0UL] += _r1;
-//CHECK-NEXT:           _result[0UL] -= _r_d1;
+//CHECK-NEXT:           * _d_x += _r1;
+//CHECK-NEXT:           * _d_x -= _r_d1;
+//CHECK-NEXT:           * _d_x;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d0 = _result[0UL];
-//CHECK-NEXT:           _result[0UL] += _r_d0;
-//CHECK-NEXT:           _result[0UL] -= _r_d0;
+//CHECK-NEXT:           double _r_d0 = * _d_x;
+//CHECK-NEXT:           * _d_x += _r_d0;
+//CHECK-NEXT:           * _d_x -= _r_d0;
+//CHECK-NEXT:           * _d_x;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -108,21 +114,23 @@ double f4(double x, double y) {
    return y;
 }
 
-//CHECK:   void f4_grad(double x, double y, double *_result) {
+//CHECK:   void f4_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       y = x;
 //CHECK-NEXT:       x = 0;
 //CHECK-NEXT:       double f4_return = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
-//CHECK-NEXT:       _result[1UL] += 1;
+//CHECK-NEXT:       * _d_y += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d1 = _result[0UL];
-//CHECK-NEXT:           _result[0UL] -= _r_d1;
+//CHECK-NEXT:           double _r_d1 = * _d_x;
+//CHECK-NEXT:           * _d_x -= _r_d1;
+//CHECK-NEXT:           * _d_x;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d0 = _result[1UL];
-//CHECK-NEXT:           _result[0UL] += _r_d0;
-//CHECK-NEXT:           _result[1UL] -= _r_d0;
+//CHECK-NEXT:           double _r_d0 = * _d_y;
+//CHECK-NEXT:           * _d_x += _r_d0;
+//CHECK-NEXT:           * _d_y -= _r_d0;
+//CHECK-NEXT:           * _d_y;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -140,7 +148,7 @@ double f5(double x, double y) {
   return t;
 }
 
-//CHECK:   void f5_grad(double x, double y, double *_result) {
+//CHECK:   void f5_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_t = 0;
@@ -184,9 +192,9 @@ double f5(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = _d_t * _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           double _r1 = _t1 * _d_t;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -204,7 +212,7 @@ double f6(double x, double y) {
   return t;
 }
 
-//CHECK:   void f6_grad(double x, double y, double *_result) {
+//CHECK:   void f6_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_t = 0;
@@ -248,9 +256,9 @@ double f6(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = _d_t * _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           double _r1 = _t1 * _d_t;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -270,7 +278,7 @@ double f7(double x, double y) {
   return t[0]; // == x
 }
 
-//CHECK:   void f7_grad(double x, double y, double *_result) {
+//CHECK:   void f7_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_t[3] = {};
@@ -301,9 +309,10 @@ double f7(double x, double y) {
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t[0] += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d6 = _result[0UL];
+//CHECK-NEXT:           double _r_d6 = * _d_x;
 //CHECK-NEXT:           _d_t[0] += _r_d6;
-//CHECK-NEXT:           _result[0UL] -= _r_d6;
+//CHECK-NEXT:           * _d_x -= _r_d6;
+//CHECK-NEXT:           * _d_x;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d5 = _d_t[0];
@@ -332,21 +341,22 @@ double f7(double x, double y) {
 //CHECK-NEXT:           _d_t[0] -= _r_d2;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d1 = _result[0UL];
-//CHECK-NEXT:           _result[1UL] += _r_d1;
-//CHECK-NEXT:           _result[0UL] -= _r_d1;
+//CHECK-NEXT:           double _r_d1 = * _d_x;
+//CHECK-NEXT:           * _d_y += _r_d1;
+//CHECK-NEXT:           * _d_x -= _r_d1;
+//CHECK-NEXT:           * _d_x;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d0 = _d_t[0];
-//CHECK-NEXT:           _result[0UL] += _r_d0;
+//CHECK-NEXT:           * _d_x += _r_d0;
 //CHECK-NEXT:           _d_t[0] -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _result[0UL] += _d_t[1];
+//CHECK-NEXT:           * _d_x += _d_t[1];
 //CHECK-NEXT:           double _r0 = _d_t[2] * _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           double _r1 = _t1 * _d_t[2];
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -356,7 +366,7 @@ double f8(double x, double y) {
   return t[3]; // == y * y
 }
 
-//CHECK:   void f8_grad(double x, double y, double *_result) {
+//CHECK:   void f8_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _d_t[4] = {};
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
@@ -370,9 +380,9 @@ double f8(double x, double y) {
 //CHECK-NEXT:       _d_t[3] += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d0 = _d_t[3];
-//CHECK-NEXT:           _result[1UL] += _r_d0;
-//CHECK-NEXT:           double _r_d1 = _result[1UL];
-//CHECK-NEXT:           _result[1UL] += _r_d1 * _t0;
+//CHECK-NEXT:           * _d_y += _r_d0;
+//CHECK-NEXT:           double _r_d1 = * _d_y;
+//CHECK-NEXT:           * _d_y += _r_d1 * _t0;
 //CHECK-NEXT:           double _r0 = _t1 * _r_d1;
 //CHECK-NEXT:           _d_t[0] += _r0;
 //CHECK-NEXT:           double _r_d2 = _d_t[0];
@@ -381,12 +391,12 @@ double f8(double x, double y) {
 //CHECK-NEXT:           _d_t[2] += _r_d3;
 //CHECK-NEXT:           _d_t[1] -= _r_d3;
 //CHECK-NEXT:           _d_t[0] -= _r_d2;
-//CHECK-NEXT:           _result[1UL] -= _r_d1;
+//CHECK-NEXT:           * _d_y -= _r_d1;
 //CHECK-NEXT:           _d_t[3] -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _result[0UL] += _d_t[1];
-//CHECK-NEXT:           _result[1UL] += _d_t[2];
+//CHECK-NEXT:           * _d_x += _d_t[1];
+//CHECK-NEXT:           * _d_y += _d_t[2];
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -396,7 +406,7 @@ double f9(double x, double y) {
   return t; // x * x * y
 }
 
-//CHECK:   void f9_grad(double x, double y, double *_result) {
+//CHECK:   void f9_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
@@ -405,7 +415,7 @@ double f9(double x, double y) {
 //CHECK-NEXT:       double t = x;
 //CHECK-NEXT:       _t1 = t;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       double &_ref0 = (t *= _t0);
+//CHECK-NEXT:       double _ref0 = (t *= _t0);
 //CHECK-NEXT:       _t3 = _ref0;
 //CHECK-NEXT:       _t2 = y;
 //CHECK-NEXT:       _ref0 *= _t2;
@@ -417,15 +427,15 @@ double f9(double x, double y) {
 //CHECK-NEXT:           double _r_d1 = _d_t;
 //CHECK-NEXT:           _d_t += _r_d1 * _t2;
 //CHECK-NEXT:           double _r1 = _t3 * _r_d1;
-//CHECK-NEXT:           _result[1UL] += _r1;
+//CHECK-NEXT:           * _d_y += _r1;
 //CHECK-NEXT:           _d_t -= _r_d1;
 //CHECK-NEXT:           double _r_d0 = _d_t;
 //CHECK-NEXT:           _d_t += _r_d0 * _t0;
 //CHECK-NEXT:           double _r0 = _t1 * _r_d0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           _d_t -= _r_d0;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       _result[0UL] += _d_t;
+//CHECK-NEXT:       * _d_x += _d_t;
 //CHECK-NEXT:   }
 
 double f10(double x, double y) {
@@ -434,7 +444,7 @@ double f10(double x, double y) {
   return t; // = y
 }
 
-//CHECK:   void f10_grad(double x, double y, double *_result) {
+//CHECK:   void f10_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x;
 //CHECK-NEXT:       t = x = y;
@@ -444,13 +454,13 @@ double f10(double x, double y) {
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d0 = _d_t;
-//CHECK-NEXT:           _result[0UL] += _r_d0;
-//CHECK-NEXT:           double _r_d1 = _result[0UL];
-//CHECK-NEXT:           _result[1UL] += _r_d1;
-//CHECK-NEXT:           _result[0UL] -= _r_d1;
+//CHECK-NEXT:           * _d_x += _r_d0;
+//CHECK-NEXT:           double _r_d1 = * _d_x;
+//CHECK-NEXT:           * _d_y += _r_d1;
+//CHECK-NEXT:           * _d_x -= _r_d1;
 //CHECK-NEXT:           _d_t -= _r_d0;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       _result[0UL] += _d_t;
+//CHECK-NEXT:       * _d_x += _d_t;
 //CHECK-NEXT:   }
 
 double f11(double x, double y) {
@@ -459,7 +469,7 @@ double f11(double x, double y) {
   return t; // = y
 }
 
-//CHECK:   void f11_grad(double x, double y, double *_result) {
+//CHECK:   void f11_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x;
 //CHECK-NEXT:       (t = x) = y;
@@ -469,13 +479,13 @@ double f11(double x, double y) {
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d1 = _d_t;
-//CHECK-NEXT:           _result[1UL] += _r_d1;
+//CHECK-NEXT:           * _d_y += _r_d1;
 //CHECK-NEXT:           _d_t -= _r_d1;
 //CHECK-NEXT:           double _r_d0 = _d_t;
-//CHECK-NEXT:           _result[0UL] += _r_d0;
+//CHECK-NEXT:           * _d_x += _r_d0;
 //CHECK-NEXT:           _d_t -= _r_d0;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       _result[0UL] += _d_t;
+//CHECK-NEXT:       * _d_x += _d_t;
 //CHECK-NEXT:   }
 
 double f12(double x, double y) {
@@ -484,14 +494,14 @@ double f12(double x, double y) {
   return t; // == max(x, y) * y;
 }
 
-//CHECK:   void f12_grad(double x, double y, double *_result) {
+//CHECK:   void f12_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double t;
 //CHECK-NEXT:       _cond0 = x > y;
-//CHECK-NEXT:       double &_ref0 = (_cond0 ? (t = x) : (t = y));
+//CHECK-NEXT:       double _ref0 = (_cond0 ? (t = x) : (t = y));
 //CHECK-NEXT:       _t1 = _ref0;
 //CHECK-NEXT:       _t0 = y;
 //CHECK-NEXT:       _ref0 *= _t0;
@@ -503,15 +513,15 @@ double f12(double x, double y) {
 //CHECK-NEXT:           double _r_d2 = (_cond0 ? _d_t : _d_t);
 //CHECK-NEXT:           (_cond0 ? _d_t : _d_t) += _r_d2 * _t0;
 //CHECK-NEXT:           double _r0 = _t1 * _r_d2;
-//CHECK-NEXT:           _result[1UL] += _r0;
+//CHECK-NEXT:           * _d_y += _r0;
 //CHECK-NEXT:           (_cond0 ? _d_t : _d_t) -= _r_d2;
 //CHECK-NEXT:           if (_cond0) {
 //CHECK-NEXT:               double _r_d0 = _d_t;
-//CHECK-NEXT:               _result[0UL] += _r_d0;
+//CHECK-NEXT:               * _d_x += _r_d0;
 //CHECK-NEXT:               _d_t -= _r_d0;
 //CHECK-NEXT:           } else {
 //CHECK-NEXT:               double _r_d1 = _d_t;
-//CHECK-NEXT:               _result[1UL] += _r_d1;
+//CHECK-NEXT:               * _d_y += _r_d1;
 //CHECK-NEXT:               _d_t -= _r_d1;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
@@ -522,7 +532,7 @@ double f13(double x, double y) {
   return t * y; // == x * x * x
 }
 
-//CHECK:   void f13_grad(double x, double y, double *_result) {
+//CHECK:   void f13_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_t = 0;
@@ -540,16 +550,16 @@ double f13(double x, double y) {
 //CHECK-NEXT:           double _r2 = 1 * _t2;
 //CHECK-NEXT:           _d_t += _r2;
 //CHECK-NEXT:           double _r3 = _t3 * 1;
-//CHECK-NEXT:           _result[1UL] += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = _d_t * _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           double _r1 = _t1 * _d_t;
-//CHECK-NEXT:           _result[1UL] += _r1;
-//CHECK-NEXT:           double _r_d0 = _result[1UL];
-//CHECK-NEXT:           _result[0UL] += _r_d0;
-//CHECK-NEXT:           _result[1UL] -= _r_d0;
+//CHECK-NEXT:           * _d_y += _r1;
+//CHECK-NEXT:           double _r_d0 = * _d_y;
+//CHECK-NEXT:           * _d_x += _r_d0;
+//CHECK-NEXT:           * _d_y -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -561,8 +571,8 @@ double f14(double i, double j) {
   return i;
 }
 
-// CHECK: void f14_grad(double i, double j, double *_result) {
-// CHECK-NEXT:     double &_d_a = _result[0UL];
+// CHECK: void f14_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+// CHECK-NEXT:     double &_d_a = * _d_i;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _t2;
@@ -576,25 +586,25 @@ double f14(double i, double j) {
 // CHECK-NEXT:     double f14_return = i;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
-// CHECK-NEXT:     _result[0UL] += 1;
+// CHECK-NEXT:     * _d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d2 = _d_a;
 // CHECK-NEXT:         _d_a += _r_d2 * _t1;
 // CHECK-NEXT:         double _r2 = _t2 * _r_d2;
-// CHECK-NEXT:         _result[0UL] += _r2;
+// CHECK-NEXT:         * _d_i += _r2;
 // CHECK-NEXT:         _d_a -= _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d1 = _d_a;
 // CHECK-NEXT:         _d_a += _r_d1;
-// CHECK-NEXT:         _result[0UL] += _r_d1;
+// CHECK-NEXT:         * _d_i += _r_d1;
 // CHECK-NEXT:         _d_a -= _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_a;
 // CHECK-NEXT:         double _r0 = _r_d0 * _t0;
 // CHECK-NEXT:         double _r1 = 2 * _r_d0;
-// CHECK-NEXT:         _result[0UL] += _r1;
+// CHECK-NEXT:         * _d_i += _r1;
 // CHECK-NEXT:         _d_a -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -611,13 +621,13 @@ double f15(double i, double j) {
   return a+c+d;
 }
 
-// CHECK: void f15_grad(double i, double j, double *_result) {
+// CHECK: void f15_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _d_b = 0;
 // CHECK-NEXT:     double &_d_a = _d_b;
-// CHECK-NEXT:     double &_d_c = _result[0UL];
-// CHECK-NEXT:     double &_d_d = _result[1UL];
+// CHECK-NEXT:     double &_d_c = * _d_i;
+// CHECK-NEXT:     double &_d_d = * _d_j;
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     double _t3;
 // CHECK-NEXT:     double _t4;
@@ -656,7 +666,7 @@ double f15(double i, double j) {
 // CHECK-NEXT:         double _r7 = _t7 * _r_d3;
 // CHECK-NEXT:         double _r8 = _r7 * _t8;
 // CHECK-NEXT:         double _r9 = 3 * _r7;
-// CHECK-NEXT:         _result[1UL] += _r9;
+// CHECK-NEXT:         * _d_j += _r9;
 // CHECK-NEXT:         _d_d -= _r_d3;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -664,7 +674,7 @@ double f15(double i, double j) {
 // CHECK-NEXT:         _d_c += _r_d2;
 // CHECK-NEXT:         double _r5 = _r_d2 * _t5;
 // CHECK-NEXT:         double _r6 = 3 * _r_d2;
-// CHECK-NEXT:         _result[0UL] += _r6;
+// CHECK-NEXT:         * _d_i += _r6;
 // CHECK-NEXT:         _d_c -= _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -672,21 +682,21 @@ double f15(double i, double j) {
 // CHECK-NEXT:         _d_b += _r_d1;
 // CHECK-NEXT:         double _r3 = _r_d1 * _t4;
 // CHECK-NEXT:         double _r4 = 2 * _r_d1;
-// CHECK-NEXT:         _result[0UL] += _r4;
+// CHECK-NEXT:         * _d_i += _r4;
 // CHECK-NEXT:         _d_b -= _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_a;
 // CHECK-NEXT:         _d_a += _r_d0 * _t2;
 // CHECK-NEXT:         double _r2 = _t3 * _r_d0;
-// CHECK-NEXT:         _result[0UL] += _r2;
+// CHECK-NEXT:         * _d_i += _r2;
 // CHECK-NEXT:         _d_a -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = _d_b * _t0;
-// CHECK-NEXT:         _result[0UL] += _r0;
+// CHECK-NEXT:         * _d_i += _r0;
 // CHECK-NEXT:         double _r1 = _t1 * _d_b;
-// CHECK-NEXT:         _result[1UL] += _r1;
+// CHECK-NEXT:         * _d_j += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -698,8 +708,8 @@ double f16(double i, double j) {
   return i;
 }
 
-// CHECK: void f16_grad(double i, double j, double *_result) {
-// CHECK-NEXT:     double &_d_a = _result[0UL];
+// CHECK: void f16_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+// CHECK-NEXT:     double &_d_a = * _d_i;
 // CHECK-NEXT:     double &_d_b = _d_a;
 // CHECK-NEXT:     double &_d_c = _d_b;
 // CHECK-NEXT:     double _t0;
@@ -715,25 +725,27 @@ double f16(double i, double j) {
 // CHECK-NEXT:     double f16_return = i;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
-// CHECK-NEXT:     _result[0UL] += 1;
+// CHECK-NEXT:     * _d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_c;
 // CHECK-NEXT:         _d_c += _r_d0 * _t0;
 // CHECK-NEXT:         double _r0 = _t1 * _r_d0;
 // CHECK-NEXT:         double _r1 = _r0 * _t2;
 // CHECK-NEXT:         double _r2 = 4 * _r0;
-// CHECK-NEXT:         _result[1UL] += _r2;
+// CHECK-NEXT:         * _d_j += _r2;
 // CHECK-NEXT:         _d_c -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 
-#define TEST(F, x, y) { \
-  result[0] = 0; result[1] = 0;\
-  auto F##grad = clad::gradient(F);\
-  F##grad.execute(x, y, result);\
-  printf("{%.2f, %.2f}\n", result[0], result[1]); \
-}
+#define TEST(F, x, y)                                                          \
+  {                                                                            \
+    result[0] = 0;                                                             \
+    result[1] = 0;                                                             \
+    auto F##grad = clad::gradient(F);                                          \
+    F##grad.execute(x, y, &result[0], &result[1]);                             \
+    printf("{%.2f, %.2f}\n", result[0], result[1]);                            \
+  }
 
 int main() {
   double result[2] = {};

--- a/test/Gradient/DiffInterface.C
+++ b/test/Gradient/DiffInterface.C
@@ -12,31 +12,31 @@ double f_1(double x, double y, double z) {
 }
 
 // all
-//CHECK:   void f_1_grad(double x, double y, double z, double *_result) {
+//CHECK:   void f_1_grad(double x, double y, double z, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y, clad::array_ref<double> _d_z) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       _t2 = z;
-//CHECK-NEXT:       double f_1_return = 0 * _t0 + 1 * _t1 + 2 * _t2;
+//CHECK-NEXT:       double f_1_return = 0 * _t0  + 1 * _t1 + 2 * _t2;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t1;
 //CHECK-NEXT:           double _r3 = 1 * 1;
-//CHECK-NEXT:           _result[1UL] += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
-//CHECK-NEXT:           _result[2UL] += _r5;
+//CHECK-NEXT:           * _d_z += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // x
-//CHECK:   void f_1_grad_0(double x, double y, double z, double *_result) {
+//CHECK:   void f_1_grad_0(double x, double y, double z, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -49,7 +49,7 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t1;
 //CHECK-NEXT:           double _r3 = 1 * 1;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
@@ -58,7 +58,7 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:   }
 
 // y
-//CHECK:   void f_1_grad_1(double x, double y, double z, double *_result) {
+//CHECK:   void f_1_grad_1(double x, double y, double z, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -73,14 +73,14 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:           double _r1 = 0 * 1;
 //CHECK-NEXT:           double _r2 = 1 * _t1;
 //CHECK-NEXT:           double _r3 = 1 * 1;
-//CHECK-NEXT:           _result[0UL] += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // z
-//CHECK:   void f_1_grad_2(double x, double y, double z, double *_result) {
+//CHECK:   void f_1_grad_2(double x, double y, double z, clad::array_ref<double> _d_z) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -97,12 +97,12 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:           double _r3 = 1 * 1;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
-//CHECK-NEXT:           _result[0UL] += _r5;
+//CHECK-NEXT:           * _d_z += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // x, y
-//CHECK:   void f_1_grad_0_1(double x, double y, double z, double *_result) {
+//CHECK:   void f_1_grad_0_1(double x, double y, double z, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -115,17 +115,17 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t1;
 //CHECK-NEXT:           double _r3 = 1 * 1;
-//CHECK-NEXT:           _result[1UL] += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // y, x
-//CHECK:   void f_1_grad_1_0(double x, double y, double z, double *_result) {
+//CHECK:   void f_1_grad_1_0(double x, double y, double z, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -138,17 +138,40 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           _result[1UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t1;
 //CHECK-NEXT:           double _r3 = 1 * 1;
-//CHECK-NEXT:           _result[0UL] += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
+//CHECK-NEXT:       }
+//CHECK-NEXT:   }
+
+// y, z
+//CHECK:   void f_1_grad_1_2(double x, double y, double z, clad::array_ref<double> _d_y, clad::array_ref<double> _d_z) {
+//CHECK-NEXT:       double _t0;
+//CHECK-NEXT:       double _t1;
+//CHECK-NEXT:       double _t2;
+//CHECK-NEXT:       _t0 = x;
+//CHECK-NEXT:       _t1 = y;
+//CHECK-NEXT:       _t2 = z;
+//CHECK-NEXT:       double f_1_return = 0 * _t0 + 1 * _t1 + 2 * _t2;
+//CHECK-NEXT:       goto _label0;
+//CHECK-NEXT:     _label0:
+//CHECK-NEXT:       {
+//CHECK-NEXT:           double _r0 = 1 * _t0;
+//CHECK-NEXT:           double _r1 = 0 * 1;
+//CHECK-NEXT:           double _r2 = 1 * _t1;
+//CHECK-NEXT:           double _r3 = 1 * 1;
+//CHECK-NEXT:           * _d_y += _r3;
+//CHECK-NEXT:           double _r4 = 1 * _t2;
+//CHECK-NEXT:           double _r5 = 2 * 1;
+//CHECK-NEXT:           * _d_z += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // x, y, z
-//CHECK:   void f_1_grad(double x, double y, double z, double *_result) {
+//CHECK:   void f_1_grad(double x, double y, double z, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y, clad::array_ref<double> _d_z) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -161,18 +184,18 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t1;
 //CHECK-NEXT:           double _r3 = 1 * 1;
-//CHECK-NEXT:           _result[1UL] += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
-//CHECK-NEXT:           _result[2UL] += _r5;
+//CHECK-NEXT:           * _d_z += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // z, y, z
-//CHECK:   void f_1_grad_2_1_0(double x, double y, double z, double *_result) {
+//CHECK:   f_1_grad_2_1_0(double x, double y, double z, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y, clad::array_ref<double> _d_z) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -185,47 +208,62 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           _result[2UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t1;
 //CHECK-NEXT:           double _r3 = 1 * 1;
-//CHECK-NEXT:           _result[1UL] += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
-//CHECK-NEXT:           _result[0UL] += _r5;
+//CHECK-NEXT:           * _d_z += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-#define TEST(F) { \
-  result[0] = 0; result[1] = 0; result[2] = 0;\
-  F.execute(0, 0, 0, result);\
-  printf("{%.2f, %.2f, %.2f}\n", result[0], result[1], result[2]); \
-}
+#define TEST(F, ...)                                                           \
+  {                                                                            \
+    result[0] = 0;                                                             \
+    result[1] = 0;                                                             \
+    result[2] = 0;                                                             \
+    F.execute(0, 0, 0, __VA_ARGS__);                                           \
+    printf("{%.2f, %.2f, %.2f}\n", result[0], result[1], result[2]);           \
+  }
 
 int main () {
   double result[3];
 
   auto f1_grad_all = clad::gradient(f_1);
-  TEST(f1_grad_all); // CHECK-EXEC: {0.00, 1.00, 2.00}
-  
+  TEST(f1_grad_all,
+       &result[0],
+       &result[1],
+       &result[2]); // CHECK-EXEC: {0.00, 1.00, 2.00}
+
   auto f1_grad_x = clad::gradient(f_1, "x");
-  TEST(f1_grad_x); // CHECK-EXEC: {0.00, 0.00, 0.00}
+  TEST(f1_grad_x, &result[0]); // CHECK-EXEC: {0.00, 0.00, 0.00}
 
   auto f1_grad_y = clad::gradient(f_1, "y");
-  TEST(f1_grad_y); // CHECK-EXEC: {1.00, 0.00, 0.00}
+  TEST(f1_grad_y, &result[1]); // CHECK-EXEC: {0.00, 1.00, 0.00}
   auto f1_grad_z = clad::gradient(f_1, "z");
-  TEST(f1_grad_z); // CHECK-EXEC: {2.00, 0.00, 0.00}
+  TEST(f1_grad_z, &result[2]); // CHECK-EXEC: {0.00, 0.00, 2.00}
 
   auto f1_grad_xy = clad::gradient(f_1, "x, y");
-  TEST(f1_grad_xy); // CHECK-EXEC: {0.00, 1.00, 0.00}
+  TEST(f1_grad_xy, &result[0], &result[1]); // CHECK-EXEC: {0.00, 1.00, 0.00}
 
-  auto f1_grad_yz = clad::gradient(f_1, "y, x");
-  TEST(f1_grad_yz); // CHECK-EXEC: {1.00, 0.00, 0.00}
+  auto f1_grad_yx = clad::gradient(f_1, "y, x");
+  TEST(f1_grad_yx, &result[0], &result[1]); // CHECK-EXEC: {0.00, 1.00, 0.00}
+
+  auto f1_grad_yz = clad::gradient(f_1, "y, z");
+  TEST(f1_grad_yz, &result[1], &result[2]); // CHECK-EXEC: {0.00, 1.00, 2.00}
 
   auto f1_grad_xyz = clad::gradient(f_1, "x, y, z");
-  TEST(f1_grad_xyz); // CHECK-EXEC: {0.00, 1.00, 2.00}
+  TEST(f1_grad_xyz,
+       &result[0],
+       &result[1],
+       &result[2]); // CHECK-EXEC: {0.00, 1.00, 2.00}
 
   auto f1_grad_zyx = clad::gradient(f_1, "z,y,x");
-  TEST(f1_grad_zyx); // CHECK-EXEC: {2.00, 1.00, 0.00}
+  TEST(f1_grad_zyx,
+       &result[0],
+       &result[1],
+       &result[2]); // CHECK-EXEC: {0.00, 1.00, 2.00}
 
   return 0;
 }

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -14,7 +14,7 @@ struct Experiment {
     x = val;
   }
 
-  // CHECK: void operator()_grad(double i, double j, double *_result) {
+  // CHECK: void operator()_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -30,9 +30,9 @@ struct Experiment {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
   // CHECK-NEXT:         double _r2 = _t2 * _r0;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -47,7 +47,7 @@ struct ExperimentConst {
     x = val;
   }
 
-  // CHECK: void operator()_grad(double i, double j, double *_result) const {
+  // CHECK: void operator()_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -63,9 +63,9 @@ struct ExperimentConst {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
   // CHECK-NEXT:         double _r2 = _t2 * _r0;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -80,7 +80,7 @@ struct ExperimentVolatile {
     x = val;
   }
 
-  // CHECK: void operator()_grad(double i, double j, double *_result) volatile {
+  // CHECK: void operator()_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     volatile double _t2;
@@ -96,9 +96,9 @@ struct ExperimentVolatile {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
   // CHECK-NEXT:         double _r2 = _t2 * _r0;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -113,7 +113,7 @@ struct ExperimentConstVolatile {
     x = val;
   }
 
-  // CHECK: void operator()_grad(double i, double j, double *_result) const volatile {
+  // CHECK: void operator()_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     volatile double _t2;
@@ -129,9 +129,9 @@ struct ExperimentConstVolatile {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
   // CHECK-NEXT:         double _r2 = _t2 * _r0;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -148,7 +148,7 @@ namespace outer {
         x = val;
       }
 
-      // CHECK: void operator()_grad(double i, double j, double *_result) {
+      // CHECK: void operator()_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
       // CHECK-NEXT:     double _t0;
       // CHECK-NEXT:     double _t1;
       // CHECK-NEXT:     double _t2;
@@ -164,9 +164,9 @@ namespace outer {
       // CHECK-NEXT:         double _r0 = 1 * _t0;
       // CHECK-NEXT:         double _r1 = _r0 * _t1;
       // CHECK-NEXT:         double _r2 = _t2 * _r0;
-      // CHECK-NEXT:         _result[0UL] += _r2;
+      // CHECK-NEXT:         * _d_i += _r2;
       // CHECK-NEXT:         double _r3 = _t3 * 1;
-      // CHECK-NEXT:         _result[1UL] += _r3;
+      // CHECK-NEXT:         * _d_j += _r3;
       // CHECK-NEXT:     }
       // CHECK-NEXT: }
     };
@@ -179,10 +179,10 @@ auto d_##E##Ref = clad::gradient(E);
 
 #define TEST(E)\
 res[0] = res[1] = 0;\
-d_##E.execute(7, 9, res);\
+d_##E.execute(7, 9, &res[0], &res[1]);\
 printf("%.2f %.2f\n", res[0], res[1]);\
 res[0] = res[1] = 0;\
-d_##E##Ref.execute(7, 9, res);\
+d_##E##Ref.execute(7, 9, &res[0], &res[1]);\
 printf("%.2f %.2f\n", res[0], res[1]);
 
 double x = 3;
@@ -198,7 +198,7 @@ int main() {
     return i*i*j;
   };
 
-  // CHECK: inline void operator()_grad(double i, double j, double *_result) const {
+  // CHECK: inline void operator()_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -213,11 +213,11 @@ int main() {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = _t2 * _r0;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -225,7 +225,7 @@ int main() {
     return x*ii*j;
   };
 
-  // CHECK: inline void operator()_grad(double ii, double j, double *_result) const {
+  // CHECK: inline void operator()_grad(double ii, double j, clad::array_ref<double> _d_ii, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -241,9 +241,9 @@ int main() {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
   // CHECK-NEXT:         double _r2 = _t2 * _r0;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_ii += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -12,23 +12,23 @@ __attribute__((always_inline)) double f_add1(double x, double y) {
   return x + y;
 }
 
-//CHECK:   void f_add1_grad(double x, double y, double *_result) __attribute__((always_inline)) {
+//CHECK:   void f_add1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) __attribute__((always_inline)) {
 //CHECK-NEXT:       double f_add1_return = x + y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _result[0UL] += 1;
-//CHECK-NEXT:           _result[1UL] += 1;
+//CHECK-NEXT:           * _d_x += 1;
+//CHECK-NEXT:           * _d_y += 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_add1_grad(double x, double y, double *_result);
+void f_add1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_add2(double x, double y) {
   return 3*x + 4*y;
 }
 
-//CHECK:   void f_add2_grad(double x, double y, double *_result) {
+//CHECK:   void f_add2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t0 = x;
@@ -39,20 +39,20 @@ double f_add2(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 3 * 1;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t1;
 //CHECK-NEXT:           double _r3 = 4 * 1;
-//CHECK-NEXT:           _result[1UL] += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_add2_grad(double x, double y, double *_result);
+void f_add2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_add3(double x, double y) {
   return 3*x + 4*y*4;
 }
 
-//CHECK:   void f_add3_grad(double x, double y, double *_result) {
+//CHECK:   void f_add3_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t0 = x;
@@ -63,36 +63,36 @@ double f_add3(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 3 * 1;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * 4;
 //CHECK-NEXT:           double _r3 = _r2 * _t1;
 //CHECK-NEXT:           double _r4 = 4 * _r2;
-//CHECK-NEXT:           _result[1UL] += _r4;
+//CHECK-NEXT:           * _d_y += _r4;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_add3_grad(double x, double y, double *_result);
+void f_add3_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_sub1(double x, double y) {
   return x - y;
 }
 
-//CHECK:   void f_sub1_grad(double x, double y, double *_result) {
+//CHECK:   void f_sub1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double f_sub1_return = x - y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _result[0UL] += 1;
-//CHECK-NEXT:           _result[1UL] += -1;
+//CHECK-NEXT:           * _d_x += 1;
+//CHECK-NEXT:           * _d_y += -1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
-void f_sub1_grad(double x, double y, double *_result);
+void f_sub1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_sub2(double x, double y) {
   return 3*x - 4*y;
 }
 
-//CHECK:   void f_sub2_grad(double x, double y, double *_result) {
+//CHECK:   void f_sub2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t0 = x;
@@ -103,20 +103,20 @@ double f_sub2(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 3 * 1;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _r2 = -1 * _t1;
 //CHECK-NEXT:           double _r3 = 4 * -1;
-//CHECK-NEXT:           _result[1UL] += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_sub2_grad(double x, double y, double *_result);
+void f_sub2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_mult1(double x, double y) {
   return x*y;
 }
 
-//CHECK:   void f_mult1_grad(double x, double y, double *_result) {
+//CHECK:   void f_mult1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t1 = x;
@@ -126,19 +126,19 @@ double f_mult1(double x, double y) {
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           double _r1 = _t1 * 1;
-//CHECK-NEXT:           _result[1UL] += _r1;
+//CHECK-NEXT:           * _d_y += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_mult1_grad(double x, double y, double *_result);
+void f_mult1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_mult2(double x, double y) {
    return 3*x*4*y;
 }
 
-//CHECK:   void f_mult2_grad(double x, double y, double *_result) {
+//CHECK:   void f_mult2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -153,19 +153,19 @@ double f_mult2(double x, double y) {
 //CHECK-NEXT:           double _r1 = _r0 * 4;
 //CHECK-NEXT:           double _r2 = _r1 * _t1;
 //CHECK-NEXT:           double _r3 = 3 * _r1;
-//CHECK-NEXT:           _result[0UL] += _r3;
+//CHECK-NEXT:           * _d_x += _r3;
 //CHECK-NEXT:           double _r4 = _t2 * 1;
-//CHECK-NEXT:           _result[1UL] += _r4;
+//CHECK-NEXT:           * _d_y += _r4;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_mult2_grad(double x, double y, double *_result);
+void f_mult2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_div1(double x, double y) {
   return x/y;
 }
 
-//CHECK:   void f_div1_grad(double x, double y, double *_result) {
+//CHECK:   void f_div1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t1 = x;
@@ -175,19 +175,19 @@ double f_div1(double x, double y) {
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 / _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           double _r1 = 1 * -_t1 / (_t0 * _t0);
-//CHECK-NEXT:           _result[1UL] += _r1;
+//CHECK-NEXT:           * _d_y += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_div1_grad(double x, double y, double *_result);
+void f_div1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_div2(double x, double y) {
   return 3*x/(4*y);
 }
 
-//CHECK:   void f_div2_grad(double x, double y, double *_result) {
+//CHECK:   void f_div2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -203,21 +203,21 @@ double f_div2(double x, double y) {
 //CHECK-NEXT:           double _r0 = 1 / _t0;
 //CHECK-NEXT:           double _r1 = _r0 * _t1;
 //CHECK-NEXT:           double _r2 = 3 * _r0;
-//CHECK-NEXT:           _result[0UL] += _r2;
+//CHECK-NEXT:           * _d_x += _r2;
 //CHECK-NEXT:           double _r3 = 1 * -_t2 / (_t0 * _t0);
 //CHECK-NEXT:           double _r4 = _r3 * _t3;
 //CHECK-NEXT:           double _r5 = 4 * _r3;
-//CHECK-NEXT:           _result[1UL] += _r5;
+//CHECK-NEXT:           * _d_y += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_div2_grad(double x, double y, double *_result);
+void f_div2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_c(double x, double y) {
   return -x*y + (x + y)*(x/y) - x*x; 
 }
 
-//CHECK:   void f_c_grad(double x, double y, double *_result) {
+//CHECK:   void f_c_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -239,31 +239,31 @@ double f_c(double x, double y) {
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           _result[0UL] += -_r0;
+//CHECK-NEXT:           * _d_x += -_r0;
 //CHECK-NEXT:           double _r1 = _t1 * 1;
-//CHECK-NEXT:           _result[1UL] += _r1;
+//CHECK-NEXT:           * _d_y += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t2;
-//CHECK-NEXT:           _result[0UL] += _r2;
-//CHECK-NEXT:           _result[1UL] += _r2;
+//CHECK-NEXT:           * _d_x += _r2;
+//CHECK-NEXT:           * _d_y += _r2;
 //CHECK-NEXT:           double _r3 = _t3 * 1;
 //CHECK-NEXT:           double _r4 = _r3 / _t4;
-//CHECK-NEXT:           _result[0UL] += _r4;
+//CHECK-NEXT:           * _d_x += _r4;
 //CHECK-NEXT:           double _r5 = _r3 * -_t5 / (_t4 * _t4);
-//CHECK-NEXT:           _result[1UL] += _r5;
+//CHECK-NEXT:           * _d_y += _r5;
 //CHECK-NEXT:           double _r6 = -1 * _t6;
-//CHECK-NEXT:           _result[0UL] += _r6;
+//CHECK-NEXT:           * _d_x += _r6;
 //CHECK-NEXT:           double _r7 = _t7 * -1;
-//CHECK-NEXT:           _result[0UL] += _r7;
+//CHECK-NEXT:           * _d_x += _r7;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_c_grad(double x, double y, double *_result);
+void f_c_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_rosenbrock(double x, double y) {
   return (x - 1) * (x - 1) + 100 * (y - x * x) * (y - x * x);
 }
 
-//CHECK:   void f_rosenbrock_grad(double x, double y, double *_result) {
+//CHECK:   void f_rosenbrock_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -287,51 +287,51 @@ double f_rosenbrock(double x, double y) {
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           double _r1 = _t1 * 1;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t2;
 //CHECK-NEXT:           double _r3 = _r2 * _t3;
 //CHECK-NEXT:           double _r4 = 100 * _r2;
-//CHECK-NEXT:           _result[1UL] += _r4;
+//CHECK-NEXT:           * _d_y += _r4;
 //CHECK-NEXT:           double _r5 = -_r4 * _t4;
-//CHECK-NEXT:           _result[0UL] += _r5;
+//CHECK-NEXT:           * _d_x += _r5;
 //CHECK-NEXT:           double _r6 = _t5 * -_r4;
-//CHECK-NEXT:           _result[0UL] += _r6;
+//CHECK-NEXT:           * _d_x += _r6;
 //CHECK-NEXT:           double _r7 = _t6 * 1;
-//CHECK-NEXT:           _result[1UL] += _r7;
+//CHECK-NEXT:           * _d_y += _r7;
 //CHECK-NEXT:           double _r8 = -_r7 * _t7;
-//CHECK-NEXT:           _result[0UL] += _r8;
+//CHECK-NEXT:           * _d_x += _r8;
 //CHECK-NEXT:           double _r9 = _t8 * -_r7;
-//CHECK-NEXT:           _result[0UL] += _r9;
+//CHECK-NEXT:           * _d_x += _r9;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_rosenbrock_grad(double x, double y, double *_result);
+void f_rosenbrock_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_cond1(double x, double y) {
   return (x > y ? x : y);
 }
 
-//CHECK:   void f_cond1_grad(double x, double y, double *_result) {
+//CHECK:   void f_cond1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       _cond0 = x > y;
 //CHECK-NEXT:       double f_cond1_return = (_cond0 ? x : y);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       if (_cond0)
-//CHECK-NEXT:           _result[0UL] += 1;
+//CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:       else
-//CHECK-NEXT:           _result[1UL] += 1;
+//CHECK-NEXT:           * _d_y += 1;
 //CHECK-NEXT:   }
 
-void f_cond1_grad(double x, double y, double *_result);
+void f_cond1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_cond2(double x, double y) {
   return (x > y ? x : (y > 0 ? y : -y));
 }
 
-//CHECK:   void f_cond2_grad(double x, double y, double *_result) {
+//CHECK:   void f_cond2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       _cond0 = x > y;
@@ -343,35 +343,35 @@ double f_cond2(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       if (_cond0)
-//CHECK-NEXT:           _result[0UL] += 1;
+//CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:       else if (_cond1)
-//CHECK-NEXT:           _result[1UL] += 1;
+//CHECK-NEXT:           * _d_y += 1;
 //CHECK-NEXT:       else
-//CHECK-NEXT:           _result[1UL] += -1;
+//CHECK-NEXT:           * _d_y += -1;
 //CHECK-NEXT:   }
 
-void f_cond2_grad(double x, double y, double *_result);
+void f_cond2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_cond3(double x, double c) {
   return (c > 0 ? x + c : x - c);
 }
 
-//CHECK:   void f_cond3_grad(double x, double c, double *_result) {
+//CHECK:   void f_cond3_grad(double x, double c, clad::array_ref<double> _d_x, clad::array_ref<double> _d_c) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       _cond0 = c > 0;
 //CHECK-NEXT:       double f_cond3_return = (_cond0 ? x + c : x - c);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:           _result[0UL] += 1;
-//CHECK-NEXT:           _result[1UL] += 1;
+//CHECK-NEXT:           * _d_x += 1;
+//CHECK-NEXT:           * _d_c += 1;
 //CHECK-NEXT:       } else {
-//CHECK-NEXT:           _result[0UL] += 1;
-//CHECK-NEXT:           _result[1UL] += -1;
+//CHECK-NEXT:           * _d_x += 1;
+//CHECK-NEXT:           * _d_c += -1;
 //CHECK-NEXT:       }
-//CHECK-NEXT:   } 
+//CHECK-NEXT:   }
 
-double f_cond3_grad(double x, double c, double *_result);
+double f_cond3_grad(double x, double c, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_if1(double x, double y) {
   if (x > y)
@@ -380,7 +380,7 @@ double f_if1(double x, double y) {
     return y;
 }
 
-//CHECK:   void f_if1_grad(double x, double y, double *_result) {
+//CHECK:   void f_if1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       _cond0 = x > y;
 //CHECK-NEXT:       if (_cond0) {
@@ -392,13 +392,13 @@ double f_if1(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:         _label0:
-//CHECK-NEXT:           _result[0UL] += 1;
+//CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:       else
 //CHECK-NEXT:         _label1:
-//CHECK-NEXT:           _result[1UL] += 1;
+//CHECK-NEXT:           * _d_y += 1;
 //CHECK-NEXT:   }
 
-double f_if1_grad(double x, double y, double *_result);
+double f_if1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 double f_if2(double x, double y) {
   if (x > y)
@@ -409,7 +409,7 @@ double f_if2(double x, double y) {
     return -y;
 }
 
-//CHECK:   void f_if2_grad(double x, double y, double *_result) {
+//CHECK:   void f_if2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       _cond0 = x > y;
@@ -428,16 +428,16 @@ double f_if2(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:         _label0:
-//CHECK-NEXT:           _result[0UL] += 1;
+//CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:       else if (_cond1)
 //CHECK-NEXT:         _label1:
-//CHECK-NEXT:           _result[1UL] += 1;
+//CHECK-NEXT:           * _d_y += 1;
 //CHECK-NEXT:       else
 //CHECK-NEXT:         _label2:
-//CHECK-NEXT:           _result[1UL] += -1;
-//CHECK-NEXT:   } 
+//CHECK-NEXT:           * _d_y += -1;
+//CHECK-NEXT:   }
 
-void f_if2_grad(double x, double y, double *_result);
+void f_if2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
 struct S {
   double c1;
@@ -445,29 +445,30 @@ struct S {
   double f(double x, double y) {
     return c1 * x + c2 * y;
   }
-   
-//CHECK:   void f_grad(double x, double y, double *_result) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       double _t3;
-//CHECK-NEXT:       _t1 = this->c1;
-//CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       _t3 = this->c2;
-//CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       double f_return = _t1 * _t0 + _t3 * _t2;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
-//CHECK-NEXT:           _result[0UL] += _r1;
-//CHECK-NEXT:           double _r2 = 1 * _t2;
-//CHECK-NEXT:           double _r3 = _t3 * 1;
-//CHECK-NEXT:           _result[1UL] += _r3;
-//CHECK-NEXT:       }
-//CHECK-NEXT:   } 
-  void f_grad(double x, double y, double *_result);
+
+  //CHECK:   void f_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
+  //CHECK-NEXT:       double _t0;
+  //CHECK-NEXT:       double _t1;
+  //CHECK-NEXT:       double _t2;
+  //CHECK-NEXT:       double _t3;
+  //CHECK-NEXT:       _t1 = this->c1;
+  //CHECK-NEXT:       _t0 = x;
+  //CHECK-NEXT:       _t3 = this->c2;
+  //CHECK-NEXT:       _t2 = y;
+  //CHECK-NEXT:       double f_return = _t1 * _t0 + _t3 * _t2;
+  //CHECK-NEXT:       goto _label0;
+  //CHECK-NEXT:     _label0:
+  //CHECK-NEXT:       {
+  //CHECK-NEXT:           double _r0 = 1 * _t0;
+  //CHECK-NEXT:           double _r1 = _t1 * 1;
+  //CHECK-NEXT:           * _d_x += _r1;
+  //CHECK-NEXT:           double _r2 = 1 * _t2;
+  //CHECK-NEXT:           double _r3 = _t3 * 1;
+  //CHECK-NEXT:           * _d_y += _r3;
+  //CHECK-NEXT:       }
+  //CHECK-NEXT:   }
+
+  void f_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 };
 
 double sum_of_powers(double x, double y, double z, double p) {
@@ -475,13 +476,20 @@ double sum_of_powers(double x, double y, double z, double p) {
 }
 
 namespace custom_derivatives {
-  void sum_of_powers_grad(double x, double y, double z, double p, double* result) {
-    result[0] += pow_darg0(x, p);
-    result[3] += pow_darg1(x, p);
-    result[1] += pow_darg0(y, p);
-    result[3] += pow_darg1(y, p);
-    result[2] += pow_darg0(z, p);
-    result[3] += pow_darg1(z, p);
+  void sum_of_powers_grad(double x,
+                          double y,
+                          double z,
+                          double p,
+                          double* _d_x,
+                          double* _d_y,
+                          double* _d_z,
+                          double* _d_p) {
+    *_d_x += pow_darg0(x, p);
+    *_d_p += pow_darg1(x, p);
+    *_d_y += pow_darg0(y, p);
+    *_d_p += pow_darg1(y, p);
+    *_d_z += pow_darg0(z, p);
+    *_d_p += pow_darg1(z, p);
   }
 }
 
@@ -489,8 +497,15 @@ double f_norm(double x, double y, double z, double d) {
   return std::pow(sum_of_powers(x, y, z, d), 1/d);
 }
 
-void f_norm_grad(double x, double y, double z, double d, double* _result);
-//CHECK:   void f_norm_grad(double x, double y, double z, double d, double *_result) {
+void f_norm_grad(double x,
+                 double y,
+                 double z,
+                 double d,
+                 double* _d_x,
+                 double* _d_y,
+                 double* _d_z,
+                 double* _d_d);
+//CHECK:   void f_norm_grad(double x, double y, double z, double d, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y, clad::array_ref<double> _d_z, clad::array_ref<double> _d_d) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -509,23 +524,27 @@ void f_norm_grad(double x, double y, double z, double d, double* _result);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _grad1[2] = {};
-//CHECK-NEXT:           custom_derivatives::pow_grad(_t4, _t6, _grad1);
-//CHECK-NEXT:           double _r0 = 1 * _grad1[0UL];
-//CHECK-NEXT:           double _grad0[4] = {};
-//CHECK-NEXT:           custom_derivatives::sum_of_powers_grad(_t0, _t1, _t2, _t3, _grad0);
-//CHECK-NEXT:           double _r1 = _r0 * _grad0[0UL];
-//CHECK-NEXT:           _result[0UL] += _r1;
-//CHECK-NEXT:           double _r2 = _r0 * _grad0[1UL];
-//CHECK-NEXT:           _result[1UL] += _r2;
-//CHECK-NEXT:           double _r3 = _r0 * _grad0[2UL];
-//CHECK-NEXT:           _result[2UL] += _r3;
-//CHECK-NEXT:           double _r4 = _r0 * _grad0[3UL];
-//CHECK-NEXT:           _result[3UL] += _r4;
-//CHECK-NEXT:           double _r5 = 1 * _grad1[1UL];
+//CHECK-NEXT:           double _grad4 = 0.;
+//CHECK-NEXT:           double _grad5 = 0.;
+//CHECK-NEXT:           custom_derivatives::pow_grad(_t4, _t6, &_grad4, &_grad5);
+//CHECK-NEXT:           double _r0 = 1 * _grad4;
+//CHECK-NEXT:           double _grad0 = 0.;
+//CHECK-NEXT:           double _grad1 = 0.;
+//CHECK-NEXT:           double _grad2 = 0.;
+//CHECK-NEXT:           double _grad3 = 0.;
+//CHECK-NEXT:           custom_derivatives::sum_of_powers_grad(_t0, _t1, _t2, _t3, &_grad0, &_grad1, &_grad2, &_grad3);
+//CHECK-NEXT:           double _r1 = _r0 * _grad0;
+//CHECK-NEXT:           * _d_x += _r1;
+//CHECK-NEXT:           double _r2 = _r0 * _grad1;
+//CHECK-NEXT:           * _d_y += _r2;
+//CHECK-NEXT:           double _r3 = _r0 * _grad2;
+//CHECK-NEXT:           * _d_z += _r3;
+//CHECK-NEXT:           double _r4 = _r0 * _grad3;
+//CHECK-NEXT:           * _d_d += _r4;
+//CHECK-NEXT:           double _r5 = 1 * _grad5;
 //CHECK-NEXT:           double _r6 = _r5 / _t5;
 //CHECK-NEXT:           double _r7 = _r5 * -1 / (_t5 * _t5);
-//CHECK-NEXT:           _result[3UL] += _r7;
+//CHECK-NEXT:           * _d_d += _r7;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -533,8 +552,8 @@ double f_sin(double x, double y) {
   return (std::sin(x) + std::sin(y))*(x + y);
 }
 
-void f_sin_grad(double x, double y, double* _result);
-//CHECK:   void f_sin_grad(double x, double y, double *_result) {
+void f_sin_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
+//CHECK:   void f_sin_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -549,30 +568,35 @@ void f_sin_grad(double x, double y, double* _result);
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = _r0 * custom_derivatives::sin_darg0(_t1);
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _r2 = _r0 * custom_derivatives::sin_darg0(_t2);
-//CHECK-NEXT:           _result[1UL] += _r2;
+//CHECK-NEXT:           * _d_y += _r2;
 //CHECK-NEXT:           double _r3 = _t3 * 1;
-//CHECK-NEXT:           _result[0UL] += _r3;
-//CHECK-NEXT:           _result[1UL] += _r3;
+//CHECK-NEXT:           * _d_x += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:       }
-//CHECK-NEXT:   } 
+//CHECK-NEXT:   }
 
 unsigned f_types(int x, float y, double z) {
   return x + y + z;
 }
 
-//CHECK:   void f_types_grad(int x, float y, double z, unsigned int *_result) {
+void f_types_grad(int x,
+                  float y,
+                  double z,
+                  clad::array_ref<unsigned int> _d_x,
+                  clad::array_ref<unsigned int> _d_y,
+                  clad::array_ref<unsigned int> _d_z);
+//CHECK:   void f_types_grad(int x, float y, double z, clad::array_ref<unsigned int> _d_x, clad::array_ref<unsigned int> _d_y, clad::array_ref<unsigned int> _d_z) {
 //CHECK-NEXT:       double f_types_return = x + y + z;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _result[0UL] += 1;
-//CHECK-NEXT:           _result[1UL] += 1;
-//CHECK-NEXT:           _result[2UL] += 1;
+//CHECK-NEXT:           * _d_x += 1;
+//CHECK-NEXT:           * _d_y += 1;
+//CHECK-NEXT:           * _d_z += 1;
 //CHECK-NEXT:       }
-//CHECK-NEXT:   } 
-void f_types_grad(int x, float y, double z, unsigned int *_result);
+//CHECK-NEXT:   }
 
 double f_decls1(double x, double y) {
   double a = 3 * x;
@@ -581,8 +605,8 @@ double f_decls1(double x, double y) {
   return 2 * c;
 }
 
-void f_decls1_grad(double x, double y, double* _result);
-//CHECK:   void f_decls1_grad(double x, double y, double *_result) {
+void f_decls1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
+//CHECK:   void f_decls1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _d_a = 0;
 //CHECK-NEXT:       double _t1;
@@ -610,12 +634,12 @@ void f_decls1_grad(double x, double y, double* _result);
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r2 = _d_b * _t1;
 //CHECK-NEXT:           double _r3 = 5 * _d_b;
-//CHECK-NEXT:           _result[1UL] += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = _d_a * _t0;
 //CHECK-NEXT:           double _r1 = 3 * _d_a;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -626,8 +650,8 @@ double f_decls2(double x, double y) {
   return a + 2 * b + c;
 }
 
-void f_decls2_grad(double x, double y, double* _result);
-//CHECK:   void f_decls2_grad(double x, double y, double *_result) {
+void f_decls2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
+//CHECK:   void f_decls2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_a = 0;
@@ -660,21 +684,21 @@ void f_decls2_grad(double x, double y, double* _result);
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r4 = _d_c * _t4;
-//CHECK-NEXT:           _result[1UL] += _r4;
+//CHECK-NEXT:           * _d_y += _r4;
 //CHECK-NEXT:           double _r5 = _t5 * _d_c;
-//CHECK-NEXT:           _result[1UL] += _r5;
+//CHECK-NEXT:           * _d_y += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r2 = _d_b * _t2;
-//CHECK-NEXT:           _result[0UL] += _r2;
+//CHECK-NEXT:           * _d_x += _r2;
 //CHECK-NEXT:           double _r3 = _t3 * _d_b;
-//CHECK-NEXT:           _result[1UL] += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = _d_a * _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           double _r1 = _t1 * _d_a;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -689,8 +713,8 @@ double f_decls3(double x, double y) {
   return b;
 }
 
-void f_decls3_grad(double x, double y, double* _result);
-//CHECK:   void f_decls3_grad(double x, double y, double *_result) {
+void f_decls3_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
+//CHECK:   void f_decls3_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _d_a = 0;
 //CHECK-NEXT:       double _t1;
@@ -749,12 +773,12 @@ void f_decls3_grad(double x, double y, double* _result);
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r2 = _d_c * _t1;
 //CHECK-NEXT:           double _r3 = 333 * _d_c;
-//CHECK-NEXT:           _result[1UL] += _r3;
+//CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = _d_a * _t0;
 //CHECK-NEXT:           double _r1 = 3 * _d_a;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -763,8 +787,8 @@ double f_issue138(double x, double y) {
     return x*x*x*x + y*y*y*y;
 }
 
-void f_issue138_grad(double x, double y, double *_result);
-//CHECK:   void f_issue138_grad(double x, double y, double *_result) {
+void f_issue138_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
+//CHECK:   void f_issue138_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _d__t1 = 0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
@@ -798,23 +822,23 @@ void f_issue138_grad(double x, double y, double *_result);
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = _r0 * _t1;
 //CHECK-NEXT:           double _r2 = _r1 * _t2;
-//CHECK-NEXT:           _result[0UL] += _r2;
+//CHECK-NEXT:           * _d_x += _r2;
 //CHECK-NEXT:           double _r3 = _t3 * _r1;
-//CHECK-NEXT:           _result[0UL] += _r3;
+//CHECK-NEXT:           * _d_x += _r3;
 //CHECK-NEXT:           double _r4 = _t4 * _r0;
-//CHECK-NEXT:           _result[0UL] += _r4;
+//CHECK-NEXT:           * _d_x += _r4;
 //CHECK-NEXT:           double _r5 = _t5 * 1;
-//CHECK-NEXT:           _result[0UL] += _r5;
+//CHECK-NEXT:           * _d_x += _r5;
 //CHECK-NEXT:           double _r6 = 1 * _t6;
 //CHECK-NEXT:           double _r7 = _r6 * _t7;
 //CHECK-NEXT:           double _r8 = _r7 * _t8;
-//CHECK-NEXT:           _result[1UL] += _r8;
+//CHECK-NEXT:           * _d_y += _r8;
 //CHECK-NEXT:           double _r9 = _t9 * _r7;
-//CHECK-NEXT:           _result[1UL] += _r9;
+//CHECK-NEXT:           * _d_y += _r9;
 //CHECK-NEXT:           double _r10 = _t11 * _r6;
-//CHECK-NEXT:           _result[1UL] += _r10;
+//CHECK-NEXT:           * _d_y += _r10;
 //CHECK-NEXT:           double _r11 = _t12 * 1;
-//CHECK-NEXT:           _result[1UL] += _r11;
+//CHECK-NEXT:           * _d_y += _r11;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -822,8 +846,8 @@ double f_const(const double a, const double b) {
   return a * b;
 }
 
-void f_const_grad(const double a, const double b, double *_result);
-//CHECK: void f_const_grad(const double a, const double b, double *_result) {
+void f_const_grad(const double a, const double b, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b);
+//CHECK: void f_const_grad(const double a, const double b, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t1 = a;
@@ -833,19 +857,21 @@ void f_const_grad(const double a, const double b, double *_result);
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_a += _r0;
 //CHECK-NEXT:           double _r1 = _t1 * 1;
-//CHECK-NEXT:           _result[1UL] += _r1;
+//CHECK-NEXT:           * _d_b += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-#define TEST(F, x, y) { \
-  result[0] = 0; result[1] = 0;\
-  clad::gradient(F);\
-  F##_grad(x, y, result);\
-  printf("Result is = {%.2f, %.2f}\n", result[0], result[1]); \
-}
- 
+#define TEST(F, x, y)                                                          \
+  {                                                                            \
+    result[0] = 0;                                                             \
+    result[1] = 0;                                                             \
+    clad::gradient(F);                                                         \
+    F##_grad(x, y, &result[0], &result[1]);                                    \
+    printf("Result is = {%.2f, %.2f}\n", result[0], result[1]);                \
+  }
+
 int main() { // expected-no-diagnostics
   double result[2];
 

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -12,7 +12,7 @@ double f1(double x) {
   return t;
 } // == x^3
 
-//CHECK:   void f1_grad(double x, double *_result) {
+//CHECK:   void f1_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
@@ -33,7 +33,7 @@ double f1(double x) {
 //CHECK-NEXT:           double _r_d0 = _d_t;
 //CHECK-NEXT:           _d_t += _r_d0 * clad::pop(_t1);
 //CHECK-NEXT:           double _r0 = clad::pop(_t2) * _r_d0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           _d_t -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -46,7 +46,7 @@ double f2(double x) {
   return t;
 } // == x^9
 
-//CHECK:   void f2_grad(double x, double *_result) {
+//CHECK:   void f2_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
@@ -74,13 +74,12 @@ double f2(double x) {
 //CHECK-NEXT:               double _r_d0 = _d_t;
 //CHECK-NEXT:               _d_t += _r_d0 * clad::pop(_t2);
 //CHECK-NEXT:               double _r0 = clad::pop(_t3) * _r_d0;
-//CHECK-NEXT:               _result[0UL] += _r0;
+//CHECK-NEXT:               * _d_x += _r0;
 //CHECK-NEXT:               _d_t -= _r_d0;
 //CHECK-NEXT:           }
 //CHECK-NEXT:           clad::pop(_t1);
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
-
 
 double f3(double x) {
   double t = 1;
@@ -92,7 +91,7 @@ double f3(double x) {
   return t;
 } // == x^2
 
-//CHECK:   void f3_grad(double x, double *_result) {
+//CHECK:   void f3_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
@@ -126,7 +125,7 @@ double f3(double x) {
 //CHECK-NEXT:               double _r_d0 = _d_t;
 //CHECK-NEXT:               _d_t += _r_d0 * clad::pop(_t1);
 //CHECK-NEXT:               double _r0 = clad::pop(_t2) * _r_d0;
-//CHECK-NEXT:               _result[0UL] += _r0;
+//CHECK-NEXT:               * _d_x += _r0;
 //CHECK-NEXT:               _d_t -= _r_d0;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
@@ -139,7 +138,7 @@ double f4(double x) {
   return t;
 } // == x^3
 
-//CHECK:   void f4_grad(double x, double *_result) {
+//CHECK:   void f4_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
@@ -159,7 +158,7 @@ double f4(double x) {
 //CHECK-NEXT:           double _r_d0 = _d_t;
 //CHECK-NEXT:           _d_t += _r_d0 * clad::pop(_t1);
 //CHECK-NEXT:           double _r0 = clad::pop(_t2) * _r_d0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           _d_t -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -170,7 +169,7 @@ double f5(double x){
   return x;
 } // == x + 10
 
-//CHECK:   void f5_grad(double x, double *_result) {
+//CHECK:   void f5_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
 //CHECK-NEXT:       _t0 = 0;
@@ -181,7 +180,7 @@ double f5(double x){
 //CHECK-NEXT:       double f5_return = x;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
-//CHECK-NEXT:       _result[0UL] += 1;
+//CHECK-NEXT:       * _d_x += 1;
 //CHECK-NEXT:       for (; _t0; _t0--)
 //CHECK-NEXT:           ;
 //CHECK-NEXT:   }
@@ -193,7 +192,7 @@ double f_sum(double *p, int n) {
   return s;
 }
 
-//CHECK:   void f_sum_grad_0(double *p, int n, double *_result) {
+//CHECK:   void f_sum_grad_0(double *p, int n, clad::array_ref<double> _d_p) {
 //CHECK-NEXT:       double _d_s = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
@@ -211,13 +210,13 @@ double f_sum(double *p, int n) {
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           double _r_d0 = _d_s;
 //CHECK-NEXT:           _d_s += _r_d0;
-//CHECK-NEXT:           _result[clad::pop(_t1)] += _r_d0;
+//CHECK-NEXT:           _d_p[clad::pop(_t1)] += _r_d0;
 //CHECK-NEXT:           _d_s -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 double sq(double x) { return x * x; }
-//CHECK:   void sq_grad(double x, double *_result) {
+//CHECK:   void sq_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t1 = x;
@@ -227,9 +226,9 @@ double sq(double x) { return x * x; }
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           double _r1 = _t1 * 1;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -240,7 +239,7 @@ double f_sum_squares(double *p, int n) {
   return s;
 }
 
-//CHECK:   void f_sum_squares_grad_0(double *p, int n, double *_result) {
+//CHECK:   void f_sum_squares_grad_0(double *p, int n, clad::array_ref<double> _d_p) {
 //CHECK-NEXT:       double _d_s = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
@@ -259,10 +258,10 @@ double f_sum_squares(double *p, int n) {
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           double _r_d0 = _d_s;
 //CHECK-NEXT:           _d_s += _r_d0;
-//CHECK-NEXT:           double _grad0[1] = {};
-//CHECK-NEXT:           sq_grad(clad::pop(_t2), _grad0);
-//CHECK-NEXT:           double _r0 = _r_d0 * _grad0[0UL];
-//CHECK-NEXT:           _result[clad::pop(_t1)] += _r0;
+//CHECK-NEXT:           double _grad0 = 0.;
+//CHECK-NEXT:           sq_grad(clad::pop(_t2), &_grad0);
+//CHECK-NEXT:           double _r0 = _r_d0 * _grad0;
+//CHECK-NEXT:           _d_p[clad::pop(_t1)] += _r0;
 //CHECK-NEXT:           _d_s -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -277,7 +276,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
   return std::log(gaus);
 }
 
-//CHECK:   void f_log_gaus_grad_1(double *x, double *p, double n, double sigma, double *_result) {
+//CHECK:   void f_log_gaus_grad_1(double *x, double *p, double n, double sigma, clad::array_ref<double> _d_p) {
 //CHECK-NEXT:       double _d_power = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
@@ -334,11 +333,12 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:           double _r8 = _r6 * -1. / (_t9 * _t9);
 //CHECK-NEXT:           double _r9 = _r8 * custom_derivatives::sqrt_darg0(_t14);
 //CHECK-NEXT:           double _r10 = _r9 * _t10;
-//CHECK-NEXT:           double _grad2[2] = {};
-//CHECK-NEXT:           custom_derivatives::pow_grad(_t11, _t12, _grad2);
-//CHECK-NEXT:           double _r11 = _r10 * _grad2[0UL];
+//CHECK-NEXT:           double _grad2 = 0.;
+//CHECK-NEXT:           double _grad3 = 0.;
+//CHECK-NEXT:           custom_derivatives::pow_grad(_t11, _t12, &_grad2, &_grad3);
+//CHECK-NEXT:           double _r11 = _r10 * _grad2;
 //CHECK-NEXT:           double _r12 = _r11 * 3.1415926535897931;
-//CHECK-NEXT:           double _r13 = _r10 * _grad2[1UL];
+//CHECK-NEXT:           double _r13 = _r10 * _grad3;
 //CHECK-NEXT:           double _r14 = _t13 * _r9;
 //CHECK-NEXT:           double _r15 = _t15 * _d_gaus;
 //CHECK-NEXT:           double _r16 = _r15 * custom_derivatives::exp_darg0(_t16);
@@ -351,18 +351,18 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:           double _r2 = _r_d1 * -_t5 / (_t4 * _t4);
 //CHECK-NEXT:           double _r3 = _r2 * _t6;
 //CHECK-NEXT:           double _r4 = 2 * _r2;
-//CHECK-NEXT:           double _grad1[1] = {};
-//CHECK-NEXT:           sq_grad(_t7, _grad1);
-//CHECK-NEXT:           double _r5 = _r4 * _grad1[0UL];
+//CHECK-NEXT:           double _grad1 = 0.;
+//CHECK-NEXT:           sq_grad(_t7, &_grad1);
+//CHECK-NEXT:           double _r5 = _r4 * _grad1;
 //CHECK-NEXT:           _d_power -= _r_d1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           double _r_d0 = _d_power;
 //CHECK-NEXT:           _d_power += _r_d0;
-//CHECK-NEXT:           double _grad0[1] = {};
-//CHECK-NEXT:           sq_grad(clad::pop(_t3), _grad0);
-//CHECK-NEXT:           double _r0 = _r_d0 * _grad0[0UL];
-//CHECK-NEXT:           _result[clad::pop(_t2)] += -_r0;
+//CHECK-NEXT:           double _grad0 = 0.;
+//CHECK-NEXT:           sq_grad(clad::pop(_t3), &_grad0);
+//CHECK-NEXT:           double _r0 = _r_d0 * _grad0;
+//CHECK-NEXT:           _d_p[clad::pop(_t2)] += -_r0;
 //CHECK-NEXT:           _d_power -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -377,7 +377,7 @@ double f_const(const double a, const double b) {
 }
 
 void f_const_grad(const double, const double, double *);
-//CHECK: void f_const_grad(const double a, const double b, double *_result) {
+//CHECK:   void f_const_grad(const double a, const double b, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b) {
 //CHECK-NEXT:       int _d_r = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
@@ -404,9 +404,9 @@ void f_const_grad(const double, const double, double *);
 //CHECK-NEXT:           }
 //CHECK-NEXT:           {
 //CHECK-NEXT:               double _r0 = _d_sq * clad::pop(_t1);
-//CHECK-NEXT:               _result[1UL] += _r0;
+//CHECK-NEXT:               * _d_b += _r0;
 //CHECK-NEXT:               double _r1 = clad::pop(_t2) * _d_sq;
-//CHECK-NEXT:               _result[1UL] += _r1;
+//CHECK-NEXT:               * _d_b += _r1;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -420,6 +420,7 @@ void f_const_grad(const double, const double, double *);
 
 int main() {
   double result[5] = {};
+  clad::array_ref<double> result_ref(result, 5);
   TEST(f1, 3); // CHECK-EXEC: {27.00}
   TEST(f2, 3); // CHECK-EXEC: {59049.00} 
   TEST(f3, 3); // CHECK-EXEC: {6.00} 
@@ -430,23 +431,22 @@ int main() {
 
   for (int i = 0; i < 5; i++) result[i] = 0;
   auto f_sum_grad = clad::gradient(f_sum, "p");
-  f_sum_grad.execute(p, 5, result);
+  f_sum_grad.execute(p, 5, result_ref);
   printf("{%.2f, %.2f, %.2f, %.2f, %.2f}\n", result[0], result[1], result[2], result[3], result[4]); // CHECK-EXEC: {1.00, 1.00, 1.00, 1.00, 1.00}
 
   for (int i = 0; i < 5; i++) result[i] = 0;
   auto f_sum_squares_grad = clad::gradient(f_sum_squares, "p");
-  f_sum_squares_grad.execute(p, 5, result);
+  f_sum_squares_grad.execute(p, 5, result_ref);
   printf("{%.2f, %.2f, %.2f, %.2f, %.2f}\n", result[0], result[1], result[2], result[3], result[4]); // CHECK-EXEC: {2.00, 4.00, 6.00, 8.00, 10.00}
 
   for (int i = 0; i < 5; i++) result[i] = 0;
   auto f_log_gaus_d_means = clad::gradient(f_log_gaus, "p"); // == { (x[i] - p[i])/sigma^2 }
   double x[] = { 1, 1, 1, 1, 1 };
-  f_log_gaus_d_means.execute(x, p, 5, 2.0, result);
+  f_log_gaus_d_means.execute(x, p, 5, 2.0, result_ref);
   printf("{%.2f, %.2f, %.2f, %.2f, %.2f}\n", result[0], result[1], result[2], result[3], result[4]); // CHECK-EXEC: {0.00, -0.25, -0.50, -0.75, -1.00}
-
   result[0] = 0;
   result[1] = 0;
   auto f_const_d = clad::gradient(f_const);
-  f_const_d.execute(2, 3, result);
+  f_const_d.execute(2, 3, &result[0], &result[1]);
   printf("{%.2f, %.2f}\n", result[0], result[1]); // CHECK-EXEC: {0.00, 18.00}
 }

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -1,8 +1,8 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oMemberFunctions.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -lm -fno-exceptions -I%S/../../include -oMemberFunctions.out 2>&1 | FileCheck %s
 // RUN: ./MemberFunctions.out | FileCheck -check-prefix=CHECK-EXEC %s
-// RUN: %cladclang -std=c++14 %s -lm -I%S/../../include -oMemberFunctions-cpp14.out 2>&1 | FileCheck %s
+// RUN: %cladclang -std=c++14 %s -lm -fno-exceptions -I%S/../../include -oMemberFunctions-cpp14.out 2>&1 | FileCheck %s
 // RUN: ./MemberFunctions-cpp14.out | FileCheck -check-prefix=CHECK-EXEC %s
-// RUN: %cladclang -std=c++17 %s -lm -I%S/../../include -oMemberFunctions-cpp17.out 2>&1 | FileCheck %s
+// RUN: %cladclang -std=c++17 %s -lm -fno-exceptions -I%S/../../include -oMemberFunctions-cpp17.out 2>&1 | FileCheck %s
 // RUN: ./MemberFunctions-cpp17.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}
@@ -14,9 +14,9 @@ public:
   double x, y;
   double mem_fn(double i, double j)  { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void mem_fn_grad(double i, double j, double *_result) {
+  // CHECK: void mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -31,19 +31,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_mem_fn(double i, double j) const { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void const_mem_fn_grad(double i, double j, double *_result) const {
+  // CHECK: void const_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -58,19 +58,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double volatile_mem_fn(double i, double j) volatile { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void volatile_mem_fn_grad(double i, double j, double *_result) volatile {
+  // CHECK: void volatile_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -85,19 +85,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_volatile_mem_fn(double i, double j) const volatile { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void const_volatile_mem_fn_grad(double i, double j, double *_result) const volatile {
+  // CHECK: void const_volatile_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -112,19 +112,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double lval_ref_mem_fn(double i, double j) & { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void lval_ref_mem_fn_grad(double i, double j, double *_result) & {
+  // CHECK: void lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) & {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -139,19 +139,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_lval_ref_mem_fn(double i, double j) const & { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, double *_result) const & {
+  // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const & {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -166,19 +166,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double volatile_lval_ref_mem_fn(double i, double j) volatile & { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) volatile & {
+  // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile & {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -193,19 +193,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_volatile_lval_ref_mem_fn(double i, double j) const volatile & { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) const volatile & {
+  // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile & {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -217,22 +217,22 @@ public:
   // CHECK-NEXT:     double const_volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
+  // CHECK-NEXT:      {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double rval_ref_mem_fn(double i, double j) && { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void rval_ref_mem_fn_grad(double i, double j, double *_result) && {
+  // CHECK: void rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) && {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -247,19 +247,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_rval_ref_mem_fn(double i, double j) const && { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, double *_result) const && {
+  // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const && {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -274,19 +274,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double volatile_rval_ref_mem_fn(double i, double j) volatile && { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) volatile && {
+  // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile && {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -301,19 +301,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_volatile_rval_ref_mem_fn(double i, double j) const volatile && { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) const volatile && {
+  // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile && {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -328,19 +328,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+  // CHECK-NEXT:  }
 
   double noexcept_mem_fn(double i, double j) noexcept { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void noexcept_mem_fn_grad(double i, double j, double *_result) noexcept {
+  // CHECK: void noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -355,19 +355,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_noexcept_mem_fn(double i, double j) const noexcept { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void const_noexcept_mem_fn_grad(double i, double j, double *_result) const noexcept {
+  // CHECK: void const_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -382,19 +382,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double volatile_noexcept_mem_fn(double i, double j) volatile noexcept { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, double *_result) volatile noexcept {
+  // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -409,19 +409,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_volatile_noexcept_mem_fn(double i, double j) const volatile noexcept { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, double *_result) const volatile noexcept {
+  // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -433,22 +433,22 @@ public:
   // CHECK-NEXT:     double const_volatile_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
+  // CHECK-NEXT:      {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double lval_ref_noexcept_mem_fn(double i, double j) & noexcept { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) & noexcept {
+  // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) & noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -463,19 +463,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_lval_ref_noexcept_mem_fn(double i, double j) const & noexcept { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const & noexcept {
+  // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const & noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -490,19 +490,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double volatile_lval_ref_noexcept_mem_fn(double i, double j) volatile & noexcept { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) volatile & noexcept {
+  // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile & noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -517,19 +517,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_volatile_lval_ref_noexcept_mem_fn(double i, double j) const volatile & noexcept { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const volatile & noexcept {
+  // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile & noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -544,19 +544,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double rval_ref_noexcept_mem_fn(double i, double j) && noexcept { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) && noexcept {
+  // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) && noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -565,25 +565,26 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     double
+  // rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_rval_ref_noexcept_mem_fn(double i, double j) const && noexcept { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const && noexcept {
+  // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const && noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -595,22 +596,22 @@ public:
   // CHECK-NEXT:     double const_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
+  // CHECK-NEXT:      {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+  // CHECK-NEXT:  }
 
   double volatile_rval_ref_noexcept_mem_fn(double i, double j) volatile && noexcept { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) volatile && noexcept {
+  // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile && noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -625,19 +626,19 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_volatile_rval_ref_noexcept_mem_fn(double i, double j) const volatile && noexcept { 
     return (x+y)*i + i*j; 
-  } 
+  }
 
-  // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const volatile && noexcept {
+  // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile && noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -652,46 +653,70 @@ public:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
-  void mem_fn_grad(double i, double j, double *_result) ; 
-  void const_mem_fn_grad(double i, double j, double *_result) ; 
-  void volatile_mem_fn_grad(double i, double j, double *_result) ; 
-  void const_volatile_mem_fn_grad(double i, double j, double *_result) ; 
-  void lval_ref_mem_fn_grad(double i, double j, double *_result) ; 
-  void const_lval_ref_mem_fn_grad(double i, double j, double *_result) ; 
-  void volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) ; 
-  void const_volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) ; 
-  void rval_ref_mem_fn_grad(double i, double j, double *_result) ; 
-  void const_rval_ref_mem_fn_grad(double i, double j, double *_result) ; 
-  void volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) ; 
-  void const_volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) ; 
-  void noexcept_mem_fn_grad(double i, double j, double *_result) ; 
-  void const_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
-  void volatile_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
-  void const_volatile_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
-  void lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
-  void const_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
-  void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
-  void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
-  void rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
-  void const_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
-  void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
-  void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) ; 
+  double partial_mem_fn(double i, double j) { return (x + y) * i + i * j; }
 
+  // CHECK: void partial_mem_fn_grad_0(double i, double j, clad::array_ref<double> _d_i) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double partial_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         * _d_i += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         * _d_i += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
+  void mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void const_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void volatile_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void const_volatile_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void const_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void volatile_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void const_volatile_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void const_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void volatile_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void const_volatile_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void const_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void volatile_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void const_volatile_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void const_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void const_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j);
+  void partial_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i);
 };
 
 double fn(double i,double j) {
   return i*i*j;
 }
 
-// CHECK: void fn_grad(double i, double j, double *_result) {
+// CHECK: void fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _t2;
@@ -706,11 +731,11 @@ double fn(double i,double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
 // CHECK-NEXT:         double _r1 = _r0 * _t1;
-// CHECK-NEXT:         _result[0UL] += _r1;
+// CHECK-NEXT:         * _d_i += _r1;
 // CHECK-NEXT:         double _r2 = _t2 * _r0;
-// CHECK-NEXT:         _result[0UL] += _r2;
+// CHECK-NEXT:         * _d_i += _r2;
 // CHECK-NEXT:         double _r3 = _t3 * 1;
-// CHECK-NEXT:         _result[1UL] += _r3;
+// CHECK-NEXT:         * _d_j += _r3;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -739,10 +764,11 @@ int main() {
   auto d_const_rval_ref_noexcept_mem_fn = clad::gradient(&SimpleFunctions::const_rval_ref_noexcept_mem_fn);
   auto d_volatile_rval_ref_noexcept_mem_fn = clad::gradient(&SimpleFunctions::volatile_rval_ref_noexcept_mem_fn);
   auto d_const_volatile_rval_ref_noexcept_mem_fn = clad::gradient(&SimpleFunctions::const_volatile_rval_ref_noexcept_mem_fn);
+  auto d_partial_mem_fn = clad::gradient(&SimpleFunctions::partial_mem_fn, "i");
 
   auto d_fn = clad::gradient(fn);
   double result[2];
-  d_fn.execute(4,5,result);
+  d_fn.execute(4, 5, &result[0], &result[1]);
   for(unsigned i=0;i<2;++i) {
     printf("%.2f ",result[i]);  //CHECK-EXEC: 40.00 16.00
   }

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -12,9 +12,7 @@ class SimpleFunctions {
 public:
   SimpleFunctions(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
   double x, y;
-  double mem_fn(double i, double j)  { 
-    return (x+y)*i + i*j; 
-  }
+  double mem_fn(double i, double j) { return (x + y) * i + i * j; }
 
   // CHECK: void mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
   // CHECK-NEXT:     double _t0;
@@ -39,9 +37,7 @@ public:
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
-  double const_mem_fn(double i, double j) const { 
-    return (x+y)*i + i*j; 
-  }
+  double const_mem_fn(double i, double j) const { return (x + y) * i + i * j; }
 
   // CHECK: void const_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     double _t0;
@@ -67,7 +63,7 @@ public:
   // CHECK-NEXT: }
 
   double volatile_mem_fn(double i, double j) volatile { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void volatile_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile {
@@ -94,7 +90,7 @@ public:
   // CHECK-NEXT: }
 
   double const_volatile_mem_fn(double i, double j) const volatile { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void const_volatile_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
@@ -120,9 +116,7 @@ public:
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
-  double lval_ref_mem_fn(double i, double j) & { 
-    return (x+y)*i + i*j; 
-  }
+  double lval_ref_mem_fn(double i, double j) & { return (x + y) * i + i * j; }
 
   // CHECK: void lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) & {
   // CHECK-NEXT:     double _t0;
@@ -148,7 +142,7 @@ public:
   // CHECK-NEXT: }
 
   double const_lval_ref_mem_fn(double i, double j) const & { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const & {
@@ -175,7 +169,7 @@ public:
   // CHECK-NEXT: }
 
   double volatile_lval_ref_mem_fn(double i, double j) volatile & { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile & {
@@ -202,7 +196,7 @@ public:
   // CHECK-NEXT: }
 
   double const_volatile_lval_ref_mem_fn(double i, double j) const volatile & { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile & {
@@ -228,9 +222,7 @@ public:
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
-  double rval_ref_mem_fn(double i, double j) && { 
-    return (x+y)*i + i*j; 
-  }
+  double rval_ref_mem_fn(double i, double j) && { return (x + y) * i + i * j; }
 
   // CHECK: void rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) && {
   // CHECK-NEXT:     double _t0;
@@ -256,7 +248,7 @@ public:
   // CHECK-NEXT: }
 
   double const_rval_ref_mem_fn(double i, double j) const && { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const && {
@@ -283,7 +275,7 @@ public:
   // CHECK-NEXT: }
 
   double volatile_rval_ref_mem_fn(double i, double j) volatile && { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile && {
@@ -310,7 +302,7 @@ public:
   // CHECK-NEXT: }
 
   double const_volatile_rval_ref_mem_fn(double i, double j) const volatile && { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile && {
@@ -337,7 +329,7 @@ public:
   // CHECK-NEXT:  }
 
   double noexcept_mem_fn(double i, double j) noexcept { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) noexcept {
@@ -364,7 +356,7 @@ public:
   // CHECK-NEXT: }
 
   double const_noexcept_mem_fn(double i, double j) const noexcept { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void const_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const noexcept {
@@ -391,7 +383,7 @@ public:
   // CHECK-NEXT: }
 
   double volatile_noexcept_mem_fn(double i, double j) volatile noexcept { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile noexcept {
@@ -418,7 +410,7 @@ public:
   // CHECK-NEXT: }
 
   double const_volatile_noexcept_mem_fn(double i, double j) const volatile noexcept { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile noexcept {
@@ -445,7 +437,7 @@ public:
   // CHECK-NEXT: }
 
   double lval_ref_noexcept_mem_fn(double i, double j) & noexcept { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) & noexcept {
@@ -472,7 +464,7 @@ public:
   // CHECK-NEXT: }
 
   double const_lval_ref_noexcept_mem_fn(double i, double j) const & noexcept { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const & noexcept {
@@ -499,7 +491,7 @@ public:
   // CHECK-NEXT: }
 
   double volatile_lval_ref_noexcept_mem_fn(double i, double j) volatile & noexcept { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile & noexcept {
@@ -526,7 +518,7 @@ public:
   // CHECK-NEXT: }
 
   double const_volatile_lval_ref_noexcept_mem_fn(double i, double j) const volatile & noexcept { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile & noexcept {
@@ -553,7 +545,7 @@ public:
   // CHECK-NEXT: }
 
   double rval_ref_noexcept_mem_fn(double i, double j) && noexcept { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) && noexcept {
@@ -581,7 +573,7 @@ public:
   // CHECK-NEXT: }
 
   double const_rval_ref_noexcept_mem_fn(double i, double j) const && noexcept { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const && noexcept {
@@ -608,7 +600,7 @@ public:
   // CHECK-NEXT:  }
 
   double volatile_rval_ref_noexcept_mem_fn(double i, double j) volatile && noexcept { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile && noexcept {
@@ -635,7 +627,7 @@ public:
   // CHECK-NEXT: }
 
   double const_volatile_rval_ref_noexcept_mem_fn(double i, double j) const volatile && noexcept { 
-    return (x+y)*i + i*j; 
+    return (x+y)*i + i*j;
   }
 
   // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile && noexcept {

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -8,7 +8,7 @@ double nonMemFn(double i) {
   return i*i;
 }
 
-// CHECK: void nonMemFn_grad(double i, double *_result) {
+// CHECK: void nonMemFn_grad(double i, clad::array_ref<double> _d_i) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     _t1 = i;
@@ -18,9 +18,9 @@ double nonMemFn(double i) {
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
-// CHECK-NEXT:         _result[0UL] += _r0;
+// CHECK-NEXT:         * _d_i += _r0;
 // CHECK-NEXT:         double _r1 = _t1 * 1;
-// CHECK-NEXT:         _result[0UL] += _r1;
+// CHECK-NEXT:         * _d_i += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/TestAgainstDiff.C
+++ b/test/Gradient/TestAgainstDiff.C
@@ -8,25 +8,25 @@
 double f(double x, double y) {
   return (x - 1) * (x - 1) + 100 * (y - x * x) * (y - x * x);
 }
-void f_grad(double x, double y, double * _result);
+void f_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
-void f_grad_old(double x, double y, double * _result) {
+void f_grad_old(double x, double y, double* _d_x, double* _d_y) {
   auto dx = clad::differentiate(f, 0);
   auto dy = clad::differentiate(f, 1);
 
-  _result[0] = dx.execute(x, y);
-  _result[1] = dy.execute(x, y);
+  *_d_x = dx.execute(x, y);
+  *_d_y = dy.execute(x, y);
 }
 
 int main() {
-  clad::gradient(f);
+  clad::gradient(f).dump();
   
   auto test = [&] (double x, double y) { // expected-no-diagnostics
     double result_old[2] = {};
     double result_new[2] = {};
 
-    f_grad_old(x, y, result_old);
-    f_grad(x, y, result_new);
+    f_grad_old(x, y, &result_old[0], &result_old[1]);
+    f_grad(x, y, &result_new[0], &result_new[1]);
 
     for (int i = 0; i < 2; i++)
       if (result_old[i] != result_new[i])

--- a/test/Hessian/ArrayErrors.C
+++ b/test/Hessian/ArrayErrors.C
@@ -1,0 +1,16 @@
+// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1
+
+#include "clad/Differentiator/Differentiator.h"
+
+//CHECK-NOT: {{.*error|warning|note:.*}}
+
+double f(int a, double *b) {
+  return b[0] * a + b[1] * a + b[2] * a;
+}
+
+int main() {
+    clad::hessian(f, 1); // expected-error {{Hessian mode differentiation w.r.t. array or pointer parameters needs explicit declaration of the indices of the array using the args parameter; did you mean 'clad::hessian(f, "b[0:<last index of b>]")'}}
+    clad::hessian(f, "a");
+    clad::hessian(f, "a, b"); // expected-error {{Hessian mode differentiation w.r.t. array or pointer parameters needs explicit declaration of the indices of the array using the args parameter; did you mean 'clad::hessian(f, "a, b[0:<last index of b>]")'}}
+    clad::hessian(f, "a, b[0:2]");
+};

--- a/test/Hessian/Arrays.C
+++ b/test/Hessian/Arrays.C
@@ -1,0 +1,47 @@
+// RUN: %cladclang %s -lm -I%S/../../include -oArrays.out 2>&1 | FileCheck %s
+// RUN: ./Arrays.out | FileCheck -check-prefix=CHECK-EXEC %s
+
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+double f(double i, double j[2]) { return i * j[0] * j[1]; }
+// CHECK: void f_hessian(double i, double j[2], clad::array_ref<double> hessianMatrix) {
+// CHECK-NEXT:     f_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 2UL));
+// CHECK-NEXT:     f_darg1_0_grad(i, j, hessianMatrix.slice(3UL, 1UL), hessianMatrix.slice(4UL, 2UL));
+// CHECK-NEXT:     f_darg1_1_grad(i, j, hessianMatrix.slice(6UL, 1UL), hessianMatrix.slice(7UL, 2UL));
+// CHECK-NEXT: }
+
+double g(double i, double j[2]) { return i * (j[0] + j[1]); }
+
+// CHECK: void g_hessian(double i, double j[2], clad::array_ref<double> hessianMatrix) {
+// CHECK-NEXT:   g_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 2UL));
+// CHECK-NEXT:   g_darg1_0_grad(i, j, hessianMatrix.slice(3UL, 1UL), hessianMatrix.slice(4UL, 2UL));
+// CHECK-NEXT:   g_darg1_1_grad(i, j, hessianMatrix.slice(6UL, 1UL), hessianMatrix.slice(7UL, 2UL));
+// CHECK-NEXT: }
+
+#define TEST(var, i, j)                                                        \
+  result[0] = result[1] = result[2] = result[3] = result[4] = result[5] =      \
+      result[6] = result[7] = result[8] = 0;                                   \
+  var.execute(i, j, result_ref);                                               \
+  printf("Result = {%.2f %.2f %.2f %.2f %.2f %.2f %.2f %.2f %.2f}\n",          \
+         result[0],                                                            \
+         result[1],                                                            \
+         result[2],                                                            \
+         result[3],                                                            \
+         result[4],                                                            \
+         result[5],                                                            \
+         result[6],                                                            \
+         result[7],                                                            \
+         result[8]);
+
+int main() {
+  double result[9];
+  clad::array_ref<double> result_ref(result, 9);
+  double x[] = {3, 4};
+
+  auto h1 = clad::hessian(f, "i, j[0:1]");
+  TEST(h1, 2, x); // CHECK-EXEC: Result = {0.00 4.00 3.00 4.00 0.00 2.00 3.00 2.00 0.00}
+  auto h2 = clad::hessian(g, "i, j[0:1]");
+  TEST(h2, 2, x); // CHECK-EXEC: Result = {0.00 1.00 1.00 1.00 0.00 0.00 1.00 0.00 0.00}
+}

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -9,8 +9,8 @@ __attribute__((always_inline)) double f_cubed_add1(double a, double b) {
   return a * a * a + b * b * b;
 }
 
-void f_cubed_add1_darg0_grad(double a, double b, double *_result);
-//CHECK:void f_cubed_add1_darg0_grad(double a, double b, double *_result) __attribute__((always_inline)) {
+void f_cubed_add1_darg0_grad(double a, double b, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b);
+//CHECK:void f_cubed_add1_darg0_grad(double a, double b, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b) __attribute__((always_inline)) {
 //CHECK-NEXT:    double _d__d_a = 0;
 //CHECK-NEXT:    double _d__d_b = 0;
 //CHECK-NEXT:    double _t0;
@@ -35,30 +35,30 @@ void f_cubed_add1_darg0_grad(double a, double b, double *_result);
 //CHECK-NEXT:    double _t18;
 //CHECK-NEXT:    double _t19;
 //CHECK-NEXT:    double _t20;
-//CHECK-NEXT:    double _d_a = 1;
-//CHECK-NEXT:    double _d_b = 0;
+//CHECK-NEXT:    double _d_a0 = 1;
+//CHECK-NEXT:    double _d_b0 = 0;
 //CHECK-NEXT:    _t1 = a;
 //CHECK-NEXT:    _t0 = a;
 //CHECK-NEXT:    double _t00 = _t1 * _t0;
 //CHECK-NEXT:    _t3 = b;
 //CHECK-NEXT:    _t2 = b;
 //CHECK-NEXT:    double _t10 = _t3 * _t2;
-//CHECK-NEXT:    _t6 = _d_a;
+//CHECK-NEXT:    _t6 = _d_a0;
 //CHECK-NEXT:    _t5 = a;
 //CHECK-NEXT:    _t8 = a;
-//CHECK-NEXT:    _t7 = _d_a;
+//CHECK-NEXT:    _t7 = _d_a0;
 //CHECK-NEXT:    _t9 = (_t6 * _t5 + _t8 * _t7);
 //CHECK-NEXT:    _t4 = a;
 //CHECK-NEXT:    _t12 = _t00;
-//CHECK-NEXT:    _t11 = _d_a;
-//CHECK-NEXT:    _t15 = _d_b;
+//CHECK-NEXT:    _t11 = _d_a0;
+//CHECK-NEXT:    _t15 = _d_b0;
 //CHECK-NEXT:    _t14 = b;
 //CHECK-NEXT:    _t17 = b;
-//CHECK-NEXT:    _t16 = _d_b;
+//CHECK-NEXT:    _t16 = _d_b0;
 //CHECK-NEXT:    _t18 = (_t15 * _t14 + _t17 * _t16);
 //CHECK-NEXT:    _t13 = b;
 //CHECK-NEXT:    _t20 = _t10;
-//CHECK-NEXT:    _t19 = _d_b;
+//CHECK-NEXT:    _t19 = _d_b0;
 //CHECK-NEXT:    double f_cubed_add1_darg0_return = _t9 * _t4 + _t12 * _t11 + _t18 * _t13 + _t20 * _t19;
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
@@ -67,13 +67,13 @@ void f_cubed_add1_darg0_grad(double a, double b, double *_result);
 //CHECK-NEXT:        double _r5 = _r4 * _t5;
 //CHECK-NEXT:        _d__d_a += _r5;
 //CHECK-NEXT:        double _r6 = _t6 * _r4;
-//CHECK-NEXT:        _result[0UL] += _r6;
+//CHECK-NEXT:        * _d_a += _r6;
 //CHECK-NEXT:        double _r7 = _r4 * _t7;
-//CHECK-NEXT:        _result[0UL] += _r7;
+//CHECK-NEXT:        * _d_a += _r7;
 //CHECK-NEXT:        double _r8 = _t8 * _r4;
 //CHECK-NEXT:        _d__d_a += _r8;
 //CHECK-NEXT:        double _r9 = _t9 * 1;
-//CHECK-NEXT:        _result[0UL] += _r9;
+//CHECK-NEXT:        * _d_a += _r9;
 //CHECK-NEXT:        double _r10 = 1 * _t11;
 //CHECK-NEXT:        _d__t0 += _r10;
 //CHECK-NEXT:        double _r11 = _t12 * 1;
@@ -82,13 +82,13 @@ void f_cubed_add1_darg0_grad(double a, double b, double *_result);
 //CHECK-NEXT:        double _r13 = _r12 * _t14;
 //CHECK-NEXT:        _d__d_b += _r13;
 //CHECK-NEXT:        double _r14 = _t15 * _r12;
-//CHECK-NEXT:        _result[1UL] += _r14;
+//CHECK-NEXT:        * _d_b += _r14;
 //CHECK-NEXT:        double _r15 = _r12 * _t16;
-//CHECK-NEXT:        _result[1UL] += _r15;
+//CHECK-NEXT:        * _d_b += _r15;
 //CHECK-NEXT:        double _r16 = _t17 * _r12;
 //CHECK-NEXT:        _d__d_b += _r16;
 //CHECK-NEXT:        double _r17 = _t18 * 1;
-//CHECK-NEXT:        _result[1UL] += _r17;
+//CHECK-NEXT:        * _d_b += _r17;
 //CHECK-NEXT:        double _r18 = 1 * _t19;
 //CHECK-NEXT:        _d__t1 += _r18;
 //CHECK-NEXT:        double _r19 = _t20 * 1;
@@ -96,21 +96,20 @@ void f_cubed_add1_darg0_grad(double a, double b, double *_result);
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _r2 = _d__t1 * _t2;
-//CHECK-NEXT:        _result[1UL] += _r2;
+//CHECK-NEXT:        * _d_b += _r2;
 //CHECK-NEXT:        double _r3 = _t3 * _d__t1;
-//CHECK-NEXT:        _result[1UL] += _r3;
+//CHECK-NEXT:        * _d_b += _r3;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _r0 = _d__t0 * _t0;
-//CHECK-NEXT:        _result[0UL] += _r0;
+//CHECK-NEXT:        * _d_a += _r0;
 //CHECK-NEXT:        double _r1 = _t1 * _d__t0;
-//CHECK-NEXT:        _result[0UL] += _r1;
+//CHECK-NEXT:        * _d_a += _r1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
-
-void f_cubed_add1_darg1_grad(double a, double b, double *_result);
-//CHECK:void f_cubed_add1_darg1_grad(double a, double b, double *_result) __attribute__((always_inline)) {
+void f_cubed_add1_darg1_grad(double a, double b, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b);
+//CHECK:void f_cubed_add1_darg1_grad(double a, double b, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b) __attribute__((always_inline)) {
 //CHECK-NEXT:    double _d__d_a = 0;
 //CHECK-NEXT:    double _d__d_b = 0;
 //CHECK-NEXT:    double _t0;
@@ -135,30 +134,30 @@ void f_cubed_add1_darg1_grad(double a, double b, double *_result);
 //CHECK-NEXT:    double _t18;
 //CHECK-NEXT:    double _t19;
 //CHECK-NEXT:    double _t20;
-//CHECK-NEXT:    double _d_a = 0;
-//CHECK-NEXT:    double _d_b = 1;
+//CHECK-NEXT:    double _d_a0 = 0;
+//CHECK-NEXT:    double _d_b0 = 1;
 //CHECK-NEXT:    _t1 = a;
 //CHECK-NEXT:    _t0 = a;
 //CHECK-NEXT:    double _t00 = _t1 * _t0;
 //CHECK-NEXT:    _t3 = b;
 //CHECK-NEXT:    _t2 = b;
 //CHECK-NEXT:    double _t10 = _t3 * _t2;
-//CHECK-NEXT:    _t6 = _d_a;
+//CHECK-NEXT:    _t6 = _d_a0;
 //CHECK-NEXT:    _t5 = a;
 //CHECK-NEXT:    _t8 = a;
-//CHECK-NEXT:    _t7 = _d_a;
+//CHECK-NEXT:    _t7 = _d_a0;
 //CHECK-NEXT:    _t9 = (_t6 * _t5 + _t8 * _t7);
 //CHECK-NEXT:    _t4 = a;
 //CHECK-NEXT:    _t12 = _t00;
-//CHECK-NEXT:    _t11 = _d_a;
-//CHECK-NEXT:    _t15 = _d_b;
+//CHECK-NEXT:    _t11 = _d_a0;
+//CHECK-NEXT:    _t15 = _d_b0;
 //CHECK-NEXT:    _t14 = b;
 //CHECK-NEXT:    _t17 = b;
-//CHECK-NEXT:    _t16 = _d_b;
+//CHECK-NEXT:    _t16 = _d_b0;
 //CHECK-NEXT:    _t18 = (_t15 * _t14 + _t17 * _t16);
 //CHECK-NEXT:    _t13 = b;
 //CHECK-NEXT:    _t20 = _t10;
-//CHECK-NEXT:    _t19 = _d_b;
+//CHECK-NEXT:    _t19 = _d_b0;
 //CHECK-NEXT:    double f_cubed_add1_darg1_return = _t9 * _t4 + _t12 * _t11 + _t18 * _t13 + _t20 * _t19;
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
@@ -167,13 +166,13 @@ void f_cubed_add1_darg1_grad(double a, double b, double *_result);
 //CHECK-NEXT:        double _r5 = _r4 * _t5;
 //CHECK-NEXT:        _d__d_a += _r5;
 //CHECK-NEXT:        double _r6 = _t6 * _r4;
-//CHECK-NEXT:        _result[0UL] += _r6;
+//CHECK-NEXT:        * _d_a += _r6;
 //CHECK-NEXT:        double _r7 = _r4 * _t7;
-//CHECK-NEXT:        _result[0UL] += _r7;
+//CHECK-NEXT:        * _d_a += _r7;
 //CHECK-NEXT:        double _r8 = _t8 * _r4;
 //CHECK-NEXT:        _d__d_a += _r8;
 //CHECK-NEXT:        double _r9 = _t9 * 1;
-//CHECK-NEXT:        _result[0UL] += _r9;
+//CHECK-NEXT:        * _d_a += _r9;
 //CHECK-NEXT:        double _r10 = 1 * _t11;
 //CHECK-NEXT:        _d__t0 += _r10;
 //CHECK-NEXT:        double _r11 = _t12 * 1;
@@ -182,13 +181,13 @@ void f_cubed_add1_darg1_grad(double a, double b, double *_result);
 //CHECK-NEXT:        double _r13 = _r12 * _t14;
 //CHECK-NEXT:        _d__d_b += _r13;
 //CHECK-NEXT:        double _r14 = _t15 * _r12;
-//CHECK-NEXT:        _result[1UL] += _r14;
+//CHECK-NEXT:        * _d_b += _r14;
 //CHECK-NEXT:        double _r15 = _r12 * _t16;
-//CHECK-NEXT:        _result[1UL] += _r15;
+//CHECK-NEXT:        * _d_b += _r15;
 //CHECK-NEXT:        double _r16 = _t17 * _r12;
 //CHECK-NEXT:        _d__d_b += _r16;
 //CHECK-NEXT:        double _r17 = _t18 * 1;
-//CHECK-NEXT:        _result[1UL] += _r17;
+//CHECK-NEXT:        * _d_b += _r17;
 //CHECK-NEXT:        double _r18 = 1 * _t19;
 //CHECK-NEXT:        _d__t1 += _r18;
 //CHECK-NEXT:        double _r19 = _t20 * 1;
@@ -196,37 +195,35 @@ void f_cubed_add1_darg1_grad(double a, double b, double *_result);
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _r2 = _d__t1 * _t2;
-//CHECK-NEXT:        _result[1UL] += _r2;
+//CHECK-NEXT:        * _d_b += _r2;
 //CHECK-NEXT:        double _r3 = _t3 * _d__t1;
-//CHECK-NEXT:        _result[1UL] += _r3;
+//CHECK-NEXT:        * _d_b += _r3;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _r0 = _d__t0 * _t0;
-//CHECK-NEXT:        _result[0UL] += _r0;
+//CHECK-NEXT:        * _d_a += _r0;
 //CHECK-NEXT:        double _r1 = _t1 * _d__t0;
-//CHECK-NEXT:        _result[0UL] += _r1;
+//CHECK-NEXT:        * _d_a += _r1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
-
-
-void f_cubed_add1_hessian(double a, double b, double *hessianMatrix);
-//CHECK: void f_cubed_add1_hessian(double a, double b, double *hessianMatrix) __attribute__((always_inline)) {
-//CHECK-NEXT:    f_cubed_add1_darg0_grad(a, b, &hessianMatrix[0UL]);
-//CHECK-NEXT:    f_cubed_add1_darg1_grad(a, b, &hessianMatrix[2UL]);
+void f_cubed_add1_hessian(double a, double b, clad::array_ref<double> hessianMatrix);
+//CHECK: void f_cubed_add1_hessian(double a, double b, clad::array_ref<double> hessianMatrix) __attribute__((always_inline)) {
+//CHECK-NEXT:    f_cubed_add1_darg0_grad(a, b, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+//CHECK-NEXT:    f_cubed_add1_darg1_grad(a, b, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
 //CHECK-NEXT: }
 
 double f_suvat1(double u, double t) {
   return ((u * t) + ((0.5) * (9.81) * (t * t)));
 }
 
-void f_suvat1_darg0_grad(double u, double t, double *_result);
-void f_suvat1_darg1_grad(double u, double t, double *_result);
+void f_suvat1_darg0_grad(double u, double t, clad::array_ref<double> _d_u, clad::array_ref<double> _d_t);
+void f_suvat1_darg1_grad(double u, double t, clad::array_ref<double> _d_u, clad::array_ref<double> _d_t);
 
-void f_suvat1_hessian(double u, double t, double *hessianMatrix);
-//CHECK:void f_suvat1_hessian(double u, double t, double *hessianMatrix) {
-//CHECK-NEXT:    f_suvat1_darg0_grad(u, t, &hessianMatrix[0UL]);
-//CHECK-NEXT:    f_suvat1_darg1_grad(u, t, &hessianMatrix[2UL]);
+void f_suvat1_hessian(double u, double t, clad::array_ref<double> hessianMatrix);
+//CHECK:void f_suvat1_hessian(double u, double t, clad::array_ref<double> hessianMatrix) {
+//CHECK-NEXT:    f_suvat1_darg0_grad(u, t, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+//CHECK-NEXT:    f_suvat1_darg1_grad(u, t, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
 //CHECK-NEXT:}
 
 double f_cond3(double x, double c) {
@@ -238,24 +235,24 @@ double f_cond3(double x, double c) {
   }
 }
 
-void f_cond3_darg0_grad(double x, double c, double *_result);
-void f_cond3_darg1_grad(double x, double c, double *_result);
+void f_cond3_darg0_grad(double x, double c, clad::array_ref<double> _d_x, clad::array_ref<double> _d_c);
+void f_cond3_darg1_grad(double x, double c, clad::array_ref<double> _d_x, clad::array_ref<double> _d_c);
 
-void f_cond3_hessian(double x, double c, double *hessianMatrix);
-//CHECK:void f_cond3_hessian(double x, double c, double *hessianMatrix) {
-//CHECK-NEXT:    f_cond3_darg0_grad(x, c, &hessianMatrix[0UL]);
-//CHECK-NEXT:    f_cond3_darg1_grad(x, c, &hessianMatrix[2UL]);
+void f_cond3_hessian(double x, double c, clad::array_ref<double> hessianMatrix);
+//CHECK:void f_cond3_hessian(double x, double c, clad::array_ref<double> hessianMatrix) {
+//CHECK-NEXT:    f_cond3_darg0_grad(x, c, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+//CHECK-NEXT:    f_cond3_darg1_grad(x, c, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
 //CHECK-NEXT:}
 
 double f_power10(double x) {
   return x * x * x * x * x * x * x * x * x * x;
 }
 
-void f_power10_darg0_grad(double x, double *_result);
+void f_power10_darg0_grad(double x, clad::array_ref<double> _d_x);
 
-void f_power10_hessian(double x, double *hessianMatrix);
-//CHECK: void f_power10_hessian(double x, double *hessianMatrix) {
-//CHECK-NEXT:     f_power10_darg0_grad(x, &hessianMatrix[0UL]);
+void f_power10_hessian(double x, clad::array_ref<double> hessianMatrix);
+//CHECK: void f_power10_hessian(double x, clad::array_ref<double> hessianMatrix) {
+//CHECK-NEXT:     f_power10_darg0_grad(x, hessianMatrix.slice(0UL, 1UL));
 //CHECK-NEXT: }
 
 struct Experiment {
@@ -265,13 +262,19 @@ struct Experiment {
     return i*i*j + j*j*i;
   }
 
-  void someMethod_darg0_grad(double i, double j, double *_result);
-  void someMethod_darg1_grad(double i, double j, double *_result);
+  void someMethod_darg0_grad(double i,
+                             double j,
+                             clad::array_ref<double> _d_i,
+                             clad::array_ref<double> _d_j);
+  void someMethod_darg1_grad(double i,
+                             double j,
+                             clad::array_ref<double> _d_i,
+                             clad::array_ref<double> _d_j);
 
-  void someMethod_hessian(double x, double *hessianMatrix);
-  // CHECK:void someMethod_hessian(double i, double j, double *hessianMatrix) {
-  // CHECK-NEXT:  this->someMethod_darg0_grad(i, j, &hessianMatrix[0UL]);
-  // CHECK-NEXT:  this->someMethod_darg1_grad(i, j, &hessianMatrix[2UL]);
+  void someMethod_hessian(double x, clad::array_ref<double> hessianMatrix);
+  // CHECK:void someMethod_hessian(double i, double j, clad::array_ref<double> hessianMatrix) {
+  // CHECK-NEXT:  this->someMethod_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+  // CHECK-NEXT:  this->someMethod_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
   // CHECK-NEXT:}
 };
 
@@ -282,13 +285,21 @@ struct Widget {
     return x*y*i*j;
   }
 
-  void memFn_1_darg0_grad(double i, double j, double *_result);
-  void memFn_1_darg1_grad(double i, double j, double *_result);
-  
-  void memFn_1_hessian(double i, double j, double *hessianMatrix);
-  // CHECK: void memFn_1_hessian(double i, double j, double *hessianMatrix) {
-  // CHECK-NEXT:     this->memFn_1_darg0_grad(i, j, &hessianMatrix[0UL]);
-  // CHECK-NEXT:     this->memFn_1_darg1_grad(i, j, &hessianMatrix[2UL]);
+  void memFn_1_darg0_grad(double i,
+                          double j,
+                          clad::array_ref<double> _d_i,
+                          clad::array_ref<double> _d_j);
+  void memFn_1_darg1_grad(double i,
+                          double j,
+                          clad::array_ref<double> _d_i,
+                          clad::array_ref<double> _d_j);
+
+  void memFn_1_hessian(double i,
+                       double j,
+                       clad::array_ref<double> hessianMatrix);
+  // CHECK: void memFn_1_hessian(double i, double j, clad::array_ref<double> hessianMatrix) {
+  // CHECK-NEXT:     this->memFn_1_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+  // CHECK-NEXT:     this->memFn_1_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
   // CHECK-NEXT: }
 
   double memFn_2(double i, double j) {
@@ -297,13 +308,21 @@ struct Widget {
     return b*y*y*i;
   }
 
-  void memFn_2_darg0_grad(double i, double j, double *_result);
-  void memFn_2_darg1_grad(double i, double j, double *_result);
-  
-  void memFn_2_hessian(double i, double j, double *hessianMatrix);
-  // CHECK: void memFn_2_hessian(double i, double j, double *hessianMatrix) {
-  // CHECK-NEXT:     this->memFn_2_darg0_grad(i, j, &hessianMatrix[0UL]);
-  // CHECK-NEXT:     this->memFn_2_darg1_grad(i, j, &hessianMatrix[2UL]);
+  void memFn_2_darg0_grad(double i,
+                          double j,
+                          clad::array_ref<double> _d_i,
+                          clad::array_ref<double> _d_j);
+  void memFn_2_darg1_grad(double i,
+                          double j,
+                          clad::array_ref<double> _d_i,
+                          clad::array_ref<double> _d_j);
+
+  void memFn_2_hessian(double i,
+                       double j,
+                       clad::array_ref<double> hessianMatrix);
+  // CHECK: void memFn_2_hessian(double i, double j, clad::array_ref<double> hessianMatrix) {
+  // CHECK-NEXT:     this->memFn_2_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+  // CHECK-NEXT:     this->memFn_2_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
   // CHECK-NEXT: }
 };
 
@@ -316,26 +335,40 @@ struct Widget {
   F##_darg0_grad(x, result);\
 }
 
-#define TEST2(F, x, y) { \
-  result[0] = 0; result[1] = 0;; result[2] = 0; result[3] = 0;\
-  auto h = clad::hessian(F);\
-  h.execute(x, y, result);\
-  printf("Result is = {%.2f, %.2f, %.2f, %.2f}\n", result[0], result[1], result[2], result[3]); \
-  F##_darg0_grad(x, y, result);\
-  F##_darg1_grad(x, y, result);\
-  F##_hessian(x, y, result);\
+#define TEST2(F, x, y)                                                         \
+  {                                                                            \
+    result[0] = 0;                                                             \
+    result[1] = 0;                                                             \
+    result[2] = 0;                                                             \
+    result[3] = 0;                                                             \
+    auto h = clad::hessian(F);                                                 \
+    h.execute(x, y, result_ref4);                                              \
+    printf("Result is = {%.2f, %.2f, %.2f, %.2f}\n",                           \
+           result[0],                                                          \
+           result[1],                                                          \
+           result[2],                                                          \
+           result[3]);                                                         \
+    F##_darg0_grad(x, y, &result[0], &result[1]);                              \
+    F##_darg1_grad(x, y, &result[2], &result[3]);                              \
+    F##_hessian(x, y, result_ref4);                                            \
 }
 
 #define TEST3(F, Obj, ...) { \
   result[0]=result[1]=result[2]=result[3]=0;\
   auto h = clad::hessian(F);\
-  h.execute(Obj, __VA_ARGS__, result);\
-  printf("Result is = {%.2f, %.2f, %.2f, %.2f}\n", result[0], result[1], result[2], result[3]);\
+  h.execute(Obj, __VA_ARGS__, result_ref4);\
+  printf("Result is = {%.2f, %.2f, %.2f, %.2f}\n", \
+         result[0],          \
+         result[1],          \
+         result[2],          \
+         result[3]);\
 }
-  
+
 
 int main() {
   double result[10];
+  clad::array_ref<double> result_ref4(result, 4);
+
   TEST2(f_cubed_add1, 1, 2); // CHECK-EXEC: Result is = {6.00, 0.00, 0.00, 12.00}
   TEST2(f_suvat1, 1, 2); // CHECK-EXEC: Result is = {0.00, 1.00, 1.00, 9.81}
   TEST2(f_cond3, 5, -2); // CHECK-EXEC: Result is = {30.00, 0.00, 0.00, 12.00}

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -14,19 +14,19 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:     return _d_i * j + i * _d_j;
 // CHECK-NEXT: }
 
-// CHECK: void nonMemFn_darg0_grad(double i, double j, double *_result) {
+// CHECK: void nonMemFn_darg0_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
 // CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _d__d_j = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     double _t3;
-// CHECK-NEXT:     double _d_i = 1;
-// CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     _t1 = _d_i;
+// CHECK-NEXT:     double _d_i0 = 1;
+// CHECK-NEXT:     double _d_j0 = 0;
+// CHECK-NEXT:     _t1 = _d_i0;
 // CHECK-NEXT:     _t0 = j;
 // CHECK-NEXT:     _t3 = i;
-// CHECK-NEXT:     _t2 = _d_j;
+// CHECK-NEXT:     _t2 = _d_j0;
 // CHECK-NEXT:     double nonMemFn_darg0_return = _t1 * _t0 + _t3 * _t2;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
@@ -34,9 +34,9 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
 // CHECK-NEXT:         _d__d_i += _r0;
 // CHECK-NEXT:         double _r1 = _t1 * 1;
-// CHECK-NEXT:         _result[1UL] += _r1;
+// CHECK-NEXT:         * _d_j += _r1;
 // CHECK-NEXT:         double _r2 = 1 * _t2;
-// CHECK-NEXT:         _result[0UL] += _r2;
+// CHECK-NEXT:         * _d_i += _r2;
 // CHECK-NEXT:         double _r3 = _t3 * 1;
 // CHECK-NEXT:         _d__d_j += _r3;
 // CHECK-NEXT:     }
@@ -48,19 +48,19 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:     return _d_i * j + i * _d_j;
 // CHECK-NEXT: }
 
-// CHECK: void nonMemFn_darg1_grad(double i, double j, double *_result) {
+// CHECK: void nonMemFn_darg1_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
 // CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _d__d_j = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     double _t3;
-// CHECK-NEXT:     double _d_i = 0;
-// CHECK-NEXT:     double _d_j = 1;
-// CHECK-NEXT:     _t1 = _d_i;
+// CHECK-NEXT:     double _d_i0 = 0;
+// CHECK-NEXT:     double _d_j0 = 1;
+// CHECK-NEXT:     _t1 = _d_i0;
 // CHECK-NEXT:     _t0 = j;
 // CHECK-NEXT:     _t3 = i;
-// CHECK-NEXT:     _t2 = _d_j;
+// CHECK-NEXT:     _t2 = _d_j0;
 // CHECK-NEXT:     double nonMemFn_darg1_return = _t1 * _t0 + _t3 * _t2;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
@@ -68,22 +68,22 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
 // CHECK-NEXT:         _d__d_i += _r0;
 // CHECK-NEXT:         double _r1 = _t1 * 1;
-// CHECK-NEXT:         _result[1UL] += _r1;
+// CHECK-NEXT:         * _d_j += _r1;
 // CHECK-NEXT:         double _r2 = 1 * _t2;
-// CHECK-NEXT:         _result[0UL] += _r2;
+// CHECK-NEXT:         * _d_i += _r2;
 // CHECK-NEXT:         double _r3 = _t3 * 1;
 // CHECK-NEXT:         _d__d_j += _r3;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void nonMemFn_hessian(double i, double j, double *hessianMatrix) {
-// CHECK-NEXT:     nonMemFn_darg0_grad(i, j, &hessianMatrix[0UL]);
-// CHECK-NEXT:     nonMemFn_darg1_grad(i, j, &hessianMatrix[2UL]);
+// CHECK: void nonMemFn_hessian(double i, double j, clad::array_ref<double> hessianMatrix) {
+// CHECK-NEXT:     nonMemFn_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+// CHECK-NEXT:     nonMemFn_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
 // CHECK-NEXT: }
 
 #define NON_MEM_FN_TEST(var)\
 res[0]=res[1]=res[2]=res[3]=0;\
-var.execute(3, 4, res);\
+var.execute(3, 4, res_ref);\
 printf("{%.2f %.2f %.2f %.2f}\n", res[0], res[1], res[2], res[3]);
 
 int main() {
@@ -94,6 +94,7 @@ int main() {
   auto nonMemFnIndirectIndirectPtr = nonMemFnIndirectPtr;
 
   double res[4];
+  clad::array_ref<double> res_ref(res, 4);
 
   auto d_nonMemFn = clad::hessian(nonMemFn);
   auto d_nonMemFnPar = clad::hessian((nonMemFn));

--- a/test/NestedCalls/NestedCalls.C
+++ b/test/NestedCalls/NestedCalls.C
@@ -37,7 +37,7 @@ double f(double x, double y) {
 //CHECK-NEXT:       return _d_t * y + t * _d_y;
 //CHECK-NEXT:   }
 
-//CHECK:   void sq_grad(double x, double *_result) {
+//CHECK:   void sq_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t1 = x;
@@ -47,29 +47,13 @@ double f(double x, double y) {
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           double _r1 = _t1 * 1;
-//CHECK-NEXT:           _result[0UL] += _r1;
+//CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-//CHECK:   void sq_grad(double x, double *_result) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       _t1 = x;
-//CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       double sq_return = _t1 * _t0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           _result[0UL] += _r0;
-//CHECK-NEXT:           double _r1 = _t1 * 1;
-//CHECK-NEXT:           _result[0UL] += _r1;
-//CHECK-NEXT:       }
-//CHECK-NEXT:   }
-
-//CHECK:   void one_grad(double x, double *_result) {
+//CHECK:   void one_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -82,20 +66,20 @@ double f(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _grad0[1] = {};
-//CHECK-NEXT:           sq_grad(_t1, _grad0);
-//CHECK-NEXT:           double _r0 = 1 * _grad0[0UL];
+//CHECK-NEXT:           double _grad0 = 0.;
+//CHECK-NEXT:           sq_grad(_t1, &_grad0);
+//CHECK-NEXT:           double _r0 = 1 * _grad0;
 //CHECK-NEXT:           double _r1 = _r0 * custom_derivatives::sin_darg0(_t0);
-//CHECK-NEXT:           _result[0UL] += _r1;
-//CHECK-NEXT:           double _grad1[1] = {};
-//CHECK-NEXT:           sq_grad(_t3, _grad1);
-//CHECK-NEXT:           double _r2 = 1 * _grad1[0UL];
+//CHECK-NEXT:           * _d_x += _r1;
+//CHECK-NEXT:           double _grad1 = 0.;
+//CHECK-NEXT:           sq_grad(_t3, &_grad1);
+//CHECK-NEXT:           double _r2 = 1 * _grad1;
 //CHECK-NEXT:           double _r3 = _r2 * custom_derivatives::cos_darg0(_t2);
-//CHECK-NEXT:           _result[0UL] += _r3;
+//CHECK-NEXT:           * _d_x += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-//CHECK:   void f_grad(double x, double y, double *_result) {
+//CHECK:   void f_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double _t1;
@@ -111,13 +95,13 @@ double f(double x, double y) {
 //CHECK-NEXT:           double _r1 = 1 * _t1;
 //CHECK-NEXT:           _d_t += _r1;
 //CHECK-NEXT:           double _r2 = _t2 * 1;
-//CHECK-NEXT:           _result[1UL] += _r2;
+//CHECK-NEXT:           * _d_y += _r2;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _grad0[1] = {};
-//CHECK-NEXT:           one_grad(_t0, _grad0);
-//CHECK-NEXT:           double _r0 = _d_t * _grad0[0UL];
-//CHECK-NEXT:           _result[0UL] += _r0;
+//CHECK-NEXT:           double _grad0 = 0.;
+//CHECK-NEXT:           one_grad(_t0, &_grad0);
+//CHECK-NEXT:           double _r0 = _d_t * _grad0;
+//CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -128,7 +112,7 @@ int main () { // expected-no-diagnostics
    
   auto gradf = clad::gradient(f);
   double result[2] = {};
-  gradf.execute(2, 3, result);
+  gradf.execute(2, 3, &result[0], &result[1]);
   printf("{%.2f, %.2f}\n", result[0], result[1]); // CHECK-EXEC: {0.00, 1.00}
   return 0;
 }

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -25,8 +25,8 @@ Double_t TFormula_example(Double_t* x, Double_t* p) {
 }
 // _grad = { x[0] + (-1) * Exp_darg0(-p[0]), x[0] + Abs_darg0(p[1]), x[0] }
 
-void TFormula_example_grad(Double_t *x, Double_t *p, Double_t *_result);
-//CHECK:   void TFormula_example_grad(Double_t *x, Double_t *p, Double_t *_result) {
+void TFormula_example_grad_1(Double_t* x, Double_t* p, Double_t* _d_p);
+//CHECK:   void TFormula_example_grad_1(Double_t *x, Double_t *p, clad::array_ref<Double_t> _d_p) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       Double_t _t1;
 //CHECK-NEXT:       Double_t _t2;
@@ -41,13 +41,13 @@ void TFormula_example_grad(Double_t *x, Double_t *p, Double_t *_result);
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = _t1 * 1;
-//CHECK-NEXT:           _result[0] += _r1;
-//CHECK-NEXT:           _result[1] += _r1;
-//CHECK-NEXT:           _result[2] += _r1;
+//CHECK-NEXT:           _d_p[0] += _r1;
+//CHECK-NEXT:           _d_p[1] += _r1;
+//CHECK-NEXT:           _d_p[2] += _r1;
 //CHECK-NEXT:           Double_t _r2 = 1 * custom_derivatives::Exp_darg0(_t2);
-//CHECK-NEXT:           _result[0] += -_r2;
+//CHECK-NEXT:           _d_p[0] += -_r2;
 //CHECK-NEXT:           Double_t _r3 = 1 * custom_derivatives::Abs_darg0(_t3);
-//CHECK-NEXT:           _result[1] += _r3;
+//CHECK-NEXT:           _d_p[1] += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -74,7 +74,7 @@ int main() {
   Double_t p[] = { -std::log(2), -1, 3 };
   Double_t result[3] = { 0 };
 
-  auto gradient = clad::gradient(TFormula_example);
+  auto gradient = clad::gradient(TFormula_example, "p");
   gradient.execute(x, p, result);
   printf("Result is = {%.2f, %.2f, %.2f}\n", result[0], result[1], result[2]); // CHECK-EXEC: Result is = {1.00, 2.00, 3.00}
 

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -148,6 +148,7 @@ namespace clad {
 
       FunctionDecl* DerivativeDecl = nullptr;
       Decl* DerivativeDeclContext = nullptr;
+      FunctionDecl* OverloadedDerivativeDecl = nullptr;
       {
         // FIXME: Move the timing inside the DerivativeBuilder. This would
         // require to pass in the DifferentiationOptions in the DiffPlan.
@@ -156,8 +157,11 @@ namespace clad {
         SimpleTimer Timer(WantTiming);
         Timer.setOutput("Generation time for " + FD->getNameAsString());
 
-        std::tie(DerivativeDecl, DerivativeDeclContext) =
-          m_DerivativeBuilder->Derive(FD, request);
+        // TODO: Maybe find a better way to declare and use
+        //  OverloadedDeclWithContext
+        std::tie(DerivativeDecl, DerivativeDeclContext,
+                 OverloadedDerivativeDecl) =
+            m_DerivativeBuilder->Derive(FD, request);
       }
 
       if (DerivativeDecl) {
@@ -169,7 +173,8 @@ namespace clad {
         // If this is the last required derivative order, replace the function
         // inside a call to clad::differentiate/gradient with its derivative.
         if (request.CallUpdateRequired && lastDerivativeOrder)
-          request.updateCall(DerivativeDecl, m_CI.getSema());
+          request.updateCall(DerivativeDecl, OverloadedDerivativeDecl,
+                             m_CI.getSema());
 
         // if enabled, print source code of the derived functions
         if (m_DO.DumpDerivedFn) {


### PR DESCRIPTION
Reverse mode and hessian mode now support array diff.

The signature of the grad function has been changed. For example, if the input function has the signature:
```c++
int f(int a, int *b)
```
then the grad function for it will have the signature:
```c++
void f_grad(int a, int *b, int* _d_a, int *_d_b)
```
Reverse mode currently doesn't differentiate w.r.t individual elements of an array. If individual elements of an array are provided the whole array is differentiated instead. This is because it doesn't cost much to do the extra work but instead makes the the output more clear.

The signature of hessian function has not changed, but there are some additional requirements when differentiating arrays. The user will need to specify the index interval of the array that needs to be differentiated using the `args` param of `clad::hessian`. Eg.
```c++
double f(int a, int b[4]); 
clad::hessian(f, "a, b[0:4]")
```