### PR TITLE
Add ability to print FP errors in error estimation.

### DIFF
--- a/demos/ErrorEstimation/CustomModel/CustomModel.h
+++ b/demos/ErrorEstimation/CustomModel/CustomModel.h
@@ -11,13 +11,13 @@
 #include "clad/Differentiator/EstimationModel.h"
 
 /// This is our dummy estimation model class.
-// We will be using this to override the virtual function in the
-// FPErrorEstimationModel class.
+/// We will be using this to override the virtual function in the
+/// FPErrorEstimationModel class.
 class CustomModel : public clad::FPErrorEstimationModel {
 public:
   CustomModel(clad::DerivativeBuilder& builder)
       : FPErrorEstimationModel(builder) {}
-  // Return an expression of the following kind:
-  //  dfdx * delta_x
+  /// Return an expression of the following kind:
+  ///  dfdx * delta_x
   clang::Expr* AssignError(clad::StmtDiff refExpr);
 };

--- a/demos/ErrorEstimation/CustomModel/print_errors.cpp
+++ b/demos/ErrorEstimation/CustomModel/print_errors.cpp
@@ -1,0 +1,74 @@
+//--------------------------------------------------------------------*- C++ -*-
+// clad - The C++ Clang-based Automatic Differentiator
+//
+// A demo describing the usage of custom estimation models with the built -in
+// error estimator of clad.
+//
+// author:  Garima Singh
+//----------------------------------------------------------------------------//
+// For information on how to run this demo, please take a look at the README
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <iostream> // For std::cout
+
+// Use a trivial dummy example to check if error printing takes place correctly.
+// Essentially sums two values together and then returns a square of the sum.
+// (i.e (x + y) * (x + y) )
+float func(float x, float y) {
+  float mul, sum;
+  sum = x + y;
+  mul = sum * sum;
+  return mul;
+}
+
+int main() {
+  // Call error-estimate on func, this time with a template parameter to signal
+  // that error printing is enabled. As demonstared in ./test.cpp, you can omit
+  // this parameter to disable error printing.
+  auto df = clad::estimate_error</*PrintErrors=*/true>(func);
+
+  // The next step is to actually define some variables we will use to execute
+  // 'df' as created above.
+  float dx = 0, dy = 0;
+  // Declare some double values eventhough our function 'func' takes in float
+  // values. This is so that we can compare errors later.
+  double x = 9.999E-4, y = 0.001E-4, final_error = 0;
+
+  // Now, we can actually first dump the code to analyse if the print code
+  // generation is correct.
+  df.dump();
+
+  // Now, we can finally run the 'df' function via 'execute'. Notice, we pass an
+  // addition argument std::cout. Clad actually prints to whatever stream you
+  // pass it.
+  df.execute(x, y, &dx, &dy, final_error, std::cout);
+  // Note: you can also pass the error printing to a file by either doing so in
+  // code:
+  //   std::ofstream myfile("my_fp_error_file");
+  //   df.execute(x, y, &dx, &dy, final_error, myfile);
+  // Or by piping output from the compilation command of this demo to a file:
+  // $ --my compile command-- > my_fp_error_file.txt
+
+  // Now let us compare the actual errors and the ones printed on the console.
+  // This is just to showcase the error values calculated by clad and the actual
+  // error values.
+  double dbl_sum, dbl_mul;
+  float sum, mul, flt_x = x, flt_y = y;
+  // Now we emulate the function.
+  dbl_sum = x + y;
+  sum = flt_x + flt_y;
+
+  dbl_mul = dbl_sum * dbl_sum;
+  mul = sum * sum;
+
+  // Calculate the errors.
+  double sum_err = std::abs(dbl_sum - sum);
+  double mul_err = std::abs(dbl_mul - mul);
+  double var_err_x = std::abs(x - flt_x);
+  double var_err_y = std::abs(y - flt_y);
+
+  // Print them for comparision.
+  std::cout << "Sum Error: " << sum_err << " Mul Error: " << mul_err
+            << " var error x: " << var_err_x << "var error y: " << var_err_y;
+}

--- a/demos/ODESolverSensitivity.cpp
+++ b/demos/ODESolverSensitivity.cpp
@@ -84,7 +84,7 @@ int main() {
     double x = x0 + h * i;
     double db = bSensitivity(x);
 
-    out << x << "\t" << abs(db) << std::endl;
+    out << x << "\t" << std::abs(db) << std::endl;
   }
   out.close();
 

