### PR TITLE
Modify BuildCallToMemFn to do perfect forwarding of `*this` object

### DIFF
--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -521,6 +521,20 @@ Sema_ActOnStartOfSwitchStmt(Sema& SemaRef, Stmt* initStmt,
 #elif LLVM_VERSION_MAJOR >= 13
 #define CLAD_COMPAT_llvm_sys_fs_Append llvm::sys::fs::OF_Append
 #endif
+
+#if CLANG_VERSION_MAJOR > 8
+static inline Qualifiers CXXMethodDecl_getMethodQualifiers(const CXXMethodDecl* MD) {
+   return MD->getMethodQualifiers();
+}
+#elif CLANG_VERSION_MAJOR == 8
+static inline Qualifiers CXXMethodDecl_getMethodQualifiers(const CXXMethodDecl* MD) {
+   return MD->getTypeQualifiers();
+}
+#elif CLANG_VERSION_MAJOR < 8
+static inline Qualifiers CXXMethodDecl_getMethodQualifiers(const CXXMethodDecl* MD) {
+   return Qualifiers::fromFastMask(MD->getTypeQualifiers());
+}
+#endif
 } // namespace clad_compat
 
 #endif //CLAD_COMPATIBILITY

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -420,10 +420,13 @@ namespace clad {
     ///
     /// \param[in] FD callee member function
     /// \param[in] argExprs function arguments expressions
+    /// \param[in] useRefQualifiedThisObj If true, then the `this` object is
+    /// perfectly forwarded while calling member functions.
     /// \returns Built member function call expression
     clang::Expr*
     BuildCallExprToMemFn(clang::CXXMethodDecl* FD,
-        llvm::MutableArrayRef<clang::Expr*> argExprs);
+                         llvm::MutableArrayRef<clang::Expr*> argExprs,
+                         bool useRefQualifiedThisObj = false);
 
     /// Build a call to a free function or member function through
     /// this pointer depending on whether the `FD` argument corresponds to a
@@ -431,10 +434,13 @@ namespace clad {
     ///
     /// \param[in] FD callee function
     /// \param[in] argExprs function arguments expressions
+    /// \param[in] useRefQualifiedThisObj If true, then the `this` object is
+    /// perfectly forwarded while calling member functions.
     /// \returns Built call expression
     clang::Expr*
     BuildCallExprToFunction(clang::FunctionDecl* FD,
-                            llvm::MutableArrayRef<clang::Expr*> argExprs);
+                            llvm::MutableArrayRef<clang::Expr*> argExprs,
+                            bool useRefQualifiedThisObj = false);
     /// Find declaration of clad::array_ref templated type.
     clang::TemplateDecl* GetCladArrayRefDecl();
     /// Create clad::array_ref<T> type.

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -177,7 +177,8 @@ namespace clad {
     m_DerivativeFnScope = getCurrentScope();
     beginBlock();
 
-    Expr* callExpr = BuildCallExprToFunction(GradientFD, callArgsRef);
+    Expr* callExpr = BuildCallExprToFunction(GradientFD, callArgsRef,
+                                             /*UseRefQualifiedThisObj=*/true);
     addToCurrentBlock(callExpr);
     Stmt* gradientOverloadBody = endBlock();
 

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -766,4 +766,56 @@ int main() {
   for(unsigned i=0;i<2;++i) {
     printf("%.2f ",result[i]);  //CHECK-EXEC: 40.00 16.00
   }
+  
+  auto d_const_volatile_lval_ref_mem_fn_i = clad::gradient(&SimpleFunctions::const_volatile_lval_ref_mem_fn, "i");
+
+  // CHECK:   void const_volatile_lval_ref_mem_fn_grad_0(double i, double j, clad::array_ref<double> _d_i) const volatile & {
+  // CHECK-NEXT:       double _d_j = 0;
+  // CHECK-NEXT:       double _t0;
+  // CHECK-NEXT:       double _t1;
+  // CHECK-NEXT:       double _t2;
+  // CHECK-NEXT:       double _t3;
+  // CHECK-NEXT:       _t1 = (this->x + this->y);
+  // CHECK-NEXT:       _t0 = i;
+  // CHECK-NEXT:       _t3 = i;
+  // CHECK-NEXT:       _t2 = j;
+  // CHECK-NEXT:       double const_volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:       goto _label0;
+  // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:       {
+  // CHECK-NEXT:           double _r0 = 1 * _t0;
+  // CHECK-NEXT:           double _r1 = _t1 * 1;
+  // CHECK-NEXT:           * _d_i += _r1;
+  // CHECK-NEXT:           double _r2 = 1 * _t2;
+  // CHECK-NEXT:           * _d_i += _r2;
+  // CHECK-NEXT:           double _r3 = _t3 * 1;
+  // CHECK-NEXT:           _d_j += _r3;
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:   }
+
+  auto d_const_volatile_rval_ref_mem_fn_j = clad::gradient(&SimpleFunctions::const_volatile_rval_ref_mem_fn, "j");
+
+  // CHECK:   void const_volatile_rval_ref_mem_fn_grad_1(double i, double j, clad::array_ref<double> _d_j) const volatile && {
+  // CHECK-NEXT:       double _d_i = 0;
+  // CHECK-NEXT:       double _t0;
+  // CHECK-NEXT:       double _t1;
+  // CHECK-NEXT:       double _t2;
+  // CHECK-NEXT:       double _t3;
+  // CHECK-NEXT:       _t1 = (this->x + this->y);
+  // CHECK-NEXT:       _t0 = i;
+  // CHECK-NEXT:       _t3 = i;
+  // CHECK-NEXT:       _t2 = j;
+  // CHECK-NEXT:       double const_volatile_rval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:       goto _label0;
+  // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:       {
+  // CHECK-NEXT:           double _r0 = 1 * _t0;
+  // CHECK-NEXT:           double _r1 = _t1 * 1;
+  // CHECK-NEXT:           _d_i += _r1;
+  // CHECK-NEXT:           double _r2 = 1 * _t2;
+  // CHECK-NEXT:           _d_i += _r2;
+  // CHECK-NEXT:           double _r3 = _t3 * 1;
+  // CHECK-NEXT:           * _d_j += _r3;
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:   }
 }


### PR DESCRIPTION
This PR updates the` BuildCallToMemFn` function to do perfect forwarding of `*this` object depending on the value of `useRefQualifiedThisObj` parameter.

This PR also fixes #292 , and now for member functions, gradient overloaded is created as follows:
```c++
void SomeMemFn_grad_0(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_0) {
  static_cast<SomeClass>(*this).memFn_grad_0(i, j, _d_i);
}

