### PR TITLE
Modify code to use effective fn name to create derived fn identifiers 

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -1,0 +1,22 @@
+// This file contains utility functions which do not belong anywhere else
+
+#ifndef CLAD_UTILS_CLADUTILS_H
+#define CLAD_UTILS_CLADUTILS_H
+
+#include <string>
+
+namespace clang {
+  class FunctionDecl;
+}
+
+namespace clad {
+  namespace utils {
+    /// If `FD` is an overloaded operator, returns a name, unique for
+    /// each operator, that can be used to create valid C++ identifiers.
+    /// Otherwise if `FD` is an ordinary function, returns the name of the
+    /// function `FD`.
+    std::string ComputeEffectiveFnName(const clang::FunctionDecl* FD);
+  }
+}
+
+#endif

--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -29,6 +29,7 @@ set_property(SOURCE Version.cpp APPEND_STRING PROPERTY COMPILE_DEFINITIONS
 
 # (Ab)use llvm facilities for adding libraries.
 add_llvm_library(cladDifferentiator
+  CladUtils.cpp
   ConstantFolder.cpp
   DerivativeBuilder.cpp
   DiffPlanner.cpp

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1,0 +1,15 @@
+#include "clad/Differentiator/CladUtils.h"
+
+#include "clang/AST/Decl.h"
+
+namespace clad {
+  namespace utils {
+    std::string ComputeEffectiveFnName(const clang::FunctionDecl* FD) {
+      // TODO: Add cases for more operators
+      switch (FD->getOverloadedOperator()) {
+        case clang::OverloadedOperatorKind::OO_Call: return "operator_call";
+        default: return FD->getNameAsString();
+      }
+    }
+  } // namespace utils
+} // namespace clad

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -10,6 +10,7 @@
 
 #include "llvm/Support/SaveAndRestore.h"
 
+#include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/Compatibility.h"
 
 using namespace clang;
@@ -317,7 +318,7 @@ namespace clad {
       request.Args = E->getArg(1);
       auto derivedFD = cast<FunctionDecl>(DRE->getDecl());
       request.Function = derivedFD;
-      request.BaseFunctionName = derivedFD->getNameAsString();
+      request.BaseFunctionName = utils::ComputeEffectiveFnName(request.Function);
 
       // FIXME: add support for nested calls to clad::differentiate/gradient
       // inside differentiated functions

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -97,19 +97,13 @@ namespace clad {
     }
     m_DerivativeOrder = request.CurrentDerivativeOrder;
     std::string s = std::to_string(m_DerivativeOrder);
-    std::string derivativeBaseName;
     if (m_DerivativeOrder == 1)
       s = "";
-    switch (FD->getOverloadedOperator()) {
-      default: derivativeBaseName = request.BaseFunctionName; break;
-      case OO_Call: derivativeBaseName = "operator_call"; break;
-    }
-
     m_ArgIndex = std::distance(
         FD->param_begin(),
         std::find(FD->param_begin(), FD->param_end(), m_IndependentVar));
     IdentifierInfo* II =
-        &m_Context.Idents.get(derivativeBaseName + "_d" + s + "arg" +
+        &m_Context.Idents.get(request.BaseFunctionName + "_d" + s + "arg" +
                               std::to_string(m_ArgIndex) + derivativeSuffix);
     SourceLocation loc{m_Function->getLocation()};
     DeclarationNameInfo name(II, loc);

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -65,6 +65,7 @@ namespace clad {
     IndependentArgRequest.Mode = DiffMode::reverse;
     IndependentArgRequest.Function = firstDerivative;
     IndependentArgRequest.Args = ReverseModeArgs;
+    IndependentArgRequest.BaseFunctionName = firstDerivative->getNameAsString();
     FunctionDecl* secondDerivative =
         plugin::ProcessDiffRequest(CP, IndependentArgRequest);
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <numeric>
 
+#include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/Compatibility.h"
 
 using namespace clang;
@@ -247,7 +248,7 @@ namespace clad {
           GetCladArrayRefOfType(m_Function->getReturnType());
     }
 
-    auto derivativeBaseName = m_Function->getNameAsString();
+    auto derivativeBaseName = request.BaseFunctionName;
     std::string gradientName = derivativeBaseName + funcPostfix();
     // To be consistent with older tests, nothing is appended to 'f_grad' if
     // we differentiate w.r.t. all the parameters at once.
@@ -958,7 +959,7 @@ namespace clad {
     // computation (e.g. assignments), we also have to emit it to execute it.
     StoreAndRef(ExprDiff.getExpr(),
                 forward,
-                m_Function->getNameAsString() + "_return",
+                utils::ComputeEffectiveFnName(m_Function) + "_return",
                 /*force*/ true);
     // Create goto to the label.
     return m_Sema.ActOnGotoStmt(noLoc, noLoc, LD).get();

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -14,7 +14,7 @@ struct Experiment {
     x = val;
   }
 
-  // CHECK: void operator()_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -23,7 +23,7 @@ struct Experiment {
   // CHECK-NEXT:     _t1 = i;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     double operator()_return = _t3 * _t0;
+  // CHECK-NEXT:     double operator_call_return = _t3 * _t0;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
@@ -47,7 +47,7 @@ struct ExperimentConst {
     x = val;
   }
 
-  // CHECK: void operator()_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
+  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -56,7 +56,7 @@ struct ExperimentConst {
   // CHECK-NEXT:     _t1 = i;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     double operator()_return = _t3 * _t0;
+  // CHECK-NEXT:     double operator_call_return = _t3 * _t0;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
@@ -80,7 +80,7 @@ struct ExperimentVolatile {
     x = val;
   }
 
-  // CHECK: void operator()_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile {
+  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     volatile double _t2;
@@ -89,7 +89,7 @@ struct ExperimentVolatile {
   // CHECK-NEXT:     _t1 = i;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     double operator()_return = _t3 * _t0;
+  // CHECK-NEXT:     double operator_call_return = _t3 * _t0;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
@@ -113,7 +113,7 @@ struct ExperimentConstVolatile {
     x = val;
   }
 
-  // CHECK: void operator()_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
+  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     volatile double _t2;
@@ -122,7 +122,7 @@ struct ExperimentConstVolatile {
   // CHECK-NEXT:     _t1 = i;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     double operator()_return = _t3 * _t0;
+  // CHECK-NEXT:     double operator_call_return = _t3 * _t0;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
@@ -148,7 +148,7 @@ namespace outer {
         x = val;
       }
 
-      // CHECK: void operator()_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+      // CHECK: void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
       // CHECK-NEXT:     double _t0;
       // CHECK-NEXT:     double _t1;
       // CHECK-NEXT:     double _t2;
@@ -157,7 +157,7 @@ namespace outer {
       // CHECK-NEXT:     _t1 = i;
       // CHECK-NEXT:     _t3 = _t2 * _t1;
       // CHECK-NEXT:     _t0 = j;
-      // CHECK-NEXT:     double operator()_return = _t3 * _t0;
+      // CHECK-NEXT:     double operator_call_return = _t3 * _t0;
       // CHECK-NEXT:     goto _label0;
       // CHECK-NEXT:   _label0:
       // CHECK-NEXT:     {
@@ -198,7 +198,7 @@ int main() {
     return i*i*j;
   };
 
-  // CHECK: inline void operator()_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
+  // CHECK: inline void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -207,7 +207,7 @@ int main() {
   // CHECK-NEXT:     _t1 = i;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     double operator()_return = _t3 * _t0;
+  // CHECK-NEXT:     double operator_call_return = _t3 * _t0;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
@@ -225,7 +225,7 @@ int main() {
     return x*ii*j;
   };
 
-  // CHECK: inline void operator()_grad(double ii, double j, clad::array_ref<double> _d_ii, clad::array_ref<double> _d_j) const {
+  // CHECK: inline void operator_call_grad(double ii, double j, clad::array_ref<double> _d_ii, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -234,7 +234,7 @@ int main() {
   // CHECK-NEXT:     _t1 = ii;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     double operator()_return = _t3 * _t0;
+  // CHECK-NEXT:     double operator_call_return = _t3 * _t0;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {


### PR DESCRIPTION
This PR modifies derived function and corresponding return variable name to valid identifiers when differentiating overloaded call operator in reverse mode. Credit goes to @grimmmyshini and @sudo-panda for bringing this error to attention. 

Extending the original function creates invalid identifiers for the derived function and the return variable name when the original function is an overloaded operator, due to parentheses in the original function name.

Effective name is the function name itself for ordinary functions and a unique name for each operator kind for overloaded operators.

Current derived function name:
```c++
void operator()_grad(...);
```

Modified derived function name:
```c++
void operator_call_grad(...);
```

Current return variable name:
```
operator()_return;
```

Modified return variable name:
```
operator_call_return;
```