### PR TITLE
Add support for reference variables in reverse mode

### DIFF
--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -553,6 +553,181 @@ double f13(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
+double f14(double i, double j) {
+  double& a = i;
+  a = 2*i;
+  a += i;
+  a *= i;
+  return i;
+}
+
+// CHECK: void f14_grad(double i, double j, double *_result) {
+// CHECK-NEXT:     double &_d_a = _result[0UL];
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     double &a = i;
+// CHECK-NEXT:     _t0 = i;
+// CHECK-NEXT:     a = 2 * _t0;
+// CHECK-NEXT:     a += i;
+// CHECK-NEXT:     _t2 = a;
+// CHECK-NEXT:     _t1 = i;
+// CHECK-NEXT:     a *= _t1;
+// CHECK-NEXT:     double f14_return = i;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _result[0UL] += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d2 = _d_a;
+// CHECK-NEXT:         _d_a += _r_d2 * _t1;
+// CHECK-NEXT:         double _r2 = _t2 * _r_d2;
+// CHECK-NEXT:         _result[0UL] += _r2;
+// CHECK-NEXT:         _d_a -= _r_d2;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d1 = _d_a;
+// CHECK-NEXT:         _d_a += _r_d1;
+// CHECK-NEXT:         _result[0UL] += _r_d1;
+// CHECK-NEXT:         _d_a -= _r_d1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d0 = _d_a;
+// CHECK-NEXT:         double _r0 = _r_d0 * _t0;
+// CHECK-NEXT:         double _r1 = 2 * _r_d0;
+// CHECK-NEXT:         _result[0UL] += _r1;
+// CHECK-NEXT:         _d_a -= _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+double f15(double i, double j) {
+  double b = i*j;
+  double& a = b;
+  double& c = i;
+  double& d = j;
+  a *= i;
+  b += 2*i;
+  c += 3*i;
+  d *= 3*j;
+  return a+c+d;
+}
+
+// CHECK: void f15_grad(double i, double j, double *_result) {
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _d_b = 0;
+// CHECK-NEXT:     double &_d_a = _d_b;
+// CHECK-NEXT:     double &_d_c = _result[0UL];
+// CHECK-NEXT:     double &_d_d = _result[1UL];
+// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     double _t3;
+// CHECK-NEXT:     double _t4;
+// CHECK-NEXT:     double _t5;
+// CHECK-NEXT:     double _t6;
+// CHECK-NEXT:     double _t7;
+// CHECK-NEXT:     double _t8;
+// CHECK-NEXT:     _t1 = i;
+// CHECK-NEXT:     _t0 = j;
+// CHECK-NEXT:     double b = _t1 * _t0;
+// CHECK-NEXT:     double &a = b;
+// CHECK-NEXT:     double &c = i;
+// CHECK-NEXT:     double &d = j;
+// CHECK-NEXT:     _t3 = a;
+// CHECK-NEXT:     _t2 = i;
+// CHECK-NEXT:     a *= _t2;
+// CHECK-NEXT:     _t4 = i;
+// CHECK-NEXT:     b += 2 * _t4;
+// CHECK-NEXT:     _t5 = i;
+// CHECK-NEXT:     c += 3 * _t5;
+// CHECK-NEXT:     _t7 = d;
+// CHECK-NEXT:     _t8 = j;
+// CHECK-NEXT:     _t6 = 3 * _t8;
+// CHECK-NEXT:     d *= _t6;
+// CHECK-NEXT:     double f15_return = a + c + d;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_a += 1;
+// CHECK-NEXT:         _d_c += 1;
+// CHECK-NEXT:         _d_d += 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d3 = _d_d;
+// CHECK-NEXT:         _d_d += _r_d3 * _t6;
+// CHECK-NEXT:         double _r7 = _t7 * _r_d3;
+// CHECK-NEXT:         double _r8 = _r7 * _t8;
+// CHECK-NEXT:         double _r9 = 3 * _r7;
+// CHECK-NEXT:         _result[1UL] += _r9;
+// CHECK-NEXT:         _d_d -= _r_d3;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d2 = _d_c;
+// CHECK-NEXT:         _d_c += _r_d2;
+// CHECK-NEXT:         double _r5 = _r_d2 * _t5;
+// CHECK-NEXT:         double _r6 = 3 * _r_d2;
+// CHECK-NEXT:         _result[0UL] += _r6;
+// CHECK-NEXT:         _d_c -= _r_d2;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d1 = _d_b;
+// CHECK-NEXT:         _d_b += _r_d1;
+// CHECK-NEXT:         double _r3 = _r_d1 * _t4;
+// CHECK-NEXT:         double _r4 = 2 * _r_d1;
+// CHECK-NEXT:         _result[0UL] += _r4;
+// CHECK-NEXT:         _d_b -= _r_d1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d0 = _d_a;
+// CHECK-NEXT:         _d_a += _r_d0 * _t2;
+// CHECK-NEXT:         double _r2 = _t3 * _r_d0;
+// CHECK-NEXT:         _result[0UL] += _r2;
+// CHECK-NEXT:         _d_a -= _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = _d_b * _t0;
+// CHECK-NEXT:         _result[0UL] += _r0;
+// CHECK-NEXT:         double _r1 = _t1 * _d_b;
+// CHECK-NEXT:         _result[1UL] += _r1;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+double f16(double i, double j) {
+  double& a = i;
+  double& b = a;
+  double& c = b;
+  c *= 4*j;
+  return i;
+}
+
+// CHECK: void f16_grad(double i, double j, double *_result) {
+// CHECK-NEXT:     double &_d_a = _result[0UL];
+// CHECK-NEXT:     double &_d_b = _d_a;
+// CHECK-NEXT:     double &_d_c = _d_b;
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     double &a = i;
+// CHECK-NEXT:     double &b = a;
+// CHECK-NEXT:     double &c = b;
+// CHECK-NEXT:     _t1 = c;
+// CHECK-NEXT:     _t2 = j;
+// CHECK-NEXT:     _t0 = 4 * _t2;
+// CHECK-NEXT:     c *= _t0;
+// CHECK-NEXT:     double f16_return = i;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _result[0UL] += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d0 = _d_c;
+// CHECK-NEXT:         _d_c += _r_d0 * _t0;
+// CHECK-NEXT:         double _r0 = _t1 * _r_d0;
+// CHECK-NEXT:         double _r1 = _r0 * _t2;
+// CHECK-NEXT:         double _r2 = 4 * _r0;
+// CHECK-NEXT:         _result[1UL] += _r2;
+// CHECK-NEXT:         _d_c -= _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+
 #define TEST(F, x, y) { \
   result[0] = 0; result[1] = 0;\
   auto F##grad = clad::gradient(F);\
