### PR TITLE
Fix array differentiation errors

### DIFF
--- a/include/clad/Differentiator/Array.h
+++ b/include/clad/Differentiator/Array.h
@@ -1,66 +1,171 @@
-#ifndef CLANG_ARRAY_H
-#define CLANG_ARRAY_H
+#ifndef CLAD_ARRAY_H
+#define CLAD_ARRAY_H
 
 #include "clad/Differentiator/CladConfig.h"
 
+#include <assert.h>
 #include <type_traits>
 
 namespace clad {
-  /// This class is not meant to be used by user. It is used by clad internally
-  /// only
-  template <typename T> class array {
-  private:
-    /// The pointer to the underlying array
-    T* m_arr = nullptr;
-    /// The size of the array
-    std::size_t m_size = 0;
+template <typename T> class array_ref;
 
-  public:
-    /// Delete default constructor
-    array() = delete;
-    /// Constructor to create an array of the specified size
-    CUDA_HOST_DEVICE array(std::size_t size)
-        : m_arr(new T[size]{static_cast<T>(0)}), m_size(size) {}
+/// This class is not meant to be used by user. It is used by clad internally
+/// only
+template <typename T> class array {
+private:
+  /// The pointer to the underlying array
+  T* m_arr = nullptr;
+  /// The size of the array
+  std::size_t m_size = 0;
 
-    /// Destructor to delete the array if it was created by array_ref
-    CUDA_HOST_DEVICE ~array() { delete[] m_arr; }
+public:
+  /// Delete default constructor
+  array() = delete;
+  /// Constructor to create an array of the specified size
+  CUDA_HOST_DEVICE array(std::size_t size)
+      : m_arr(new T[size]{static_cast<T>(0)}), m_size(size) {}
 
-    /// Returns the size of the underlying array
-    CUDA_HOST_DEVICE std::size_t size() { return m_size; }
-    /// Returns the ptr of the underlying array
-    CUDA_HOST_DEVICE T* ptr() { return m_arr; }
-    /// Returns the reference to the location at the index of the underlying
-    /// array
-    CUDA_HOST_DEVICE T& operator[](std::size_t i) { return m_arr[i]; }
-    /// Returns the reference to the underlying array
-    CUDA_HOST_DEVICE T& operator*() { return *m_arr; }
+  /// Destructor to delete the array if it was created by array_ref
+  CUDA_HOST_DEVICE ~array() { delete[] m_arr; }
 
-    // Arithmetic overloads
-    /// Divides the number from every element in the array
-    CUDA_HOST_DEVICE array<T>& operator/=(T n) {
-      for (std::size_t i = 0; i < m_size; i++)
-        m_arr[i] /= n;
-      return *this;
-    }
-    /// Multiplies the number to every element in the array
-    CUDA_HOST_DEVICE array<T>& operator*=(T n) {
-      for (std::size_t i = 0; i < m_size; i++)
-        m_arr[i] *= n;
-      return *this;
-    }
-    /// Adds the number to every element in the array
-    CUDA_HOST_DEVICE array<T>& operator+=(T n) {
-      for (std::size_t i = 0; i < m_size; i++)
-        m_arr[i] += n;
-      return *this;
-    }
-    /// Subtracts the number from every element in the array
-    CUDA_HOST_DEVICE array<T>& operator-=(T n) {
-      for (std::size_t i = 0; i < m_size; i++)
-        m_arr[i] -= n;
-      return *this;
-    }
-  };
+  /// Returns the size of the underlying array
+  CUDA_HOST_DEVICE std::size_t size() { return m_size; }
+  /// Returns the ptr of the underlying array
+  CUDA_HOST_DEVICE T* ptr() { return m_arr; }
+  /// Returns the reference to the location at the index of the underlying
+  /// array
+  CUDA_HOST_DEVICE T& operator[](std::size_t i) { return m_arr[i]; }
+  /// Returns the reference to the underlying array
+  CUDA_HOST_DEVICE T& operator*() { return *m_arr; }
+
+  // Arithmetic overloads
+  /// Divides the number from every element in the array
+  CUDA_HOST_DEVICE array<T>& operator/=(T n) {
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] /= n;
+    return *this;
+  }
+  /// Multiplies the number to every element in the array
+  CUDA_HOST_DEVICE array<T>& operator*=(T n) {
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] *= n;
+    return *this;
+  }
+  /// Adds the number to every element in the array
+  CUDA_HOST_DEVICE array<T>& operator+=(T n) {
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] += n;
+    return *this;
+  }
+  /// Subtracts the number from every element in the array
+  CUDA_HOST_DEVICE array<T>& operator-=(T n) {
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] -= n;
+    return *this;
+  }
+  /// Initializes the clad::array to the given array
+  CUDA_HOST_DEVICE array<T>& operator=(T* arr) {
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] = arr[i];
+    return *this;
+  }
+  /// Performs element wise addition
+  CUDA_HOST_DEVICE array<T>& operator+=(T* arr) {
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] += arr[i];
+    return *this;
+  }
+  /// Performs element wise subtraction
+  CUDA_HOST_DEVICE array<T>& operator-=(T* arr) {
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] -= arr[i];
+    return *this;
+  }
+  /// Performs element wise multiplication
+  CUDA_HOST_DEVICE array<T>& operator*=(T* arr) {
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] *= arr[i];
+    return *this;
+  }
+  /// Performs element wise division
+  CUDA_HOST_DEVICE array<T>& operator/=(T* arr) {
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] /= arr[i];
+    return *this;
+  }
+  /// Initializes the clad::array to the given clad::array_ref
+  CUDA_HOST_DEVICE array<T>& operator=(array_ref<T>& arr) {
+    assert(arr.size() == m_size);
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] = arr[i];
+    return *this;
+  }
+  /// Performs element wise addition
+  CUDA_HOST_DEVICE array<T>& operator+=(array_ref<T>& arr) {
+    assert(arr.size() == m_size);
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] += arr[i];
+    return *this;
+  }
+  /// Performs element wise subtraction
+  CUDA_HOST_DEVICE array<T>& operator-=(array_ref<T>& arr) {
+    assert(arr.size() == m_size);
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] -= arr[i];
+    return *this;
+  }
+  /// Performs element wise multiplication
+  CUDA_HOST_DEVICE array<T>& operator*=(array_ref<T>& arr) {
+    assert(arr.size() == m_size);
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] *= arr[i];
+    return *this;
+  }
+  /// Performs element wise division
+  CUDA_HOST_DEVICE array<T>& operator/=(array_ref<T>& arr) {
+    assert(arr.size() == m_size);
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] /= arr[i];
+    return *this;
+  }
+  /// Initializes the clad::array to the given clad::array
+  CUDA_HOST_DEVICE array<T>& operator=(array<T>& arr) {
+    assert(arr.size() == m_size);
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] = arr[i];
+    return *this;
+  }
+  /// Performs element wise addition
+  CUDA_HOST_DEVICE array<T>& operator+=(array<T>& arr) {
+    assert(arr.size() == m_size);
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] += arr[i];
+    return *this;
+  }
+  /// Performs element wise subtraction
+  CUDA_HOST_DEVICE array<T>& operator-=(array<T>& arr) {
+    assert(arr.size() == m_size);
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] -= arr[i];
+    return *this;
+  }
+  /// Performs element wise multiplication
+  CUDA_HOST_DEVICE array<T>& operator*=(array<T>& arr) {
+    assert(arr.size() == m_size);
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] *= arr[i];
+    return *this;
+  }
+  /// Performs element wise division
+  CUDA_HOST_DEVICE array<T>& operator/=(array<T>& arr) {
+    assert(arr.size() == m_size);
+    for (std::size_t i = 0; i < m_size; i++)
+      m_arr[i] /= arr[i];
+    return *this;
+  }
+  /// Implicitly converts from clad::array to pointer to an array of type T
+  CUDA_HOST_DEVICE operator T*() const { return m_arr; }
+};
 } // namespace clad
 
 #endif // CLANG_ARRAY_H

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -61,21 +61,13 @@ namespace clad {
         return "_grad";
     }
 
