### PR TITLE
Add support for break and continue stmts in reverse mode loops

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -3,11 +3,10 @@
 #ifndef CLAD_UTILS_CLADUTILS_H
 #define CLAD_UTILS_CLADUTILS_H
 
-#include <string>
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
 
-namespace clang {
-  class FunctionDecl;
-}
+#include <string>
 
 namespace clad {
   namespace utils {
@@ -16,6 +15,18 @@ namespace clad {
     /// Otherwise if `FD` is an ordinary function, returns the name of the
     /// function `FD`.
     std::string ComputeEffectiveFnName(const clang::FunctionDecl* FD);
+
+    /// Creates and returns a compound statement having statements as follows:
+    /// {`S`, all the statement of `initial` in sequence}    
+    clang::CompoundStmt* PrependAndCreateCompoundStmt(clang::ASTContext& C,
+                                                      clang::Stmt* initial,
+                                                      clang::Stmt* S);
+
+    /// Creates and returns a compound statement having statements as follows:
+    /// {all the statements of `initial` in sequence, `S`}
+    clang::CompoundStmt* AppendAndCreateCompoundStmt(clang::ASTContext& C,
+                                                     clang::Stmt* initial,
+                                                     clang::Stmt* S);
   }
 }
 

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -387,6 +387,8 @@ namespace clad {
     /// Instantiate clad::tape<T> type.
     clang::QualType GetCladTapeOfType(clang::QualType T);
 
+    clang::DeclRefExpr* GetCladTapePushDRE();
+
     /// Assigns the Init expression to VD after performing the necessary
     /// implicit conversion. This is required as clang doesn't add implicit
     /// conversions while assigning values to variables which are initialized

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1,15 +1,46 @@
 #include "clad/Differentiator/CladUtils.h"
 
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clad/Differentiator/Compatibility.h"
+#include "llvm/ADT/SmallVector.h"
 
+using namespace clang;
 namespace clad {
   namespace utils {
-    std::string ComputeEffectiveFnName(const clang::FunctionDecl* FD) {
+    static SourceLocation noLoc{};
+    
+    std::string ComputeEffectiveFnName(const FunctionDecl* FD) {
       // TODO: Add cases for more operators
       switch (FD->getOverloadedOperator()) {
-        case clang::OverloadedOperatorKind::OO_Call: return "operator_call";
+        case OverloadedOperatorKind::OO_Call: return "operator_call";
         default: return FD->getNameAsString();
       }
+    }
+
+    CompoundStmt* PrependAndCreateCompoundStmt(ASTContext& C, Stmt* initial,
+                                               Stmt* S) {
+      llvm::SmallVector<Stmt*, 16> block;
+      block.push_back(S);
+      if (CompoundStmt* CS = dyn_cast<CompoundStmt>(initial))
+        block.append(CS->body_begin(), CS->body_end());
+      else 
+        block.push_back(initial);
+      auto stmtsRef = llvm::makeArrayRef(block.begin(), block.end());
+      return clad_compat::CompoundStmt_Create(C, stmtsRef, noLoc, noLoc);
+    }
+
+    CompoundStmt* AppendAndCreateCompoundStmt(ASTContext& C, Stmt* initial,
+                                              Stmt* S) {
+      llvm::SmallVector<Stmt*, 16> block;
+      assert(isa<CompoundStmt>(initial) &&
+             "initial should be of type `clang::CompoundStmt`");
+      if (CompoundStmt* CS = dyn_cast<CompoundStmt>(initial))
+        block.append(CS->body_begin(), CS->body_end());
+      block.push_back(S);
+      auto stmtsRef = llvm::makeArrayRef(block.begin(), block.end());
+      return clad_compat::CompoundStmt_Create(C, stmtsRef, noLoc, noLoc);
     }
   } // namespace utils
 } // namespace clad

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -8,6 +8,7 @@
 
 #include "ConstantFolder.h"
 
+#include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/DiffPlanner.h"
 #include "clad/Differentiator/ErrorEstimator.h"
 #include "clad/Differentiator/StmtClone.h"
@@ -1144,18 +1145,6 @@ namespace clad {
     return StmtDiff(Clone(BL), constant0);
   }
 
-  /// Creates and returns a compound statement having statements as follows:
-  /// {`stmt`, all the statement of `CS` in sequence}
-  static CompoundStmt* PrependAndCreateCompoundStmt(ASTContext& C,
-                                                    const CompoundStmt* CS,
-                                                    Stmt* stmt) {
-    llvm::SmallVector<Stmt*, 16> block;
-    block.push_back(stmt);
-    block.insert(block.end(), CS->body_begin(), CS->body_end());
-    auto stmtsRef = llvm::makeArrayRef(block.begin(), block.end());
-    return clad_compat::CompoundStmt_Create(C, stmtsRef, noLoc, noLoc);
-  }
-
   StmtDiff ForwardModeVisitor::VisitWhileStmt(const WhileStmt* WS) {
     // begin scope for while loop
     beginScope(Scope::ContinueScope | Scope::BreakScope | Scope::DeclScope |
@@ -1213,7 +1202,7 @@ namespace clad {
     // }
     if (condVarClone) {
       bodyResult =
-          PrependAndCreateCompoundStmt(m_Sema.getASTContext(),
+          utils::PrependAndCreateCompoundStmt(m_Sema.getASTContext(),
                                        cast<CompoundStmt>(bodyResult),
                                        BuildDeclStmt(condVarRes.getDecl_dx()));
     }

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -571,6 +571,15 @@ namespace clad {
     return Result.getValue();
   }
 
+  DeclRefExpr* VisitorBase::GetCladTapePushDRE() {
+    LookupResult& pushLR = GetCladTapePush();
+    CXXScopeSpec CSS;
+    CSS.Extend(m_Context, GetCladNamespace(), noLoc, noLoc);
+    DeclRefExpr* pushDRE = m_Sema.BuildDeclarationNameExpr(CSS, pushLR, false)
+                               .getAs<DeclRefExpr>();
+    return pushDRE;
+  }
+
   LookupResult& VisitorBase::GetCladTapePop() {
     static llvm::Optional<LookupResult> Result{};
     if (Result)

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -938,6 +938,572 @@ double fn13(double i, double j) {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
+double fn14(double i, double j) {
+  int choice = 5;
+  double res = 0;
+  while (choice--) {
+    if (choice > 3) {
+      res += i;
+      continue;
+    }
+    if (choice > 1) {
+      res += j;
+      continue;
+    }
+
+    if (choice > 0) {
+      res += i * j;
+      continue;
+    }
+  }
+  return res;
+}
+
+// CHECK: void fn14_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+// CHECK-NEXT:     int _d_choice = 0;
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     unsigned long _t0;
+// CHECK-NEXT:     clad::tape<bool> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t3 = {};
+// CHECK-NEXT:     clad::tape<bool> _t5 = {};
+// CHECK-NEXT:     clad::tape<bool> _t7 = {};
+// CHECK-NEXT:     clad::tape<double> _t8 = {};
+// CHECK-NEXT:     clad::tape<double> _t9 = {};
+// CHECK-NEXT:     int choice = 5;
+// CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     while (choice--)
+// CHECK-NEXT:         {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             bool _t1 = choice > 3;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (_t1) {
+// CHECK-NEXT:                     res += i;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         clad::push(_t3, 1UL);
+// CHECK-NEXT:                         continue;
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 clad::push(_t2, _t1);
+// CHECK-NEXT:             }
+// CHECK-NEXT:             bool _t4 = choice > 1;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (_t4) {
+// CHECK-NEXT:                     res += j;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         clad::push(_t3, 2UL);
+// CHECK-NEXT:                         continue;
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 clad::push(_t5, _t4);
+// CHECK-NEXT:             }
+// CHECK-NEXT:             bool _t6 = choice > 0;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (_t6) {
+// CHECK-NEXT:                     res += clad::push(_t9, i) * clad::push(_t8, j);
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         clad::push(_t3, 3UL);
+// CHECK-NEXT:                         continue;
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 clad::push(_t7, _t6);
+// CHECK-NEXT:             }
+// CHECK-NEXT:             clad::push(_t3, 4UL);
+// CHECK-NEXT:         }
+// CHECK-NEXT:     double fn14_return = res;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     while (_t0)
+// CHECK-NEXT:         {
+// CHECK-NEXT:             switch (clad::pop(_t3)) {
+// CHECK-NEXT:               case 4UL:
+// CHECK-NEXT:                 ;
+// CHECK-NEXT:                 if (clad::pop(_t7)) {
+// CHECK-NEXT:                   case 3UL:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         double _r_d2 = _d_res;
+// CHECK-NEXT:                         _d_res += _r_d2;
+// CHECK-NEXT:                         double _r0 = _r_d2 * clad::pop(_t8);
+// CHECK-NEXT:                         * _d_i += _r0;
+// CHECK-NEXT:                         double _r1 = clad::pop(_t9) * _r_d2;
+// CHECK-NEXT:                         * _d_j += _r1;
+// CHECK-NEXT:                         _d_res -= _r_d2;
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 if (clad::pop(_t5)) {
+// CHECK-NEXT:                   case 2UL:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         double _r_d1 = _d_res;
+// CHECK-NEXT:                         _d_res += _r_d1;
+// CHECK-NEXT:                         * _d_j += _r_d1;
+// CHECK-NEXT:                         _d_res -= _r_d1;
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 if (clad::pop(_t2)) {
+// CHECK-NEXT:                   case 1UL:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         double _r_d0 = _d_res;
+// CHECK-NEXT:                         _d_res += _r_d0;
+// CHECK-NEXT:                         * _d_i += _r_d0;
+// CHECK-NEXT:                         _d_res -= _r_d0;
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             }
+// CHECK-NEXT:             _t0--;
+// CHECK-NEXT:         }
+// CHECK-NEXT: }
+
+double fn15(double i, double j) {
+  int choice = 5;
+  double res = 0;
+  while (choice--) {
+    if (choice > 2)
+      continue;
+    int another_choice = 3;
+    while (another_choice--) {
+      if (another_choice > 1) {
+        res += i;
+        continue;
+      }
+      if (another_choice > 0) {
+        res += j;
+      }
+    }
+  }
+  return res;
+}
+
+// CHECK: void fn15_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+// CHECK-NEXT:     int _d_choice = 0;
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     unsigned long _t0;
+// CHECK-NEXT:     clad::tape<bool> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t3 = {};
+// CHECK-NEXT:     int _d_another_choice = 0;
+// CHECK-NEXT:     clad::tape<unsigned long> _t4 = {};
+// CHECK-NEXT:     clad::tape<bool> _t6 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t7 = {};
+// CHECK-NEXT:     clad::tape<bool> _t9 = {};
+// CHECK-NEXT:     int choice = 5;
+// CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     while (choice--)
+// CHECK-NEXT:         {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             bool _t1 = choice > 2;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (_t1) {
+// CHECK-NEXT:                     clad::push(_t3, 1UL);
+// CHECK-NEXT:                     continue;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 clad::push(_t2, _t1);
+// CHECK-NEXT:             }
+// CHECK-NEXT:             int another_choice = 3;
+// CHECK-NEXT:             clad::push(_t4, 0UL);
+// CHECK-NEXT:             while (another_choice--)
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     clad::back(_t4)++;
+// CHECK-NEXT:                     bool _t5 = another_choice > 1;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         if (_t5) {
+// CHECK-NEXT:                             res += i;
+// CHECK-NEXT:                             {
+// CHECK-NEXT:                                 clad::push(_t7, 1UL);
+// CHECK-NEXT:                                 continue;
+// CHECK-NEXT:                             }
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                         clad::push(_t6, _t5);
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                     bool _t8 = another_choice > 0;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         if (_t8) {
+// CHECK-NEXT:                             res += j;
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                         clad::push(_t9, _t8);
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                     clad::push(_t7, 2UL);
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             clad::push(_t3, 2UL);
+// CHECK-NEXT:         }
+// CHECK-NEXT:     double fn15_return = res;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     while (_t0)
+// CHECK-NEXT:         {
+// CHECK-NEXT:             switch (clad::pop(_t3)) {
+// CHECK-NEXT:               case 2UL:
+// CHECK-NEXT:                 ;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     while (clad::back(_t4))
+// CHECK-NEXT:                         {
+// CHECK-NEXT:                             switch (clad::pop(_t7)) {
+// CHECK-NEXT:                               case 2UL:
+// CHECK-NEXT:                                 ;
+// CHECK-NEXT:                                 if (clad::pop(_t9)) {
+// CHECK-NEXT:                                     {
+// CHECK-NEXT:                                         double _r_d1 = _d_res;
+// CHECK-NEXT:                                         _d_res += _r_d1;
+// CHECK-NEXT:                                         * _d_j += _r_d1;
+// CHECK-NEXT:                                         _d_res -= _r_d1;
+// CHECK-NEXT:                                     }
+// CHECK-NEXT:                                 }
+// CHECK-NEXT:                                 if (clad::pop(_t6)) {
+// CHECK-NEXT:                                   case 1UL:
+// CHECK-NEXT:                                     ;
+// CHECK-NEXT:                                     {
+// CHECK-NEXT:                                         double _r_d0 = _d_res;
+// CHECK-NEXT:                                         _d_res += _r_d0;
+// CHECK-NEXT:                                         * _d_i += _r_d0;
+// CHECK-NEXT:                                         _d_res -= _r_d0;
+// CHECK-NEXT:                                     }
+// CHECK-NEXT:                                 }
+// CHECK-NEXT:                             }
+// CHECK-NEXT:                             clad::back(_t4)--;
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                     clad::pop(_t4);
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 _d_another_choice = 0;
+// CHECK-NEXT:                 if (clad::pop(_t2))
+// CHECK-NEXT:                   case 1UL:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             _t0--;
+// CHECK-NEXT:         }
+// CHECK-NEXT: }
+
+double fn16(double i, double j) {
+  int counter = 5;
+  double res=0;
+  for (int ii=0; ii<counter; ++ii) {
+    if (ii == 4) {
+      res += i*j;
+      break;
+    }
+    if (ii > 2) {
+      res += 2*i;
+      continue;
+    }
+    res += i + j;
+  }
+  return res;
+}
+
+// CHECK: void fn16_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+// CHECK-NEXT:     int _d_counter = 0;
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     unsigned long _t0;
+// CHECK-NEXT:     int _d_ii = 0;
+// CHECK-NEXT:     clad::tape<bool> _t2 = {};
+// CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     clad::tape<double> _t4 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t5 = {};
+// CHECK-NEXT:     clad::tape<bool> _t7 = {};
+// CHECK-NEXT:     clad::tape<double> _t8 = {};
+// CHECK-NEXT:     int counter = 5;
+// CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     for (int ii = 0; ii < counter; ++ii) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         bool _t1 = ii == 4;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (_t1) {
+// CHECK-NEXT:                 res += clad::push(_t4, i) * clad::push(_t3, j);
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     clad::push(_t5, 1UL);
+// CHECK-NEXT:                     break;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             }
+// CHECK-NEXT:             clad::push(_t2, _t1);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         bool _t6 = ii > 2;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (_t6) {
+// CHECK-NEXT:                 res += 2 * clad::push(_t8, i);
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     clad::push(_t5, 2UL);
+// CHECK-NEXT:                     continue;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             }
+// CHECK-NEXT:             clad::push(_t7, _t6);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         res += i + j;
+// CHECK-NEXT:         clad::push(_t5, 3UL);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     double fn16_return = res;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     for (; _t0; _t0--)
+// CHECK-NEXT:         switch (clad::pop(_t5)) {
+// CHECK-NEXT:           case 3UL:
+// CHECK-NEXT:             ;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 double _r_d2 = _d_res;
+// CHECK-NEXT:                 _d_res += _r_d2;
+// CHECK-NEXT:                 * _d_i += _r_d2;
+// CHECK-NEXT:                 * _d_j += _r_d2;
+// CHECK-NEXT:                 _d_res -= _r_d2;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             if (clad::pop(_t7)) {
+// CHECK-NEXT:               case 2UL:
+// CHECK-NEXT:                 ;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     double _r_d1 = _d_res;
+// CHECK-NEXT:                     _d_res += _r_d1;
+// CHECK-NEXT:                     double _r2 = _r_d1 * clad::pop(_t8);
+// CHECK-NEXT:                     double _r3 = 2 * _r_d1;
+// CHECK-NEXT:                     * _d_i += _r3;
+// CHECK-NEXT:                     _d_res -= _r_d1;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             }
+// CHECK-NEXT:             if (clad::pop(_t2)) {
+// CHECK-NEXT:               case 1UL:
+// CHECK-NEXT:                 ;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     double _r_d0 = _d_res;
+// CHECK-NEXT:                     _d_res += _r_d0;
+// CHECK-NEXT:                     double _r0 = _r_d0 * clad::pop(_t3);
+// CHECK-NEXT:                     * _d_i += _r0;
+// CHECK-NEXT:                     double _r1 = clad::pop(_t4) * _r_d0;
+// CHECK-NEXT:                     * _d_j += _r1;
+// CHECK-NEXT:                     _d_res -= _r_d0;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT: }
+
+double fn17(double i, double j) {
+  int counter = 5;
+  double res = 0;
+  for (int ii=0; ii<counter; ++ii) {
+    int jj = ii;
+    if (ii < 2)
+      continue;
+    while (jj--) {
+      if (jj < 3) {
+        res += i*j;
+        break;
+      } else {
+        continue;
+      }
+      res += i*i*j*j;
+    }
+  }
+  return res;
+}
+
+// CHECK: void fn17_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+// CHECK-NEXT:     int _d_counter = 0;
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     unsigned long _t0;
+// CHECK-NEXT:     int _d_ii = 0;
+// CHECK-NEXT:     int _d_jj = 0;
+// CHECK-NEXT:     clad::tape<bool> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t3 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t4 = {};
+// CHECK-NEXT:     clad::tape<bool> _t6 = {};
+// CHECK-NEXT:     clad::tape<double> _t7 = {};
+// CHECK-NEXT:     clad::tape<double> _t8 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t9 = {};
+// CHECK-NEXT:     clad::tape<double> _t10 = {};
+// CHECK-NEXT:     clad::tape<double> _t11 = {};
+// CHECK-NEXT:     clad::tape<double> _t12 = {};
+// CHECK-NEXT:     clad::tape<double> _t13 = {};
+// CHECK-NEXT:     clad::tape<double> _t14 = {};
+// CHECK-NEXT:     clad::tape<double> _t15 = {};
+// CHECK-NEXT:     int counter = 5;
+// CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     for (int ii = 0; ii < counter; ++ii) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         int jj = ii;
+// CHECK-NEXT:         bool _t1 = ii < 2;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (_t1) {
+// CHECK-NEXT:                 clad::push(_t3, 1UL);
+// CHECK-NEXT:                 continue;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             clad::push(_t2, _t1);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         clad::push(_t4, 0UL);
+// CHECK-NEXT:         while (jj--)
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 clad::back(_t4)++;
+// CHECK-NEXT:                 bool _t5 = jj < 3;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     if (_t5) {
+// CHECK-NEXT:                         res += clad::push(_t8, i) * clad::push(_t7, j);
+// CHECK-NEXT:                         {
+// CHECK-NEXT:                             clad::push(_t9, 1UL);
+// CHECK-NEXT:                             break;
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                     } else {
+// CHECK-NEXT:                         {
+// CHECK-NEXT:                             clad::push(_t9, 2UL);
+// CHECK-NEXT:                             continue;
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                     clad::push(_t6, _t5);
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 res += clad::push(_t15, clad::push(_t14, clad::push(_t13, i) * clad::push(_t12, i)) * clad::push(_t11, j)) * clad::push(_t10, j);
+// CHECK-NEXT:                 clad::push(_t9, 3UL);
+// CHECK-NEXT:             }
+// CHECK-NEXT:         clad::push(_t3, 2UL);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     double fn17_return = res;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     for (; _t0; _t0--)
+// CHECK-NEXT:         switch (clad::pop(_t3)) {
+// CHECK-NEXT:           case 2UL:
+// CHECK-NEXT:             ;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 while (clad::back(_t4))
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         switch (clad::pop(_t9)) {
+// CHECK-NEXT:                           case 3UL:
+// CHECK-NEXT:                             ;
+// CHECK-NEXT:                             {
+// CHECK-NEXT:                                 double _r_d1 = _d_res;
+// CHECK-NEXT:                                 _d_res += _r_d1;
+// CHECK-NEXT:                                 double _r2 = _r_d1 * clad::pop(_t10);
+// CHECK-NEXT:                                 double _r3 = _r2 * clad::pop(_t11);
+// CHECK-NEXT:                                 double _r4 = _r3 * clad::pop(_t12);
+// CHECK-NEXT:                                 * _d_i += _r4;
+// CHECK-NEXT:                                 double _r5 = clad::pop(_t13) * _r3;
+// CHECK-NEXT:                                 * _d_i += _r5;
+// CHECK-NEXT:                                 double _r6 = clad::pop(_t14) * _r2;
+// CHECK-NEXT:                                 * _d_j += _r6;
+// CHECK-NEXT:                                 double _r7 = clad::pop(_t15) * _r_d1;
+// CHECK-NEXT:                                 * _d_j += _r7;
+// CHECK-NEXT:                                 _d_res -= _r_d1;
+// CHECK-NEXT:                             }
+// CHECK-NEXT:                             if (clad::pop(_t6)) {
+// CHECK-NEXT:                               case 1UL:
+// CHECK-NEXT:                                 ;
+// CHECK-NEXT:                                 {
+// CHECK-NEXT:                                     double _r_d0 = _d_res;
+// CHECK-NEXT:                                     _d_res += _r_d0;
+// CHECK-NEXT:                                     double _r0 = _r_d0 * clad::pop(_t7);
+// CHECK-NEXT:                                     * _d_i += _r0;
+// CHECK-NEXT:                                     double _r1 = clad::pop(_t8) * _r_d0;
+// CHECK-NEXT:                                     * _d_j += _r1;
+// CHECK-NEXT:                                     _d_res -= _r_d0;
+// CHECK-NEXT:                                 }
+// CHECK-NEXT:                             } else {
+// CHECK-NEXT:                               case 2UL:
+// CHECK-NEXT:                                 ;
+// CHECK-NEXT:                             }
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                         clad::back(_t4)--;
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                 clad::pop(_t4);
+// CHECK-NEXT:             }
+// CHECK-NEXT:             if (clad::pop(_t2))
+// CHECK-NEXT:               case 1UL:
+// CHECK-NEXT:                 ;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 _d_ii += _d_jj;
+// CHECK-NEXT:                 _d_jj = 0;
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT: }
+
+double fn18(double i, double j) {
+  int choice = 5;
+  double res = 0;
+  for (int counter=0; counter<choice; ++counter) 
+    if (counter < 2)
+      res += i+j;
+    else if (counter < 4)
+      continue;
+    else {
+      res += 2*i + 2*j;
+      break;
+    }
+  return res;
+}
+
+// CHECK: void fn18_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+// CHECK-NEXT:     int _d_choice = 0;
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     unsigned long _t0;
+// CHECK-NEXT:     int _d_counter = 0;
+// CHECK-NEXT:     clad::tape<bool> _t2 = {};
+// CHECK-NEXT:     clad::tape<bool> _t4 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t5 = {};
+// CHECK-NEXT:     clad::tape<double> _t6 = {};
+// CHECK-NEXT:     clad::tape<double> _t7 = {};
+// CHECK-NEXT:     int choice = 5;
+// CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     for (int counter = 0; counter < choice; ++counter) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         bool _t1 = counter < 2;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (_t1)
+// CHECK-NEXT:                 res += i + j;
+// CHECK-NEXT:             else {
+// CHECK-NEXT:                 bool _t3 = counter < 4;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     if (_t3) {
+// CHECK-NEXT:                         clad::push(_t5, 1UL);
+// CHECK-NEXT:                         continue;
+// CHECK-NEXT:                     } else {
+// CHECK-NEXT:                         res += 2 * clad::push(_t6, i) + 2 * clad::push(_t7, j);
+// CHECK-NEXT:                         {
+// CHECK-NEXT:                             clad::push(_t5, 2UL);
+// CHECK-NEXT:                             break;
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                     clad::push(_t4, _t3);
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             }
+// CHECK-NEXT:             clad::push(_t2, _t1);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         clad::push(_t5, 3UL);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     double fn18_return = res;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     for (; _t0; _t0--)
+// CHECK-NEXT:         switch (clad::pop(_t5)) {
+// CHECK-NEXT:           case 3UL:
+// CHECK-NEXT:             ;
+// CHECK-NEXT:             if (clad::pop(_t2)) {
+// CHECK-NEXT:                 double _r_d0 = _d_res;
+// CHECK-NEXT:                 _d_res += _r_d0;
+// CHECK-NEXT:                 * _d_i += _r_d0;
+// CHECK-NEXT:                 * _d_j += _r_d0;
+// CHECK-NEXT:                 _d_res -= _r_d0;
+// CHECK-NEXT:             } else if (clad::pop(_t4))
+// CHECK-NEXT:               case 1UL:
+// CHECK-NEXT:                 ;
+// CHECK-NEXT:             else {
+// CHECK-NEXT:               case 2UL:
+// CHECK-NEXT:                 ;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     double _r_d1 = _d_res;
+// CHECK-NEXT:                     _d_res += _r_d1;
+// CHECK-NEXT:                     double _r0 = _r_d1 * clad::pop(_t6);
+// CHECK-NEXT:                     double _r1 = 2 * _r_d1;
+// CHECK-NEXT:                     * _d_i += _r1;
+// CHECK-NEXT:                     double _r2 = _r_d1 * clad::pop(_t7);
+// CHECK-NEXT:                     double _r3 = 2 * _r_d1;
+// CHECK-NEXT:                     * _d_j += _r3;
+// CHECK-NEXT:                     _d_res -= _r_d1;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT: }
+
 #define TEST(F, x) { \
   result[0] = 0; \
   auto F##grad = clad::gradient(F);\
@@ -989,4 +1555,9 @@ int main() {
   TEST_2(fn11, 3, 5);     // CHECK-EXEC: {18.00, 3.00}
   TEST_2(fn12, 3, 5);     // CHECK-EXEC: {54.00, 18.00}
   TEST_2(fn13, 3, 5);     // CHECK-EXEC: {3.00, 6.00}
-}
+  TEST_2(fn14, 3, 5);     // CHECK-EXEC: {6.00, 5.00}
+  TEST_2(fn15, 3, 5);     // CHECK-EXEC: {3.00, 3.00}
+  TEST_2(fn16, 3, 5);     // CHECK-EXEC: {10.00, 6.00}
+  TEST_2(fn17, 3, 5);     // CHECK-EXEC: {15.00, 9.00}
+  TEST_2(fn18, 3, 5);     // CHECK-EXEC: {4.00, 4.00}
+} 


### PR DESCRIPTION
This PR adds support for using `break` and `continue` statements in the loops (`for`, `while`, `do-while`) in clad reverse-mode AD.

The main problem introduced by `break` and `continue` statements was that these statements abruptly change the control flow of the code. This can lead to running a different set of statements in each iteration of the loop. This requires somehow keeping track of which statements were executed in the forward iteration so that the corresponding derived statements can be executed in (reverse) in the reverse iteration. 

For example, consider this code

```c++
while (choice--) {
  if (choice > 3) {
    res += i;
    continue;
  }
  if (choice > 1) {
    res += j;
    continue;
  }

  if (choice > 0) {
    res += i * j;
    continue;
  }
}
```

If `choice` = 1, then we need to execute `res += i*j` in the forward iteration and corresponding derived statement in the reverse iteration, and so on for different values of `choice`. The key here is which statements are executed are known only at runtime. So we require some construct that allows us to decide which code blocks to run at runtime depending on which `break`/`continue` was hit. 

My proposed solution uses `switch` statement for this purpose. The switch statement will enclose the entire body of the loop and only execute the derived statements of statements that were executed in the associated forward iteration. Switch statement essentially works here as a goto statement that allows specifying which label to execute at runtime. We can specify a case label for each `break`/`continue` statement, keep track of which `break`/`continue` was hit and then execute statements under the associated case label. 

For example, 

```c++
while (choice--) {
  if (choice > 5) {
    res = i;
    continue;
  }
  if (choice > 3) {
    res = j;
    continue;
  }
}
```
In reverse mode, this code shown above will get transformed to: 

```c++
while (_t0)
        {
            switch (clad::pop(_t3)) {
                case 3UL:
                ;
                if (clad::pop(_t5)) {
                  case 2UL:
                    ;
                    {
                        double _r_d1 = _d_res;
                        * _d_j += _r_d1;
                        _d_res -= _r_d1;
                    }
                }
                if (clad::pop(_t2)) {
                  case 1UL:
                    ;
                    {
                        double _r_d0 = _d_res;
                        * _d_i += _r_d0;
                        _d_res -= _r_d0;
                    }
                }
            }
            _t0--;
        }
```

With this solution, the transformation of loops that do not contain any `break`/`continue` statements will not be affected.

Closes #293 