### PR TITLE
Modify .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,12 +10,13 @@ DerivePointerAlignment: false
 PointerAlignment: Left
 
 AlignAfterOpenBracket: Align
-PenaltyBreakBeforeFirstCallParameter: 50
+PenaltyBreakBeforeFirstCallParameter: 1000
 AlignOperands: true
 AllowShortCaseLabelsOnASingleLine: true
 IndentCaseLabels: true
-BinPackParameters: false
-BinPackArguments: false
+BinPackParameters: true
+BinPackArguments: true
+AllowAllArgumentsOnNextLine: false
 
 IncludeCategories:
   - Regex:           '^"[^/]+\"'


### PR DESCRIPTION
It will now align arguments with the opening bracket and can have multiple arguments in one line.