### PR TITLE
Add initial support for diff class types in the forw mode

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -159,6 +159,19 @@ namespace clad {
     /// Returns true if `T1` and `T2` have same cononical type; otherwise
     /// returns false.
     bool SameCanonicalType(clang::QualType T1, clang::QualType T2);
+    
+    /// Builds `base->member` expression or `base.member` expression depending
+    /// on if the `base` is of pointer type or not.
+    ///
+    /// \note This function always build LValue member expression.
+    clang::MemberExpr* BuildMemberExpr(clang::Sema& semaRef, clang::Expr* base,
+                                       clang::ValueDecl* member);
+
+    bool isDifferentiableType(clang::QualType T);
+
+    /// Returns a valid `SourceLocation` to be used in places where clang
+    /// requires a valid `SourceLocation`.
+    clang::SourceLocation GetValidSLoc(clang::Sema& semaRef);
   } // namespace utils
 }
 

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -192,7 +192,7 @@ namespace clad {
     execute(Args&&... args) CUDA_HOST_DEVICE {
       if (!m_Function) {
         printf("CladFunction is invalid\n");
-        return static_cast<return_type_t<F>>(0);
+        return static_cast<return_type_t<F>>(return_type_t<F>());
       }
       // here static_cast is used to achieve perfect forwarding
       return execute_helper(m_Function, static_cast<Args>(args)...);

--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -81,7 +81,13 @@ namespace clad {
 
     StmtDiff VisitSwitchStmt(const clang::SwitchStmt* SS);
     StmtDiff VisitBreakStmt(const clang::BreakStmt* BS);
-    
+    StmtDiff VisitCXXConstructExpr(const clang::CXXConstructExpr* CE);
+    StmtDiff VisitExprWithCleanups(const clang::ExprWithCleanups* EWC);
+    StmtDiff
+    VisitMaterializeTemporaryExpr(const clang::MaterializeTemporaryExpr* MTE);
+    StmtDiff
+    VisitCXXTemporaryObjectExpr(const clang::CXXTemporaryObjectExpr* TOE);
+
   private:
     /// Helper function for differentiating the switch statement body.
     ///

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -57,11 +57,11 @@ namespace clad {
         GetCladTapeOfType(getNonConstType(E->getType(), m_Context, m_Sema));
     LookupResult& Push = GetCladTapePush();
     LookupResult& Pop = GetCladTapePop();
-    Expr* TapeRef = BuildDeclRef(GlobalStoreImpl(TapeType, prefix));
+    Expr* TapeRef =
+        BuildDeclRef(GlobalStoreImpl(TapeType, prefix, getZeroInit(TapeType)));
     auto VD = cast<VarDecl>(cast<DeclRefExpr>(TapeRef)->getDecl());
     // Add fake location, since Clang AST does assert(Loc.isValid()) somewhere.
     VD->setLocation(m_Function->getLocation());
-    m_Sema.AddInitializerToDecl(VD, getZeroInit(TapeType), false);
     CXXScopeSpec CSS;
     CSS.Extend(m_Context, GetCladNamespace(), noLoc, noLoc);
     auto PopDRE = m_Sema
@@ -2373,7 +2373,8 @@ namespace clad {
       Var = BuildVarDecl(Type, identifier, init, false, nullptr,
                          clang::VarDecl::InitializationStyle::CallInit);
     } else {
-      Var = BuildVarDecl(Type, identifier, init);
+      Var = BuildVarDecl(Type, identifier, init, false, nullptr,
+                         VarDecl::InitializationStyle::CInit);
     }
 
     // Add the declaration to the body of the gradient function.

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -71,7 +71,10 @@ namespace clad {
     if (Init) {
       m_Sema.AddInitializerToDecl(VD, Init, DirectInit);
       VD->setInitStyle(IS);
+    } else {
+      m_Sema.ActOnUninitializedDecl(VD);
     }
+    m_Sema.FinalizeDeclaration(VD);
     // Add the identifier to the scope and IdResolver
     m_Sema.PushOnScopeChains(VD, getCurrentScope(), /*AddToContext*/ false);
     return VD;
@@ -609,7 +612,9 @@ namespace clad {
     // build the clad::tape<clad::array_ref>> = {};
     QualType RefType = GetCladArrayRefOfType(retType);
     QualType TapeType = GetCladTapeOfType(RefType);
-    auto VD = BuildVarDecl(TapeType);
+    auto VD = BuildVarDecl(
+        TapeType, "_t", getZeroInit(TapeType), /*DirectInit=*/false,
+        /*TSI=*/nullptr, VarDecl::InitializationStyle::CInit);
     NumericalDiffMultiArg.push_back(BuildDeclStmt(VD));
     Expr* TapeRef = BuildDeclRef(VD);
     NumDiffArgs.push_back(TapeRef);

--- a/test/FirstDerivative/CallArguments.C
+++ b/test/FirstDerivative/CallArguments.C
@@ -65,7 +65,7 @@ float f_const_args_func_3(const float x, float y) {
 // CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
 // CHECK-NEXT: }
 
-struct Vec { float x,y,z; };
+struct Vec { float x=0, y=0, z=0; };
 float f_const_args_func_4(float x, float y, const Vec v) {
   return x * x + y * y - v.x;
 }
@@ -73,7 +73,8 @@ float f_const_args_func_4(float x, float y, const Vec v) {
 // CHECK: float f_const_args_func_4_darg0(float x, float y, const Vec v) {
 // CHECK-NEXT: float _d_x = 1;
 // CHECK-NEXT: float _d_y = 0;
-// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
+// CHECK-NEXT:     const Vec _d_v;
+// CHECK-NEXT:     return _d_x * x + x * _d_x + _d_y * y + y * _d_y - _d_v.x;
 // CHECK-NEXT: }
 
 float f_const_args_func_5(float x, float y, const Vec &v) {
@@ -83,7 +84,8 @@ float f_const_args_func_5(float x, float y, const Vec &v) {
 // CHECK: float f_const_args_func_5_darg0(float x, float y, const Vec &v) {
 // CHECK-NEXT: float _d_x = 1;
 // CHECK-NEXT: float _d_y = 0;
-// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
+// CHECK-NEXT:     const Vec _d_v;
+// CHECK-NEXT:     return _d_x * x + x * _d_x + _d_y * y + y * _d_y - _d_v.x;
 // CHECK-NEXT: }
 
 float f_const_args_func_6(const float x, const float y, const Vec &v) {
@@ -93,7 +95,8 @@ float f_const_args_func_6(const float x, const float y, const Vec &v) {
 // CHECK: float f_const_args_func_6_darg0(const float x, const float y, const Vec &v) {
 // CHECK-NEXT: const float _d_x = 1;
 // CHECK-NEXT: const float _d_y = 0;
-// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
+// CHECK-NEXT:     const Vec _d_v;
+// CHECK-NEXT:     return _d_x * x + x * _d_x + _d_y * y + y * _d_y - _d_v.x;
 // CHECK-NEXT: }
 
 float f_const_helper(const float x) {

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -1,0 +1,146 @@
+// RUN: %cladclang %s -I%S/../../include -oUserDefinedTypes.out 2>&1 | FileCheck %s
+// RUN: ./UserDefinedTypes.out | FileCheck -check-prefix=CHECK-EXEC %s
+
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+std::pair<double, double> fn1(double i, double j) {
+  std::pair<double, double> c(3, 5), d({7.00, 9.00});
+  std::pair<double, double> e = d;
+  c.first += i;
+  c.second += 2 * i + j;
+  d.first += 2 * i;
+  d.second += i;
+  c.first += d.first;
+  c.second += d.second;
+  return c;
+}
+
+// CHECK: std::pair<double, double> fn1_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     std::pair<double, double> _d_c(0, 0), _d_d({0., 0.});
+// CHECK-NEXT:     std::pair<double, double> c(3, 5), d({7., 9.});
+// CHECK-NEXT:     std::pair<double, double> _d_e = _d_d;
+// CHECK-NEXT:     std::pair<double, double> e = d;
+// CHECK-NEXT:     _d_c.first += _d_i;
+// CHECK-NEXT:     c.first += i;
+// CHECK-NEXT:     _d_c.second += 0 * i + 2 * _d_i + _d_j;
+// CHECK-NEXT:     c.second += 2 * i + j;
+// CHECK-NEXT:     _d_d.first += 0 * i + 2 * _d_i;
+// CHECK-NEXT:     d.first += 2 * i;
+// CHECK-NEXT:     _d_d.second += _d_i;
+// CHECK-NEXT:     d.second += i;
+// CHECK-NEXT:     _d_c.first += _d_d.first;
+// CHECK-NEXT:     c.first += d.first;
+// CHECK-NEXT:     _d_c.second += _d_d.second;
+// CHECK-NEXT:     c.second += d.second;
+// CHECK-NEXT:     return _d_c;
+// CHECK-NEXT: }
+
+std::pair<double, double> fn2(double i, double j) {
+  std::pair<double, double> c, d;
+  std::pair<double, double> e = d;
+  return std::pair<double, double>();
+}
+
+// CHECK: std::pair<double, double> fn2_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     std::pair<double, double> _d_c, _d_d;
+// CHECK-NEXT:     std::pair<double, double> c, d;
+// CHECK-NEXT:     std::pair<double, double> _d_e = _d_d;
+// CHECK-NEXT:     std::pair<double, double> e = d;
+// CHECK-NEXT:     return std::pair<double, double>();
+// CHECK-NEXT: }
+
+std::pair<double, double> fn3(double i, double j) {
+  std::pair<double, double> c, d;
+  std::pair<double, double> e = d;
+  return {};
+}
+
+// CHECK: std::pair<double, double> fn3_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     std::pair<double, double> _d_c, _d_d;
+// CHECK-NEXT:     std::pair<double, double> c, d;
+// CHECK-NEXT:     std::pair<double, double> _d_e = _d_d;
+// CHECK-NEXT:     std::pair<double, double> e = d;
+// CHECK-NEXT:     return {};
+// CHECK-NEXT: }
+
+std::pair<double, double> fn4(double i, double j) {
+  std::pair<double, double> c, d;
+  std::pair<double, double> e = d;
+  return std::pair<double, double>(1, 3);
+}
+
+// CHECK: std::pair<double, double> fn4_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     std::pair<double, double> _d_c, _d_d;
+// CHECK-NEXT:     std::pair<double, double> c, d;
+// CHECK-NEXT:     std::pair<double, double> _d_e = _d_d;
+// CHECK-NEXT:     std::pair<double, double> e = d;
+// CHECK-NEXT:     return std::pair<double, double>(0, 0);
+// CHECK-NEXT: }
+
+template<typename T, unsigned N>
+struct Tensor {
+  T data[N] = {};
+};
+
+Tensor<double, 5> fn5(double i, double j) {
+  Tensor<double, 5> T;
+  for (int l=0; l<5; ++l) {
+    T.data[l] = (l+1)*i;
+  }
+  return T;
+} 
+
+// CHECK: Tensor<double, 5> fn5_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     Tensor<double, 5> _d_T;
+// CHECK-NEXT:     Tensor<double, 5> T;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _d_l = 0;
+// CHECK-NEXT:         for (int l = 0; l < 5; ++l) {
+// CHECK-NEXT:             int _t0 = (l + 1);
+// CHECK-NEXT:             _d_T.data[l] = (_d_l + 0) * i + _t0 * _d_i;
+// CHECK-NEXT:             T.data[l] = _t0 * i;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return _d_T;
+// CHECK-NEXT: }
+
+#define INIT(fn, ...) auto d_##fn = clad::differentiate(fn, __VA_ARGS__);
+
+#define TEST_PAIR_OF_DOUBLES(fn, ...)                                          \
+  {                                                                            \
+    auto res = d_##fn.execute(__VA_ARGS__);                                    \
+    printf("{%.2f, %.2f}\n", res.first, res.second);                           \
+  }
+
+#define TEST_TENSOR_DOUBLE_5(fn, ...)                                          \
+  {                                                                            \
+    auto res = d_##fn.execute(__VA_ARGS__);                                    \
+    printf("{%.2f, %.2f, %.2f, %.2f, %.2f}\n", res.data[0], res.data[1],       \
+           res.data[2], res.data[3], res.data[4]);                             \
+  }
+
+int main() {
+  INIT(fn1, "i");
+  INIT(fn2, "i");
+  INIT(fn3, "i");
+  INIT(fn4, "i");
+  INIT(fn5, "i");
+
+  TEST_PAIR_OF_DOUBLES(fn1, 3, 5);  // CHECK-EXEC: {3.00, 3.00}
+  TEST_PAIR_OF_DOUBLES(fn2, 3, 5);  // CHECK-EXEC: {0.00, 0.00}
+  TEST_PAIR_OF_DOUBLES(fn3, 3, 5);  // CHECK-EXEC: {0.00, 0.00}
+  TEST_PAIR_OF_DOUBLES(fn4, 3, 5);  // CHECK-EXEC: {0.00, 0.00}
+  TEST_TENSOR_DOUBLE_5(fn5, 3, 5);  // CHECK-EXEC: {1.00, 2.00, 3.00, 4.00, 5.00}
+}


### PR DESCRIPTION
This PR adds initial support for differentiating class types with respect to scalar numerical types using the forward mode AD.

Given a function:
![Screenshot from 2022-02-28 20-10-43](https://user-images.githubusercontent.com/40723498/156002198-a1c0f6ee-3252-483e-9a8f-5e57c135bea2.png)

The forward mode automatic differentiation allows us to compute derivative of _all_ the output variables with respect to a single input variable (independent variable) in a single pass. Mathematically, the forward mode AD allows us to efficiently compute columns of the jacobian matrix. Up till now, we are not utilising this ability of the forward mode AD -- since we only supported differentiating scalar type with respect to a scalar type. 
Thus, differentiation of aggregate types in the forward mode AD will allow us to utilize this ability and obtain multiple derivatives in a single call to the derived function. 

Clad requires the following assumptions to be true when differentiating a class type:
- Class should represent a real vector space. 
- Class should have a default constructor. Class variables initialised by the default constructor should represent 0 tangent vector -- that is, all real data members should be equal to 0. 

Differentiation of class types in the forward mode AD currently have the following limitations:
- Calls to member functions are not supported.
- Calls to overloaded operators are not supported.
- Initialising class type variables using non-default constructor are not supported.
- Class cannot have pointer or reference data members.

Most of these limitations will be removed soon.