### PR TITLE
Modify clad function to throw error on mismatch of arguments

### DIFF
--- a/test/ForwardMode/NotEnoughArgError.C
+++ b/test/ForwardMode/NotEnoughArgError.C
@@ -1,0 +1,18 @@
+// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1
+// CHECK-NOT: {{.*warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+double func1(double x, double y) {
+  return x * x + y * y;
+}
+
+int main () {
+  auto func1_dx = clad::differentiate(func1, "x");
+
+  func1_dx.execute(5);
+  // expected-error@clad/Differentiator/Differentiator.h:113 {{too few arguments to function call, expected 2, have 1}}
+  // expected-note@clad/Differentiator/Differentiator.h:245 {{in instantiation of function template specialization 'clad::execute_with_default_args<false, double, double (*)(double, double), int, true>' requested here}}
+  // expected-note@clad/Differentiator/Differentiator.h:196 {{in instantiation of function template specialization 'clad::CladFunction<double (*)(double, double), clad::NoObject, false>::execute_helper<double (*)(double, double), int>' requested here}}
+  // expected-note@NotEnoughArgError.C:13 {{in instantiation of function template specialization 'clad::CladFunction<double (*)(double, double), clad::NoObject, false>::execute<int, double (*)(double, double)>' requested here}}
+}


### PR DESCRIPTION
Fixes #378 

The padding of supplied args with default args has been removed from all modes other than reverse mode. So they will throw error if less number of args are supplied.

For reverse mode the plugin needs to provide the `CladFunction` with the number of arguments so that it can check if the correct number of arguments are provided. This is yet to be implemented.