### PR TITLE
Add initial support for differentiating user-defined types in the reverse mode.

### DIFF
--- a/include/clad/Differentiator/Array.h
+++ b/include/clad/Differentiator/Array.h
@@ -27,10 +27,16 @@ public:
 
   template <typename U>
   CUDA_HOST_DEVICE array(clad::array_ref<U> arr)
-      : m_arr(new T[arr.size()]{static_cast<T>(0)}), m_size(arr.size()) {
+      : m_arr(new T[arr.size()]{static_cast<T>(T())}), m_size(arr.size()) {
     (*this) = arr;
   }
 
+  template <typename U>
+  CUDA_HOST_DEVICE array(U* a, std::size_t size)
+      : m_arr(new T[size]{static_cast<T>(T())}), m_size(size) {
+    for (std::size_t i = 0; i < size; ++i)
+      m_arr[i] = a[i];
+  }
   /// Destructor to delete the array if it was created by array_ref
   CUDA_HOST_DEVICE ~array() { delete[] m_arr; }
 

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -159,19 +159,50 @@ namespace clad {
     /// Returns true if `T1` and `T2` have same cononical type; otherwise
     /// returns false.
     bool SameCanonicalType(clang::QualType T1, clang::QualType T2);
-    
+
     /// Builds `base->member` expression or `base.member` expression depending
     /// on if the `base` is of pointer type or not.
-    ///
-    /// \note This function always build LValue member expression.
-    clang::MemberExpr* BuildMemberExpr(clang::Sema& semaRef, clang::Expr* base,
-                                       clang::ValueDecl* member);
+    clang::MemberExpr* BuildMemberExpr(clang::Sema& semaRef, clang::Scope* S,
+                                       clang::Expr* base,
+                                       llvm::StringRef memberName);
 
     bool isDifferentiableType(clang::QualType T);
 
     /// Returns a valid `SourceLocation` to be used in places where clang
     /// requires a valid `SourceLocation`.
     clang::SourceLocation GetValidSLoc(clang::Sema& semaRef);
+
+    /// Given an expression `E`, this function builds and returns the expression
+    /// `(E)`.
+    clang::ParenExpr* BuildParenExpr(clang::Sema& semaRef, clang::Expr* E);
+
+    /// Returns `IdentifierInfo` that represents the value in the `identifier`
+    /// parameter.
+    clang::IdentifierInfo* GetIdentifierInfo(clang::Sema& semaRef,
+                                             llvm::StringRef identifier);
+
+    /// Builds parameter variable declaration.
+    ///
+    /// This function is just a convenient routine that internally calls
+    /// `clang::ParmVarDecl::Create`.
+    clang::ParmVarDecl*
+    BuildParmVarDecl(clang::Sema& semaRef, clang::DeclContext* DC,
+                     clang::IdentifierInfo* II, clang::QualType T,
+                     clang::StorageClass SC = clang::StorageClass::SC_None,
+                     clang::Expr* defArg = nullptr);
+
+    /// If `T` represents an array or a pointer type then returns the
+    /// corresponding array element or the pointee type. Otherwise, if `T` is
+    /// neither an array nor a pointer type, then simply returns `T`.
+    clang::QualType GetValueType(clang::QualType T);
+
+    /// Builds and returns the init expression to initialise `clad::array` and
+    /// `clad::array_ref` from a constant array.
+    ///
+    /// More concretely, it builds the following init list expression:
+    /// `{arr, arrSize}`
+    clang::Expr* BuildCladArrayInitByConstArray(clang::Sema& semaRef,
+                                                clang::Expr* constArrE);
   } // namespace utils
 }
 

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -384,7 +384,7 @@ namespace clad {
   // GradientDerivedFnTraits specializations for pure function pointer types
   template <class ReturnType, class... Args>
   struct GradientDerivedFnTraits<ReturnType (*)(Args...)> {
-    using type = void (*)(Args..., OutputParamType_t<Args, ReturnType>...);
+    using type = void (*)(Args..., OutputParamType_t<Args, void>...);
   };
 
   /// These macro expansions are used to cover all possible cases of
@@ -400,7 +400,7 @@ namespace clad {
   template <typename R, typename C, typename... Args>                          \
   struct GradientDerivedFnTraits<R (C::*)(Args...) cv vol ref noex> {          \
     using type = void (C::*)(Args...,                                          \
-                             OutputParamType_t<Args, R>...) cv vol ref noex;   \
+                             OutputParamType_t<Args, void>...) cv vol ref noex;   \
   };
 
 #if __cpp_noexcept_function_type > 0

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -682,8 +682,8 @@ namespace clad {
              "Member functions are not supported yet!");
       // Here we are implicitly assuming that the derived type and the original
       // types are same. This may not be necessarily true in the future.
-      auto derivedME =
-          utils::BuildMemberExpr(m_Sema, baseDiff.getExpr_dx(), field);
+      auto derivedME = utils::BuildMemberExpr(
+          m_Sema, getCurrentScope(), baseDiff.getExpr_dx(), field->getName());
       return {clonedME, derivedME};
     }
   }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -1,0 +1,269 @@