@@ -575,4 +750,7 @@ int main() {
   TEST(f11, 3, 4); // CHECK-EXEC: {0.00, 1.00}
   TEST(f12, 3, 4); // CHECK-EXEC: {0.00, 8.00}
   TEST(f13, 3, 4); // CHECK-EXEC: {27.00, 0.00}
+  TEST(f14, 3, 4);  // CHECK-EXEC: {96.00, 0.00}
+  TEST(f15, 3, 4);  // CHECK-EXEC: {30.00, 33.00}
+  TEST(f16, 3, 4);  // CHECK-EXEC: {16.00, 12.00}
 }

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -247,24 +247,6 @@ void f_cond3_hessian(double x, double c, double *hessianMatrix);
 //CHECK-NEXT:    f_cond3_darg1_grad(x, c, &hessianMatrix[2UL]);
 //CHECK-NEXT:}
 
-
-struct Experiment {
-  double x, y;
-  Experiment (double p_x, double p_y) : x(p_x), y(p_y) {}
-  double someMethod (double i, double j) {
-    return i*i*j + j*j*i;
-  }
-
-  void f_someMethod_darg0_grad(double i, double j, double *_result);
-  void f_someMethod_darg1_grad(double i, double j, double *_result);
-
-  void f_someMethod_hessian(double x, double *hessianMatrix);
-  // CHECK:void someMethod_hessian(double i, double j, double *hessianMatrix) {
-  // CHECK-NEXT:  this->someMethod_darg0_grad(i, j, &hessianMatrix[0UL]);
-  // CHECK-NEXT:  this->someMethod_darg1_grad(i, j, &hessianMatrix[2UL]);
-  // CHECK-NEXT:}
-};
-
 double f_power10(double x) {
   return x * x * x * x * x * x * x * x * x * x;
 }
@@ -276,7 +258,54 @@ void f_power10_hessian(double x, double *hessianMatrix);
 //CHECK-NEXT:     f_power10_darg0_grad(x, &hessianMatrix[0UL]);
 //CHECK-NEXT: }
 
