### PR TITLE
Fix code leaks cause by Tape.h.

### DIFF
--- a/include/clad/Differentiator/Tape.h
+++ b/include/clad/Differentiator/Tape.h
@@ -28,6 +28,13 @@ namespace clad {
     using iterator = pointer;
     using const_iterator = const_pointer;
 
+    CUDA_HOST_DEVICE ~tape_impl(){
+      destroy(begin(), end());
+      // delete the old data here to make sure we do not leak anything.
+      ::operator delete(const_cast<void*>(
+            static_cast<const volatile void*>(_data)));
+    }
+
     /// Move values from old to new storage
     CUDA_HOST_DEVICE T* AllocateRawStorage(std::size_t _capacity) {
       #ifdef __CUDACC__
@@ -120,6 +127,9 @@ namespace clad {
       MoveData(begin(), end(), new_data);
       // Destroy all values in the old storage.
       destroy(begin(), end());
+      // delete the old data here to make sure we do not leak anything.
+      ::operator delete(const_cast<void*>(
+            static_cast<const volatile void*>(_data)));
       _data = new_data;
     }
 


### PR DESCRIPTION
This PR aims to fix the memory leaks caused by ```clad::tape```.  These happen because memory allocated by ```clad::tape``` is not freed after reallocation/destruction. 

**Leak check for TapeMemory.h [via valgrind] pre fix:**
```
==18498== HEAP SUMMARY:
==18498==     in use at exit: 107,616 bytes in 165 blocks
==18498==   total heap usage: 166 allocs, 1 frees, 180,320 bytes allocated
==18498== 
==18498== LEAK SUMMARY:
==18498==    definitely lost: 107,616 bytes in 165 blocks
==18498==    indirectly lost: 0 bytes in 0 blocks
==18498==      possibly lost: 0 bytes in 0 blocks
==18498==    still reachable: 0 bytes in 0 blocks
==18498==         suppressed: 0 bytes in 0 blocks
==18498== Rerun with --leak-check=full to see details of leaked memory
```

with primary culprits being: 
<pre><code>
==18520== 29,184 bytes in 15 blocks are definitely lost in loss record 11 of 11
==18520==    at 0x4C3240F: operator new(unsigned long, std::nothrow_t const&) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
<b>==18520==    by 0x402C79: clad::tape_impl<long double>::AllocateRawStorage(unsigned long) (Tape.h:38)</b>
==18520==    by 0x402B7F: clad::tape_impl<long double>::grow() (Tape.h:115)
==18520==    by 0x402AEE: void clad::tape_impl<long double>::emplace_back<long double&>(long double&) (Tape.h:47)
==18520==    by 0x402A7E: long double clad::push<long double>(clad::tape_impl<long double>&, long double) (Differentiator.h:57)
==18520==    by 0x400C37: void func<long double>(long double, int) (TapeMemory.C:13)
==18520==    by 0x4007D5: main (TapeMemory.C:32)
</code>