+// RUN: %cladclang %s -I%S/../../include -oUserDefinedTypes.out 2>&1 -lstdc++ -lm | FileCheck %s
+// RUN: ./UserDefinedTypes.out | FileCheck -check-prefix=CHECK-EXEC %s
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+#include "../TestUtils.h"
+#include <utility>
+
+using pairdd = std::pair<double, double>;
+
+double fn1(pairdd p, double i) {
+    double res = p.first + 2*p.second + 3*i;
+    return res;
+}
+
+// CHECK: void fn1_grad(pairdd p, double i, clad::array_ref<pairdd> _d_p, clad::array_ref<double> _d_i) {
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     _t0 = p.second;
+// CHECK-NEXT:     _t1 = i;
+// CHECK-NEXT:     double res = p.first + 2 * _t0 + 3 * _t1;
+// CHECK-NEXT:     double fn1_return = res;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         (* _d_p).first += _d_res;
+// CHECK-NEXT:         double _r0 = _d_res * _t0;
+// CHECK-NEXT:         double _r1 = 2 * _d_res;
+// CHECK-NEXT:         (* _d_p).second += _r1;
+// CHECK-NEXT:         double _r2 = _d_res * _t1;
+// CHECK-NEXT:         double _r3 = 3 * _d_res;
+// CHECK-NEXT:         * _d_i += _r3;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+struct Tangent {
+    Tangent() {}
+    double data[5] = {};
+    void updateTo(double d) {
+        for (int i=0; i<5; ++i)
+            data[i] = d;
+    }
+};
+
+double sum(Tangent& t) {
+    double res=0;
+    for (int i=0; i<5; ++i)
+        res += t.data[i];
+    return res;
+}
+
+// CHECK: void sum_pullback(Tangent &t, double _d_y, clad::array_ref<Tangent> _d_t) {
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     unsigned long _t0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     clad::tape<int> _t1 = {};
+// CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     for (int i = 0; i < 5; ++i) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         res += t.data[clad::push(_t1, i)];
+// CHECK-NEXT:     }
+// CHECK-NEXT:     double sum_return = res;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += _d_y;
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         double _r_d0 = _d_res;
+// CHECK-NEXT:         _d_res += _r_d0;
+// CHECK-NEXT:         int _t2 = clad::pop(_t1);
+// CHECK-NEXT:         (* _d_t).data[_t2] += _r_d0;
+// CHECK-NEXT:         _d_res -= _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+double sum(double *data) {
+    double res = 0;
+    for (int i=0; i<5; ++i)
+        res += data[i];
+    return res;
+}
+
+// CHECK: void sum_pullback(double *data, double _d_y, clad::array_ref<double> _d_data) {
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     unsigned long _t0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     clad::tape<int> _t1 = {};
+// CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     for (int i = 0; i < 5; ++i) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         res += data[clad::push(_t1, i)];
+// CHECK-NEXT:     }
+// CHECK-NEXT:     double sum_return = res;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += _d_y;
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         double _r_d0 = _d_res;
+// CHECK-NEXT:         _d_res += _r_d0;
+// CHECK-NEXT:         int _t2 = clad::pop(_t1);
+// CHECK-NEXT:         _d_data[_t2] += _r_d0;
+// CHECK-NEXT:         _d_res -= _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+double fn2(Tangent t, double i) {
+    double res = sum(t);
+    res += sum(t.data) + i + 2*t.data[0];
+    return res;
+}
+
+// CHECK: void fn2_grad(Tangent t, double i, clad::array_ref<Tangent> _d_t, clad::array_ref<double> _d_i) {
+// CHECK-NEXT:     Tangent _t0;
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     clad::array<double> _t1(5UL);
+// CHECK-NEXT:     double _t3;
+// CHECK-NEXT:     _t0 = t;
+// CHECK-NEXT:     double res = sum(t);
+// CHECK-NEXT:     _t1 = t.data;
+// CHECK-NEXT:     _t3 = t.data[0];
+// CHECK-NEXT:     res += sum(t.data) + i + 2 * _t3;
+// CHECK-NEXT:     double fn2_return = res;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d0 = _d_res;
+// CHECK-NEXT:         _d_res += _r_d0;
+// CHECK-NEXT:         clad::array_ref<double> _t2 = {(* _d_t).data, 5UL};
+// CHECK-NEXT:         sum_pullback(_t1, _r_d0, _t2);
+// CHECK-NEXT:         clad::array<double> _r1({(* _d_t).data, 5UL});
+// CHECK-NEXT:         * _d_i += _r_d0;
+// CHECK-NEXT:         double _r2 = _r_d0 * _t3;
+// CHECK-NEXT:         double _r3 = 2 * _r_d0;
+// CHECK-NEXT:         (* _d_t).data[0] += _r3;
+// CHECK-NEXT:         _d_res -= _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         sum_pullback(_t0, _d_res, &(* _d_t));
+// CHECK-NEXT:         Tangent _r0 = (* _d_t);
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+double fn3(double i, double j) {
+    Tangent t;
+    t.data[0] = 2*i;
+    t.data[1] = 5*i + 3*j;
+    return sum(t);
+}
+
+// CHECK: void fn3_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+// CHECK-NEXT:     Tangent _d_t({});
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     Tangent _t3;
+// CHECK-NEXT:     Tangent t;
+// CHECK-NEXT:     _t0 = i;
+// CHECK-NEXT:     t.data[0] = 2 * _t0;
+// CHECK-NEXT:     _t1 = i;
+// CHECK-NEXT:     _t2 = j;
+// CHECK-NEXT:     t.data[1] = 5 * _t1 + 3 * _t2;
+// CHECK-NEXT:     _t3 = t;
+// CHECK-NEXT:     double fn3_return = sum(t);
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         sum_pullback(_t3, 1, &_d_t);
+// CHECK-NEXT:         Tangent _r6 = _d_t;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d1 = _d_t.data[1];
+// CHECK-NEXT:         double _r2 = _r_d1 * _t1;
+// CHECK-NEXT:         double _r3 = 5 * _r_d1;
+// CHECK-NEXT:         * _d_i += _r3;
+// CHECK-NEXT:         double _r4 = _r_d1 * _t2;
+// CHECK-NEXT:         double _r5 = 3 * _r_d1;
+// CHECK-NEXT:         * _d_j += _r5;
+// CHECK-NEXT:         _d_t.data[1] -= _r_d1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d0 = _d_t.data[0];
+// CHECK-NEXT:         double _r0 = _r_d0 * _t0;
+// CHECK-NEXT:         double _r1 = 2 * _r_d0;
+// CHECK-NEXT:         * _d_i += _r1;
+// CHECK-NEXT:         _d_t.data[0] -= _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+double fn4(double i, double j) {
+    pairdd p(1, 3);
+    pairdd q({7, 5});
+    return p.first*i + p.second*j + q.first*i + q.second*j;
+}
+
+// CHECK: void fn4_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+// CHECK-NEXT:     pairdd _d_p({});
+// CHECK-NEXT:     pairdd _d_q({});
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     double _t3;
+// CHECK-NEXT:     double _t4;
+// CHECK-NEXT:     double _t5;
+// CHECK-NEXT:     double _t6;
+// CHECK-NEXT:     double _t7;
+// CHECK-NEXT:     pairdd p(1, 3);
+// CHECK-NEXT:     pairdd q({7, 5});
+// CHECK-NEXT:     _t1 = p.first;
+// CHECK-NEXT:     _t0 = i;
+// CHECK-NEXT:     _t3 = p.second;
+// CHECK-NEXT:     _t2 = j;
+// CHECK-NEXT:     _t5 = q.first;
+// CHECK-NEXT:     _t4 = i;
+// CHECK-NEXT:     _t7 = q.second;
+// CHECK-NEXT:     _t6 = j;
+// CHECK-NEXT:     double fn4_return = _t1 * _t0 + _t3 * _t2 + _t5 * _t4 + _t7 * _t6;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 1 * _t0;
+// CHECK-NEXT:         _d_p.first += _r0;
+// CHECK-NEXT:         double _r1 = _t1 * 1;
+// CHECK-NEXT:         * _d_i += _r1;
+// CHECK-NEXT:         double _r2 = 1 * _t2;
+// CHECK-NEXT:         _d_p.second += _r2;
+// CHECK-NEXT:         double _r3 = _t3 * 1;
+// CHECK-NEXT:         * _d_j += _r3;
+// CHECK-NEXT:         double _r4 = 1 * _t4;
+// CHECK-NEXT:         _d_q.first += _r4;
+// CHECK-NEXT:         double _r5 = _t5 * 1;
+// CHECK-NEXT:         * _d_i += _r5;
+// CHECK-NEXT:         double _r6 = 1 * _t6;
+// CHECK-NEXT:         _d_q.second += _r6;
+// CHECK-NEXT:         double _r7 = _t7 * 1;
+// CHECK-NEXT:         * _d_j += _r7;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+namespace std {
+void print(const pairdd& p) { printf("%.2f, %.2f", p.first, p.second); }
+} // namespace std
+
+void print(const Tangent& t) {
+  for (int i = 0; i < 5; ++i) {
+    printf("%.2f", t.data[i]);
+    if (i != 4)
+      printf(", ");
+  }
+}
+
+int main() {
+    pairdd p(3, 5), d_p;
+    double i = 3, d_i, d_j;
+    Tangent t, d_t;
+
+    INIT_GRADIENT(fn1);
+    INIT_GRADIENT(fn2);
+    INIT_GRADIENT(fn3);
+    INIT_GRADIENT(fn4);
+
+    TEST_GRADIENT(fn1, /*numOfDerivativeArgs=*/2, p, i, &d_p, &d_i);    // CHECK-EXEC: {1.00, 2.00, 3.00}
+    TEST_GRADIENT(fn2, /*numOfDerivativeArgs=*/2, t, i, &d_t, &d_i);    // CHECK-EXEC: {4.00, 2.00, 2.00, 2.00, 2.00, 1.00}
+    TEST_GRADIENT(fn3, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);    // CHECK-EXEC: {7.00, 3.00}
+    TEST_GRADIENT(fn4, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);    // CHECK-EXEC: {8.00, 8.00}
+}

