### PR TITLE
Comment out TODOs from clad user documentation

### DIFF
--- a/docs/userDocs/source/index.rst
+++ b/docs/userDocs/source/index.rst
@@ -60,9 +60,11 @@ Features
 - Features numerical differentiation support, to be used where automatic
   differentiation is not feasible.
 
-.. todo::
+.. comment::
 
-   Add more features such as error estimation, custom derivatives etc.
+   .. todo::
+
+      Add more features such as error estimation, custom derivatives etc.
 
 The User Guide
 ---------------

--- a/docs/userDocs/source/user/details.rst
+++ b/docs/userDocs/source/user/details.rst
@@ -245,19 +245,21 @@ derivative functions. The whole clad's operation sequence is the following:
 
 .. _clad_limitations:
 
-Clad limitations
-------------------
+.. comment::
 
-.. todo::
-  Add clad limitations, some of the limitations are:
+   Clad limitations
+   ------------------
+
+   .. todo::
+      Add clad limitations, some of the limitations are:
   
-  1) Do not support differentiating overloaded functions.
-  2) Clad differentiation functions do not work in non top-level contexts, 
-     such as inside a function.
-  3) Many C++ syntax are not supported such as complex pointer usage,
-     for-range loops, new and delete operators, iterators usage, custom classes etc
-  4) Currently ``clad::jacobian`` do not support array differentiation.
-  5) Error estimation framework do not support forward propagation of errors.
+      1) Do not support differentiating overloaded functions.
+      2) Clad differentiation functions do not work in non top-level contexts, 
+         such as inside a function.
+      3) Many C++ syntax are not supported such as complex pointer usage,
+         for-range loops, new and delete operators, iterators usage, custom classes etc
+      4) Currently ``clad::jacobian`` do not support array differentiation.
+      5) Error estimation framework do not support forward propagation of errors.
 
 .. note::
 

--- a/docs/userDocs/source/user/gettingStarted.rst
+++ b/docs/userDocs/source/user/gettingStarted.rst
@@ -90,10 +90,12 @@ by one directly to the clang compiler. This method also preserve all the
 options and flags that are usually set by the compiler driver such as 
 default header search paths. 
 
-.. todo::
+.. comment::
+   
+   .. todo::
 
-   Should we explain about or give an external link to read more about difference
-   between the clang compiler driver and the clang compiler?
+      Should we explain about or give an external link to read more about difference
+      between the clang compiler driver and the clang compiler?
 
 What can Clad differentiate
 ----------------------------
@@ -143,9 +145,11 @@ We can also print the generated derived function, for studying or
 debugging purposes, through a ``clad::CladFunction`` object by calling 
 ``clad::CladFunction::dump`` member function.
 
-.. todo:: 
+.. comment::
+   
+   .. todo:: 
 
-   Should we add more information about CladFunction here?
+      Should we add more information about CladFunction here?
 
 Differentiating a function
 ----------------------------
@@ -429,24 +433,32 @@ Few important things to note through this example:
     // passing function by pointer
     auto d_E = clad::differentiate(&E, "i");
 
-Array differentiation
---------------------------------
-
-.. todo:: 
-
-   Add array differentiation quickstart documentation.
-
-
-Automatically shifting to Numerical differentiation
------------------------------------------------------
-
-.. todo::
-
-   Add numerical differentiation quickstart documentation.
-
-Error estimation framework
--------------------------------
-
-.. todo::
+.. comment::
    
-   Add error estimation framework quickstart documentation.
+   Array differentiation
+   --------------------------------
+
+   .. todo:: 
+
+      Add array differentiation quickstart documentation.
+
+
+.. comment::
+
+   Automatically shifting to Numerical differentiation
+   -----------------------------------------------------
+
+
+   .. todo::
+
+      Add numerical differentiation quickstart documentation.
+
+.. comment::
+
+   Error estimation framework
+   -------------------------------
+
+
+   .. todo::
+   
+      Add error estimation framework quickstart documentation.


### PR DESCRIPTION
This PR comments out TODOs from the RestructureText files for clad user documentation.

Updated user documentation: https://trying-read-the-docs.readthedocs.io/en/latest/