### PR TITLE
Move ErrorEstimationModelRegistry to EstimationModel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,32 +19,32 @@ jobs:
 
         include:
           - name: osx-clang-runtime5
-            os: macos-latest
+            os: macos-10.15
             compiler: clang
             clang-runtime: '5.0'
 
           - name: osx-clang-runtime6
-            os: macos-latest
+            os: macos-10.15
             compiler: clang
             clang-runtime: '6.0'
 
           - name: osx-clang-runtime7
-            os: macos-latest
+            os: macos-10.15
             compiler: clang
             clang-runtime: '7'
 
           - name: osx-clang-runtime8
-            os: macos-latest
+            os: macos-10.15
             compiler: clang
             clang-runtime: '8'
 
           - name: osx-clang-runtime9
-            os: macos-latest
+            os: macos-10.15
             compiler: clang
             clang-runtime: '9'
 
           - name: osx-clang-runtime10
-            os: macos-latest
+            os: macos-10.15
             compiler: clang
             clang-runtime: '10'
 

--- a/demos/ErrorEstimation/CustomModel/CMakeLists.txt
+++ b/demos/ErrorEstimation/CustomModel/CMakeLists.txt
@@ -15,7 +15,6 @@ endif()
 # generate it by default. Then the library requires _ZTIN4clad22FPErrorEstimationModelE
 # but it does not find it and fails to load.
 target_compile_options(cladCustomModelPlugin PUBLIC -fno-rtti)
-target_include_directories(cladCustomModelPlugin PUBLIC ${CLAD_SOURCE_DIR})
 
 set_target_properties(cladCustomModelPlugin PROPERTIES  LIBRARY_OUTPUT_DIRECTORY ".")
 if(APPLE)

--- a/demos/ErrorEstimation/CustomModel/CustomModel.cpp
+++ b/demos/ErrorEstimation/CustomModel/CustomModel.cpp
@@ -12,6 +12,6 @@ clang::Expr* CustomModel::SetError(clang::VarDecl* decl) { return nullptr; }
 
 // We need this statement to register our model with clad. Without this, clad
 // will NOT be able to resolve to our overidden functions properly.
-static clad::plugin::ErrorEstimationModelRegistry::Add<
+static clad::ErrorEstimationModelRegistry::Add<
     clad::EstimationPluginHelper<CustomModel>>
     CX("customModel", "Custom model for error estimation in clad");

--- a/demos/ErrorEstimation/CustomModel/CustomModel.h
+++ b/demos/ErrorEstimation/CustomModel/CustomModel.h
@@ -9,7 +9,6 @@
 // For information on how to run this demo, please take a look at the README.
 
 #include "clad/Differentiator/EstimationModel.h"
-#include "tools/ClangPlugin.h"
 
 /// This is our dummy estimation model class.
 // We will be using this to override the virtual function in the

--- a/include/clad/Differentiator/EstimationModel.h
+++ b/include/clad/Differentiator/EstimationModel.h
@@ -3,6 +3,8 @@
 
 #include "VisitorBase.h"
 
+#include "llvm/Support/Registry.h"
+
 #include <unordered_map>
 
 namespace clang {
@@ -138,6 +140,8 @@ namespace clad {
     clang::Expr* SetError(clang::VarDecl* decl) override;
   };
 
+  /// Register any custom error estimation model a user provides
+  using ErrorEstimationModelRegistry = llvm::Registry<EstimationPlugin>;
 } // namespace clad
 
 #endif // CLAD_ESTIMATION_MODEL_H

--- a/lib/Differentiator/EstimationModel.cpp
+++ b/lib/Differentiator/EstimationModel.cpp
@@ -5,6 +5,7 @@
 #include "clang/AST/Expr.h"
 #include "clang/AST/OperationKinds.h"
 
+#include "llvm/Support/Registry.h"
 using namespace clang;
 
 namespace clad {
@@ -63,3 +64,7 @@ namespace clad {
   Expr* TaylorApprox::SetError(VarDecl* declStmt) { return nullptr; }
 
 } // namespace clad
+
+// instantiate our error estimation model registry so that we can register
+// custom models passed by users as a shared lib
+LLVM_INSTANTIATE_REGISTRY(clad::ErrorEstimationModelRegistry)

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -23,7 +23,6 @@
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/Lookup.h"
 
-#include "llvm/Support/Registry.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -285,7 +284,3 @@ X("clad", "Produces derivatives or arbitrary functions");
 
 static PragmaHandlerRegistry::Add<CladPragmaHandler>
     Y("clad", "Clad pragma directives handler.");
-
-// instantiate our error estimation model registry so that we can register
-// custom models passed by users as a shared lib
-LLVM_INSTANTIATE_REGISTRY(ErrorEstimationModelRegistry)

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -31,10 +31,7 @@ namespace clang {
 
 namespace clad {
   struct DiffRequest;
-  class EstimationPlugin;
   namespace plugin {
-    /// Register any custom error estimation model a user provides
-    using ErrorEstimationModelRegistry = llvm::Registry<EstimationPlugin>;
     struct DifferentiationOptions {
       DifferentiationOptions()
           : DumpSourceFn(false), DumpSourceFnAST(false), DumpDerivedFn(false),


### PR DESCRIPTION
This PR moves `ErrorEstimationModelRegistry` to EstimationModel files. 

Thus, now only `clad/Differentiator/EstimationModel.h` file have to be included to create custom model. 

This PR also changes the scope of `ErrorEstimationModelRegistry` from `clad::plugin` to just `clad::`