### PR TITLE
Add initial support for reverse mode visitor plugin system

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -7,9 +7,16 @@
 #include "clang/AST/Decl.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Sema/Sema.h"
+#include "clang/AST/Type.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <string>
+
+namespace clang {
+  class ASTContext;
+  class FunctionDecl;
+  class StringLiteral;
+}
 
 namespace clad {
   namespace utils {
@@ -125,7 +132,18 @@ namespace clad {
     /// \param[in] DC
     clang::DeclContext* GetOutermostDC(clang::Sema& semaRef,
                                        clang::DeclContext* DC);
-    } // namespace utils
+
+    /// Creates a `StringLiteral` node to represent string literal
+    /// "`str`".
+    ///
+    ///\param C reference to `ASTContext` object.
+    ///\param[in] str string literal to create.
+    clang::StringLiteral* CreateStringLiteral(clang::ASTContext& C,
+                                              llvm::StringRef str);
+
+    /// Returns true if `QT` is Array or Pointer Type, otherwise returns false.
+    bool isArrayOrPointerType(const clang::QualType QT);
+  } // namespace utils
 }
 
 #endif

--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -44,8 +44,6 @@ namespace clad {
 namespace clad {
   class ErrorEstimationHandler;
   class FPErrorEstimationModel;
-  // A pointer to a the handler to be used for estimation requests.
-  extern std::unique_ptr<ErrorEstimationHandler> errorEstHandler;
 
   /// A pair of FunctionDecl and potential enclosing context, e.g. a function
   /// in nested namespaces.
@@ -84,6 +82,8 @@ namespace clad {
     /// A flag to keep track of whether error diagnostics are requested by user
     /// for numerical differentiation.
     bool m_PrintNumericalDiffErrorDiag = false;
+    // A pointer to a the handler to be used for estimation requests.
+    std::unique_ptr<ErrorEstimationHandler> m_ErrorEstHandler;
     DeclWithContext cloneFunction(const clang::FunctionDecl* FD,
                                   clad::VisitorBase VB, clang::DeclContext* DC,
                                   clang::Sema& m_Sema,

--- a/include/clad/Differentiator/ErrorEstimator.h
+++ b/include/clad/Differentiator/ErrorEstimator.h
@@ -2,232 +2,278 @@
 #define CLAD_ERROR_ESTIMATOR_H
 
 #include "EstimationModel.h"
-#include "ReverseModeVisitor.h"
+#include "clad/Differentiator/ExternalRMVSource.h"
 #include "clad/Differentiator/ReverseModeVisitorDirectionKinds.h"
+
+#include "clang/AST/OperationKinds.h"
+
+#include <stack>
+
 namespace clang {
-  class Stmt;
-  class Expr;
-  class Decl;
-  class VarDecl;
-  class ParmVarDecl;
-  class FunctionDecl;
-  class CompoundStmt;
+class Stmt;
+class Expr;
+class Decl;
+class VarDecl;
+class ParmVarDecl;
+class FunctionDecl;
+class CompoundStmt;
 } // namespace clang
 
 namespace clad {
-  /// The estimation handler which interfaces with Clad's reverse mode visitors
-  /// to fetch derivatives.
-  class ErrorEstimationHandler : public ReverseModeVisitor {
-    /// Keeps a track of the delta error expression we shouldn't emit.
-    bool m_DoNotEmitDelta;
-    /// Reference to the final error parameter in the augumented target
-    /// function.
-    clang::Expr* m_FinalError;
-    /// Reference to the return error expression.
-    clang::Expr* m_RetErrorExpr;
-    /// An instance of the custom error estimation model to be used.
-    FPErrorEstimationModel* m_EstModel; // We do not own this.
-    /// A set of assignments resulting for declaration statments.
-    VisitorBase::Stmts m_ForwardReplStmts;
-    /// A vector to keep track of error statements for delayed emission.
-    VisitorBase::Stmts m_ReverseErrorStmts;
-    /// The index expression for emitting final errors for input param errors.
-    clang::Expr* m_IdxExpr;
-    /// A set of declRefExprs for parameter value replacements.
-    std::unordered_map<const clang::VarDecl*, clang::Expr*> m_ParamRepls;
+/// The estimation handler which interfaces with Clad's reverse mode visitors
+/// to fetch derivatives.
+class ErrorEstimationHandler : public ExternalRMVSource {
+  // FIXME: Find a good way to modularize using declarations that are used in
+  // multiple header files. 
+  // `Stmts` is originally defined in `VisitorBase`.
+  using Stmts = llvm::SmallVector<clang::Stmt*, 16>;
+  /// Keeps a track of the delta error expression we shouldn't emit.
+  bool m_DoNotEmitDelta;
+  /// Reference to the final error parameter in the augumented target
+  /// function.
+  clang::Expr* m_FinalError;
+  /// Reference to the return error expression.
+  clang::Expr* m_RetErrorExpr;
+  /// An instance of the custom error estimation model to be used.
+  FPErrorEstimationModel* m_EstModel; // We do not own this.
+  /// A set of assignments resulting for declaration statments.
+  Stmts m_ForwardReplStmts;
+  /// A vector to keep track of error statements for delayed emission.
+  Stmts m_ReverseErrorStmts;
+  /// The index expression for emitting final errors for input param errors.
+  clang::Expr* m_IdxExpr;
+  /// A set of declRefExprs for parameter value replacements.
+  std::unordered_map<const clang::VarDecl*, clang::Expr*> m_ParamRepls;
 
-  public:
-    ErrorEstimationHandler(DerivativeBuilder& builder)
-        : ReverseModeVisitor(builder), m_DoNotEmitDelta(false),
-          m_FinalError(nullptr), m_RetErrorExpr(nullptr), m_EstModel(nullptr),
-          m_IdxExpr(nullptr) {}
-    ~ErrorEstimationHandler() {}
+  std::stack<bool> m_ShouldEmit;
+  ReverseModeVisitor* m_RMV;
+  clang::Expr* m_DeltaVar = nullptr;
+  llvm::SmallVectorImpl<clang::QualType>* m_ParamTypes = nullptr;
+  llvm::SmallVectorImpl<clang::ParmVarDecl*>* m_Params = nullptr;
 
-    /// Function to set the error estimation model currently in use.
-    ///
-    /// \param[in] estModel The error estimation model, can be either
-    /// an in-built one (TaylorApprox) or one provided by the user.
-    void SetErrorEstimationModel(FPErrorEstimationModel* estModel);
+public:
+  using direction = rmv::direction;
+  ErrorEstimationHandler()
+      : m_DoNotEmitDelta(false), m_FinalError(nullptr), m_RetErrorExpr(nullptr),
+        m_EstModel(nullptr), m_IdxExpr(nullptr) {}
+  ~ErrorEstimationHandler() {}
 
-    /// \param[in] finErrExpr The final error expression.
-    void SetFinalErrorExpr(clang::Expr* finErrExpr) {
-      m_FinalError = finErrExpr;
-    }
+  /// Function to set the error estimation model currently in use.
+  ///
+  /// \param[in] estModel The error estimation model, can be either
+  /// an in-built one (TaylorApprox) or one provided by the user.
+  void SetErrorEstimationModel(FPErrorEstimationModel* estModel);
 
-    /// Shorthand to get array subscript expressions.
-    ///
-    /// \param[in] arrBase The base expression of the array.
-    /// \param[in] idx The index expression.
-    /// \param[in] isCladSpType Keeps track of if we have to build a clad
-    /// special type (i.e. clad::Array or clad::ArrayRef).
-    ///
-    /// \returns An expression of the kind arrBase[idx].
-    clang::Expr* getArraySubscriptExpr(clang::Expr* arrBase, clang::Expr* idx,
-                                       bool isCladSpType = true);
+  /// \param[in] finErrExpr The final error expression.
+  void SetFinalErrorExpr(clang::Expr* finErrExpr) { m_FinalError = finErrExpr; }
 
-    /// \returns The final error expression so far.
-    clang::Expr* GetFinalErrorExpr() { return m_FinalError; }
+  /// Shorthand to get array subscript expressions.
+  ///
+  /// \param[in] arrBase The base expression of the array.
+  /// \param[in] idx The index expression.
+  /// \param[in] isCladSpType Keeps track of if we have to build a clad
+  /// special type (i.e. clad::Array or clad::ArrayRef).
+  ///
+  /// \returns An expression of the kind arrBase[idx].
+  clang::Expr* getArraySubscriptExpr(clang::Expr* arrBase, clang::Expr* idx,
+                                     bool isCladSpType = true);
 
-    /// Function to build the final error statemnt of the function. This is the
-    /// last statement of any target function in error estimation and
-    /// aggregates the error in all the registered variables.
-    void BuildFinalErrorStmt();
+  /// \returns The final error expression so far.
+  clang::Expr* GetFinalErrorExpr() { return m_FinalError; }
 
-    /// Function to emit error statements into the derivative body.
-    ///
-    /// \param[in] var The variable whose error statement we want to emit.
-    /// \param[in] deltaVar The "_delta_" expression of the variable 'var'.
-    /// \param[in] errorExpr The error expression (LHS) of the variable 'var'.
-    /// \param[in] isInsideLoop A flag to indicate if 'val' is inside a loop.
-    void AddErrorStmtToBlock(clang::Expr* var, clang::Expr* deltaVar,
-                             clang::Expr* errorExpr, bool isInsideLoop = false);
+  /// Function to build the final error statemnt of the function. This is the
+  /// last statement of any target function in error estimation and
+  /// aggregates the error in all the registered variables.
+  void BuildFinalErrorStmt();
 
-    /// Emit the error estimation related statements that were saved to be
-    /// emitted at later points into specific blocks.
-    ///
-    /// \param[in] d The direction of the block in which to emit the
-    /// statements.
-    void EmitErrorEstimationStmts(direction d = direction::forward);
+  /// Function to emit error statements into the derivative body.
+  ///
+  /// \param[in] var The variable whose error statement we want to emit.
+  /// \param[in] deltaVar The "_delta_" expression of the variable 'var'.
+  /// \param[in] errorExpr The error expression (LHS) of the variable 'var'.
+  /// \param[in] isInsideLoop A flag to indicate if 'val' is inside a loop.
+  void AddErrorStmtToBlock(clang::Expr* var, clang::Expr* deltaVar,
+                           clang::Expr* errorExpr, bool isInsideLoop = false);
 
-    /// We should save the return value if it is an arithmetic expression,
-    /// since we also need to take into account the error in that expression.
-    ///
-    /// \param[in] retExpr The return expression.
-    /// \param[in] retDeclRefExpr The temporary value in which the return
-    /// expression is stored.
-    void SaveReturnExpr(clang::Expr* retExpr,
-                        clang::DeclRefExpr* retDeclRefExpr);
+  /// Emit the error estimation related statements that were saved to be
+  /// emitted at later points into specific blocks.
+  ///
+  /// \param[in] d The direction of the block in which to emit the
+  /// statements.
+  void EmitErrorEstimationStmts(direction d = direction::forward);
 
-    /// Emit the error for parameters of nested functions.
-    ///
-    /// \param[in] fnDecl The function declaration of the nested function.
-    /// \param[in] CallArgs The orignal call arguments of the function call.
-    /// \param[in] ArgResultDecls The differentiated call arguments.
-    /// \param[in] numArgs The number of call args.
-    void EmitNestedFunctionParamError(
-        clang::FunctionDecl* fnDecl,
-        llvm::SmallVectorImpl<clang::Expr*>& CallArgs,
-        llvm::SmallVectorImpl<clang::VarDecl*>& ArgResultDecls, size_t numArgs);
+  /// We should save the return value if it is an arithmetic expression,
+  /// since we also need to take into account the error in that expression.
+  ///
+  /// \param[in] retExpr The return expression.
+  /// \param[in] retDeclRefExpr The temporary value in which the return
+  /// expression is stored.
+  void SaveReturnExpr(clang::Expr* retExpr, clang::DeclRefExpr* retDeclRefExpr);
 
-    /// Save values of registered variables so that they can be replaced
-    /// properly in case of re-assignments.
-    ///
-    /// \param[in] val The value to save.
-    /// \param[in] isInsideLoop A flag to indicate if 'val' is inside a loop.
-    ///
-    /// \returns The saved variable and its derivative.
-    StmtDiff SaveValue(clang::Expr* val, bool isInLoop = false);
+  /// Emit the error for parameters of nested functions.
+  ///
+  /// \param[in] fnDecl The function declaration of the nested function.
+  /// \param[in] CallArgs The orignal call arguments of the function call.
+  /// \param[in] ArgResultDecls The differentiated call arguments.
+  /// \param[in] numArgs The number of call args.
+  void EmitNestedFunctionParamError(
+      clang::FunctionDecl* fnDecl,
+      llvm::SmallVectorImpl<clang::Expr*>& CallArgs,
+      llvm::SmallVectorImpl<clang::VarDecl*>& ArgResultDecls, size_t numArgs);
 
-    /// Save the orignal values of the input parameters in case of
-    /// re-assignments.
-    ///
-    /// \param[in] paramRef The DeclRefExpr of the input parameter.
-    void SaveParamValue(clang::DeclRefExpr* paramRef);
+  /// Save values of registered variables so that they can be replaced
+  /// properly in case of re-assignments.
+  ///
+  /// \param[in] val The value to save.
+  /// \param[in] isInsideLoop A flag to indicate if 'val' is inside a loop.
+  ///
+  /// \returns The saved variable and its derivative.
+  StmtDiff SaveValue(clang::Expr* val, bool isInLoop = false);
 
-    /// Register variables to be used while accumulating error.
-    /// Register variable declarations so that they may be used while
-    /// calculating the final error estimates. Any unregistered variables will
-    /// not be considered for the final estimation.
-    ///
-    /// \param[in] VD The variable declaration to be registered.
-    /// \param[in] toCurrentScope Add the created "_delta_" variable declaration
-    /// to the current scope instead of the global scope.
-    ///
-    /// \returns The Variable declaration of the '_delta_' prefixed variable.
-    clang::Expr* RegisterVariable(clang::VarDecl* VD,
-                                  bool toCurrentScope = false);
+  /// Save the orignal values of the input parameters in case of
+  /// re-assignments.
+  ///
+  /// \param[in] paramRef The DeclRefExpr of the input parameter.
+  void SaveParamValue(clang::DeclRefExpr* paramRef);
 
-    /// Checks if a variable can be registered for error estimation.
-    ///
-    /// \param[in] VD The variable declaration to be registered.
-    ///
-    /// \returns True if the variable can be registered, false otherwise.
-    bool CanRegisterVariable(clang::VarDecl* VD);
+  /// Register variables to be used while accumulating error.
+  /// Register variable declarations so that they may be used while
+  /// calculating the final error estimates. Any unregistered variables will
+  /// not be considered for the final estimation.
+  ///
+  /// \param[in] VD The variable declaration to be registered.
+  /// \param[in] toCurrentScope Add the created "_delta_" variable declaration
+  /// to the current scope instead of the global scope.
+  ///
+  /// \returns The Variable declaration of the '_delta_' prefixed variable.
+  clang::Expr* RegisterVariable(clang::VarDecl* VD,
+                                bool toCurrentScope = false);
 
-    /// Calculate aggregate error from m_EstimateVar.
-    /// Builds the final error estimation statement.
-    clang::Stmt* CalculateAggregateError();
+  /// Checks if a variable can be registered for error estimation.
+  ///
+  /// \param[in] VD The variable declaration to be registered.
+  ///
+  /// \returns True if the variable can be registered, false otherwise.
+  bool CanRegisterVariable(clang::VarDecl* VD);
 
-    /// Get the underlying DeclRefExpr type it it exists.
-    ///
-    /// \param[in] expr The expression whose DeclRefExpr is requested.
-    ///
-    /// \returns The DeclRefExpr of input or null.
-    clang::DeclRefExpr* GetUnderlyingDeclRefOrNull(clang::Expr* expr);
+  /// Calculate aggregate error from m_EstimateVar.
+  /// Builds the final error estimation statement.
+  clang::Stmt* CalculateAggregateError();
 
-    /// Get the parameter replacement (if any).
-    ///
-    /// \param[in] VD The parameter variable declaration to get replacement
-    /// for.
-    ///
-    /// \returns The underlying replaced Expr.
-    clang::Expr* GetParamReplacement(const clang::ParmVarDecl* VD);
+  /// Get the underlying DeclRefExpr type it it exists.
+  ///
+  /// \param[in] expr The expression whose DeclRefExpr is requested.
+  ///
+  /// \returns The DeclRefExpr of input or null.
+  clang::DeclRefExpr* GetUnderlyingDeclRefOrNull(clang::Expr* expr);
 
-    /// An abstraction of the error estimation model's AssignError.
-    ///
-    /// \param[in] val The variable to get the error for.
-    /// \param[in] valDiff The derivative of the variable 'var'
-    ///
-    /// \returns The error in the variable 'var'.
-    clang::Expr* GetError(clang::Expr* var, clang::Expr* varDiff) {
-      return m_EstModel->AssignError({var, varDiff});
-    }
+  /// Get the parameter replacement (if any).
+  ///
+  /// \param[in] VD The parameter variable declaration to get replacement
+  /// for.
+  ///
+  /// \returns The underlying replaced Expr.
+  clang::Expr* GetParamReplacement(const clang::ParmVarDecl* VD);
 
-    /// An abstraction of the error estimation model's IsVariableRegistered.
-    ///
-    /// \param[in] VD The variable declaration to check the status of.
-    ///
-    /// \returns the reference to the respective '_delta_' expression if the
-    /// variable is registered, null otherwise.
-    clang::Expr* IsRegistered(clang::VarDecl* VD) {
-      return m_EstModel->IsVariableRegistered(VD);
-    }
+  /// An abstraction of the error estimation model's AssignError.
+  ///
+  /// \param[in] val The variable to get the error for.
+  /// \param[in] valDiff The derivative of the variable 'var'
+  ///
+  /// \returns The error in the variable 'var'.
+  clang::Expr* GetError(clang::Expr* var, clang::Expr* varDiff) {
+    return m_EstModel->AssignError({var, varDiff});
+  }
 
-    /// This function adds the final error and the other parameter errors to the
-    /// forward block.
-    ///
-    /// \param[in] params A vector of the parameter decls.
-    /// \param[in] numParams The number of orignal parameters.
-    void EmitFinalErrorStmts(llvm::SmallVectorImpl<clang::ParmVarDecl*>& params,
-                             unsigned numParams);
+  /// An abstraction of the error estimation model's IsVariableRegistered.
+  ///
+  /// \param[in] VD The variable declaration to check the status of.
+  ///
+  /// \returns the reference to the respective '_delta_' expression if the
+  /// variable is registered, null otherwise.
+  clang::Expr* IsRegistered(clang::VarDecl* VD) {
+    return m_EstModel->IsVariableRegistered(VD);
+  }
 
-    /// This function emits the error in unary operations.
-    ///
-    /// \param[in] var The variable to emit the error for.
-    /// \param[in] isInsideLoop A flag to keep track of if we are inside a
-    /// loop.
-    void EmitUnaryOpErrorStmts(StmtDiff var, bool isInsideLoop);
+  /// This function adds the final error and the other parameter errors to the
+  /// forward block.
+  ///
+  /// \param[in] params A vector of the parameter decls.
+  /// \param[in] numParams The number of orignal parameters.
+  void EmitFinalErrorStmts(llvm::SmallVectorImpl<clang::ParmVarDecl*>& params,
+                           unsigned numParams);
 
-    /// This function registers all LHS declRefExpr in binary operations.
-    ///
-    /// \param[in] LExpr The LHS of the operation.
-    /// \param[in] RExpr The RHS of the operation.
-    /// \param[in] isAssign A flag to know if the current operation is a simple
-    /// assignment.
-    ///
-    /// \returns The delta value of the input 'var'.
-    clang::Expr* RegisterBinaryOpLHS(clang::Expr* LExpr, clang::Expr* RExpr,
-                                     bool isAssign);
+  /// This function emits the error in unary operations.
+  ///
+  /// \param[in] var The variable to emit the error for.
+  /// \param[in] isInsideLoop A flag to keep track of if we are inside a
+  /// loop.
+  void EmitUnaryOpErrorStmts(StmtDiff var, bool isInsideLoop);
 
-    /// This function emits the error in a binary operation.
-    ///
-    /// \param[in] LExpr The LHS of the operation.
-    /// \param[in] oldValue The derivative of the target function with respect
-    /// to the LHS.
-    /// \param[in] deltaVar The delta value of the LHS.
-    /// \param[in] isInsideLoop A flag to keep track of if we are inside a
-    /// loop.
-    void EmitBinaryOpErrorStmts(clang::Expr* LExpr, clang::Expr* oldValue,
-                                clang::Expr* deltaVar, bool isInsideLoop);
+  /// This function registers all LHS declRefExpr in binary operations.
+  ///
+  /// \param[in] LExpr The LHS of the operation.
+  /// \param[in] RExpr The RHS of the operation.
+  /// \param[in] isAssign A flag to know if the current operation is a simple
+  /// assignment.
+  ///
+  /// \returns The delta value of the input 'var'.
+  clang::Expr* RegisterBinaryOpLHS(clang::Expr* LExpr, clang::Expr* RExpr,
+                                   bool isAssign);
 
-    /// This function emits the error in declaration statements.
-    ///
-    /// \param[in] VDDiff The variable declaration to calculate the error in.
-    /// \param[in] isInsideLoop A flag to keep track of if we are inside a
-    /// loop.
-    void EmitDeclErrorStmts(VarDeclDiff VDDiff, bool isInsideLoop);
-  };
+  /// This function emits the error in a binary operation.
+  ///
+  /// \param[in] LExpr The LHS of the operation.
+  /// \param[in] oldValue The derivative of the target function with respect
+  /// to the LHS.
+  /// \param[in] deltaVar The delta value of the LHS.
+  /// \param[in] isInsideLoop A flag to keep track of if we are inside a
+  /// loop.
+  void EmitBinaryOpErrorStmts(clang::Expr* LExpr, clang::Expr* oldValue,
+                              clang::Expr* deltaVar, bool isInsideLoop);
 
+  /// This function emits the error in declaration statements.
+  ///
+  /// \param[in] VDDiff The variable declaration to calculate the error in.
+  /// \param[in] isInsideLoop A flag to keep track of if we are inside a
+  /// loop.
+  void EmitDeclErrorStmts(VarDeclDiff VDDiff, bool isInsideLoop);
+
+  void InitialiseRMV(ReverseModeVisitor& RMV) override;
+  void ForgetRMV() override;
+  void ActBeforeCreatingDerivedFnParamTypes(unsigned&) override;
+  void ActAfterCreatingDerivedFnParamTypes(
+      llvm::SmallVectorImpl<clang::QualType>& paramTypes) override;
+  void ActAfterCreatingDerivedFnParams(
+      llvm::SmallVectorImpl<clang::ParmVarDecl*>& params) override;
+  void ActBeforeCreatingDerivedFnBodyScope() override;
+  void ActOnEndOfDerivedFnBody() override;
+  void ActBeforeDifferentiatingStmtInVisitCompoundStmt() override;
+  void ActAfterProcessingStmtInVisitCompoundStmt() override;
+  void ActBeforeDifferentiatingSingleStmtBranchInVisitIfStmt() override;
+  void ActBeforeFinalisingVisitBranchSingleStmtInIfVisitStmt() override;
+  void ActBeforeDifferentiatingLoopInitStmt() override;
+  void ActBeforeDifferentiatingSingleStmtLoopBody() override;
+  void ActAfterProcessingSingleStmtBodyInVisitForLoop() override;
+  void
+  ActBeforeFinalisingVisitReturnStmt(StmtDiff& ExprDiff,
+                                     clang::Expr*& retDeclRefExpr) override;
+  void ActBeforeFinalisingPostIncDecOp(StmtDiff& diff) override;
+  void ActBeforeFinalizingVisitCallExpr(
+      const clang::CallExpr*& CE, clang::Expr*& fnDecl,
+      llvm::SmallVectorImpl<clang::Expr*>& CallArgs,
+      llvm::SmallVectorImpl<clang::VarDecl*>& ArgResultDecls,
+      bool asGrad) override;
+  void
+  ActAfterCloningLHSOfAssignOp(clang::Expr*& LCloned, clang::Expr*& R,
+                               clang::BinaryOperator::Opcode& opCode) override;
+  void ActBeforeFinalisingAssignOp(clang::Expr*&, clang::Expr*&) override;
+  void ActBeforeFinalizingDifferentiateSingleStmt(const direction& d) override;
+  void ActBeforeFinalizingDifferentiateSingleExpr(const direction& d) override;
+  void ActBeforeFinalizingVisitDeclStmt(
+      llvm::SmallVectorImpl<clang::Decl*>& decls,
+      llvm::SmallVectorImpl<clang::Decl*>& declsDiff);
+};
 } // namespace clad
 
 #endif // CLAD_ERROR_ESTIMATOR_H

--- a/include/clad/Differentiator/ErrorEstimator.h
+++ b/include/clad/Differentiator/ErrorEstimator.h
@@ -3,7 +3,7 @@
 
 #include "EstimationModel.h"
 #include "ReverseModeVisitor.h"
-
+#include "clad/Differentiator/ReverseModeVisitorDirectionKinds.h"
 namespace clang {
   class Stmt;
   class Expr;
@@ -87,7 +87,7 @@ namespace clad {
     ///
     /// \param[in] d The direction of the block in which to emit the
     /// statements.
-    void EmitErrorEstimationStmts(direction d = forward);
+    void EmitErrorEstimationStmts(direction d = direction::forward);
 
     /// We should save the return value if it is an arithmetic expression,
     /// since we also need to take into account the error in that expression.

--- a/include/clad/Differentiator/ExternalRMVSource.h
+++ b/include/clad/Differentiator/ExternalRMVSource.h
@@ -1,63 +1,161 @@
 #ifndef CLAD_EXTERNAL_RMV_SOURCE_H
 #define CLAD_EXTERNAL_RMV_SOURCE_H
 
-#include "llvm/ADT/SmallVector.h"
+#include "clad/Differentiator/ParseDiffArgsTypes.h"
+#include "clad/Differentiator/ReverseModeVisitorDirectionKinds.h"
 
-namespace clang {
-  class ValueDecl;
-}
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/OperationKinds.h"
+#include "clang/AST/Type.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace clad {
 
-  class ReverseModeVisitor;
-  class DiffRequest;
-  // Should we include `DerivativeBuilder.h` instead? `DiffParams` is originally
-  // defined in `DerivativeBuilder.h`.
-  using DiffParams = llvm::SmallVector<const clang::ValueDecl*, 16>;
+class ReverseModeVisitor;
+class DiffRequest;
+class StmtDiff;
+class VarDeclDiff;
 
-  /// An abstract interface that should be implemented by external sources
-  /// that provide additional behaviour, in the form of callbacks at crucial
-  /// locations, to the reverse mode visitor.
-  class ExternalRMVSource {
-  public:
-    ExternalRMVSource() = default;
+using direction = rmv::direction;
 
-    /// Initialise the external source with the ReverseModeVisitor
-    virtual void InitialiseRMV(ReverseModeVisitor& RMV) {}
+// FIXME: We should find the common denominator of functionality for all
+// visitors (Forward and Reverse) and use this as a common way to listen to
+// what they do. Therefore, ideally, in the future, this class should not rely
+// on `ReverseModeVisitor`
+/// An abstract interface that should be implemented by external sources
+/// that provide additional behaviour, in the form of callbacks at crucial
+/// locations, to the reverse mode visitor.
+///
+/// External sources should be attached to the reverse mode visitor object by
+/// using `ReverseModeVisitor::AddExternalSource`.
+class ExternalRMVSource {
+public:
+  ExternalRMVSource() = default;
 
-    /// Informs the external source that associated `ReverseModeVisitor`
-    /// object is no longer available.
-    virtual void ForgetRMV() {};
+  /// Initialise the external source with the ReverseModeVisitor object.
+  virtual void InitialiseRMV(ReverseModeVisitor& RMV) {}
 
-    /// This is called at the beginning of the `ReverseModeVisitor::Derive`
-    /// function.
-    virtual void ActOnStartOfDerive() {}
+  /// Informs the external source that the associated `ReverseModeVisitor`
+  /// object is no longer available.
+  virtual void ForgetRMV(){};
 
-    /// This is called at the end of the `ReverseModeVisitor::Derive`
-    /// function.
-    virtual void ActOnEndOfDerive() {}
+  /// This is called at the beginning of the `ReverseModeVisitor::Derive`
+  /// function.
+  virtual void ActOnStartOfDerive() {}
 
-    /// This is called just after differentiation arguments are parsed
-    /// in `ReverseModeVisitor::Derive`.
-    ///
-    ///\param[in] request differentiation request
-    ///\param[in] args differentiation args
-    virtual void ActAfterParsingDiffArgs(const DiffRequest& request,
-                                         DiffParams& args) {}
+  /// This is called at the end of the `ReverseModeVisitor::Derive`
+  /// function.
+  virtual void ActOnEndOfDerive() {}
 
-    /// This is called just before the scopes are created for the derived
-    /// function.
-    virtual void ActBeforeCreatingDerivedFnScope() {}
+  /// This is called just after differentiation arguments are parsed
+  /// in `ReverseModeVisitor::Derive`.
+  ///
+  ///\param[in] request differentiation request
+  ///\param[in] args differentiation args
+  virtual void ActAfterParsingDiffArgs(const DiffRequest& request,
+                                       DiffParams& args) {}
 
-    /// This is called just after the scopes for the derived functions have been
-    /// created.
-    virtual void ActAfterCreatingDerivedFnScope() {}
+  /// This is called just before creating derived function parameter types.
+  virtual void ActBeforeCreatingDerivedFnParamTypes(unsigned& numExtraParam) {}
 
-    /// This is called at the beginning of the derived function body.
-    virtual void ActOnStartOfDerivedFnBody() {}
+  /// This is called just after creating derived function parameter types.
+  ///
+  /// \param paramTypes sequence container containing derived function
+  /// parameter types.
+  virtual void ActAfterCreatingDerivedFnParamTypes(
+      llvm::SmallVectorImpl<clang::QualType>& paramTypes) {}
+  virtual void ActAfterCreatingDerivedFnParams(
+      llvm::SmallVectorImpl<clang::ParmVarDecl*>& params) {}
 
-    /// This is called at the end of the derived function body.
-    virtual void ActOnEndOfDerivedFnBody() {}
-  };
+  /// This is called just before the scope is created for the derived
+  /// function.
+  virtual void ActBeforeCreatingDerivedFnScope() {}
+
+  /// This is called just after the scope for the derived function is
+  /// created.
+  virtual void ActAfterCreatingDerivedFnScope() {}
+
+  /// This is called just before the scope is created for the derived
+  /// function body.
+  virtual void ActBeforeCreatingDerivedFnBodyScope() {}
+
+  /// This is called at the beginning of the derived function body.
+  /// \param request differentiation request
+  virtual void ActOnStartOfDerivedFnBody(const DiffRequest& request) {}
+
+  /// This is called at the end of the derived function body.
+  virtual void ActOnEndOfDerivedFnBody() {}
+
+  /// This is called just before differentiating each statement in the
+  /// `VisitCompoundStmt` method.
+  virtual void ActBeforeDifferentiatingStmtInVisitCompoundStmt() {}
+
+  /// This is called after differentiating and processing each statement in
+  /// the `ViistCompoundStmt` method.
+  virtual void ActAfterProcessingStmtInVisitCompoundStmt() {}
+
+  /// This is called just before differentiating if-branch body statement
+  /// that is not contained in a compound statement.
+  virtual void ActBeforeDifferentiatingSingleStmtBranchInVisitIfStmt() {}
+
+  /// This is called just before finalising processing of Single statement
+  /// branch in `VisitBranch` lambda in
+  virtual void ActBeforeFinalisingVisitBranchSingleStmtInIfVisitStmt() {}
+
+  /// This is called just before differentiating init statement of loops.
+  virtual void ActBeforeDifferentiatingLoopInitStmt() {}
+
+  /// This is called just before differentiating loop body that is not
+  /// contained in the compound statement.
+  virtual void ActBeforeDifferentiatingSingleStmtLoopBody() {}
+
+  /// This is called just after processing single statement for loop body.
+  virtual void ActAfterProcessingSingleStmtBodyInVisitForLoop() {}
+
+  /// This is called just before finalising `VisitReturnStmt`.
+  virtual void
+  ActBeforeFinalisingVisitReturnStmt(StmtDiff& ExprDiff,
+                                     clang::Expr*& retDeclRefExpr) {}
+
+  /// This ic called just before finalising `VisitCallExpr`.
+  ///
+  /// \param CE call expression that is being visited.
+  /// \param CallArgs
+  /// \param ArgResultDecls
+  virtual void ActBeforeFinalizingVisitCallExpr(
+      const clang::CallExpr*& CE, clang::Expr*& OverloadedDerivedFn,
+      llvm::SmallVectorImpl<clang::Expr*>& CallArgs,
+      llvm::SmallVectorImpl<clang::VarDecl*>& ArgResultDecls, bool asGrad) {}
+
+  /// This is called just before finalising processing of post and pre
+  /// increment and decrement operations.
+  virtual void ActBeforeFinalisingPostIncDecOp(StmtDiff& diff){};
+
+  /// This is called just after cloning of LHS assignment operation.
+  virtual void ActAfterCloningLHSOfAssignOp(clang::Expr*&, clang::Expr*&,
+                                            clang::BinaryOperatorKind& opCode) {
+  }
+
+  /// This is called just after finaising processing of assignment operator.
+  virtual void ActBeforeFinalisingAssignOp(clang::Expr*&, clang::Expr*&){};
+
+  /// This is called at that beginning of
+  /// `ReverseModeVisitor::DifferentiateSingleStmt`.
+  virtual void ActOnStartOfDifferentiateSingleStmt(){};
+
+  /// This is called just before finalising
+  /// `ReverseModeVisitor::DifferentiateSingleStmt`.
+  virtual void ActBeforeFinalizingDifferentiateSingleStmt(const direction& d) {}
+
+  /// This is called just before finalising
+  /// `ReverseModeVisitor::DifferentiateSingleExpr`.
+  virtual void ActBeforeFinalizingDifferentiateSingleExpr(const direction& d) {}
+
+  virtual void ActBeforeFinalizingVisitDeclStmt(
+      llvm::SmallVectorImpl<clang::Decl*>& decls,
+      llvm::SmallVectorImpl<clang::Decl*>& declsDiff) {}
+};
 } // namespace clad
 #endif

--- a/include/clad/Differentiator/ExternalRMVSource.h
+++ b/include/clad/Differentiator/ExternalRMVSource.h
@@ -1,0 +1,63 @@
+#ifndef CLAD_EXTERNAL_RMV_SOURCE_H
+#define CLAD_EXTERNAL_RMV_SOURCE_H
+
+#include "llvm/ADT/SmallVector.h"
+
+namespace clang {
+  class ValueDecl;
+}
+
+namespace clad {
+
+  class ReverseModeVisitor;
+  class DiffRequest;
+  // Should we include `DerivativeBuilder.h` instead? `DiffParams` is originally
+  // defined in `DerivativeBuilder.h`.
+  using DiffParams = llvm::SmallVector<const clang::ValueDecl*, 16>;
+
+  /// An abstract interface that should be implemented by external sources
+  /// that provide additional behaviour, in the form of callbacks at crucial
+  /// locations, to the reverse mode visitor.
+  class ExternalRMVSource {
+  public:
+    ExternalRMVSource() = default;
+
+    /// Initialise the external source with the ReverseModeVisitor
+    virtual void InitialiseRMV(ReverseModeVisitor& RMV) {}
+
+    /// Informs the external source that associated `ReverseModeVisitor`
+    /// object is no longer available.
+    virtual void ForgetRMV() {};
+
+    /// This is called at the beginning of the `ReverseModeVisitor::Derive`
+    /// function.
+    virtual void ActOnStartOfDerive() {}
+
+    /// This is called at the end of the `ReverseModeVisitor::Derive`
+    /// function.
+    virtual void ActOnEndOfDerive() {}
+
+    /// This is called just after differentiation arguments are parsed
+    /// in `ReverseModeVisitor::Derive`.
+    ///
+    ///\param[in] request differentiation request
+    ///\param[in] args differentiation args
+    virtual void ActAfterParsingDiffArgs(const DiffRequest& request,
+                                         DiffParams& args) {}
+
+    /// This is called just before the scopes are created for the derived
+    /// function.
+    virtual void ActBeforeCreatingDerivedFnScope() {}
+
+    /// This is called just after the scopes for the derived functions have been
+    /// created.
+    virtual void ActAfterCreatingDerivedFnScope() {}
+
+    /// This is called at the beginning of the derived function body.
+    virtual void ActOnStartOfDerivedFnBody() {}
+
+    /// This is called at the end of the derived function body.
+    virtual void ActOnEndOfDerivedFnBody() {}
+  };
+} // namespace clad
+#endif

--- a/include/clad/Differentiator/MultiplexExternalRMVSource.h
+++ b/include/clad/Differentiator/MultiplexExternalRMVSource.h
@@ -1,0 +1,35 @@
+#ifndef MULTIPLEX_EXTERNAL_RMV_SOURCE_H
+#define MULTIPLEX_EXTERNAL_RMV_SOURCE_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "clad/Differentiator/ExternalRMVSource.h"
+
+namespace clad {
+  class DiffRequest;
+
+  // is `ExternalRMVSourceMultiplexer` a better name for the class?
+  /// Manages multiple external RMV sources.
+  class MultiplexExternalRMVSource : public ExternalRMVSource {
+  private:
+    llvm::SmallVector<ExternalRMVSource*, 4> m_Sources;
+
+  public:
+    MultiplexExternalRMVSource() = default;
+    /// Adds `source` to the sequence of external RMV sources managed by this
+    /// multiplexer.
+    void AddSource(ExternalRMVSource& source);
+    void InitialiseRMV(ReverseModeVisitor& RMV) override;
+    void ForgetRMV() override;
+
+    void ActOnStartOfDerive() override;
+    void ActOnEndOfDerive() override;
+    void ActAfterParsingDiffArgs(const DiffRequest& request,
+                                 DiffParams& args) override;
+    void ActBeforeCreatingDerivedFnScope() override;
+    void ActAfterCreatingDerivedFnScope() override;
+    void ActOnStartOfDerivedFnBody() override;
+    void ActOnEndOfDerivedFnBody() override;
+  };
+} // namespace clad
+
+#endif

--- a/include/clad/Differentiator/MultiplexExternalRMVSource.h
+++ b/include/clad/Differentiator/MultiplexExternalRMVSource.h
@@ -1,35 +1,67 @@
 #ifndef MULTIPLEX_EXTERNAL_RMV_SOURCE_H
 #define MULTIPLEX_EXTERNAL_RMV_SOURCE_H
 
-#include "llvm/ADT/SmallVector.h"
 #include "clad/Differentiator/ExternalRMVSource.h"
 
+#include "llvm/ADT/SmallVector.h"
+
 namespace clad {
-  class DiffRequest;
+class DiffRequest;
 
-  // is `ExternalRMVSourceMultiplexer` a better name for the class?
-  /// Manages multiple external RMV sources.
-  class MultiplexExternalRMVSource : public ExternalRMVSource {
-  private:
-    llvm::SmallVector<ExternalRMVSource*, 4> m_Sources;
+// is `ExternalRMVSourceMultiplexer` a better name for the class?
+/// Manages multiple external RMV sources.
+class MultiplexExternalRMVSource : public ExternalRMVSource {
+private:
+  llvm::SmallVector<ExternalRMVSource*, 4> m_Sources;
 
-  public:
-    MultiplexExternalRMVSource() = default;
-    /// Adds `source` to the sequence of external RMV sources managed by this
-    /// multiplexer.
-    void AddSource(ExternalRMVSource& source);
-    void InitialiseRMV(ReverseModeVisitor& RMV) override;
-    void ForgetRMV() override;
+public:
+  MultiplexExternalRMVSource() = default;
+  /// Adds `source` to the sequence of external RMV sources managed by this
+  /// multiplexer.
+  void AddSource(ExternalRMVSource& source);
+  void InitialiseRMV(ReverseModeVisitor& RMV) override;
+  void ForgetRMV() override;
 
-    void ActOnStartOfDerive() override;
-    void ActOnEndOfDerive() override;
-    void ActAfterParsingDiffArgs(const DiffRequest& request,
-                                 DiffParams& args) override;
-    void ActBeforeCreatingDerivedFnScope() override;
-    void ActAfterCreatingDerivedFnScope() override;
-    void ActOnStartOfDerivedFnBody() override;
-    void ActOnEndOfDerivedFnBody() override;
-  };
+  void ActOnStartOfDerive() override;
+  void ActOnEndOfDerive() override;
+  void ActAfterParsingDiffArgs(const DiffRequest& request,
+                               DiffParams& args) override;
+  void ActBeforeCreatingDerivedFnParamTypes(unsigned& numExtraParams) override;
+  void ActAfterCreatingDerivedFnParamTypes(
+      llvm::SmallVectorImpl<clang::QualType>& paramTypes) override;
+  void ActAfterCreatingDerivedFnParams(
+      llvm::SmallVectorImpl<clang::ParmVarDecl*>& params) override;
+  void ActBeforeCreatingDerivedFnScope() override;
+  void ActAfterCreatingDerivedFnScope() override;
+  void ActBeforeCreatingDerivedFnBodyScope() override;
+  void ActOnStartOfDerivedFnBody(const DiffRequest& request) override;
+  void ActOnEndOfDerivedFnBody() override;
+  void ActBeforeDifferentiatingStmtInVisitCompoundStmt() override;
+  void ActAfterProcessingStmtInVisitCompoundStmt() override;
+  void ActBeforeDifferentiatingSingleStmtBranchInVisitIfStmt() override;
+  void ActBeforeFinalisingVisitBranchSingleStmtInIfVisitStmt() override;
+  void ActBeforeDifferentiatingLoopInitStmt() override;
+  void ActBeforeDifferentiatingSingleStmtLoopBody() override;
+  void ActAfterProcessingSingleStmtBodyInVisitForLoop() override;
+  void
+  ActBeforeFinalisingVisitReturnStmt(StmtDiff& ExprDiff,
+                                     clang::Expr*& retDeclRefExpr) override;
+  void ActBeforeFinalizingVisitCallExpr(
+      const clang::CallExpr*& CE, clang::Expr*& OverloadedDerivedFn,
+      llvm::SmallVectorImpl<clang::Expr*>& CallArgs,
+      llvm::SmallVectorImpl<clang::VarDecl*>& ArgResultDecls,
+      bool asGrad) override;
+  void ActBeforeFinalisingPostIncDecOp(StmtDiff& diff) override;
+  void ActAfterCloningLHSOfAssignOp(clang::Expr*&, clang::Expr*&,
+                                    clang::BinaryOperatorKind& opCode) override;
+  void ActBeforeFinalisingAssignOp(clang::Expr*&, clang::Expr*&) override;
+  void ActOnStartOfDifferentiateSingleStmt() override;
+  void ActBeforeFinalizingDifferentiateSingleStmt(const direction& d) override;
+  void ActBeforeFinalizingDifferentiateSingleExpr(const direction& d) override;
+  void ActBeforeFinalizingVisitDeclStmt(
+      llvm::SmallVectorImpl<clang::Decl*>& decls,
+      llvm::SmallVectorImpl<clang::Decl*>& declsDiff) override;
+};
 } // namespace clad
 
 #endif

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -19,6 +19,9 @@
 #include <unordered_map>
 
 namespace clad {
+  class MultiplexExternalRMVSource;
+  class ExternalRMVSource;
+
   /// A visitor for processing the function code in reverse mode.
   /// Used to compute derivatives by clad::gradient.
   class ReverseModeVisitor
@@ -53,6 +56,7 @@ namespace clad {
     unsigned outputArrayCursor = 0;
     unsigned numParams = 0;
     bool isVectorValued = false;
+    MultiplexExternalRMVSource* m_ExternalSource = nullptr;
 
     const char* funcPostfix() const {
       if (isVectorValued)
@@ -406,7 +410,6 @@ namespace clad {
                                    clang::Stmt* forLoopIncDiff = nullptr,
                                    bool isForLoop = false);
 
-
     /// This class modifies forward and reverse blocks of the loop
     /// body so that `break` and `continue` statements are correctly
     /// handled. `break` and `continue` statements are handled by 
@@ -503,6 +506,13 @@ namespace clad {
     void PopBreakContStmtHandler() {
       m_BreakContStmtHandlers.pop_back();
     }
+                                   
+    /// Registers an external RMV source.
+    ///
+    /// Multiple external RMV source can be registered by calling this function
+    /// multiple times.
+    ///\paramp[in] source An external RMV source
+    void AddExternalSource(ExternalRMVSource& source);
   };
 } // end namespace clad
 

--- a/include/clad/Differentiator/ReverseModeVisitorDirectionKinds.h
+++ b/include/clad/Differentiator/ReverseModeVisitorDirectionKinds.h
@@ -1,0 +1,11 @@
+#ifndef CLAD_REVERSE_MODE_VISITOR_DIRECTION_KINDS
+#define CLAD_REVERSE_MODE_VISITOR_DIRECTION_KINDS
+
+namespace clad {
+  namespace rmv {
+    /// An enum to operate between forward and reverse passes.
+    enum direction : int { forward, reverse };
+  } // namespace rmv
+} // namespace clad
+
+#endif

--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -36,6 +36,7 @@ add_llvm_library(cladDifferentiator
   ForwardModeVisitor.cpp
   HessianModeVisitor.cpp
   JacobianModeVisitor.cpp
+  MultiplexExternalRMVSource.cpp
   ReverseModeVisitor.cpp
   ErrorEstimator.cpp
   EstimationModel.cpp

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -31,12 +31,10 @@ using namespace clang;
 
 namespace clad {
 
-  std::unique_ptr<ErrorEstimationHandler> errorEstHandler = nullptr;
-
   DerivativeBuilder::DerivativeBuilder(clang::Sema& S, plugin::CladPlugin& P)
     : m_Sema(S), m_CladPlugin(P), m_Context(S.getASTContext()),
       m_NodeCloner(new utils::StmtClone(m_Sema, m_Context)),
-      m_BuiltinDerivativesNSD(nullptr), m_NumericalDiffNSD(nullptr) {}
+      m_BuiltinDerivativesNSD(nullptr), m_NumericalDiffNSD(nullptr), m_ErrorEstHandler(nullptr) {}
 
   DerivativeBuilder::~DerivativeBuilder() {}
 
@@ -178,16 +176,18 @@ namespace clad {
       JacobianModeVisitor J(*this);
       result = J.Derive(FD, request);
     } else if (request.Mode == DiffMode::error_estimation) {
+      ReverseModeVisitor R(*this);
       // Set the handler.
-      errorEstHandler.reset(new ErrorEstimationHandler(*this));
+      m_ErrorEstHandler.reset(new ErrorEstimationHandler());
       // Set error estimation model. If no custom model provided by user,
       // use the built in Taylor approximation model.
       if (!m_EstModel) {
         m_EstModel.reset(new TaylorApprox(*this));
       }
-      errorEstHandler->SetErrorEstimationModel(m_EstModel.get());
+      m_ErrorEstHandler->SetErrorEstimationModel(m_EstModel.get());
+      R.AddExternalSource(*m_ErrorEstHandler);
       // Finally begin estimation.
-      result = errorEstHandler->Derive(FD, request);
+      result = R.Derive(FD, request);
       // Once we are done, we want to clear the model for any further
       // calls to estimate_error.
       m_EstModel->clearEstimationVariables();

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -14,7 +14,6 @@
 
 #include "clad/Differentiator/DiffPlanner.h"
 #include "clad/Differentiator/StmtClone.h"
-
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/Sema/Sema.h"

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -213,27 +213,7 @@ namespace clad {
       FD->print(Out, Policy);
       Out.flush();
 
-      // Copied and adapted from clang::Sema::ActOnStringLiteral.
-      QualType CharTyConst = C.CharTy;
-      CharTyConst.addConst();
-      // Get an array type for the string, according to C99 6.4.5. This includes
-      // the nul terminator character as well as the string length for pascal
-      // strings.
-      QualType StrTy =
-          clad_compat::getConstantArrayType(C, CharTyConst,
-                                            llvm::APInt(32,
-                                                        Out.str().size() + 1),
-                                            /*SizeExpr=*/nullptr,
-                                            ArrayType::Normal,
-                                            /*IndexTypeQuals*/ 0);
-
-      StringLiteral* SL =
-        StringLiteral::Create(C,
-                              Out.str(),
-                              StringLiteral::Ascii,
-                              /*Pascal*/false,
-                              StrTy,
-                              noLoc);
+      StringLiteral* SL = utils::CreateStringLiteral(C, Out.str());
       Expr* newArg =
         SemaRef.ImpCastExprToType(SL,
                                   Arg->getType(),

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -1,4 +1,6 @@
 #include "clad/Differentiator/ErrorEstimator.h"
+
+#include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/DerivativeBuilder.h"
 #include "clad/Differentiator/DiffPlanner.h"
 #include "clad/Differentiator/ReverseModeVisitor.h"
@@ -8,6 +10,7 @@
 using namespace clang;
 
 namespace clad {
+
 QualType getUnderlyingArrayType(QualType baseType, ASTContext& C) {
   if (baseType->isArrayType()) {
     return C.getBaseElementType(baseType);
@@ -16,469 +19,638 @@ QualType getUnderlyingArrayType(QualType baseType, ASTContext& C) {
   }
 }
 
-  void ErrorEstimationHandler::SetErrorEstimationModel(
-      FPErrorEstimationModel* estModel) {
-    m_EstModel = estModel;
+void ErrorEstimationHandler::SetErrorEstimationModel(
+    FPErrorEstimationModel* estModel) {
+  m_EstModel = estModel;
+}
+
+Expr* ErrorEstimationHandler::getArraySubscriptExpr(
+    Expr* arrBase, Expr* idx, bool isCladSpType /*=true*/) {
+  if (isCladSpType) {
+    return m_RMV->m_Sema
+        .ActOnArraySubscriptExpr(m_RMV->getCurrentScope(), arrBase,
+                                 arrBase->getExprLoc(), idx, noLoc)
+        .get();
+  } else {
+    return m_RMV->m_Sema
+        .CreateBuiltinArraySubscriptExpr(arrBase, noLoc, idx, noLoc)
+        .get();
+  }
+}
+
+void ErrorEstimationHandler::BuildFinalErrorStmt() {
+  Expr* finExpr = nullptr;
+  // If we encountered any arithmetic expression in the return statement,
+  // we must add its error to the final estimate.
+  if (m_RetErrorExpr) {
+    auto flitr =
+        FloatingLiteral::Create(m_RMV->m_Context, llvm::APFloat(1.0), true,
+                                m_RMV->m_Context.DoubleTy, noLoc);
+    finExpr = m_EstModel->AssignError(StmtDiff(m_RetErrorExpr, flitr));
   }
 
-  Expr*
-  ErrorEstimationHandler::getArraySubscriptExpr(Expr* arrBase, Expr* idx,
-                                                bool isCladSpType /*=true*/) {
-    if (isCladSpType) {
-      return m_Sema
-          .ActOnArraySubscriptExpr(getCurrentScope(), arrBase,
-                                   arrBase->getExprLoc(), idx, noLoc)
-          .get();
-    } else {
-      return m_Sema.CreateBuiltinArraySubscriptExpr(arrBase, noLoc, idx, noLoc)
-          .get();
-    }
+  // Build the final error statement with the sum of all _delta_*.
+  Expr* addErrorExpr = m_EstModel->CalculateAggregateError();
+  if (addErrorExpr) {
+    if (finExpr)
+      addErrorExpr = m_RMV->BuildOp(BO_Add, addErrorExpr, finExpr);
+  } else if (finExpr) {
+    addErrorExpr = finExpr;
   }
 
-  void ErrorEstimationHandler::BuildFinalErrorStmt() {
-    Expr* finExpr = nullptr;
-    // If we encountered any arithmetic expression in the return statement,
-    // we must add its error to the final estimate.
-    if (m_RetErrorExpr) {
-      auto flitr = FloatingLiteral::Create(m_Context, llvm::APFloat(1.0), true,
-                                           m_Context.DoubleTy, noLoc);
-      finExpr = m_EstModel->AssignError(StmtDiff(m_RetErrorExpr, flitr));
-    }
+  // Finally add the final error expression to the derivative body.
+  m_RMV->addToCurrentBlock(
+      m_RMV->BuildOp(BO_AddAssign, m_FinalError, addErrorExpr),
+      direction::forward);
+}
 
-    // Build the final error statement with the sum of all _delta_*.
-    Expr* addErrorExpr = m_EstModel->CalculateAggregateError();
-    if (addErrorExpr) {
-      if (finExpr)
-        addErrorExpr = BuildOp(BO_Add, addErrorExpr, finExpr);
-    } else if (finExpr) {
-      addErrorExpr = finExpr;
-    }
-
-    // Finally add the final error expression to the derivative body.
-    addToCurrentBlock(BuildOp(BO_AddAssign, m_FinalError, addErrorExpr),
-                      direction::forward);
-  }
-
-  void
-  ErrorEstimationHandler::AddErrorStmtToBlock(Expr* var, Expr* deltaVar,
-                                              Expr* errorExpr,
-                                              bool isInsideLoop /*=false*/) {
-    if (auto ASE = dyn_cast<ArraySubscriptExpr>(var)) {
-      // If inside loop, the index has been pushed twice
-      // (once by ArraySubscriptExpr and the second time by us)
-      // pop and store it in a temporary variable to reuse later.
-      // FIXME: build add assign into he same expression i.e.
-      // _final_error += _delta_arr[pop(_t0)] += <-Error Expr->
-      // to avoid storage of the pop value.
-      Expr* popVal = ASE->getIdx();
-      if (isInsideLoop) {
-        LookupResult& Pop = GetCladTapePop();
-        CXXScopeSpec CSS;
-        CSS.Extend(m_Context, GetCladNamespace(), noLoc, noLoc);
-        auto PopDRE = m_Sema
-                          .BuildDeclarationNameExpr(CSS, Pop,
-                                                    /*AcceptInvalidDecl=*/false)
-                          .get();
-        Expr* tapeRef = dyn_cast<CallExpr>(popVal)->getArg(0);
-        popVal = m_Sema
-                     .ActOnCallExpr(getCurrentScope(), PopDRE, noLoc, tapeRef,
-                                    noLoc)
-                     .get();
-        popVal = StoreAndRef(popVal, direction::reverse);
-      }
-      // If the variable declration refers to an array element
-      // create the suitable _delta_arr[i] (because we have not done
-      // this before).
-      deltaVar = getArraySubscriptExpr(deltaVar, popVal);
-      addToCurrentBlock(BuildOp(BO_AddAssign, deltaVar, errorExpr), direction::reverse);
-      // immediately emit fin_err += delta_[].
-      // This is done to avoid adding all errors at the end
-      // and only add the errors that were calculated.
-      addToCurrentBlock(BuildOp(BO_AddAssign, m_FinalError, deltaVar), direction::reverse);
-
-    } else
-      addToCurrentBlock(BuildOp(BO_AddAssign, deltaVar, errorExpr), direction::reverse);
-  }
-
-  void
-  ErrorEstimationHandler::EmitErrorEstimationStmts(direction d /*=forward*/) {
-    if (d == direction::forward) {
-      while (!m_ForwardReplStmts.empty())
-        addToCurrentBlock(m_ForwardReplStmts.pop_back_val(), d);
-    } else {
-      while (!m_ReverseErrorStmts.empty())
-        addToCurrentBlock(m_ReverseErrorStmts.pop_back_val(), d);
-    }
-  }
-
-  void ErrorEstimationHandler::SaveReturnExpr(Expr* retExpr,
-                                              DeclRefExpr* retDeclRefExpr) {
-    // If the return expression is a declRefExpr or is a non-floating point
-    // type, we should not do anything.
-    if (GetUnderlyingDeclRefOrNull(retExpr) ||
-        !retDeclRefExpr->getType()->isFloatingType())
-      return;
-
-    // Build a variable to store the current return value.
-    // This will be helpful in the case that we have multiple
-    // returns.
-    if (!m_RetErrorExpr) {
-      auto retVarDecl = BuildVarDecl(m_Context.DoubleTy, "_ret_value",
-                                     getZeroInit(m_Context.DoubleTy));
-      AddToGlobalBlock(BuildDeclStmt(retVarDecl));
-      m_RetErrorExpr = BuildDeclRef(retVarDecl);
-    }
-    addToCurrentBlock(BuildOp(BO_Assign, m_RetErrorExpr, retDeclRefExpr),
-                      direction::forward);
-  }
-
-  void ErrorEstimationHandler::EmitNestedFunctionParamError(
-      FunctionDecl* fnDecl, llvm::SmallVectorImpl<Expr*>& CallArgs,
-      llvm::SmallVectorImpl<VarDecl*>& ArgResultDecls, size_t numArgs) {
-    assert(fnDecl && "Must have a value");
-    for (size_t i = 0; i < numArgs; i++) {
-      if (!fnDecl->getParamDecl(0)->getType()->isLValueReferenceType())
-        continue;
-      Expr* errorExpr = m_EstModel->AssignError(
-          {CallArgs[i], BuildDeclRef(ArgResultDecls[i])});
-      Expr* errorStmt = BuildOp(BO_AddAssign, m_FinalError, errorExpr);
-      m_ReverseErrorStmts.push_back(errorStmt);
-    }
-  }
-
-  StmtDiff ErrorEstimationHandler::SaveValue(Expr* val,
-                                             bool isInsideLoop /*=false*/) {
-    // Definite not null.
-    DeclRefExpr* declRefVal = GetUnderlyingDeclRefOrNull(val);
-    assert(declRefVal && "Val cannot be null!");
-    std::string name = "_EERepl_" + declRefVal->getDecl()->getNameAsString();
+void ErrorEstimationHandler::AddErrorStmtToBlock(Expr* var, Expr* deltaVar,
+                                                 Expr* errorExpr,
+                                                 bool isInsideLoop /*=false*/) {
+  if (auto ASE = dyn_cast<ArraySubscriptExpr>(var)) {
+    // If inside loop, the index has been pushed twice
+    // (once by ArraySubscriptExpr and the second time by us)
+    // pop and store it in a temporary variable to reuse later.
+    // FIXME: build add assign into he same expression i.e.
+    // _final_error += _delta_arr[pop(_t0)] += <-Error Expr->
+    // to avoid storage of the pop value.
+    Expr* popVal = ASE->getIdx();
     if (isInsideLoop) {
-      auto tape = MakeCladTapeFor(val, name);
-      m_ForwardReplStmts.push_back(tape.Push);
-      // Nice to store pop values becuase user might refer to getExpr
-      // multiple times in Assign Error.
-      Expr* popVal = StoreAndRef(tape.Pop, direction::reverse);
-      return StmtDiff(tape.Push, popVal);
-    } else {
-      QualType QTval = val->getType();
-      if (auto AType = dyn_cast<ArrayType>(QTval))
-        QTval = AType->getElementType();
-
-      auto savedVD = GlobalStoreImpl(QTval, name);
-      auto savedRef = BuildDeclRef(savedVD);
-      m_ForwardReplStmts.push_back(BuildOp(BO_Assign, savedRef, val));
-      return StmtDiff(savedRef, savedRef);
+      LookupResult& Pop = m_RMV->GetCladTapePop();
+      CXXScopeSpec CSS;
+      CSS.Extend(m_RMV->m_Context, m_RMV->GetCladNamespace(), noLoc, noLoc);
+      auto PopDRE = m_RMV->m_Sema
+                        .BuildDeclarationNameExpr(CSS, Pop,
+                                                  /*AcceptInvalidDecl=*/false)
+                        .get();
+      Expr* tapeRef = dyn_cast<CallExpr>(popVal)->getArg(0);
+      popVal = m_RMV->m_Sema
+                   .ActOnCallExpr(m_RMV->getCurrentScope(), PopDRE, noLoc,
+                                  tapeRef, noLoc)
+                   .get();
+      popVal = m_RMV->StoreAndRef(popVal, direction::reverse);
     }
+    // If the variable declration refers to an array element
+    // create the suitable _delta_arr[i] (because we have not done
+    // this before).
+    deltaVar = getArraySubscriptExpr(deltaVar, popVal);
+    m_RMV->addToCurrentBlock(m_RMV->BuildOp(BO_AddAssign, deltaVar, errorExpr),
+                             direction::reverse);
+    // immediately emit fin_err += delta_[].
+    // This is done to avoid adding all errors at the end
+    // and only add the errors that were calculated.
+    m_RMV->addToCurrentBlock(
+        m_RMV->BuildOp(BO_AddAssign, m_FinalError, deltaVar),
+        direction::reverse);
+
+  } else
+    m_RMV->addToCurrentBlock(m_RMV->BuildOp(BO_AddAssign, deltaVar, errorExpr),
+                             direction::reverse);
+}
+
+void ErrorEstimationHandler::EmitErrorEstimationStmts(
+    ReverseModeVisitor::direction d /*=forward*/) {
+  if (d == direction::forward) {
+    while (!m_ForwardReplStmts.empty())
+      m_RMV->addToCurrentBlock(m_ForwardReplStmts.pop_back_val(), d);
+  } else {
+    while (!m_ReverseErrorStmts.empty())
+      m_RMV->addToCurrentBlock(m_ReverseErrorStmts.pop_back_val(), d);
   }
+}
 
-  void ErrorEstimationHandler::SaveParamValue(DeclRefExpr* paramRef) {
-    assert(paramRef && "Must have a value");
-    VarDecl* paramDecl = cast<VarDecl>(paramRef->getDecl());
-    QualType paramType = paramRef->getType();
-    std::string name = "_EERepl_" + paramDecl->getNameAsString();
-    VarDecl* savedDecl;
-    if (isArrayOrPointerType(paramType)) {
-      auto diffVar = m_Variables[paramDecl];
-      auto QType =
-          GetCladArrayOfType(getUnderlyingArrayType(paramType, m_Context));
-      savedDecl =
-          BuildVarDecl(QType, name, BuildArrayRefSizeExpr(diffVar),
-                       /*DirectInit=*/false,
-                       /*TSI=*/nullptr, VarDecl::InitializationStyle::CallInit);
-      AddToGlobalBlock(BuildDeclStmt(savedDecl));
-      Stmts loopBody;
-      // Get iter variable.
-      auto loopIdx =
-          BuildVarDecl(m_Context.IntTy, "i", getZeroInit(m_Context.IntTy));
-      auto currIdx = BuildDeclRef(loopIdx);
-      // Build the assign expression.
-      loopBody.push_back(BuildOp(
-          BO_Assign, getArraySubscriptExpr(BuildDeclRef(savedDecl), currIdx),
-          getArraySubscriptExpr(paramRef, currIdx,
-                                /*isCladSpType=*/false)));
-      Expr* conditionExpr =
-          BuildOp(BO_LT, currIdx, BuildArrayRefSizeExpr(diffVar));
-      Expr* incExpr = BuildOp(UO_PostInc, currIdx);
-      // Make for loop.
-      Stmt* ArrayParamLoop = new (m_Context)
-          ForStmt(m_Context, BuildDeclStmt(loopIdx), conditionExpr, nullptr,
-                  incExpr, MakeCompoundStmt(loopBody), noLoc, noLoc, noLoc);
-      AddToGlobalBlock(ArrayParamLoop);
-    } else
-      savedDecl = GlobalStoreImpl(paramType, name, paramRef);
-    m_ParamRepls.emplace(paramDecl, BuildDeclRef(savedDecl));
+void ErrorEstimationHandler::SaveReturnExpr(Expr* retExpr,
+                                            DeclRefExpr* retDeclRefExpr) {
+  // If the return expression is a declRefExpr or is a non-floating point
+  // type, we should not do anything.
+  if (GetUnderlyingDeclRefOrNull(retExpr) ||
+      !retDeclRefExpr->getType()->isFloatingType())
+    return;
+
+  // Build a variable to store the current return value.
+  // This will be helpful in the case that we have multiple
+  // returns.
+  if (!m_RetErrorExpr) {
+    auto retVarDecl =
+        m_RMV->BuildVarDecl(m_RMV->m_Context.DoubleTy, "_ret_value",
+                            m_RMV->getZeroInit(m_RMV->m_Context.DoubleTy));
+    m_RMV->AddToGlobalBlock(m_RMV->BuildDeclStmt(retVarDecl));
+    m_RetErrorExpr = m_RMV->BuildDeclRef(retVarDecl);
   }
+  m_RMV->addToCurrentBlock(
+      m_RMV->BuildOp(BO_Assign, m_RetErrorExpr, retDeclRefExpr),
+      direction::forward);
+}
 
-  Expr*
-  ErrorEstimationHandler::RegisterVariable(VarDecl* VD,
-                                           bool toCurrentScope /*=false*/) {
-    if (!CanRegisterVariable(VD))
-      return nullptr;
-    // Get the init error from setError.
-    Expr* init = m_EstModel->SetError(VD);
-    auto VDType = VD->getType();
-    // The type of the _delta_ value should be customisable.
-    QualType QType;
-    Expr* deltaVar = nullptr;
-    auto diffVar = m_Variables[VD];
-    if (isCladArrayType(diffVar->getType())) {
-      VarDecl* EstVD;
-      auto sizeExpr = BuildArrayRefSizeExpr(diffVar);
-      QType = GetCladArrayOfType(getUnderlyingArrayType(VDType, m_Context));
-      EstVD =
-          BuildVarDecl(QType, "_delta_" + VD->getNameAsString(), sizeExpr,
-                       /*DirectInit=*/false,
-                       /*TSI=*/nullptr, VarDecl::InitializationStyle::CallInit);
-      if (!toCurrentScope)
-        AddToGlobalBlock(BuildDeclStmt(EstVD));
-      else
-        addToCurrentBlock(BuildDeclStmt(EstVD), direction::forward);
-      deltaVar = BuildDeclRef(EstVD);
-    } else {
-      QType = isArrayOrPointerType(VDType) ? VDType : m_Context.DoubleTy;
-      init = init ? init : getZeroInit(QType);
-      // Store the "_delta_*" value.
-      if (!toCurrentScope) {
-        auto EstVD =
-            GlobalStoreImpl(QType, "_delta_" + VD->getNameAsString(), init);
-        deltaVar = BuildDeclRef(EstVD);
-      } else {
-        deltaVar =
-            StoreAndRef(init, QType, direction::forward, "_delta_" + VD->getNameAsString(),
-                        /*forceDeclCreation=*/true);
-      }
-    }
-    // Register the variable for estimate calculation.
-    m_EstModel->AddVarToEstimate(VD, deltaVar);
-    return deltaVar;
+void ErrorEstimationHandler::EmitNestedFunctionParamError(
+    FunctionDecl* fnDecl, llvm::SmallVectorImpl<Expr*>& CallArgs,
+    llvm::SmallVectorImpl<VarDecl*>& ArgResultDecls, size_t numArgs) {
+  assert(fnDecl && "Must have a value");
+  for (size_t i = 0; i < numArgs; i++) {
+    if (!fnDecl->getParamDecl(0)->getType()->isLValueReferenceType())
+      continue;
+    Expr* errorExpr = m_EstModel->AssignError(
+        {CallArgs[i], m_RMV->BuildDeclRef(ArgResultDecls[i])});
+    Expr* errorStmt = m_RMV->BuildOp(BO_AddAssign, m_FinalError, errorExpr);
+    m_ReverseErrorStmts.push_back(errorStmt);
   }
+}
 
-  bool ErrorEstimationHandler::CanRegisterVariable(VarDecl* VD) {
+StmtDiff ErrorEstimationHandler::SaveValue(Expr* val,
+                                           bool isInsideLoop /*=false*/) {
+  // Definite not null.
+  DeclRefExpr* declRefVal = GetUnderlyingDeclRefOrNull(val);
+  assert(declRefVal && "Val cannot be null!");
+  std::string name = "_EERepl_" + declRefVal->getDecl()->getNameAsString();
+  if (isInsideLoop) {
+    auto tape = m_RMV->MakeCladTapeFor(val, name);
+    m_ForwardReplStmts.push_back(tape.Push);
+    // Nice to store pop values becuase user might refer to getExpr
+    // multiple times in Assign Error.
+    Expr* popVal = m_RMV->StoreAndRef(tape.Pop, direction::reverse);
+    return StmtDiff(tape.Push, popVal);
+  } else {
+    QualType QTval = val->getType();
+    if (auto AType = dyn_cast<ArrayType>(QTval))
+      QTval = AType->getElementType();
 
-    // Get the types on the declartion and initalization expression.
-    QualType varDeclBase = VD->getType();
-    QualType varDeclType = isArrayOrPointerType(varDeclBase)
-                               ? getUnderlyingArrayType(varDeclBase, m_Context)
-                               : varDeclBase;
-    const Expr* init = VD->getInit();
-    // If declarationg type in not floating point type, we want to do two
-    // things.
-    if (!varDeclType->isFloatingType()) {
-      // Firstly, we want to check if the declaration is a lossy conversion.
-      // For example, if we have something like:
-      // double y = 2.77788;
-      // int x = y <-- This causes truncation in y,
-      // making _delta_x = y - (double)x
-      // For now, we will just warn the user of casts like these
-      // because we assume the cast is intensional.
-      if (init && init->IgnoreImpCasts()->getType()->isFloatingType())
-        diag(DiagnosticsEngine::Warning, VD->getEndLoc(),
-             "Lossy assignment from '%0' to '%1', this error will not be "
-             "taken into cosideration while estimation",
-             {init->IgnoreImpCasts()->getType().getAsString(),
-              varDeclBase.getAsString()});
-      // Secondly, we want to only register floating-point types
-      // So return false here.
-      return false;
-    }
-    // Next, we want to check if there is an assignment that leads to
-    // truncation, for example, something like so
-    // double y = ...some double value...
-    // float x = y; <-- This leads to rounding of the lower bits
-    // making _delta_x = y - (double)x
-    // For now, we shall just warn against such assignments...
-    // FIXME: figure how to do this out elegantly.
-
-    // Now, we can register the variable.
-    // So return true here.
-    return true;
+    auto savedVD = m_RMV->GlobalStoreImpl(QTval, name);
+    auto savedRef = m_RMV->BuildDeclRef(savedVD);
+    m_ForwardReplStmts.push_back(m_RMV->BuildOp(BO_Assign, savedRef, val));
+    return StmtDiff(savedRef, savedRef);
   }
+}
 
-  DeclRefExpr* ErrorEstimationHandler::GetUnderlyingDeclRefOrNull(Expr* expr) {
-    // First check if it is an array subscript expression.
-    ArraySubscriptExpr* temp = dyn_cast<ArraySubscriptExpr>(
-        expr->IgnoreImplicit());
-    // The see if it is convertiable to a DeclRefExpr.
-    if (temp)
-      return dyn_cast<DeclRefExpr>(temp->getBase()->IgnoreImplicit());
-    else
-      return dyn_cast<DeclRefExpr>(expr->IgnoreImplicit());
-  }
+void ErrorEstimationHandler::SaveParamValue(DeclRefExpr* paramRef) {
+  assert(paramRef && "Must have a value");
+  VarDecl* paramDecl = cast<VarDecl>(paramRef->getDecl());
+  QualType paramType = paramRef->getType();
+  std::string name = "_EERepl_" + paramDecl->getNameAsString();
+  VarDecl* savedDecl;
+  if (utils::isArrayOrPointerType(paramType)) {
+    auto diffVar = m_RMV->m_Variables[paramDecl];
+    auto QType = m_RMV->GetCladArrayOfType(
+        getUnderlyingArrayType(paramType, m_RMV->m_Context));
+    savedDecl = m_RMV->BuildVarDecl(
+        QType, name, m_RMV->BuildArrayRefSizeExpr(diffVar),
+        /*DirectInit=*/false,
+        /*TSI=*/nullptr, VarDecl::InitializationStyle::CallInit);
+    m_RMV->AddToGlobalBlock(m_RMV->BuildDeclStmt(savedDecl));
+    ReverseModeVisitor::Stmts loopBody;
+    // Get iter variable.
+    auto loopIdx =
+        m_RMV->BuildVarDecl(m_RMV->m_Context.IntTy, "i",
+                            m_RMV->getZeroInit(m_RMV->m_Context.IntTy));
+    auto currIdx = m_RMV->BuildDeclRef(loopIdx);
+    // Build the assign expression.
+    loopBody.push_back(m_RMV->BuildOp(
+        BO_Assign,
+        getArraySubscriptExpr(m_RMV->BuildDeclRef(savedDecl), currIdx),
+        getArraySubscriptExpr(paramRef, currIdx,
+                              /*isCladSpType=*/false)));
+    Expr* conditionExpr =
+        m_RMV->BuildOp(BO_LT, currIdx, m_RMV->BuildArrayRefSizeExpr(diffVar));
+    Expr* incExpr = m_RMV->BuildOp(UO_PostInc, currIdx);
+    // Make for loop.
+    Stmt* ArrayParamLoop = new (m_RMV->m_Context) ForStmt(
+        m_RMV->m_Context, m_RMV->BuildDeclStmt(loopIdx), conditionExpr, nullptr,
+        incExpr, m_RMV->MakeCompoundStmt(loopBody), noLoc, noLoc, noLoc);
+    m_RMV->AddToGlobalBlock(ArrayParamLoop);
+  } else
+    savedDecl = m_RMV->GlobalStoreImpl(paramType, name, paramRef);
+  m_ParamRepls.emplace(paramDecl, m_RMV->BuildDeclRef(savedDecl));
+}
 
-  Expr* ErrorEstimationHandler::GetParamReplacement(const ParmVarDecl* VD) {
-    auto it = m_ParamRepls.find(VD);
-    if (it != m_ParamRepls.end())
-      return it->second;
+Expr* ErrorEstimationHandler::RegisterVariable(VarDecl* VD,
+                                               bool toCurrentScope /*=false*/) {
+  if (!CanRegisterVariable(VD))
     return nullptr;
+  // Get the init error from setError.
+  Expr* init = m_EstModel->SetError(VD);
+  auto VDType = VD->getType();
+  // The type of the _delta_ value should be customisable.
+  QualType QType;
+  Expr* deltaVar = nullptr;
+  auto diffVar = m_RMV->m_Variables[VD];
+  if (m_RMV->isCladArrayType(diffVar->getType())) {
+    VarDecl* EstVD;
+    auto sizeExpr = m_RMV->BuildArrayRefSizeExpr(diffVar);
+    QType = m_RMV->GetCladArrayOfType(
+        getUnderlyingArrayType(VDType, m_RMV->m_Context));
+    EstVD = m_RMV->BuildVarDecl(
+        QType, "_delta_" + VD->getNameAsString(), sizeExpr,
+        /*DirectInit=*/false,
+        /*TSI=*/nullptr, VarDecl::InitializationStyle::CallInit);
+    if (!toCurrentScope)
+      m_RMV->AddToGlobalBlock(m_RMV->BuildDeclStmt(EstVD));
+    else
+      m_RMV->addToCurrentBlock(m_RMV->BuildDeclStmt(EstVD), direction::forward);
+    deltaVar = m_RMV->BuildDeclRef(EstVD);
+  } else {
+    QType = utils::isArrayOrPointerType(VDType) ? VDType
+                                                : m_RMV->m_Context.DoubleTy;
+    init = init ? init : m_RMV->getZeroInit(QType);
+    // Store the "_delta_*" value.
+    if (!toCurrentScope) {
+      auto EstVD = m_RMV->GlobalStoreImpl(
+          QType, "_delta_" + VD->getNameAsString(), init);
+      deltaVar = m_RMV->BuildDeclRef(EstVD);
+    } else {
+      deltaVar = m_RMV->StoreAndRef(init, QType, direction::forward,
+                                    "_delta_" + VD->getNameAsString(),
+                                    /*forceDeclCreation=*/true);
+    }
   }
+  // Register the variable for estimate calculation.
+  m_EstModel->AddVarToEstimate(VD, deltaVar);
+  return deltaVar;
+}
 
-  void ErrorEstimationHandler::EmitFinalErrorStmts(
-      llvm::SmallVectorImpl<ParmVarDecl*>& params, unsigned numParams) {
-    // Emit error variables of parameters at the end.
-    for (size_t i = 0; i < numParams; i++) {
-      // Right now, we just ignore them since we have no way of knowing
-      // the size of an array.
-      // if (isArrayOrPointerType(params[i]->getType()))
-      //   continue;
+bool ErrorEstimationHandler::CanRegisterVariable(VarDecl* VD) {
 
-      // Check if the declaration was registered
-      auto decl = dyn_cast<VarDecl>(params[i]);
-      Expr* deltaVar = IsRegistered(decl);
+  // Get the types on the declartion and initalization expression.
+  QualType varDeclBase = VD->getType();
+  QualType varDeclType =
+      utils::isArrayOrPointerType(varDeclBase)
+          ? getUnderlyingArrayType(varDeclBase, m_RMV->m_Context)
+          : varDeclBase;
+  const Expr* init = VD->getInit();
+  // If declarationg type in not floating point type, we want to do two
+  // things.
+  if (!varDeclType->isFloatingType()) {
+    // Firstly, we want to check if the declaration is a lossy conversion.
+    // For example, if we have something like:
+    // double y = 2.77788;
+    // int x = y <-- This causes truncation in y,
+    // making _delta_x = y - (double)x
+    // For now, we will just warn the user of casts like these
+    // because we assume the cast is intensional.
+    if (init && init->IgnoreImpCasts()->getType()->isFloatingType())
+      m_RMV->diag(DiagnosticsEngine::Warning, VD->getEndLoc(),
+                  "Lossy assignment from '%0' to '%1', this error will not be "
+                  "taken into cosideration while estimation",
+                  {init->IgnoreImpCasts()->getType().getAsString(),
+                   varDeclBase.getAsString()});
+    // Secondly, we want to only register floating-point types
+    // So return false here.
+    return false;
+  }
+  // Next, we want to check if there is an assignment that leads to
+  // truncation, for example, something like so
+  // double y = ...some double value...
+  // float x = y; <-- This leads to rounding of the lower bits
+  // making _delta_x = y - (double)x
+  // For now, we shall just warn against such assignments...
+  // FIXME: figure how to do this out elegantly.
 
-      // If not registered, check if it is eligible for registration and do
-      // the needful.
-      if (!deltaVar) {
-        deltaVar = RegisterVariable(decl, /*toCurrentScope=*/true);
-      }
+  // Now, we can register the variable.
+  // So return true here.
+  return true;
+}
 
-      // If till now, we have a delta declaration, emit it into the code.
-      if (deltaVar) {
-        if (!isArrayOrPointerType(params[i]->getType())) {
-          // Since we need the input value of x, check for a replacement.
-          // If no replacement found, use the actual declRefExpr.
-          auto savedVal = GetParamReplacement(params[i]);
-          savedVal = savedVal ? savedVal : BuildDeclRef(decl);
-          // Finally emit the error.
-          auto errorExpr = GetError(savedVal, m_Variables[decl]);
-          addToCurrentBlock(BuildOp(BO_AddAssign, deltaVar, errorExpr));
+DeclRefExpr* ErrorEstimationHandler::GetUnderlyingDeclRefOrNull(Expr* expr) {
+  // First check if it is an array subscript expression.
+  ArraySubscriptExpr* temp =
+      dyn_cast<ArraySubscriptExpr>(expr->IgnoreImplicit());
+  // The see if it is convertiable to a DeclRefExpr.
+  if (temp)
+    return dyn_cast<DeclRefExpr>(temp->getBase()->IgnoreImplicit());
+  else
+    return dyn_cast<DeclRefExpr>(expr->IgnoreImplicit());
+}
+
+Expr* ErrorEstimationHandler::GetParamReplacement(const ParmVarDecl* VD) {
+  auto it = m_ParamRepls.find(VD);
+  if (it != m_ParamRepls.end())
+    return it->second;
+  return nullptr;
+}
+
+void ErrorEstimationHandler::EmitFinalErrorStmts(
+    llvm::SmallVectorImpl<ParmVarDecl*>& params, unsigned numParams) {
+  // Emit error variables of parameters at the end.
+  for (size_t i = 0; i < numParams; i++) {
+    // Right now, we just ignore them since we have no way of knowing
+    // the size of an array.
+    // if (m_RMV->isArrayOrPointerType(params[i]->getType()))
+    //   continue;
+
+    // Check if the declaration was registered
+    auto decl = dyn_cast<VarDecl>(params[i]);
+    Expr* deltaVar = IsRegistered(decl);
+
+    // If not registered, check if it is eligible for registration and do
+    // the needful.
+    if (!deltaVar) {
+      deltaVar = RegisterVariable(decl, /*toCurrentScope=*/true);
+    }
+
+    // If till now, we have a delta declaration, emit it into the code.
+    if (deltaVar) {
+      if (!m_RMV->isArrayOrPointerType(params[i]->getType())) {
+        // Since we need the input value of x, check for a replacement.
+        // If no replacement found, use the actual declRefExpr.
+        auto savedVal = GetParamReplacement(params[i]);
+        savedVal = savedVal ? savedVal : m_RMV->BuildDeclRef(decl);
+        // Finally emit the error.
+        auto errorExpr = GetError(savedVal, m_RMV->m_Variables[decl]);
+        m_RMV->addToCurrentBlock(
+            m_RMV->BuildOp(BO_AddAssign, deltaVar, errorExpr));
+      } else {
+        auto LdiffExpr = m_RMV->m_Variables[decl];
+        VarDecl* idxExprDecl = nullptr;
+        // Save our index expression so it can be used later.
+        if (!m_IdxExpr) {
+          idxExprDecl =
+              m_RMV->BuildVarDecl(m_RMV->m_Context.IntTy, "i",
+                                  m_RMV->getZeroInit(m_RMV->m_Context.IntTy));
+          m_IdxExpr = m_RMV->BuildDeclRef(idxExprDecl);
+        }
+        Expr *Ldiff, *Ldelta;
+        Ldiff = getArraySubscriptExpr(
+            LdiffExpr, m_IdxExpr, m_RMV->isCladArrayType(LdiffExpr->getType()));
+        Ldelta = getArraySubscriptExpr(deltaVar, m_IdxExpr);
+        auto savedVal = GetParamReplacement(params[i]);
+        savedVal = savedVal ? savedVal : m_RMV->BuildDeclRef(decl);
+        auto LRepl = getArraySubscriptExpr(savedVal, m_IdxExpr);
+        // Build the loop to put in reverse mode.
+        Expr* errorExpr = GetError(LRepl, Ldiff);
+        auto commonVarDecl =
+            m_RMV->BuildVarDecl(errorExpr->getType(), "_t", errorExpr);
+        Expr* commonVarExpr = m_RMV->BuildDeclRef(commonVarDecl);
+        Expr* deltaAssignExpr =
+            m_RMV->BuildOp(BO_AddAssign, Ldelta, commonVarExpr);
+        Expr* finalAssignExpr =
+            m_RMV->BuildOp(BO_AddAssign, m_FinalError, commonVarExpr);
+        ReverseModeVisitor::Stmts loopBody;
+        loopBody.push_back(m_RMV->BuildDeclStmt(commonVarDecl));
+        loopBody.push_back(deltaAssignExpr);
+        loopBody.push_back(finalAssignExpr);
+        Expr* conditionExpr = m_RMV->BuildOp(
+            BO_LT, m_IdxExpr, m_RMV->BuildArrayRefSizeExpr(LdiffExpr));
+        Expr* incExpr = m_RMV->BuildOp(UO_PostInc, m_IdxExpr);
+        Stmt* ArrayParamLoop = new (m_RMV->m_Context)
+            ForStmt(m_RMV->m_Context, nullptr, conditionExpr, nullptr, incExpr,
+                    m_RMV->MakeCompoundStmt(loopBody), noLoc, noLoc, noLoc);
+        // For multiple array parameters, we want to keep the same
+        // iterative variable, so reset that here in the case that this
+        // is not out first array.
+        if (!idxExprDecl) {
+          m_RMV->addToCurrentBlock(
+              m_RMV->BuildOp(BO_Assign, m_IdxExpr,
+                             m_RMV->getZeroInit(m_RMV->m_Context.IntTy)));
         } else {
-          auto LdiffExpr = m_Variables[decl];
-          VarDecl* idxExprDecl = nullptr;
-          // Save our index expression so it can be used later.
-          if (!m_IdxExpr) {
-            idxExprDecl = BuildVarDecl(m_Context.IntTy, "i",
-                                       getZeroInit(m_Context.IntTy));
-            m_IdxExpr = BuildDeclRef(idxExprDecl);
-          }
-          Expr *Ldiff, *Ldelta;
-          Ldiff = getArraySubscriptExpr(LdiffExpr, m_IdxExpr,
-                                        isCladArrayType(LdiffExpr->getType()));
-          Ldelta = getArraySubscriptExpr(deltaVar, m_IdxExpr);
-          auto savedVal = GetParamReplacement(params[i]);
-          savedVal = savedVal ? savedVal : BuildDeclRef(decl);
-          auto LRepl = getArraySubscriptExpr(savedVal, m_IdxExpr);
-          // Build the loop to put in reverse mode.
-          Expr* errorExpr = GetError(LRepl, Ldiff);
-          auto commonVarDecl =
-              BuildVarDecl(errorExpr->getType(), "_t", errorExpr);
-          Expr* commonVarExpr = BuildDeclRef(commonVarDecl);
-          Expr* deltaAssignExpr = BuildOp(BO_AddAssign, Ldelta, commonVarExpr);
-          Expr* finalAssignExpr =
-              BuildOp(BO_AddAssign, m_FinalError, commonVarExpr);
-          Stmts loopBody;
-          loopBody.push_back(BuildDeclStmt(commonVarDecl));
-          loopBody.push_back(deltaAssignExpr);
-          loopBody.push_back(finalAssignExpr);
-          Expr* conditionExpr = BuildOp(BO_LT, m_IdxExpr,
-                                        BuildArrayRefSizeExpr(LdiffExpr));
-          Expr* incExpr = BuildOp(UO_PostInc, m_IdxExpr);
-          Stmt* ArrayParamLoop = new (m_Context)
-              ForStmt(m_Context, nullptr, conditionExpr, nullptr, incExpr,
-                      MakeCompoundStmt(loopBody), noLoc, noLoc, noLoc);
-          // For multiple array parameters, we want to keep the same
-          // iterative variable, so reset that here in the case that this
-          // is not out first array.
-          if (!idxExprDecl) {
-            addToCurrentBlock(
-                BuildOp(BO_Assign, m_IdxExpr, getZeroInit(m_Context.IntTy)));
-          } else {
-            addToCurrentBlock(BuildDeclStmt(idxExprDecl));
-          }
-          addToCurrentBlock(ArrayParamLoop);
+          m_RMV->addToCurrentBlock(m_RMV->BuildDeclStmt(idxExprDecl));
         }
-      }
-    }
-    BuildFinalErrorStmt();
-  }
-
-  void ErrorEstimationHandler::EmitUnaryOpErrorStmts(StmtDiff var,
-                                                     bool isInsideLoop) {
-    // If the sub-expression is a declRefExpr, we should emit an error.
-    if (DeclRefExpr* DRE = GetUnderlyingDeclRefOrNull(var.getExpr())) {
-      // First check if it was registered.
-      // If not, we don't care about it.
-      if (auto deltaVar = IsRegistered(cast<VarDecl>(DRE->getDecl()))) {
-        // Create a variable/tape call to store the current value of the
-        // the sub-expression so that it can be used later.
-        StmtDiff savedVar = GlobalStoreAndRef(DRE, "_EERepl_" +
-                                                       DRE->getDecl()
-                                                           ->getNameAsString());
-        if (isInsideLoop) {
-          // It is nice to save the pop value.
-          // We do not know how many times the user will use dx,
-          // hence we should pop values beforehand to avoid unequal pushes
-          // and and pops.
-          Expr* popVal = StoreAndRef(savedVar.getExpr_dx(), direction::reverse);
-          savedVar = {savedVar.getExpr(), popVal};
-        }
-        Expr* erroExpr = GetError(savedVar.getExpr_dx(), var.getExpr_dx());
-        AddErrorStmtToBlock(var.getExpr(), deltaVar, erroExpr, isInsideLoop);
+        m_RMV->addToCurrentBlock(ArrayParamLoop);
       }
     }
   }
+  BuildFinalErrorStmt();
+}
 
-  Expr* ErrorEstimationHandler::RegisterBinaryOpLHS(Expr* LExpr, Expr* RExpr,
-                                                    bool isAssign) {
-    DeclRefExpr* LRef = GetUnderlyingDeclRefOrNull(LExpr);
-    DeclRefExpr* RRef = GetUnderlyingDeclRefOrNull(RExpr);
-    VarDecl* Ldecl = LRef ? dyn_cast<VarDecl>(LRef->getDecl()) : nullptr;
-    // In the case that an RHS expression is a declReference, we do not emit
-    // any error because the assignment operation entials zero error.
-    // However, for compound assignment operators, the RHS may be a
-    // declRefExpr but here we will need to emit its error.
-    // This variable checks for the above conditions.
-    bool declRefOk = !RRef || !isAssign;
-    Expr* deltaVar = nullptr;
-    // If the LHS can be decayed to a VarDecl and all other requirements
-    // are met, we should register the variable if it has not been already.
-    // We also do not support array input types yet.
-    if (Ldecl && declRefOk) {
-      deltaVar = IsRegistered(Ldecl);
-      // Usually we would expect independent variable to qualify for these
-      // checks.
-      if (!deltaVar) {
-        deltaVar = RegisterVariable(Ldecl);
-        SaveParamValue(LRef);
+void ErrorEstimationHandler::EmitUnaryOpErrorStmts(StmtDiff var,
+                                                   bool isInsideLoop) {
+  // If the sub-expression is a declRefExpr, we should emit an error.
+  if (DeclRefExpr* DRE = GetUnderlyingDeclRefOrNull(var.getExpr())) {
+    // First check if it was registered.
+    // If not, we don't care about it.
+    if (auto deltaVar = IsRegistered(cast<VarDecl>(DRE->getDecl()))) {
+      // Create a variable/tape call to store the current value of the
+      // the sub-expression so that it can be used later.
+      StmtDiff savedVar = m_RMV->GlobalStoreAndRef(
+          DRE, "_EERepl_" + DRE->getDecl()->getNameAsString());
+      if (isInsideLoop) {
+        // It is nice to save the pop value.
+        // We do not know how many times the user will use dx,
+        // hence we should pop values beforehand to avoid unequal pushes
+        // and and pops.
+        Expr* popVal =
+            m_RMV->StoreAndRef(savedVar.getExpr_dx(), direction::reverse);
+        savedVar = {savedVar.getExpr(), popVal};
       }
-    }
-    return deltaVar;
-  }
-
-  void ErrorEstimationHandler::EmitBinaryOpErrorStmts(Expr* LExpr,
-                                                      Expr* oldValue,
-                                                      Expr* deltaVar,
-                                                      bool isInsideLoop) {
-    if (!deltaVar)
-      return;
-    // For now save all lhs.
-    // FIXME: We can optimize stores here by using the ones created
-    // previously.
-    StmtDiff savedExpr = SaveValue(LExpr, isInsideLoop);
-    // Assign the error.
-    Expr* errorExpr = GetError(savedExpr.getExpr_dx(), oldValue);
-    AddErrorStmtToBlock(LExpr, deltaVar, errorExpr, isInsideLoop);
-    // If there are assign statements to emit in reverse, do that.
-    EmitErrorEstimationStmts(direction::reverse);
-  }
-
-  void ErrorEstimationHandler::EmitDeclErrorStmts(VarDeclDiff VDDiff,
-                                                  bool isInsideLoop) {
-    auto VD = VDDiff.getDecl();
-    if (!CanRegisterVariable(VD))
-      return;
-    // Build the delta expresion for the variable to be registered.
-    auto EstVD = RegisterVariable(VD);
-    DeclRefExpr* VDRef = BuildDeclRef(VD);
-    // FIXME: We should do this for arrays too.
-    if (!VD->getType()->isArrayType()) {
-      StmtDiff savedDecl = SaveValue(VDRef, isInsideLoop);
-      // If the VarDecl has an init, we should assign it with an error.
-      if (VD->getInit() && !GetUnderlyingDeclRefOrNull(VD->getInit())) {
-        Expr* errorExpr = GetError(savedDecl.getExpr_dx(),
-                                   BuildDeclRef(VDDiff.getDecl_dx()));
-        AddErrorStmtToBlock(VDRef, EstVD, errorExpr, isInsideLoop);
-      }
+      Expr* erroExpr = GetError(savedVar.getExpr_dx(), var.getExpr_dx());
+      AddErrorStmtToBlock(var.getExpr(), deltaVar, erroExpr, isInsideLoop);
     }
   }
+}
 
+Expr* ErrorEstimationHandler::RegisterBinaryOpLHS(Expr* LExpr, Expr* RExpr,
+                                                  bool isAssign) {
+  DeclRefExpr* LRef = GetUnderlyingDeclRefOrNull(LExpr);
+  DeclRefExpr* RRef = GetUnderlyingDeclRefOrNull(RExpr);
+  VarDecl* Ldecl = LRef ? dyn_cast<VarDecl>(LRef->getDecl()) : nullptr;
+  // In the case that an RHS expression is a declReference, we do not emit
+  // any error because the assignment operation entials zero error.
+  // However, for compound assignment operators, the RHS may be a
+  // declRefExpr but here we will need to emit its error.
+  // This variable checks for the above conditions.
+  bool declRefOk = !RRef || !isAssign;
+  Expr* deltaVar = nullptr;
+  // If the LHS can be decayed to a VarDecl and all other requirements
+  // are met, we should register the variable if it has not been already.
+  // We also do not support array input types yet.
+  if (Ldecl && declRefOk) {
+    deltaVar = IsRegistered(Ldecl);
+    // Usually we would expect independent variable to qualify for these
+    // checks.
+    if (!deltaVar) {
+      deltaVar = RegisterVariable(Ldecl);
+      SaveParamValue(LRef);
+    }
+  }
+  return deltaVar;
+}
+
+void ErrorEstimationHandler::EmitBinaryOpErrorStmts(Expr* LExpr, Expr* oldValue,
+                                                    Expr* deltaVar,
+                                                    bool isInsideLoop) {
+  if (!deltaVar)
+    return;
+  // For now save all lhs.
+  // FIXME: We can optimize stores here by using the ones created
+  // previously.
+  StmtDiff savedExpr = SaveValue(LExpr, isInsideLoop);
+  // Assign the error.
+  Expr* errorExpr = GetError(savedExpr.getExpr_dx(), oldValue);
+  AddErrorStmtToBlock(LExpr, deltaVar, errorExpr, isInsideLoop);
+  // If there are assign statements to emit in reverse, do that.
+  EmitErrorEstimationStmts(direction::reverse);
+}
+
+void ErrorEstimationHandler::EmitDeclErrorStmts(VarDeclDiff VDDiff,
+                                                bool isInsideLoop) {
+  auto VD = VDDiff.getDecl();
+  if (!CanRegisterVariable(VD))
+    return;
+  // Build the delta expresion for the variable to be registered.
+  auto EstVD = RegisterVariable(VD);
+  DeclRefExpr* VDRef = m_RMV->BuildDeclRef(VD);
+  // FIXME: We should do this for arrays too.
+  if (!VD->getType()->isArrayType()) {
+    StmtDiff savedDecl = SaveValue(VDRef, isInsideLoop);
+    // If the VarDecl has an init, we should assign it with an error.
+    if (VD->getInit() && !GetUnderlyingDeclRefOrNull(VD->getInit())) {
+      Expr* errorExpr = GetError(savedDecl.getExpr_dx(),
+                                 m_RMV->BuildDeclRef(VDDiff.getDecl_dx()));
+      AddErrorStmtToBlock(VDRef, EstVD, errorExpr, isInsideLoop);
+    }
+  }
+}
+
+void ErrorEstimationHandler::InitialiseRMV(ReverseModeVisitor& RMV) {
+  m_RMV = &RMV;
+}
+
+void ErrorEstimationHandler::ForgetRMV() { m_RMV = nullptr; }
+
+void ErrorEstimationHandler::ActBeforeCreatingDerivedFnParamTypes(
+    unsigned& numExtraParam) {
+  numExtraParam += 1;
+}
+
+void ErrorEstimationHandler::ActAfterCreatingDerivedFnParamTypes(
+    llvm::SmallVectorImpl<QualType>& paramTypes) {
+  m_ParamTypes = &paramTypes;
+  // If we are performing error estimation, our gradient function
+  // will have an extra argument which will hold the final error value
+  paramTypes.push_back(
+      m_RMV->m_Context.getLValueReferenceType(m_RMV->m_Context.DoubleTy));
+};
+
+void ErrorEstimationHandler::ActAfterCreatingDerivedFnParams(
+    llvm::SmallVectorImpl<ParmVarDecl*>& params) {
+  m_Params = &params;
+  // If in error estimation mode, create the error parameter
+  ASTContext& context = m_RMV->m_Context;
+  // Repeat the above but for the error ouput var "_final_error"
+  ParmVarDecl* errorVarDecl = ParmVarDecl::Create(
+      context, m_RMV->m_Derivative, noLoc, noLoc,
+      &context.Idents.get("_final_error"), m_ParamTypes->back(),
+      context.getTrivialTypeSourceInfo(m_ParamTypes->back(), noLoc),
+      params.front()->getStorageClass(),
+      /*DefArg=*/nullptr);
+  params.push_back(errorVarDecl);
+  m_RMV->m_Sema.PushOnScopeChains(params.back(), m_RMV->getCurrentScope(),
+                                  /*AddToContext=*/false);
+}
+
+void ErrorEstimationHandler::ActBeforeCreatingDerivedFnBodyScope() {
+  // Reference to the final error statement
+  SetFinalErrorExpr(m_RMV->BuildDeclRef(m_Params->back()));
+}
+
+void ErrorEstimationHandler::ActOnEndOfDerivedFnBody() {
+  // Since 'return' is not an assignment, add its error to _final_error
+  // given it is not a DeclRefExpr.
+  EmitFinalErrorStmts(*m_Params, m_RMV->m_Function->getNumParams());
+}
+
+void ErrorEstimationHandler::ActBeforeDifferentiatingStmtInVisitCompoundStmt() {
+  m_ShouldEmit.push(true);
+}
+
+void ErrorEstimationHandler::ActAfterProcessingStmtInVisitCompoundStmt() {
+  // In error estimation mode, if we have any residual statements
+  // to be emitted into the forward or revese blocks, we should
+  // emit them here. This is to maintain the correct order of
+  // statements generated.
+  EmitErrorEstimationStmts(direction::forward);
+  EmitErrorEstimationStmts(direction::reverse);
+}
+
+void ErrorEstimationHandler::
+    ActBeforeDifferentiatingSingleStmtBranchInVisitIfStmt() {
+  m_ShouldEmit.push(true);
+}
+
+void ErrorEstimationHandler::
+    ActBeforeFinalisingVisitBranchSingleStmtInIfVisitStmt() {
+  // In error estimation, manually emit the code here instead of
+  // DifferentiateSingleStmt to maintain correct order.
+  EmitErrorEstimationStmts(direction::forward);
+}
+
+void ErrorEstimationHandler::ActBeforeDifferentiatingLoopInitStmt() {
+  m_ShouldEmit.push(true);
+}
+
+void ErrorEstimationHandler::ActBeforeDifferentiatingSingleStmtLoopBody() {
+  m_ShouldEmit.push(false);
+}
+
+void ErrorEstimationHandler::ActAfterProcessingSingleStmtBodyInVisitForLoop() {
+  // Emit some statemnts later to maintain correct statement order.
+  EmitErrorEstimationStmts(direction::forward);
+}
+
+void ErrorEstimationHandler::ActBeforeFinalisingVisitReturnStmt(
+    StmtDiff& ExprDiff, clang::Expr*& retDeclRefExpr) {
+  // If the return expression is not a DeclRefExpression and is of type
+  // float, we should add it to the error estimate because returns are
+  // similiar to implicit assigns.
+  SaveReturnExpr(ExprDiff.getExpr(), cast<DeclRefExpr>(retDeclRefExpr));
+}
+
+void ErrorEstimationHandler::ActBeforeFinalisingPostIncDecOp(StmtDiff& diff) {
+  EmitUnaryOpErrorStmts(diff, m_RMV->isInsideLoop);
+}
+
+void ErrorEstimationHandler::ActBeforeFinalizingVisitCallExpr(
+    const clang::CallExpr*& CE, clang::Expr*& OverloadedDerivedFn,
+    llvm::SmallVectorImpl<Expr*>& CallArgs,
+    llvm::SmallVectorImpl<VarDecl*>& ArgResultDecls, bool asGrad) {
+  if (OverloadedDerivedFn && asGrad) {
+    // Derivative was found.
+    FunctionDecl* fnDecl =
+        dyn_cast<CallExpr>(OverloadedDerivedFn)->getDirectCallee();
+
+    // If in error estimation, build the statement for the error
+    // in the input prameters (if of reference type) to call and save to
+    // emit them later.
+
+    EmitNestedFunctionParamError(fnDecl, CallArgs, ArgResultDecls,
+                                 CE->getNumArgs());
+  }
+}
+
+void ErrorEstimationHandler::ActAfterCloningLHSOfAssignOp(
+    clang::Expr*& LCloned, clang::Expr*& R,
+    clang::BinaryOperator::Opcode& opCode) {
+  m_DeltaVar = RegisterBinaryOpLHS(LCloned, R,
+                                   /*isAssign=*/opCode == BO_Assign);
+}
+
+void ErrorEstimationHandler::ActBeforeFinalisingAssignOp(
+    clang::Expr*& LCloned, clang::Expr*& oldValue) {
+  // Now, we should emit the delta for LHS if it met all the
+  // requirements previously.
+  EmitBinaryOpErrorStmts(LCloned, oldValue, m_DeltaVar, m_RMV->isInsideLoop);
+}
+
+void ErrorEstimationHandler::ActBeforeFinalizingDifferentiateSingleStmt(
+    const direction& d) {
+  // We might have some expressions to emit, so do that here.
+  if (m_ShouldEmit.top())
+    EmitErrorEstimationStmts(d);
+  m_ShouldEmit.pop();
+}
+
+void ErrorEstimationHandler::ActBeforeFinalizingDifferentiateSingleExpr(
+    const direction& d) {
+  // We might have some expressions to emit, so do that here.
+  EmitErrorEstimationStmts(d);
+}
+
+void ErrorEstimationHandler::ActBeforeFinalizingVisitDeclStmt(
+    llvm::SmallVectorImpl<Decl*>& decls,
+    llvm::SmallVectorImpl<Decl*>& declsDiff) {
+  // For all dependent variables, we register them for estimation
+  // here.
+  for (size_t i = 0; i < decls.size(); i++) {
+    VarDeclDiff VDDiff(static_cast<VarDecl*>(decls[0]),
+                       static_cast<VarDecl*>(declsDiff[0]));
+    EmitDeclErrorStmts(VDDiff, m_RMV->isInsideLoop);
+  }
+}
 } // namespace clad

--- a/lib/Differentiator/MultiplexExternalRMVSource.cpp
+++ b/lib/Differentiator/MultiplexExternalRMVSource.cpp
@@ -1,61 +1,202 @@
 #include "clad/Differentiator/MultiplexExternalRMVSource.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace clang;
 namespace clad {
-  // void MultiplexExternalRMVSource::MultiplexExternalRMVSource() {}
-  void MultiplexExternalRMVSource::AddSource(ExternalRMVSource& source) {
-    m_Sources.push_back(&source);
-  }
+// void MultiplexExternalRMVSource::MultiplexExternalRMVSource() {}
+void MultiplexExternalRMVSource::AddSource(ExternalRMVSource& source) {
+  m_Sources.push_back(&source);
+}
 
-  void MultiplexExternalRMVSource::InitialiseRMV(ReverseModeVisitor& RMV) {
-    for (auto source : m_Sources) {
-      source->InitialiseRMV(RMV);
-    }
+void MultiplexExternalRMVSource::InitialiseRMV(ReverseModeVisitor& RMV) {
+  for (auto source : m_Sources) {
+    source->InitialiseRMV(RMV);
   }
+}
 
-  void MultiplexExternalRMVSource::ForgetRMV() {
-    for (auto source : m_Sources)
-      source->ForgetRMV();
-  }
+void MultiplexExternalRMVSource::ForgetRMV() {
+  for (auto source : m_Sources)
+    source->ForgetRMV();
+}
 
-  void MultiplexExternalRMVSource::ActOnStartOfDerive() {
-    for (auto source : m_Sources) {
-      source->ActOnStartOfDerive();
-    }
+void MultiplexExternalRMVSource::ActOnStartOfDerive() {
+  for (auto source : m_Sources) {
+    source->ActOnStartOfDerive();
   }
+}
 
-  void MultiplexExternalRMVSource::ActOnEndOfDerive() {
-    for (auto source : m_Sources) {
-      source->ActOnEndOfDerive();
-    }
+void MultiplexExternalRMVSource::ActOnEndOfDerive() {
+  for (auto source : m_Sources) {
+    source->ActOnEndOfDerive();
   }
+}
 
-  void MultiplexExternalRMVSource::ActAfterParsingDiffArgs(const DiffRequest& request,
-                                                           DiffParams& args) {
-    for (auto source : m_Sources) {
-      source->ActAfterParsingDiffArgs(request, args);
-    }
+void MultiplexExternalRMVSource::ActAfterParsingDiffArgs(
+    const DiffRequest& request, DiffParams& args) {
+  for (auto source : m_Sources) {
+    source->ActAfterParsingDiffArgs(request, args);
   }
+}
 
-  void MultiplexExternalRMVSource::ActBeforeCreatingDerivedFnScope() {
-    for (auto source : m_Sources) {
-      source->ActBeforeCreatingDerivedFnScope();
-    }
+void MultiplexExternalRMVSource::ActBeforeCreatingDerivedFnParamTypes(
+    unsigned& numExtraParams) {
+  for (auto source : m_Sources) {
+    source->ActBeforeCreatingDerivedFnParamTypes(numExtraParams);
   }
+};
+void MultiplexExternalRMVSource::ActAfterCreatingDerivedFnParamTypes(
+    llvm::SmallVectorImpl<clang::QualType>& paramTypes) {
+  for (auto source : m_Sources) {
+    source->ActAfterCreatingDerivedFnParamTypes(paramTypes);
+  }
+}
+void MultiplexExternalRMVSource::ActAfterCreatingDerivedFnParams(
+    llvm::SmallVectorImpl<clang::ParmVarDecl*>& params) {
+  // llvm::errs() << "Reaching multiplexer ActAfterCreatingDerivedFnParams\n";
+  for (auto source : m_Sources) {
+    source->ActAfterCreatingDerivedFnParams(params);
+  }
+}
 
-  void MultiplexExternalRMVSource::ActAfterCreatingDerivedFnScope() {
-    for (auto source : m_Sources) {
-      source->ActAfterCreatingDerivedFnScope();
-    }
+void MultiplexExternalRMVSource::ActBeforeCreatingDerivedFnScope() {
+  for (auto source : m_Sources) {
+    source->ActBeforeCreatingDerivedFnScope();
   }
+}
 
-  void MultiplexExternalRMVSource::ActOnStartOfDerivedFnBody() {
-    for (auto source : m_Sources) {
-      source->ActOnStartOfDerivedFnBody();
-    }
+void MultiplexExternalRMVSource::ActAfterCreatingDerivedFnScope() {
+  for (auto source : m_Sources) {
+    source->ActAfterCreatingDerivedFnScope();
   }
+}
 
-  void MultiplexExternalRMVSource::ActOnEndOfDerivedFnBody() {
-    for (auto source : m_Sources) {
-      source->ActOnEndOfDerivedFnBody();
-    }
+void MultiplexExternalRMVSource::ActBeforeCreatingDerivedFnBodyScope() {
+  for (auto source : m_Sources) {
+    source->ActBeforeCreatingDerivedFnBodyScope();
   }
+}
+
+void MultiplexExternalRMVSource::ActOnStartOfDerivedFnBody(
+    const DiffRequest& request) {
+  for (auto source : m_Sources) {
+    source->ActOnStartOfDerivedFnBody(request);
+  }
+}
+
+void MultiplexExternalRMVSource::ActOnEndOfDerivedFnBody() {
+  for (auto source : m_Sources) {
+    source->ActOnEndOfDerivedFnBody();
+  }
+}
+
+void MultiplexExternalRMVSource::
+    ActBeforeDifferentiatingStmtInVisitCompoundStmt() {
+  for (auto source : m_Sources) {
+    source->ActBeforeDifferentiatingStmtInVisitCompoundStmt();
+  }
+}
+
+void MultiplexExternalRMVSource::ActAfterProcessingStmtInVisitCompoundStmt() {
+  for (auto source : m_Sources) {
+    source->ActAfterProcessingStmtInVisitCompoundStmt();
+  }
+}
+
+void MultiplexExternalRMVSource::
+    ActBeforeDifferentiatingSingleStmtBranchInVisitIfStmt() {
+  for (auto source : m_Sources) {
+    source->ActBeforeDifferentiatingSingleStmtBranchInVisitIfStmt();
+  }
+}
+
+void MultiplexExternalRMVSource::
+    ActBeforeFinalisingVisitBranchSingleStmtInIfVisitStmt() {
+  for (auto source : m_Sources) {
+    source->ActBeforeFinalisingVisitBranchSingleStmtInIfVisitStmt();
+  }
+}
+
+void MultiplexExternalRMVSource::ActBeforeDifferentiatingLoopInitStmt() {
+  for (auto source : m_Sources) {
+    source->ActBeforeDifferentiatingLoopInitStmt();
+  }
+}
+
+void MultiplexExternalRMVSource::ActBeforeDifferentiatingSingleStmtLoopBody() {
+  for (auto source : m_Sources) {
+    source->ActBeforeDifferentiatingSingleStmtLoopBody();
+  }
+}
+
+void MultiplexExternalRMVSource::
+    ActAfterProcessingSingleStmtBodyInVisitForLoop() {
+  for (auto source : m_Sources) {
+    source->ActAfterProcessingSingleStmtBodyInVisitForLoop();
+  }
+}
+
+void MultiplexExternalRMVSource::ActBeforeFinalisingVisitReturnStmt(
+    StmtDiff& ExprDiff, clang::Expr*& retDeclRefExpr) {
+  for (auto source : m_Sources) {
+    source->ActBeforeFinalisingVisitReturnStmt(ExprDiff, retDeclRefExpr);
+  }
+}
+
+void MultiplexExternalRMVSource::ActBeforeFinalizingVisitCallExpr(
+    const clang::CallExpr*& CE, clang::Expr*& OverloadedDerivedFn,
+    llvm::SmallVectorImpl<clang::Expr*>& CallArgs,
+    llvm::SmallVectorImpl<clang::VarDecl*>& ArgResultDecls, bool asGrad) {
+  for (auto source : m_Sources) {
+    source->ActBeforeFinalizingVisitCallExpr(CE, OverloadedDerivedFn, CallArgs,
+                                             ArgResultDecls, asGrad);
+  }
+}
+
+void MultiplexExternalRMVSource::ActBeforeFinalisingPostIncDecOp(
+    StmtDiff& diff) {
+  for (auto source : m_Sources) {
+    source->ActBeforeFinalisingPostIncDecOp(diff);
+  }
+}
+void MultiplexExternalRMVSource::ActAfterCloningLHSOfAssignOp(
+    clang::Expr*& LCloned, clang::Expr*& R, clang::BinaryOperatorKind& opCode) {
+  for (auto source : m_Sources) {
+    source->ActAfterCloningLHSOfAssignOp(LCloned, R, opCode);
+  }
+}
+
+void MultiplexExternalRMVSource::ActBeforeFinalisingAssignOp(
+    clang::Expr*& LCloned, clang::Expr*& oldValue) {
+  for (auto source : m_Sources) {
+    source->ActBeforeFinalisingAssignOp(LCloned, oldValue);
+  }
+}
+
+void MultiplexExternalRMVSource::ActOnStartOfDifferentiateSingleStmt() {
+  for (auto source : m_Sources) {
+    source->ActOnStartOfDifferentiateSingleStmt();
+  }
+}
+
+void MultiplexExternalRMVSource::ActBeforeFinalizingDifferentiateSingleStmt(
+    const direction& d) {
+  for (auto source : m_Sources) {
+    source->ActBeforeFinalizingDifferentiateSingleStmt(d);
+  }
+}
+
+void MultiplexExternalRMVSource::ActBeforeFinalizingDifferentiateSingleExpr(
+    const direction& d) {
+  for (auto source : m_Sources) {
+    source->ActBeforeFinalizingDifferentiateSingleExpr(d);
+  }
+}
+
+void MultiplexExternalRMVSource::ActBeforeFinalizingVisitDeclStmt(
+    llvm::SmallVectorImpl<clang::Decl*>& decls,
+    llvm::SmallVectorImpl<clang::Decl*>& declsDiff) {
+  for (auto source : m_Sources) {
+    source->ActBeforeFinalizingVisitDeclStmt(decls, declsDiff);
+  }
+}
 } // namespace clad

--- a/lib/Differentiator/MultiplexExternalRMVSource.cpp
+++ b/lib/Differentiator/MultiplexExternalRMVSource.cpp
@@ -1,0 +1,61 @@
+#include "clad/Differentiator/MultiplexExternalRMVSource.h"
+namespace clad {
+  // void MultiplexExternalRMVSource::MultiplexExternalRMVSource() {}
+  void MultiplexExternalRMVSource::AddSource(ExternalRMVSource& source) {
+    m_Sources.push_back(&source);
+  }
+
+  void MultiplexExternalRMVSource::InitialiseRMV(ReverseModeVisitor& RMV) {
+    for (auto source : m_Sources) {
+      source->InitialiseRMV(RMV);
+    }
+  }
+
+  void MultiplexExternalRMVSource::ForgetRMV() {
+    for (auto source : m_Sources)
+      source->ForgetRMV();
+  }
+
+  void MultiplexExternalRMVSource::ActOnStartOfDerive() {
+    for (auto source : m_Sources) {
+      source->ActOnStartOfDerive();
+    }
+  }
+
+  void MultiplexExternalRMVSource::ActOnEndOfDerive() {
+    for (auto source : m_Sources) {
+      source->ActOnEndOfDerive();
+    }
+  }
+
+  void MultiplexExternalRMVSource::ActAfterParsingDiffArgs(const DiffRequest& request,
+                                                           DiffParams& args) {
+    for (auto source : m_Sources) {
+      source->ActAfterParsingDiffArgs(request, args);
+    }
+  }
+
+  void MultiplexExternalRMVSource::ActBeforeCreatingDerivedFnScope() {
+    for (auto source : m_Sources) {
+      source->ActBeforeCreatingDerivedFnScope();
+    }
+  }
+
+  void MultiplexExternalRMVSource::ActAfterCreatingDerivedFnScope() {
+    for (auto source : m_Sources) {
+      source->ActAfterCreatingDerivedFnScope();
+    }
+  }
+
+  void MultiplexExternalRMVSource::ActOnStartOfDerivedFnBody() {
+    for (auto source : m_Sources) {
+      source->ActOnStartOfDerivedFnBody();
+    }
+  }
+
+  void MultiplexExternalRMVSource::ActOnEndOfDerivedFnBody() {
+    for (auto source : m_Sources) {
+      source->ActOnEndOfDerivedFnBody();
+    }
+  }
+} // namespace clad


### PR DESCRIPTION
This PR adds initial support for the reverse mode visitor plugin system. 

Reverse mode visitor plugins are external sources that can provide additional functionality to the reverse mode visitor by utilising callbacks at crucial locations. 

Here we are making an assumption that most plugins will only require modifying the behaviour of reverse mode at few crucial locations that are less in number and spread throughout the `ReverseModeVisitor` class. Reverse mode visitor plugins should only be used for adding relatively simple features.

## Implementation details

Basic design is inspired by [ExternalSemaSource](https://clang.llvm.org/doxygen/classclang_1_1ExternalSemaSource.html) and [MultiplexExternalSemaSource](https://clang.llvm.org/doxygen/MultiplexExternalSemaSource_8cpp.html) class.

Callbacks are available of the following flavours:

- `ActOnStartOf(Event)` and `ActOnEndOf(Event)`
   Here _Event_ should be a `ReverseModeVisitor` member function. The behaviour of these 2 flavours of events can be 
   described as:

   ```
   ReturnType ReverseModeVisitor::MemberFunction(...) {
     ActOnStartOf(Event)
     fn step 1
     fn step 2
     ...
     ...
     fn step N
     ActOnEndOf(Event)
   }

- `ActBefore(Event)` and `ActAfter(Event)`
   Here _Event_ should be an event containing single or multiple steps. The behaviour of these 2 flavours can be 
   described as:

   ```
   ActBefore(Event)
   Event step 1
   Event step 2
   ...
   ...
   Event step N
   ActAfter(Event)
   ```
- `ActBeforeFinalising(Event)`
   Again, here event is an event that contains single or multiple steps. Finalising an event means the cleanup/adding 
   statements to the current block/Getting current forward and reverse block /returning statements or anything 
   that can be roughly fit under these categories. An example of this flavour of event:

   ```
   ActBeforeFinalising(Event)
   Stmt* Forward = unwrapIfSingleStmt(endBlock(direction::forward));
   Stmt* Reverse = unwrapIfSingleStmt(BranchDiff.getStmt_dx());
   return StmtDiff(Forward, Reverse);
   ```

Any new callbacks that need to be added should also be of one of the flavours described above to maintain consistency in the plugin callbacks API.

## Usage details 

To create a reverse mode visitor plugin, a new class that inherits from `ExternalRMVSource` class should be created to describe the plugin behaviour.
This plugin class should override any callback functions that it needs to implement the required functionality. 

Any number of plugins can be registered to a reverse mode visitor object using the `ReverseModeVisitor::AddExternalSource` member function. 

Internally, reverse mode visitor uses a `MultiplexExternalRMVSource` object for this purpose. For each crucial location, multiplexer calls the callback function for each plugin in the same sequence in which the plugins were registered. 

Ideally, plugins functionality should be isolated and independent from each other. 

Please feel free to give any suggestions for improving the reverse mode plugin system. 
