### PR TITLE
Fix segfault on clad::tape resize.

### DIFF
--- a/test/Misc/TapeMemory.C
+++ b/test/Misc/TapeMemory.C
@@ -1,0 +1,41 @@
+// RUN: %cladclang %s -x c++ -lstdc++ -I%S/../../include -oTapeMemory.out 2>&1
+// RUN: ./TapeMemory.out
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+class A {};
+
+// Minimum viable code to test for tape pushes/pops
+template <typename T> void func(T x, int n) {
+  clad::tape<T> t = {};
+  for (int i = 0; i < n; i++) {
+    clad::push<T>(t, x);
+  }
+  for (int i = 0; i < n; i++) {
+    clad::pop<T>(t);
+  }
+}
+
+int main() {
+
+  int block = 32, n = 5;
+  int dummy = 0;
+  for (int i = 0; i < n; i++, block *= 2) {
+    // Scalar types
+    func<bool>(0, block);
+    func<char>(0, block);
+    func<int>(0, block);
+    func<float>(0, block);
+    func<double>(0, block);
+    func<long>(0, block);
+    func<long double>(0, block);
+    // Const/Volatile types
+    func<const int>(static_cast<const int>(dummy), block);
+    func<volatile float>(static_cast<volatile float>(dummy), block);
+    func<const volatile double>(static_cast<const volatile double>(dummy),
+                                block);
+    // custom type
+    func<A>(A(), block);
+  }
+}


### PR DESCRIPTION
This aims to fix the memory bug in ```Tape.h``` that causes clad to fail horribly on tape resizes due to an invalid write error. 

<details> <summary>valgrind report</summary>
==5512== Invalid write of size 4
==5512== at 0x40092D: void clad::tape_impl<float>::emplace_back<float&>(float&) (Tape.h:47)
==5512== by 0x4008CD: float clad::push<float>(clad::tape_impl<float>&, float) (Differentiator.h:57)
==5512== by 0x400823: func(float, int) (random.cpp:7)
==5512== by 0x40086F: main (random.cpp:14)

==5512== Address 0x5bd6e40 is 0 bytes after a block of size 256 alloc'd
==5512== at 0x4C3240F: operator new(unsigned long, std::nothrow_t const&) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5512== by 0x400AD9: clad::tape_impl<float>::AllocateRawStorage(unsigned long) (Tape.h:37)
==5512== by 0x40099F: clad::tape_impl<float>::grow() (Tape.h:92)
==5512== by 0x40090E: void clad::tape_impl<float>::emplace_back<float&>(float&) (Tape.h:46)
==5512== by 0x4008CD: float clad::push<float>(clad::tape_impl<float>&, float) (Differentiator.h:57)
==5512== by 0x400823: func(float, int) (random.cpp:7)
==5512== by 0x40086F: main (random.cpp:14)
==5512==
</details>

The diagnosis of the error is provided as an example below:

```cpp
T* new_data = AllocateRawStorage(_capacity); 
// New data allocated here, new_data points to 0x000 (lets assume), _data points to 0x100 (again, assumption).
// The _size value is 32, end() is 0x121 (0x100 + (hex)32) and begin() is 0x100.
// Allocated memory to new data: 0x000 + 32 * 2 = 0x040.
// So valid (contiguous) bounds for new data are -> [0x000 - 0x040]
assert(new_data);

for (auto i = begin(), e = end(); i != e; ++i, ++new_data)
new(new_data) T(std::move(*i));
// At the end of this, new_data points to 0x020, _data still points to 0x121.

// Destroy all values in the old storage.
destroy(begin(), end());
_data = new_data;
//Here, begin() changes to 0x020 and end() changes to 0x040.
// Now, emplace_back attemtemps to write at the end().
// however recall that the only valid interval for new_data to write is 0x000 - 0x040.
// So pushing a new element to the tape 
// (clad will use a positional new at end()) after resize causes clad to write to 0x041 (in this case)
// hence causing the segfault with 0 offset.

```

So to fix this, we just need an intermediate pointer to do the increment and then assign the orignal pointer to data later. So basically:

```cpp
T* new_data = AllocateRawStorage(_capacity);
assert(new_data);
auto current = new_data;
for (auto i = begin(), e = end(); i != e; ++i, ++current)
    new(current) T(std::move(*i));
destroy(begin(), end());
_data = new_data;
```

**Solution implemented:**
The solution implemented is taken from ```std::unitialized_copy```  just to make sure we do things the intended way.