### PR TITLE
Add support for differentiating calls to member functions in the reverse mode

### DIFF
--- a/include/clad/Differentiator/CladConfig.h
+++ b/include/clad/Differentiator/CladConfig.h
@@ -31,16 +31,16 @@ void trap(int code) {
 
 #ifdef  __CUDACC__
 template<typename T>
-__device__ T* addressof(T& r) {
+__device__ T* clad_addressof(T& r) {
   return __builtin_addressof(r);
 }
 template<typename T>
-__host__ T* addressof(T& r) {
+__host__ T* clad_addressof(T& r) {
   return std::addressof(r);
 }
 #else
 template<typename T>
-T* addressof(T& r) {
+T* clad_addressof(T& r) {
   return std::addressof(r);
 }
 #endif

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -148,6 +148,8 @@ namespace clad {
     clang::DeclarationNameInfo BuildDeclarationNameInfo(clang::Sema& S,
                                                         llvm::StringRef name);
 
+    /// Returns true if the function has any reference or pointer parameter;
+    /// otherwise returns false.
     bool HasAnyReferenceOrPointerArgument(const clang::FunctionDecl* FD);
 
     /// Returns true if `T` is a reference, pointer or array type.
@@ -196,8 +198,9 @@ namespace clad {
                      clang::TypeSourceInfo* TSI = nullptr);
 
     /// If `T` represents an array or a pointer type then returns the
-    /// corresponding array element or the pointee type. Otherwise, if `T` is
-    /// neither an array nor a pointer type, then simply returns `T`.
+    /// corresponding array element or the pointee type. If `T` is a reference
+    /// type then return the corresponding non-reference type. Otherwise, if `T`
+    /// is neither an array nor a pointer type, then simply returns `T`.
     clang::QualType GetValueType(clang::QualType T);
 
     /// Builds and returns the init expression to initialise `clad::array` and
@@ -207,6 +210,10 @@ namespace clad {
     /// `{arr, arrSize}`
     clang::Expr* BuildCladArrayInitByConstArray(clang::Sema& semaRef,
                                                 clang::Expr* constArrE);
+
+    /// Returns true if `FD` is a class static method; otherwise returns
+    /// false.
+    bool IsStaticMethod(const clang::FunctionDecl* FD);
   } // namespace utils
 }
 

--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -577,5 +577,22 @@ static inline Expr* GetSubExpr(const MaterializeTemporaryExpr* MTE) {
 #else
 #define CLAD_COMPAT_IS_LIST_INITIALIZATION_PARAM(E) , E->isListInitialization()
 #endif
+
+#if CLANG_VERSION_MAJOR < 9
+static inline QualType
+CXXMethodDecl_GetThisObjectType(Sema& semaRef, const CXXMethodDecl* MD) {
+  ASTContext& C = semaRef.getASTContext();
+  const CXXRecordDecl* RD = MD->getParent();
+  auto RDType = RD->getTypeForDecl();
+  auto thisObjectQType = C.getQualifiedType(
+      RDType, clad_compat::CXXMethodDecl_getMethodQualifiers(MD));
+  return thisObjectQType;
+}
+#else
+static inline QualType
+CXXMethodDecl_GetThisObjectType(Sema& semaRef, const CXXMethodDecl* MD) {
+  return MD->getThisObjectType();
+}
+#endif
 } // namespace clad_compat
 #endif //CLAD_COMPATIBILITY

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -103,7 +103,7 @@ namespace clad {
             typename std::enable_if<EnablePadding, bool>::type = true>
   CUDA_HOST_DEVICE return_type_t<F>
   execute_with_default_args(list<Rest...>, F f, Args&&... args) {
-    return f(static_cast<Args>(args)..., static_cast<Rest>(0)...);
+    return f(static_cast<Args>(args)..., static_cast<Rest>(nullptr)...);
   }
 
   template <bool EnablePadding, class... Rest, class F, class... Args,
@@ -122,7 +122,7 @@ namespace clad {
                                                   Args&&... args)
       -> return_type_t<decltype(f)> {
     return (static_cast<Obj>(obj).*f)(static_cast<Args>(args)...,
-                                      static_cast<Rest>(0)...);
+                                      static_cast<Rest>(nullptr)...);
   }
 
   template <bool EnablePadding, class... Rest, class ReturnType, class C,

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -399,8 +399,9 @@ namespace clad {
 #define GradientDerivedFnTraits_AddSPECS(var, cv, vol, ref, noex)              \
   template <typename R, typename C, typename... Args>                          \
   struct GradientDerivedFnTraits<R (C::*)(Args...) cv vol ref noex> {          \
-    using type = void (C::*)(Args...,                                          \
-                             OutputParamType_t<Args, void>...) cv vol ref noex;   \
+    using type =                                                               \
+        void (C::*)(Args..., OutputParamType_t<C, void>,                       \
+                    OutputParamType_t<Args, void>...) cv vol ref noex;         \
   };
 
 #if __cpp_noexcept_function_type > 0

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -62,6 +62,11 @@ namespace clad {
     unsigned outputArrayCursor = 0;
     unsigned numParams = 0;
     bool isVectorValued = false;
+    /// Stores derivative expression of the implicit `this` pointer.
+    ///
+    /// \note `this` pointer derivative expression is always of the class object
+    /// type rather than the pointer type.
+    clang::Expr* m_ThisExprDerivative = nullptr;
     // FIXME: Should we make this an object instead of a pointer?
     // Downside of making it an object: We will need to include
     // 'MultiplexExternalRMVSource.h' file

--- a/include/clad/Differentiator/Tape.h
+++ b/include/clad/Differentiator/Tape.h
@@ -110,7 +110,7 @@ namespace clad {
       // allocation properly.
       for (; first != last; ++first, (void)++current) {
         ::new (const_cast<void*>(
-            static_cast<const volatile void*>(addressof(*current))))
+            static_cast<const volatile void*>(clad_addressof(*current))))
           T(std::move(*first));
       }
     }

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -403,9 +403,9 @@ namespace clad {
     /// \returns Built member function call expression
     ///  Base.MemberFunction(ArgExprs) or Base->MemberFunction(ArgExprs)
     clang::Expr*
-    BuildCallExprToMemFn(clang::Expr* Base, bool isArrow,
-                         llvm::StringRef MemberFunctionName,
-                         llvm::MutableArrayRef<clang::Expr*> ArgExprs);
+    BuildCallExprToMemFn(clang::Expr* Base, llvm::StringRef MemberFunctionName,
+                         llvm::MutableArrayRef<clang::Expr*> ArgExprs,
+                         clang::ValueDecl* memberDecl = nullptr);
 
     /// Build a call to member function through this pointer.
     ///

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -98,13 +98,15 @@ namespace clad {
   FunctionDecl* ReverseModeVisitor::CreateGradientOverload() {
     auto gradientParams = m_Derivative->parameters();
     auto gradientNameInfo = m_Derivative->getNameInfo();
+    bool isStaticMethod = utils::IsStaticMethod(m_Function);
     // Calculate the total number of parameters that would be required for
     // automatic differentiation in the derived function if all args are
     // requested.
     // FIXME: Here we are assuming all function parameters are of differentiable
     // type. Ideally, we should not make any such assumption.
     std::size_t totalDerivedParamsSize = m_Function->getNumParams() * 2;
-
+    std::size_t numOfDerivativeParams =
+        m_Function->getNumParams() + !isStaticMethod;
     // All output parameters will be of type `clad::array_ref<void>`. These
     // parameters will be casted to correct type before the call to the actual
     // derived function.
@@ -121,7 +123,7 @@ namespace clad {
     // Add types for representing parameter derivatives.
     // FIXME: We are assuming all function parameters are differentiable. We
     // should not make any such assumptions.
-    for (std::size_t i = 0; i < m_Function->getNumParams(); ++i)
+    for (std::size_t i = 0; i < numOfDerivativeParams; ++i)
       paramTypes.push_back(outputParamType);
 
     auto gradFuncOverloadEPI =
@@ -157,7 +159,7 @@ namespace clad {
       callArgs.push_back(BuildDeclRef(VD));
     }
 
-    for (std::size_t i = 0; i < m_Function->getNumParams(); ++i) {
+    for (std::size_t i = 0; i < numOfDerivativeParams; ++i) {
       IdentifierInfo* II = nullptr;
       StorageClass SC = StorageClass::SC_None;
       std::size_t effectiveGradientIndex = m_Function->getNumParams() + i;
@@ -464,8 +466,11 @@ namespace clad {
     DiffParams args{};
     std::copy(FD->param_begin(), FD->param_end(), std::back_inserter(args));
 
-    assert(!args.empty() && "Cannot generate pullback function of a function "
-                            "with no differentiable arguments");
+    bool isStaticMethod = utils::IsStaticMethod(FD);
+
+    assert((!args.empty() || !isStaticMethod) &&
+           "Cannot generate pullback function of a function "
+           "with no differentiable arguments");
 
     auto derivativeName = request.BaseFunctionName + "_pullback";
     auto DNI = utils::BuildDeclarationNameInfo(m_Sema, derivativeName);
@@ -1127,9 +1132,10 @@ namespace clad {
     }
 
     auto NArgs = FD->getNumParams();
-    // If the function has no args then we assume that it is not related
-    // to independent variables and does not contribute to gradient.
-    if (!NArgs)
+    // If the function has no args and is not a member function call then we
+    // assume that it is not related to independent variables and does not
+    // contribute to gradient.
+    if (!NArgs && !isa<CXXMemberCallExpr>(CE))
       return StmtDiff(Clone(CE));
 
     // Stores the call arguments for the function to be derived
@@ -1146,8 +1152,10 @@ namespace clad {
     // f(x = y))
     // If the callee function takes arguments by reference then it can affect
     // derivatives even if there is no `dfdx()` and thus we should call the
-    // derived function.
-    if (!dfdx() && !utils::HasAnyReferenceOrPointerArgument(FD)) {
+    // derived function. In the case of member functions, `implicit`
+    // this object is always passed by reference.
+    if (!dfdx() && !utils::HasAnyReferenceOrPointerArgument(FD) &&
+        !isa<CXXMemberCallExpr>(CE)) {
       for (const Expr* Arg : CE->arguments()) {
         StmtDiff ArgDiff = Visit(Arg, dfdx());
         CallArgs.push_back(ArgDiff.getExpr());
@@ -1339,7 +1347,8 @@ namespace clad {
     // function).
     bool asGrad = true;
 
-    if (NArgs == 1 && !utils::HasAnyReferenceOrPointerArgument(FD)) {
+    if (NArgs == 1 && !utils::HasAnyReferenceOrPointerArgument(FD) &&
+        !isa<CXXMethodDecl>(FD)) {
       IdentifierInfo* II =
           &m_Context.Idents.get(FD->getNameAsString() + "_pushforward");
       // Try to find it in builtin derivatives
@@ -1365,6 +1374,8 @@ namespace clad {
     // corresponding grad variable expression (_grad0).
     llvm::SmallVector<std::pair<VarDecl*, Expr*>, 4> argResultsAndGrads;
 
+    // Stores differentiation result of implicit `this` object, if any.
+    StmtDiff baseDiff;
     // If it has more args or f_darg0 was not found, we look for its pullback
     // function.
     if (!OverloadedDerivedFn) {
@@ -1383,6 +1394,30 @@ namespace clad {
         requiredValueType = m_Context.DoubleTy;
         ArrayDiffArgType = GetCladArrayOfType(requiredValueType);
       }
+      /// Add base derivative expression in the derived call output args list if
+      /// `CE` is a call to an instance member function.
+      if (auto MCE = dyn_cast<CXXMemberCallExpr>(CE)) {
+        baseDiff = Visit(MCE->getImplicitObjectArgument());
+        StmtDiff baseDiffStore = GlobalStoreAndRef(baseDiff.getExpr());
+        if (isInsideLoop) {
+          addToCurrentBlock(baseDiffStore.getExpr());
+          VarDecl* baseLocalVD = BuildVarDecl(
+              baseDiffStore.getExpr_dx()->getType(),
+              CreateUniqueIdentifier("_r"), baseDiffStore.getExpr_dx(),
+              /*DirectInit=*/false, /*TSI=*/nullptr,
+              VarDecl::InitializationStyle::CInit);
+          auto& block = getCurrentBlock(direction::reverse);
+          block.insert(block.begin() + insertionPoint,
+                       BuildDeclStmt(baseLocalVD));
+          insertionPoint += 1;
+          Expr* baseLocalE = BuildDeclRef(baseLocalVD);
+          baseDiffStore = {baseDiffStore.getExpr(), baseLocalE};
+        }
+        baseDiff = {baseDiffStore.getExpr_dx(), baseDiff.getExpr_dx()};
+        DerivedCallOutputArgs.push_back(
+            BuildOp(UnaryOperatorKind::UO_AddrOf, baseDiff.getExpr_dx()));
+      }
+
       for (auto argDerivative : CallArgDx) {
         gradVarDecl = nullptr;
         gradVarExpr = nullptr;
@@ -1543,7 +1578,8 @@ namespace clad {
         // FIXME: Add support for reference arguments to the numerical diff. If
         // it already correctly support reference arguments then confirm the
         // support and add tests for the same.
-        if (!pullbackFD && !utils::HasAnyReferenceOrPointerArgument(FD)) {
+        if (!pullbackFD && !utils::HasAnyReferenceOrPointerArgument(FD) &&
+            !isa<CXXMethodDecl>(FD)) {
           // Try numerically deriving it.
           // Build a clone call expression so that we can correctly
           // scope the function to be differentiated.
@@ -1579,11 +1615,17 @@ namespace clad {
             usingNumericalDiff = true;
           }
         } else if (pullbackFD) {
-          OverloadedDerivedFn =
-              m_Sema
-                  .ActOnCallExpr(getCurrentScope(), BuildDeclRef(pullbackFD),
-                                 noLoc, pullbackCallArgs, noLoc)
-                  .get();
+          if (auto MCE = dyn_cast<CXXMemberCallExpr>(CE)) {
+            Expr* baseE = baseDiff.getExpr();
+            OverloadedDerivedFn = BuildCallExprToMemFn(
+                baseE, pullbackFD->getName(), pullbackCallArgs, pullbackFD);
+          } else {
+            OverloadedDerivedFn =
+                m_Sema
+                    .ActOnCallExpr(getCurrentScope(), BuildDeclRef(pullbackFD),
+                                   noLoc, pullbackCallArgs, noLoc)
+                    .get();
+          }
         }
       }
     }
@@ -1684,6 +1726,16 @@ namespace clad {
         m_ExternalSource->ActBeforeFinalisingPostIncDecOp(diff);
     } else if (opCode == UO_PreInc || opCode == UO_PreDec) {
       diff = Visit(UnOp->getSubExpr(), dfdx());
+    } else if (opCode == UnaryOperatorKind::UO_Real ||
+               opCode == UnaryOperatorKind::UO_Imag) {
+      diff = VisitWithExplicitNoDfDx(UnOp->getSubExpr());
+      ResultRef = BuildOp(opCode, diff.getExpr_dx());
+      /// Create and add `__real r += dfdx()` expression.
+      if (dfdx()) {
+        Expr* add_assign = BuildOp(BO_AddAssign, ResultRef, dfdx());
+        // Add it to the body statements.
+        addToCurrentBlock(add_assign, direction::reverse);
+      }
     } else {
       // We should not output any warning on visiting boolean conditions
       // FIXME: We should support boolean differentiation or ignore it
@@ -2714,7 +2766,7 @@ namespace clad {
 
   StmtDiff ReverseModeVisitor::VisitCXXThisExpr(const CXXThisExpr* CTE) {
     Expr* clonedCTE = Clone(CTE);
-    return {clonedCTE, nullptr};
+    return {clonedCTE, m_ThisExprDerivative};
   }
 
   StmtDiff
@@ -2800,7 +2852,17 @@ namespace clad {
         else
           paramTypes.push_back(m_Function->getReturnType());
       }
-  
+
+      if (auto MD = dyn_cast<CXXMethodDecl>(m_Function)) {
+        const CXXRecordDecl* RD = MD->getParent();
+        if (MD->isInstance() && !RD->isLambda()) {
+          QualType thisType =
+              clad_compat::CXXMethodDecl_getThisType(m_Sema, MD);
+          paramTypes.push_back(
+              GetParameterDerivativeType(effectiveReturnType, thisType));
+        }
+      }
+
       for (auto PVD : m_Function->parameters()) {
         auto it = std::find(std::begin(diffParams), std::end(diffParams), PVD);
         if (it != std::end(diffParams))
@@ -2826,6 +2888,20 @@ namespace clad {
     if (m_Mode == DiffMode::experimental_pullback &&
         !m_Function->getReturnType()->isVoidType()) {
       ++dParamTypesIdx;
+    }
+
+    if (auto MD = dyn_cast<CXXMethodDecl>(m_Function)) {
+      const CXXRecordDecl* RD = MD->getParent();
+      if (!isVectorValued && MD->isInstance() && !RD->isLambda()) {
+        auto thisDerivativePVD = utils::BuildParmVarDecl(
+            m_Sema, m_Derivative, CreateUniqueIdentifier("_d_this"),
+            derivativeFnType->getParamType(dParamTypesIdx));
+        paramDerivatives.push_back(thisDerivativePVD);
+        Expr* deref = BuildOp(UnaryOperatorKind::UO_Deref,
+                              BuildDeclRef(thisDerivativePVD));
+        m_ThisExprDerivative = utils::BuildParenExpr(m_Sema, deref);
+        ++dParamTypesIdx;
+      }
     }
 
     for (auto PVD : m_Function->parameters()) {

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -6,15 +6,13 @@
 
 struct Experiment {
   mutable double x, y;
-  Experiment(double p_x, double p_y) : x(p_x), y(p_y) {}
-  double operator()(double i, double j) {
-    return x*i*j;
-  }
-  void setX(double val) {
-    x = val;
-  }
+  Experiment(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
+  double operator()(double i, double j) { return x * i * j; }
+  void setX(double val) { x = val; }
 
-  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+  Experiment& operator=(const Experiment& E) = default;
+
+  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<Experiment> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -29,6 +27,7 @@ struct Experiment {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
+  // CHECK-NEXT:         (* _d_this).x += _r1;
   // CHECK-NEXT:         double _r2 = _t2 * _r0;
   // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
@@ -39,15 +38,13 @@ struct Experiment {
 
 struct ExperimentConst {
   mutable double x, y;
-  ExperimentConst(double p_x, double p_y) : x(p_x), y(p_y) {}
-  double operator()(double i, double j) const {
-    return x*i*j;
-  }
-  void setX(double val) const {
-    x = val;
-  }
+  ExperimentConst(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
+  double operator()(double i, double j) const { return x * i * j; }
+  void setX(double val) const { x = val; }
 
-  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
+  ExperimentConst& operator=(const ExperimentConst& E) = default;
+
+  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<ExperimentConst> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -62,6 +59,7 @@ struct ExperimentConst {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
+  // CHECK-NEXT:         (* _d_this).x += _r1;
   // CHECK-NEXT:         double _r2 = _t2 * _r0;
   // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
@@ -72,15 +70,18 @@ struct ExperimentConst {
 
 struct ExperimentVolatile {
   mutable double x, y;
-  ExperimentVolatile(double p_x, double p_y) : x(p_x), y(p_y) {}
-  double operator()(double i, double j) volatile {
-    return x*i*j;
-  }
-  void setX(double val) volatile {
-    x = val;
-  }
+  ExperimentVolatile(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
+  double operator()(double i, double j) volatile { return x * i * j; }
+  void setX(double val) volatile { x = val; }
 
-  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile {
+  volatile ExperimentVolatile&
+  operator=(volatile ExperimentVolatile&& E) volatile {
+    x = E.x;
+    y = E.y;
+    return (*this);
+  };
+
+  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<volatile ExperimentVolatile> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     volatile double _t2;
@@ -95,6 +96,7 @@ struct ExperimentVolatile {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
+  // CHECK-NEXT:         (* _d_this).x += _r1;
   // CHECK-NEXT:         double _r2 = _t2 * _r0;
   // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
@@ -105,15 +107,18 @@ struct ExperimentVolatile {
 
 struct ExperimentConstVolatile {
   mutable double x, y;
-  ExperimentConstVolatile(double p_x, double p_y) : x(p_x), y(p_y) {}
-  double operator()(double i, double j) const volatile {
-    return x*i*j;
-  }
-  void setX(double val) const volatile {
-    x = val;
-  }
+  ExperimentConstVolatile(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
+  double operator()(double i, double j) const volatile { return x * i * j; }
+  void setX(double val) const volatile { x = val; }
 
-  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
+  const volatile ExperimentConstVolatile&
+  operator=(const volatile ExperimentConstVolatile& E) const volatile {
+    x = E.x;
+    y = E.y;
+    return (*this);
+  };
+
+  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<volatile ExperimentConstVolatile> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     volatile double _t2;
@@ -128,6 +133,7 @@ struct ExperimentConstVolatile {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
+  // CHECK-NEXT:         (* _d_this).x += _r1;
   // CHECK-NEXT:         double _r2 = _t2 * _r0;
   // CHECK-NEXT:         * _d_i += _r2;
   // CHECK-NEXT:         double _r3 = _t3 * 1;
@@ -137,66 +143,73 @@ struct ExperimentConstVolatile {
 };
 
 namespace outer {
-  namespace inner {
-    struct ExperimentNNS {
-      mutable double x, y;
-      ExperimentNNS(double p_x, double p_y) : x(p_x), y(p_y) {}
-      double operator()(double i, double j) {
-        return x*i*j;
-      }
-      void setX(double val) {
-        x = val;
-      }
+namespace inner {
+struct ExperimentNNS {
+  mutable double x, y;
+  ExperimentNNS(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
+  double operator()(double i, double j) { return x * i * j; }
+  void setX(double val) { x = val; }
 
-      // CHECK: void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
-      // CHECK-NEXT:     double _t0;
-      // CHECK-NEXT:     double _t1;
-      // CHECK-NEXT:     double _t2;
-      // CHECK-NEXT:     double _t3;
-      // CHECK-NEXT:     _t2 = this->x;
-      // CHECK-NEXT:     _t1 = i;
-      // CHECK-NEXT:     _t3 = _t2 * _t1;
-      // CHECK-NEXT:     _t0 = j;
-      // CHECK-NEXT:     double operator_call_return = _t3 * _t0;
-      // CHECK-NEXT:     goto _label0;
-      // CHECK-NEXT:   _label0:
-      // CHECK-NEXT:     {
-      // CHECK-NEXT:         double _r0 = 1 * _t0;
-      // CHECK-NEXT:         double _r1 = _r0 * _t1;
-      // CHECK-NEXT:         double _r2 = _t2 * _r0;
-      // CHECK-NEXT:         * _d_i += _r2;
-      // CHECK-NEXT:         double _r3 = _t3 * 1;
-      // CHECK-NEXT:         * _d_j += _r3;
-      // CHECK-NEXT:     }
-      // CHECK-NEXT: }
-    };
-  }
-}
+  ExperimentNNS& operator=(const ExperimentNNS& E) = default;
 
-#define INIT(E)\
-auto d_##E = clad::gradient(&E);\
-auto d_##E##Ref = clad::gradient(E);
+  // CHECK: void operator_call_grad(double i, double j, clad::array_ref<ExperimentNNS> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     double _t2;
+  // CHECK-NEXT:     double _t3;
+  // CHECK-NEXT:     _t2 = this->x;
+  // CHECK-NEXT:     _t1 = i;
+  // CHECK-NEXT:     _t3 = _t2 * _t1;
+  // CHECK-NEXT:     _t0 = j;
+  // CHECK-NEXT:     double operator_call_return = _t3 * _t0;
+  // CHECK-NEXT:     goto _label0;
+  // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         double _r1 = _r0 * _t1;
+  // CHECK-NEXT:         (* _d_this).x += _r1;
+  // CHECK-NEXT:         double _r2 = _t2 * _r0;
+  // CHECK-NEXT:         * _d_i += _r2;
+  // CHECK-NEXT:         double _r3 = _t3 * 1;
+  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+};
+} // namespace inner
+} // namespace outer
 
-#define TEST(E)\
-res[0] = res[1] = 0;\
-d_##E.execute(7, 9, &res[0], &res[1]);\
-printf("%.2f %.2f\n", res[0], res[1]);\
-res[0] = res[1] = 0;\
-d_##E##Ref.execute(7, 9, &res[0], &res[1]);\
-printf("%.2f %.2f\n", res[0], res[1]);
+#define INIT(E)                                                                \
+  auto E##_grad = clad::gradient(&E);                                          \
+  auto E##Ref_grad = clad::gradient(E);
+
+#define TEST(E, d_E)                                                           \
+  res[0] = res[1] = 0;                                                         \
+  d_E = decltype(d_E)();                                                       \
+  E##_grad.execute(7, 9, &d_E, &res[0], &res[1]);                              \
+  printf("%.2f %.2f\n", res[0], res[1]);                                       \
+  res[0] = res[1] = 0;                                                         \
+  d_E = decltype(d_E)();                                                       \
+  E##Ref_grad.execute(7, 9, &d_E, &res[0], &res[1]);                           \
+  printf("%.2f %.2f\n", res[0], res[1]);
+
+#define TEST_LAMBDA(E)                                                         \
+  res[0] = res[1] = 0;                                                         \
+  E##_grad.execute(7, 9, &res[0], &res[1]);                                    \
+  printf("%.2f %.2f\n", res[0], res[1]);                                       \
+  res[0] = res[1] = 0;                                                         \
+  E##Ref_grad.execute(7, 9, &res[0], &res[1]);                                 \
+  printf("%.2f %.2f\n", res[0], res[1]);
 
 double x = 3;
 
 int main() {
-  Experiment E(3, 5);
+  Experiment E(3, 5), d_E, d_E_Const;
   const ExperimentConst E_Const(3, 5);
-  volatile ExperimentVolatile E_Volatile(3, 5);
+  volatile ExperimentVolatile E_Volatile(3, 5), d_E_Volatile, d_E_ConstVolatile;
   const volatile ExperimentConstVolatile E_ConstVolatile(3, 5);
-  outer::inner::ExperimentNNS E_NNS(3, 5);
+  outer::inner::ExperimentNNS E_NNS(3, 5), d_E_NNS;
 
-  auto lambda = [](double i, double j) {
-    return i*i*j;
-  };
+  auto lambda = [](double i, double j) { return i * i * j; };
 
   // CHECK: inline void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     double _t0;
@@ -221,9 +234,7 @@ int main() {
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
-  auto lambdaWithCapture = [&](double ii, double j) {
-    return x*ii*j;
-  };
+  auto lambdaWithCapture = [&](double ii, double j) { return x * ii * j; };
 
   // CHECK: inline void operator_call_grad(double ii, double j, clad::array_ref<double> _d_ii, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     double _t0;
@@ -257,22 +268,22 @@ int main() {
   INIT(lambda);
   INIT(lambdaWithCapture);
 
-  TEST(E);                    // CHECK-EXEC: 27.00 21.00
-                              // CHECK-EXEC: 27.00 21.00
-  TEST(E_Const);              // CHECK-EXEC: 27.00 21.00
-                              // CHECK-EXEC: 27.00 21.00
-  TEST(E_Volatile);           // CHECK-EXEC: 27.00 21.00
-                              // CHECK-EXEC: 27.00 21.00
-  TEST(E_ConstVolatile);      // CHECK-EXEC: 27.00 21.00
-                              // CHECK-EXEC: 27.00 21.00
+  TEST(E, d_E);                               // CHECK-EXEC: 27.00 21.00
+                                              // CHECK-EXEC: 27.00 21.00
+  TEST(E_Const, d_E_Const);                   // CHECK-EXEC: 27.00 21.00
+                                              // CHECK-EXEC: 27.00 21.00
+  TEST(E_Volatile, d_E_Volatile);             // CHECK-EXEC: 27.00 21.00
+                                              // CHECK-EXEC: 27.00 21.00
+  TEST(E_ConstVolatile, d_E_ConstVolatile);   // CHECK-EXEC: 27.00 21.00
+                                              // CHECK-EXEC: 27.00 21.00
 
-  TEST(E_NNS);                // CHECK-EXEC: 27.00 21.00
-                              // CHECK-EXEC: 27.00 21.00
-  TEST(lambda);               // CHECK-EXEC: 126.00 49.00
-                              // CHECK-EXEC: 126.00 49.00
+  TEST(E_NNS, d_E_NNS);                       // CHECK-EXEC: 27.00 21.00
+                                              // CHECK-EXEC: 27.00 21.00
+  TEST_LAMBDA(lambda);                        // CHECK-EXEC: 126.00 49.00
+                                              // CHECK-EXEC: 126.00 49.00
 
-  TEST(lambdaWithCapture);    // CHECK-EXEC: 27.00 21.00
-                              // CHECK-EXEC: 27.00 21.00
+  TEST_LAMBDA(lambdaWithCapture);             // CHECK-EXEC: 27.00 21.00
+                                              // CHECK-EXEC: 27.00 21.00
 
   E.setX(6);
   E_Const.setX(6);
@@ -281,17 +292,17 @@ int main() {
   E_NNS.setX(6);
   x = 6;
 
-  TEST(E);                  // CHECK-EXEC: 54.00 42.00
-                            // CHECK-EXEC: 54.00 42.00
-  TEST(E_Const);            // CHECK-EXEC: 54.00 42.00
-                            // CHECK-EXEC: 54.00 42.00
-  TEST(E_Volatile);         // CHECK-EXEC: 54.00 42.00
-                            // CHECK-EXEC: 54.00 42.00
-  TEST(E_ConstVolatile);    // CHECK-EXEC: 54.00 42.00
-                            // CHECK-EXEC: 54.00 42.00
+  TEST(E, d_E);                               // CHECK-EXEC: 54.00 42.00
+                                              // CHECK-EXEC: 54.00 42.00
+  TEST(E_Const, d_E_Const);                   // CHECK-EXEC: 54.00 42.00
+                                              // CHECK-EXEC: 54.00 42.00
+  TEST(E_Volatile, d_E_Volatile);             // CHECK-EXEC: 54.00 42.00
+                                              // CHECK-EXEC: 54.00 42.00
+  TEST(E_ConstVolatile, d_E_ConstVolatile);   // CHECK-EXEC: 54.00 42.00
+                                              // CHECK-EXEC: 54.00 42.00
 
-  TEST(E_NNS);              // CHECK-EXEC: 54.00 42.00
-                            // CHECK-EXEC: 54.00 42.00
-  TEST(lambdaWithCapture);  // CHECK-EXEC: 54.00 42.00
-                            // CHECK-EXEC: 54.00 42.00
+  TEST(E_NNS, d_E_NNS);                       // CHECK-EXEC: 54.00 42.00
+                                              // CHECK-EXEC: 54.00 42.00
+  TEST_LAMBDA(lambdaWithCapture);             // CHECK-EXEC: 54.00 42.00
+                                              // CHECK-EXEC: 54.00 42.00
 }

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -446,7 +446,7 @@ struct S {
     return c1 * x + c2 * y;
   }
 
-  //CHECK:   void f_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
+  //CHECK:   void f_grad(double x, double y, clad::array_ref<S> _d_this, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
   //CHECK-NEXT:       double _t0;
   //CHECK-NEXT:       double _t1;
   //CHECK-NEXT:       double _t2;
@@ -460,9 +460,11 @@ struct S {
   //CHECK-NEXT:     _label0:
   //CHECK-NEXT:       {
   //CHECK-NEXT:           double _r0 = 1 * _t0;
+  //CHECK-NEXT:           (* _d_this).c1 += _r0;
   //CHECK-NEXT:           double _r1 = _t1 * 1;
   //CHECK-NEXT:           * _d_x += _r1;
   //CHECK-NEXT:           double _r2 = 1 * _t2;
+  //CHECK-NEXT:           (* _d_this).c2 += _r2;
   //CHECK-NEXT:           double _r3 = _t3 * 1;
   //CHECK-NEXT:           * _d_y += _r3;
   //CHECK-NEXT:       }

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -14,7 +14,7 @@ public:
   double x, y;
   double mem_fn(double i, double j) { return (x + y) * i + i * j; }
 
-  // CHECK: void mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+  // CHECK: void mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -28,6 +28,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -39,7 +41,7 @@ public:
 
   double const_mem_fn(double i, double j) const { return (x + y) * i + i * j; }
 
-  // CHECK: void const_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
+  // CHECK: void const_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -53,6 +55,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -66,7 +70,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile {
+  // CHECK: void volatile_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -80,6 +84,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -93,7 +99,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
+  // CHECK: void const_volatile_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -107,6 +113,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -118,7 +126,7 @@ public:
 
   double lval_ref_mem_fn(double i, double j) & { return (x + y) * i + i * j; }
 
-  // CHECK: void lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) & {
+  // CHECK: void lval_ref_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) & {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -132,6 +140,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -145,7 +155,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const & {
+  // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const & {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -159,6 +169,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -172,7 +184,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile & {
+  // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile & {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -186,6 +198,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -199,7 +213,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile & {
+  // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile & {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -211,8 +225,10 @@ public:
   // CHECK-NEXT:     double const_volatile_lval_ref_mem_fn_return = _t1 * _t0 + _t3 * _t2;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:      {
+  // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -224,7 +240,7 @@ public:
 
   double rval_ref_mem_fn(double i, double j) && { return (x + y) * i + i * j; }
 
-  // CHECK: void rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) && {
+  // CHECK: void rval_ref_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) && {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -238,6 +254,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -251,7 +269,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const && {
+  // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const && {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -265,6 +283,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -278,7 +298,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile && {
+  // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile && {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -292,6 +312,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -305,7 +327,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile && {
+  // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile && {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -319,6 +341,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -326,13 +350,13 @@ public:
   // CHECK-NEXT:         double _r3 = _t3 * 1;
   // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
-  // CHECK-NEXT:  }
+  // CHECK-NEXT: }
 
   double noexcept_mem_fn(double i, double j) noexcept { 
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) noexcept {
+  // CHECK: void noexcept_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -346,6 +370,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -359,7 +385,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const noexcept {
+  // CHECK: void const_noexcept_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -373,6 +399,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -386,7 +414,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile noexcept {
+  // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -400,6 +428,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -413,7 +443,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile noexcept {
+  // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -425,8 +455,10 @@ public:
   // CHECK-NEXT:     double const_volatile_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:      {
+  // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -440,7 +472,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) & noexcept {
+  // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) & noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -454,6 +486,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -467,7 +501,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const & noexcept {
+  // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const & noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -481,6 +515,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -494,7 +530,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile & noexcept {
+  // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile & noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -508,6 +544,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -521,7 +559,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile & noexcept {
+  // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile & noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -535,6 +573,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -548,7 +588,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) && noexcept {
+  // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) && noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -557,12 +597,13 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     double
-  // rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
+  // CHECK-NEXT:     double rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -576,7 +617,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const && noexcept {
+  // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const && noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -588,8 +629,10 @@ public:
   // CHECK-NEXT:     double const_rval_ref_noexcept_mem_fn_return = _t1 * _t0 + _t3 * _t2;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
-  // CHECK-NEXT:      {
+  // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -597,13 +640,13 @@ public:
   // CHECK-NEXT:         double _r3 = _t3 * 1;
   // CHECK-NEXT:         * _d_j += _r3;
   // CHECK-NEXT:     }
-  // CHECK-NEXT:  }
+  // CHECK-NEXT: }
 
   double volatile_rval_ref_noexcept_mem_fn(double i, double j) volatile && noexcept { 
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile && noexcept {
+  // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile && noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -617,6 +660,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -630,7 +675,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile && noexcept {
+  // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile && noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
   // CHECK-NEXT:     double _t2;
@@ -644,6 +689,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -655,7 +702,7 @@ public:
 
   double partial_mem_fn(double i, double j) { return (x + y) * i + i * j; }
 
-  // CHECK: void partial_mem_fn_grad_0(double i, double j, clad::array_ref<double> _d_i) {
+  // CHECK: void partial_mem_fn_grad_0(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i) {
   // CHECK-NEXT:     double _d_j = 0;
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     double _t1;
@@ -670,6 +717,8 @@ public:
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
+  // CHECK-NEXT:         (* _d_this).x += _r0;
+  // CHECK-NEXT:         (* _d_this).y += _r0;
   // CHECK-NEXT:         double _r1 = _t1 * 1;
   // CHECK-NEXT:         * _d_i += _r1;
   // CHECK-NEXT:         double _r2 = 1 * _t2;
@@ -769,7 +818,7 @@ int main() {
   
   auto d_const_volatile_lval_ref_mem_fn_i = clad::gradient(&SimpleFunctions::const_volatile_lval_ref_mem_fn, "i");
 
-  // CHECK:   void const_volatile_lval_ref_mem_fn_grad_0(double i, double j, clad::array_ref<double> _d_i) const volatile & {
+  // CHECK:   void const_volatile_lval_ref_mem_fn_grad_0(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i) const volatile & {
   // CHECK-NEXT:       double _d_j = 0;
   // CHECK-NEXT:       double _t0;
   // CHECK-NEXT:       double _t1;
@@ -784,6 +833,8 @@ int main() {
   // CHECK-NEXT:     _label0:
   // CHECK-NEXT:       {
   // CHECK-NEXT:           double _r0 = 1 * _t0;
+  // CHECK-NEXT:           (* _d_this).x += _r0;
+  // CHECK-NEXT:           (* _d_this).y += _r0;
   // CHECK-NEXT:           double _r1 = _t1 * 1;
   // CHECK-NEXT:           * _d_i += _r1;
   // CHECK-NEXT:           double _r2 = 1 * _t2;
@@ -795,7 +846,7 @@ int main() {
 
   auto d_const_volatile_rval_ref_mem_fn_j = clad::gradient(&SimpleFunctions::const_volatile_rval_ref_mem_fn, "j");
 
-  // CHECK:   void const_volatile_rval_ref_mem_fn_grad_1(double i, double j, clad::array_ref<double> _d_j) const volatile && {
+  // CHECK:   void const_volatile_rval_ref_mem_fn_grad_1(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_j) const volatile && {
   // CHECK-NEXT:       double _d_i = 0;
   // CHECK-NEXT:       double _t0;
   // CHECK-NEXT:       double _t1;
@@ -810,6 +861,8 @@ int main() {
   // CHECK-NEXT:     _label0:
   // CHECK-NEXT:       {
   // CHECK-NEXT:           double _r0 = 1 * _t0;
+  // CHECK-NEXT:           (* _d_this).x += _r0;
+  // CHECK-NEXT:           (* _d_this).y += _r0;
   // CHECK-NEXT:           double _r1 = _t1 * 1;
   // CHECK-NEXT:           _d_i += _r1;
   // CHECK-NEXT:           double _r2 = 1 * _t2;

--- a/test/Gradient/TemplateFunctors.C
+++ b/test/Gradient/TemplateFunctors.C
@@ -6,12 +6,13 @@
 
 template <typename T> struct Experiment {
   mutable T x, y;
-  Experiment(T p_x, T p_y) : x(p_x), y(p_y) {}
+  Experiment(T p_x = 0, T p_y = 0) : x(p_x), y(p_y) {}
   T operator()(T i, T j) { return x * i * i + y * j; }
   void setX(T val) { x = val; }
+  Experiment& operator=(const Experiment& E) = default;
 };
 
-// CHECK: void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+// CHECK: void operator_call_grad(double i, double j, clad::array_ref<Experiment<double> > _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _t2;
@@ -30,11 +31,13 @@ template <typename T> struct Experiment {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
 // CHECK-NEXT:         double _r1 = _r0 * _t1;
+// CHECK-NEXT:         (* _d_this).x += _r1;
 // CHECK-NEXT:         double _r2 = _t2 * _r0;
 // CHECK-NEXT:         * _d_i += _r2;
 // CHECK-NEXT:         double _r3 = _t3 * 1;
 // CHECK-NEXT:         * _d_i += _r3;
 // CHECK-NEXT:         double _r4 = 1 * _t4;
+// CHECK-NEXT:         (* _d_this).y += _r4;
 // CHECK-NEXT:         double _r5 = _t5 * 1;
 // CHECK-NEXT:         * _d_j += _r5;
 // CHECK-NEXT:     }
@@ -42,14 +45,15 @@ template <typename T> struct Experiment {
 
 template <> struct Experiment<long double> {
   mutable long double x, y;
-  Experiment(long double p_x, long double p_y) : x(p_x), y(p_y) {}
+  Experiment(long double p_x = 0, long double p_y = 0) : x(p_x), y(p_y) {}
   long double operator()(long double i, long double j) {
     return x * i * i * j + y * j * i;
   }
   void setX(long double val) { x = val; }
+  Experiment& operator=(const Experiment& E) = default;
 };
 
-// CHECK: void operator_call_grad(long double i, long double j, clad::array_ref<long double> _d_i, clad::array_ref<long double> _d_j) {
+// CHECK: void operator_call_grad(long double i, long double j, clad::array_ref<Experiment<long double> > _d_this, clad::array_ref<long double> _d_i, clad::array_ref<long double> _d_j) {
 // CHECK-NEXT:     long double _t0;
 // CHECK-NEXT:     long double _t1;
 // CHECK-NEXT:     long double _t2;
@@ -77,6 +81,7 @@ template <> struct Experiment<long double> {
 // CHECK-NEXT:         long double _r0 = 1 * _t0;
 // CHECK-NEXT:         long double _r1 = _r0 * _t1;
 // CHECK-NEXT:         long double _r2 = _r1 * _t2;
+// CHECK-NEXT:         (* _d_this).x += _r2;
 // CHECK-NEXT:         long double _r3 = _t3 * _r1;
 // CHECK-NEXT:         * _d_i += _r3;
 // CHECK-NEXT:         long double _r4 = _t4 * _r0;
@@ -85,6 +90,7 @@ template <> struct Experiment<long double> {
 // CHECK-NEXT:         * _d_j += _r5;
 // CHECK-NEXT:         long double _r6 = 1 * _t6;
 // CHECK-NEXT:         long double _r7 = _r6 * _t7;
+// CHECK-NEXT:         (* _d_this).y += _r7;
 // CHECK-NEXT:         long double _r8 = _t8 * _r6;
 // CHECK-NEXT:         * _d_j += _r8;
 // CHECK-NEXT:         long double _r9 = _t9 * 1;
@@ -94,12 +100,13 @@ template <> struct Experiment<long double> {
 
 template <typename T> struct ExperimentConstVolatile {
   mutable T x, y;
-  ExperimentConstVolatile(T p_x, T p_y) : x(p_x), y(p_y) {}
+  ExperimentConstVolatile(T p_x = 0, T p_y = 0) : x(p_x), y(p_y) {}
   T operator()(T i, T j) const volatile { return x * i * i + y * j; }
   void setX(T val) const volatile { x = val; }
+  ExperimentConstVolatile& operator=(const ExperimentConstVolatile& E) = default;
 };
 
-// CHECK: void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
+// CHECK: void operator_call_grad(double i, double j, clad::array_ref<volatile ExperimentConstVolatile<double> > _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     volatile double _t2;
@@ -118,11 +125,13 @@ template <typename T> struct ExperimentConstVolatile {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
 // CHECK-NEXT:         double _r1 = _r0 * _t1;
+// CHECK-NEXT:         (* _d_this).x += _r1;
 // CHECK-NEXT:         double _r2 = _t2 * _r0;
 // CHECK-NEXT:         * _d_i += _r2;
 // CHECK-NEXT:         double _r3 = _t3 * 1;
 // CHECK-NEXT:         * _d_i += _r3;
 // CHECK-NEXT:         double _r4 = 1 * _t4;
+// CHECK-NEXT:         (* _d_this).y += _r4;
 // CHECK-NEXT:         double _r5 = _t5 * 1;
 // CHECK-NEXT:         * _d_j += _r5;
 // CHECK-NEXT:     }
@@ -130,14 +139,15 @@ template <typename T> struct ExperimentConstVolatile {
 
 template <> struct ExperimentConstVolatile<long double> {
   mutable long double x, y;
-  ExperimentConstVolatile(long double p_x, long double p_y) : x(p_x), y(p_y) {}
+  ExperimentConstVolatile(long double p_x = 0, long double p_y = 0) : x(p_x), y(p_y) {}
   long double operator()(long double i, long double j) const volatile {
     return x * i * i * j + y * j * i;
   }
   void setX(long double val) const volatile { x = val; }
+  ExperimentConstVolatile& operator=(const ExperimentConstVolatile& E) = default;
 };
 
-// CHECK: void operator_call_grad(long double i, long double j, clad::array_ref<long double> _d_i, clad::array_ref<long double> _d_j) const volatile {
+// CHECK: void operator_call_grad(long double i, long double j, clad::array_ref<volatile ExperimentConstVolatile<long double> > _d_this, clad::array_ref<long double> _d_i, clad::array_ref<long double> _d_j) const volatile {
 // CHECK-NEXT:     long double _t0;
 // CHECK-NEXT:     long double _t1;
 // CHECK-NEXT:     long double _t2;
@@ -165,6 +175,7 @@ template <> struct ExperimentConstVolatile<long double> {
 // CHECK-NEXT:         long double _r0 = 1 * _t0;
 // CHECK-NEXT:         long double _r1 = _r0 * _t1;
 // CHECK-NEXT:         long double _r2 = _r1 * _t2;
+// CHECK-NEXT:         (* _d_this).x += _r2;
 // CHECK-NEXT:         long double _r3 = _t3 * _r1;
 // CHECK-NEXT:         * _d_i += _r3;
 // CHECK-NEXT:         long double _r4 = _t4 * _r0;
@@ -173,6 +184,7 @@ template <> struct ExperimentConstVolatile<long double> {
 // CHECK-NEXT:         * _d_j += _r5;
 // CHECK-NEXT:         long double _r6 = 1 * _t6;
 // CHECK-NEXT:         long double _r7 = _r6 * _t7;
+// CHECK-NEXT:         (* _d_this).y += _r7;
 // CHECK-NEXT:         long double _r8 = _t8 * _r6;
 // CHECK-NEXT:         * _d_j += _r8;
 // CHECK-NEXT:         long double _r9 = _t9 * 1;
@@ -184,20 +196,24 @@ template <> struct ExperimentConstVolatile<long double> {
   auto d_##E = clad::gradient(&E);                                             \
   auto d_##E##Ref = clad::gradient(E);
 
-#define TEST_DOUBLE(E, ...)                                                    \
+#define TEST_DOUBLE(E, dE, ...)                                                \
   res[0] = res[1] = 0;                                                         \
-  d_##E.execute(__VA_ARGS__, di_ref, dj_ref);                                  \
+  dE = decltype(dE)();                                                         \
+  d_##E.execute(__VA_ARGS__, &dE, di_ref, dj_ref);                             \
   printf("{%.2f, %.2f} ", res[0], res[1]);                                     \
   res[0] = res[1] = 0;                                                         \
-  d_##E##Ref.execute(__VA_ARGS__, di_ref, dj_ref);                             \
+  dE = decltype(dE)();                                                         \
+  d_##E##Ref.execute(__VA_ARGS__, &dE, di_ref, dj_ref);                        \
   printf("{%.2f, %.2f}\n", res[0], res[1]);
 
-#define TEST_LONG_DOUBLE(E, ...)                                               \
+#define TEST_LONG_DOUBLE(E, dE, ...)                                           \
   res_ld[0] = res_ld[1] = 0;                                                   \
-  d_##E.execute(__VA_ARGS__, di_ref_ld, dj_ref_ld);                            \
+  dE = decltype(dE)();                                                         \
+  d_##E.execute(__VA_ARGS__, &dE, di_ref_ld, dj_ref_ld);                       \
   printf("{%.2Lf, %.2Lf} ", res_ld[0], res_ld[1]);                             \
   res_ld[0] = res_ld[1] = 0;                                                   \
-  d_##E##Ref.execute(__VA_ARGS__, di_ref_ld, dj_ref_ld);                       \
+  dE = decltype(dE)();                                                         \
+  d_##E##Ref.execute(__VA_ARGS__, &dE, di_ref_ld, dj_ref_ld);                  \
   printf("{%.2Lf, %.2Lf}\n", res_ld[0], res_ld[1]);
 
 int main() {
@@ -206,28 +222,28 @@ int main() {
   clad::array_ref<double> di_ref(res, 1), dj_ref(res + 1, 1);
   clad::array_ref<long double> di_ref_ld(res_ld, 1), dj_ref_ld(res_ld + 1, 1);
 
-  Experiment<double> E_double(3, 5);
-  Experiment<long double> E_ld(3, 5);
-  ExperimentConstVolatile<double> EConstVolatile_double(3, 5);
-  ExperimentConstVolatile<long double> EConstVolatile_ld(3, 5);
+  Experiment<double> E_double(3, 5), dE_double;
+  Experiment<long double> E_ld(3, 5), dE_ld;
+  ExperimentConstVolatile<double> EConstVolatile_double(3, 5), dEConstVolatile_double;
+  ExperimentConstVolatile<long double> EConstVolatile_ld(3, 5), dEConstVolatile_ld;
 
   INIT(E_double);
   INIT(E_ld);
   INIT(EConstVolatile_double);
   INIT(EConstVolatile_ld);
 
-  TEST_DOUBLE(E_double, 7, 9);                  // CHECK-EXEC: {42.00, 5.00} {42.00, 5.00}
-  TEST_LONG_DOUBLE(E_ld, 7, 9);                 // CHECK-EXEC: {423.00, 182.00} {423.00, 182.00}
-  TEST_DOUBLE(EConstVolatile_double, 7, 9);     // CHECK-EXEC: {42.00, 5.00} {42.00, 5.00}
-  TEST_LONG_DOUBLE(EConstVolatile_ld, 7, 9);    // CHECK-EXEC: {423.00, 182.00} {423.00, 182.00}
+  TEST_DOUBLE(E_double, dE_double, 7, 9);                               // CHECK-EXEC: {42.00, 5.00} {42.00, 5.00}
+  TEST_LONG_DOUBLE(E_ld, dE_ld, 7, 9);                                  // CHECK-EXEC: {423.00, 182.00} {423.00, 182.00}
+  TEST_DOUBLE(EConstVolatile_double, dEConstVolatile_double, 7, 9);     // CHECK-EXEC: {42.00, 5.00} {42.00, 5.00}
+  TEST_LONG_DOUBLE(EConstVolatile_ld, dEConstVolatile_ld, 7, 9);        // CHECK-EXEC: {423.00, 182.00} {423.00, 182.00}
 
   E_double.setX(5);
   E_ld.setX(5);
   EConstVolatile_double.setX(5);
   EConstVolatile_ld.setX(5);
 
-  TEST_DOUBLE(E_double, 7, 9);                  // CHECK-EXEC: {70.00, 5.00} {70.00, 5.00}
-  TEST_LONG_DOUBLE(E_ld, 7, 9);                 // CHECK-EXEC: {675.00, 280.00} {675.00, 280.00}
-  TEST_DOUBLE(EConstVolatile_double, 7, 9);     // CHECK-EXEC: {70.00, 5.00} {70.00, 5.00}
-  TEST_LONG_DOUBLE(EConstVolatile_ld, 7, 9);    // CHECK-EXEC: {675.00, 280.00} {675.00, 280.00}
+  TEST_DOUBLE(E_double, dE_double, 7, 9);                               // CHECK-EXEC: {70.00, 5.00} {70.00, 5.00}
+  TEST_LONG_DOUBLE(E_ld, dE_ld, 7, 9);                                  // CHECK-EXEC: {675.00, 280.00} {675.00, 280.00}
+  TEST_DOUBLE(EConstVolatile_double, dEConstVolatile_double, 7, 9);     // CHECK-EXEC: {70.00, 5.00} {70.00, 5.00}
+  TEST_LONG_DOUBLE(EConstVolatile_ld, dEConstVolatile_ld, 7, 9);        // CHECK-EXEC: {675.00, 280.00} {675.00, 280.00}
 }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -5,6 +5,7 @@
 #include "clad/Differentiator/Differentiator.h"
 #include "../TestUtils.h"
 #include <utility>
+#include <complex>
 
 using pairdd = std::pair<double, double>;
 
@@ -36,12 +37,19 @@ double fn1(pairdd p, double i) {
 // CHECK-NEXT: }
 
 struct Tangent {
-    Tangent() {}
-    double data[5] = {};
-    void updateTo(double d) {
-        for (int i=0; i<5; ++i)
-            data[i] = d;
-    }
+  Tangent() {}
+  double data[5] = {};
+  void updateTo(double d) {
+    for (int i = 0; i < 5; ++i)
+      data[i] = d;
+  }
+
+  double someMemFn(double i, double j) {
+    return data[0] * i + data[1] * j + 3 * data[2] + data[3] * data[4];
+  }
+  double someMemFn2(double i, double j) const {
+      return data[0]*i + data[1]*i*j;
+  }
 };
 
 double sum(Tangent& t) {
@@ -240,8 +248,331 @@ double fn4(double i, double j) {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
+// CHECK: void someMemFn_grad(double i, double j, clad::array_ref<Tangent> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     double _t3;
+// CHECK-NEXT:     double _t4;
+// CHECK-NEXT:     double _t5;
+// CHECK-NEXT:     double _t6;
+// CHECK-NEXT:     _t1 = this->data[0];
+// CHECK-NEXT:     _t0 = i;
+// CHECK-NEXT:     _t3 = this->data[1];
+// CHECK-NEXT:     _t2 = j;
+// CHECK-NEXT:     _t4 = this->data[2];
+// CHECK-NEXT:     _t6 = this->data[3];
+// CHECK-NEXT:     _t5 = this->data[4];
+// CHECK-NEXT:     double someMemFn_return = _t1 * _t0 + _t3 * _t2 + 3 * _t4 + _t6 * _t5;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 1 * _t0;
+// CHECK-NEXT:         (* _d_this).data[0] += _r0;
+// CHECK-NEXT:         double _r1 = _t1 * 1;
+// CHECK-NEXT:         * _d_i += _r1;
+// CHECK-NEXT:         double _r2 = 1 * _t2;
+// CHECK-NEXT:         (* _d_this).data[1] += _r2;
+// CHECK-NEXT:         double _r3 = _t3 * 1;
+// CHECK-NEXT:         * _d_j += _r3;
+// CHECK-NEXT:         double _r4 = 1 * _t4;
+// CHECK-NEXT:         double _r5 = 3 * 1;
+// CHECK-NEXT:         (* _d_this).data[2] += _r5;
+// CHECK-NEXT:         double _r6 = 1 * _t5;
+// CHECK-NEXT:         (* _d_this).data[3] += _r6;
+// CHECK-NEXT:         double _r7 = _t6 * 1;
+// CHECK-NEXT:         (* _d_this).data[4] += _r7;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+double fn5(const Tangent& t, double i) {
+    return t.someMemFn2(i, i);
+}
+
+// CHECK: void someMemFn2_pullback(double i, double j, double _d_y, clad::array_ref<Tangent> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     double _t3;
+// CHECK-NEXT:     double _t4;
+// CHECK-NEXT:     double _t5;
+// CHECK-NEXT:     _t1 = this->data[0];
+// CHECK-NEXT:     _t0 = i;
+// CHECK-NEXT:     _t4 = this->data[1];
+// CHECK-NEXT:     _t3 = i;
+// CHECK-NEXT:     _t5 = _t4 * _t3;
+// CHECK-NEXT:     _t2 = j;
+// CHECK-NEXT:     double someMemFn2_return = _t1 * _t0 + _t5 * _t2;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = _d_y * _t0;
+// CHECK-NEXT:         (* _d_this).data[0] += _r0;
+// CHECK-NEXT:         double _r1 = _t1 * _d_y;
+// CHECK-NEXT:         * _d_i += _r1;
+// CHECK-NEXT:         double _r2 = _d_y * _t2;
+// CHECK-NEXT:         double _r3 = _r2 * _t3;
+// CHECK-NEXT:         (* _d_this).data[1] += _r3;
+// CHECK-NEXT:         double _r4 = _t4 * _r2;
+// CHECK-NEXT:         * _d_i += _r4;
+// CHECK-NEXT:         double _r5 = _t5 * _d_y;
+// CHECK-NEXT:         * _d_j += _r5;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: void fn5_grad(const Tangent &t, double i, clad::array_ref<Tangent> _d_t, clad::array_ref<double> _d_i) {
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     Tangent _t2;
+// CHECK-NEXT:     _t0 = i;
+// CHECK-NEXT:     _t1 = i;
+// CHECK-NEXT:     _t2 = t;
+// CHECK-NEXT:     double fn5_return = t.someMemFn2(_t0, _t1);
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _grad0 = 0.;
+// CHECK-NEXT:         double _grad1 = 0.;
+// CHECK-NEXT:         _t2.someMemFn2_pullback(_t0, _t1, 1, &(* _d_t), &_grad0, &_grad1);
+// CHECK-NEXT:         double _r0 = _grad0;
+// CHECK-NEXT:         * _d_i += _r0;
+// CHECK-NEXT:         double _r1 = _grad1;
+// CHECK-NEXT:         * _d_i += _r1;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+using dcomplex = std::complex<double>;
+
+double fn6(dcomplex c, double i) {
+    c.real(5*i);
+    double res = c.real() + 3*c.imag() + 6*i;
+    res += 4*c.real();
+    return res;
+}
+
+// CHECK: void real_pullback({{.*}} [[__val:.*]], clad::array_ref<complex<double> > _d_this, clad::array_ref<double> [[_d___val:[a-zA-Z_]*]]){{.*}} {
+// CHECK-NEXT:     {{(__real)?}} this->[[_M_value:.*]] = [[__val]];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d0 ={{( __real)?}} (* _d_this).[[_M_value]];
+// CHECK-NEXT:         * [[_d___val]] += _r_d0;
+// CHECK-NEXT:         {{(__real)?}} (* _d_this).[[_M_value]] -= _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: constexpr void real_pullback(double _d_y, clad::array_ref<complex<double> > _d_this){{.*}} {
+// CHECK-NEXT:     double real_return ={{( __real)?}} this->[[_M_value:.*]];
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {{(__real)?}} (* _d_this).[[_M_value]] += _d_y;
+// CHECK-NEXT: }
+
+// CHECK: constexpr void imag_pullback(double _d_y, clad::array_ref<complex<double> > _d_this){{.*}} {
+// CHECK-NEXT:     double imag_return ={{( __imag)?}} this->[[_M_value:.*]];
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {{(__imag)?}} (* _d_this).[[_M_value]] += _d_y;
+// CHECK-NEXT: }
+
+// CHECK: void fn6_grad(dcomplex c, double i, clad::array_ref<dcomplex> _d_c, clad::array_ref<double> _d_i) {
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     dcomplex _t2;
+// CHECK-NEXT:     dcomplex _t3;
+// CHECK-NEXT:     double _t4;
+// CHECK-NEXT:     dcomplex _t5;
+// CHECK-NEXT:     double _t6;
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     double _t7;
+// CHECK-NEXT:     dcomplex _t8;
+// CHECK-NEXT:     _t0 = i;
+// CHECK-NEXT:     _t1 = 5 * _t0;
+// CHECK-NEXT:     _t2 = c;
+// CHECK-NEXT:     c.real(_t1);
+// CHECK-NEXT:     _t3 = c;
+// CHECK-NEXT:     _t5 = c;
+// CHECK-NEXT:     _t4 = c.imag();
+// CHECK-NEXT:     _t6 = i;
+// CHECK-NEXT:     double res = c.real() + 3 * _t4 + 6 * _t6;
+// CHECK-NEXT:     _t8 = c;
+// CHECK-NEXT:     _t7 = c.real();
+// CHECK-NEXT:     res += 4 * _t7;
+// CHECK-NEXT:     double fn6_return = res;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d0 = _d_res;
+// CHECK-NEXT:         _d_res += _r_d0;
+// CHECK-NEXT:         double _r7 = _r_d0 * _t7;
+// CHECK-NEXT:         double _r8 = 4 * _r_d0;
+// CHECK-NEXT:         _t8.real_pullback(_r8, &(* _d_c));
+// CHECK-NEXT:         _d_res -= _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _t3.real_pullback(_d_res, &(* _d_c));
+// CHECK-NEXT:         double _r3 = _d_res * _t4;
+// CHECK-NEXT:         double _r4 = 3 * _d_res;
+// CHECK-NEXT:         _t5.imag_pullback(_r4, &(* _d_c));
+// CHECK-NEXT:         double _r5 = _d_res * _t6;
+// CHECK-NEXT:         double _r6 = 6 * _d_res;
+// CHECK-NEXT:         * _d_i += _r6;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _grad0 = 0.;
+// CHECK-NEXT:         _t2.real_pullback(_t1, &(* _d_c), &_grad0);
+// CHECK-NEXT:         double _r0 = _grad0;
+// CHECK-NEXT:         double _r1 = _r0 * _t0;
+// CHECK-NEXT:         double _r2 = 5 * _r0;
+// CHECK-NEXT:         * _d_i += _r2;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+double fn7(dcomplex c1, dcomplex c2) {
+    c1.real(c2.imag() + 5*c2.real());
+    return c1.real() + 3*c1.imag();
+}
+
+// CHECK: void fn7_grad(dcomplex c1, dcomplex c2, clad::array_ref<dcomplex> _d_c1, clad::array_ref<dcomplex> _d_c2) {
+// CHECK-NEXT:     dcomplex _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     dcomplex _t2;
+// CHECK-NEXT:     double _t3;
+// CHECK-NEXT:     dcomplex _t4;
+// CHECK-NEXT:     dcomplex _t5;
+// CHECK-NEXT:     double _t6;
+// CHECK-NEXT:     dcomplex _t7;
+// CHECK-NEXT:     _t0 = c2;
+// CHECK-NEXT:     _t2 = c2;
+// CHECK-NEXT:     _t1 = c2.real();
+// CHECK-NEXT:     _t3 = c2.imag() + 5 * _t1;
+// CHECK-NEXT:     _t4 = c1;
+// CHECK-NEXT:     c1.real(_t3);
+// CHECK-NEXT:     _t5 = c1;
+// CHECK-NEXT:     _t7 = c1;
+// CHECK-NEXT:     _t6 = c1.imag();
+// CHECK-NEXT:     double fn7_return = c1.real() + 3 * _t6;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _t5.real_pullback(1, &(* _d_c1));
+// CHECK-NEXT:         double _r3 = 1 * _t6;
+// CHECK-NEXT:         double _r4 = 3 * 1;
+// CHECK-NEXT:         _t7.imag_pullback(_r4, &(* _d_c1));
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _grad0 = 0.;
+// CHECK-NEXT:         _t4.real_pullback(_t3, &(* _d_c1), &_grad0);
+// CHECK-NEXT:         double _r0 = _grad0;
+// CHECK-NEXT:         _t0.imag_pullback(_r0, &(* _d_c2));
+// CHECK-NEXT:         double _r1 = _r0 * _t1;
+// CHECK-NEXT:         double _r2 = 5 * _r0;
+// CHECK-NEXT:         _t2.real_pullback(_r2, &(* _d_c2));
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+double fn8(Tangent t, dcomplex c) {
+  t.updateTo(c.real());
+  return sum(t);
+}
+
+// CHECK: void updateTo_pullback(double d, clad::array_ref<Tangent> _d_this, clad::array_ref<double> _d_d) {
+// CHECK-NEXT:     unsigned long _t0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     clad::tape<int> _t1 = {};
+// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     for (int i = 0; i < 5; ++i) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         this->data[clad::push(_t1, i)] = d;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         int _t2 = clad::pop(_t1);
+// CHECK-NEXT:         double _r_d0 = (* _d_this).data[_t2];
+// CHECK-NEXT:         * _d_d += _r_d0;
+// CHECK-NEXT:         (* _d_this).data[_t2] -= _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: void fn8_grad(Tangent t, dcomplex c, clad::array_ref<Tangent> _d_t, clad::array_ref<dcomplex> _d_c) {
+// CHECK-NEXT:     dcomplex _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     Tangent _t2;
+// CHECK-NEXT:     Tangent _t3;
+// CHECK-NEXT:     _t0 = c;
+// CHECK-NEXT:     _t1 = c.real();
+// CHECK-NEXT:     _t2 = t;
+// CHECK-NEXT:     t.updateTo(_t1);
+// CHECK-NEXT:     _t3 = t;
+// CHECK-NEXT:     double fn8_return = sum(t);
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         sum_pullback(_t3, 1, &(* _d_t));
+// CHECK-NEXT:         Tangent _r1 = (* _d_t);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _grad0 = 0.;
+// CHECK-NEXT:         _t2.updateTo_pullback(_t1, &(* _d_t), &_grad0);
+// CHECK-NEXT:         double _r0 = _grad0;
+// CHECK-NEXT:         _t0.real_pullback(_r0, &(* _d_c));
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+double fn9(Tangent t, dcomplex c) {
+  double res = 0;
+  for (int i=0; i<5; ++i) {
+    res += c.real() + 2*c.imag();
+  }
+  res += sum(t);
+  return res;
+}
+
+// CHECK: void fn9_grad(Tangent t, dcomplex c, clad::array_ref<Tangent> _d_t, clad::array_ref<dcomplex> _d_c) {
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     unsigned long _t0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     clad::tape<dcomplex> _t1 = {};
+// CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     clad::tape<dcomplex> _t3 = {};
+// CHECK-NEXT:     Tangent _t4;
+// CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     for (int i = 0; i < 5; ++i) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         clad::push(_t1, c);
+// CHECK-NEXT:         clad::push(_t3, c);
+// CHECK-NEXT:         res += c.real() + 2 * clad::push(_t2, c.imag());
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _t4 = t;
+// CHECK-NEXT:     res += sum(t);
+// CHECK-NEXT:     double fn9_return = res;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r_d1 = _d_res;
+// CHECK-NEXT:         _d_res += _r_d1;
+// CHECK-NEXT:         sum_pullback(_t4, _r_d1, &(* _d_t));
+// CHECK-NEXT:         Tangent _r4 = (* _d_t);
+// CHECK-NEXT:         _d_res -= _r_d1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             double _r_d0 = _d_res;
+// CHECK-NEXT:             _d_res += _r_d0;
+// CHECK-NEXT:             std{{(::__1)?}}::complex<double> _r0 = clad::pop(_t1);
+// CHECK-NEXT:             _r0.real_pullback(_r_d0, &(* _d_c));
+// CHECK-NEXT:             double _r1 = _r_d0 * clad::pop(_t2);
+// CHECK-NEXT:             double _r2 = 2 * _r_d0;
+// CHECK-NEXT:             std{{(::__1)?}}::complex<double> _r3 = clad::pop(_t3);
+// CHECK-NEXT:             _r3.imag_pullback(_r2, &(* _d_c));
+// CHECK-NEXT:             _d_res -= _r_d0;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
 namespace std {
 void print(const pairdd& p) { printf("%.2f, %.2f", p.first, p.second); }
+void print(const dcomplex& c) {printf("%.2f, %.2f", c.real(), c.imag());}
 } // namespace std
 
 void print(const Tangent& t) {
@@ -256,14 +587,30 @@ int main() {
     pairdd p(3, 5), d_p;
     double i = 3, d_i, d_j;
     Tangent t, d_t;
+    dcomplex c1, c2, d_c1, d_c2;
+    auto memFn1 = &Tangent::someMemFn;
 
     INIT_GRADIENT(fn1);
     INIT_GRADIENT(fn2);
     INIT_GRADIENT(fn3);
     INIT_GRADIENT(fn4);
-
+    INIT_GRADIENT(memFn1);
+    INIT_GRADIENT(fn5);
+    INIT_GRADIENT(fn6);
+    INIT_GRADIENT(fn7);
+    INIT_GRADIENT(fn8);
+    INIT_GRADIENT(fn9);
+    
     TEST_GRADIENT(fn1, /*numOfDerivativeArgs=*/2, p, i, &d_p, &d_i);    // CHECK-EXEC: {1.00, 2.00, 3.00}
     TEST_GRADIENT(fn2, /*numOfDerivativeArgs=*/2, t, i, &d_t, &d_i);    // CHECK-EXEC: {4.00, 2.00, 2.00, 2.00, 2.00, 1.00}
     TEST_GRADIENT(fn3, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);    // CHECK-EXEC: {7.00, 3.00}
     TEST_GRADIENT(fn4, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);    // CHECK-EXEC: {8.00, 8.00}
+    t.updateTo(5);
+    TEST_GRADIENT(memFn1, /*numOfDerivativeArgs=*/3, t, 3, 5, &d_t, &d_i, &d_j);   // CHECK-EXEC: {3.00, 5.00, 3.00, 5.00, 5.00, 5.00, 5.00}
+    t.updateTo(5);
+    TEST_GRADIENT(fn5, /*numOfDerivativeArgs=*/2, t, 3, &d_t, &d_i);    // CHECK-EXEC: {3.00, 9.00, 0.00, 0.00, 0.00, 35.00}
+    TEST_GRADIENT(fn6, /*numOfDerivativeArgs=*/2, c1, 3, &d_c1, &d_i);  // CHECK-EXEC: {0.00, 3.00, 31.00}
+    TEST_GRADIENT(fn7, /*numOfDerivativeArgs=*/2, c1, c2, &d_c1, &d_c2);// CHECK-EXEC: {0.00, 3.00, 5.00, 1.00}
+    TEST_GRADIENT(fn8, /*numOfDerivativeArgs=*/2, t, c1, &d_t, &d_c1);  // CHECK-EXEC: {0.00, 0.00, 0.00, 0.00, 0.00, 5.00, 0.00}
+    TEST_GRADIENT(fn9, /*numOfDerivativeArgs=*/2, t, c1, &d_t, &d_c1);  // CHECK-EXEC: {1.00, 1.00, 1.00, 1.00, 1.00, 5.00, 10.00}
 }

--- a/test/Hessian/Functors.C
+++ b/test/Hessian/Functors.C
@@ -6,7 +6,7 @@
 
 struct Experiment {
   mutable double x, y;
-  Experiment(double p_x, double p_y) : x(p_x), y(p_y) {}
+  Experiment(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
   double operator()(double i, double j) {
     return x*i*i*j + y*i*j*j;
   }
@@ -15,14 +15,16 @@ struct Experiment {
   }
 
   // CHECK: void operator_call_hessian(double i, double j, clad::array_ref<double> hessianMatrix) {
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
+  // CHECK-NEXT:     Experiment _d_this;
+  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+  // CHECK-NEXT:     Experiment _d_this0;
+  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
   // CHECK-NEXT: }
 };
 
 struct ExperimentConst {
   mutable double x, y;
-  ExperimentConst(double p_x, double p_y) : x(p_x), y(p_y) {}
+  ExperimentConst(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
   double operator()(double i, double j) const {
     return x*i*i*j + y*i*j*j;
   }
@@ -31,14 +33,16 @@ struct ExperimentConst {
   }
 
   // CHECK: void operator_call_hessian(double i, double j, clad::array_ref<double> hessianMatrix) const {
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
+  // CHECK-NEXT:     ExperimentConst _d_this;
+  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+  // CHECK-NEXT:     ExperimentConst _d_this0;
+  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
   // CHECK-NEXT: }
 };
 
 struct ExperimentVolatile {
   mutable double x, y;
-  ExperimentVolatile(double p_x, double p_y) : x(p_x), y(p_y) {}
+  ExperimentVolatile(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
   double operator()(double i, double j) volatile {
     return x*i*i*j + y*i*j*j;
   }
@@ -47,14 +51,16 @@ struct ExperimentVolatile {
   }
 
   // CHECK: void operator_call_hessian(double i, double j, clad::array_ref<double> hessianMatrix) volatile {
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
+  // CHECK-NEXT:     volatile ExperimentVolatile _d_this;
+  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+  // CHECK-NEXT:     volatile ExperimentVolatile _d_this0;
+  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
   // CHECK-NEXT: }
 };
 
 struct ExperimentConstVolatile {
   mutable double x, y;
-  ExperimentConstVolatile(double p_x, double p_y) : x(p_x), y(p_y) {}
+  ExperimentConstVolatile(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
   double operator()(double i, double j) const volatile {
     return x*i*i*j + y*i*j*j;
   }
@@ -63,8 +69,10 @@ struct ExperimentConstVolatile {
   }
 
   // CHECK: void operator_call_hessian(double i, double j, clad::array_ref<double> hessianMatrix) const volatile {
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
+  // CHECK-NEXT:     volatile ExperimentConstVolatile _d_this;
+  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+  // CHECK-NEXT:     volatile ExperimentConstVolatile _d_this0;
+  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
   // CHECK-NEXT: }
 };
 
@@ -72,7 +80,7 @@ namespace outer {
   namespace inner {
     struct ExperimentNNS {
       mutable double x, y;
-      ExperimentNNS(double p_x, double p_y) : x(p_x), y(p_y) {}
+      ExperimentNNS(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
       double operator()(double i, double j) {
         return x*i*i*j + y*i*j*j;
       }
@@ -81,8 +89,10 @@ namespace outer {
       }
 
       // CHECK: void operator_call_hessian(double i, double j, clad::array_ref<double> hessianMatrix) {
-      // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
-      // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
+      // CHECK-NEXT:     outer::inner::ExperimentNNS _d_this;
+      // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+      // CHECK-NEXT:     outer::inner::ExperimentNNS _d_this0;
+      // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
       // CHECK-NEXT: }
     };
 

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -257,7 +257,7 @@ void f_power10_hessian(double x, clad::array_ref<double> hessianMatrix);
 
 struct Experiment {
   double x, y;
-  Experiment (double p_x, double p_y) : x(p_x), y(p_y) {}
+  Experiment (double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
   double someMethod (double i, double j) {
     return i*i*j + j*j*i;
   }
@@ -272,15 +272,17 @@ struct Experiment {
                              clad::array_ref<double> _d_j);
 
   void someMethod_hessian(double x, clad::array_ref<double> hessianMatrix);
-  // CHECK:void someMethod_hessian(double i, double j, clad::array_ref<double> hessianMatrix) {
-  // CHECK-NEXT:  this->someMethod_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
-  // CHECK-NEXT:  this->someMethod_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
-  // CHECK-NEXT:}
+  // CHECK: void someMethod_hessian(double i, double j, clad::array_ref<double> hessianMatrix) {
+  // CHECK-NEXT:     Experiment _d_this;
+  // CHECK-NEXT:     this->someMethod_darg0_grad(i, j, &_d_this, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+  // CHECK-NEXT:     Experiment _d_this0;
+  // CHECK-NEXT:     this->someMethod_darg1_grad(i, j, &_d_this0, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
+  // CHECK-NEXT: }
 };
 
 struct Widget {
   double x, y;
-  Widget(double p_x, double p_y) : x(p_x), y(p_y) {}
+  Widget(double p_x=0, double p_y=0) : x(p_x), y(p_y) {}
   double memFn_1(double i, double j) {
     return x*y*i*j;
   }
@@ -298,8 +300,10 @@ struct Widget {
                        double j,
                        clad::array_ref<double> hessianMatrix);
   // CHECK: void memFn_1_hessian(double i, double j, clad::array_ref<double> hessianMatrix) {
-  // CHECK-NEXT:     this->memFn_1_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
-  // CHECK-NEXT:     this->memFn_1_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
+  // CHECK-NEXT:     Widget _d_this;
+  // CHECK-NEXT:     this->memFn_1_darg0_grad(i, j, &_d_this, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+  // CHECK-NEXT:     Widget _d_this0;
+  // CHECK-NEXT:     this->memFn_1_darg1_grad(i, j, &_d_this0, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
   // CHECK-NEXT: }
 
   double memFn_2(double i, double j) {
@@ -321,8 +325,10 @@ struct Widget {
                        double j,
                        clad::array_ref<double> hessianMatrix);
   // CHECK: void memFn_2_hessian(double i, double j, clad::array_ref<double> hessianMatrix) {
-  // CHECK-NEXT:     this->memFn_2_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
-  // CHECK-NEXT:     this->memFn_2_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
+  // CHECK-NEXT:     Widget _d_this;
+  // CHECK-NEXT:     this->memFn_2_darg0_grad(i, j, &_d_this, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+  // CHECK-NEXT:     Widget _d_this0;
+  // CHECK-NEXT:     this->memFn_2_darg1_grad(i, j, &_d_this0, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
   // CHECK-NEXT: }
 };
 

--- a/test/Hessian/TemplateFunctors.C
+++ b/test/Hessian/TemplateFunctors.C
@@ -6,19 +6,21 @@
 
 template <typename T> struct Experiment {
   mutable T x, y;
-  Experiment(T p_x, T p_y) : x(p_x), y(p_y) {}
+  Experiment(T p_x=0, T p_y=0) : x(p_x), y(p_y) {}
   T operator()(T i, T j) { return x * i * i * j + y * j * j * i; }
   void setX(T val) { x = val; }
 };
 
 // CHECK: void operator_call_hessian(double i, double j, clad::array_ref<double> hessianMatrix) {
-// CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
-// CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
+// CHECK-NEXT:     Experiment<double> _d_this;
+// CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+// CHECK-NEXT:     Experiment<double> _d_this0;
+// CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
 // CHECK-NEXT: }
 
 template <> struct Experiment<long double> {
   mutable long double x, y;
-  Experiment(long double p_x, long double p_y) : x(p_x), y(p_y) {}
+  Experiment(long double p_x=0, long double p_y=0) : x(p_x), y(p_y) {}
   long double operator()(long double i, long double j) {
     return i * i * j + j * j * i;
   }
@@ -26,8 +28,10 @@ template <> struct Experiment<long double> {
 };
 
 // CHECK: void operator_call_hessian(long double i, long double j, clad::array_ref<long double> hessianMatrix) {
-// CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
-// CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
+// CHECK-NEXT:     Experiment<long double> _d_this;
+// CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix.slice(0UL, 1UL), hessianMatrix.slice(1UL, 1UL));
+// CHECK-NEXT:     Experiment<long double> _d_this0;
+// CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix.slice(2UL, 1UL), hessianMatrix.slice(3UL, 1UL));
 // CHECK-NEXT: }
 
 #define INIT(E)                   \


### PR DESCRIPTION
This PR adds support for differentiating calls to member functions in the reverse mode AD.

This PR introduces a breaking change in the signature of derived member functions. Earlier we were considering data members to be constant while differentiating member functions. This is no longer the case, and thus now we need a separate variable to store derivative of the function value with respect to implicit `this` pointer. To allow users to obtain derivatives with respect to the implicit `this` object, derived member function prototype has been changed to include a derivative parameter for the implicit `this` pointer.

For example: 

```cpp
struct SomeStruct {
  double memFn(double i, long double j) {...}
};
```

This function will have the gradient function as follows:

```cpp
void memFn(double i, long double j, clad::array_ref<SomeStruct> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {...}
```

Class type support hasn't been fully-added to the hessian differentiation mode. It is because there is no easy way to represent the hessian matrix when class types are involved. Nonetheless, when differentiating member functions using the hessian differentiation mode, data members are considered differentiable. This is made feasible by creating and passing a dummy `_d_this` variable when calling gradient routine inside the hessian function.

This PR also adds support for C99 language extension of `__real` and `__imag` unary operators in the reverse mode AD. This in turn allows us to perform basic differentiation of `std::complex` types.