### PR TITLE
Add support for differentiating functors in forward mode

### DIFF
--- a/demos/Functor.cpp
+++ b/demos/Functor.cpp
@@ -1,0 +1,47 @@
+//--------------------------------------------------------------------*- C++ -*-
+// clad - The C++ Clang-based Automatic Differentiator
+//
+// A demo, describing how to differentiate a functor (an object of class
+// type with user defined call operator)
+//
+//----------------------------------------------------------------------------//
+
+// To run the demo please type:
+// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/libclad.so  -I../include/ -x c++ -std=c++11 Functor.cpp
+//
+// A typical invocation would be:
+// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
+// -I../include/ -x c++ -std=c++11 Functor.cpp
+
+// Necessary for clad to work include
+#include "clad/Differentiator/Differentiator.h"
+
+class Equation {
+  double m_x, m_y;
+
+  public:
+  Equation(double x, double y) : m_x(x), m_y(y) {}
+  double operator()(double i, double j) {
+    return m_x*i*j; + m_y*i*j;
+  }
+};
+
+int main() {
+  Equation E(3, 5);
+  
+  // Functor object can be passed in 2 ways:
+
+  // 1) by reference
+  auto d_E = clad::differentiate(E, "i");
+
+  // 2) as pointer
+  auto d_E_pointer = clad::differentiate(&E, "i");
+
+  // no need to explicitly pass functor object as the first argument.
+  double res1 = d_E.execute(7, 9);
+  double res2 = d_E_pointer.execute(7, 9);
+
+  printf("%.2f %.2f", res1, res2);
+}

--- a/demos/Functor.cpp
+++ b/demos/Functor.cpp
@@ -36,19 +36,59 @@ int main() {
   Equation E(3, 5);
 
   // Functor is an object of any type which have user defined call operator.
+  //
   // Clad differentiation functions can directly differentiate functors.
-  // Functors can be passed to clad differentiation functions in two distinct ways:
+  // Functors can be passed to clad differentiation functions in two distinct
+  // ways:
 
   // 1) Pass by reference
   // differentiates `E` wrt parameter `i`
+  // object `E` is saved in the `CladFunction` object `d_E`
   auto d_E = clad::differentiate(E, "i");
 
   // 2) Pass as pointers
   // differentiates `E` wrt parameter `i`
+  // object `E` is saved in the `CladFunction` object `d_E_pointer`
   auto d_E_pointer = clad::differentiate(&E, "i");
 
   // calculate differentiation of `E` when (i, j) = (7, 9)
   double res1 = d_E.execute(7, 9);
   double res2 = d_E_pointer.execute(7, 9);
+  printf("%.2f %.2f", res1, res2);
+
+  Equation AnotherE(11, 13);
+
+  // If differentiation of `E` is not needed, then `d_E` and `d_E_pointer` can
+  // be reused for computing differentiation of another functor of the same
+  // type by modifying the saved object in `CladFunction`. This can save
+  // computation time.
+  d_E.setObject(&AnotherE);
+  d_E_pointer.setObject(&AnotherE);
+
+  // calculate differentiation of `AnotherE` when (i, j) = (7, 9)
+  res1 = d_E.execute(7, 9);
+  res2 = d_E_pointer.execute(7, 9);
+  printf("%.2f %.2f", res1, res2);
+
+  // Differentiation of any other functor of the same type can also be computed
+  // without changing the saved object in `CladFunction` object by explicitly
+  // passing the functor as the first argument while calling
+  // `CladFunction::execute`.
+  // Calculates differentiation of `E` when (i, j) = (7, 9)
+  res1 = d_E.execute(E, 7, 9);
+  res2 = d_E_pointer.execute(E, 7, 9);
+  printf("%.2f %.2f", res1, res2);
+
+  // Saved object in `CladFunction` object can be removed using
+  // `CladFunction::clearObject`
+  d_E.clearObject();
+  d_E_pointer.clearObject();
+
+  // Now it is necessary to explicitly pass the functor object while calling
+  // `CladFunction::execute`, since no saved object is available.
+  // Calculates differentiation of `E` when (i, j) = (7, 9)
+  res1 = d_E.execute(E, 7, 9);
+  // Calculates differentiation of `AnotherE` when (i, j) = (7, 9)
+  res2 = d_E_pointer.execute(AnotherE, 7, 9);
   printf("%.2f %.2f", res1, res2);
 }

--- a/demos/Functor.cpp
+++ b/demos/Functor.cpp
@@ -18,6 +18,7 @@
 // Necessary for clad to work include
 #include "clad/Differentiator/Differentiator.h"
 
