### PR TITLE
Fix typo in clad::tape_impl::size().

### DIFF
--- a/include/clad/Differentiator/Tape.h
+++ b/include/clad/Differentiator/Tape.h
@@ -57,7 +57,7 @@ namespace clad {
       _size += 1;
     }
 
-    CUDA_HOST_DEVICE std::size_t size() const { return size; }
+    CUDA_HOST_DEVICE std::size_t size() const { return _size; }
     CUDA_HOST_DEVICE iterator begin() {
       return reinterpret_cast<iterator>(_data);
     }


### PR DESCRIPTION
This PR fixes a small typo in ```clad::tape_impl::size()``` that causes the calls to ```size()``` to fail.