### PR TITLE
Fix multiple computation of derived statement in forward mode

### DIFF
--- a/test/FirstDerivative/BasicArithmeticAll.C
+++ b/test/FirstDerivative/BasicArithmeticAll.C
@@ -29,8 +29,85 @@ float basic_1(int x) {
 
 float basic_1_darg0(int x);
 
+double fn1(double i, double j) {
+  double t = 1;
+  (t *= j) *= (i *= i);
+  return t; // return i*i*j;
+}
+
+// CHECK:  double fn1_darg0(double i, double j) {
+// CHECK-NEXT:      double _d_i = 1;
+// CHECK-NEXT:      double _d_j = 0;
+// CHECK-NEXT:      double _d_t = 0;
+// CHECK-NEXT:      double t = 1;
+// CHECK-NEXT:      double &_t0 = (_d_t = _d_t * j + t * _d_j);
+// CHECK-NEXT:      double &_t1 = (t *= j);
+// CHECK-NEXT:      double &_t2 = (_d_i = _d_i * i + i * _d_i);
+// CHECK-NEXT:      double &_t3 = (i *= i);
+// CHECK-NEXT:      _t0 = _t0 * _t3 + _t1 * _t2;
+// CHECK-NEXT:      _t1 *= _t3;
+// CHECK-NEXT:      return _d_t;
+// CHECK-NEXT:  }
+
+double fn2(double i, double j) {
+  double t = i*i*j*j;
+  (t /= i*j)*=(j);
+  return t; // return i*j*j;
+}
+
+// CHECK:  double fn2_darg0(double i, double j) {
+// CHECK-NEXT:      double _d_i = 1;
+// CHECK-NEXT:      double _d_j = 0;
+// CHECK-NEXT:      double _t0 = i * i;
+// CHECK-NEXT:      double _t1 = _t0 * j;
+// CHECK-NEXT:      double _d_t = ((_d_i * i + i * _d_i) * j + _t0 * _d_j) * j + _t1 * _d_j;
+// CHECK-NEXT:      double t = _t1 * j;
+// CHECK-NEXT:      double _t2 = _d_i * j + i * _d_j;
+// CHECK-NEXT:      double _t3 = i * j;
+// CHECK-NEXT:      double &_t4 = (_d_t = (_d_t * _t3 - t * _t2) / (_t3 * _t3));
+// CHECK-NEXT:      double &_t5 = (t /= _t3);
+// CHECK-NEXT:      _t4 = _t4 * j + _t5 * _d_j;
+// CHECK-NEXT:      _t5 *= j;
+// CHECK-NEXT:      return _d_t;
+// CHECK-NEXT:  }
+
+double fn3(double i, double j) {
+  double t = 1;
+  ((t*=(i*j))*=j)*=i;
+  return t; // i*i*j*j
+}
+
+// CHECK:  double fn3_darg0(double i, double j) {
+// CHECK-NEXT:      double _d_i = 1;
+// CHECK-NEXT:      double _d_j = 0;
+// CHECK-NEXT:      double _d_t = 0;
+// CHECK-NEXT:      double t = 1;
+// CHECK-NEXT:      double _t0 = (_d_i * j + i * _d_j);
+// CHECK-NEXT:      double _t1 = (i * j);
+// CHECK-NEXT:      double &_t2 = (_d_t = _d_t * _t1 + t * _t0);
+// CHECK-NEXT:      double &_t3 = (t *= _t1);
+// CHECK-NEXT:      double &_t4 = (_t2 = _t2 * j + _t3 * _d_j);
+// CHECK-NEXT:      double &_t5 = (_t3 *= j);
+// CHECK-NEXT:      _t4 = _t4 * i + _t5 * _d_i;
+// CHECK-NEXT:      _t5 *= i;
+// CHECK-NEXT:      return _d_t;
+// CHECK-NEXT:  }
+
+#define INIT(fn, arg) auto d_##fn = clad::differentiate(fn, arg);
+#define TEST(fn, ...) printf("%.2f\n", d_##fn.execute(__VA_ARGS__));
+
 int main () {
   clad::differentiate(basic_1, 0);
   printf("Result is = %f\n", basic_1_darg0(1)); // CHECK-EXEC: Result is = -6
+  INIT(fn1, "i");
+  INIT(fn2, "i");
+  INIT(fn3, "i");
+
+  TEST(fn1, 3, 5);  // CHECK-EXEC: 30.00
+  TEST(fn1, 5, 7);  // CHECK-EXEC: 70.00
+  TEST(fn2, 3, 5);  // CHECK-EXEC: 25.00
+  TEST(fn2, 5, 7);  // CHECK-EXEC: 49.00
+  TEST(fn3, 3, 5);  // CHECK-EXEC: 150.00
+  TEST(fn3, 5, 7);  // CHECK-EXEC: 490.00
   return 0;
 }

--- a/test/FirstDerivative/Loops.C
+++ b/test/FirstDerivative/Loops.C
@@ -201,9 +201,10 @@ double f4_inc_darg0(double x, int y);
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_i = 0;
 //CHECK-NEXT:           for (i = 0; i < y; [&]             {
-//CHECK-NEXT:                   double _t1 = std::sin(x);
-//CHECK-NEXT:                   _d_r = _d_r * _t1 + r * (custom_derivatives::sin_darg0(x) * _d_x);
-//CHECK-NEXT:                   r *= _t1;
+//CHECK-NEXT:               double _t2 = custom_derivatives::sin_darg0(x) * _d_x;
+//CHECK-NEXT:               double _t3 = std::sin(x);
+//CHECK-NEXT:               _d_r = _d_r * _t3 + r * _t2;
+//CHECK-NEXT:               r *= _t3;
 //CHECK:        }
 //CHECK:        ())
 //CHECK-NEXT:           i++;

--- a/test/ForwardMode/Functors.C
+++ b/test/ForwardMode/Functors.C
@@ -302,15 +302,17 @@ struct WidgetPointer {
   // CHECK-NEXT:       double &_t0 = this->arr[3];
   // CHECK-NEXT:       double &_t1 = this->arr[3];
   // CHECK-NEXT:       double &_t2 = this->i;
-  // CHECK-NEXT:       double _t3 = _t0 * _t1;
-  // CHECK-NEXT:       _d_i = _d_i * _t3 + _t2 * (1 * _t1 + _t0 * 1);
-  // CHECK-NEXT:       _t2 *= _t3;
-  // CHECK-NEXT:       double &_t4 = this->arr[5];
+  // CHECK-NEXT:       double _t3 = 1 * _t1 + _t0 * 1;
+  // CHECK-NEXT:       double _t4 = _t0 * _t1;
+  // CHECK-NEXT:       _d_i = _d_i * _t4 + _t2 * _t3;
+  // CHECK-NEXT:       _t2 *= _t4;
   // CHECK-NEXT:       double &_t5 = this->arr[5];
-  // CHECK-NEXT:       double &_t6 = this->j;
-  // CHECK-NEXT:       double _t7 = _t4 * _t5;
-  // CHECK-NEXT:       _d_j = _d_j * _t7 + _t6 * (0 * _t5 + _t4 * 0);
-  // CHECK-NEXT:       _t6 *= _t7;
+  // CHECK-NEXT:       double &_t6 = this->arr[5];
+  // CHECK-NEXT:       double &_t7 = this->j;
+  // CHECK-NEXT:       double _t8 = 0 * _t6 + _t5 * 0;
+  // CHECK-NEXT:       double _t9 = _t5 * _t6;
+  // CHECK-NEXT:       _d_j = _d_j * _t9 + _t7 * _t8;
+  // CHECK-NEXT:       _t7 *= _t9;
   // CHECK-NEXT:       return _d_i + _d_j + _d_temp;
   // CHECK-NEXT:   }
 
@@ -330,15 +332,17 @@ struct WidgetPointer {
   // CHECK-NEXT:       double &_t0 = this->arr[3];
   // CHECK-NEXT:       double &_t1 = this->arr[3];
   // CHECK-NEXT:       double &_t2 = this->i;
-  // CHECK-NEXT:       double _t3 = _t0 * _t1;
-  // CHECK-NEXT:       _d_i = _d_i * _t3 + _t2 * (0 * _t1 + _t0 * 0);
-  // CHECK-NEXT:       _t2 *= _t3;
-  // CHECK-NEXT:       double &_t4 = this->arr[5];
+  // CHECK-NEXT:       double _t3 = 0 * _t1 + _t0 * 0;
+  // CHECK-NEXT:       double _t4 = _t0 * _t1;
+  // CHECK-NEXT:       _d_i = _d_i * _t4 + _t2 * _t3;
+  // CHECK-NEXT:       _t2 *= _t4;
   // CHECK-NEXT:       double &_t5 = this->arr[5];
-  // CHECK-NEXT:       double &_t6 = this->j;
-  // CHECK-NEXT:       double _t7 = _t4 * _t5;
-  // CHECK-NEXT:       _d_j = _d_j * _t7 + _t6 * (1 * _t5 + _t4 * 1);
-  // CHECK-NEXT:       _t6 *= _t7;
+  // CHECK-NEXT:       double &_t6 = this->arr[5];
+  // CHECK-NEXT:       double &_t7 = this->j;
+  // CHECK-NEXT:       double _t8 = 1 * _t6 + _t5 * 1;
+  // CHECK-NEXT:       double _t9 = _t5 * _t6;
+  // CHECK-NEXT:       _d_j = _d_j * _t9 + _t7 * _t8;
+  // CHECK-NEXT:       _t7 *= _t9;
   // CHECK-NEXT:       return _d_i + _d_j + _d_temp;
   // CHECK-NEXT:   }
 


### PR DESCRIPTION
This PR fixes incorrect evaluation of derivative due to executing same derived statement multiple times and storing the reference to the original expression before calculating its derivative. See the corresponding issue #297 for more details.

Closes #297 