### PR TITLE
Preserve original member function qualifiers in the derived function.

### DIFF
--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -245,105 +245,110 @@ namespace clad {
   };
   
   // specializations for member functions pointer types with only cv-qualifiers
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const> {
+    using type = void (C::*)(Args..., ReturnType*) const;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile> {
+    using type = void (C::*)(Args..., ReturnType*) volatile;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile> {
+    using type = void (C::*)(Args..., ReturnType*) const volatile;
   };
 
   // specializations for member functions pointer types with 
   // reference qualifiers and with and without cv-qualifiers
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &> {
+    using type = void (C::*)(Args..., ReturnType*) &;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &> {
+    using type = void (C::*)(Args..., ReturnType*) const &;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &> {
+    using type = void (C::*)(Args..., ReturnType*) volatile &;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &> {
+    using type = void (C::*)(Args..., ReturnType*) const volatile &;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &&> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) &&> {
+    using type = void (C::*)(Args..., ReturnType*) &&;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &&> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const &&> {
+    using type = void (C::*)(Args..., ReturnType*) const &&;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &&> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile &&> {
+    using type = void (C::*)(Args..., ReturnType*) volatile &&;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &&> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile &&> {
+    using type = void (C::*)(Args..., ReturnType*) const volatile &&;
   };
 
   // specializations for noexcept member functions
   #if __cpp_noexcept_function_type > 0
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) noexcept> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) noexcept> {
+    using type = void (C::*)(Args..., ReturnType*) noexcept;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const noexcept> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const noexcept> {
+    using type = void (C::*)(Args..., ReturnType*) const noexcept;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile noexcept> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile noexcept> {
+    using type = void (C::*)(Args..., ReturnType*) volatile noexcept;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile noexcept> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)
+                                    const volatile noexcept> {
+    using type = void (C::*)(Args..., ReturnType*) const volatile noexcept;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) & noexcept> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) & noexcept> {
+    using type = void (C::*)(Args..., ReturnType*) & noexcept;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const & noexcept> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const & noexcept> {
+    using type = void (C::*)(Args..., ReturnType*) const & noexcept;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile & noexcept> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile& noexcept> {
+    using type = void (C::*)(Args..., ReturnType*) volatile& noexcept;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile & noexcept> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)
+                                    const volatile& noexcept> {
+    using type = void (C::*)(Args..., ReturnType*) const volatile& noexcept;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) && noexcept> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) && noexcept> {
+    using type = void (C::*)(Args..., ReturnType*) && noexcept;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const && noexcept> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const && noexcept> {
+    using type = void (C::*)(Args..., ReturnType*) const && noexcept;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) volatile && noexcept> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(
+      Args...) volatile&& noexcept> {
+    using type = void (C::*)(Args..., ReturnType*) volatile&& noexcept;
   };
-  template <class ReturnType, class C, class... Args> 
-  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...) const volatile && noexcept> { 
-    using type = void (C::*)(Args..., ReturnType*); 
+  template <class ReturnType, class C, class... Args>
+  struct ExtractDerivedFnTraits<ReturnType (C::*)(Args...)
+                                    const volatile&& noexcept> {
+    using type = void (C::*)(Args..., ReturnType*) const volatile&& noexcept;
   };
-  #endif
+#endif
 } // namespace clad
 
 #endif // FUNCTION_TRAITS

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -136,13 +136,14 @@ namespace clad {
       // The last parameter is the output parameter of the R* type.
       paramTypes.back() = m_Context.getPointerType(m_Function->getReturnType());
     }
+    auto originalFnType = dyn_cast<FunctionProtoType>(m_Function->getType());
     // For a function f of type R(A1, A2, ..., An),
     // the type of the gradient function is void(A1, A2, ..., An, R*).
     QualType gradientFunctionType = m_Context.getFunctionType(
         m_Context.VoidTy,
         llvm::ArrayRef<QualType>(paramTypes.data(), paramTypes.size()),
         // Cast to function pointer.
-        FunctionProtoType::ExtProtoInfo());
+        originalFnType->getExtProtoInfo());
 
     // Create the gradient function declaration.
     llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -13,652 +13,652 @@ public:
   SimpleFunctions(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
   double x, y;
   double mem_fn(double i, double j)  { 
-   return (x+y)*i + i*j; 
- } 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void mem_fn_grad(double i, double j, double *_result) {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void mem_fn_grad(double i, double j, double *_result) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double const_mem_fn(double i, double j) const { 
-   return (x+y)*i + i*j; 
- } 
+  double const_mem_fn(double i, double j) const { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void const_mem_fn_grad(double i, double j, double *_result) const {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double const_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void const_mem_fn_grad(double i, double j, double *_result) const {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double volatile_mem_fn(double i, double j) volatile { 
-   return (x+y)*i + i*j; 
- } 
+  double volatile_mem_fn(double i, double j) volatile { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void volatile_mem_fn_grad(double i, double j, double *_result) volatile {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double volatile_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void volatile_mem_fn_grad(double i, double j, double *_result) volatile {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double volatile_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double const_volatile_mem_fn(double i, double j) const volatile { 
-   return (x+y)*i + i*j; 
- } 
+  double const_volatile_mem_fn(double i, double j) const volatile { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void const_volatile_mem_fn_grad(double i, double j, double *_result) const volatile {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double const_volatile_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void const_volatile_mem_fn_grad(double i, double j, double *_result) const volatile {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_volatile_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double lval_ref_mem_fn(double i, double j) & { 
-   return (x+y)*i + i*j; 
- } 
+  double lval_ref_mem_fn(double i, double j) & { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void lval_ref_mem_fn_grad(double i, double j, double *_result) & {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void lval_ref_mem_fn_grad(double i, double j, double *_result) & {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double const_lval_ref_mem_fn(double i, double j) const & { 
-   return (x+y)*i + i*j; 
- } 
+  double const_lval_ref_mem_fn(double i, double j) const & { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, double *_result) const & {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double const_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, double *_result) const & {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double volatile_lval_ref_mem_fn(double i, double j) volatile & { 
-   return (x+y)*i + i*j; 
- } 
+  double volatile_lval_ref_mem_fn(double i, double j) volatile & { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) volatile & {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) volatile & {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double const_volatile_lval_ref_mem_fn(double i, double j) const volatile & { 
-   return (x+y)*i + i*j; 
- } 
+  double const_volatile_lval_ref_mem_fn(double i, double j) const volatile & { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) const volatile & {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double const_volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) const volatile & {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double rval_ref_mem_fn(double i, double j) && { 
-   return (x+y)*i + i*j; 
- } 
+  double rval_ref_mem_fn(double i, double j) && { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void rval_ref_mem_fn_grad(double i, double j, double *_result) && {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void rval_ref_mem_fn_grad(double i, double j, double *_result) && {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double const_rval_ref_mem_fn(double i, double j) const && { 
-   return (x+y)*i + i*j; 
- } 
+  double const_rval_ref_mem_fn(double i, double j) const && { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, double *_result) const && {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double const_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, double *_result) const && {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double volatile_rval_ref_mem_fn(double i, double j) volatile && { 
-   return (x+y)*i + i*j; 
- } 
+  double volatile_rval_ref_mem_fn(double i, double j) volatile && { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) volatile && {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double volatile_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) volatile && {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double volatile_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double const_volatile_rval_ref_mem_fn(double i, double j) const volatile && { 
-   return (x+y)*i + i*j; 
- } 
+  double const_volatile_rval_ref_mem_fn(double i, double j) const volatile && { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) const volatile && {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double const_volatile_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) const volatile && {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_volatile_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double noexcept_mem_fn(double i, double j) noexcept { 
-   return (x+y)*i + i*j; 
- } 
+  double noexcept_mem_fn(double i, double j) noexcept { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void noexcept_mem_fn_grad(double i, double j, double *_result) noexcept {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void noexcept_mem_fn_grad(double i, double j, double *_result) noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double const_noexcept_mem_fn(double i, double j) const noexcept { 
-   return (x+y)*i + i*j; 
- } 
+  double const_noexcept_mem_fn(double i, double j) const noexcept { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void const_noexcept_mem_fn_grad(double i, double j, double *_result) const noexcept {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double const_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void const_noexcept_mem_fn_grad(double i, double j, double *_result) const noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double volatile_noexcept_mem_fn(double i, double j) volatile noexcept { 
-   return (x+y)*i + i*j; 
- } 
+  double volatile_noexcept_mem_fn(double i, double j) volatile noexcept { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, double *_result) volatile noexcept {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double volatile_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, double *_result) volatile noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double volatile_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double const_volatile_noexcept_mem_fn(double i, double j) const volatile noexcept { 
-   return (x+y)*i + i*j; 
- } 
+  double const_volatile_noexcept_mem_fn(double i, double j) const volatile noexcept { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, double *_result) const volatile noexcept {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double const_volatile_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, double *_result) const volatile noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_volatile_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double lval_ref_noexcept_mem_fn(double i, double j) & noexcept { 
-   return (x+y)*i + i*j; 
- } 
+  double lval_ref_noexcept_mem_fn(double i, double j) & noexcept { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) & noexcept {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) & noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double const_lval_ref_noexcept_mem_fn(double i, double j) const & noexcept { 
-   return (x+y)*i + i*j; 
- } 
+  double const_lval_ref_noexcept_mem_fn(double i, double j) const & noexcept { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const & noexcept {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double const_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const & noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double volatile_lval_ref_noexcept_mem_fn(double i, double j) volatile & noexcept { 
-   return (x+y)*i + i*j; 
- } 
+  double volatile_lval_ref_noexcept_mem_fn(double i, double j) volatile & noexcept { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) volatile & noexcept {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double volatile_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) volatile & noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double volatile_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double const_volatile_lval_ref_noexcept_mem_fn(double i, double j) const volatile & noexcept { 
-   return (x+y)*i + i*j; 
- } 
+  double const_volatile_lval_ref_noexcept_mem_fn(double i, double j) const volatile & noexcept { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const volatile & noexcept {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double const_volatile_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const volatile & noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_volatile_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double rval_ref_noexcept_mem_fn(double i, double j) && noexcept { 
-   return (x+y)*i + i*j; 
- } 
+  double rval_ref_noexcept_mem_fn(double i, double j) && noexcept { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) && noexcept {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) && noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double const_rval_ref_noexcept_mem_fn(double i, double j) const && noexcept { 
-   return (x+y)*i + i*j; 
- } 
+  double const_rval_ref_noexcept_mem_fn(double i, double j) const && noexcept { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const && noexcept {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double const_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const && noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double volatile_rval_ref_noexcept_mem_fn(double i, double j) volatile && noexcept { 
-   return (x+y)*i + i*j; 
- } 
+  double volatile_rval_ref_noexcept_mem_fn(double i, double j) volatile && noexcept { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) volatile && noexcept {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double volatile_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) volatile && noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double volatile_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
- double const_volatile_rval_ref_noexcept_mem_fn(double i, double j) const volatile && noexcept { 
-   return (x+y)*i + i*j; 
- } 
+  double const_volatile_rval_ref_noexcept_mem_fn(double i, double j) const volatile && noexcept { 
+    return (x+y)*i + i*j; 
+  } 
 
- // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const volatile && noexcept {
- // CHECK-NEXT:     double _t0;
- // CHECK-NEXT:     double _t1;
- // CHECK-NEXT:     double _t2;
- // CHECK-NEXT:     double _t3;
- // CHECK-NEXT:     _t1 = (this->x + this->y);
- // CHECK-NEXT:     _t0 = i;
- // CHECK-NEXT:     _t3 = i;
- // CHECK-NEXT:     _t2 = j;
- // CHECK-NEXT:     double const_volatile_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
- // CHECK-NEXT:     goto _label0;
- // CHECK-NEXT:   _label0:
- // CHECK-NEXT:     {
- // CHECK-NEXT:         double _r0 = 1 * _t0;
- // CHECK-NEXT:         double _r1 = _t1 * 1;
- // CHECK-NEXT:         _result[0UL] += _r1;
- // CHECK-NEXT:         double _r2 = 1 * _t2;
- // CHECK-NEXT:         _result[0UL] += _r2;
- // CHECK-NEXT:         double _r3 = _t3 * 1;
- // CHECK-NEXT:         _result[1UL] += _r3;
- // CHECK-NEXT:     }
- // CHECK-NEXT: }
+  // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const volatile && noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t1 = (this->x + this->y);
+  // CHECK-NEXT:     _t0 = i;
+  // CHECK-NEXT:     _t3 = i;
+  // CHECK-NEXT:     _t2 = j;
+  // CHECK-NEXT:     double const_volatile_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _t1 * 1;
+  // CHECK-NEXT:         _result[0UL] += _r1;
+  // CHECK-NEXT:         double _r2 = 1 * _t2;
+  // CHECK-NEXT:         _result[0UL] += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _result[1UL] += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
   void mem_fn_grad(double i, double j, double *_result) ; 
   void const_mem_fn_grad(double i, double j, double *_result) ; 
@@ -742,7 +742,6 @@ int main() {
 
   auto d_fn = clad::gradient(fn);
   double result[2];
-  result[0]=result[1]=0;
   d_fn.execute(4,5,result);
   for(unsigned i=0;i<2;++i) {
     printf("%.2f ",result[i]);  //CHECK-EXEC: 40.00 16.00

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -13,652 +13,652 @@ public:
   SimpleFunctions(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
   double x, y;
   double mem_fn(double i, double j)  { 
-    return (x+y)*i + i*j; 
-  } 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void mem_fn_grad(double i, double j, double *_result) {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double const_mem_fn(double i, double j) const { 
-    return (x+y)*i + i*j; 
-  } 
+ double const_mem_fn(double i, double j) const { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void const_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double const_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void const_mem_fn_grad(double i, double j, double *_result) const {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double const_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double volatile_mem_fn(double i, double j) volatile { 
-    return (x+y)*i + i*j; 
-  } 
+ double volatile_mem_fn(double i, double j) volatile { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void volatile_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double volatile_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void volatile_mem_fn_grad(double i, double j, double *_result) volatile {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double volatile_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double const_volatile_mem_fn(double i, double j) const volatile { 
-    return (x+y)*i + i*j; 
-  } 
+ double const_volatile_mem_fn(double i, double j) const volatile { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void const_volatile_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double const_volatile_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void const_volatile_mem_fn_grad(double i, double j, double *_result) const volatile {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double const_volatile_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double lval_ref_mem_fn(double i, double j) & { 
-    return (x+y)*i + i*j; 
-  } 
+ double lval_ref_mem_fn(double i, double j) & { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void lval_ref_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void lval_ref_mem_fn_grad(double i, double j, double *_result) & {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double const_lval_ref_mem_fn(double i, double j) const & { 
-    return (x+y)*i + i*j; 
-  } 
+ double const_lval_ref_mem_fn(double i, double j) const & { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double const_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, double *_result) const & {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double const_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double volatile_lval_ref_mem_fn(double i, double j) volatile & { 
-    return (x+y)*i + i*j; 
-  } 
+ double volatile_lval_ref_mem_fn(double i, double j) volatile & { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) volatile & {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double const_volatile_lval_ref_mem_fn(double i, double j) const volatile & { 
-    return (x+y)*i + i*j; 
-  } 
+ double const_volatile_lval_ref_mem_fn(double i, double j) const volatile & { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double const_volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, double *_result) const volatile & {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double const_volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double rval_ref_mem_fn(double i, double j) && { 
-    return (x+y)*i + i*j; 
-  } 
+ double rval_ref_mem_fn(double i, double j) && { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void rval_ref_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void rval_ref_mem_fn_grad(double i, double j, double *_result) && {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double const_rval_ref_mem_fn(double i, double j) const && { 
-    return (x+y)*i + i*j; 
-  } 
+ double const_rval_ref_mem_fn(double i, double j) const && { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double const_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, double *_result) const && {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double const_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double volatile_rval_ref_mem_fn(double i, double j) volatile && { 
-    return (x+y)*i + i*j; 
-  } 
+ double volatile_rval_ref_mem_fn(double i, double j) volatile && { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double volatile_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) volatile && {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double volatile_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double const_volatile_rval_ref_mem_fn(double i, double j) const volatile && { 
-    return (x+y)*i + i*j; 
-  } 
+ double const_volatile_rval_ref_mem_fn(double i, double j) const volatile && { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double const_volatile_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, double *_result) const volatile && {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double const_volatile_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double noexcept_mem_fn(double i, double j) noexcept { 
-    return (x+y)*i + i*j; 
-  } 
+ double noexcept_mem_fn(double i, double j) noexcept { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void noexcept_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void noexcept_mem_fn_grad(double i, double j, double *_result) noexcept {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double const_noexcept_mem_fn(double i, double j) const noexcept { 
-    return (x+y)*i + i*j; 
-  } 
+ double const_noexcept_mem_fn(double i, double j) const noexcept { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void const_noexcept_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double const_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void const_noexcept_mem_fn_grad(double i, double j, double *_result) const noexcept {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double const_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double volatile_noexcept_mem_fn(double i, double j) volatile noexcept { 
-    return (x+y)*i + i*j; 
-  } 
+ double volatile_noexcept_mem_fn(double i, double j) volatile noexcept { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double volatile_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, double *_result) volatile noexcept {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double volatile_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double const_volatile_noexcept_mem_fn(double i, double j) const volatile noexcept { 
-    return (x+y)*i + i*j; 
-  } 
+ double const_volatile_noexcept_mem_fn(double i, double j) const volatile noexcept { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double const_volatile_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, double *_result) const volatile noexcept {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double const_volatile_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double lval_ref_noexcept_mem_fn(double i, double j) & noexcept { 
-    return (x+y)*i + i*j; 
-  } 
+ double lval_ref_noexcept_mem_fn(double i, double j) & noexcept { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) & noexcept {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double const_lval_ref_noexcept_mem_fn(double i, double j) const & noexcept { 
-    return (x+y)*i + i*j; 
-  } 
+ double const_lval_ref_noexcept_mem_fn(double i, double j) const & noexcept { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double const_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const & noexcept {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double const_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double volatile_lval_ref_noexcept_mem_fn(double i, double j) volatile & noexcept { 
-    return (x+y)*i + i*j; 
-  } 
+ double volatile_lval_ref_noexcept_mem_fn(double i, double j) volatile & noexcept { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double volatile_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) volatile & noexcept {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double volatile_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double const_volatile_lval_ref_noexcept_mem_fn(double i, double j) const volatile & noexcept { 
-    return (x+y)*i + i*j; 
-  } 
+ double const_volatile_lval_ref_noexcept_mem_fn(double i, double j) const volatile & noexcept { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double const_volatile_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const volatile & noexcept {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double const_volatile_lval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double rval_ref_noexcept_mem_fn(double i, double j) && noexcept { 
-    return (x+y)*i + i*j; 
-  } 
+ double rval_ref_noexcept_mem_fn(double i, double j) && noexcept { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) && noexcept {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double const_rval_ref_noexcept_mem_fn(double i, double j) const && noexcept { 
-    return (x+y)*i + i*j; 
-  } 
+ double const_rval_ref_noexcept_mem_fn(double i, double j) const && noexcept { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double const_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const && noexcept {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double const_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double volatile_rval_ref_noexcept_mem_fn(double i, double j) volatile && noexcept { 
-    return (x+y)*i + i*j; 
-  } 
+ double volatile_rval_ref_noexcept_mem_fn(double i, double j) volatile && noexcept { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double volatile_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) volatile && noexcept {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double volatile_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
-  double const_volatile_rval_ref_noexcept_mem_fn(double i, double j) const volatile && noexcept { 
-    return (x+y)*i + i*j; 
-  } 
+ double const_volatile_rval_ref_noexcept_mem_fn(double i, double j) const volatile && noexcept { 
+   return (x+y)*i + i*j; 
+ } 
 
-  // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     double _t2;
-  // CHECK-NEXT:     double _t3;
-  // CHECK-NEXT:     _t1 = (this->x + this->y);
-  // CHECK-NEXT:     _t0 = i;
-  // CHECK-NEXT:     _t3 = i;
-  // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double const_volatile_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * _t0;
-  // CHECK-NEXT:         double _r1 = _t1 * 1;
-  // CHECK-NEXT:         _result[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * _t2;
-  // CHECK-NEXT:         _result[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = _t3 * 1;
-  // CHECK-NEXT:         _result[1UL] += _r3;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+ // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_result) const volatile && noexcept {
+ // CHECK-NEXT:     double _t0;
+ // CHECK-NEXT:     double _t1;
+ // CHECK-NEXT:     double _t2;
+ // CHECK-NEXT:     double _t3;
+ // CHECK-NEXT:     _t1 = (this->x + this->y);
+ // CHECK-NEXT:     _t0 = i;
+ // CHECK-NEXT:     _t3 = i;
+ // CHECK-NEXT:     _t2 = j;
+ // CHECK-NEXT:     double const_volatile_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+ // CHECK-NEXT:     goto _label0;
+ // CHECK-NEXT:   _label0:
+ // CHECK-NEXT:     {
+ // CHECK-NEXT:         double _r0 = 1 * _t0;
+ // CHECK-NEXT:         double _r1 = _t1 * 1;
+ // CHECK-NEXT:         _result[0UL] += _r1;
+ // CHECK-NEXT:         double _r2 = 1 * _t2;
+ // CHECK-NEXT:         _result[0UL] += _r2;
+ // CHECK-NEXT:         double _r3 = _t3 * 1;
+ // CHECK-NEXT:         _result[1UL] += _r3;
+ // CHECK-NEXT:     }
+ // CHECK-NEXT: }
 
   void mem_fn_grad(double i, double j, double *_result) ; 
   void const_mem_fn_grad(double i, double j, double *_result) ; 
@@ -742,6 +742,7 @@ int main() {
 
   auto d_fn = clad::gradient(fn);
   double result[2];
+  result[0]=result[1]=0;
   d_fn.execute(4,5,result);
   for(unsigned i=0;i<2;++i) {
     printf("%.2f ",result[i]);  //CHECK-EXEC: 40.00 16.00


### PR DESCRIPTION
When differentiating member functions using `clad::gradient`, member function qualifiers (`const`, `volatile`, `noexcept`, `&`, `&&`) were not preserved. For example, differentiating,

```c++
double const_volatile_mem_fn(double i, double j) const volatile;
```

will create the gradient function with the following prototype.

```c++
void const_volatile_mem_fn_grad(double i, double j, double *_result); // const volatile qualifiers lost
```

This PR fixes this behaviour, and the gradient function will now have all the qualifiers of the original function.

Benefits of preserving member function qualifiers
- Increased consistency in the library, since differentiation using `clad::differentiate` preserve original qualifiers.
- Increased usability of derived functions in cases where constness is involved. For example, const member functions can be called on both `const` and non-const objects, so users will also expect the same behaviour from derived functions of those const member functions, but if the `const` qualifier is not preserved, then the derived function can only be called on non-const objects, thus restricting its usage. 

Closes #210 