-    /// Removes the local as well as non-local const qualifiers from a QualType
-    /// and returns a new type.
+    /// Removes the local const qualifiers from a QualType and returns a new
+    /// type.
     static clang::QualType
     getNonConstType(clang::QualType T, clang::ASTContext& C, clang::Sema& S) {
-      if (T->isPointerType()) {
-        clang::Qualifiers quals(T->getPointeeType().getQualifiers());
-        quals.removeConst();
-        clang::QualType newType = S.BuildQualifiedType(
-            T->getPointeeType().getUnqualifiedType(), noLoc, quals);
-        return C.getPointerType(newType);
-      } else {
         clang::Qualifiers quals(T.getQualifiers());
         quals.removeConst();
         return S.BuildQualifiedType(T.getUnqualifiedType(), noLoc, quals);
-      }
     }
 
   public:

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -435,8 +435,8 @@ namespace clad {
     clang::TemplateDecl* GetCladArrayRefDecl();
     /// Create clad::array_ref<T> type.
     clang::QualType GetCladArrayRefOfType(clang::QualType T);
-    /// Checks if the type is of clad::array_ref<T> type
-    bool isArrayRefType(clang::QualType QT);
+    /// Checks if the type is of clad::array<T> or clad::array_ref<T> type
+    bool isCladArrayType(clang::QualType QT);
     /// Find declaration of clad::array templated type.
     clang::TemplateDecl* GetCladArrayDecl();
     /// Create clad::array<T> type.

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -221,7 +221,7 @@ QualType getUnderlyingArrayType(QualType baseType, ASTContext& C) {
     QualType QType;
     Expr* deltaVar = nullptr;
     auto diffVar = m_Variables[VD];
-    if (isArrayRefType(diffVar->getType())) {
+    if (isCladArrayType(diffVar->getType())) {
       VarDecl* EstVD;
       auto sizeExpr = BuildArrayRefSizeExpr(diffVar);
       QType = GetCladArrayOfType(getUnderlyingArrayType(VDType, m_Context));
@@ -352,7 +352,7 @@ QualType getUnderlyingArrayType(QualType baseType, ASTContext& C) {
           }
           Expr *Ldiff, *Ldelta;
           Ldiff = getArraySubscriptExpr(LdiffExpr, m_IdxExpr,
-                                        isArrayRefType(LdiffExpr->getType()));
+                                        isCladArrayType(LdiffExpr->getType()));
           Ldelta = getArraySubscriptExpr(deltaVar, m_IdxExpr);
           auto savedVal = GetParamReplacement(params[i]);
           savedVal = savedVal ? savedVal : BuildDeclRef(decl);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -965,8 +965,10 @@ namespace clad {
     for (unsigned i = 0, e = ILE->getNumInits(); i < e; i++) {
       Expr* I =
           ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, i);
-      Expr* array_at_i =
-          m_Sema.CreateBuiltinArraySubscriptExpr(dfdx(), noLoc, I, noLoc).get();
+      Expr* array_at_i = m_Sema
+                             .ActOnArraySubscriptExpr(getCurrentScope(), dfdx(),
+                                                      noLoc, I, noLoc)
+                             .get();
       Expr* clonedEI = Visit(ILE->getInit(i), array_at_i).getExpr();
       clonedExprs[i] = clonedEI;
     }
@@ -1414,9 +1416,10 @@ namespace clad {
                                             llvm::APInt(size_type_bits, i),
                                             size_type, noLoc);
             // Create the Result[I] expression.
-            auto ithResult =
-                m_Sema.CreateBuiltinArraySubscriptExpr(Result, noLoc, I, noLoc)
-                    .get();
+            auto ithResult = m_Sema
+                                 .ActOnArraySubscriptExpr(
+                                     getCurrentScope(), Result, noLoc, I, noLoc)
+                                 .get();
             // Create df/dxi * Result[I]
             Expr* di = BuildOp(BO_Mul, dfdx(), ithResult);
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1894,10 +1894,7 @@ namespace clad {
     for (auto D : DS->decls()) {
       if (auto VD = dyn_cast<VarDecl>(D)) {
         VarDeclDiff VDDiff = DifferentiateVarDecl(VD);
-        // For all dependent variables, we register them for estimation
-        // here.
-        if (m_ErrorEstimationEnabled)
-          errorEstHandler->EmitDeclErrorStmts(VDDiff, isInsideLoop);
+
         // Check if decl's name is the same as before. The name may be changed
         // if decl name collides with something in the derivative body.
         // This can happen in rare cases, e.g. when the original function
@@ -1930,6 +1927,16 @@ namespace clad {
     Stmt* DSClone = BuildDeclStmt(decls);
     Stmt* DSDiff = BuildDeclStmt(declsDiff);
     addToBlock(DSDiff, m_Globals);
+
+    // For all dependent variables, we register them for estimation
+    // here.
+    if (m_ErrorEstimationEnabled) {
+      for (size_t i = 0; i < decls.size(); i++) {
+        VarDeclDiff VDDiff(static_cast<VarDecl*>(decls[0]),
+                           static_cast<VarDecl*>(declsDiff[0]));
+        errorEstHandler->EmitDeclErrorStmts(VDDiff, isInsideLoop);
+      }
+    }
     return StmtDiff(DSClone);
   }
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1011,7 +1011,7 @@ namespace clad {
     if (isArrayOrPointerType(target->getType()))
       // Create the target[idx] expression.
       result = BuildArraySubscript(target, reverseIndices);
-    else if (isArrayRefType(target->getType())) {
+    else if (isCladArrayType(target->getType())) {
       result = m_Sema
                    .ActOnArraySubscriptExpr(getCurrentScope(), target,
                                             ASE->getExprLoc(),
@@ -1250,7 +1250,7 @@ namespace clad {
           Result = nullptr;
           ResultExpr = nullptr;
           ResultII = CreateUniqueIdentifier(funcPostfix());
-          if (arg && (isArrayRefType(arg->getType()) ||
+          if (arg && (isCladArrayType(arg->getType()) ||
                       isArrayOrPointerType(arg->getType()))) {
             Expr* SizeE;
             if (auto CAT = dyn_cast<ConstantArrayType>(arg->getType())) {
@@ -1259,7 +1259,7 @@ namespace clad {
                                                         CAT->getSize()
                                                             .getZExtValue());
             } else {
-              assert(isArrayRefType(arg->getType()) &&
+              assert(isCladArrayType(arg->getType()) &&
                      "Size couldn't be determined. Please make sure the diff "
                      "variables are either constant sized arrays or of type "
                      "clad::array_ref");

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -560,8 +560,10 @@ namespace clad {
                                 /*MemberFunctionName=*/"slice", Args);
   }
 
-  bool VisitorBase::isArrayRefType(QualType QT) {
-    return QT.getAsString().find("clad::array_ref") != std::string::npos;
+  bool VisitorBase::isCladArrayType(QualType QT) {
+    // FIXME: Replace this check with a clang decl check
+    return QT.getAsString().find("clad::array") != std::string::npos ||
+           QT.getAsString().find("clad::array_ref") != std::string::npos;
   }
 
   Expr* VisitorBase::GetSingleArgCentralDiffCall(

--- a/test/Arrays/Arrays.C
+++ b/test/Arrays/Arrays.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oArrays.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -lm -lstdc++ -I%S/../../include -oArrays.out 2>&1 | FileCheck %s
 // RUN: ./Arrays.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}
@@ -90,8 +90,8 @@ double const_dot_product(double x, double y, double z) {
 //CHECK-NEXT:   }
 
 //CHECK:   void const_dot_product_grad(double x, double y, double z, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y, clad::array_ref<double> _d_z) {
-//CHECK-NEXT:       double _d_vars[3] = {};
-//CHECK-NEXT:       double _d_consts[3] = {};
+//CHECK-NEXT:       clad::array<double> _d_vars(3UL);
+//CHECK-NEXT:       clad::array<double> _d_consts(3UL);
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -140,109 +140,110 @@ double const_matmul_sum(double a, double b, double c, double d) {
   return C[0][0] + C[0][1] + C[1][0] + C[1][1];
 }
 
-//CHECK:   double const_matmul_sum_darg0(double a, double b, double c, double d) {
-//CHECK-NEXT:       double _d_a = 1;
-//CHECK-NEXT:       double _d_b = 0;
-//CHECK-NEXT:       double _d_c = 0;
-//CHECK-NEXT:       double _d_d = 0;
-//CHECK-NEXT:       double _d_A[2][2] = {{[{][{]}}_d_a, _d_b}, {_d_c, _d_d}};
-//CHECK-NEXT:       double A[2][2] = {{[{][{]}}a, b}, {c, d}};
-//CHECK-NEXT:       double _d_B[2][2] = {{[{][{]}}0, 0}, {0, 0}};
-//CHECK-NEXT:       double B[2][2] = {{[{][{]}}1, 2}, {3, 4}};
-//CHECK-NEXT:       double _d_C[2][2] = {{[{][{]}}_d_A[0][0] * B[0][0] + A[0][0] * _d_B[0][0] + _d_A[0][1] * B[1][0] + A[0][1] * _d_B[1][0], _d_A[0][0] * B[0][1] + A[0][0] * _d_B[0][1] + _d_A[0][1] * B[1][1] + A[0][1] * _d_B[1][1]}, {_d_A[1][0] * B[0][0] + A[1][0] * _d_B[0][0] + _d_A[1][1] * B[1][0] + A[1][1] * _d_B[1][0], _d_A[1][0] * B[0][1] + A[1][0] * _d_B[0][1] + _d_A[1][1] * B[1][1] + A[1][1] * _d_B[1][1]}};
-//CHECK-NEXT:       double C[2][2] = {{[{][{]}}A[0][0] * B[0][0] + A[0][1] * B[1][0], A[0][0] * B[0][1] + A[0][1] * B[1][1]}, {A[1][0] * B[0][0] + A[1][1] * B[1][0], A[1][0] * B[0][1] + A[1][1] * B[1][1]}};
-//CHECK-NEXT:       return _d_C[0][0] + _d_C[0][1] + _d_C[1][0] + _d_C[1][1];
-//CHECK-NEXT:   }
+// FIXME: Add multi index support to clad::array and clad::array_ref
+//:   double const_matmul_sum_darg0(double a, double b, double c, double d) {
+//:       double _d_a = 1;
+//:       double _d_b = 0;
+//:       double _d_c = 0;
+//:       double _d_d = 0;
+//:       double _d_A[2][2] = {{[{][{]}}_d_a, _d_b}, {_d_c, _d_d}};
+//:       double A[2][2] = {{[{][{]}}a, b}, {c, d}};
+//:       double _d_B[2][2] = {{[{][{]}}0, 0}, {0, 0}};
+//:       double B[2][2] = {{[{][{]}}1, 2}, {3, 4}};
+//:       double _d_C[2][2] = {{[{][{]}}_d_A[0][0] * B[0][0] + A[0][0] * _d_B[0][0] + _d_A[0][1] * B[1][0] + A[0][1] * _d_B[1][0], _d_A[0][0] * B[0][1] + A[0][0] * _d_B[0][1] + _d_A[0][1] * B[1][1] + A[0][1] * _d_B[1][1]}, {_d_A[1][0] * B[0][0] + A[1][0] * _d_B[0][0] + _d_A[1][1] * B[1][0] + A[1][1] * _d_B[1][0], _d_A[1][0] * B[0][1] + A[1][0] * _d_B[0][1] + _d_A[1][1] * B[1][1] + A[1][1] * _d_B[1][1]}};
+//:       double C[2][2] = {{[{][{]}}A[0][0] * B[0][0] + A[0][1] * B[1][0], A[0][0] * B[0][1] + A[0][1] * B[1][1]}, {A[1][0] * B[0][0] + A[1][1] * B[1][0], A[1][0] * B[0][1] + A[1][1] * B[1][1]}};
+//:       return _d_C[0][0] + _d_C[0][1] + _d_C[1][0] + _d_C[1][1];
+//:   }
 
-//CHECK:   void const_matmul_sum_grad(double a, double b, double c, double d, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b, clad::array_ref<double> _d_c, clad::array_ref<double> _d_d) {
-//CHECK-NEXT:       double _d_A[2][2] = {};
-//CHECK-NEXT:       double _d_B[2][2] = {};
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       double _t3;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       double _t5;
-//CHECK-NEXT:       double _t6;
-//CHECK-NEXT:       double _t7;
-//CHECK-NEXT:       double _t8;
-//CHECK-NEXT:       double _t9;
-//CHECK-NEXT:       double _t10;
-//CHECK-NEXT:       double _t11;
-//CHECK-NEXT:       double _t12;
-//CHECK-NEXT:       double _t13;
-//CHECK-NEXT:       double _t14;
-//CHECK-NEXT:       double _t15;
-//CHECK-NEXT:       double _d_C[2][2] = {};
-//CHECK-NEXT:       double A[2][2] = {{[{][{]}}a, b}, {c, d}};
-//CHECK-NEXT:       double B[2][2] = {{[{][{]}}1, 2}, {3, 4}};
-//CHECK-NEXT:       _t1 = A[0][0];
-//CHECK-NEXT:       _t0 = B[0][0];
-//CHECK-NEXT:       _t3 = A[0][1];
-//CHECK-NEXT:       _t2 = B[1][0];
-//CHECK-NEXT:       _t5 = A[0][0];
-//CHECK-NEXT:       _t4 = B[0][1];
-//CHECK-NEXT:       _t7 = A[0][1];
-//CHECK-NEXT:       _t6 = B[1][1];
-//CHECK-NEXT:       _t9 = A[1][0];
-//CHECK-NEXT:       _t8 = B[0][0];
-//CHECK-NEXT:       _t11 = A[1][1];
-//CHECK-NEXT:       _t10 = B[1][0];
-//CHECK-NEXT:       _t13 = A[1][0];
-//CHECK-NEXT:       _t12 = B[0][1];
-//CHECK-NEXT:       _t15 = A[1][1];
-//CHECK-NEXT:       _t14 = B[1][1];
-//CHECK-NEXT:       double C[2][2] = {{[{][{]}}_t1 * _t0 + _t3 * _t2, _t5 * _t4 + _t7 * _t6}, {_t9 * _t8 + _t11 * _t10, _t13 * _t12 + _t15 * _t14}};
-//CHECK-NEXT:       double const_matmul_sum_return = C[0][0] + C[0][1] + C[1][0] + C[1][1];
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
-//CHECK-NEXT:       {
-//CHECK-NEXT:           _d_C[0][0] += 1;
-//CHECK-NEXT:           _d_C[0][1] += 1;
-//CHECK-NEXT:           _d_C[1][0] += 1;
-//CHECK-NEXT:           _d_C[1][1] += 1;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = _d_C[0][0] * _t0;
-//CHECK-NEXT:           _d_A[0][0] += _r0;
-//CHECK-NEXT:           double _r1 = _t1 * _d_C[0][0];
-//CHECK-NEXT:           _d_B[0][0] += _r1;
-//CHECK-NEXT:           double _r2 = _d_C[0][0] * _t2;
-//CHECK-NEXT:           _d_A[0][1] += _r2;
-//CHECK-NEXT:           double _r3 = _t3 * _d_C[0][0];
-//CHECK-NEXT:           _d_B[1][0] += _r3;
-//CHECK-NEXT:           double _r4 = _d_C[0][1] * _t4;
-//CHECK-NEXT:           _d_A[0][0] += _r4;
-//CHECK-NEXT:           double _r5 = _t5 * _d_C[0][1];
-//CHECK-NEXT:           _d_B[0][1] += _r5;
-//CHECK-NEXT:           double _r6 = _d_C[0][1] * _t6;
-//CHECK-NEXT:           _d_A[0][1] += _r6;
-//CHECK-NEXT:           double _r7 = _t7 * _d_C[0][1];
-//CHECK-NEXT:           _d_B[1][1] += _r7;
-//CHECK-NEXT:           double _r8 = _d_C[1][0] * _t8;
-//CHECK-NEXT:           _d_A[1][0] += _r8;
-//CHECK-NEXT:           double _r9 = _t9 * _d_C[1][0];
-//CHECK-NEXT:           _d_B[0][0] += _r9;
-//CHECK-NEXT:           double _r10 = _d_C[1][0] * _t10;
-//CHECK-NEXT:           _d_A[1][1] += _r10;
-//CHECK-NEXT:           double _r11 = _t11 * _d_C[1][0];
-//CHECK-NEXT:           _d_B[1][0] += _r11;
-//CHECK-NEXT:           double _r12 = _d_C[1][1] * _t12;
-//CHECK-NEXT:           _d_A[1][0] += _r12;
-//CHECK-NEXT:           double _r13 = _t13 * _d_C[1][1];
-//CHECK-NEXT:           _d_B[0][1] += _r13;
-//CHECK-NEXT:           double _r14 = _d_C[1][1] * _t14;
-//CHECK-NEXT:           _d_A[1][1] += _r14;
-//CHECK-NEXT:           double _r15 = _t15 * _d_C[1][1];
-//CHECK-NEXT:           _d_B[1][1] += _r15;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       {
-//CHECK-NEXT:           * _d_a += _d_A[0][0];
-//CHECK-NEXT:           * _d_b += _d_A[0][1];
-//CHECK-NEXT:           * _d_c += _d_A[1][0];
-//CHECK-NEXT:           * _d_d += _d_A[1][1];
-//CHECK-NEXT:       }
-//CHECK-NEXT:   }
+//:   void const_matmul_sum_grad(double a, double b, double c, double d, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b, clad::array_ref<double> _d_c, clad::array_ref<double> _d_d) {
+//:       double _d_A[2][2] = {};
+//:       double _d_B[2][2] = {};
+//:       double _t0;
+//:       double _t1;
+//:       double _t2;
+//:       double _t3;
+//:       double _t4;
+//:       double _t5;
+//:       double _t6;
+//:       double _t7;
+//:       double _t8;
+//:       double _t9;
+//:       double _t10;
+//:       double _t11;
+//:       double _t12;
+//:       double _t13;
+//:       double _t14;
+//:       double _t15;
+//:       double _d_C[2][2] = {};
+//:       double A[2][2] = {{[{][{]}}a, b}, {c, d}};
+//:       double B[2][2] = {{[{][{]}}1, 2}, {3, 4}};
+//:       _t1 = A[0][0];
+//:       _t0 = B[0][0];
+//:       _t3 = A[0][1];
+//:       _t2 = B[1][0];
+//:       _t5 = A[0][0];
+//:       _t4 = B[0][1];
+//:       _t7 = A[0][1];
+//:       _t6 = B[1][1];
+//:       _t9 = A[1][0];
+//:       _t8 = B[0][0];
+//:       _t11 = A[1][1];
+//:       _t10 = B[1][0];
+//:       _t13 = A[1][0];
+//:       _t12 = B[0][1];
+//:       _t15 = A[1][1];
+//:       _t14 = B[1][1];
+//:       double C[2][2] = {{[{][{]}}_t1 * _t0 + _t3 * _t2, _t5 * _t4 + _t7 * _t6}, {_t9 * _t8 + _t11 * _t10, _t13 * _t12 + _t15 * _t14}};
+//:       double const_matmul_sum_return = C[0][0] + C[0][1] + C[1][0] + C[1][1];
+//:       goto _label0;
+//:     _label0:
+//:       {
+//:           _d_C[0][0] += 1;
+//:           _d_C[0][1] += 1;
+//:           _d_C[1][0] += 1;
+//:           _d_C[1][1] += 1;
+//:       }
+//:       {
+//:           double _r0 = _d_C[0][0] * _t0;
+//:           _d_A[0][0] += _r0;
+//:           double _r1 = _t1 * _d_C[0][0];
+//:           _d_B[0][0] += _r1;
+//:           double _r2 = _d_C[0][0] * _t2;
+//:           _d_A[0][1] += _r2;
+//:           double _r3 = _t3 * _d_C[0][0];
+//:           _d_B[1][0] += _r3;
+//:           double _r4 = _d_C[0][1] * _t4;
+//:           _d_A[0][0] += _r4;
+//:           double _r5 = _t5 * _d_C[0][1];
+//:           _d_B[0][1] += _r5;
+//:           double _r6 = _d_C[0][1] * _t6;
+//:           _d_A[0][1] += _r6;
+//:           double _r7 = _t7 * _d_C[0][1];
+//:           _d_B[1][1] += _r7;
+//:           double _r8 = _d_C[1][0] * _t8;
+//:           _d_A[1][0] += _r8;
+//:           double _r9 = _t9 * _d_C[1][0];
+//:           _d_B[0][0] += _r9;
+//:           double _r10 = _d_C[1][0] * _t10;
+//:           _d_A[1][1] += _r10;
+//:           double _r11 = _t11 * _d_C[1][0];
+//:           _d_B[1][0] += _r11;
+//:           double _r12 = _d_C[1][1] * _t12;
+//:           _d_A[1][0] += _r12;
+//:           double _r13 = _t13 * _d_C[1][1];
+//:           _d_B[0][1] += _r13;
+//:           double _r14 = _d_C[1][1] * _t14;
+//:           _d_A[1][1] += _r14;
+//:           double _r15 = _t15 * _d_C[1][1];
+//:           _d_B[1][1] += _r15;
+//:       }
+//:       {
+//:           * _d_a += _d_A[0][0];
+//:           * _d_b += _d_A[0][1];
+//:           * _d_c += _d_A[1][0];
+//:           * _d_d += _d_A[1][1];
+//:       }
+//:   }
 
 int main () { // expected-no-diagnostics
   auto dsum = clad::differentiate(sum, 0);
@@ -257,14 +258,15 @@ int main () { // expected-no-diagnostics
   double result[3] = {};
   gradcdp.execute(11, 12, 13, &result[0], &result[1], &result[2]);
   printf("{%.2f, %.2f, %.2f}\n", result[0], result[1], result[2]); // CHECK-EXEC: {1.00, 2.00, 3.00}
- 
-  auto dcms = clad::differentiate(const_matmul_sum, 0);
-  printf("%.2f\n", dcms.execute(11, 12, 13, 14)); // CHECK-EXEC: 3.00
+
+//  FIXME: Add multi index support to clad::array and clad::array_ref
+//  auto dcms = clad::differentiate(const_matmul_sum, 0);
+//  printf("%.2f\n", dcms.execute(11, 12, 13, 14)); // : 3.00
   
-  auto grad = clad::gradient(const_matmul_sum);
-  double result2[4] = {};
-  grad.execute(
-      11, 12, 13, 14, &result2[0], &result2[1], &result2[2], &result2[3]);
-  printf("{%.2f, %.2f, %.2f, %.2f}\n", result2[0], result2[1], result2[2], result2[3]); // CHECK-EXEC: {3.00, 7.00, 3.00, 7.00}
+//  auto grad = clad::gradient(const_matmul_sum);
+//  double result2[4] = {};
+//  grad.execute(
+//      11, 12, 13, 14, &result2[0], &result2[1], &result2[2], &result2[3]);
+//  printf("{%.2f, %.2f, %.2f, %.2f}\n", result2[0], result2[1], result2[2], result2[3]); // : {3.00, 7.00, 3.00, 7.00}
   return 0;
 }

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -108,9 +108,9 @@ float func4(float x, float y) {
 }
 
 //CHECK: void func4_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
+//CHECK-NEXT:     double _d_z = 0;
 //CHECK-NEXT:     double _delta_z = 0;
 //CHECK-NEXT:     double _EERepl_z0;
-//CHECK-NEXT:     double _d_z = 0;
 //CHECK-NEXT:     double _delta_x = 0;
 //CHECK-NEXT:     float _EERepl_x0 = x;
 //CHECK-NEXT:     float _EERepl_x1;
@@ -207,7 +207,6 @@ float func7(float x, float y) { return (x * y); }
 //CHECK-NEXT: }
 
 int main() {
-
   clad::estimate_error(func);
   clad::estimate_error(func2);
   clad::estimate_error(func3);

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -23,9 +23,9 @@ float func(float x, float y) {
 //CHECK-NEXT:     float _EERepl_y2;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _delta_z = 0;
 //CHECK-NEXT:     float _EERepl_z0;
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     x = x + y;
 //CHECK-NEXT:     _EERepl_x1 = x;
 //CHECK-NEXT:     _EERepl_y1 = y;
@@ -85,9 +85,9 @@ float func2(float x, float y) {
 //CHECK-NEXT:     float _EERepl_x1;
 //CHECK-NEXT:     float _t2;
 //CHECK-NEXT:     float _t3;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _delta_z = 0;
 //CHECK-NEXT:     float _EERepl_z0;
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     _t1 = y;
 //CHECK-NEXT:     _t0 = y;
 //CHECK-NEXT:     x = x - y - _t1 * _t0;
@@ -140,9 +140,9 @@ float func3(float x, float y) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _EERepl_x1;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _delta_z = 0;
 //CHECK-NEXT:     float _EERepl_z0;
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float _t2;
 //CHECK-NEXT:     float _t3;
 //CHECK-NEXT:     float _t4;
@@ -150,9 +150,9 @@ float func3(float x, float y) {
 //CHECK-NEXT:     double _delta_y = 0;
 //CHECK-NEXT:     float _EERepl_y0 = y;
 //CHECK-NEXT:     float _EERepl_y1;
+//CHECK-NEXT:     float _d_t = 0;
 //CHECK-NEXT:     double _delta_t = 0;
 //CHECK-NEXT:     float _EERepl_t0;
-//CHECK-NEXT:     float _d_t = 0;
 //CHECK-NEXT:     _t1 = y;
 //CHECK-NEXT:     _t0 = y;
 //CHECK-NEXT:     x = x - y - _t1 * _t0;
@@ -302,9 +302,9 @@ float func6(float x, float y) {
 //CHECK: void func6_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _delta_z = 0;
 //CHECK-NEXT:     float _EERepl_z0;
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float _t2;
 //CHECK-NEXT:     float _t3;
 //CHECK-NEXT:     double _ret_value0 = 0;
@@ -388,9 +388,9 @@ float func8(float x, float y) {
 
 //CHECK: void func8_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
 //CHECK-NEXT:     float _t0;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _delta_z = 0;
 //CHECK-NEXT:     float _EERepl_z0;
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     float z = y + helper2(_t0);
 //CHECK-NEXT:     _EERepl_z0 = z;
@@ -415,7 +415,6 @@ float func8(float x, float y) {
 //CHECK-NEXT: }
 
 int main() {
-
   clad::estimate_error(func);
   clad::estimate_error(func2);
   clad::estimate_error(func3);

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -22,9 +22,9 @@ float func(float x, float y) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _EERepl_y1;
+//CHECK-NEXT:     float _d_temp = 0;
 //CHECK-NEXT:     double _delta_temp = 0;
 //CHECK-NEXT:     float _EERepl_temp0;
-//CHECK-NEXT:     float _d_temp = 0;
 //CHECK-NEXT:     float _t2;
 //CHECK-NEXT:     float _t3;
 //CHECK-NEXT:     float _EERepl_temp1;
@@ -99,9 +99,9 @@ float func2(float x) {
 //CHECK: void func2_grad(float x, clad::array_ref<float> _d_x, double &_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _delta_z = 0;
 //CHECK-NEXT:     float _EERepl_z0;
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     float _t2;
@@ -241,7 +241,6 @@ float func4(float x, float y) {
 //CHECK-NEXT: }
 
 int main() {
-
   clad::estimate_error(func);
   clad::estimate_error(func2);
   clad::estimate_error(func3);

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -13,9 +13,9 @@ float func(float* p, int n) {
 }
 
 //CHECK: void func_grad(float *p, int n, clad::array_ref<float> _d_p, clad::array_ref<float> _d_n, double &_final_error) {
+//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     double _delta_sum = 0;
 //CHECK-NEXT:     float _EERepl_sum0;
-//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<int> _t1 = {};
@@ -65,16 +65,16 @@ float func2(float x) {
 }
 
 //CHECK: void func2_grad(float x, clad::array_ref<float> _d_x, double &_final_error) {
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _delta_z = 0;
 //CHECK-NEXT:     float _EERepl_z0;
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
+//CHECK-NEXT:     float _d_m = 0;
 //CHECK-NEXT:     double _delta_m = 0;
 //CHECK-NEXT:     clad::tape<float> _EERepl_m0 = {};
-//CHECK-NEXT:     float _d_m = 0;
 //CHECK-NEXT:     clad::tape<float> _EERepl_z1 = {};
 //CHECK-NEXT:     float z;
 //CHECK-NEXT:     _EERepl_z0 = z;
@@ -123,8 +123,8 @@ float func3(float x, float y) {
 }
 
 //CHECK: void func3_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
-//CHECK-NEXT:     clad::array<double> _delta_arr(3UL);
 //CHECK-NEXT:     clad::array<double> _d_arr(3UL);
+//CHECK-NEXT:     clad::array<double> _delta_arr(_d_arr.size());
 //CHECK-NEXT:     double _EERepl_arr0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
@@ -189,9 +189,9 @@ float func4(float x[10], float y[10]) {
 }
 
 //CHECK: void func4_grad(float x[10], float y[10], clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
+//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     double _delta_sum = 0;
 //CHECK-NEXT:     float _EERepl_sum0;
-//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<int> _t1 = {};
@@ -385,7 +385,6 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT: }
 
 int main() {
-
   clad::estimate_error(func);
   clad::estimate_error(func2);
   clad::estimate_error(func3);

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -123,8 +123,8 @@ float func3(float x, float y) {
 }
 
 //CHECK: void func3_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
-//CHECK-NEXT:     double _delta_arr[3] = {};
-//CHECK-NEXT:     double _d_arr[3] = {};
+//CHECK-NEXT:     clad::array<double> _delta_arr(3UL);
+//CHECK-NEXT:     clad::array<double> _d_arr(3UL);
 //CHECK-NEXT:     double _EERepl_arr0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
@@ -150,6 +150,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:         _delta_arr[2] += _r_d2 * _EERepl_arr2 * {{.+}};
 //CHECK-NEXT:         _final_error += _delta_arr[2];
 //CHECK-NEXT:         _d_arr[2] -= _r_d2;
+//CHECK-NEXT:         _d_arr[2];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r_d1 = _d_arr[1];
@@ -160,6 +161,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:         _delta_arr[1] += _r_d1 * _EERepl_arr1 * {{.+}};
 //CHECK-NEXT:         _final_error += _delta_arr[1];
 //CHECK-NEXT:         _d_arr[1] -= _r_d1;
+//CHECK-NEXT:         _d_arr[1];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r_d0 = _d_arr[0];
@@ -168,6 +170,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:         _delta_arr[0] += _r_d0 * _EERepl_arr0 * {{.+}};
 //CHECK-NEXT:         _final_error += _delta_arr[0];
 //CHECK-NEXT:         _d_arr[0] -= _r_d0;
+//CHECK-NEXT:         _d_arr[0];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
 //CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -14,9 +14,9 @@ double runningSum(float* f, int n) {
 }
 
 //CHECK: void runningSum_grad(float *f, int n, clad::array_ref<double> _d_f, clad::array_ref<double> _d_n, double &_final_error) {
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double _delta_sum = 0;
 //CHECK-NEXT:     double _EERepl_sum0;
-//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<int> _t1 = {};
@@ -68,9 +68,9 @@ double mulSum(float* a, float* b, int n) {
 }
 
 //CHECK: void mulSum_grad(float *a, float *b, int n, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b, clad::array_ref<double> _d_n, double &_final_error) {
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double _delta_sum = 0;
 //CHECK-NEXT:     double _EERepl_sum0;
-//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<unsigned long> _t1 = {};
@@ -141,9 +141,9 @@ double divSum(float* a, float* b, int n) {
 }
 
 //CHECK: void divSum_grad(float *a, float *b, int n, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b, clad::array_ref<double> _d_n, double &_final_error) {
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double _delta_sum = 0;
 //CHECK-NEXT:     double _EERepl_sum0;
-//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -oReverseAssignments.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -lstdc++ -oReverseAssignments.out 2>&1 | FileCheck %s
 // RUN: ./ReverseAssignments.out | FileCheck -check-prefix=CHECK-EXEC %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
 
@@ -281,7 +281,7 @@ double f7(double x, double y) {
 //CHECK:   void f7_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       double _d_t[3] = {};
+//CHECK-NEXT:       clad::array<double> _d_t(3UL);
 //CHECK-NEXT:       double _t2;
 //CHECK-NEXT:       double _t3;
 //CHECK-NEXT:       double _t4;
@@ -319,6 +319,7 @@ double f7(double x, double y) {
 //CHECK-NEXT:           _d_t[0] += _r_d5;
 //CHECK-NEXT:           _d_t[1] += -_r_d5;
 //CHECK-NEXT:           _d_t[0] -= _r_d5;
+//CHECK-NEXT:           _d_t[0];
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d4 = _d_t[0];
@@ -326,6 +327,7 @@ double f7(double x, double y) {
 //CHECK-NEXT:           double _r3 = _r_d4 * -_t5 / (_t4 * _t4);
 //CHECK-NEXT:           _d_t[1] += _r3;
 //CHECK-NEXT:           _d_t[0] -= _r_d4;
+//CHECK-NEXT:           _d_t[0];
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d3 = _d_t[0];
@@ -333,12 +335,14 @@ double f7(double x, double y) {
 //CHECK-NEXT:           double _r2 = _t3 * _r_d3;
 //CHECK-NEXT:           _d_t[1] += _r2;
 //CHECK-NEXT:           _d_t[0] -= _r_d3;
+//CHECK-NEXT:           _d_t[0];
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d2 = _d_t[0];
 //CHECK-NEXT:           _d_t[0] += _r_d2;
 //CHECK-NEXT:           _d_t[1] += _r_d2;
 //CHECK-NEXT:           _d_t[0] -= _r_d2;
+//CHECK-NEXT:           _d_t[0];
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d1 = * _d_x;
@@ -350,7 +354,10 @@ double f7(double x, double y) {
 //CHECK-NEXT:           double _r_d0 = _d_t[0];
 //CHECK-NEXT:           * _d_x += _r_d0;
 //CHECK-NEXT:           _d_t[0] -= _r_d0;
+//CHECK-NEXT:           _d_t[0];
 //CHECK-NEXT:       }
+//CHECK-NEXT:       _d_t[0];
+//CHECK-NEXT:       _d_t[0];
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += _d_t[1];
 //CHECK-NEXT:           double _r0 = _d_t[2] * _t0;
@@ -367,7 +374,7 @@ double f8(double x, double y) {
 }
 
 //CHECK:   void f8_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
-//CHECK-NEXT:       double _d_t[4] = {};
+//CHECK-NEXT:       clad::array<double> _d_t(4UL);
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double t[4] = {1, x, y, 1};
@@ -393,6 +400,7 @@ double f8(double x, double y) {
 //CHECK-NEXT:           _d_t[0] -= _r_d2;
 //CHECK-NEXT:           * _d_y -= _r_d1;
 //CHECK-NEXT:           _d_t[3] -= _r_d0;
+//CHECK-NEXT:           _d_t[3];
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += _d_t[1];

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -140,6 +140,97 @@ void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatr
 //CHECK-NEXT:  }
 //CHECK-NEXT:}
 
+double multiply(double x, double y) { return x * y; }
+//CHECK: void multiply_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
+//CHECK-NEXT:    double _t0;
+//CHECK-NEXT:    double _t1;
+//CHECK-NEXT:    _t1 = x;
+//CHECK-NEXT:    _t0 = y;
+//CHECK-NEXT:    double multiply_return = _t1 * _t0;
+//CHECK-NEXT:    goto _label0;
+//CHECK-NEXT:  _label0:
+//CHECK-NEXT:    {
+//CHECK-NEXT:        double _r0 = 1 * _t0;
+//CHECK-NEXT:        * _d_x += _r0;
+//CHECK-NEXT:        double _r1 = _t1 * 1;
+//CHECK-NEXT:        * _d_y += _r1;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
+void f_4(double x, double y, double z, double *_result) {
+  double constant = 42;
+
+  _result[0] = multiply(x, y) * constant;
+  _result[1] = multiply(y, z) * constant;
+  _result[2] = multiply(z, x) * constant;
+}
+
+void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatrix);
+//CHECK: void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatrix) {
+//CHECK-NEXT:    double _d_constant = 0;
+//CHECK-NEXT:    double _t0;
+//CHECK-NEXT:    double _t1;
+//CHECK-NEXT:    double _t2;
+//CHECK-NEXT:    double _t3;
+//CHECK-NEXT:    double _t4;
+//CHECK-NEXT:    double _t5;
+//CHECK-NEXT:    double _t6;
+//CHECK-NEXT:    double _t7;
+//CHECK-NEXT:    double _t8;
+//CHECK-NEXT:    double _t9;
+//CHECK-NEXT:    double _t10;
+//CHECK-NEXT:    double _t11;
+//CHECK-NEXT:    double constant = 42;
+//CHECK-NEXT:    _t1 = x;
+//CHECK-NEXT:    _t2 = y;
+//CHECK-NEXT:    _t3 = multiply(_t1, _t2);
+//CHECK-NEXT:    _t0 = constant;
+//CHECK-NEXT:    _result[0] = multiply(x, y) * constant;
+//CHECK-NEXT:    _t5 = y;
+//CHECK-NEXT:    _t6 = z;
+//CHECK-NEXT:    _t7 = multiply(_t5, _t6);
+//CHECK-NEXT:    _t4 = constant;
+//CHECK-NEXT:    _result[1] = multiply(y, z) * constant;
+//CHECK-NEXT:    _t9 = z;
+//CHECK-NEXT:    _t10 = x;
+//CHECK-NEXT:    _t11 = multiply(_t9, _t10);
+//CHECK-NEXT:    _t8 = constant;
+//CHECK-NEXT:    _result[2] = multiply(z, x) * constant;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        double _r8 = 1 * _t8;
+//CHECK-NEXT:        double _jac4 = 0.;
+//CHECK-NEXT:        double _jac5 = 0.;
+//CHECK-NEXT:        multiply_grad(_t9, _t10, &_jac4, &_jac5);
+//CHECK-NEXT:        double _r9 = _r8 * _jac4;
+//CHECK-NEXT:        jacobianMatrix[8UL] += _r9;
+//CHECK-NEXT:        double _r10 = _r8 * _jac5;
+//CHECK-NEXT:        jacobianMatrix[6UL] += _r10;
+//CHECK-NEXT:        double _r11 = _t11 * 1;
+//CHECK-NEXT:    }
+//CHECK-NEXT:    {
+//CHECK-NEXT:        double _r4 = 1 * _t4;
+//CHECK-NEXT:        double _jac2 = 0.;
+//CHECK-NEXT:        double _jac3 = 0.;
+//CHECK-NEXT:        multiply_grad(_t5, _t6, &_jac2, &_jac3);
+//CHECK-NEXT:        double _r5 = _r4 * _jac2;
+//CHECK-NEXT:        jacobianMatrix[4UL] += _r5;
+//CHECK-NEXT:        double _r6 = _r4 * _jac3;
+//CHECK-NEXT:        jacobianMatrix[5UL] += _r6;
+//CHECK-NEXT:        double _r7 = _t7 * 1;
+//CHECK-NEXT:    }
+//CHECK-NEXT:    {
+//CHECK-NEXT:        double _r0 = 1 * _t0;
+//CHECK-NEXT:        double _jac0 = 0.;
+//CHECK-NEXT:        double _jac1 = 0.;
+//CHECK-NEXT:        multiply_grad(_t1, _t2, &_jac0, &_jac1);
+//CHECK-NEXT:        double _r1 = _r0 * _jac0;
+//CHECK-NEXT:        jacobianMatrix[0UL] += _r1;
+//CHECK-NEXT:        double _r2 = _r0 * _jac1;
+//CHECK-NEXT:        jacobianMatrix[1UL] += _r2;
+//CHECK-NEXT:        double _r3 = _t3 * 1;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
 
 #define TEST(F, x, y, z) { \
   result[0] = 0; result[1] = 0; result[2] = 0;\
@@ -160,4 +251,5 @@ int main() {
   double outputarr[9];
   TEST(f_1, 1, 2, 3); // CHECK-EXEC: Result is = {3.00, 0.00, 0.00, 3.00, 12.00, 0.00, -2.00, 0.00, 60.00}
   TEST(f_3, 1, 2, 3); // CHECK-EXEC: Result is = {22.69, 0.00, 0.00, 0.00, -17.48, 0.00, 0.00, 0.00, -41.58}
+  TEST(f_4, 1, 2, 3); // CHECK-EXEC: Result is = {84.00, 42.00, 0.00, 0.00, 126.00, 84.00, 126.00, 0.00, 42.00}
 }

--- a/test/Misc/CladArray.C
+++ b/test/Misc/CladArray.C
@@ -1,0 +1,146 @@
+// RUN: %cladclang %s -x c++ -lstdc++ -I%S/../../include -oCladArray.out 2>&1
+// RUN: ./CladArray.out
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+int main() {
+  clad::array<int> test_arr(3);
+  clad::array<int> clad_arr(3);
+  int arr[] = {2, 2, 2};
+  clad::array_ref<int> arr_ref(arr, 3);
+
+  for (int i = 0; i < 3; i++) {
+    test_arr[i] = 0;
+    clad_arr[i] = i + 1;
+  }
+
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 0
+  //CHECK-EXEC: 1 : 0
+  //CHECK-EXEC: 2 : 0
+
+  test_arr = clad_arr;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 2
+  //CHECK-EXEC: 1 : 2
+  //CHECK-EXEC: 2 : 3
+
+  test_arr += clad_arr;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 2
+  //CHECK-EXEC: 1 : 4
+  //CHECK-EXEC: 2 : 6
+
+  test_arr -= clad_arr;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 1
+  //CHECK-EXEC: 1 : 2
+  //CHECK-EXEC: 2 : 3
+
+  test_arr *= clad_arr;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 1
+  //CHECK-EXEC: 1 : 4
+  //CHECK-EXEC: 2 : 9
+
+  test_arr /= clad_arr;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 1
+  //CHECK-EXEC: 1 : 2
+  //CHECK-EXEC: 2 : 3
+
+  test_arr += arr;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 3
+  //CHECK-EXEC: 1 : 4
+  //CHECK-EXEC: 2 : 5
+
+  test_arr -= arr;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 1
+  //CHECK-EXEC: 1 : 2
+  //CHECK-EXEC: 2 : 3
+
+  test_arr *= arr;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 2
+  //CHECK-EXEC: 1 : 4
+  //CHECK-EXEC: 2 : 6
+
+  test_arr /= arr;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 1
+  //CHECK-EXEC: 1 : 2
+  //CHECK-EXEC: 2 : 3
+
+  test_arr = arr;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 2
+  //CHECK-EXEC: 1 : 2
+  //CHECK-EXEC: 2 : 2
+
+  test_arr = clad_arr;
+
+  test_arr += arr_ref;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 3
+  //CHECK-EXEC: 1 : 4
+  //CHECK-EXEC: 2 : 5
+
+  test_arr -= arr_ref;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 1
+  //CHECK-EXEC: 1 : 2
+  //CHECK-EXEC: 2 : 3
+
+  test_arr *= arr_ref;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 2
+  //CHECK-EXEC: 1 : 4
+  //CHECK-EXEC: 2 : 6
+
+  test_arr /= arr_ref;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 1
+  //CHECK-EXEC: 1 : 2
+  //CHECK-EXEC: 2 : 3
+
+  test_arr = arr_ref;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %d\n", i, test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 2
+  //CHECK-EXEC: 1 : 2
+  //CHECK-EXEC: 2 : 2
+}

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -106,9 +106,9 @@
 //CHECK_FLOAT_SUM-NOT: {{.*error|warning|note:.*}}
 
 //CHECK_FLOAT_SUM: void vanillaSum_grad(float x, unsigned int n, clad::array_ref<float> _d_x, clad::array_ref<float> _d_n, double &_final_error) {
+//CHECK_FLOAT_SUM:     float _d_sum = 0;
 //CHECK_FLOAT_SUM:     double _delta_sum = 0;
 //CHECK_FLOAT_SUM:     float _EERepl_sum0;
-//CHECK_FLOAT_SUM:     float _d_sum = 0;
 //CHECK_FLOAT_SUM:     unsigned long _t0;
 //CHECK_FLOAT_SUM:     unsigned int _d_i = 0;
 //CHECK_FLOAT_SUM:     clad::tape<float> _EERepl_sum1 = {};
@@ -153,9 +153,9 @@
 // RUN: ./CustomModelTest.out | FileCheck -check-prefix CHECK_CUSTOM_MODEL_EXEC %s
 // CHECK_CUSTOM_MODEL_EXEC-NOT:{{.*error|warning|note:.*}}
 // CHECK_CUSTOM_MODEL_EXEC: The code is: void func_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
+// CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    double _delta_z = 0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _EERepl_z0;
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _EERepl_z1;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    _EERepl_z0 = z;


### PR DESCRIPTION
These fixes allow clad to work on ADBench functions:

- Element wise vector operations
- ConstantArrayType specialization in DifferentiateVarDecl function
- getNonConstType no longer removes non-local const qualifiers
- ArraySubscriptExprs are created using ActOnArraySubscriptExpr

The ADBench code is available in [sudo-panda/ADBench](https://github.com/sudo-panda/ADBench/tree/clad-ba) repository.

There is a FIXME added in the Arrays/Arrays.C test as clad::array and clad::array_ref currently do not support multidimensional arrays.
