### PR TITLE
Add array diff to forward mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For a function `f` of several inputs and single (scalar) output, forward mode AD
 1. `f` is a pointer to a function or a method to be differentiated
 2. `ARGS` is either:
   * a single numerical literal indicating an index of independent variable (e.g. `0` for `x`, `1` for `y`)
-  * a string literal with the name of independent variable (as stated in the *definition* of `f`, e.g. `"x"` or `"y"`)
+  * a string literal with the name of independent variable (as stated in the *definition* of `f`, e.g. `"x"` or `"y"`), and if the variable is an array the index needs to be specified, e.g. `"arr[1]"`
 
 Generated derivative function has the same signature as the original function `f`, however its return value is the value of the derivative.
 

--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -37,6 +37,25 @@ namespace clad {
     class CladPlugin;
     clang::FunctionDecl* ProcessDiffRequest(CladPlugin& P, DiffRequest& request);
   }
+
+  struct IndexInterval {
+    size_t Start;
+    size_t Finish;
+
+    IndexInterval() : Start(0), Finish(0) {}
+
+    IndexInterval(size_t first, size_t last) : Start(first), Finish(last + 1) {}
+
+    IndexInterval(size_t index) : Start(index), Finish(index + 1) {}
+
+    size_t size() {
+      return Finish - Start;
+    }
+
+    bool isInInterval(size_t n) {
+      return n >= Start && n <= Finish;
+    }
+  };
 }
 
 namespace clad {
@@ -44,8 +63,11 @@ namespace clad {
   // in nested namespaces
   using DeclWithContext = std::pair<clang::FunctionDecl*, clang::Decl*>;
   using DiffParams = llvm::SmallVector<const clang::VarDecl*, 16>;
+  using IndexIntervalTable = llvm::SmallVector<IndexInterval, 16>;
+  using DiffParamsWithIndices = std::pair<DiffParams, IndexIntervalTable>;
 
-  using VectorOutputs = std::vector<std::unordered_map<const clang::VarDecl*, clang::Expr*>>;
+  using VectorOutputs =
+      std::vector<std::unordered_map<const clang::VarDecl*, clang::Expr*>>;
 
   static clang::SourceLocation noLoc{};
   class VisitorBase;

--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -25,6 +25,7 @@ namespace clad {
         public VisitorBase {
   private:
     const clang::VarDecl* m_IndependentVar = nullptr;
+    unsigned m_IndependentVarIndex = ~0;
     unsigned m_DerivativeOrder = ~0;
     unsigned m_ArgIndex = ~0;
 

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -135,6 +135,10 @@ namespace clad {
       return S.ActOnCallExpr(V.getCurrentScope(), lambda, noLoc, {}, noLoc)
           .get();
     }
+    /// For a qualtype QT returns if it's type is Array or Pointer Type
+    static bool isArrayOrPointerType(const clang::QualType QT) {
+      return QT->isArrayType() || QT->isPointerType();
+    }
 
   public:
     clang::CompoundStmt* MakeCompoundStmt(const Stmts& Stmts);

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -256,17 +256,17 @@ namespace clad {
     /// independent parameter(s) for differentiation. There are three valid
     /// options for the argument expression:
     ///   1) A string literal, containing comma-separated names of function's
-    ///   parameters,
-    ///      as defined in function's defintion. The function will be
-    ///      differentiated w.r.t. all the specified parameters.
+    ///      parameters, as defined in function's definition. If any of the
+    ///      parameters are of array or pointer type the indexes of the array
+    ///      that needs to be differentiated can also be specified, e.g.
+    ///      "arr[1]" or "arr[2:5]". The function will be differentiated w.r.t.
+    ///      all the specified parameters.
     ///   2) A numeric literal. The function will be differentiated w.r.t. to
-    ///   the
-    ///      parameter corresponding to literal's value index.
+    ///      the parameter corresponding to literal's value index.
     ///   3) If no argument is provided, a default argument is used. The
-    ///   function
-    ///      will be differentiated w.r.t. to its every parameter.
-    DiffParams parseDiffArgs(const clang::Expr* diffArgs,
-                             const clang::FunctionDecl* FD);
+    ///      function will be differentiated w.r.t. to its every parameter.
+    DiffParamsWithIndices parseDiffArgs(const clang::Expr* diffArgs,
+                                        const clang::FunctionDecl* FD);
 
     /// Get an expression used to zero-initialize given type.
     /// Returns 0 for scalar types, otherwise {}.

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -34,8 +34,9 @@ namespace clad {
   DeclWithContext HessianModeVisitor::Derive(const clang::FunctionDecl* FD,
                                              const DiffRequest& request) {
     DiffParams args{};
+    IndexIntervalTable indexIntervalTable{};
     if (request.Args)
-      args = parseDiffArgs(request.Args, FD);
+      std::tie(args, indexIntervalTable) = parseDiffArgs(request.Args, FD);
     else
       std::copy(FD->param_begin(), FD->param_end(), std::back_inserter(args));
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -86,7 +86,7 @@ namespace clad {
 
     DiffParams args{};
     if (request.Args)
-      args = parseDiffArgs(request.Args, FD);
+      std::tie(args, std::ignore) = parseDiffArgs(request.Args, FD);
     else
       std::copy(FD->param_begin(), FD->param_end(), std::back_inserter(args));
     if (args.empty())

--- a/test/Arrays/ArrayErrorsForwardMode.C
+++ b/test/Arrays/ArrayErrorsForwardMode.C
@@ -1,0 +1,25 @@
+// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1
+
+#include "clad/Differentiator/Differentiator.h"
+
+//CHECK-NOT: {{.*error|warning|note:.*}}
+
+double addArr(double *arr) {
+  return arr[0] + arr[1] + arr[2] + arr[3];
+}
+
+struct Double {
+  double n;
+};
+
+double addDoubleArr(Double *arr) { // expected-error {{attempted differentiation w.r.t. a parameter ('arr') which is not an array or pointer of a real type}}
+  return arr[0].n + arr[1].n + arr[2].n + arr[3].n;
+}
+
+int main() {
+  clad::differentiate(addArr, "arr[1:2]"); // expected-error {{Forward mode differentiation w.r.t. several parameters at once is not supported, call 'clad::differentiate' for each parameter separately}}
+
+  clad::differentiate(addArr, "arr[2:1]"); // expected-error {{Range specified in 'arr[2:1]' is in incorrect format}}
+
+  clad::differentiate(addDoubleArr, "arr[1]");
+}

--- a/test/Arrays/ArrayInputsForwardMode.C
+++ b/test/Arrays/ArrayInputsForwardMode.C
@@ -1,0 +1,56 @@
+// RUN: %cladclang %s -lm -I%S/../../include -oArrayInputsForwardMode.out 2>&1 | FileCheck %s
+// RUN: ./ArrayInputsForwardMode.out | FileCheck -check-prefix=CHECK-EXEC %s
+
+//CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+double multiply(double *arr) {
+  return arr[0] * arr[1];
+}
+
+//CHECK:   double multiply_darg0_1(double *arr) {
+//CHECK-NEXT:       return 0 * arr[1] + arr[0] * 1;
+//CHECK-NEXT:   }
+
+double divide(double *arr) {
+  return arr[0] / arr[1];
+}
+
+//CHECK:   double divide_darg0_1(double *arr) {
+//CHECK_NEXT:       return (0 * arr[1] - arr[0] * 1) / (arr[1] * arr[1]);
+//CHECK_NEXT:   }
+
+double addArr(double *arr, int n) {
+  double ret = 0;
+  for (int i = 0; i < n; i++) {
+    ret += arr[i];
+  }
+  return ret;
+}
+
+//CHECK:   double addArr_darg0_1(double *arr, int n) {
+//CHECK-NEXT:       int _d_n = 0;
+//CHECK-NEXT:       double _d_ret = 0;
+//CHECK-NEXT:       double ret = 0;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int _d_i = 0;
+//CHECK-NEXT:           for (int i = 0; i < n; i++) {
+//CHECK-NEXT:               _d_ret += (i == 1);
+//CHECK-NEXT:               ret += arr[i];
+//CHECK-NEXT:           }
+//CHECK-NEXT:       }
+//CHECK-NEXT:       return _d_ret;
+//CHECK-NEXT:   }
+
+int main() {
+  double arr[] = {1, 2, 3, 4, 5};
+  auto multiply_dx = clad::differentiate(multiply, "arr[1]");
+  printf("Result = {%.2f}\n", multiply_dx.execute(arr)); // CHECK-EXEC: Result = {1.00}
+
+  auto divide_dx = clad::differentiate(divide, "arr[1]");
+  printf("Result = {%.2f}\n", divide_dx.execute(arr)); // CHECK-EXEC: Result = {-0.25}
+
+  auto addArr_dx = clad::differentiate(addArr, "arr[1]");
+  printf("Result = {%.2f}\n", addArr_dx.execute(arr, 5)); // CHECK-EXEC: Result = {1.00}
+}

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -50,12 +50,40 @@ void TFormula_example_grad(Double_t *x, Double_t *p, Double_t *_result);
 //CHECK-NEXT:           _result[1] += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
-      
+
+// forward mode differentiation w.r.t. p[0]:
+//CHECK:   Double_t TFormula_example_darg1_0(Double_t *x, Double_t *p) {
+//CHECK-NEXT:       double _t0 = (p[0] + p[1] + p[2]);
+//CHECK-NEXT:       return 0 * _t0 + x[0] * (1 + 0 + 0) + custom_derivatives::Exp_darg0(-p[0]) * -1 + custom_derivatives::Abs_darg0(p[1]) * 0;
+//CHECK-NEXT:   }
+
+// forward mode differentiation w.r.t. p[1]:
+//CHECK:   Double_t TFormula_example_darg1_1(Double_t *x, Double_t *p) {
+//CHECK-NEXT:       double _t0 = (p[0] + p[1] + p[2]);
+//CHECK-NEXT:       return 0 * _t0 + x[0] * (0 + 1 + 0) + custom_derivatives::Exp_darg0(-p[0]) * -0 + custom_derivatives::Abs_darg0(p[1]) * 1;
+//CHECK-NEXT:   }
+
+// forward mode differentiation w.r.t. p[2]:
+//CHECK:   Double_t TFormula_example_darg1_2(Double_t *x, Double_t *p) {
+//CHECK-NEXT:       double _t0 = (p[0] + p[1] + p[2]);
+//CHECK-NEXT:       return 0 * _t0 + x[0] * (0 + 0 + 1) + custom_derivatives::Exp_darg0(-p[0]) * -0 + custom_derivatives::Abs_darg0(p[1]) * 0;
+//CHECK-NEXT:   }
+
 int main() {
-  auto gradient = clad::gradient(TFormula_example);
   Double_t x[] = { 3 };
   Double_t p[] = { -std::log(2), -1, 3 };
   Double_t result[3] = { 0 };
+
+  auto gradient = clad::gradient(TFormula_example);
   gradient.execute(x, p, result);
   printf("Result is = {%.2f, %.2f, %.2f}\n", result[0], result[1], result[2]); // CHECK-EXEC: Result is = {1.00, 2.00, 3.00}
+
+  auto differentiation0 = clad::differentiate(TFormula_example, "p[0]");
+  printf("Result is = {%.2f}\n", differentiation0.execute(x, p)); // CHECK-EXEC: Result is = {1.00}
+
+  auto differentiation1 = clad::differentiate(TFormula_example, "p[1]");
+  printf("Result is = {%.2f}\n", differentiation1.execute(x, p)); // CHECK-EXEC: Result is = {2.00}
+
+  auto differentiation2 = clad::differentiate(TFormula_example, "p[2]");
+  printf("Result is = {%.2f}\n", differentiation2.execute(x, p)); // CHECK-EXEC: Result is = {3.00}
 }


### PR DESCRIPTION
`parseDiffArgs` now supports specifying the elements w.r.t. to which the function is to be differentiated.

`ForwardModeVisitor` can now differentiate w.r.t. to any input array element. To support array diff forward mode stores the index of the requested array. It then checks the `ArraySubscriptExpr` being differentiated and if it is equal to the array element requested it returns `1`.

N.B. More tests need to be added before this is merged