### PR TITLE
Removed strcpy and strlen Definitions from Differentiator.h and inlin…

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -20,12 +20,12 @@
 
 extern "C" {
   int printf(const char* fmt, ...);
-  char* strcpy (char* destination, const char* source);
-  size_t strlen(const char*);
 #if defined(__APPLE__) || defined(_MSC_VER)
+  extern size_t strlen(const char*);
   void* malloc(size_t);
   void free(void *ptr);
 #else
+  extern size_t strlen(const char*) __THROW __attribute_pure__ __nonnull ((1));
   void* malloc(size_t) __THROW __attribute_malloc__ __wur;
   void free(void *ptr) __THROW;
 #endif


### PR DESCRIPTION
strcpy function was not used anywhere else in the codebase and hence I removed its definition from Differentiator.h. strlen was used once in Differentiator.h, which i replaced it with the code of strlen.

Closes #388 