--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -137,6 +137,11 @@ namespace clad {
     /// an in-built one (TaylorApprox) or one provided by the user.
     void
     SetErrorEstimationModel(std::unique_ptr<FPErrorEstimationModel> estModel);
+    /// Function to initialize the \c ostream object if error printing was
+    /// requested.
+    ///
+    /// \returns the equivalent QualType of \c ostream objects.
+    clang::QualType GetErrorFileType();
     /// Fuction to set the error diagnostic printing value for numerical
     /// differentiation.
     ///

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -53,6 +53,8 @@ namespace clad {
     /// differentiated, for example, when we are computing higher
     /// order derivatives.
     const clang::CXXRecordDecl* Functor = nullptr;
+    /// Controls if floating-point error estimates should be printed.
+    bool PrintFPErrors = false;
 
     /// Stores differentiation parameters information. Stored information
     /// includes info on indices range for array parameters, and nested data

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -439,8 +439,20 @@ namespace clad {
                                    code, f);
   }
 
-  template <typename ArgSpec = const char*, typename F,
-            typename DerivedFnType = GradientDerivedEstFnTraits_t<F>>
+  /// Generates a function which computes the floating-point(FP) error estimates
+  /// as dictated either by an in-built Taylor Approximation model or a custom
+  /// user provided one. Can also print error information to a specified
+  /// output stream.
+  ///
+  /// \param[in] f the function to calculate FP errors for.
+  /// \tparam printErrors A value that toggles printing of FP errors to an
+  /// output stream.
+  ///
+  /// \returns `CladFunction` object to access the corresponding derived
+  /// function.
+  template <
+      bool printErrors = false, typename ArgSpec = const char*, typename F,
+      typename DerivedFnType = GradientDerivedEstFnTraits_t<F, printErrors>>
   CladFunction<DerivedFnType> __attribute__((annotate("E")))
   estimate_error(F f, ArgSpec args = "",
                  DerivedFnType derivedFn = static_cast<DerivedFnType>(nullptr),

--- a/include/clad/Differentiator/ErrorEstimator.h
+++ b/include/clad/Differentiator/ErrorEstimator.h
@@ -44,11 +44,16 @@ class ErrorEstimationHandler : public ExternalRMVSource {
   clang::Expr* m_IdxExpr;
   /// A set of declRefExprs for parameter value replacements.
   std::unordered_map<const clang::VarDecl*, clang::Expr*> m_ParamRepls;
+  /// A variable to hold the type of the "ofstream" object.
+  clang::QualType m_ErrorFileType;
+  /// A variable to keep track of if error printing is enabled.
+  bool m_PrintErrors = false;
+  /// A variable to store the "ofstream" object.
+  clang::DeclRefExpr* m_ErrorFile = nullptr;
 
   std::stack<bool> m_ShouldEmit;
   ReverseModeVisitor* m_RMV;
   clang::Expr* m_DeltaVar = nullptr;
-  llvm::SmallVectorImpl<clang::QualType>* m_ParamTypes = nullptr;
   llvm::SmallVectorImpl<clang::ParmVarDecl*>* m_Params = nullptr;
 
 public:
@@ -58,14 +63,17 @@ public:
         m_EstModel(nullptr), m_IdxExpr(nullptr) {}
   ~ErrorEstimationHandler() {}
 
+  /// A function to set the \c ofstream file type.
+  void SetErrorFileType(clang::QualType qt) { m_ErrorFileType = qt; }
+
+  /// A function to enable error printing.
+  void EnableErrorPrinting() { m_PrintErrors = true; }
+
   /// Function to set the error estimation model currently in use.
   ///
   /// \param[in] estModel The error estimation model, can be either
   /// an in-built one (TaylorApprox) or one provided by the user.
   void SetErrorEstimationModel(FPErrorEstimationModel* estModel);
-
-  /// \param[in] finErrExpr The final error expression.
-  void SetFinalErrorExpr(clang::Expr* finErrExpr) { m_FinalError = finErrExpr; }
 
   /// Shorthand to get array subscript expressions.
   ///
@@ -81,6 +89,20 @@ public:
   /// \returns The final error expression so far.
   clang::Expr* GetFinalErrorExpr() { return m_FinalError; }
 
+  /// Function to generate an expression of type:
+  /// '<--ostream-object--> << "<--source-info-->" << <--expression-->;'
+  ///
+  /// \param[in] var_name The name of the variable whose error contribution we
+  /// are printing.
+  /// \param[in] var The variable whose error contribution we
+  /// are printing.
+  /// \param[in] var_dx The derivative of 'var'.
+  /// \param[in] var_err The error associated with 'var'.
+  ///
+  /// \returns The print expression to be added to code.
+  clang::Expr* GetPrintExpr(std::string var_name, clang::Expr* var,
+                            clang::Expr* var_dx, clang::Expr* var_err);
+
   /// Function to build the final error statemnt of the function. This is the
   /// last statement of any target function in error estimation and
   /// aggregates the error in all the registered variables.
@@ -92,8 +114,11 @@ public:
   /// \param[in] deltaVar The "_delta_" expression of the variable 'var'.
   /// \param[in] errorExpr The error expression (LHS) of the variable 'var'.
   /// \param[in] isInsideLoop A flag to indicate if 'val' is inside a loop.
+  /// \param[in] errorPrint The print expression to be ouput into the error
+  /// file.
   void AddErrorStmtToBlock(clang::Expr* var, clang::Expr* deltaVar,
-                           clang::Expr* errorExpr, bool isInsideLoop = false);
+                           clang::Expr* errorExpr, bool isInsideLoop = false,
+                           clang::Expr* errorPrint = nullptr);
 
   /// Emit the error estimation related statements that were saved to be
   /// emitted at later points into specific blocks.
@@ -246,7 +271,6 @@ public:
       llvm::SmallVectorImpl<clang::QualType>& paramTypes) override;
   void ActAfterCreatingDerivedFnParams(
       llvm::SmallVectorImpl<clang::ParmVarDecl*>& params) override;
-  void ActBeforeCreatingDerivedFnBodyScope() override;
   void ActOnEndOfDerivedFnBody() override;
   void ActBeforeDifferentiatingStmtInVisitCompoundStmt() override;
   void ActAfterProcessingStmtInVisitCompoundStmt() override;

--- a/include/clad/Differentiator/EstimationModel.h
+++ b/include/clad/Differentiator/EstimationModel.h
@@ -104,6 +104,50 @@ namespace clad {
     /// \returns The error expression for declaration statements.
     virtual clang::Expr* SetError(clang::VarDecl* decl);
 
+    /// A utility function to return an \c std::string as a \c clang::Expr* .
+    ///
+    /// \param[in] expr The \c std::string you want to convert.
+    ///
+    /// \returns A \c clang::Expr* corresponding to the input string that
+    /// can be used for code generation.
+    clang::Expr* getAsExpr(std::string expr);
+
+    /// Prints any error associated information to a user-specified output
+    /// stream as described by the following function. This function is
+    /// beneficial to print any intermediate error values that would
+    /// otherwise be inaccessible to the user. An example usage for this is
+    /// as described below:
+    ///
+    /// \n \code
+    /// void Print(std::string varName, StmtDiff
+    /// refExpr, clang::Expr* errExpr, llvm::SmallVectorImpl<clang::Expr*>& out)
+    /// {
+    ///   out.push_back(varName);
+    ///   out.push_back(getAsExpr(":"));
+    ///   out.push_back(errExpr);
+    /// }
+    /// \endcode
+    /// The above will print all the intermediate error values to an output
+    /// stream as the following:
+    /// variable-name : variable-error
+    /// Other strings/variables can be added to what is printed by simply
+    /// adding them to the output vector in the order they should appear.
+    ///
+    /// Note: It is possible to also return an empty vector here (equivalent
+    /// to leaving the body of the function empty), in which case clad will not
+    /// print anything.
+    ///
+    /// \param[in] varName the name of the variable won which print is called.
+    /// \param[in] refEXpr The actual and derivative value of the variable we
+    /// are currently visiting.
+    /// \param[in] errExpr The created intermediate error expression of the
+    /// variable.
+    /// \param[out] out The vector to add the expressions to be printed, is
+    /// received empty.
+    virtual void Print(std::string varName, StmtDiff refExpr,
+                       clang::Expr* errExpr,
+                       llvm::SmallVectorImpl<clang::Expr*>& out) {}
+
     /// Calculate aggregate error from m_EstimateVar.
     ///
     /// \returns the final error estimation statement.
@@ -149,6 +193,10 @@ namespace clad {
     // Return an expression of the following kind:
     // std::abs(dfdx * delta_x * Em)
     clang::Expr* AssignError(StmtDiff refExpr) override;
+
+    // For now, we return just the error expression value.
+    void Print(std::string varName, StmtDiff refExpr, clang::Expr* errExpr,
+               llvm::SmallVectorImpl<clang::Expr*>& out) override;
   };
 
   /// Register any custom error estimation model a user provides

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -552,6 +552,9 @@ namespace clad {
         request.Mode = DiffMode::reverse;
       } else {
         request.Mode = DiffMode::error_estimation;
+        llvm::APSInt val =
+            FD->getTemplateSpecializationArgs()->get(0).getAsIntegral();
+        request.PrintFPErrors = val.getZExtValue();
       }
       request.CallContext = E;
       request.CallUpdateRequired = true;

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -59,14 +59,30 @@ void ErrorEstimationHandler::BuildFinalErrorStmt() {
   }
 
   // Finally add the final error expression to the derivative body.
+  // Here, since this is the final error, we do not print it when error
+  // printing is requested, users can print this error themselves if they
+  // so feel to.
   m_RMV->addToCurrentBlock(
       m_RMV->BuildOp(BO_AddAssign, m_FinalError, addErrorExpr),
       direction::forward);
+
+  if (m_ErrorFile) {
+    for (auto var : m_EstModel->m_EstimateVar) {
+      auto delta = var.second;
+      auto deltaDecl = var.first;
+      Expr* printDelta = m_RMV->BuildOp(
+          BO_Shl, m_ErrorFile,
+          m_EstModel->getAsExpr("\nFinal error contribution by " +
+                                deltaDecl->getNameAsString() + " = "));
+      m_RMV->addToCurrentBlock(m_RMV->BuildOp(BO_Shl, printDelta, delta),
+                               direction::forward);
+    }
+  }
 }
 
-void ErrorEstimationHandler::AddErrorStmtToBlock(Expr* var, Expr* deltaVar,
-                                                 Expr* errorExpr,
-                                                 bool isInsideLoop /*=false*/) {
+void ErrorEstimationHandler::AddErrorStmtToBlock(
+    Expr* var, Expr* deltaVar, Expr* errorExpr, bool isInsideLoop /*=false*/,
+    Expr* errorPrint /*=nullptr*/) {
   if (auto ASE = dyn_cast<ArraySubscriptExpr>(var)) {
     // If inside loop, the index has been pushed twice
     // (once by ArraySubscriptExpr and the second time by us)
@@ -102,10 +118,11 @@ void ErrorEstimationHandler::AddErrorStmtToBlock(Expr* var, Expr* deltaVar,
     m_RMV->addToCurrentBlock(
         m_RMV->BuildOp(BO_AddAssign, m_FinalError, deltaVar),
         direction::reverse);
-
   } else
     m_RMV->addToCurrentBlock(m_RMV->BuildOp(BO_AddAssign, deltaVar, errorExpr),
                              direction::reverse);
+  // Add the print error statement if any printing was requested.
+  m_RMV->addToCurrentBlock(errorPrint, direction::reverse);
 }
 
 void ErrorEstimationHandler::EmitErrorEstimationStmts(
@@ -280,7 +297,7 @@ bool ErrorEstimationHandler::CanRegisterVariable(VarDecl* VD) {
           ? getUnderlyingArrayType(varDeclBase, m_RMV->m_Context)
           : varDeclBase;
   const Expr* init = VD->getInit();
-  // If declarationg type in not floating point type, we want to do two
+  // If declaration type in not floating point type, we want to do two
   // things.
   if (!varDeclType->isFloatingType()) {
     // Firstly, we want to check if the declaration is a lossy conversion.
@@ -331,36 +348,52 @@ Expr* ErrorEstimationHandler::GetParamReplacement(const ParmVarDecl* VD) {
   return nullptr;
 }
 
+Expr* ErrorEstimationHandler::GetPrintExpr(std::string var_name, Expr* var,
+                                           Expr* var_dx, Expr* var_err) {
+  if (!m_ErrorFile)
+    return nullptr;
+  llvm::SmallVector<Expr*, 8> toPrnt = {};
+  m_EstModel->Print(var_name, {var, var_dx}, var_err, toPrnt);
+  assert(toPrnt.size() &&
+         "To print expression is empty even when error printing is enabled.");
+  Expr* printExpr = m_ErrorFile;
+  for (size_t i = 0; i < toPrnt.size(); i++) {
+    printExpr = m_RMV->BuildOp(BO_Shl, printExpr, toPrnt[i]);
+  }
+  return printExpr;
+}
+
 void ErrorEstimationHandler::EmitFinalErrorStmts(
     llvm::SmallVectorImpl<ParmVarDecl*>& params, unsigned numParams) {
   // Emit error variables of parameters at the end.
   for (size_t i = 0; i < numParams; i++) {
     // Right now, we just ignore them since we have no way of knowing
     // the size of an array.
-    // if (m_RMV->isArrayOrPointerType(params[i]->getType()))
+    // if (isArrayOrPointerType(params[i]->getType()))
     //   continue;
-
     // Check if the declaration was registered
     auto decl = dyn_cast<VarDecl>(params[i]);
     Expr* deltaVar = IsRegistered(decl);
-
     // If not registered, check if it is eligible for registration and do
     // the needful.
     if (!deltaVar) {
       deltaVar = RegisterVariable(decl, /*toCurrentScope=*/true);
     }
-
     // If till now, we have a delta declaration, emit it into the code.
     if (deltaVar) {
-      if (!m_RMV->isArrayOrPointerType(params[i]->getType())) {
+      if (!clad::utils::isArrayOrPointerType(params[i]->getType())) {
         // Since we need the input value of x, check for a replacement.
         // If no replacement found, use the actual declRefExpr.
         auto savedVal = GetParamReplacement(params[i]);
         savedVal = savedVal ? savedVal : m_RMV->BuildDeclRef(decl);
         // Finally emit the error.
         auto errorExpr = GetError(savedVal, m_RMV->m_Variables[decl]);
+        auto errorPrntExpr =
+            GetPrintExpr(params[i]->getNameAsString(), savedVal,
+                         m_RMV->m_Variables[decl], errorExpr);
         m_RMV->addToCurrentBlock(
             m_RMV->BuildOp(BO_AddAssign, deltaVar, errorExpr));
+        m_RMV->addToCurrentBlock(errorPrntExpr);
       } else {
         auto LdiffExpr = m_RMV->m_Variables[decl];
         VarDecl* idxExprDecl = nullptr;
@@ -387,9 +420,13 @@ void ErrorEstimationHandler::EmitFinalErrorStmts(
             m_RMV->BuildOp(BO_AddAssign, Ldelta, commonVarExpr);
         Expr* finalAssignExpr =
             m_RMV->BuildOp(BO_AddAssign, m_FinalError, commonVarExpr);
-        ReverseModeVisitor::Stmts loopBody;
+        Stmts loopBody;
         loopBody.push_back(m_RMV->BuildDeclStmt(commonVarDecl));
         loopBody.push_back(deltaAssignExpr);
+        // Build and add the print error expression.
+        if (m_ErrorFile)
+          loopBody.push_back(GetPrintExpr(params[i]->getNameAsString(), LRepl,
+                                          Ldiff, commonVarExpr));
         loopBody.push_back(finalAssignExpr);
         Expr* conditionExpr = m_RMV->BuildOp(
             BO_LT, m_IdxExpr, m_RMV->BuildArrayRefSizeExpr(LdiffExpr));
@@ -420,7 +457,8 @@ void ErrorEstimationHandler::EmitUnaryOpErrorStmts(StmtDiff var,
   if (DeclRefExpr* DRE = GetUnderlyingDeclRefOrNull(var.getExpr())) {
     // First check if it was registered.
     // If not, we don't care about it.
-    if (auto deltaVar = IsRegistered(cast<VarDecl>(DRE->getDecl()))) {
+    auto decl = cast<VarDecl>(DRE->getDecl());
+    if (auto deltaVar = IsRegistered(decl)) {
       // Create a variable/tape call to store the current value of the
       // the sub-expression so that it can be used later.
       StmtDiff savedVar = m_RMV->GlobalStoreAndRef(
@@ -435,7 +473,11 @@ void ErrorEstimationHandler::EmitUnaryOpErrorStmts(StmtDiff var,
         savedVar = {savedVar.getExpr(), popVal};
       }
       Expr* erroExpr = GetError(savedVar.getExpr_dx(), var.getExpr_dx());
-      AddErrorStmtToBlock(var.getExpr(), deltaVar, erroExpr, isInsideLoop);
+      Expr* prntExpr =
+          GetPrintExpr(decl->getNameAsString(), savedVar.getExpr_dx(),
+                       var.getExpr_dx(), erroExpr);
+      AddErrorStmtToBlock(var.getExpr(), deltaVar, erroExpr, isInsideLoop,
+                          prntExpr);
     }
   }
 }
@@ -477,8 +519,11 @@ void ErrorEstimationHandler::EmitBinaryOpErrorStmts(Expr* LExpr, Expr* oldValue,
   // previously.
   StmtDiff savedExpr = SaveValue(LExpr, isInsideLoop);
   // Assign the error.
+  auto decl = GetUnderlyingDeclRefOrNull(LExpr)->getDecl();
   Expr* errorExpr = GetError(savedExpr.getExpr_dx(), oldValue);
-  AddErrorStmtToBlock(LExpr, deltaVar, errorExpr, isInsideLoop);
+  Expr* prntExpr = GetPrintExpr(decl->getNameAsString(), savedExpr.getExpr_dx(),
+                                oldValue, errorExpr);
+  AddErrorStmtToBlock(LExpr, deltaVar, errorExpr, isInsideLoop, prntExpr);
   // If there are assign statements to emit in reverse, do that.
   EmitErrorEstimationStmts(direction::reverse);
 }
@@ -496,9 +541,12 @@ void ErrorEstimationHandler::EmitDeclErrorStmts(VarDeclDiff VDDiff,
     StmtDiff savedDecl = SaveValue(VDRef, isInsideLoop);
     // If the VarDecl has an init, we should assign it with an error.
     if (VD->getInit() && !GetUnderlyingDeclRefOrNull(VD->getInit())) {
-      Expr* errorExpr = GetError(savedDecl.getExpr_dx(),
-                                 m_RMV->BuildDeclRef(VDDiff.getDecl_dx()));
-      AddErrorStmtToBlock(VDRef, EstVD, errorExpr, isInsideLoop);
+      auto varDeclExpr = m_RMV->BuildDeclRef(VDDiff.getDecl_dx());
+      Expr* errorExpr = GetError(savedDecl.getExpr_dx(), varDeclExpr);
+      Expr* prntExpr =
+          GetPrintExpr(VD->getNameAsString(), savedDecl.getExpr_dx(),
+                       varDeclExpr, errorExpr);
+      AddErrorStmtToBlock(VDRef, EstVD, errorExpr, isInsideLoop, prntExpr);
     }
   }
 }
@@ -511,16 +559,20 @@ void ErrorEstimationHandler::ForgetRMV() { m_RMV = nullptr; }
 
 void ErrorEstimationHandler::ActBeforeCreatingDerivedFnParamTypes(
     unsigned& numExtraParam) {
-  numExtraParam += 1;
+  numExtraParam += 1 + m_PrintErrors;
 }
 
 void ErrorEstimationHandler::ActAfterCreatingDerivedFnParamTypes(
     llvm::SmallVectorImpl<QualType>& paramTypes) {
-  m_ParamTypes = &paramTypes;
   // If we are performing error estimation, our gradient function
   // will have an extra argument which will hold the final error value
   paramTypes.push_back(
       m_RMV->m_Context.getLValueReferenceType(m_RMV->m_Context.DoubleTy));
+  // If error printing was enabled, add another param type for it.
+  if (m_PrintErrors) {
+    paramTypes.push_back(
+        m_RMV->m_Context.getLValueReferenceType(m_ErrorFileType));
+  }
 };
 
 void ErrorEstimationHandler::ActAfterCreatingDerivedFnParams(
@@ -528,21 +580,33 @@ void ErrorEstimationHandler::ActAfterCreatingDerivedFnParams(
   m_Params = &params;
   // If in error estimation mode, create the error parameter
   ASTContext& context = m_RMV->m_Context;
+  QualType finErrorType = context.getLValueReferenceType(context.DoubleTy);
   // Repeat the above but for the error ouput var "_final_error"
-  ParmVarDecl* errorVarDecl = ParmVarDecl::Create(
-      context, m_RMV->m_Derivative, noLoc, noLoc,
-      &context.Idents.get("_final_error"), m_ParamTypes->back(),
-      context.getTrivialTypeSourceInfo(m_ParamTypes->back(), noLoc),
-      params.front()->getStorageClass(),
-      /*DefArg=*/nullptr);
+  ParmVarDecl* errorVarDecl =
+      ParmVarDecl::Create(context, m_RMV->m_Derivative, noLoc, noLoc,
+                          &context.Idents.get("_final_error"), finErrorType,
+                          context.getTrivialTypeSourceInfo(finErrorType, noLoc),
+                          params.front()->getStorageClass(),
+                          /*DefArg=*/nullptr);
+  m_FinalError = m_RMV->BuildDeclRef(errorVarDecl);
   params.push_back(errorVarDecl);
-  m_RMV->m_Sema.PushOnScopeChains(params.back(), m_RMV->getCurrentScope(),
+  m_RMV->m_Sema.PushOnScopeChains(errorVarDecl, m_RMV->getCurrentScope(),
                                   /*AddToContext=*/false);
-}
-
-void ErrorEstimationHandler::ActBeforeCreatingDerivedFnBodyScope() {
-  // Reference to the final error statement
-  SetFinalErrorExpr(m_RMV->BuildDeclRef(m_Params->back()));
+  // If printing of error estimates was requested, build another parameter to
+  // store the ofstream object.
+  if (m_PrintErrors) {
+    QualType prntErrorType = context.getLValueReferenceType(m_ErrorFileType);
+    ParmVarDecl* VD = ParmVarDecl::Create(
+        context, m_RMV->m_Derivative, noLoc, noLoc,
+        &context.Idents.get("_error_stream"), prntErrorType,
+        context.getTrivialTypeSourceInfo(prntErrorType, noLoc),
+        params.front()->getStorageClass(),
+        /*DefArg=*/nullptr);
+    m_ErrorFile = m_RMV->BuildDeclRef(VD);
+    params.push_back(VD);
+    m_RMV->m_Sema.PushOnScopeChains(VD, m_RMV->getCurrentScope(),
+                                    /*AddToContext=*/false);
+  }
 }
 
 void ErrorEstimationHandler::ActOnEndOfDerivedFnBody() {

--- a/lib/Differentiator/EstimationModel.cpp
+++ b/lib/Differentiator/EstimationModel.cpp
@@ -1,5 +1,4 @@
 #include "clad/Differentiator/EstimationModel.h"
-
 #include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/DerivativeBuilder.h"
 
@@ -14,6 +13,10 @@ using namespace clang;
 namespace clad {
 
   FPErrorEstimationModel::~FPErrorEstimationModel() {}
+
+  Expr* FPErrorEstimationModel::getAsExpr(std::string expr) {
+    return utils::CreateStringLiteral(m_Context, expr);
+  }
 
   Expr* FPErrorEstimationModel::IsVariableRegistered(const VarDecl* VD) {
     auto it = m_EstimateVar.find(VD);
@@ -100,6 +103,17 @@ namespace clad {
     auto absExpr = GetFunctionCall("abs", "std", params);
     // Return the built error expression.
     return absExpr;
+  }
+
+  // Return the error expression of the variable we are visiting.
+  void TaylorApprox::Print(std::string varName, StmtDiff refExpr, Expr* errExpr,
+                           llvm::SmallVectorImpl<Expr*>& out) {
+    // Return the following clang:expr:
+    // Variable-name : variable-error
+    out.push_back(getAsExpr(varName));
+    out.push_back(getAsExpr(" : "));
+    out.push_back(errExpr);
+    out.push_back(getAsExpr("\n"));
   }
 
 } // namespace clad

--- a/test/ErrorEstimation/PrintErrors.C
+++ b/test/ErrorEstimation/PrintErrors.C
@@ -1,0 +1,91 @@
+// RUN: %cladclang %s -x c++ -lstdc++ -I%S/../../include -oPrintErrors.out 2>&1 | FileCheck %s
+// RUN: ./PrintErrors.out | FileCheck -check-prefix=CHECK-EXEC %s
+
+//CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <fstream> // Necessary for printing data to file.
+#include <iostream> 
+
+float func1(float x, float y) {
+  x = x - y - y * y;
+  float t = x * y * y;
+  return t;
+}
+
+//CHECK: void func1_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error, {{.+}}ostream &_error_stream) {
+//CHECK-NEXT:     double _delta_x = 0;
+//CHECK-NEXT:     float _EERepl_x0 = x;
+//CHECK-NEXT:     float _t0;
+//CHECK-NEXT:     float _t1;
+//CHECK-NEXT:     float _EERepl_x1;
+//CHECK-NEXT:     float _t2;
+//CHECK-NEXT:     float _t3;
+//CHECK-NEXT:     float _t4;
+//CHECK-NEXT:     float _t5;
+//CHECK-NEXT:     float _d_t = 0;
+//CHECK-NEXT:     double _delta_t = 0;
+//CHECK-NEXT:     float _EERepl_t0;
+//CHECK-NEXT:     _t1 = y;
+//CHECK-NEXT:     _t0 = y;
+//CHECK-NEXT:     x = x - y - _t1 * _t0;
+//CHECK-NEXT:     _EERepl_x1 = x;
+//CHECK-NEXT:     _t4 = x;
+//CHECK-NEXT:     _t3 = y;
+//CHECK-NEXT:     _t5 = _t4 * _t3;
+//CHECK-NEXT:     _t2 = y;
+//CHECK-NEXT:     float t = _t5 * _t2;
+//CHECK-NEXT:     _EERepl_t0 = t;
+//CHECK-NEXT:     float func1_return = t;
+//CHECK-NEXT:     goto _label0;
+//CHECK-NEXT:   _label0:
+//CHECK-NEXT:     _d_t += 1;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         float _r2 = _d_t * _t2;
+//CHECK-NEXT:         float _r3 = _r2 * _t3;
+//CHECK-NEXT:         * _d_x += _r3;
+//CHECK-NEXT:         float _r4 = _t4 * _r2;
+//CHECK-NEXT:         * _d_y += _r4;
+//CHECK-NEXT:         float _r5 = _t5 * _d_t;
+//CHECK-NEXT:         * _d_y += _r5;
+//CHECK-NEXT:         _delta_t += std::abs(_d_t * _EERepl_t0 * {{.+}});
+//CHECK-NEXT:         _error_stream << "t" << " : " << std::abs(_d_t * _EERepl_t0 * {{.+}}) << "\n";
+//CHECK-NEXT:     }
+//CHECK-NEXT:     {
+//CHECK-NEXT:         float _r_d0 = * _d_x;
+//CHECK-NEXT:         * _d_x += _r_d0;
+//CHECK-NEXT:         * _d_y += -_r_d0;
+//CHECK-NEXT:         float _r0 = -_r_d0 * _t0;
+//CHECK-NEXT:         * _d_y += _r0;
+//CHECK-NEXT:         float _r1 = _t1 * -_r_d0;
+//CHECK-NEXT:         * _d_y += _r1;
+//CHECK-NEXT:         _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
+//CHECK-NEXT:         _error_stream << "x" << " : " << std::abs(_r_d0 * _EERepl_x1 * {{.+}}) << "\n";
+//CHECK-NEXT:         * _d_x -= _r_d0;
+//CHECK-NEXT:         * _d_x;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * _EERepl_x0 * {{.+}});
+//CHECK-NEXT:     _error_stream << "x" << " : " << std::abs(* _d_x * _EERepl_x0 * {{.+}}) << "\n";
+//CHECK-NEXT:     double _delta_y = 0;
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
+//CHECK-NEXT:     _error_stream << "y" << " : " << std::abs(* _d_y * y * {{.+}}) << "\n";
+//CHECK-NEXT:     _final_error += _delta_{{x|y|t}} + _delta_{{x|y|t}} + _delta_{{x|y|t}};
+//CHECK-NEXT:     _error_stream << "\nFinal error contribution by {{x|y|t}} = " << _delta_{{x|y|t}};
+//CHECK-NEXT:     _error_stream << "\nFinal error contribution by {{x|y|t}} = " << _delta_{{x|y|t}};
+//CHECK-NEXT:     _error_stream << "\nFinal error contribution by {{x|y|t}} = " << _delta_{{x|y|t}};
+//CHECK-NEXT: }
+
+int main(){
+  auto err_func = clad::estimate_error<true>(func1);
+  float res[2] = {0};
+  double x = 0.7779, y = 0.999999, err = 0;
+  err_func.execute(x, y, &res[0], &res[1], err, std::cout);
+  //CHECK-EXEC: t : {{.+}}
+  //CHECK-EXEC: x : {{.+}}
+  //CHECK-EXEC: x : {{.+}}
+  //CHECK-EXEC: y : {{.+}}
+  //CHECK-EXEC: Final error contribution by {{x|y|t}} = {{.+}}
+  //CHECK-EXEC: Final error contribution by {{x|y|t}} = {{.+}}
+  //CHECK-EXEC: Final error contribution by {{x|y|t}} = {{.+}}
+}


### PR DESCRIPTION
Allow users to print intermediate floating-point errors to a file. This PR will allow users to use the "-fprint-error-ests-to-file" and enable printing of whatever they specify in the custom model's ```Print``` function. This will not only enable users to get access to intermediate error and derivative values (something they would not have otherwise) automatically but also allow them a deeper insight into the error analysis. One can perform analysis like error sensitivity of variables through this feature, all they have to do is implement the ```Print``` function as such it prints the sensitivity of each variable of interest.

 A possible pitfall of this implementation is that we have no way (at least not a non-complex way) to attach source information to the "Print" values of each variable, i.e. currently we print to the file something like this: "var_name : <--expr specified by Print-->". Now, this is very terse and can easily become confusing for larger codes where the same variable appears multiple times as the variable of interest. A better implementation would see the printing of something like: "var_name : var_src_line_no : <--expr specified by Print-->" where the ```var_src_line_no``` specifies the line number of the occurrence of that specific variable, tying each "Print" value to an expression in the code.

- [ ] ~Add a demo for sensitivity analysis. (closes #295)~
- [ ] Update the website tutorial to add the ```Print``` function there.