### PR TITLE
Fix overload derivative decl not being added to codegen

### DIFF
--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -343,10 +343,11 @@ static inline ConstexprSpecKind Function_GetConstexprKind(const FunctionDecl* F)
 // Clang 9 add one extra param (Ctx) in some constructors.
 
 #if CLANG_VERSION_MAJOR < 9
-   #define CLAD_COMPAT_CLANG9_MemberExpr_ExtraParams /**/
+   #define CLAD_COMPAT_CLANG9_MemberExpr_ExtraParams(NOUR) /**/
 #elif CLANG_VERSION_MAJOR >= 9
-   #define CLAD_COMPAT_CLANG9_MemberExpr_ExtraParams ,Node->isNonOdrUse()
+   #define CLAD_COMPAT_CLANG9_MemberExpr_ExtraParams(NOUR) ,NOUR
 #endif
+
 
 
 // Clang 9 change PragmaIntroducerKind ===> PragmaIntroducer.

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -206,7 +206,6 @@ namespace clad {
     clang::QualType DerivedOutputParamType;
     if (request.Mode == DiffMode::jacobian) {
       isVectorValued = true;
-      args.pop_back();
       unsigned lastArgN = m_Function->getNumParams() - 1;
       outputArrayStr = m_Function->getParamDecl(lastArgN)->getNameAsString();
       DerivedOutputParamType = m_Function->getParamDecl(lastArgN)->getType();
@@ -219,13 +218,18 @@ namespace clad {
     std::string gradientName = derivativeBaseName + funcPostfix();
     // To be consistent with older tests, nothing is appended to 'f_grad' if
     // we differentiate w.r.t. all the parameters at once.
-    if (!std::equal(FD->param_begin(), FD->param_end(), std::begin(args))) {
+    if (!(args.size() == FD->getNumParams() &&
+          std::equal(FD->param_begin(), FD->param_end(), std::begin(args)))) {
       for (auto arg : args) {
         auto it = std::find(FD->param_begin(), FD->param_end(), arg);
         auto idx = std::distance(FD->param_begin(), it);
         gradientName += ('_' + std::to_string(idx));
       }
     }
+
+    if (isVectorValued)
+      args.pop_back();
+
     IdentifierInfo* II = &m_Context.Idents.get(gradientName);
     DeclarationNameInfo name(II, noLoc);
 

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -93,8 +93,8 @@ Stmt* StmtClone::VisitMemberExpr(MemberExpr* Node) {
                                   Node->getType(),
                                   Node->getValueKind(),
                                   Node->getObjectKind()
-                                  CLAD_COMPAT_CLANG9_MemberExpr_ExtraParams
-                                  );
+                                  CLAD_COMPAT_CLANG9_MemberExpr_ExtraParams(
+                                      Node->isNonOdrUse()));
   // Copy Value and Type dependent
   clad_compat::ExprSetDeps(result, Node);
   return result;

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -614,7 +614,7 @@ namespace clad {
                      /*Fn=*/exprFunc,
                      /*LParenLoc=*/noLoc,
                      /*ArgExprs=*/llvm::MutableArrayRef<Expr*>(argExprs),
-                     /*RParenLoc=*/noLoc)
+                     /*RParenLoc=*/m_Function->getLocation())
                  .get();
     }
     return call;

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -111,7 +111,7 @@ double f8(float x) {
 // CHECK-NEXT:   return custom_derivatives::pow_darg0(x, 2) * (_d_x + 0);
 // CHECK-NEXT: }
 
-void f8_grad(float x, double* _d_x);
+void f8_grad(float x, clad::array_ref<double> _d_x);
 
 // CHECK: void f8_grad(float x, clad::array_ref<double> _d_x) {
 // CHECK-NEXT:     float _t0;

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -130,9 +130,13 @@ namespace clad {
       return true; // Happiness
     }
 
+    static void ProcessTopLevelDecl(CompilerInstance& CI, Decl* D) {
+      CI.getASTConsumer().HandleTopLevelDecl(DeclGroupRef(D));
+    }
+
     FunctionDecl* CladPlugin::ProcessDiffRequest(DiffRequest& request) {
       const FunctionDecl* FD = request.Function;
-      //set up printing policy
+      // set up printing policy
       clang::LangOptions LangOpts;
       LangOpts.CPlusPlus = true;
       clang::PrintingPolicy Policy(LangOpts);
@@ -197,8 +201,9 @@ namespace clad {
         bool isTU = DerivativeDeclOrEnclosingContext->getDeclContext()->
           isTranslationUnit();
         if (isTU) {
-          m_CI.getASTConsumer().HandleTopLevelDecl(DeclGroupRef(
-            DerivativeDeclOrEnclosingContext));
+          ProcessTopLevelDecl(m_CI, DerivativeDeclOrEnclosingContext);
+          if (OverloadedDerivativeDecl)
+            ProcessTopLevelDecl(m_CI, OverloadedDerivativeDecl);
         }
 
         // Last requested order was computed, return the result.


### PR DESCRIPTION
- Fixes linker not able to find overload code
- Fixes `setPreviousDecl` called for wrong decl