### PR TITLE
Restructure README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,41 @@
+<div align="center">
+
+# Clad
+
 [![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/clad)](https://github.com/conda-forge/clad-feedstock)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/clad/badges/license.svg)](https://anaconda.org/conda-forge/clad)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/clad/badges/platforms.svg)](https://anaconda.org/conda-forge/clad)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/clad/badges/downloads.svg)](https://anaconda.org/conda-forge/clad)
 
-| Linux & OSX: | Coverity | Codecov | Binder 
-|:---:|:---:|:---:| :---:|
-[![Linux & Osx Status](https://github.com/vgvassilev/clad/workflows/Clad-CI/badge.svg)](https://github.com/vgvassilev/clad/actions?query=workflow%3AClad-CI) | <a href="https://scan.coverity.com/projects/vgvassilev-clad"> <img alt="Coverity Scan Build Status" src="https://scan.coverity.com/projects/16418/badge.svg"/> </a> | [![codecov]( https://codecov.io/gh/vgvassilev/clad/branch/master/graph/badge.svg)](https://codecov.io/gh/vgvassilev/clad) | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/vgvassilev/clad/master?labpath=%2Fdemos%2FJupyter%2FIntro.ipynb)
-
-# Conda Installation
-
-Clad is available using [conda](https://anaconda.org/conda-forge/clad):
-
-```bash
-conda install -c conda-forge clad
-```
-
-If you have already added `conda-forge` as a channel, the `-c conda-forge` is unnecessary. Adding the channel is recommended because it ensures that all of your packages use compatible versions:
-
-```bash
-conda config --add channels conda-forge
-conda update --all
-```
-
-# Clad
-Clad enables [automatic differentiation (AD)](https://en.wikipedia.org/wiki/Automatic_differentiation) for C++. It is based on LLVM compiler infrastructure and is a plugin for [Clang compiler](http://clang.llvm.org/). Clad is based on source code transformation. Given C++ source code of a mathematical function, it can automatically generate C++ code for computing derivatives of the function. It supports both forward-mode and reverse-mode AD.
-## How to use Clad
-
-### Wtih Jupyter Notebooks
-
-[xeus-cling](https://github.com/jupyter-xeus/xeus-cling) provides a Jupyter kernel for C++ with the help of the C++ interpreter Cling and the native implementation of the Jupyter protocol xeus. Within the xeus-cling framework, Clad can enable automatic differentiation (AD) such that users can automatically generate C++ code for their computation of derivatives of their functions.
-
-To set up your environment, use:
-
-```
-mamba create -n xeus-clad -c conda-forge clad xeus-cling jupyterlab
-
-conda activate xeus-clad
-```
-
-Next, running ```jupyter notebook``` will show 3 new kernels for `C++ 11/14/17` with Clad attached. 
-
-Try out a Clad [tutorial](https://compiler-research.org/tutorials/clad_jupyter/) interactively in your browser through binder: 
-
+[![Linux & Osx Status](https://github.com/vgvassilev/clad/workflows/Clad-CI/badge.svg)](https://github.com/vgvassilev/clad/actions?query=workflow%3AClad-CI) <a href="https://scan.coverity.com/projects/vgvassilev-clad"> <img alt="Coverity Scan Build Status" src="https://scan.coverity.com/projects/16418/badge.svg"/> </a>
+[![codecov]( https://codecov.io/gh/vgvassilev/clad/branch/master/graph/badge.svg)](https://codecov.io/gh/vgvassilev/clad)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/vgvassilev/clad/master?labpath=%2Fdemos%2FJupyter%2FIntro.ipynb)
 
-### As a plugin for Clang
-Since Clad is a Clang plugin, it must be properly attached when Clang compiler is invoked. First, the plugin must be built to get `libclad.so` (or `.dylib`). To compile `SourceFile.cpp` with Clad enabled use:
-```
-clang -cc1 -x c++ -std=c++11 -load /full/path/to/lib/clad.so -plugin clad SourceFile.cpp
-```
 
-To compile using clang-9, use: 
-```
-clang-9 -I /full/path/to/include/  -x c++ -std=c++11 -fplugin=/full/path/to/lib/clad.so SourceFile.cpp -o sourcefile -lstdc++ -lm
-```
+Clad is a source-transformation [automatic differentiation (AD)](https://en.wikipedia.org/wiki/Automatic_differentiation) library for C++,<br/>implemented as a plugin for the [Clang compiler](http://clang.llvm.org/). 
 
-To save the Clad generated derivative code to `Deritives.cpp` add:
-```
--Xclang -plugin-arg-clad -Xclang -fgenerate-source-file
-```
+#### [Usage](#how-to-use-clad) | [Installation](#how-to-install) | [Further Reading](#further-reading) | [Documentation](https://trying-read-the-docs.readthedocs.io/en/latest/index.html) | [Contributing](#how-to-contribute)
+</div>
 
-To print the Clad generated derivative add:
-```
--Xclang -plugin-arg-clad -Xclang -fdump-derived-fn
-```
+## About Clad
+Clad enables automatic differentiation (AD) for C++. It is based on LLVM compiler infrastructure and is a plugin for Clang compiler. Clad is based on source code transformation. Given C++ source code of a mathematical function, it can automatically generate C++ code for computing derivatives of the function. It supports both forward-mode and reverse-mode AD.Clad has extensive coverage of modern C++ features and a robust fallback and recovery system in place.
 
-Clad provides four API functions:
-- `clad::differentiate` to use forward-mode AD
-- `clad::gradient` to use reverse-mode AD
-- `clad::hessian` to compute Hessian matrix using a combination of forward-mode and reverse-mode AD
-- `clad::jacobian` to compute Jacobian matrix using reverse-mode AD
+## How to use Clad
+
+Clad provides five API functions:
+- [`clad::differentiate`](#forward-mode---claddifferentiate) to use forward-mode AD.
+- [`clad::gradient`](#reverse-mode---cladgradient) to use reverse-mode AD.
+- [`clad::hessian`](#hessian-mode---cladhessian) to compute Hessian matrix using a combination of forward-mode and reverse-mode AD.
+- [`clad::jacobian`](#jacobian-mode---cladjacobian) to compute Jacobian matrix using reverse-mode AD.
+- [`clad::estimate-error`](#floating-point-error-estimation---cladestimate_error) to compute the floating-point error of the given program using reverse-mode AD.
 
 API functions are used to label an existing function for differentiation.
-Both functions return a functor object containing the generated derivative which can be called via `.execute` method, which forwards provided arguments to the generated derivative function. Example:
-```cpp
-#include "clad/Differentiator/Differentiator.h"
-#include <iostream>
+Both functions return a functor object containing the generated derivative which can be called via `.execute` method, which forwards provided arguments to the generated derivative function.
 
-double f(double x, double y) { return x * y; }
+For a guide on compiling your clad-based programs, look [here](#compiling-and-executing-your-code-with-clad).
 
-int main() {
-  auto f_dx = clad::differentiate(f, "x");
-  std::cout << f_dx.execute(3, 4) << std::endl; // prints: 4
-  f_dx.dump(); // prints:
-  /* double f_darg0(double x, double y) {
-       double _d_x = 1; double _d_y = 0;
-       return _d_x * y + x * _d_y;
-     } */
-}
-```
-### Forward mode
-For a function `f` of several inputs and single (scalar) output, forward mode AD can be used to compute (or, in case of Clad, create a function) computing a directional derivative of `f` with respect to a *single* specified input variable. Derivative function created by the forward-mode AD is guaranteed to have *at most* a constant factor (around 2-3) more arithmetical operations compared to the original function.
+### Forward mode - `clad::differentiate`
+For a function `f` of several inputs and single (scalar) output, forward mode AD can be used to compute (or, in case of Clad, create a function) a directional derivative of `f` with respect to a *single* specified input variable. Derivative function created by the forward-mode AD is guaranteed to have *at most* a constant factor (around 2-3) more arithmetical operations compared to the original function.
 
 `clad::differentiate(f, ARGS)` takes 2 arguments:
 1. `f` is a pointer to a function or a method to be differentiated
@@ -98,10 +43,25 @@ For a function `f` of several inputs and single (scalar) output, forward mode AD
   * a single numerical literal indicating an index of independent variable (e.g. `0` for `x`, `1` for `y`)
   * a string literal with the name of independent variable (as stated in the *definition* of `f`, e.g. `"x"` or `"y"`), and if the variable is an array the index needs to be specified, e.g. `"arr[1]"`
 
-Generated derivative function has the same signature as the original function `f`, however its return value is the value of the derivative.
+Generated derivative function has the same signature as the original function `f`, however its return value is the value of the derivative. Example:
+```cpp
+#include "clad/Differentiator/Differentiator.h"
+#include <iostream>
 
-### Reverse mode
-When a function has many inputs and derivatives w.r.t. every input (i.e. gradient vector) are required, reverse-mode AD is a better alternative to the forward-mode. Reverse-mode AD allows to compute the gradient of `f` using *at most* a constant factor (around 4) more arithmetical operations compared to the original function. While its constant factor and memory overhead is higher than that of the forward-mode, it is independent of the number of inputs. E.g. for a function having N inputs and consisting of T arithmetical operations, computing its gradient takes a single execution of the reverse-mode AD and around 4\*T operations, while it would take N executions of the forward-mode, this requiring up to N\*3\*T operations.
+double f(double x, double y) { return x * y; }
+
+int main() {
+  // Call clad to generate the derivative of f wrt x.
+  auto f_dx = clad::differentiate(f, "x");
+  // Execute the generated derivative function.
+  std::cout << f_dx.execute(/*x=*/3, /*y=*/4) << std::endl;
+  // Dump the generated derivative code to standard output.
+  f_dx.dump();
+}
+```
+
+### Reverse mode - `clad::gradient`
+Reverse-mode AD allows computing the gradient of `f` using *at most* a constant factor (around 4) more arithmetical operations compared to the original function. While its constant factor and memory overhead is higher than that of the forward-mode, it is independent of the number of inputs. E.g. for a function having N inputs and consisting of T arithmetical operations, computing its gradient takes a single execution of the reverse-mode AD and around 4\*T operations, while it would take N executions of the forward-mode, this requiring up to N\*3\*T operations.
 
 `clad::gradient(f, /*optional*/ ARGS)` takes 1 or 2 arguments:
 1. `f` is a pointer to a function or a method to be differentiated
@@ -117,79 +77,21 @@ double dx = 0, dy = 0;
 f_grad.execute(x, y, &dx, &dy);
 std::cout << "dx: " << dx << ' ' << "dy: " << dy << std::endl;
 
-auto f_dx_dy = clad::gradient(f, "x, y"); // same effect as before
-
+// Same effect as before.
+auto f_dx_dy = clad::gradient(f, "x, y"); 
 auto f_dy_dx = clad::gradient(f, "y, x");
+
 // The same effect can be achieved by using an array instead of individual variables.
 double result2[2] = {};
-f_dy_dx.execute(x, y, &result2[0], &result2[1]);
+f_dy_dx.execute(x, y, /*dx=*/&result2[0], /*dy=*/&result2[1]);
 // note that the derivatives are mapped to the "result" indices in the same order as they were specified in the argument:
 std::cout << "dy: " << result2[0] << ' ' << "dx: " << result2[1] << std::endl;
 ```
-Note: *we are working on improving the gradient interface*.
-## What can be differentiated
-Clad is based on compile-time analysis and transformation of C++ abstract syntax tree (Clang AST). This means that Clad must be able to see the body of a function to differentiate it (e.g. if a function is defined in an external library there is no way for Clad to get its AST).
+### Hessian mode - `clad::hessian`
 
-We aim to support every piece of modern C++ syntax, however at the moment only the a subset of C++ is supported and there are some constraints on functions that can be differentiated with Clad:
-* Only builtin C++ scalar numeric types (e.g. `double`, `float`, `int`) are fully supported
-* Differentiated functions must return a single value of supported scalar numeric type
-* Differentiated functions can have arbitrary number or inputs of supported scalar numeric types
-* Clad can also differentiate `struct`/`class` methods, however at the moment there is no way to differentiate them w.r.t. member fields
+### Jacobian mode - `clad::jacobian`
 
-Note: *we are currently working on vector inputs*
-
-The following subset of C++ syntax is supported at the moment:
-* Numerical literals, builtin arithmetic operators `+`, `-`, `*`, `/`
-* Variable declarations of supported types (including local variables in `{}` blocks)
-* Inside functions, builtin arrays (e.g. `double x[1][2][3];`) of supported types and subscript operator `x[i]`
-* Direct assignments to variables via `=` and `+=`, `-=`, `*=`, `/=`, `++`, `--`
-* Conditional operator `?:` and boolean expressions
-* Comma operator `,`
-* Control flow: `if` statements and `for` loops (*work on loops in the reverse-mode is in progress*)
-* Calls to other functions, including recursion
-
-Note: Clad currently differentiates types such as `int`/`char`/`boolean` as any real type (such as `float`, `double`, etc.) would be differentiated. Users should keep in mind that Clad *does not* warn against lossy casts, which on differentiation may result in incorrect derivatives.
-
-Note: If for any reason clad is unable to algorithmically differentiate a function, it automatically switches to numerically differentiating the same. To disable this behavior, please compile your programs with the `-DCLAD_NO_NUM_DIFF` flag. The numerical differentiation functionality can also be used standalone over a wide range of function signatures with minimal user intervention. [This presentation](https://indico.cern.ch/event/1066812/contributions/4495279/attachments/2301763/3915404/Numerical%20Differentiaition%20.pdf) provides more information on what can be numerically differentiated. For a comprehensive demo on using custom user defined types with numerical differentiation, you can check out [this demo](https://github.com/vgvassilev/clad/blob/master/demos/CustomTypeNumDiff.cpp).
-
-## Specifying custom derivatives
-Sometimes Clad may be unable to differentiate your function (e.g. if its definition is in a library and source code is not available). Alternatively, an efficient/more numerically stable expression for derivatives may be know. In such cases, it is useful to be able to specify a custom derivatives for your function.
-
-Clad supports that functionality by allowing to specify your own derivatives in `namespace custom_derivatives`. For a function named `FNAME` you can specify:
-* a custom derivative w.r.t `I`-th argument by defining a function `FNAME_dargI` inside `namespace custom_derivatives`
-* a custom gradient w.r.t every argument by defining a function `FNAME_grad` inside `namespace custom_derivatives`
-
-When Clad will encounter a function `FNAME`, it will first do a lookup inside the `custom_derivatives` namespace to try to find a suitable custom function, and only if none is found will proceed to automatically derive it.
-
-Example:
-* Suppose that you have a function `my_pow(x, y)` which computes `x` to the power of `y`. However, Clad is not able to differentiate `my_pow`'s body (e.g. it calls an external library or uses some non-differentiable approximation):
-```cpp
-double my_pow(double x, double y) { // something non-differentiable here... }
-```
-However, you know analytical formulas of its derivatives, and you can easily specify custom derivatives:
-```cpp
-namespace custom_derivatives {
-  double my_pow_darg0(double x, double y) { return y * my_pow(x, y - 1); }
-  double my_pow_darg1(dobule x, double y) { return my_pow(x, y) * std::log(x); }
-}
-```
-You can also specify a custom gradient:
-```cpp
-namespace custom_derivatives {
-  void my_pow_grad(double x, double y, array_ref<double> _d_x, array_ref<double> _d_y) {
-     double t = my_pow(x, y - 1);
-     *_d_x = y * t;
-     *_d_y = x * t * std::log(x);
-   }
-}
-```
-Whenever Clad will encounter `my_pow` inside differentiated function, it will find and use provided custom funtions instead of attempting to differentiate it.
-
-Note: Clad provides custom derivatives for some mathematical functions from `<cmath>` inside `clad/Differentiator/BuiltinDerivatives.h`.
-
-Note: *the concept of custom_derivatives will be reviewed soon, we intend to provide a different interface and avoid function name-based specifications and by-name lookups*.
-
-## Using Clad's floating point error estimation framework
+### Floating-point error estimation - `clad::estimate_error`
 
 Clad is capable of annotating a given function with floating point error estimation code using the reverse mode of AD. An interface similar to `clad::gradient(f)` is provided as follows:
 
@@ -211,21 +113,66 @@ df.execute(x, y, &d_x, &d_y, final_error);
 ```
 The above example generates the the error code using an in-built taylor approximation model. However, clad is capable of using any user defined custom model, for information on how to use you own custom model, please visit [this demo](https://github.com/vgvassilev/clad/tree/master/demos/ErrorEstimation/CustomModel).
 
-More details on this framework can be found [here](https://indico.cern.ch/event/1040761/contributions/4371613/attachments/2268248/3851583/floating_point_error_est.pdf).
+More detail on the APIs can be found under clad's [user documentation](https://trying-read-the-docs.readthedocs.io/en/latest/index.html).
+### Compiling and executing your code with clad
 
-## How Clad works
-Clad is a plugin for the Clang compiler. It relies on the Clang to build the AST ([Clang AST](https://clang.llvm.org/docs/IntroductionToTheClangAST.html)) of user's source code. Then, [CladPlugin](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/tools/ClangPlugin.h#L48), implemented as `clang::ASTConsumer` analyzes the AST to find differentiation requests for clad and process those requests by building Clang AST for derivative functions. The whole clad's operation sequence is the following:
-* Clang parses user's source code and builds the AST.
-* [`CladPlugin`](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/tools/ClangPlugin.cpp#L63) analyzes the built AST and starts the traversal via [`HandleTopLevelDecl`](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/tools/ClangPlugin.cpp#L67).
-* [`DiffCollector`](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/lib/Differentiator/DiffPlanner.cpp#L141) does the [traversal](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/tools/ClangPlugin.cpp#L79) and looks at every call expression to find all the differentiation requests (through calls to `clad::differentiate(f, ...)` or `clad::gradient(f, ...)`).
-* `CladPlugin` [processes](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/tools/ClangPlugin.cpp#L82) every found request.
-* Processing each request involves calling to [`DerivativeBuilder::Derive`](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/tools/ClangPlugin.cpp#L113) which then [switches](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/lib/Differentiator/DerivativeBuilder.cpp#L77) do either [`ForwardModeVisitor::Derive`](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/lib/Differentiator/DerivativeBuilder.cpp#L407) or [`ReverseModeVisitor::Derive`](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/lib/Differentiator/DerivativeBuilder.cpp#L1506), depending on which AD mode was requested.
-* `ForwardModeVisitor` and `ReverseModeVisitor` are derived from `clang::StmtVisitor`. In the `Derive` method they analyze the AST of the declaration of the original function and create the AST for the declaration of derivative function. Then they proceed to recursively `Visit` every Stmt in original function's body and build the body for the derivative function. Forward/Reverse mode AD algorithm is implemented in `Visit...` methods, which are executed depending on the kind of AST node visited.
-* The AST of the newly built derivative function's declaration is returned to `CladPlugin`, where the call to `clad::differentiate(f, ...)/clad::gradient(f, ...)` is [updated](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/tools/ClangPlugin.cpp#L122) and `f` is replaced by a reference to the newly created derivative function `f_...`. This effectively results in the execution of `clad::differentiate(f_...)/clad::gradient(f_...)`, which constructs `CladFunction` with a pointer to the newly created derivative. Therefore, user's calls to `.execute` method will invoke the newly generated derivative.
-* Finally, derivative's AST is [passed](https://github.com/vgvassilev/clad/blob/a264195f00792feeebe63ac7a8ab815c02d20eee/tools/ClangPlugin.cpp#L145) for further processing by Clang compiler (LLVM IR generation, optimizations, machine code generation, etc.).
+#### Using Jupyter Notebooks
+
+[xeus-cling](https://github.com/jupyter-xeus/xeus-cling) provides a Jupyter kernel for C++ with the help of the C++ interpreter Cling and the native implementation of the Jupyter protocol xeus. Within the xeus-cling framework, Clad can enable automatic differentiation (AD) such that users can automatically generate C++ code for their computation of derivatives of their functions.
+
+To set up your environment, use:
+
+```
+mamba create -n xeus-clad -c conda-forge clad xeus-cling jupyterlab
+
+conda activate xeus-clad
+```
+
+Next, running ```jupyter notebook``` will show 3 new kernels for `C++ 11/14/17` with Clad attached. 
+
+Try out a Clad [tutorial](https://compiler-research.org/tutorials/clad_jupyter/) interactively in your browser through binder: 
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/vgvassilev/clad/master?labpath=%2Fdemos%2FJupyter%2FIntro.ipynb)
+
+#### Using as a plugin for Clang
+Since Clad is a Clang plugin, it must be properly attached when Clang compiler is invoked. First, the plugin must be built to get `libclad.so` (or `.dylib`). To compile `SourceFile.cpp` with Clad enabled use:
+```
+clang -cc1 -x c++ -std=c++11 -load /full/path/to/lib/clad.so -plugin clad SourceFile.cpp
+```
+
+To compile using clang-9, use: 
+```
+clang-9 -I /full/path/to/include/  -x c++ -std=c++11 -fplugin=/full/path/to/lib/clad.so SourceFile.cpp -o sourcefile -lstdc++ -lm
+```
+
+To save the Clad generated derivative code to `Derivatives.cpp` add:
+```
+-Xclang -plugin-arg-clad -Xclang -fgenerate-source-file
+```
+
+To print the Clad generated derivative add:
+```
+-Xclang -plugin-arg-clad -Xclang -fdump-derived-fn
+```
 
 ## How to install
 At the moment, LLVM/Clang 5.0.x - 12.0.1 are supported.
+
+
+### Conda Installation
+
+Clad is available using [conda](https://anaconda.org/conda-forge/clad):
+
+```bash
+conda install -c conda-forge clad
+```
+
+If you have already added `conda-forge` as a channel, the `-c conda-forge` is unnecessary. Adding the channel is recommended because it ensures that all of your packages use compatible versions:
+
+```bash
+conda config --add channels conda-forge
+conda update --all
+```
 
 ###  Building from source (example was tested on Ubuntu 18.04 LTS)
   ```
@@ -266,8 +213,54 @@ cmake ../clad -DLLVM_DIR=/usr/local/Cellar/llvm/12.0.0_1/lib/cmake/llvm -DClang_
     cmake -DCMAKE_BUILD_TYPE=Debug -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_INSTALL_PREFIX=../inst -DLLVM_EXTERNAL_LIT="`which lit`" ../src/
     make && make install
   ```
-  ## Recent Contributors
-  [![](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/images/0)](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/links/0)[![](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/images/1)](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/links/1)[![](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/images/2)](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/links/2)[![](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/images/3)](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/links/3)[![](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/images/4)](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/links/4)[![](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/images/5)](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/links/5)[![](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/images/6)](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/links/6)[![](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/images/7)](https://sourcerer.io/fame/vgvassilev/vgvassilev/clad/links/7)
+
+## Further reading
+
+### What can be differentiated
+Clad is based on compile-time analysis and transformation of C++ abstract syntax tree (Clang AST). This means that Clad must be able to see the body of a function to differentiate it (e.g. if a function is defined in an external library there is no way for Clad to get its AST).
+
+
+
+Note: Clad currently differentiates types such as `int`/`char`/`boolean` as any real type (such as `float`, `double`, etc.) would be differentiated. Users should keep in mind that Clad *does not* warn against lossy casts, which on differentiation may result in incorrect derivatives.
+
+Note: If for any reason clad is unable to algorithmically differentiate a function, it automatically switches to numerically differentiating the same. To disable this behavior, please compile your programs with the `-DCLAD_NO_NUM_DIFF` flag. The numerical differentiation functionality can also be used standalone over a wide range of function signatures with minimal user intervention. [This presentation](https://indico.cern.ch/event/1066812/contributions/4495279/attachments/2301763/3915404/Numerical%20Differentiaition%20.pdf) provides more information on what can be numerically differentiated. For a comprehensive demo on using custom user defined types with numerical differentiation, you can check out [this demo](https://github.com/vgvassilev/clad/blob/master/demos/CustomTypeNumDiff.cpp).
+
+### Specifying custom derivatives
+Sometimes Clad may be unable to differentiate your function (e.g. if its definition is in a library and source code is not available). Alternatively, an efficient/more numerically stable expression for derivatives may be know. In such cases, it is useful to be able to specify a custom derivatives for your function.
+
+Clad supports that functionality by allowing to specify your own derivatives in `namespace custom_derivatives`. For a function named `FNAME` you can specify:
+* a custom derivative w.r.t `I`-th argument by defining a function `FNAME_dargI` inside `namespace custom_derivatives`
+* a custom gradient w.r.t every argument by defining a function `FNAME_grad` inside `namespace custom_derivatives`
+
+When Clad will encounter a function `FNAME`, it will first do a lookup inside the `custom_derivatives` namespace to try to find a suitable custom function, and only if none is found will proceed to automatically derive it.
+
+Example:
+* Suppose that you have a function `my_pow(x, y)` which computes `x` to the power of `y`. However, Clad is not able to differentiate `my_pow`'s body (e.g. it calls an external library or uses some non-differentiable approximation):
+```cpp
+double my_pow(double x, double y) { // something non-differentiable here... }
+```
+However, you know analytical formulas of its derivatives, and you can easily specify custom derivatives:
+```cpp
+namespace custom_derivatives {
+  double my_pow_darg0(double x, double y) { return y * my_pow(x, y - 1); }
+  double my_pow_darg1(dobule x, double y) { return my_pow(x, y) * std::log(x); }
+}
+```
+You can also specify a custom gradient:
+```cpp
+namespace custom_derivatives {
+  void my_pow_grad(double x, double y, array_ref<double> _d_x, array_ref<double> _d_y) {
+     double t = my_pow(x, y - 1);
+     *_d_x = y * t;
+     *_d_y = x * t * std::log(x);
+   }
+}
+```
+Whenever Clad will encounter `my_pow` inside differentiated function, it will find and use provided custom functions instead of attempting to differentiate it.
+
+Note: Clad provides custom derivatives for some mathematical functions from `<cmath>` inside `clad/Differentiator/BuiltinDerivatives.h`.
+
+Details on custom derivatives, other supported C++ syntax (already supported or in-progress) and further resources can be found over at clad's [user documentation](https://trying-read-the-docs.readthedocs.io/en/latest/index.html).
 
   ## Citing Clad
 ```latex
@@ -291,20 +284,8 @@ cmake ../clad -DLLVM_DIR=/usr/local/Cellar/llvm/12.0.0_1/lib/cmake/llvm -DClang_
 }
 ```
 
-## Additional references
-[ACAT 2014 Slides](https://indico.cern.ch/event/258092/session/8/contribution/90/material/slides/0.pdf)  
-[Martin's GSoC2014 Final Report](https://indico.cern.ch/event/337174/contribution/2/material/slides/0.pdf)  
-[LLVM Poster](http://llvm.org/devmtg/2013-11/slides/Vassilev-Poster.pdf)  
-[Violeta's GSoC2013 Final Report](http://prezi.com/g1iggppw76wl/autodiff/)  
-[DIANA-HEP Meeting 2018](https://indico.cern.ch/event/760152/contributions/3153263/attachments/1730121/2795841/Clad-DIANA-HEP.pdf)  
-[Demo at CERN](https://indico.cern.ch/event/808843/contributions/3368929/attachments/1817666/2971512/clad_demo.pdf)
-
 ##  Founders
 Founder of the project is Vassil Vassilev as part of his research interests and vision. He holds the exclusive copyright and other related rights, described in Copyright.txt.
-
-##  Contributors
-We have quite a few contributors, whose contribution is described briefly in
-Credits.txt. If you don't find your name among the list of contributors, please contact us!
 
 ##  License
 clad is an open source project, licensed by GNU LESSER GENERAL PUBLIC
@@ -315,8 +296,5 @@ folder.
 Please see License.txt for further information.
 
 ##  How to Contribute
-As stated in 2. clad is an open source project. Like most of the open
-source projects we constantly lack of manpower and contributions of any sort are
-very welcome. The best starting point is to download the source code and start
-playing with it. There are a lot of tests showing implicitly the available
-functionality.
+
+We are always looking for improvements to the tool, as such open-source developers are greatly appreciated! If you are interested in getting started with contributing to clad, make sure you checkout our [contribution guide]().


### PR DESCRIPTION
Adds simple restructuring to README.md. There are still 4 tasks left to do here:

1. Fill in the Hessian mode section
2. Fill in the Jacobian mode section
3. Fill in the contributor's guide link once we have a contributing.txt.
4. Fill in the 'what can be differentiated' section briefly.


