### PR TITLE
Modify clad::hessian to support differentiating member functions.

### DIFF
--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -316,6 +316,26 @@ namespace clad {
       VD->setInit(ICAR.get());
 
     }
+
+    /// Build a call to member function through this pointer.
+    ///
+    /// \param[in] FD callee member function
+    /// \param[in] argExprs function arguments expressions
+    /// \returns Built member function call expression
+    clang::Expr*
+    BuildCallExprToMemFn(clang::CXXMethodDecl* FD,
+        llvm::MutableArrayRef<clang::Expr*> argExprs);
+
+    /// Build a call to a free function or member function through
+    /// this pointer depending on whether the `FD` argument corresponds to a
+    /// free function or a member function.
+    ///
+    /// \param[in] FD callee function
+    /// \param[in] argExprs function arguments expressions
+    /// \returns Built call expression
+    clang::Expr* 
+    BuildCallExprToFunction(clang::FunctionDecl* FD,
+        llvm::MutableArrayRef<clang::Expr*> argExprs);
   };
 } // end namespace clad
 

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -195,7 +195,6 @@ namespace clad {
     // Creates callExprs to the second derivative functions genereated
     // and creates maps array elements to input array.
     for (size_t i = 0, e = secDerivFuncs.size(); i < e; ++i) {
-      Expr* exprFunc = BuildDeclRef(secDerivFuncs[i]);
       const int numIndependentArgs = secDerivFuncs[i]->getNumParams();
 
       auto size_type = m_Context.getSizeType();
@@ -226,15 +225,7 @@ namespace clad {
                      });
       DeclRefToParams.pop_back();
       DeclRefToParams.push_back(addressArrayExpr);
-
-      Expr* call =
-          m_Sema
-              .ActOnCallExpr(getCurrentScope(),
-                             exprFunc,
-                             noLoc,
-                             llvm::MutableArrayRef<Expr*>(DeclRefToParams),
-                             noLoc)
-              .get();
+      Expr* call = BuildCallExprToFunction(secDerivFuncs[i], DeclRefToParams);
       CompStmtSave.push_back(call);
     }
 


### PR DESCRIPTION
Progress Checklist:
- [x] Modify `clad::hessian` to support differentiating member functions for clang>=9
- [x] Fix compatibility issues to support earlier clang versions
- [x] Add basic tests