### PR TITLE
Add information regarding clad's floating-point error estimation framework to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,30 @@ Note: Clad provides custom derivatives for some mathematical functions from `<cm
 
 Note: *the concept of custom_derivatives will be reviewed soon, we intend to provide a different interface and avoid function name-based specifications and by-name lookups*.
 
+## Using Clad's floating point error estimation framework
+
+Clad is capable of annotating a given function with floating point error estimation code using the reverse mode of AD. An interface similar to `clad::gradient(f)` is provided as follows:
+
+`clad::estimate_error(f)` takes 1 argument:
+1. `f` is a pointer to the function or method to be annotated with floating point error estimation code.
+
+The function signature of the generated code is the same as from `clad::gradient(f)` with the exception that it has an extra argument at the end of type `double&`, which returns the total floating point error in the function by reference. For a user function `double f(double, double)` example usage is described below:
+
+```cpp
+// Generate the floating point error estimation code for 'f'.
+auto df = clad::estimate_error(f);
+// Print the generated code to standard output.
+df.dump();
+// Declare the necessary variables.
+double x, y, d_x, d_y, final_error = 0;
+// Finally call execute on the generated code.
+df.execute(x, y, &d_x, &d_y, final_error);
+// After this, 'final_error' contains the floating point error in function 'f'.
+```
+The above example generates the the error code using an in-built taylor approximation model. However, clad is capable of using any user defined custom model, for information on how to use you own custom model, please visit [this demo](https://github.com/vgvassilev/clad/tree/master/demos/ErrorEstimation/CustomModel).
+
+More details on this framework can be found [here](https://indico.cern.ch/event/1040761/contributions/4371613/attachments/2268248/3851583/floating_point_error_est.pdf).
+
 ## How Clad works
 Clad is a plugin for the Clang compiler. It relies on the Clang to build the AST ([Clang AST](https://clang.llvm.org/docs/IntroductionToTheClangAST.html)) of user's source code. Then, [CladPlugin](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/tools/ClangPlugin.h#L48), implemented as `clang::ASTConsumer` analyzes the AST to find differentiation requests for clad and process those requests by building Clang AST for derivative functions. The whole clad's operation sequence is the following:
 * Clang parses user's source code and builds the AST.

--- a/demos/ErrorEstimation/CustomModel/README.md
+++ b/demos/ErrorEstimation/CustomModel/README.md
@@ -1,16 +1,15 @@
 # Using your custom estimation model with clad 
-Clad's error estimation framework provides users with a choice to write their own custom error models and use those to generate estimation code. By default clad uses the Taylor series approximation model to estimate errors in a function, however this model might not be the most sutiable alternative in many cases. In such scenarios, a user may prefer to write their own model to get better fp error estimates. 
+Clad's error estimation framework provides users with a choice to write their own custom error models and use those to generate estimation code. By default clad uses the Taylor series approximation model to estimate errors in a function, however this model might not be the most suitable alternative in many cases. In such scenarios, a user may prefer to write their own model to get better fp error estimates. 
 
-The aim of this demo is to illustrate how one can integrate a custom model with clad. For in depth information on how to *write* your own custom estimation model, check out the tutorials here.
- <!--- TODO: Add doc link -->
+The aim of this demo is to illustrate how one can integrate a custom model with clad. For in depth information on how to *write* your own custom estimation model, check out [this tutorial](https://compiler-research.org/tutorials/fp_error_estimation_clad_tutorial/).
 
 ## Building the demo
 
-Before we can use the custom model, it must be compiled into a [shared object](https://www.thegeekstuff.com/2012/06/linux-shared-libraries/). To do this, you can use your favourite compiler. For this demo, we will be using the clang compiler.
+Before we can use the custom model, it must be compiled into a [shared object](https://www.thegeekstuff.com/2012/06/linux-shared-libraries/). To do this, you can use your favorite compiler. For this demo, we will be using the clang compiler.
 
 Firstly, we shall set up some environment variables to simplify following the rest of the tutorial.
 
-After building the code as specifed in the [README.md](https://github.com/vgvassilev/clad#how-to-install), run the following command to set environment variables which we will use later:
+After building the code as specified in the [README.md](https://github.com/vgvassilev/clad#how-to-install), run the following command to set environment variables which we will use later:
 
 ```bash
 $ export CLAD_INST=$PWD/../inst;
@@ -75,6 +74,4 @@ The code is: void func_grad(float x, float y, clad::array_ref<float> _d_x, clad:
 
 Here, notice that the result in the ```_delta_z``` variable  now reflects the error expression defined in the custom model we just compiled!
 
-This demo is also a runnable test under ```CLAD_BASE/test/Misc/RunDemos.C``` and will run as a part of the lit test suite. Thus, the same can be verfied by running ```make check-clad```.
-
-> For information on how to use clad functions and more dev related information, check out our docs here! <<!--TODO: Add doc link>>
+This demo is also a runnable test under ```CLAD_BASE/test/Misc/RunDemos.C``` and will run as a part of the lit test suite. Thus, the same can be verified by running ```make check-clad```.


### PR DESCRIPTION
This PR addresses two issues:

- Fix spellings and todo links in the error estimation demo README.md.
- Add a section for fp error estimation framework to the main README.md (This is knowingly kept brief to avoid over cluttering of the README). 