### PR TITLE
Fix building of nested name specifiers in getArg function

### DIFF
--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -46,7 +46,7 @@ namespace clad {
             } else {
               TraverseStmt(VD->getInit());
             }
-          } else if (auto FD = dyn_cast<FunctionDecl>(DRE->getDecl()))
+          } else if (isa<FunctionDecl>(DRE->getDecl()))
             m_FnDRE = DRE;
           return false;
         }
@@ -144,10 +144,7 @@ namespace clad {
           // method, to maintain consistency with member function
           // differentiation.
           CXXScopeSpec CSS;
-          CSS.Extend(m_SemaRef.getASTContext(),
-                     RD->getIdentifier(),
-                     /*IdentifierLoc=*/noLoc,
-                     /*ColonColonLoc=*/noLoc);
+          BuildNNS(callOperator->getDeclContext(), CSS);
 
           // `ExprValueKind::VK_RValue` is used because functions are
           // decomposed to function pointers and thus a temporary is
@@ -158,9 +155,50 @@ namespace clad {
                                          ExprValueKind::VK_RValue,
                                          noLoc,
                                          &CSS));
-          m_FnDRE = cast<DeclRefExpr>(newFnDRE);
-
+          m_FnDRE = cast<DeclRefExpr>(newFnDRE);          
           return false;
+        }
+      private:
+        /// Creates nested name specifier associated with declaration context
+        /// argument `DC`. 
+        ///
+        /// For example, given a structure defined as,
+        /// namespace A {
+        /// namespace B {
+        ///   struct SomeStruct {};
+        /// }
+        /// }
+        ///
+        /// Passing `SomeStruct` as declaration context will create
+        /// nested name specifier of the form `::A::B::struct SomeClass::`
+        /// in `CXXScopeSpec` argument `CSS`.
+        /// \note Currently only namespace and class/struct nested name specifiers
+        /// are supported.
+        ///
+        /// \param[in] DC
+        /// \param[out] CSS
+        void BuildNNS(DeclContext* DC, CXXScopeSpec& CSS) {
+          assert(DC && "Must provide a non null DeclContext");
+
+          // parent name specifier should be added first
+          if (DC->getParent())
+            BuildNNS(DC->getParent(), CSS);
+
+          ASTContext& Context = m_SemaRef.getASTContext();
+
+          if (auto ND = dyn_cast<NamespaceDecl>(DC)) {
+            CSS.Extend(Context, ND,
+                       /*NamespaceLoc=*/noLoc,
+                       /*ColonColonLoc=*/noLoc);
+          } else if (auto RD = dyn_cast<CXXRecordDecl>(DC)) {
+            auto RDQType = RD->getTypeForDecl()->getCanonicalTypeInternal();
+            auto RDTypeSourceInfo = Context.getTrivialTypeSourceInfo(RDQType);
+            CSS.Extend(Context,
+                       /*TemplateKWLoc=*/noLoc, RDTypeSourceInfo->getTypeLoc(),
+                       /*ColonColonLoc=*/noLoc);
+          } else if (isa<TranslationUnitDecl>(DC)) {
+            CSS.MakeGlobal(Context, /*ColonColonLoc=*/noLoc);
+          }
         }
     } finder(SemaRef, call->getArg(0)->getBeginLoc());
     finder.TraverseStmt(call->getArg(0));

--- a/test/ForwardMode/Functors.C
+++ b/test/ForwardMode/Functors.C
@@ -100,6 +100,10 @@ namespace outer {
       // CHECK-NEXT:     return (0. * i + _t0 * _d_i) * j + _t1 * _d_j;
       // CHECK-NEXT: }   
     };
+
+    auto lambdaNNS = [](double i, double j) {
+      return i*i*j;
+    };
   }
 }
 
