### PR TITLE
[cmake] Try to fix the subsequent benchmarks.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -665,7 +665,7 @@ jobs:
       if: ${{ matrix.benchmark }}
       run: |
         cd obj
-        ctest -V
+        cmake --build . --target benchmark-clad -j4
         cd ..
 
         # Get the performance for previous version. If it were a PR the master
@@ -675,9 +675,7 @@ jobs:
         git checkout $hash
         cd obj
         cmake --build . --target clean -- -j4
-        # FIXME: Add a target called clad-benchmarks and build only it.
-        cmake --build . -- -j4
-        ctest -V
+        cmake --build . --target benchmark-clad -j4
 
         # Compare:
         pip3 install -r  ./googlebenchmark-prefix/src/googlebenchmark/tools/requirements.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,10 +287,6 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
 
   # Add benchmarking infrastructure.
   if (CLAD_ENABLE_BENCHMARKS)
-    set(CTEST_BUILD_NAME ${ROOT_ARCHITECTURE}-${CMAKE_BUILD_TYPE})
-    enable_testing()
-    include(GoogleBenchmark)
-    include(AddCladBenchmark)
     add_subdirectory(benchmark)
   endif(CLAD_ENABLE_BENCHMARKS)
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,2 +1,24 @@
+set(CTEST_BUILD_NAME ${ROOT_ARCHITECTURE}-${CMAKE_BUILD_TYPE})
+enable_testing()
+
+include(GoogleBenchmark)
+include(AddCladBenchmark)
+
 CB_ADD_GBENCHMARK(Simple Simple.cpp)
 CB_ADD_GBENCHMARK(AlgorithmicComplexity AlgorithmicComplexity.cpp)
+
+set (CLAD_BENCHMARK_DEPS clad)
+get_property(_benchmark_names DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY TESTS)
+
+foreach (name ${_benchmark_names})
+  get_test_property(${name} LABELS _labels)
+  if (_labels MATCHES ".*benchmark.*")
+    get_test_property(${name} DEPENDS _deps)
+    list(APPEND CLAD_BENCHMARK_DEPS ${_deps})
+  endif()
+endforeach()
+
+add_custom_target(benchmark-clad COMMAND ${CMAKE_CTEST_COMMAND} -V
+  DEPENDS ${CLAD_BENCHMARK_DEPS})
+
+set_target_properties(benchmark-clad PROPERTIES FOLDER "Clad benchmarks")


### PR DESCRIPTION
We now have added another target benchmark-clad which will rebuild what's necessary and run the benchmarks. In addition we now track more rigorously when a branch changes and re-configure clad so that we can have two different json files which can be compared against.