--- a/test/TestUtils.h
+++ b/test/TestUtils.h
@@ -1,0 +1,114 @@
+#ifndef TEST_TEST_UTILS_H
+#define TEST_TEST_UTILS_H
+#include "clad/Differentiator/ArrayRef.h"
+
+#include <cstdio>
+#include <type_traits>
+#include <utility>
+
+namespace test_utils {
+
+void print(const char* s) { printf("%s", s); }
+
+void print(double d) { printf("%.2f", d); }
+
+void print(int i) { printf("%d", i); }
+
+void print() {}
+
+template <typename T> void print(clad::array_ref<T> arr) {
+  for (std::size_t i = 0; i < arr.size(); ++i) {
+    print(arr[i]);
+    if (i != arr.size() - 1)
+      printf(", ");
+  }
+}
+
+template <typename Arg, typename... Args> void print(Arg* arg, Args... args);
+
+// Prints comma separated list of all the arguments values.
+template <typename Arg, typename... Args,
+          class = typename std::enable_if<!std::is_pointer<Arg>::value>::type>
+void print(Arg arg, Args... args) {
+  print(arg);
+  if (sizeof...(Args) > 0)
+    printf(", ");
+  print(args...);
+}
+
+template <typename Arg, typename... Args> void print(Arg* arg, Args... args) {
+  print(*arg);
+  if (sizeof...(Args) > 0)
+    printf(", ");
+  print(args...);
+}
+
+// Prints comma separated list of all the arguments values enclosed in curly
+// braces and terminated by a new line.
+template <typename... Args> void display(Args... args) {
+  printf("{");
+  print(args...);
+  printf("}\n");
+}
+
+template <std::size_t...> struct index_pack {};
+
+template <std::size_t l, std::size_t r, std::size_t... S>
+struct GenerateRange : GenerateRange<l + 1, r, S..., l> {};
+
+template <std::size_t l, std::size_t... S> struct GenerateRange<l, l, S...> {
+  using type = index_pack<S..., l>;
+};
+
+void reset() {}
+
+template <typename Arg,
+          class = typename std::enable_if<!std::is_pointer<Arg>::value>::type>
+void reset(Arg& arg) {
+  arg = Arg();
+}
+
+template <typename Arg> void reset(Arg* arg) { *arg = Arg(); }
+
+template <typename T> void reset(clad::array_ref<T> arr) {
+  for (std::size_t i = 0; i < arr.size(); ++i)
+    reset(arr[i]);
+}
+
+template <typename Arg, typename... Args> void reset(Arg& arg, Args&... args) {
+  reset(arg);
+  reset(args...);
+}
+
+template <class CF, std::size_t... S, class... Args>
+void run_gradient_impl(CF cf, index_pack<S...> s, Args&&... args) {
+  std::tuple<Args...> t = {args...};
+  reset(std::get<S>(t)...);
+  cf.execute(args...);
+  display(std::get<S>(t)...);
+}
+
+template <std::size_t NumOfDerivativeArgs, class CF, class... Args>
+void run_gradient(CF cf, Args&&... args) {
+  using DerivativeArgsRange =
+      typename GenerateRange<sizeof...(Args) - NumOfDerivativeArgs,
+                             sizeof...(Args) - 1>::type;
+  run_gradient_impl(cf, DerivativeArgsRange(), std::forward<Args>(args)...);
+}
+
+#define INIT_GRADIENT_ALL(fn) auto fn##_grad = clad::gradient(fn);
+
+#define INIT_GRADIENT_SPECIFIC(fn, args)                                       \
+  auto fn##_grad = clad::gradient(fn, args);
+
+#define GET_MACRO(_1, _2, MACRO, ...) MACRO
+
+#define INIT_GRADIENT(...)                                                     \
+  GET_MACRO(__VA_ARGS__, INIT_GRADIENT_SPECIFIC, INIT_GRADIENT_ALL)            \
+  (__VA_ARGS__)
+
+#define TEST_GRADIENT(fn, numOfDerivativeArgs, ...)                            \
+  test_utils::run_gradient<numOfDerivativeArgs>(fn##_grad, __VA_ARGS__);
+
+#endif
+}


### PR DESCRIPTION
This PR adds initial support for differentiating a scalar built-in numerical type with respect to user-defined types using the reverse-mode AD.

The reverse mode automatic differentiation allows to efficiently compute the derivative of a single output variable with respect to all the input variables. Mathematically, the reverse mode AD allows to efficiently compute rows of the Jacobian matrix. 

Clad requires the following assumptions to be true while differentiating with respect to class types in the reverse mode AD:

- Class should represent a real vector space.
- Class should have a default constructor that zero initialises all the data members of the class. That is, a newly default constructed class object should represent 0 tangent vector. 

Differentiation with respect to class types in the reverse mode AD currently has the following limitations:

- Calls to member functions are not supported
- Calls to overloaded operators are not supported
- Initialising class type variables using non-default constructors that take non-literal arguments (non-zero derivatives) are not supported.
- Class cannot have pointer or reference data members.

Most of these limitations will be removed soon.

## Overloaded derived function

This PR also modifies the overloaded derivative function mechanism as described in the issue #394 . Two most important changes are as follows:

- Overloaded derived function is now created for all the derived functions that are generated using the reverse mode AD.
  Earlier, we were not creating the overloaded derived function if gradient was requested with respect to all the original
  function parameters.

- Type of all the parameters derivatives is: `clad::array_ref<void>`. It gets converted to (by `static_cast`) 
  to correct type before being passed as an argument to the actual derived function call.


## Test Utilities

Apart from the class type support this PR also adds test utilities for writing gradient tests. 

Gradient test utility interface is as follows: 

Two overloads are provided for `INIT_GRADIENT` Macro -- initialise gradient function using `clad::gradient`
```
INIT_GRADIENT(fn);  // Initialises derived function that computes gradient with respect to all function parameters
INIT_GRADIENT(fn, args);  // Initialises derived function that computes gradient with respect to all elements described by 'args'
```

To perform a test on the initialised gradient functions, `TEST_GRADIENT` Macro is provided.

```cpp
std::pair<double, long double> p(3, 7), d_p;
Tangent t, d_t;
double d_i, d_j;
// Reset (to zero) all the derivative args, executes gradient function and then prints 
// all the derivatives separated by commas and enclosed within curly braces
TEST_GRADIENT(fn1, /*NumOfDerivativeArgs=*/4, 1.00, 2, p, t, &d_i, &d_j, &d_p, &d_t);
```

References #394 , #395 