@@ -114,10 +118,12 @@ double x=3;
 
 int main() {
   Experiment E(3, 5);
+  auto E_Again = E;
   const ExperimentConst E_Const(3, 5);
   volatile ExperimentVolatile E_Volatile(3, 5);
   const volatile ExperimentConstVolatile E_ConstVolatile(3, 5);
   outer::inner::ExperimentNNS E_NNS(3, 5);
+  auto E_NNS_Again = E_NNS;
   auto lambda = [](double i, double j) {
     return i*i*j;
   };
@@ -140,33 +146,52 @@ int main() {
   // CHECK-NEXT:     return (0 * i + x * _d_i) * jj + _t0 * _d_jj;
   // CHECK-NEXT: }
 
+  auto lambdaNNS = outer::inner::lambdaNNS;
+
+  // CHECK: inline double operator_call_darg0(double i, double j) const {
+  // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     double _t0 = i * i;
+  // CHECK-NEXT:     return (_d_i * i + i * _d_i) * j + _t0 * _d_j;
+  // CHECK-NEXT: }
+
   INIT(E);
+  INIT(E_Again);
   INIT(E_Const);
   INIT(E_Volatile);
   INIT(E_ConstVolatile);
   INIT(E_NNS);
+  INIT(E_NNS_Again);
   INIT(lambda);
   INIT(lambdaWithCapture);
+  INIT(lambdaNNS);
 
-  TEST(E);                // CHECK-EXEC: 27.00 27.00
-  TEST(E_Const);          // CHECK-EXEC: 27.00 27.00
-  TEST(E_Volatile);       // CHECK-EXEC: 27.00 27.00
-  TEST(E_ConstVolatile);  // CHECK-EXEC: 27.00 27.00
-  TEST(E_NNS);            // CHECK-EXEC: 27.00 27.00
-  TEST(lambda);           // CHECK-EXEC: 126.00 126.00
-  TEST(lambdaWithCapture);// CHECK-EXEC: 27.00 27.00
+  TEST(E);                  // CHECK-EXEC: 27.00 27.00
+  TEST(E_Again);            // CHECK-EXEC: 27.00 27.00
+  TEST(E_Const);            // CHECK-EXEC: 27.00 27.00
+  TEST(E_Volatile);         // CHECK-EXEC: 27.00 27.00
+  TEST(E_ConstVolatile);    // CHECK-EXEC: 27.00 27.00
+  TEST(E_NNS);              // CHECK-EXEC: 27.00 27.00
+  TEST(E_NNS_Again);        // CHECK-EXEC: 27.00 27.00
+  TEST(lambda);             // CHECK-EXEC: 126.00 126.00
+  TEST(lambdaWithCapture);  // CHECK-EXEC: 27.00 27.00
+  TEST(lambdaNNS);          // CHECK-EXEC: 126.00 126.00
 
   E.setX(6);
+  E_Again.setX(6);
   E_Const.setX(6);
   E_Volatile.setX(6);
   E_ConstVolatile.setX(6);
   E_NNS.setX(6);
+  E_NNS_Again.setX(6);
   x = 6;
 
-  TEST(E);                // CHECK-EXEC: 54.00 54.00
-  TEST(E_Const);          // CHECK-EXEC: 54.00 54.00
-  TEST(E_Volatile);       // CHECK-EXEC: 54.00 54.00
-  TEST(E_ConstVolatile);  // CHECK-EXEC: 54.00 54.00
-  TEST(E_NNS);            // CHECK-EXEC: 54.00 54.00
-  TEST(lambdaWithCapture);// CHECK-EXEC: 54.00 54.00
+  TEST(E);                  // CHECK-EXEC: 54.00 54.00
+  TEST(E_Again);            // CHECK-EXEC: 54.00 54.00
+  TEST(E_Const);            // CHECK-EXEC: 54.00 54.00
+  TEST(E_Volatile);         // CHECK-EXEC: 54.00 54.00
+  TEST(E_ConstVolatile);    // CHECK-EXEC: 54.00 54.00
+  TEST(E_NNS);              // CHECK-EXEC: 54.00 54.00
+  TEST(E_NNS_Again);        // CHECK-EXEC: 54.00 54.00
+  TEST(lambdaWithCapture);  // CHECK-EXEC: 54.00 54.00
 }


### PR DESCRIPTION
This PR modifies code in getArg function to build correct and complete nested name specifiers for the call operator.
It also fixes the failing asserts in clang debug build on running tests for differentiating functors. Credit goes to @grimmmyshini and @sudo-panda for bringing this error to attention. 

The root cause of the failing assert was lambda types not having any associated identifiers. This was causing issues while creating correct nested name specifiers for the call operator.