+// A class type with user-defined call operator
 class Equation {
   double m_x, m_y;
 
@@ -26,22 +27,28 @@ class Equation {
   double operator()(double i, double j) {
     return m_x*i*j; + m_y*i*j;
   }
+  void setX(double x) {
+    m_x = x;
+  }
 };
 
 int main() {
   Equation E(3, 5);
-  
-  // Functor object can be passed in 2 ways:
 
-  // 1) by reference
+  // Functor is an object of any type which have user defined call operator.
+  // Clad differentiation functions can directly differentiate functors.
+  // Functors can be passed to clad differentiation functions in two distinct ways:
+
+  // 1) Pass by reference
+  // differentiates `E` wrt parameter `i`
   auto d_E = clad::differentiate(E, "i");
 
-  // 2) as pointer
+  // 2) Pass as pointers
+  // differentiates `E` wrt parameter `i`
   auto d_E_pointer = clad::differentiate(&E, "i");
 
-  // no need to explicitly pass functor object as the first argument.
+  // calculate differentiation of `E` when (i, j) = (7, 9)
   double res1 = d_E.execute(7, 9);
   double res2 = d_E_pointer.execute(7, 9);
-
   printf("%.2f %.2f", res1, res2);
 }

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -157,10 +157,9 @@ namespace clad {
     }
     /// Constructor overload for initializing `m_Functor` when functor
     /// is passed by reference.
-    // ! Please confirm if `CUDA_HOST_DEVICE` should be added in the constructor overload.
     CUDA_HOST_DEVICE
     CladFunction(CladFunctionType f, const char* code, FunctorType& functor)
-        : CladFunction(f, code, &functor){};
+        : CladFunction(f, code, &functor) {};
 
     // Intentionally leak m_Code, otherwise we have to link against c++ runtime,
     // i.e -lstdc++.
@@ -209,7 +208,7 @@ namespace clad {
   /// please see `clad::gradient`. 
   /// \param[in] fn function to differentiate 
   /// \param[in] args independent parameter information 
-  /// \return `CladFunction` object to access the corresponding derived function.
+  /// \returns `CladFunction` object to access the corresponding derived function.
   template <unsigned N = 1,
             typename ArgSpec = const char*,
             typename F,

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -72,14 +72,15 @@ namespace clad {
   /// Helper function for executing non-member derived functions.
   /// RedundantType is only present to keep signature same as of execute_helper
   /// member function counterpart.
-  template<class F, class RedundantType, class... Args> 
-  return_type_t<F> execute_helper(F f, RedundantType* redundant, Args&&... args) {
-      return f(static_cast<Args>(args)... );
+  template <class F, class RedundantType, class... Args>
+  return_type_t<F>
+  execute_helper(F f, RedundantType* redundant, Args&&... args) {
+    return f(static_cast<Args>(args)...);
   }
 
   /// Helper functions for executing member derived functions.
-  /// If user have passed object explicitly, then this specialization will be used and 
-  /// derived fn will be called through the passed object.
+  /// If user have passed object explicitly, then this specialization will be
+  /// used and derived fn will be called through the passed object.
   template <class ReturnType,
             class C,
             class FunctorType,
@@ -97,8 +98,9 @@ namespace clad {
     return (static_cast<Obj>(obj).*f)(static_cast<Args>(args)...);
   }
 
-  // If user have not passed object explicitly, then this specialization will be used
-  // and derived fn will be called through the object saved in `CladFunction`.
+  /// If user have not passed object explicitly, then this specialization will
+  /// be used and derived fn will be called through the object saved in
+  /// `CladFunction`.
   template <class ReturnType,
             class C,
             class FunctorType,
@@ -108,6 +110,8 @@ namespace clad {
             class... Args>
   auto execute_helper(ReturnType C::*f, FunctorType* functor, Args&&... args)
       -> return_type_t<decltype(f)> {
+    assert(functor && "No default object set, explicitly pass an object to "
+                      "CladFunction::execute");
     return (functor->*f)(static_cast<Args>(args)...);
   }
 
@@ -118,7 +122,8 @@ namespace clad {
   /// const correctness of functor types.
   /// Default value of `Functor` here is temporary, and should be removed once all
   /// clad differentiation functions support differentiating functors.
-  template <typename F, typename FunctorT = ExtractFunctorTraits_t<F>> class CladFunction {
+  template <typename F, typename FunctorT = ExtractFunctorTraits_t<F>>
+  class CladFunction {
   public:
     using CladFunctionType = F;
     using FunctorType = FunctorT;
@@ -196,13 +201,14 @@ namespace clad {
   // This will be useful in fucture when we are ready to support partial diff.
   //
 
-  /// \brief Differentiates function using forward mode.
+  /// Differentiates function using forward mode.
   ///
-  /// Performs partial differentiation of the `fn` argument using forward mode wrt
-  /// parameter specified in `args`. To differentiate `fn` wrt several parameters, 
-  /// please see `clad::gradient`.
-  /// \param[in] fn function to differentiate
-  /// \param[in] args independent parameter information
+  /// Performs partial differentiation of the `fn` argument using forward mode
+  /// wrt parameter specified in `args`. Template parameter `N` denotes
+  /// the derivative order. To differentiate `fn` wrt several parameters,
+  /// please see `clad::gradient`. 
+  /// \param[in] fn function to differentiate 
+  /// \param[in] args independent parameter information 
   /// \return `CladFunction` object to access the corresponding derived function.
   template <unsigned N = 1,
             typename ArgSpec = const char*,
@@ -210,13 +216,15 @@ namespace clad {
             typename DerivedFnType = ExtractDerivedFnTraitsForwMode_t<F>,
             typename = typename std::enable_if<
                 !std::is_class<remove_reference_and_pointer_t<F>>::value>::type>
-  CladFunction<DerivedFnType, ExtractFunctorTraits_t<F>> __attribute__((annotate("D")))
+  CladFunction<DerivedFnType, ExtractFunctorTraits_t<F>> __attribute__((
+      annotate("D")))
   differentiate(F fn,
                 ArgSpec args = "",
                 DerivedFnType derivedFn = static_cast<DerivedFnType>(nullptr),
                 const char* code = "") {
     assert(fn && "Must pass in a non-0 argument");
-    return CladFunction<DerivedFnType, ExtractFunctorTraits_t<F>>(derivedFn, code);
+    return CladFunction<DerivedFnType, ExtractFunctorTraits_t<F>>(derivedFn,
+                                                                  code);
   }
 
   /// Specialization for differentiating functors.

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -75,6 +75,7 @@ namespace clad {
   template <class F, class RedundantType, class... Args>
   return_type_t<F>
   execute_helper(F f, RedundantType* redundant, Args&&... args) {
+    // `static_cast` is required here for perfect forwarding.
     return f(static_cast<Args>(args)...);
   }
 
@@ -95,6 +96,7 @@ namespace clad {
                       FunctorType* functor,
                       Obj&& obj,
                       Args&&... args) -> return_type_t<decltype(f)> {
+    // `static_cast` is required here for perfect forwarding.                       
     return (static_cast<Obj>(obj).*f)(static_cast<Args>(args)...);
   }
 
@@ -112,6 +114,7 @@ namespace clad {
       -> return_type_t<decltype(f)> {
     assert(functor && "No default object set, explicitly pass an object to "
                       "CladFunction::execute");
+    // `static_cast` is required here for perfect forwarding.
     return (functor->*f)(static_cast<Args>(args)...);
   }
 

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -208,6 +208,23 @@ namespace clad {
     void dump() const {
       printf("The code is: %s\n", getCode());
     }
+
+    /// Set object pointed by the functor as the default object for
+    /// executing derived member function.
+    void setObject(FunctorType* functor) {
+      m_Functor = functor;
+    } 
+
+    /// Set functor object as the default object for executing derived
+    // member function.
+    void setObject(FunctorType& functor) {
+      m_Functor = &functor;
+    }
+
+    /// Clears default object (if any) for executing derived member function.
+    void clearObject() {
+      m_Functor = nullptr;
+    }
   };
 
   // This is the function which will be instantiated with the concrete arguments

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -120,8 +120,8 @@ namespace clad {
   // 'normal' use of std::{function,mem_fn} from the ones we must differentiate.
   /// Explicitly passing `FunctorT` type is necessary for maintaining 
   /// const correctness of functor types.
-  /// Default value of `Functor` here is temporary, and should be removed once all
-  /// clad differentiation functions support differentiating functors.
+  /// Default value of `Functor` here is temporary, and should be removed 
+  /// once all clad differentiation functions support differentiating functors.
   template <typename F, typename FunctorT = ExtractFunctorTraits_t<F>>
   class CladFunction {
   public:

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -1,5 +1,6 @@
 #ifndef FUNCTION_TRAITS
 #define FUNCTION_TRAITS
+#include <type_traits>
 
 namespace clad {
 
@@ -349,6 +350,159 @@ namespace clad {
     using type = void (C::*)(Args..., ReturnType*) const volatile&& noexcept;
   };
 #endif
+
+  /**
+   * \brief Utility type trait to remove both reference and pointer
+   * from type `T`.
+   * 
+   * First removes any reference qualifier associated with `T`, 
+   * then removes any associated pointer. Resulting type is provided 
+   * as member typedef `type`.
+   */
+  template <typename T> struct remove_reference_and_pointer {
+    using type = typename std::remove_pointer<
+        typename std::remove_reference<T>::type>::type;
+  };
+
+  /**
+   * \brief Helper type for remove_reference_and_pointer.
+   */
+  template <typename T>
+  using remove_reference_and_pointer_t =
+      typename remove_reference_and_pointer<T>::type;
+
+  /** 
+   * \brief Check whether class 'C` defines call operator. Provides the member 
+   * constant `value` which is equal to true, if class defines call operator.
+   * Otherwise `value` is equal to false.
+   * 
+   */
+  template<typename C, typename = void>
+  struct has_call_operator : std::false_type {};
+
+  template <typename C>
+  struct has_call_operator<
+      C,
+      typename std::enable_if<(sizeof(&C::operator()) > 0)>::type> : std::true_type {
+  };
+
+  /**
+  * \brief Compute type of derived function of function, method or functor when
+  * differentiated using forward differentiation mode (`clad::differentiate`).
+  * Computed type is provided as member typedef `type`.
+  * 
+  * More precisely, this type trait behaves as following:
+  * 
+  * - If `F` is a function pointer type 
+  *   Defines member typedef `type` same as the type of the function pointer.
+  *   
+  * - If `F` is a member function pointer type
+  *   Defines member typedef `type` same as the type of the member function pointer.
+  *   
+  * - If `F` is class type, class reference type, class pointer type, or
+  *   reference to class pointer type.
+  *   Defines member typedef `type` same as the type of the overloaded call
+  *   operator member function of the class.
+  * 
+  * - For all other cases, no member typedef `type` is provided.
+  */
+  template<class F, class = void>
+  struct ExtractDerivedFnTraitsForwMode {};
+
+  /**
+   * \brief Helper type for ExtractDerivedFnTraitsForwMode
+   * 
+   */
+  template<class F>
+  using ExtractDerivedFnTraitsForwMode_t = 
+      typename ExtractDerivedFnTraitsForwMode<F>::type;
+
+  /// Specialization for free function pointer type
+  template <class F>
+  struct ExtractDerivedFnTraitsForwMode<
+      F*,
+      typename std::enable_if<std::is_function<F>::value>::type> {
+    using type = remove_reference_and_pointer_t<F>*;
+  };
+
+  /// Specialization for member function pointer type
+  template <class F>
+  struct ExtractDerivedFnTraitsForwMode<
+      F,
+      typename std::enable_if<std::is_member_function_pointer<F>::value>::type> {
+    using type = typename std::decay<F>::type;
+  };
+
+  /// Specialization for class types
+  template <class F>
+  struct ExtractDerivedFnTraitsForwMode<
+      F,
+      typename std::enable_if<std::is_class<remove_reference_and_pointer_t<F>>::value>::type> {
+    using ClassType = typename std::decay<remove_reference_and_pointer_t<F>>::type;
+    static_assert(has_call_operator<ClassType>::value,
+                  "Passed object do not have overloaded call operator member function");
+    using type = decltype(&ClassType::operator());
+  };
+
+  /**
+   * \brief Placeholder type for denoting no object type exists.
+   * 
+   * This is used by `ExtractFunctorTraits` type trait as value of member
+   * typedef `type` to denote no functor type exist.
+   */
+  class NoObject {};
+
+  /**
+   * \brief Compute class type from member function type, deduced type is 
+   * void if free function type is provided. If class type is provided, 
+   * then deduced type is same as that of the provided class type.
+   * 
+   * More precisely, this type trait behaves as following:
+   * 
+   * - If `F` is a function pointer type
+   *   Defines member typedef `type` as the type of class `NoObject`.
+   * 
+   * - If `F` is a memeber function pointer type
+   *   Defines member typedef `type` as the type of the corresponding class 
+   *   of the member function pointer.
+   *   
+   * - If `F` is class type, class reference type, class pointer type, or 
+   *   reference to class pointer type
+   *   Defines member typedef 'type` same as the type of the class.
+   * 
+   * - For all other cases, no member typedef `type` is provided.
+   */
+  
+  template<class F, class = void>
+  struct ExtractFunctorTraits {};
+  
+  /**
+   * \brief Helper type for ExtractFunctorTraits
+   */
+  template<class F>
+  using ExtractFunctorTraits_t = typename ExtractFunctorTraits<F>::type;
+
+  /// Specialization for free function pointer types
+  template <class F>
+  struct ExtractFunctorTraits<
+      F*,
+      typename std::enable_if<
+          std::is_function<F>::value>::type> {
+    using type = NoObject;
+  };
+
+  /// Specialization for member function pointer types
+  template <class ReturnType, class C>
+  struct ExtractFunctorTraits<ReturnType C::*, void> {
+    using type = C;
+  };
+
+  /// Specialization for class types
+  template<class F>
+  struct ExtractFunctorTraits<F, 
+      typename std::enable_if<std::is_class<remove_reference_and_pointer_t<F>>::value>::type> {
+    using type = remove_reference_and_pointer_t<F>;
+  };
 } // namespace clad
 
 #endif // FUNCTION_TRAITS

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -383,8 +383,15 @@ namespace clad {
   template <typename C>
   struct has_call_operator<
       C,
-      typename std::enable_if<(sizeof(&remove_reference_and_pointer_t<C>::operator()) > 0)>::type>
+      typename std::enable_if<(
+          sizeof(&remove_reference_and_pointer_t<C>::operator()) > 0)>::type>
       : std::true_type {};
+
+  /// Placeholder type for denoting no function type exists
+  ///
+  /// This is used by `ExtractDerivedFnTraitsForwMode` type trait as value
+  /// for member typedef `type` to denote no function type exists.
+  class NoFunction {};
 
   /// Compute type of derived function of function, method or functor when
   /// differentiated using forward differentiation mode (`clad::differentiate`).
@@ -409,13 +416,6 @@ namespace clad {
   /// This type trait is specific to forward mode differentiation since the
   /// rules for computing the signature of derived functions are different for 
   /// forward and reverse mode.
-  
-  /// Placeholder type for denoting no function type exists
-  ///
-  /// This is used by `ExtractDerivedFnTraitsForwMode` type trait as value
-  /// for member typedef `type` to denote no function type exists.
-  class NoFunction {};
-
   template <class F, class = void> struct ExtractDerivedFnTraitsForwMode {};
 
   /// Helper type for ExtractDerivedFnTraitsForwMode
@@ -448,16 +448,18 @@ namespace clad {
   struct ExtractDerivedFnTraitsForwMode<
       F,
       typename std::enable_if<
-          std::is_class<remove_reference_and_pointer_t<F>>::value && has_call_operator<F>::value>::type> {
+          std::is_class<remove_reference_and_pointer_t<F>>::value &&
+          has_call_operator<F>::value>::type> {
     using ClassType =
         typename std::decay<remove_reference_and_pointer_t<F>>::type;
     using type = decltype(&ClassType::operator());
   };
-template <class F>
+  template <class F>
   struct ExtractDerivedFnTraitsForwMode<
       F,
       typename std::enable_if<
-          std::is_class<remove_reference_and_pointer_t<F>>::value && !has_call_operator<F>::value>::type> {
+          std::is_class<remove_reference_and_pointer_t<F>>::value &&
+          !has_call_operator<F>::value>::type> {
     using type = NoFunction*;
   };
 

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -351,70 +351,58 @@ namespace clad {
   };
 #endif
 
-  /**
-   * \brief Utility type trait to remove both reference and pointer
-   * from type `T`.
-   * 
-   * First removes any reference qualifier associated with `T`, 
-   * then removes any associated pointer. Resulting type is provided 
-   * as member typedef `type`.
-   */
+  /// Utility type trait to remove both reference and pointer
+  /// from type `T`.
+  ///
+  /// First removes any reference qualifier associated with `T`,
+  /// then removes any associated pointer. Resulting type is provided
+  /// as member typedef `type`.
   template <typename T> struct remove_reference_and_pointer {
     using type = typename std::remove_pointer<
         typename std::remove_reference<T>::type>::type;
   };
 
-  /**
-   * \brief Helper type for remove_reference_and_pointer.
-   */
+  /// Helper type for remove_reference_and_pointer.
   template <typename T>
   using remove_reference_and_pointer_t =
       typename remove_reference_and_pointer<T>::type;
 
-  /** 
-   * \brief Check whether class 'C` defines call operator. Provides the member 
-   * constant `value` which is equal to true, if class defines call operator.
-   * Otherwise `value` is equal to false.
-   * 
-   */
-  template<typename C, typename = void>
+  /// Check whether class 'C` defines call operator. Provides the member
+  /// constant `value` which is equal to true, if class defines call operator.
+  /// Otherwise `value` is equal to false.
+  template <typename C, typename = void>
   struct has_call_operator : std::false_type {};
 
   template <typename C>
   struct has_call_operator<
       C,
-      typename std::enable_if<(sizeof(&C::operator()) > 0)>::type> : std::true_type {
-  };
+      typename std::enable_if<(sizeof(&C::operator()) > 0)>::type>
+      : std::true_type {};
 
-  /**
-  * \brief Compute type of derived function of function, method or functor when
-  * differentiated using forward differentiation mode (`clad::differentiate`).
-  * Computed type is provided as member typedef `type`.
-  * 
-  * More precisely, this type trait behaves as following:
-  * 
-  * - If `F` is a function pointer type 
-  *   Defines member typedef `type` same as the type of the function pointer.
-  *   
-  * - If `F` is a member function pointer type
-  *   Defines member typedef `type` same as the type of the member function pointer.
-  *   
-  * - If `F` is class type, class reference type, class pointer type, or
-  *   reference to class pointer type.
-  *   Defines member typedef `type` same as the type of the overloaded call
-  *   operator member function of the class.
-  * 
-  * - For all other cases, no member typedef `type` is provided.
-  */
-  template<class F, class = void>
-  struct ExtractDerivedFnTraitsForwMode {};
+  /// Compute type of derived function of function, method or functor when
+  /// differentiated using forward differentiation mode (`clad::differentiate`).
+  /// Computed type is provided as member typedef `type`.
+  ///
+  /// More precisely, this type trait behaves as following:
+  ///
+  /// - If `F` is a function pointer type
+  ///   Defines member typedef `type` same as the type of the function pointer.
+  ///
+  /// - If `F` is a member function pointer type
+  ///   Defines member typedef `type` same as the type of the member function
+  /// pointer.
+  ///
+  /// - If `F` is class type, class reference type, class pointer type, or
+  ///   reference to class pointer type.
+  ///   Defines member typedef `type` same as the type of the overloaded call
+  ///   operator member function of the class.
+  ///
+  /// - For all other cases, no member typedef `type` is provided.
+  template <class F, class = void> struct ExtractDerivedFnTraitsForwMode {};
 
-  /**
-   * \brief Helper type for ExtractDerivedFnTraitsForwMode
-   * 
-   */
-  template<class F>
-  using ExtractDerivedFnTraitsForwMode_t = 
+  /// Helper type for ExtractDerivedFnTraitsForwMode
+  template <class F>
+  using ExtractDerivedFnTraitsForwMode_t =
       typename ExtractDerivedFnTraitsForwMode<F>::type;
 
   /// Specialization for free function pointer type
@@ -429,7 +417,8 @@ namespace clad {
   template <class F>
   struct ExtractDerivedFnTraitsForwMode<
       F,
-      typename std::enable_if<std::is_member_function_pointer<F>::value>::type> {
+      typename std::enable_if<
+          std::is_member_function_pointer<F>::value>::type> {
     using type = typename std::decay<F>::type;
   };
 
@@ -437,57 +426,51 @@ namespace clad {
   template <class F>
   struct ExtractDerivedFnTraitsForwMode<
       F,
-      typename std::enable_if<std::is_class<remove_reference_and_pointer_t<F>>::value>::type> {
-    using ClassType = typename std::decay<remove_reference_and_pointer_t<F>>::type;
-    static_assert(has_call_operator<ClassType>::value,
-                  "Passed object do not have overloaded call operator member function");
+      typename std::enable_if<
+          std::is_class<remove_reference_and_pointer_t<F>>::value>::type> {
+    using ClassType =
+        typename std::decay<remove_reference_and_pointer_t<F>>::type;
+    static_assert(
+        has_call_operator<ClassType>::value,
+        "Passed object do not have overloaded call operator member function");
     using type = decltype(&ClassType::operator());
   };
 
-  /**
-   * \brief Placeholder type for denoting no object type exists.
-   * 
-   * This is used by `ExtractFunctorTraits` type trait as value of member
-   * typedef `type` to denote no functor type exist.
-   */
+  /// Placeholder type for denoting no object type exists.
+  ///
+  /// This is used by `ExtractFunctorTraits` type trait as value of member
+  /// typedef `type` to denote no functor type exist.
   class NoObject {};
 
-  /**
-   * \brief Compute class type from member function type, deduced type is 
-   * void if free function type is provided. If class type is provided, 
-   * then deduced type is same as that of the provided class type.
-   * 
-   * More precisely, this type trait behaves as following:
-   * 
-   * - If `F` is a function pointer type
-   *   Defines member typedef `type` as the type of class `NoObject`.
-   * 
-   * - If `F` is a memeber function pointer type
-   *   Defines member typedef `type` as the type of the corresponding class 
-   *   of the member function pointer.
-   *   
-   * - If `F` is class type, class reference type, class pointer type, or 
-   *   reference to class pointer type
-   *   Defines member typedef 'type` same as the type of the class.
-   * 
-   * - For all other cases, no member typedef `type` is provided.
-   */
-  
-  template<class F, class = void>
-  struct ExtractFunctorTraits {};
-  
-  /**
-   * \brief Helper type for ExtractFunctorTraits
-   */
-  template<class F>
+  /// Compute class type from member function type, deduced type is
+  /// void if free function type is provided. If class type is provided,
+  /// then deduced type is same as that of the provided class type.
+  ///
+  /// More precisely, this type trait behaves as following :
+  ///
+  /// - If `F` is a function pointer type
+  ///   Defines member typedef `type` as the type of class `NoObject`.
+  ///
+  /// - If `F` is a memeber function pointer type
+  ///   Defines member typedef `type` as the type of the corresponding class
+  ///   of the member function pointer.
+  ///
+  /// - If `F` is class type, class reference type, class pointer type, or
+  ///   reference to class pointer type
+  ///   Defines member typedef 'type` same as the type of the class.
+  ///
+  /// - For all other cases, no member typedef `type` is provided.
+  template <class F, class = void> struct ExtractFunctorTraits {};
+
+  /// Helper type for ExtractFunctorTraits
+  template <class F>
   using ExtractFunctorTraits_t = typename ExtractFunctorTraits<F>::type;
 
   /// Specialization for free function pointer types
   template <class F>
   struct ExtractFunctorTraits<
       F*,
-      typename std::enable_if<
-          std::is_function<F>::value>::type> {
+      typename std::enable_if<std::is_function<F>::value>::type> {
     using type = NoObject;
   };
 
@@ -498,9 +481,11 @@ namespace clad {
   };
 
   /// Specialization for class types
-  template<class F>
-  struct ExtractFunctorTraits<F, 
-      typename std::enable_if<std::is_class<remove_reference_and_pointer_t<F>>::value>::type> {
+  template <class F>
+  struct ExtractFunctorTraits<
+      F,
+      typename std::enable_if<
+          std::is_class<remove_reference_and_pointer_t<F>>::value>::type> {
     using type = remove_reference_and_pointer_t<F>;
   };
 } // namespace clad

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -398,6 +398,11 @@ namespace clad {
   ///   operator member function of the class.
   ///
   /// - For all other cases, no member typedef `type` is provided.
+  ///
+  /// This type trait is specific to forward mode differentiation since the
+  /// rules for computing the signature of derived functions are different for 
+  /// forward and reverse mode.
+  
   template <class F, class = void> struct ExtractDerivedFnTraitsForwMode {};
 
   /// Helper type for ExtractDerivedFnTraitsForwMode

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -90,6 +90,10 @@ namespace clad {
                 m_SemaRef.Diags.getCustomDiagID(DiagnosticsEngine::Level::Error,
                                                 diagFmt);
             m_SemaRef.Diag(m_Root->getBeginLoc(), diagId) << RD->getName();
+
+            // Emit diagnostics for candidate functions
+            for (auto candidateFn : LR)
+              m_SemaRef.NoteOverloadCandidate(candidateFn, cast<FunctionDecl>(candidateFn));
           }
 
           // Multiple overloads of call operators are not supported,

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -77,15 +77,15 @@ namespace clad {
           // Emit error diagnostics
           if (LR.empty()) {
             const char diagFmt[] =
-                "No call operator is defined for the class %0";
+                "'%0' has no defined operator()";
             auto diagId =
                 m_SemaRef.Diags.getCustomDiagID(DiagnosticsEngine::Level::Error,
                                                 diagFmt);
             m_SemaRef.Diag(m_Root->getBeginLoc(), diagId) << RD->getName();
           } else if (LR.size() > 1) {
             const char diagFmt[] =
-                "Class %0 defines multiple overloads of call operator. "
-                "Multiple overloads of call operators are not supported.";
+                "'%0' has multiple definitions of operator()."
+                "Multiple definitions of call operators are not supported.";
             auto diagId =
                 m_SemaRef.Diags.getCustomDiagID(DiagnosticsEngine::Level::Error,
                                                 diagFmt);
@@ -103,8 +103,8 @@ namespace clad {
           // method, to maintain consistency with member function
           // differentiation.
           CXXScopeSpec CSS;
-          CSS.Extend(/*Context=*/m_SemaRef.getASTContext(),
-                     /*Identifier=*/RD->getIdentifier(),
+          CSS.Extend(m_SemaRef.getASTContext(),
+                     RD->getIdentifier(),
                      /*IdentifierLoc=*/noLoc,
                      /*ColonColonLoc=*/noLoc);
 
@@ -112,11 +112,11 @@ namespace clad {
           // decomposed to function pointers and thus a temporary is
           // created for the function pointer.
           auto newFnDRE = clad_compat::GetResult<Expr*>(
-              m_SemaRef.BuildDeclRefExpr(/*D=*/callOperator,
-                                         /*Ty=*/callOperator->getType(),
-                                         /*VK=*/ExprValueKind::VK_RValue,
-                                         /*Loc=*/noLoc,
-                                         /*SS=*/&CSS));
+              m_SemaRef.BuildDeclRefExpr(callOperator,
+                                         callOperator->getType(),
+                                         ExprValueKind::VK_RValue,
+                                         noLoc,
+                                         &CSS));
           m_FnDRE = cast<DeclRefExpr>(newFnDRE);
 
           // Creating Unary operator to maintain consistency with
@@ -126,8 +126,8 @@ namespace clad {
                 m_SemaRef
                     .BuildUnaryOp(/*S=*/nullptr,
                                   /*OpLoc=*/noLoc,
-                                  /*Opc=*/UnaryOperatorKind::UO_AddrOf,
-                                  /*Input=*/m_FnDRE)
+                                  UnaryOperatorKind::UO_AddrOf,
+                                  m_FnDRE)
                     .get();
             *m_RelevantAncestor = newUnOp;
           }

--- a/test/ForwardMode/FunctorErrors.C
+++ b/test/ForwardMode/FunctorErrors.C
@@ -18,16 +18,15 @@ struct ExperimentMultipleCallOperators {
   }
 };
 
-struct ExperimentPrivateCallOperator {
-  private:
-    double operator()(double i, double j) { // expected-note {{candidate function}}
-      return i*i;
-    }
+class ExperimentPrivateCallOperator {
+  double operator()(double i, double j) { // expected-note {{implicitly declared private here}}
+    return i*i;
+  }
 };
 
 struct ExperimentProtectedCallOperator {
   protected:
-    double operator()(double i, double j) { // expected-note {{candidate function}}
+    double operator()(double i, double j) { // expected-note {{declared protected here}}
       return i*i;
     }
 };

--- a/test/ForwardMode/FunctorErrors.C
+++ b/test/ForwardMode/FunctorErrors.C
@@ -18,10 +18,28 @@ struct ExperimentMultipleCallOperators {
   }
 };
 
+struct ExperimentPrivateCallOperator {
+  private:
+    double operator()(double i, double j) { // expected-note {{candidate function}}
+      return i*i;
+    }
+};
+
+struct ExperimentProtectedCallOperator {
+  protected:
+    double operator()(double i, double j) { // expected-note {{candidate function}}
+      return i*i;
+    }
+};
+
 int main() {
   ExperimentNoCallOperator E_NoCallOperator;
   auto d_NoCallOperator = clad::differentiate(E_NoCallOperator, "i"); // expected-error {{'ExperimentNoCallOperator' has no defined operator()}}
   d_NoCallOperator.execute(1, 3);
   ExperimentMultipleCallOperators E_MultipleCallOperators;
-  auto d_MultipleCallOperators = clad::differentiate(E_MultipleCallOperators, "i"); // expected-error {{'ExperimentMultipleCallOperators' has multiple definitions of operator().Multiple definitions of call operators are not supported.}}
+  auto d_MultipleCallOperators = clad::differentiate(E_MultipleCallOperators, "i"); // expected-error {{'ExperimentMultipleCallOperators' has multiple definitions of operator(). Multiple definitions of call operators are not supported.}}
+  ExperimentPrivateCallOperator E_PrivateCallOperator;
+  auto d_PrivateCallOperator = clad::differentiate(E_PrivateCallOperator, "i"); // expected-error {{'ExperimentPrivateCallOperator' contains private call operator. Differentiation of private/protected call operator is not supported.}}
+  ExperimentProtectedCallOperator E_ProtectedCallOperator;
+  auto d_ProtectedCallOperator = clad::differentiate(E_ProtectedCallOperator, "i"); // expected-error {{'ExperimentProtectedCallOperator' contains protected call operator. Differentiation of private/protected call operator is not supported.}}
 }

--- a/test/ForwardMode/FunctorErrors.C
+++ b/test/ForwardMode/FunctorErrors.C
@@ -7,13 +7,13 @@ struct ExperimentNoCallOperator {
 };
 
 struct ExperimentMultipleCallOperators {
-  double operator()(double i, double j) {
+  double operator()(double i, double j) { // expected-note {{candidate function}}
     return i*j;
   }
-  double operator()(double i) {
+  double operator()(double i) { // expected-note {{candidate function}}
     return i*i;
   }
-  double operator()(double i) const {
+  double operator()(double i) const { // expected-note {{candidate function}}
     return i*i*i;
   }
 };
@@ -24,5 +24,4 @@ int main() {
   d_NoCallOperator.execute(1, 3);
   ExperimentMultipleCallOperators E_MultipleCallOperators;
   auto d_MultipleCallOperators = clad::differentiate(E_MultipleCallOperators, "i"); // expected-error {{'ExperimentMultipleCallOperators' has multiple definitions of operator().Multiple definitions of call operators are not supported.}}
-  d_MultipleCallOperators.execute(3, 5);
 }

--- a/test/ForwardMode/Functors.C
+++ b/test/ForwardMode/Functors.C
@@ -103,9 +103,6 @@ namespace outer {
   }
 }
 
-
-  
-
 #define INIT(E)\
 auto d_##E = clad::differentiate(&E, "i");\
 auto d_##E##Ref = clad::differentiate(E, "i");

--- a/test/ForwardMode/Functors.C
+++ b/test/ForwardMode/Functors.C
@@ -1,0 +1,210 @@
+// RUN: %cladclang %s -I%S/../../include -oFunctors.out 2>&1 | FileCheck %s
+// RUN: ./Functors.out | FileCheck -check-prefix=CHECK-EXEC %s
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+struct Experiment {
+  double x, y;
+  Experiment(double p_x, double p_y) : x(p_x), y(p_y) {}
+
+  double operator()(double i, double j) {
+    return x*i + y*j;
+  }
+
+  // CHECK: double operator_call_darg0(double i, double j) {
+  // CHECK-NEXT:   double _d_i = 1;
+  // CHECK-NEXT:   double _d_j = 0;
+  // CHECK-NEXT:   double &_t0 = this->x;
+  // CHECK-NEXT:   double &_t1 = this->y;
+  // CHECK-NEXT:   return 0. * i + _t0 * _d_i + 0. * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+};
+
+struct ExperimentConstCallOperator {
+  double x, y;
+  ExperimentConstCallOperator(double p_x, double p_y) : x(p_x), y(p_y) {}
+
+  double operator()(double i, double j) const {
+    return x*i + y*j;
+  }
+
+  // CHECK: double operator_call_darg0(double i, double j) {
+  // CHECK-NEXT:   double _d_i = 1;
+  // CHECK-NEXT:   double _d_j = 0;
+  // CHECK-NEXT:   double &_t0 = this->x;
+  // CHECK-NEXT:   double &_t1 = this->y;
+  // CHECK-NEXT:   return 0. * i + _t0 * _d_i + 0. * j + _t1 * _d_j;
+  // CHECK-NEXT: }
+};
+
+namespace Outer {
+  namespace Inner {
+    struct Experiment {
+      double x, y;
+      Experiment(double p_x, double p_y) : x(p_x), y(p_y) {}
+
+      double operator()(double i, double j) { return x * i + y * j; }
+
+      // CHECK: double operator_call_darg0(double i, double j) {
+      // CHECK-NEXT:   double _d_i = 1;
+      // CHECK-NEXT:   double _d_j = 0;
+      // CHECK-NEXT:   double &_t0 = this->x;
+      // CHECK-NEXT:   double &_t1 = this->y;
+      // CHECK-NEXT:   return 0. * i + _t0 * _d_i + 0. * j + _t1 * _d_j;
+      // CHECK-NEXT: }
+    };
+  }
+}
+
+class Widget {
+  mutable double x;
+  double y;
+public:
+  Widget(double p_x, double p_y) : x(p_x), y(p_y) {}
+  double operator()(double i, double j, double k) {
+    return x*(i+j) + y*k;
+  }
+  void setX(double p_x) {
+    x = p_x;
+  }
+
+  // CHECK: double operator_call_darg0(double i, double j, double k) {
+  // CHECK-NEXT:  double _d_i = 1;
+  // CHECK-NEXT:  double _d_j = 0;
+  // CHECK-NEXT:  double _d_k = 0;
+  // CHECK-NEXT:  double &_t0 = this->x;
+  // CHECK-NEXT:  double _t1 = (i + j);
+  // CHECK-NEXT:  double &_t2 = this->y;
+  // CHECK-NEXT:  return 0. * _t1 + _t0 * (_d_i + _d_j) + 0. * k + _t2 * _d_k;
+  // CHECK-NEXT:}
+
+};
+
+class WidgetConstCallOperator {
+  double y;
+  mutable double x;
+public:
+  WidgetConstCallOperator(double p_x, double p_y) : x(p_x), y(p_y) {}
+  double operator()(double i, double j, double k) const {
+    return x*(i+j) + y*k;
+  }
+  void setX(double p_x) const {
+    x = p_x;
+  }
+
+  // CHECK: double operator_call_darg0(double i, double j, double k) {
+  // CHECK-NEXT:  double _d_i = 1;
+  // CHECK-NEXT:  double _d_j = 0;
+  // CHECK-NEXT:  double _d_k = 0;
+  // CHECK-NEXT:  double &_t0 = this->x;
+  // CHECK-NEXT:  double _t1 = (i + j);
+  // CHECK-NEXT:  double &_t2 = this->y;
+  // CHECK-NEXT:  return 0. * _t1 + _t0 * (_d_i + _d_j) + 0. * k + _t2 * _d_k;
+  // CHECK-NEXT:}
+
+};
+
+namespace Outer {
+  namespace Inner {
+    class Widget {
+      mutable double x;
+      double y;
+
+    public:
+      Widget(double p_x, double p_y) : x(p_x), y(p_y) {}
+      double operator()(double i, double j, double k) {
+        return x * (i + j) + y * k;
+      }
+      void setX(double p_x) { x = p_x; }
+
+      // CHECK: double operator_call_darg0(double i, double j, double k) {
+      // CHECK-NEXT:  double _d_i = 1;
+      // CHECK-NEXT:  double _d_j = 0;
+      // CHECK-NEXT:  double _d_k = 0;
+      // CHECK-NEXT:  double &_t0 = this->x;
+      // CHECK-NEXT:  double _t1 = (i + j);
+      // CHECK-NEXT:  double &_t2 = this->y;
+      // CHECK-NEXT:  return 0. * _t1 + _t0 * (_d_i + _d_j) + 0. * k + _t2 *
+      // _d_k; CHECK-NEXT:}
+    };
+  }
+}
+
+#define EXECUTE(CF, ...)\
+  printf("%.2f\n", CF.execute(__VA_ARGS__));
+
+int main() {
+  Experiment E(11, 33);
+  Widget W(3, 7);
+
+  const ExperimentConstCallOperator constE(11, 33);
+  const WidgetConstCallOperator constW(3, 7);
+
+  Outer::Inner::Experiment NSE(33, 35);
+  Outer::Inner::Widget NSW(49, 121);
+
+  auto lambda = [](double i, double j) {
+    return i*i*j;
+  };
+
+  // CHECK: inline double operator_call_darg0(double i, double j) const {
+  // CHECK-NEXT:   double _d_i = 1;
+  // CHECK-NEXT:   double _d_j = 0;
+  // CHECK-NEXT:   double _t0 = i * i;
+  // CHECK-NEXT:   return (_d_i * i + i * _d_i) * j + _t0 * _d_j;
+  // CHECK-NEXT: }
+
+  auto d_E = clad::differentiate(&E, "i");
+  auto d_ERef = clad::differentiate(E, "i");
+  auto d_constE = clad::differentiate(&constE, "i");
+  auto d_constERef = clad::differentiate(constE, "i");
+  auto d_NSE = clad::differentiate(&NSE, "i");
+  auto d_NSERef = clad::differentiate(NSE, "i");
+
+  auto d_W = clad::differentiate(&W, "i");
+  auto d_WRef = clad::differentiate(W, "i");
+  auto d_constW = clad::differentiate(&constW, "i");
+  auto d_constWRef = clad::differentiate(constW, "i");
+  auto d_NSW = clad::differentiate(&NSW, "i");
+  auto d_NSWRef = clad::differentiate(NSW, "i");
+
+  auto d_lambda = clad::differentiate(&lambda, "i");
+  auto d_lambdaRef = clad::differentiate(lambda, "i");
+
+  EXECUTE(d_E, 1, 3);         // CHECK-EXEC: 11.00
+  EXECUTE(d_ERef, 1, 3);      // CHECK-EXEC: 11.00
+  EXECUTE(d_constE, 1, 3);    // CHECK-EXEC: 11.00
+  EXECUTE(d_constERef, 1, 3); // CHECK-EXEC: 11.00
+  EXECUTE(d_NSE, 1, 3);       // CHECK-EXEC: 33.00
+  EXECUTE(d_NSERef, 1, 3);    // CHECK-EXEC: 33.00
+
+  EXECUTE(d_W, 1, 3, 5);          // CHECK-EXEC: 3.00
+  EXECUTE(d_WRef, 1, 3, 5);       // CHECK-EXEC: 3.00
+  EXECUTE(d_constW, 1, 3, 5);     // CHECK-EXEC: 3.00
+  EXECUTE(d_constWRef, 1, 3, 5);  // CHECK-EXEC: 3.00
+  EXECUTE(d_NSW, 1, 3, 5);        // CHECK-EXEC: 49.00
+  EXECUTE(d_NSWRef, 1, 3, 5);     // CHECK-EXEC: 49.00
+
+  EXECUTE(d_lambda, 3, 5);    // CHECK-EXEC: 30.00
+  EXECUTE(d_lambdaRef, 3, 5); // CHECK-EXEC: 30.00
+
+  E.x = 121;
+  NSE.x = 289;
+
+  W.setX(9);
+  constW.setX(9);
+  NSW.setX(121);
+
+  EXECUTE(d_E, 1, 3);     // CHECK-EXEC: 121.00
+  EXECUTE(d_ERef, 1, 3);  // CHECK-EXEC: 121.00
+  EXECUTE(d_NSE, 1, 3);   // CHECK-EXEC: 289.00
+  EXECUTE(d_NSERef, 1, 3);// CHECK-EXEC: 289.00
+
+  EXECUTE(d_W, 1, 3, 5);          // CHECK-EXEC: 9.00
+  EXECUTE(d_WRef, 1, 3, 5);       // CHECK-EXEC: 9.00
+  EXECUTE(d_constW, 1, 3, 5);     // CHECK-EXEC: 9.00
+  EXECUTE(d_constWRef, 1, 3, 5);  // CHECK-EXEC: 9.00
+  EXECUTE(d_NSW, 1, 3, 5);        // CHECK-EXEC: 121.00
+  EXECUTE(d_NSWRef, 1, 3, 5);     // CHECK-EXEC: 121.00
+}

--- a/test/ForwardMode/MemberFunctions.C
+++ b/test/ForwardMode/MemberFunctions.C
@@ -751,5 +751,11 @@ int main() {
 
   RVAL_REF_TEST(const_volatile_rval_ref_noexcept_mem_fn_with_var_arg_list, 3, 5)  // CHECK-EXEC: 30.00 
                                                                                   // CHECK-EXEC: 33.00 
-
+  d_mem_fn.setObject(&expr_1);
+  printf("%.2f %.2f", d_mem_fn.execute(3, 5), d_mem_fn.execute(expr_2, 3, 5));  // CHECK-EXEC: 30.00
+                                                                                // CHECK-EXEC: 33.00
+  d_mem_fn.clearObject();
+  d_mem_fn.setObject(expr_1);
+  printf("%.2f %.2f", d_mem_fn.execute(3, 5), d_mem_fn.execute(expr_2, 3, 5));  // CHECK-EXEC: 30.00
+                                                                                // CHECK-EXEC: 33.00
 }

--- a/test/Functors/Errors.C
+++ b/test/Functors/Errors.C
@@ -1,0 +1,28 @@
+// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+struct ExperimentNoCallOperator {
+};
+
+struct ExperimentMultipleCallOperators {
+  double operator()(double i, double j) {
+    return i*j;
+  }
+  double operator()(double i) {
+    return i*i;
+  }
+  double operator()(double i) const {
+    return i*i*i;
+  }
+};
+
+int main() {
+  ExperimentNoCallOperator E_NoCallOperator;
+  auto d_NoCallOperator = clad::differentiate(E_NoCallOperator, "i"); // expected-error {{No call operator is defined for the class ExperimentNoCallOperator}}
+  d_NoCallOperator.execute(1, 3);
+  ExperimentMultipleCallOperators E_MultipleCallOperators;
+  auto d_MultipleCallOperators = clad::differentiate(E_MultipleCallOperators, "i"); // expected-error {{Class ExperimentMultipleCallOperators defines multiple overloads of call operator. Multiple overloads of call operators are not supported.}}
+  d_MultipleCallOperators.execute(3, 5);
+}

--- a/test/Functors/Errors.C
+++ b/test/Functors/Errors.C
@@ -20,9 +20,9 @@ struct ExperimentMultipleCallOperators {
 
 int main() {
   ExperimentNoCallOperator E_NoCallOperator;
-  auto d_NoCallOperator = clad::differentiate(E_NoCallOperator, "i"); // expected-error {{No call operator is defined for the class ExperimentNoCallOperator}}
+  auto d_NoCallOperator = clad::differentiate(E_NoCallOperator, "i"); // expected-error {{'ExperimentNoCallOperator' has no defined operator()}}
   d_NoCallOperator.execute(1, 3);
   ExperimentMultipleCallOperators E_MultipleCallOperators;
-  auto d_MultipleCallOperators = clad::differentiate(E_MultipleCallOperators, "i"); // expected-error {{Class ExperimentMultipleCallOperators defines multiple overloads of call operator. Multiple overloads of call operators are not supported.}}
+  auto d_MultipleCallOperators = clad::differentiate(E_MultipleCallOperators, "i"); // expected-error {{'ExperimentMultipleCallOperators' has multiple definitions of operator().Multiple definitions of call operators are not supported.}}
   d_MultipleCallOperators.execute(3, 5);
 }


### PR DESCRIPTION
This PR aims to add support for differentiating functors in the forward differentiation mode.

- [x] Implicitly differentiate `operator()` member function when functor is passed
- [x] Implicitly pass functor while executing derived function using `CladFunction`
- [x] Add tests
- [x] Add user-friendly errors using `Sema` diagnostics when an object of class without overloaded `operator()` or multiple overloads of call operator is passed to be differentiated.
- [x] Add demo

By differentiating functors, I mean, differentiating the `operator()` member function when a functor is passed, and implicitly executing the derived function using the passed functor.

Functors can be passed to `clad::differentiate` both by reference and as pointers. For example:
```c++
Experiment E; // a functor
auto d_fn = clad::differentiate(&E, "i");
auto d_fnRef = clad::differentiate(E, "i");
...
...
std::cout<<d_fn.execute(1,  3)<<"\n"; // no need to pass object while executing derived function.
```
## Implemented solution

The solution is implemented in 2 steps:
- Differentiate `operator()` member function whenever functor (class type object) is passed to be differentiated.
- Execute derived function through the functor object.

**1st Step Implementation:**

DiffPlanner `getArgFunction` is responsible for obtaining function to be differentiated from the call expression of clad differentiation functions.

It currently behaves as follows:
- Return `DeclRefExpr` node of the 1st argument (which is, the function to be differentiated), and update the `RelevantAncestor` parameter to the nearest ancestor of 1st argument which is of type `ImplicitCastExpr` or `UnaryOperator`.

`getArgFunction` has been modified such that, whenever a class type object is to be differentiated, it provides all the data for the `operator()` member function of the class type. By all the data, I am referring to `DeclRefExpr` of the `operator()` method, the correct nearest ancestor for the `operator()` method.

But since the `operator()` method hasn't actually passed, these nodes (`DeclRefExpr` and ancestors of the `operator()` method) does not actually exist, and needs to be created inside `getArgFunction`. This effectively converts calls to differentiate class type object to calls to differentiate a member function for the rest of the clad.

**2nd Step Implementation:**

`CladFunction` has been modified to save an object through which derived member functions should be called when the user does not explicitly pass an object while calling `CladFunction::execute`

This behaviour is summarised in the following code snippet:

```c++
SomeClass A, B;
auto d_memFn = clad::differentiate(&SomeClass::SomeMemberFn, "i");
d_memFn.setObject(&A); // set A as default object for executing derived fn
d_memFn.execute(1, 3); // calls A.derivedFn(1, 3);
d_memFn.execute(B, 1, 3); // calls B.derivedFn(1, 3);
``` 
When a functor object is passed to be differentiated, it is saved in the corresponding `CladFunction` object so that it can be automatically taken by the `CladFunction::execute` method to call the derived member function.

**Modifications to `clad::differentiate`**

`clad::differentiate` is modified to have 2 overloads, one for differentiating functions (and methods), and the other for differentiating functors.
2 separate overloads are required because function (and method) pointers need to be passed by value whereas objects need to be passed by reference (because we need to determine `constness` property (among others) of passed functor object)
