### PR TITLE
Add initial support for pushforward functions to diff fn calls

### DIFF
--- a/include/clad/Differentiator/DiffMode.h
+++ b/include/clad/Differentiator/DiffMode.h
@@ -5,6 +5,7 @@ namespace clad {
   enum class DiffMode {
     unknown = 0,
     forward,
+    experimental_pushforward,
     reverse,
     hessian,
     jacobian,

--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -12,6 +12,7 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Sema/Sema.h"
+#include "clad/Differentiator/DiffMode.h"
 
 #include <array>
 #include <stack>
@@ -28,7 +29,7 @@ namespace clad {
     unsigned m_IndependentVarIndex = ~0;
     unsigned m_DerivativeOrder = ~0;
     unsigned m_ArgIndex = ~0;
-
+    DiffMode m_Mode;
   public:
     ForwardModeVisitor(DerivativeBuilder& builder);
     ~ForwardModeVisitor();
@@ -42,6 +43,8 @@ namespace clad {
     ///
     OverloadedDeclWithContext Derive(const clang::FunctionDecl* FD,
                                      const DiffRequest& request);
+    OverloadedDeclWithContext DerivePushforward(const clang::FunctionDecl* FD,
+                                                const DiffRequest& request);
     StmtDiff VisitArraySubscriptExpr(const clang::ArraySubscriptExpr* ASE);
     StmtDiff VisitBinaryOperator(const clang::BinaryOperator* BinOp);
     StmtDiff VisitCallExpr(const clang::CallExpr* CE);

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -449,6 +449,9 @@ namespace clad {
     clang::Expr*
     BuildArrayRefSliceExpr(clang::Expr* Base,
                            llvm::MutableArrayRef<clang::Expr*> Args);
+    clang::ParmVarDecl* CloneParmVarDecl(const clang::ParmVarDecl* PVD,
+                                         clang::IdentifierInfo* II,
+                                         bool pushOnScopeChains = false);
     /// A function to get the single argument "forward_central_difference"
     /// call expression for the given arguments.
     ///

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -147,6 +147,9 @@ namespace clad {
     if (request.Mode == DiffMode::forward) {
       ForwardModeVisitor V(*this);
       result = V.Derive(FD, request);
+    } else if (request.Mode == DiffMode::experimental_pushforward) {
+      ForwardModeVisitor V(*this);
+      result = V.DerivePushforward(FD, request);
     } else if (request.Mode == DiffMode::reverse) {
       ReverseModeVisitor V(*this);
       result = V.Derive(FD, request);

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -659,4 +659,20 @@ namespace clad {
     }
   }
 
+  ParmVarDecl* VisitorBase::CloneParmVarDecl(const ParmVarDecl* PVD,
+                                             IdentifierInfo* II,
+                                             bool pushOnScopeChains) {
+    Expr* newPVDDefaultArg = nullptr;
+    if (PVD->hasDefaultArg()) {
+      newPVDDefaultArg = Clone(PVD->getDefaultArg());
+    }
+    auto newPVD = ParmVarDecl::Create(
+        m_Context, m_Sema.CurContext, noLoc, noLoc, II, PVD->getType(),
+        PVD->getTypeSourceInfo(), PVD->getStorageClass(), newPVDDefaultArg);
+    if (pushOnScopeChains && newPVD->getIdentifier()) {
+      m_Sema.PushOnScopeChains(newPVD, getCurrentScope(),
+                               /*AddToContext=*/false);
+    }
+    return newPVD;
+  }
 } // end namespace clad

--- a/test/FirstDerivative/FunctionCalls.C
+++ b/test/FirstDerivative/FunctionCalls.C
@@ -76,12 +76,16 @@ float test_3() {
 // CHECK-NOT: float test_3_darg0() {
 
 float test_4(int x) {
-  return overloaded(); // expected-warning {{function 'overloaded' was not differentiated because clad failed to differentiate it and no suitable overload was found in namespace 'custom_derivatives', and function may not be eligible for numerical differentiation.}}
+  return overloaded();
 }
+
+// CHECK: int overloaded_pushforward() {
+// CHECK-NEXT:     return 0;
+// CHECK-NEXT: }
 
 // CHECK: float test_4_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: return 0;
+// CHECK-NEXT: return overloaded_pushforward();
 // CHECK-NEXT: }
 
 float test_5(int x) {

--- a/test/FirstDerivative/Recursive.C
+++ b/test/FirstDerivative/Recursive.C
@@ -13,13 +13,22 @@ int f_dec(int arg) {
   else
     return f_dec(arg-1);
 }
-// CHECK:   int f_dec_darg0(int arg) {
-// CHECK-NEXT:       int _d_arg = 1;
-// CHECK-NEXT:       if (arg == 0)
-// CHECK-NEXT:           return _d_arg;
-// CHECK-NEXT:       else
-// CHECK-NEXT:           return f_dec_darg0(arg - 1) * (_d_arg - 0);
-// CHECK-NEXT:   }
+
+// CHECK: int f_dec_pushforward(int arg, int _d_arg) {
+// CHECK-NEXT:     if (arg == 0)
+// CHECK-NEXT:         return _d_arg;
+// CHECK-NEXT:     else
+// CHECK-NEXT:         return f_dec_pushforward(arg - 1, _d_arg - 0);
+// CHECK-NEXT: }
+
+// CHECK: int f_dec_darg0(int arg) {
+// CHECK-NEXT:     int _d_arg = 1;
+// CHECK-NEXT:     if (arg == 0)
+// CHECK-NEXT:         return _d_arg;
+// CHECK-NEXT:     else
+// CHECK-NEXT:         return f_dec_pushforward(arg - 1, _d_arg - 0);
+// CHECK-NEXT: }
+
 int f_dec_darg0(int arg);
 
 int f_pow(int arg, int p) {
@@ -29,24 +38,31 @@ int f_pow(int arg, int p) {
     return arg * f_pow(arg, p - 1);
 }
 
-// FIXME-CHECK: int f_pow_darg0(int arg, int p) {
-// FIXME-CHECK-NEXT:   int _d_arg = 1;
-// FIXME-CHECK-NEXT:   int _d_p = 0;
-// FIXME-CHECK-NEXT:   if (p == 0)
-// FIXME-CHECK-NEXT:     return 0;
-// FIXME-CHECK-NEXT:   else {
-// FIXME-CHECK-NEXT:     int _t0 = f_pow(arg, p - 1);
-// FIXME-CHECK-NEXT:     return _d_arg * _t0 + arg * (f_pow_darg0(arg, p - 1) * (_d_arg + _d_p - 0));
-// FIXME-CHECK-NEXT:   }
-// FIXME-CHECK-NEXT: }
+// CHECK: int f_pow_pushforward(int arg, int p, int _d_arg, int _d_p) {
+// CHECK-NEXT:     if (p == 0)
+// CHECK-NEXT:         return 0;
+// CHECK-NEXT:     else {
+// CHECK-NEXT:         int _t0 = f_pow(arg, p - 1);
+// CHECK-NEXT:         return _d_arg * _t0 + arg * f_pow_pushforward(arg, p - 1, _d_arg, _d_p - 0);
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: int f_pow_darg0(int arg, int p) {
+// CHECK-NEXT:     int _d_arg = 1;
+// CHECK-NEXT:     int _d_p = 0;
+// CHECK-NEXT:     if (p == 0)
+// CHECK-NEXT:         return 0;
+// CHECK-NEXT:     else {
+// CHECK-NEXT:         int _t0 = f_pow(arg, p - 1);
+// CHECK-NEXT:         return _d_arg * _t0 + arg * f_pow_pushforward(arg, p - 1, _d_arg, _d_p - 0);
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 int f_pow_darg0(int arg, int p);
-// == p * f_pow(arg, p - 1)
 
 int main() {
   clad::differentiate(f_dec, 0);
   printf("Result is = %d\n", f_dec_darg0(2)); // CHECK-EXEC: Result is = 1
-  // This test is currently broken. TODO: fix calls in the forward mode.
-  //clad::differentiate(f_pow, 0);
-  //printf("Result is = %d\n", f_pow_darg0(10, 2)); //cCHECK-EXEC: Result is = 20
+  clad::differentiate(f_pow, 0);
+  printf("Result is = %d\n", f_pow_darg0(10, 2)); //CHECK-EXEC: Result is = 20
 }

--- a/test/NestedCalls/NestedCalls.C
+++ b/test/NestedCalls/NestedCalls.C
@@ -9,28 +9,26 @@
 extern "C" int printf(const char* fmt, ...);
 
 double sq(double x) { return x * x; }
-//CHECK:   double sq_darg0(double x) {
-//CHECK-NEXT:       double _d_x = 1;
-//CHECK-NEXT:       return _d_x * x + x * _d_x;
-//CHECK-NEXT:   } 
+// CHECK: double sq_pushforward(double x, double _d_x) {
+// CHECK-NEXT:     return _d_x * x + x * _d_x;
+// CHECK-NEXT: }
 
 double one(double x) { return sq(std::sin(x)) + sq(std::cos(x)); }
-//CHECK:   double one_darg0(double x) {
-//CHECK-NEXT:       double _d_x = 1;
-//CHECK-NEXT:       return sq_darg0(std::sin(x)) * (custom_derivatives::sin_darg0(x) * _d_x) + sq_darg0(std::cos(x)) * (custom_derivatives::cos_darg0(x) * _d_x);
-//CHECK-NEXT:   }
+// CHECK: double one_pushforward(double x, double _d_x) {
+// CHECK-NEXT:     return sq_pushforward(std::sin(x), custom_derivatives::sin_darg0(x) * _d_x) + sq_pushforward(std::cos(x), custom_derivatives::cos_darg0(x) * _d_x);
+// CHECK-NEXT: }
 
 double f(double x, double y) {
   double t = one(x);
   return t * y;
 }
-//CHECK:   double f_darg0(double x, double y) {
-//CHECK-NEXT:       double _d_x = 1;
-//CHECK-NEXT:       double _d_y = 0;
-//CHECK-NEXT:       double _d_t = one_darg0(x) * _d_x;
-//CHECK-NEXT:       double t = one(x);
-//CHECK-NEXT:       return _d_t * y + t * _d_y;
-//CHECK-NEXT:   }
+// CHECK: double f_darg0(double x, double y) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     double _d_y = 0;
+// CHECK-NEXT:     double _d_t = one_pushforward(x, _d_x);
+// CHECK-NEXT:     double t = one(x);
+// CHECK-NEXT:     return _d_t * y + t * _d_y;
+// CHECK-NEXT: }
 
 //CHECK:   void sq_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       double _t0;


### PR DESCRIPTION
This PR adds support for building and using pushforward functions to differentiate function calls in the forward mode differentiation. 

For example: 

```c++
double fn(double i, double j) {
  ...
  double res =  another_fn(u, v, w);
  ...
}
```
gets differentiated to:

```c++
double fn_darg0(double i, double j) {
  ...
  double _d_res = another_fn_pushforward(u, v, w, _d_u, _d_v, _d_w);
  double res = another_fn(u, v, w);
  ...
}
```

The pushforward function approach correctly handles reference parameters as well. Therefore, the function `fn` described below gets differentiated correctly:
```c++
void square_inplace(double& u) {
  u = u*u;
}

// derivative: 2*i
double fn(double i, double j) {
  square_inplace(i);
  double res = i;
  return i;
}
```

Current limitations: 
- pushforward functions approach cannot work with pointer/array parameters, because we do not know the size of the array represented by the pointer parameter. We can combat this by using a dynamic array class (such as `std::vector`) to store derivatives of pointers.

Closes #168 
Closes #316 