### PR TITLE
Fix push to master workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,8 +668,11 @@ jobs:
         ctest -V
         cd ..
 
-        # Get the performance for the current master
-        git checkout master
+        # Get the performance for previous version. If it were a PR the master
+        # or the previous hash
+        hash=$([[ -z "${{ github.event.pull_request }}" ]] && echo ${{ github.event.before }} || echo master)
+        echo "Running git checkout $hash"
+        git checkout $hash
         cd obj
         cmake --build . --target clean -- -j4
         # FIXME: Add a target called clad-benchmarks and build only it.
@@ -692,7 +695,10 @@ jobs:
         cd ..
     - name: Failed job config
       if: ${{ failure() }}
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
       run: |
+        echo "$GITHUB_CONTEXT"
         export
         if [[ "runner.os" == "Linux" ]]; then
           apt-mark showhold
@@ -711,7 +717,7 @@ jobs:
     - name: Setup tmate session
       if: ${{ failure() }}
       uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 1 # When debugging increase to a suitable value!
+      timeout-minutes: 20 # When debugging increase to a suitable value!
     - name: Prepare code coverage report
       if: ${{ success() && (matrix.coverage == true) }}
       run: |

--- a/cmake/modules/AddCladBenchmark.cmake
+++ b/cmake/modules/AddCladBenchmark.cmake
@@ -1,10 +1,5 @@
 # Change the default compiler to the clang which we run clad upon.
 set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
-execute_process(WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                COMMAND git rev-parse --abbrev-ref HEAD
-                OUTPUT_VARIABLE CURRENT_REPO_BRANCH
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-
 #----------------------------------------------------------------------------
 # function CB_ADD_GBENCHMARK(<benchmark> source1 source2... LIBRARIES libs)
 #----------------------------------------------------------------------------
@@ -57,6 +52,12 @@ function(CB_ADD_GBENCHMARK benchmark)
   if(ARG_DEPENDS)
     add_dependencies(${benchmark} ${ARG_DEPENDS})
   endif()
+
+  # Find the current branch.
+  execute_process(WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                  COMMAND git rev-parse --abbrev-ref HEAD
+                  OUTPUT_VARIABLE CURRENT_REPO_BRANCH
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   # Add benchmark as a CTest
   add_test(NAME clad-${benchmark}


### PR DESCRIPTION
We cannot compare benchmarks against the master if we are on the master. This patch should resolve it by checking out to the previous hash the master was before the run while keeping the same behavior for the PR builds.