### PR TITLE
Make clang-format more llvm-compliant

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,23 +1,8 @@
-
 BasedOnStyle: LLVM
-IndentWidth: 2
-NamespaceIndentation: All
-ColumnLimit: 80
 
 Language: Cpp
 Standard: Cpp11
-DerivePointerAlignment: false
 PointerAlignment: Left
-
-AlignAfterOpenBracket: Align
-PenaltyBreakBeforeFirstCallParameter: 1000
-PenaltyBreakAssignment: 1000
-AlignOperands: true
-AllowShortCaseLabelsOnASingleLine: true
-IndentCaseLabels: true
-BinPackParameters: true
-BinPackArguments: true
-AllowAllArgumentsOnNextLine: false
 
 IncludeCategories:
   - Regex:           '^"[^/]+\"'


### PR DESCRIPTION
Hi @parth-07 and @sudo-panda, maybe we should be just use the formatting close to llvm. What do you think?