### PR TITLE
[codecov] Use a secure post-build action to upload the coverage info.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,17 +343,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.6
-    - name: Save PR Info
-      if: ${{ matrix.coverage == true }}
-      run: |
-        mkdir -p ./pr
-        echo ${{ github.event.number }} > ./pr/NR
-        echo ${{ github.repository }} > ./pr/REPO
-    - uses: actions/upload-artifact@v2
-      if: ${{ matrix.coverage == true }}
-      with:
-        name: pr
-        path: pr/
     - uses: nelonoel/branch-name@v1.0.1
     - name: Setup default Build Type
       run: |
@@ -628,11 +617,18 @@ jobs:
         # output coverage data for debugging (optional)
         lcov --list coverage.info
 
-    - name: Upload to codecov.io
-      if: ${{ success() && (matrix.coverage == true) }}
-      uses: codecov/codecov-action@v1
+    - name: Save PR Info
+      if: ${{ matrix.coverage == true }}
+      run: |
+        mkdir -p ./pr
+        echo ${{ github.event.number }} > ./pr/NR
+        echo ${{ github.repository }} > ./pr/REPO
+        cp coverage.info ./pr
+    - uses: actions/upload-artifact@v2
+      if: ${{ matrix.coverage == true }}
       with:
-        file: ./coverage.info
+        name: pr
+        path: pr/
 
     - name: Upload report to coverity_scan
       if: ${{ success() && (matrix.coverity == true) }}

--- a/.github/workflows/postci.yml
+++ b/.github/workflows/postci.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   knowall:
     runs-on: ubuntu-latest
-    if: false # Disable temporary the workflow.
     if: >
       ${{ github.event.workflow_run.event == 'pull_request'}}
     steps:
@@ -38,11 +37,18 @@ jobs:
         echo "PR_NUMBER=`cat ./NR`" >> $GITHUB_ENV
         echo "PR_REPO=`cat ./REPO`" >> $GITHUB_ENV
 
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN}}
+        file: ./coverage.info
+
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
     - name: Invoke workflow clang-format on compiler-research
+      if: false # Disable temporary the workflow.
       uses: benc-uk/workflow-dispatch@v1
       with:
         workflow: SuggestFormattingChanges


### PR DESCRIPTION
Apparently, the token-less upload has become problematic recently for external
forks. We want to try uploading the coverage information using tokens but that
can only happen outside of the PR jobs as there might be malicious PRs which can
steal tokens.

This patch relies on the post-pr build action to upload the relevant information.