### PR TITLE
Add no-op cast to function arg in num diff.

### DIFF
--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -736,7 +736,15 @@ namespace clad {
     DeclarationNameInfo DNInfo(name, noLoc);
     // Build function args.
     llvm::SmallVector<Expr*, 16U> NumDiffArgs;
-    NumDiffArgs.push_back(targetFuncCall);
+    // build a c style cast around target function call to avoid ambiguity 
+    // for overload and function templates when the generated code is printed.
+    QualType targetQT = targetFuncCall->getType();
+    auto castExp = CStyleCastExpr::Create(
+        m_Context, targetQT, targetFuncCall->getValueKind(), CastKind::CK_NoOp,
+        targetFuncCall, 0 /*FPO=*/CLAD_COMPAT_CLANG12_CastExpr_DefaultFPO,
+        m_Context.getTrivialTypeSourceInfo(targetQT),
+        targetFuncCall->getBeginLoc(), targetFuncCall->getEndLoc());
+    NumDiffArgs.push_back(castExp);
     NumDiffArgs.push_back(targetArg);
     NumDiffArgs.push_back(ConstantFolder::synthesizeLiteral(m_Context.IntTy,
                                                             m_Context,
@@ -761,7 +769,15 @@ namespace clad {
     DeclarationName name(II);
     DeclarationNameInfo DNInfo(name, noLoc);
     llvm::SmallVector<Expr*, 16U> NumDiffArgs = {};
-    NumDiffArgs.push_back(targetFuncCall);
+    // build a c style cast around target function call to avoid ambiguity 
+    // for overload and function templates when the generated code is printed.
+    QualType targetQT = targetFuncCall->getType();
+    auto castExp = CStyleCastExpr::Create(
+        m_Context, targetQT, targetFuncCall->getValueKind(), CastKind::CK_NoOp,
+        targetFuncCall, 0 /*FPO=*/CLAD_COMPAT_CLANG12_CastExpr_DefaultFPO,
+        m_Context.getTrivialTypeSourceInfo(targetQT),
+        targetFuncCall->getBeginLoc(), targetFuncCall->getEndLoc());
+    NumDiffArgs.push_back(castExp);
     // build the clad::tape<clad::array_ref>> = {};
     QualType RefType = GetCladArrayRefOfType(retType);
     QualType TapeType = GetCladTapeOfType(RefType);

--- a/test/NumericalDiff/GradientMultiArg.C
+++ b/test/NumericalDiff/GradientMultiArg.C
@@ -26,7 +26,7 @@ double test_1(double x, double y){
 // CHECK-NEXT:         clad::tape<clad::array_ref<double> > _t2 = {};
 // CHECK-NEXT:         clad::push(_t2, &_grad0);
 // CHECK-NEXT:         clad::push(_t2, &_grad1);
-// CHECK-NEXT:         numerical_diff::central_difference(std::hypot, _t2, 0, _t0, _t1);
+// CHECK-NEXT:         numerical_diff::central_difference((double (*)(double, double){{.*}})std::hypot, _t2, 0, _t0, _t1);
 // CHECK-NEXT:         double _r0 = 1 * _grad0;
 // CHECK-NEXT:         * _d_x += _r0;
 // CHECK-NEXT:         double _r1 = 1 * _grad1;

--- a/test/NumericalDiff/NumDiff.C
+++ b/test/NumericalDiff/NumDiff.C
@@ -17,7 +17,7 @@ double test_1(double x){
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r0 = 1 * numerical_diff::forward_central_difference(tanh, _t0, 0, 0, _t0);
+//CHECK-NEXT:         double _r0 = 1 * numerical_diff::forward_central_difference((double (*)(double){{.*}})tanh, _t0, 0, 0, _t0);
 //CHECK-NEXT:         * _d_x += _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -28,7 +28,7 @@ double test_2(double x){
 }
 //CHECK: double test_2_darg0(double x) {
 //CHECK-NEXT:     double _d_x = 1;
-//CHECK-NEXT:     return numerical_diff::forward_central_difference(std::log10, x, 0, 0, x) * _d_x;
+//CHECK-NEXT:     return numerical_diff::forward_central_difference((double (*)(double){{.*}})std::log10, x, 0, 0, x) * _d_x;
 //CHECK-NEXT: }
 
 int main(){

--- a/test/NumericalDiff/PrintErrorNumDiff.C
+++ b/test/NumericalDiff/PrintErrorNumDiff.C
@@ -21,7 +21,7 @@ double test_1(double x){
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r0 = 1 * numerical_diff::forward_central_difference(tanh, _t0, 0, 1, _t0);
+//CHECK-NEXT:         double _r0 = 1 * numerical_diff::forward_central_difference((double (*)(double){{.*}})tanh, _t0, 0, 1, _t0);
 //CHECK-NEXT:         * _d_x += _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }


### PR DESCRIPTION
Add a no-op c-style cast in the function argument to numerical differentiation so that the printing of the generated code retains the context(type) of the function argument. Earlier the printed code could not be run standalone, however, if we explicitly specify the type of the function as a cast, there is no ambiguity in template instantiations of the numerical diff function.

This solution allows us to cover the case of function templates and overloads without introducing unnecessary complexity.