### PR TITLE
Modify .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,6 +11,7 @@ PointerAlignment: Left
 
 AlignAfterOpenBracket: Align
 PenaltyBreakBeforeFirstCallParameter: 1000
+PenaltyBreakAssignment: 1000
 AlignOperands: true
 AllowShortCaseLabelsOnASingleLine: true
 IndentCaseLabels: true


### PR DESCRIPTION
Make penalty for breaking after assignment equal to the penalty for breaking before first call parameter