### PR TITLE
Refactor building params routine in the reverse mode AD.

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -185,11 +185,15 @@ namespace clad {
     ///
     /// This function is just a convenient routine that internally calls
     /// `clang::ParmVarDecl::Create`.
+    ///
+    /// \note `TSI` parameter only needs to be provided if the type should be
+    /// represented exactly how it was represented in the source code.
     clang::ParmVarDecl*
     BuildParmVarDecl(clang::Sema& semaRef, clang::DeclContext* DC,
                      clang::IdentifierInfo* II, clang::QualType T,
                      clang::StorageClass SC = clang::StorageClass::SC_None,
-                     clang::Expr* defArg = nullptr);
+                     clang::Expr* defArg = nullptr,
+                     clang::TypeSourceInfo* TSI = nullptr);
 
     /// If `T` represents an array or a pointer type then returns the
     /// corresponding array element or the pointee type. Otherwise, if `T` is

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -10,6 +10,7 @@
 #include "clad/Differentiator/Compatibility.h"
 #include "clad/Differentiator/VisitorBase.h"
 #include "clad/Differentiator/ReverseModeVisitorDirectionKinds.h"
+#include "clad/Differentiator/ParseDiffArgsTypes.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Sema/Sema.h"
@@ -549,6 +550,24 @@ namespace clad {
     /// multiple times.
     ///\paramp[in] source An external RMV source
     void AddExternalSource(ExternalRMVSource& source);
+
+    /// Computes and returns the sequence of derived function parameter types.
+    ///
+    /// Information about the original function and the differentiation mode
+    /// are taken from the data member variables. In particular, `m_Function`,
+    /// `m_Mode` data members should be correctly set before using this
+    /// function.
+    llvm::SmallVector<clang::QualType, 8> ComputeParamTypes(const DiffParams& diffParams);
+
+    /// Builds and returns the sequence of derived function parameters.
+    ///
+    /// Information about the original function, derived function, derived
+    /// function parameter types and the differentiation mode are implicitly
+    /// taken from the data member variables. In particular, `m_Function`,
+    /// `m_Mode` and `m_Derivative` should be correctly set before using this
+    /// function.
+    llvm::SmallVector<clang::ParmVarDecl*, 8>
+    BuildParams(DiffParams& diffParams);
   };
 } // end namespace clad
 

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -225,9 +225,11 @@ namespace clad {
     clang::ParmVarDecl*
     BuildParmVarDecl(clang::Sema& semaRef, clang::DeclContext* DC,
                      clang::IdentifierInfo* II, clang::QualType T,
-                     clang::StorageClass SC, clang::Expr* defArg) {
+                     clang::StorageClass SC, clang::Expr* defArg,
+                     clang::TypeSourceInfo* TSI) {
       ASTContext& C = semaRef.getASTContext();
-      TypeSourceInfo* TSI = C.getTrivialTypeSourceInfo(T, noLoc);
+      if (!TSI)
+        TSI = C.getTrivialTypeSourceInfo(T, noLoc);
       ParmVarDecl* PVD =
           ParmVarDecl::Create(C, DC, noLoc, noLoc, II, T, TSI, SC, defArg);
       return PVD;

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -254,10 +254,7 @@ namespace clad {
                                              PVD->getType(),
                                              PVD->getTypeSourceInfo(),
                                              PVD->getStorageClass(),
-                                             // Clone default arg if present.
-                                             (PVD->hasDefaultArg()
-                                                  ? Clone(PVD->getDefaultArg())
-                                                  : nullptr));
+                                             /*DefArg=*/nullptr);
                      if (VD->getIdentifier())
                        m_Sema.PushOnScopeChains(VD,
                                                 getCurrentScope(),

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -150,11 +150,9 @@ namespace clad {
     callArgs.reserve(gradientParams.size());
 
     for (auto PVD : m_Function->parameters()) {
-      Expr* GVDDefArg =
-          PVD->hasDefaultArg() ? Clone(PVD->getDefaultArg()) : nullptr;
-      auto VD = utils::BuildParmVarDecl(m_Sema, gradientOverloadFD,
-                                        PVD->getIdentifier(), PVD->getType(),
-                                        PVD->getStorageClass(), GVDDefArg);
+      auto VD = utils::BuildParmVarDecl(
+          m_Sema, gradientOverloadFD, PVD->getIdentifier(), PVD->getType(),
+          PVD->getStorageClass(), /*defArg=*/nullptr, PVD->getTypeSourceInfo());
       overloadParams.push_back(VD);
       callArgs.push_back(BuildDeclRef(VD));
     }
@@ -2833,8 +2831,7 @@ namespace clad {
     for (auto PVD : m_Function->parameters()) {
       auto newPVD = utils::BuildParmVarDecl(
           m_Sema, m_Derivative, PVD->getIdentifier(), PVD->getType(),
-          PVD->getStorageClass(), Clone(PVD->getDefaultArg()),
-          PVD->getTypeSourceInfo());
+          PVD->getStorageClass(), /*DefArg=*/nullptr, PVD->getTypeSourceInfo());
       params.push_back(newPVD);
 
       if (newPVD->getIdentifier())

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -358,6 +358,10 @@ double fn5(double* arr, int n) {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
+double fn6(double i=0, double j=0) {
+  return i*j;
+}
+
 template<typename T>
 void reset(T* arr, int n) {
   for (int i=0; i<n; ++i)
@@ -402,6 +406,7 @@ int main() {
   INIT(fn3);
   INIT(fn4);
   INIT(fn5);
+  INIT(fn6);
 
   TEST1(fn1, 11);               // CHECK-EXEC: {3.00}
   TEST2(fn2, 3, 5);             // CHECK-EXEC: {1.00, 3.00}
@@ -409,5 +414,6 @@ int main() {
   double arr[5] = {1, 2, 3, 4, 5};
   TEST_ARR5(fn4, arr, 5);       // CHECK-EXEC: {23.00, 3.00, 3.00, 3.00, 3.00}
   TEST_ARR5(fn5, arr, 5);       // CHECK-EXEC: {5.00, 1.00, 0.00, 0.00, 0.00}
+  TEST2(fn6, 3, 5);             // CHECK-EXEC: {5.00, 3.00}
 }
 

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -326,6 +326,16 @@ struct Widget {
   // CHECK-NEXT: }
 };
 
+double fn_def_arg(double i=0, double j=0) {
+  return 2*i*j;
+}
+
+void fn_def_arg_darg0_grad(double, double, clad::array_ref<double>,
+                           clad::array_ref<double>);
+void fn_def_arg_darg1_grad(double, double, clad::array_ref<double>,
+                           clad::array_ref<double>);
+void fn_def_arg_hessian(double, double, clad::array_ref<double>);
+
 #define TEST1(F, x) { \
   result[0] = 0;\
   auto h = clad::hessian(F);\
@@ -378,4 +388,5 @@ int main() {
   TEST3(&Experiment::someMethod, E, 3, 5);  // CHECK-EXEC: Result is = {10.00, 16.00, 16.00, 6.00}
   TEST3(&Widget::memFn_1, W, 7, 9); // CHECK-EXEC: Result is = {0.00, 15.00, 15.00, 0.00}
   TEST3(&Widget::memFn_2, W, 7, 9); // CHECK-EXEC: Result is = {5400.00, 4200.00, 4200.00, 0.00}
+  TEST2(fn_def_arg, 3, 5);  // CHECK-EXEC: Result is = {0.00, 2.00, 2.00, 0.00}
 }


### PR DESCRIPTION
This PR refactors `ReverseModeVisitor::Derive` and `ReverseModeVisitor::DerivePullback` such that the derived function parameter types and the parameters declarations are computed and built in separate subroutines. This facilitates the reuse of the common code between different differentiation modes supported by the reverse mode (DiffMode::reverse, DiffMode::experimental_pullback, and DiffMode::jacobian).

This PR also fixes the differentiation of functions consisting of default args in the reverse mode AD. 

Closes #393 