### PR TITLE
Create derived variables for parameters which are not independent

### DIFF
--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -25,6 +25,8 @@ gaus_grad_1(double* x, double* p, double sigma, int dim, clad::array_ref<double>
 auto gaus_g = clad::gradient(gaus, "p");
 
 // CHECK:    void gaus_grad_1(double *x, double *p, double sigma, int dim, clad::array_ref<double> _d_p) __attribute__((device)) __attribute__((host)) {
+// CHECK-NEXT:       double _d_sigma = 0;
+// CHECK-NEXT:       int _d_dim = 0;    
 // CHECK-NEXT:       double _d_t = 0;
 // CHECK-NEXT:       unsigned long _t0;
 // CHECK-NEXT:       int _d_i = 0;
@@ -80,11 +82,13 @@ auto gaus_g = clad::gradient(gaus, "p");
 // CHECK-NEXT:           double _r11 = _r10 * 3.1415926535897931;
 // CHECK-NEXT:           double _r12 = _r9 * _grad1;
 // CHECK-NEXT:           double _r13 = _r12 / 2.;
+// CHECK-NEXT:           _d_dim += -_r13;
 // CHECK-NEXT:           double _r14 = _t16 * _r8;
 // CHECK-NEXT:           double _grad2 = 0.;
 // CHECK-NEXT:           double _grad3 = 0.;
 // CHECK-NEXT:           custom_derivatives::pow_grad(_t17, -0.5, &_grad2, &_grad3);
 // CHECK-NEXT:           double _r15 = _r14 * _grad2;
+// CHECK-NEXT:           _d_sigma += _r15;
 // CHECK-NEXT:           double _r16 = _r14 * _grad3;
 // CHECK-NEXT:           double _r17 = _t18 * 1;
 // CHECK-NEXT:           double _r18 = _r17 * custom_derivatives::exp_darg0(_t19);
@@ -98,7 +102,9 @@ auto gaus_g = clad::gradient(gaus, "p");
 // CHECK-NEXT:           double _r4 = _r3 * _t9;
 // CHECK-NEXT:           double _r5 = _r4 * _t10;
 // CHECK-NEXT:           double _r6 = 2 * _r4;
+// CHECK-NEXT:           _d_sigma += _r6;
 // CHECK-NEXT:           double _r7 = _t11 * _r3;
+// CHECK-NEXT:           _d_sigma += _r7;
 // CHECK-NEXT:           _d_t -= _r_d1;
 // CHECK-NEXT:       }
 // CHECK-NEXT:       for (; _t0; _t0--) {

--- a/test/Gradient/DiffInterface.C
+++ b/test/Gradient/DiffInterface.C
@@ -37,6 +37,8 @@ double f_1(double x, double y, double z) {
 
 // x
 //CHECK:   void f_1_grad_0(double x, double y, double z, clad::array_ref<double> _d_x) {
+//CHECK-NEXT:       double _d_y = 0;
+//CHECK-NEXT:       double _d_z = 0;  
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -52,13 +54,17 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t1;
 //CHECK-NEXT:           double _r3 = 1 * 1;
+//CHECK-NEXT:           _d_y += _r3;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
+//CHECK-NEXT:           _d_z += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // y
 //CHECK:   void f_1_grad_1(double x, double y, double z, clad::array_ref<double> _d_y) {
+//CHECK-NEXT:       double _d_x = 0;
+//CHECK-NEXT:       double _d_z = 0;  
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -71,16 +77,20 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
+//CHECK-NEXT:           _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t1;
 //CHECK-NEXT:           double _r3 = 1 * 1;
 //CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
+//CHECK-NEXT:           _d_z += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // z
 //CHECK:   void f_1_grad_2(double x, double y, double z, clad::array_ref<double> _d_z) {
+//CHECK-NEXT:       double _d_x = 0;
+//CHECK-NEXT:       double _d_y = 0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -93,8 +103,10 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
+//CHECK-NEXT:           _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t1;
 //CHECK-NEXT:           double _r3 = 1 * 1;
+//CHECK-NEXT:          _d_y += _r3;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
 //CHECK-NEXT:           * _d_z += _r5;
@@ -103,6 +115,7 @@ double f_1(double x, double y, double z) {
 
 // x, y
 //CHECK:   void f_1_grad_0_1(double x, double y, double z, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
+//CHECK-NEXT:       double _d_z = 0; 
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -121,11 +134,13 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
+//CHECK-NEXT:           _d_z += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // y, x
 //CHECK:   void f_1_grad_1_0(double x, double y, double z, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
+//CHECK-NEXT:       double _d_z = 0; 
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -144,11 +159,13 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:           * _d_y += _r3;
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
+// CHECK-NEXT:         _d_z += _r5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // y, z
 //CHECK:   void f_1_grad_1_2(double x, double y, double z, clad::array_ref<double> _d_y, clad::array_ref<double> _d_z) {
+// CHECK-NEXT:     double _d_x = 0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -161,6 +178,7 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
+// CHECK-NEXT:          _d_x += _r1;
 //CHECK-NEXT:           double _r2 = 1 * _t1;
 //CHECK-NEXT:           double _r3 = 1 * 1;
 //CHECK-NEXT:           * _d_y += _r3;

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -193,6 +193,7 @@ double f_sum(double *p, int n) {
 }
 
 //CHECK:   void f_sum_grad_0(double *p, int n, clad::array_ref<double> _d_p) {
+//CHECK-NEXT:       int _d_n = 0;
 //CHECK-NEXT:       double _d_s = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
@@ -240,6 +241,7 @@ double f_sum_squares(double *p, int n) {
 }
 
 //CHECK:   void f_sum_squares_grad_0(double *p, int n, clad::array_ref<double> _d_p) {
+//CHECK-NEXT:       int _d_n = 0;
 //CHECK-NEXT:       double _d_s = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
@@ -277,6 +279,8 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 }
 
 //CHECK:   void f_log_gaus_grad_1(double *x, double *p, double n, double sigma, clad::array_ref<double> _d_p) {
+//CHECK-NEXT:       double _d_n = 0;
+//CHECK-NEXT:       double _d_sigma = 0;
 //CHECK-NEXT:       double _d_power = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
@@ -339,7 +343,9 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:           double _r11 = _r10 * _grad2;
 //CHECK-NEXT:           double _r12 = _r11 * 3.1415926535897931;
 //CHECK-NEXT:           double _r13 = _r10 * _grad3;
+//CHECK-NEXT:           _d_n += _r13;
 //CHECK-NEXT:           double _r14 = _t13 * _r9;
+//CHECK-NEXT:           _d_sigma += _r14;
 //CHECK-NEXT:           double _r15 = _t15 * _d_gaus;
 //CHECK-NEXT:           double _r16 = _r15 * custom_derivatives::exp_darg0(_t16);
 //CHECK-NEXT:           _d_power += _r16;
@@ -354,6 +360,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:           double _grad1 = 0.;
 //CHECK-NEXT:           sq_grad(_t7, &_grad1);
 //CHECK-NEXT:           double _r5 = _r4 * _grad1;
+//CHECK-NEXT:           _d_sigma += _r5;
 //CHECK-NEXT:           _d_power -= _r_d1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       for (; _t0; _t0--) {

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -656,6 +656,7 @@ public:
   double partial_mem_fn(double i, double j) { return (x + y) * i + i * j; }
 
   // CHECK: void partial_mem_fn_grad_0(double i, double j, clad::array_ref<double> _d_i) {
+  // CHECK-NEXT:     double _d_j = 0;
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -674,6 +675,7 @@ public:
   // CHECK-NEXT:         double _r2 = 1 * _t2;
   // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         _d_j += _r3;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 


### PR DESCRIPTION
This PR modifies reverse mode differentiation by creating a derived variable for all parameters. And thus produces correct derived function for cases like these:
```c++
double fn(double i, double j) {
  j = i;
  return j;
}

int main() {
  auto d_fn = clad::gradient(fn, "i");
  double res[2] = {};
  d_fn.execute(3, 5, res);
  std::cout<<res[0]<<"\n";  // gives 0; expected: 1
}
```

Derived function produced:
```c++
void fn_grad_0(double i, double j, double *_result) {
    double _d_j = 0;
    j = i;
    double fn_return = j;
    goto _label0;
  _label0:
    _d_j += 1;
    {
        double _r_d0 = _d_j;
        _result[0UL] += _r_d0;
        _d_j -= _r_d0;
    }
}
```

Closes #265