+struct Experiment {
+  double x, y;
+  Experiment (double p_x, double p_y) : x(p_x), y(p_y) {}
+  double someMethod (double i, double j) {
+    return i*i*j + j*j*i;
+  }
 
+  void someMethod_darg0_grad(double i, double j, double *_result);
+  void someMethod_darg1_grad(double i, double j, double *_result);
+
+  void someMethod_hessian(double x, double *hessianMatrix);
+  // CHECK:void someMethod_hessian(double i, double j, double *hessianMatrix) {
+  // CHECK-NEXT:  this->someMethod_darg0_grad(i, j, &hessianMatrix[0UL]);
+  // CHECK-NEXT:  this->someMethod_darg1_grad(i, j, &hessianMatrix[2UL]);
+  // CHECK-NEXT:}
+};
+
+struct Widget {
+  double x, y;
+  Widget(double p_x, double p_y) : x(p_x), y(p_y) {}
+  double memFn_1(double i, double j) {
+    return x*y*i*j;
+  }
+
+  void memFn_1_darg0_grad(double i, double j, double *_result);
+  void memFn_1_darg1_grad(double i, double j, double *_result);
+  
+  void memFn_1_hessian(double i, double j, double *hessianMatrix);
+  // CHECK: void memFn_1_hessian(double i, double j, double *hessianMatrix) {
+  // CHECK-NEXT:     this->memFn_1_darg0_grad(i, j, &hessianMatrix[0UL]);
+  // CHECK-NEXT:     this->memFn_1_darg1_grad(i, j, &hessianMatrix[2UL]);
+  // CHECK-NEXT: }
+
+  double memFn_2(double i, double j) {
+    double a = x*i*j;
+    double b = 4*a;
+    return b*y*y*i;
+  }
+
+  void memFn_2_darg0_grad(double i, double j, double *_result);
+  void memFn_2_darg1_grad(double i, double j, double *_result);
+  
+  void memFn_2_hessian(double i, double j, double *hessianMatrix);
+  // CHECK: void memFn_2_hessian(double i, double j, double *hessianMatrix) {
+  // CHECK-NEXT:     this->memFn_2_darg0_grad(i, j, &hessianMatrix[0UL]);
+  // CHECK-NEXT:     this->memFn_2_darg1_grad(i, j, &hessianMatrix[2UL]);
+  // CHECK-NEXT: }
+};
 
 #define TEST1(F, x) { \
   result[0] = 0;\
@@ -301,7 +330,7 @@ void f_power10_hessian(double x, double *hessianMatrix);
   result[0]=result[1]=result[2]=result[3]=0;\
   auto h = clad::hessian(F);\
   h.execute(Obj, __VA_ARGS__, result);\
-  printf("Result is = {%.2f, %.2f, %.2f, %2.f}\n", result[0], result[1], result[2], result[3]);\
+  printf("Result is = {%.2f, %.2f, %.2f, %.2f}\n", result[0], result[1], result[2], result[3]);\
 }
   
 
@@ -310,7 +339,10 @@ int main() {
   TEST2(f_cubed_add1, 1, 2); // CHECK-EXEC: Result is = {6.00, 0.00, 0.00, 12.00}
   TEST2(f_suvat1, 1, 2); // CHECK-EXEC: Result is = {0.00, 1.00, 1.00, 9.81}
   TEST2(f_cond3, 5, -2); // CHECK-EXEC: Result is = {30.00, 0.00, 0.00, 12.00}
-  Experiment E(11, 17);
-  TEST3(&Experiment::someMethod, E, 3, 5);  // CHECK-EXEC: Result is = {10.00, 16.00, 16.00,  6}
   TEST1(f_power10, 5); // CHECK-EXEC: Result is = {35156250.00}
+  Experiment E(11, 17);
+  Widget W(3, 5);
+  TEST3(&Experiment::someMethod, E, 3, 5);  // CHECK-EXEC: Result is = {10.00, 16.00, 16.00, 6.00}
+  TEST3(&Widget::memFn_1, W, 7, 9); // CHECK-EXEC: Result is = {0.00, 15.00, 15.00, 0.00}
+  TEST3(&Widget::memFn_2, W, 7, 9); // CHECK-EXEC: Result is = {5400.00, 4200.00, 4200.00, 0.00}
 }


### PR DESCRIPTION
Progress checklist:
- [x] Add support for reference variables in reverse mode
- [x] Add tests

### Solution:
```c++
double &a = b;
```
Generally, derived variables are initialised with 0, but in the case of reference variables, they should be initialised with the derived variable of the variable they are referencing to. Thus, the updated definition of `_d_a` will be, 
```c++
double& _d_a = _d_b;
```
And since, reference variables are referencing an already declared and derived variable, their definition does not need to be derived.

Closes #253 
