### PR TITLE
Add support for diff calls to mem fns in the forw mode

### DIFF
--- a/demos/ComputerGraphics/smallpt/SmallPT.cpp
+++ b/demos/ComputerGraphics/smallpt/SmallPT.cpp
@@ -53,7 +53,7 @@ struct Vec {
 
 struct Ray {
   Vec o, d; // Origin and direction
-
+  Ray() : o(), d() {}
   Ray(Vec o_, Vec d_): o(o_), d(d_) {}
 };
 
@@ -69,6 +69,7 @@ public:
   Vec e, c; // emission, color
   Refl_t refl; // reflection type (DIFFuse, SPECular, REFRactive)
 
+  Solid() : e(), c(), refl() {}
   Solid(Vec e_, Vec c_, Refl_t refl_): e(e_), c(c_), refl(refl_) {}
 
   // returns distance, 0 if nohit
@@ -83,6 +84,7 @@ public:
 class ImplicitSolid : public Solid {
 public:
 
+  ImplicitSolid() {}
   ImplicitSolid(Vec e_, Vec c_, Refl_t refl_): Solid(e_, c_, refl_) {}
 
   // Return signed distance to nearest point on solid surface
@@ -164,6 +166,7 @@ public:
   double r; // radius
   Vec p; // position
 
+  Sphere() : r(), p() {}
   Sphere(double r_, Vec p_, Vec e_, Vec c_, Refl_t refl_):
     r(r_), p(p_), ImplicitSolid(e_, c_, refl_) {
     // Move to Normal when execute can call polymorphic diffs
@@ -252,9 +255,9 @@ class HyperbolicSolid : public ImplicitSolid {
 public:
   double r; // radius
   Vec p; // position
-
-  HyperbolicSolid(double r_, Vec p_, Vec e_, Vec c_, Refl_t refl_):
-    r(r_), p(p_), ImplicitSolid(e_, c_, refl_) {
+  HyperbolicSolid() : r(), p() {}
+  HyperbolicSolid(double r_, Vec p_, Vec e_, Vec c_, Refl_t refl_)
+      : r(r_), p(p_), ImplicitSolid(e_, c_, refl_) {
     // FIXME: Move to Normal when execute can call polymorphic diffs.
     auto hyperbolic_func_dx = clad::differentiate(&HyperbolicSolid::distance_func, 0);
     auto hyperbolic_func_dy = clad::differentiate(&HyperbolicSolid::distance_func, 1);

--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -594,5 +594,25 @@ CXXMethodDecl_GetThisObjectType(Sema& semaRef, const CXXMethodDecl* MD) {
   return MD->getThisObjectType();
 }
 #endif
+
+#if CLANG_VERSION_MAJOR < 9
+template <typename T>
+typename std::enable_if<std::is_pointer<T>::value, T>::type EmptyOptional() {
+  return nullptr;
+}
+#elif CLANG_VERSION_MAJOR >= 9
+template <typename T> llvm::Optional<T> EmptyOptional() {
+  return llvm::Optional<T>();
+}
+#endif
+
+#if CLANG_VERSION_MAJOR < 12
+#define CLAD_COMPAT_SubstNonTypeTemplateParmExpr_isReferenceParameter_ExtraParam( \
+    Node) /**/
+#else
+#define CLAD_COMPAT_SubstNonTypeTemplateParmExpr_isReferenceParameter_ExtraParam( \
+    Node)                                                                         \
+  Node->isReferenceParameter(),
+#endif
 } // namespace clad_compat
 #endif //CLAD_COMPATIBILITY

--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -28,6 +28,7 @@ namespace clad {
     unsigned m_IndependentVarIndex = ~0;
     unsigned m_DerivativeOrder = ~0;
     unsigned m_ArgIndex = ~0;
+    
   public:
     ForwardModeVisitor(DerivativeBuilder& builder);
     ~ForwardModeVisitor();
@@ -87,7 +88,7 @@ namespace clad {
     VisitMaterializeTemporaryExpr(const clang::MaterializeTemporaryExpr* MTE);
     StmtDiff
     VisitCXXTemporaryObjectExpr(const clang::CXXTemporaryObjectExpr* TOE);
-
+    StmtDiff VisitCXXThisExpr(const clang::CXXThisExpr* CTE);
   private:
     /// Helper function for differentiating the switch statement body.
     ///

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -62,11 +62,6 @@ namespace clad {
     unsigned outputArrayCursor = 0;
     unsigned numParams = 0;
     bool isVectorValued = false;
-    /// Stores derivative expression of the implicit `this` pointer.
-    ///
-    /// \note `this` pointer derivative expression is always of the class object
-    /// type rather than the pointer type.
-    clang::Expr* m_ThisExprDerivative = nullptr;
     // FIXME: Should we make this an object instead of a pointer?
     // Downside of making it an object: We will need to include
     // 'MultiplexExternalRMVSource.h' file

--- a/include/clad/Differentiator/StmtClone.h
+++ b/include/clad/Differentiator/StmtClone.h
@@ -113,6 +113,7 @@ namespace utils {
     DECLARE_CLONE_FN(CXXConstructExpr)
     DECLARE_CLONE_FN(CXXTemporaryObjectExpr)
     DECLARE_CLONE_FN(MaterializeTemporaryExpr)
+    DECLARE_CLONE_FN(SubstNonTypeTemplateParmExpr)
     // `ConstantExpr` node is only available after clang 7.
     #if CLANG_VERSION_MAJOR > 7
     DECLARE_CLONE_FN(ConstantExpr)

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -110,6 +110,14 @@ namespace clad {
     VectorOutputs m_VectorOutput;
     /// The functor type that is currently being differentiated, if any.
     const clang::CXXRecordDecl* m_Functor = nullptr;
+    /// Stores derivative expression of the implicit `this` pointer.
+    ///
+    /// In the forward mode, `this` pointer derivative expression is of pointer
+    /// type. In the reverse mode, `this` pointer derivative expression is of
+    /// object type.
+    // FIXME: Fix this inconsistency, by making `this` pointer derivative
+    // expression to be of object type in the reverse mode as well.
+    clang::Expr* m_ThisExprDerivative = nullptr;
     /// A function used to wrap result of visiting E in a lambda. Returns a call
     /// to the built lambda. Func is a functor that will be invoked inside
     /// lambda scope and block. Statements inside lambda are expected to be

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -224,7 +224,7 @@ namespace clad {
       if (isArrayOrPointerType(T))
         T = T->getPointeeOrArrayElementType()->getCanonicalTypeInternal();
       T = T.getNonReferenceType();
-      if (T->isRealType() || T->isRecordType())
+      if (T->isRealType() || T->isStructureOrClassType())
         return true;
       return false;
     }

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -1170,6 +1170,10 @@ namespace clad {
     else if (opKind == UO_PostInc || opKind == UO_PostDec ||
              opKind == UO_PreInc || opKind == UO_PreDec) {
       return StmtDiff(op, diff.getExpr_dx());
+    } /* For supporting complex types */
+    else if (opKind == UnaryOperatorKind::UO_Real ||
+             opKind == UnaryOperatorKind::UO_Imag) {
+      return StmtDiff(op, BuildOp(opKind, diff.getExpr_dx()));
     } else {
       unsupportedOpWarn(UnOp->getEndLoc());
       auto zero =

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -132,6 +132,7 @@ DEFINE_CLONE_EXPR(CXXBoolLiteralExpr, (Node->getValue(), Node->getType(), Node->
 DEFINE_CLONE_EXPR(CXXNullPtrLiteralExpr, (Node->getType(), Node->getSourceRange().getBegin()))
 DEFINE_CLONE_EXPR(CXXThisExpr, (Node->getSourceRange().getBegin(), Node->getType(), Node->isImplicit()))
 DEFINE_CLONE_EXPR(CXXThrowExpr, (Clone(Node->getSubExpr()), Node->getType(), Node->getThrowLoc(), Node->isThrownVariableInScope()))
+DEFINE_CLONE_EXPR(SubstNonTypeTemplateParmExpr, (Node->getType(), Node->getValueKind(), Node->getBeginLoc(), Node->getParameter(), CLAD_COMPAT_SubstNonTypeTemplateParmExpr_isReferenceParameter_ExtraParam(Node) Node->getReplacement()))
 //BlockExpr
 //BlockDeclRefExpr
 

--- a/test/FirstDerivative/ClassMethodCall.C
+++ b/test/FirstDerivative/ClassMethodCall.C
@@ -17,6 +17,8 @@ public:
 
   //CHECK:   int f_darg0(int x) __attribute__((always_inline)) {
   //CHECK-NEXT:       int _d_x = 1;
+  //CHECK-NEXT:       A _d_this_obj;
+  //CHECK-NEXT:       A *_d_this = &_d_this_obj;
   //CHECK-NEXT:       return _d_x;
   //CHECK-NEXT:   }
 
@@ -28,6 +30,8 @@ public:
   //CHECK:   int g_1_darg0(int x, int y) {
   //CHECK-NEXT:       int _d_x = 1;
   //CHECK-NEXT:       int _d_y = 0;
+  //CHECK-NEXT:       A _d_this_obj;
+  //CHECK-NEXT:       A *_d_this = &_d_this_obj;
   //CHECK-NEXT:       return _d_x * x + x * _d_x + _d_y;
   //CHECK-NEXT:   }
 
@@ -35,6 +39,8 @@ public:
   //CHECK:   int g_1_darg1(int x, int y) {
   //CHECK-NEXT:       int _d_x = 0;
   //CHECK-NEXT:       int _d_y = 1;
+  //CHECK-NEXT:       A _d_this_obj;
+  //CHECK-NEXT:       A *_d_this = &_d_this_obj;
   //CHECK-NEXT:       return _d_x * x + x * _d_x + _d_y;
   //CHECK-NEXT:   }
 
@@ -45,12 +51,16 @@ public:
   //CHECK:   int g_2_darg0(int x, int y) {
   //CHECK-NEXT:       int _d_x = 1;
   //CHECK-NEXT:       int _d_y = 0;
+  //CHECK-NEXT:       A _d_this_obj;
+  //CHECK-NEXT:       A *_d_this = &_d_this_obj;
   //CHECK-NEXT:       return _d_x + _d_y * y + y * _d_y;
   //CHECK-NEXT:   }
 
   //CHECK:   int g_2_darg1(int x, int y) {
   //CHECK-NEXT:       int _d_x = 0;
   //CHECK-NEXT:       int _d_y = 1;
+  //CHECK-NEXT:       A _d_this_obj;
+  //CHECK-NEXT:       A *_d_this = &_d_this_obj;
   //CHECK-NEXT:       return _d_x + _d_y * y + y * _d_y;
   //CHECK-NEXT:   }
 
@@ -66,6 +76,8 @@ public:
   //CHECK:   float vm_darg0(float x, float y) {
   //CHECK-NEXT:       float _d_x = 1;
   //CHECK-NEXT:       float _d_y = 0;
+  //CHECK-NEXT:       A _d_this_obj;
+  //CHECK-NEXT:       A *_d_this = &_d_this_obj;
   //CHECK-NEXT:       return _d_x + _d_y;
   //CHECK-NEXT:   }
 
@@ -83,6 +95,8 @@ public:
   //CHECK:   float vm_darg0(float x, float y) override {
   //CHECK-NEXT:       float _d_x = 1;
   //CHECK-NEXT:       float _d_y = 0;
+  //CHECK-NEXT:       B _d_this_obj;
+  //CHECK-NEXT:       B *_d_this = &_d_this_obj;
   //CHECK-NEXT:       return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
   //CHECK-NEXT:   }
 
@@ -107,6 +121,8 @@ int main () {
   //CHECK-EXEC:   float vm_darg0(float x, float y) override {
   //CHECK-EXEC-NEXT:       float _d_x = 1;
   //CHECK-EXEC-NEXT:       float _d_y = 0;
+  //CHECK-EXEC-NEXT:       B _d_this_obj;
+  //CHECK-EXEC-NEXT:       B *_d_this = &_d_this_obj;
   //CHECK-EXEC-NEXT:       return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
   //CHECK-EXEC-NEXT:   }
 

--- a/test/FirstDerivative/Overloads.C
+++ b/test/FirstDerivative/Overloads.C
@@ -73,21 +73,29 @@ int main () {
   auto f1_darg0_float_A = clad::differentiate((float(A::*)(float))&A::f1, 0);
 //CHECK: float f1_darg0(float x) {
 //CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     A _d_this_obj;
+// CHECK-NEXT:     A *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x + _d_x + _d_x;
 //CHECK-NEXT: }
   auto f1_darg0_double_A = clad::differentiate((double(A::*)(double))&A::f1, 0);
 //CHECK: double f1_darg0(double x) {
 //CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     A _d_this_obj;
+// CHECK-NEXT:     A *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x + _d_x + _d_x + _d_x;
 //CHECK-NEXT: }
   auto f1_darg0_float_B = clad::differentiate((float(B::*)(float))&B::f1, 0);
 //CHECK: float f1_darg0(float x) {
 //CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     B _d_this_obj;
+// CHECK-NEXT:     B *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x + _d_x + _d_x + _d_x + _d_x;
 //CHECK-NEXT: }
   auto f1_darg0_int_B = clad::differentiate((int(B::*)(int))&B::f1, 0);
 //CHECK: int f1_darg0(int x) {
 //CHECK-NEXT:     int _d_x = 1;
+// CHECK-NEXT:     B _d_this_obj;
+// CHECK-NEXT:     B *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x;
 //CHECK-NEXT: }
   // resolve to float(B::*)(float)
@@ -98,6 +106,8 @@ int main () {
   auto f1_darg0_double_B1 = clad::differentiate((double(B1::*)(double))&B1::f1, 0);
 //CHECK: double f1_darg0(double x) {
 //CHECK-NEXT:     double _d_x = 1;
+//CHECK-NEXT:     B1 _d_this_obj;
+//CHECK-NEXT:     B1 *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x + _d_x + _d_x + _d_x + _d_x + _d_x;
 //CHECK-NEXT: }
   printf("Result is = %f\n", f1_darg0_float_A.execute(a, 2.0)); // CHECK-EXEC: Result is = 3.0000

--- a/test/FirstDerivative/StructMethodCall.C
+++ b/test/FirstDerivative/StructMethodCall.C
@@ -13,6 +13,8 @@ public:
 
   // CHECK: int f_darg0(int x) {
   // CHECK-NEXT: int _d_x = 1;
+  // CHECK-NEXT:     A _d_this_obj;
+  // CHECK-NEXT:     A *_d_this = &_d_this_obj;
   // CHECK-NEXT: return _d_x;
   // CHECK-NEXT: }
 
@@ -23,12 +25,16 @@ public:
   // CHECK: int g_1_darg0(int x, int y) {
   // CHECK-NEXT: int _d_x = 1;
   // CHECK-NEXT: int _d_y = 0;
+  // CHECK-NEXT:     A _d_this_obj;
+  // CHECK-NEXT:     A *_d_this = &_d_this_obj;
   // CHECK-NEXT: return _d_x * x + x * _d_x + _d_y;
   // CHECK-NEXT: }
 
   // CHECK: int g_1_darg1(int x, int y) {
   // CHECK-NEXT: int _d_x = 0;
   // CHECK-NEXT: int _d_y = 1;
+  // CHECK-NEXT:     A _d_this_obj;
+  // CHECK-NEXT:     A *_d_this = &_d_this_obj;
   // CHECK-NEXT: return _d_x * x + x * _d_x + _d_y;
   // CHECK-NEXT: }
 
@@ -39,12 +45,16 @@ public:
   // CHECK: int g_2_darg0(int x, int y) {
   // CHECK-NEXT: int _d_x = 1;
   // CHECK-NEXT: int _d_y = 0;
+  // CHECK-NEXT:     A _d_this_obj;
+  // CHECK-NEXT:     A *_d_this = &_d_this_obj;
   // CHECK-NEXT: return _d_x + _d_y * y + y * _d_y;
   // CHECK-NEXT: }
 
   // CHECK: int g_2_darg1(int x, int y) {
   // CHECK-NEXT: int _d_x = 0;
   // CHECK-NEXT: int _d_y = 1;
+  // CHECK-NEXT:     A _d_this_obj;
+  // CHECK-NEXT:     A *_d_this = &_d_this_obj;
   // CHECK-NEXT: return _d_x + _d_y * y + y * _d_y;
   // CHECK-NEXT: }
 

--- a/test/FirstDerivative/VirtualMethodsCall.C
+++ b/test/FirstDerivative/VirtualMethodsCall.C
@@ -44,12 +44,16 @@ public:
 //CHECK: float vm_darg0(float x, float y) {
 //CHECK-NEXT:       float _d_x = 1;
 //CHECK-NEXT:       float _d_y = 0;
+//CHECK-NEXT:      A _d_this_obj;
+//CHECK-NEXT:      A *_d_this = &_d_this_obj;
 //CHECK-NEXT:       return _d_x + _d_y;
 //CHECK-NEXT: }
     auto vm_darg1_cf = clad::differentiate(&A::vm, 1);
 //CHECK:   float vm_darg1(float x, float y) {
 //CHECK-NEXT:       float _d_x = 0;
 //CHECK-NEXT:       float _d_y = 1;
+//CHECK-NEXT:       A _d_this_obj;
+//CHECK-NEXT:       A *_d_this = &_d_this_obj;
 //CHECK-NEXT:       return _d_x + _d_y;
 //CHECK-NEXT: }
     return vm_darg0(x, y) + vm_darg1(x, y);
@@ -150,16 +154,22 @@ int main () {
   auto f_darg0_A = clad::differentiate(&A::f, 0);
 //CHECK: float f_darg0(float x) {
 //CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     A _d_this_obj;
+// CHECK-NEXT:     A *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x;
 //CHECK-NEXT: }
   auto f_darg0_B = clad::differentiate(&B::f, 0);
 //CHECK: float f_darg0(float x) {
 //CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     B _d_this_obj;
+// CHECK-NEXT:     B *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x * x + x * _d_x;
 //CHECK-NEXT: }
   auto f_darg0_B1 = clad::differentiate(&B1::f, 0);
 //CHECK: float f_darg0(float x) {
 //CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     B1 _d_this_obj;
+// CHECK-NEXT:     B1 *_d_this = &_d_this_obj;
 //CHECK-NEXT:     float _t0 = x * x;
 //CHECK-NEXT:     return (_d_x * x + x * _d_x) * x + _t0 * _d_x;
 //CHECK-NEXT: }
@@ -173,12 +183,16 @@ int main () {
 //CHECK: float vm_darg0(float x, float y) override {
 //CHECK-NEXT:     float _d_x = 1;
 //CHECK-NEXT:     float _d_y = 0;
+// CHECK-NEXT:     B _d_this_obj;
+// CHECK-NEXT:     B *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
 //CHECK-NEXT: }
   auto vm_darg0_B = clad::differentiate((float(B::*)(float,float))&B::vm, 0);
 //CHECK: float vm_darg1(float x, float y) override {
 //CHECK-NEXT:     float _d_x = 0;
 //CHECK-NEXT:     float _d_y = 1;
+// CHECK-NEXT:     B _d_this_obj;
+// CHECK-NEXT:     B *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
 //CHECK-NEXT: }
   auto vm_darg1_A = clad::differentiate((float(A::*)(float,float))&A::vm, 1);
@@ -189,24 +203,32 @@ int main () {
 //CHECK: float vm1_darg0(float x, float y) {
 //CHECK-NEXT:     float _d_x = 1;
 //CHECK-NEXT:     float _d_y = 0;
+// CHECK-NEXT:     A _d_this_obj;
+// CHECK-NEXT:     A *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x - _d_y;
 //CHECK-NEXT: }
   auto vm1_darg0_B = clad::differentiate((float(B::*)(float,float))&B::vm1, 0);
 //CHECK: float vm1_darg0(float x, float y) override {
 //CHECK-NEXT:    float _d_x = 1;
 //CHECK-NEXT:     float _d_y = 0;
+// CHECK-NEXT:     B _d_this_obj;
+// CHECK-NEXT:     B *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x * x + x * _d_x - (_d_y * y + y * _d_y);
 //CHECK-NEXT: }
   auto vm1_darg1_A = clad::differentiate((float(A::*)(float,float))&A::vm1, 1);
 //CHECK: float vm1_darg1(float x, float y) {
 //CHECK-NEXT:     float _d_x = 0;
 //CHECK-NEXT:     float _d_y = 1;
+// CHECK-NEXT:     A _d_this_obj;
+// CHECK-NEXT:     A *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x - _d_y;
 //CHECK-NEXT: }
   auto vm1_darg1_B = clad::differentiate((float(B::*)(float,float))&B::vm1, 1);
 //CHECK: float vm1_darg1(float x, float y) override {
 //CHECK-NEXT:     float _d_x = 0;
 //CHECK-NEXT:     float _d_y = 1;
+// CHECK-NEXT:     B _d_this_obj;
+// CHECK-NEXT:     B *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x * x + x * _d_x - (_d_y * y + y * _d_y);
 //CHECK-NEXT: }
   printf("Result is = %f\n", vm_darg0_A.execute(a, 2.0f, 3.0f)); // CHECK-EXEC: Result is = 1.0000
@@ -236,12 +258,16 @@ int main () {
 //CHECK: float vm_darg0(float x, float y) override {
 //CHECK-NEXT:     float _d_x = 1;
 //CHECK-NEXT:     float _d_y = 0;
+// CHECK-NEXT:     B1 _d_this_obj;
+// CHECK-NEXT:     B1 *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x * y + x * _d_y + _d_x * y + x * _d_y;
 //CHECK-NEXT: }
   auto vm_darg1_B1 = clad::differentiate(&B1::vm, 1);
 //CHECK: float vm_darg1(float x, float y) override {
 //CHECK-NEXT:     float _d_x = 0;
 //CHECK-NEXT:     float _d_y = 1;
+// CHECK-NEXT:     B1 _d_this_obj;
+// CHECK-NEXT:     B1 *_d_this = &_d_this_obj;
 //CHECK-NEXT:     return _d_x * y + x * _d_y + _d_x * y + x * _d_y;
 //CHECK-NEXT: }
   printf("Result is = %f\n", b1.m(3, 4)); // CHECK-EXEC: Result is = 14.0000

--- a/test/ForwardMode/FunctorErrors.C
+++ b/test/ForwardMode/FunctorErrors.C
@@ -35,6 +35,7 @@ struct Widget {
   double i, j;
   const char* char_arr[10];
   char** p2p_char;
+  Widget() : i(0), j(0) {}
   Widget(double p_i, double p_j) : i(p_i), j(p_j) {}
   double operator()() {
     char **p;

--- a/test/ForwardMode/Functors.C
+++ b/test/ForwardMode/Functors.C
@@ -6,6 +6,7 @@
 
 struct Experiment {
   mutable double x, y;
+  Experiment() : x(0), y(0) {}
   Experiment(double p_x, double p_y) : x(p_x), y(p_y) {}
   double operator()(double i, double j) {
     return x*i*j;
@@ -17,6 +18,8 @@ struct Experiment {
   // CHECK: double operator_call_darg0(double i, double j) {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     Experiment _d_this_obj;
+  // CHECK-NEXT:     Experiment *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _d_x = 0;
   // CHECK-NEXT:     double _d_y = 0;
   // CHECK-NEXT:     double &_t0 = this->x;
@@ -27,6 +30,7 @@ struct Experiment {
 
 struct ExperimentConst {
   mutable double x, y;
+  ExperimentConst() : x(0), y(0) {}
   ExperimentConst(double p_x, double p_y) : x(p_x), y(p_y) {}
   double operator()(double i, double j) const {
     return x*i*j;
@@ -38,6 +42,8 @@ struct ExperimentConst {
   // CHECK: double operator_call_darg0(double i, double j) const {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const ExperimentConst _d_this_obj;
+  // CHECK-NEXT:     const ExperimentConst *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _d_x = 0;
   // CHECK-NEXT:     double _d_y = 0;
   // CHECK-NEXT:     double &_t0 = this->x;
@@ -48,6 +54,7 @@ struct ExperimentConst {
 
 struct ExperimentVolatile {
   mutable double x, y;
+  ExperimentVolatile() : x(0), y(0) {}
   ExperimentVolatile(double p_x, double p_y) : x(p_x), y(p_y) {}
   double operator()(double i, double j) volatile {
     return x*i*j;
@@ -59,6 +66,8 @@ struct ExperimentVolatile {
   // CHECK: double operator_call_darg0(double i, double j) volatile {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile ExperimentVolatile _d_this_obj;
+  // CHECK-NEXT:     volatile ExperimentVolatile *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _d_x = 0;
   // CHECK-NEXT:     double _d_y = 0;
   // CHECK-NEXT:     volatile double &_t0 = this->x;
@@ -69,6 +78,7 @@ struct ExperimentVolatile {
 
 struct ExperimentConstVolatile {
   mutable double x, y;
+  ExperimentConstVolatile() : x(0), y(0) {}
   ExperimentConstVolatile(double p_x, double p_y) : x(p_x), y(p_y) {}
   double operator()(double i, double j) const volatile {
     return x*i*j;
@@ -80,6 +90,8 @@ struct ExperimentConstVolatile {
   // CHECK: double operator_call_darg0(double i, double j) const volatile {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile ExperimentConstVolatile _d_this_obj;
+  // CHECK-NEXT:     const volatile ExperimentConstVolatile *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _d_x = 0;
   // CHECK-NEXT:     double _d_y = 0;
   // CHECK-NEXT:     volatile double &_t0 = this->x;
@@ -92,6 +104,7 @@ namespace outer {
   namespace inner {
     struct ExperimentNNS {
       mutable double x, y;
+      ExperimentNNS() : x(0), y(0) {}
       ExperimentNNS(double p_x, double p_y) : x(p_x), y(p_y) {}
       double operator()(double i, double j) {
         return x*i*j;
@@ -103,6 +116,8 @@ namespace outer {
       // CHECK: double operator_call_darg0(double i, double j) {
       // CHECK-NEXT:     double _d_i = 1;
       // CHECK-NEXT:     double _d_j = 0;
+      // CHECK-NEXT:     outer::inner::ExperimentNNS _d_this_obj;
+      // CHECK-NEXT:     outer::inner::ExperimentNNS *_d_this = &_d_this_obj;
       // CHECK-NEXT:     double _d_x = 0;
       // CHECK-NEXT:     double _d_y = 0;
       // CHECK-NEXT:     double &_t0 = this->x;
@@ -120,6 +135,7 @@ namespace outer {
 struct Widget {
   double i, j;
   const char* char_arr[10];
+  Widget() : i(0), j(0) {}
   Widget(double p_i, double p_j) : i(p_i), j(p_j) {}
   double operator()() {
     j = i * i;
@@ -128,6 +144,8 @@ struct Widget {
   }
 
   // CHECK:   double operator_call_darg0() {
+  // CHECK-NEXT:       Widget _d_this_obj;
+  // CHECK-NEXT:       Widget *_d_this = &_d_this_obj;
   // CHECK-NEXT:       double _d_i = 1;
   // CHECK-NEXT:       double _d_j = 0;
   // CHECK-NEXT:       double &_t0 = this->i;
@@ -156,6 +174,7 @@ struct WidgetConstVolatile {
   mutable double i, j;
   char** s;
   char* char_arr[10];
+  WidgetConstVolatile() : i(0), j(0) {}
   WidgetConstVolatile(double p_i, double p_j) : i(p_i), j(p_j) {}
   double operator()() const volatile {
     j = i * i;
@@ -164,6 +183,8 @@ struct WidgetConstVolatile {
   }
 
   // CHECK:   double operator_call_darg0() const volatile {
+  // CHECK-NEXT:       const volatile WidgetConstVolatile _d_this_obj;
+  // CHECK-NEXT:       const volatile WidgetConstVolatile *_d_this = &_d_this_obj;
   // CHECK-NEXT:       double _d_i = 1;
   // CHECK-NEXT:       double _d_j = 0;
   // CHECK-NEXT:       volatile double &_t0 = this->i;
@@ -191,6 +212,7 @@ struct WidgetConstVolatile {
 struct WidgetArr {
   mutable double i, j;
   double arr[10];
+  WidgetArr() : i(0), j(0), arr{} {}
   WidgetArr(double p_i, double p_j) : i(p_i), j(p_j) {
     for (int i=0; i<10; ++i)
       arr[i] = i;
@@ -207,6 +229,8 @@ struct WidgetArr {
   }
 
   // CHECK:   double operator_call_darg2_3() {
+  // CHECK-NEXT:       WidgetArr _d_this_obj;
+  // CHECK-NEXT:       WidgetArr *_d_this = &_d_this_obj;
   // CHECK-NEXT:       double _d_i = 0;
   // CHECK-NEXT:       double _d_j = 0;
   // CHECK-NEXT:       double _d_arr[10] = {0, 0, 0, 1, 0, 0, 0, 0, 0, 0};
@@ -231,6 +255,8 @@ struct WidgetArr {
   // CHECK-NEXT:   }
 
   // CHECK:   double operator_call_darg2_5() {
+  // CHECK-NEXT:       WidgetArr _d_this_obj;
+  // CHECK-NEXT:       WidgetArr *_d_this = &_d_this_obj;
   // CHECK-NEXT:       double _d_i = 0;
   // CHECK-NEXT:       double _d_j = 0;
   // CHECK-NEXT:       double _d_arr[10] = {0, 0, 0, 0, 0, 1, 0, 0, 0, 0};
@@ -266,6 +292,7 @@ struct WidgetArr {
 struct WidgetPointer {
   mutable double i, j;
   double* arr;
+  WidgetPointer() : i(0), j(0) {}
   WidgetPointer(double p_i, double p_j) : i(p_i), j(p_j) {
     arr = static_cast<double*>(malloc(sizeof(double)*10));
     for (int i=0; i<10; ++i) {
@@ -287,6 +314,8 @@ struct WidgetPointer {
   }
 
   // CHECK:   double operator_call_darg2_3() {
+  // CHECK-NEXT:       WidgetPointer _d_this_obj;
+  // CHECK-NEXT:       WidgetPointer *_d_this = &_d_this_obj;
   // CHECK-NEXT:       double _d_i = 0;
   // CHECK-NEXT:       double _d_j = 0;
   // CHECK-NEXT:       double *_d_arr = nullptr;
@@ -317,6 +346,8 @@ struct WidgetPointer {
   // CHECK-NEXT:   }
 
   // CHECK:   double operator_call_darg2_5() {
+  // CHECK-NEXT:       WidgetPointer _d_this_obj;
+  // CHECK-NEXT:       WidgetPointer *_d_this = &_d_this_obj;
   // CHECK-NEXT:       double _d_i = 0;
   // CHECK-NEXT:       double _d_j = 0;
   // CHECK-NEXT:       double *_d_arr = nullptr;

--- a/test/ForwardMode/MemberFunctions.C
+++ b/test/ForwardMode/MemberFunctions.C
@@ -11,7 +11,8 @@
 extern "C" int printf(const char *fmt, ...);
 class SimpleFunctions {
 public:
-  SimpleFunctions(double p_x = 0, double p_y = 0) : x(p_x), y(p_y) {}
+  SimpleFunctions() noexcept : x(0), y(0) {}
+  SimpleFunctions(double p_x, double p_y) noexcept : x(p_x), y(p_y) {}
   double x, y;
   double mem_fn(double i, double j)  { 
     return (x+y)*i + i*j*j; 
@@ -20,9 +21,11 @@ public:
   // CHECK: double mem_fn_darg0(double i, double j) {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double mem_fn_with_var_arg_list(double i, double j, ...)  { 
@@ -32,9 +35,11 @@ public:
   // CHECK: double mem_fn_with_var_arg_list_darg0(double i, double j, ...) {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_mem_fn(double i, double j) const { 
@@ -44,9 +49,11 @@ public:
   // CHECK: double const_mem_fn_darg0(double i, double j) const {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_mem_fn_with_var_arg_list(double i, double j, ...) const { 
@@ -56,9 +63,11 @@ public:
   // CHECK: double const_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double volatile_mem_fn(double i, double j) volatile { 
@@ -68,9 +77,11 @@ public:
   // CHECK: double volatile_mem_fn_darg0(double i, double j) volatile {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double volatile_mem_fn_with_var_arg_list(double i, double j, ...) volatile { 
@@ -80,9 +91,11 @@ public:
   // CHECK: double volatile_mem_fn_with_var_arg_list_darg0(double i, double j, ...) volatile {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_volatile_mem_fn(double i, double j) const volatile { 
@@ -92,9 +105,11 @@ public:
   // CHECK: double const_volatile_mem_fn_darg0(double i, double j) const volatile {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_volatile_mem_fn_with_var_arg_list(double i, double j, ...) const volatile { 
@@ -104,9 +119,11 @@ public:
   // CHECK: double const_volatile_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const volatile {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double lval_ref_mem_fn(double i, double j) & { 
@@ -116,9 +133,11 @@ public:
   // CHECK: double lval_ref_mem_fn_darg0(double i, double j) & {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double lval_ref_mem_fn_with_var_arg_list(double i, double j, ...) & { 
@@ -128,9 +147,11 @@ public:
   // CHECK: double lval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) & {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_lval_ref_mem_fn(double i, double j) const & { 
@@ -140,9 +161,11 @@ public:
   // CHECK: double const_lval_ref_mem_fn_darg0(double i, double j) const & {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_lval_ref_mem_fn_with_var_arg_list(double i, double j, ...) const & { 
@@ -152,9 +175,11 @@ public:
   // CHECK: double const_lval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const & {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double volatile_lval_ref_mem_fn(double i, double j) volatile & { 
@@ -164,9 +189,11 @@ public:
   // CHECK: double volatile_lval_ref_mem_fn_darg0(double i, double j) volatile & {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double volatile_lval_ref_mem_fn_with_var_arg_list(double i, double j, ...) volatile & { 
@@ -176,9 +203,11 @@ public:
   // CHECK: double volatile_lval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) volatile & {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_volatile_lval_ref_mem_fn(double i, double j) const volatile & { 
@@ -188,9 +217,11 @@ public:
   // CHECK: double const_volatile_lval_ref_mem_fn_darg0(double i, double j) const volatile & {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_volatile_lval_ref_mem_fn_with_var_arg_list(double i, double j, ...) const volatile & { 
@@ -200,9 +231,11 @@ public:
   // CHECK: double const_volatile_lval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const volatile & {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double rval_ref_mem_fn(double i, double j) && { 
@@ -212,9 +245,11 @@ public:
   // CHECK: double rval_ref_mem_fn_darg0(double i, double j) && {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double rval_ref_mem_fn_with_var_arg_list(double i, double j, ...) && { 
@@ -224,9 +259,11 @@ public:
   // CHECK: double rval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) && {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_rval_ref_mem_fn(double i, double j) const && { 
@@ -236,9 +273,11 @@ public:
   // CHECK: double const_rval_ref_mem_fn_darg0(double i, double j) const && {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_rval_ref_mem_fn_with_var_arg_list(double i, double j, ...) const && { 
@@ -248,9 +287,11 @@ public:
   // CHECK: double const_rval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const && {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double volatile_rval_ref_mem_fn(double i, double j) volatile && { 
@@ -260,9 +301,11 @@ public:
   // CHECK: double volatile_rval_ref_mem_fn_darg0(double i, double j) volatile && {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double volatile_rval_ref_mem_fn_with_var_arg_list(double i, double j, ...) volatile && { 
@@ -272,9 +315,11 @@ public:
   // CHECK: double volatile_rval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) volatile && {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_volatile_rval_ref_mem_fn(double i, double j) const volatile && { 
@@ -284,9 +329,11 @@ public:
   // CHECK: double const_volatile_rval_ref_mem_fn_darg0(double i, double j) const volatile && {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_volatile_rval_ref_mem_fn_with_var_arg_list(double i, double j, ...) const volatile && { 
@@ -296,9 +343,11 @@ public:
   // CHECK: double const_volatile_rval_ref_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const volatile && {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double noexcept_mem_fn(double i, double j) noexcept { 
@@ -308,9 +357,11 @@ public:
   // CHECK: double noexcept_mem_fn_darg0(double i, double j) noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double noexcept_mem_fn_with_var_arg_list(double i, double j, ...) noexcept { 
@@ -320,9 +371,11 @@ public:
   // CHECK: double noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_noexcept_mem_fn(double i, double j) const noexcept { 
@@ -332,9 +385,11 @@ public:
   // CHECK: double const_noexcept_mem_fn_darg0(double i, double j) const noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) const noexcept { 
@@ -344,9 +399,11 @@ public:
   // CHECK: double const_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double volatile_noexcept_mem_fn(double i, double j) volatile noexcept { 
@@ -356,9 +413,11 @@ public:
   // CHECK: double volatile_noexcept_mem_fn_darg0(double i, double j) volatile noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double volatile_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) volatile noexcept { 
@@ -368,9 +427,11 @@ public:
   // CHECK: double volatile_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) volatile noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_volatile_noexcept_mem_fn(double i, double j) const volatile noexcept { 
@@ -380,9 +441,11 @@ public:
   // CHECK: double const_volatile_noexcept_mem_fn_darg0(double i, double j) const volatile noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_volatile_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) const volatile noexcept { 
@@ -392,9 +455,11 @@ public:
   // CHECK: double const_volatile_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const volatile noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double lval_ref_noexcept_mem_fn(double i, double j) & noexcept { 
@@ -404,9 +469,11 @@ public:
   // CHECK: double lval_ref_noexcept_mem_fn_darg0(double i, double j) & noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double lval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) & noexcept { 
@@ -416,9 +483,11 @@ public:
   // CHECK: double lval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) & noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_lval_ref_noexcept_mem_fn(double i, double j) const & noexcept { 
@@ -428,9 +497,11 @@ public:
   // CHECK: double const_lval_ref_noexcept_mem_fn_darg0(double i, double j) const & noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_lval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) const & noexcept { 
@@ -440,9 +511,11 @@ public:
   // CHECK: double const_lval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const & noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double volatile_lval_ref_noexcept_mem_fn(double i, double j) volatile & noexcept { 
@@ -452,9 +525,11 @@ public:
   // CHECK: double volatile_lval_ref_noexcept_mem_fn_darg0(double i, double j) volatile & noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double volatile_lval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) volatile & noexcept { 
@@ -464,9 +539,11 @@ public:
   // CHECK: double volatile_lval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) volatile & noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_volatile_lval_ref_noexcept_mem_fn(double i, double j) const volatile & noexcept { 
@@ -476,9 +553,11 @@ public:
   // CHECK: double const_volatile_lval_ref_noexcept_mem_fn_darg0(double i, double j) const volatile & noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_volatile_lval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) const volatile & noexcept { 
@@ -488,9 +567,11 @@ public:
   // CHECK: double const_volatile_lval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const volatile & noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double rval_ref_noexcept_mem_fn(double i, double j) && noexcept { 
@@ -500,9 +581,11 @@ public:
   // CHECK: double rval_ref_noexcept_mem_fn_darg0(double i, double j) && noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double rval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) && noexcept { 
@@ -512,9 +595,11 @@ public:
   // CHECK: double rval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) && noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_rval_ref_noexcept_mem_fn(double i, double j) const && noexcept { 
@@ -524,9 +609,11 @@ public:
   // CHECK: double const_rval_ref_noexcept_mem_fn_darg0(double i, double j) const && noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_rval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) const && noexcept { 
@@ -536,9 +623,11 @@ public:
   // CHECK: double const_rval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const && noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double volatile_rval_ref_noexcept_mem_fn(double i, double j) volatile && noexcept { 
@@ -548,9 +637,11 @@ public:
   // CHECK: double volatile_rval_ref_noexcept_mem_fn_darg0(double i, double j) volatile && noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double volatile_rval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) volatile && noexcept { 
@@ -560,9 +651,11 @@ public:
   // CHECK: double volatile_rval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) volatile && noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_volatile_rval_ref_noexcept_mem_fn(double i, double j) const volatile && noexcept { 
@@ -572,9 +665,11 @@ public:
   // CHECK: double const_volatile_rval_ref_noexcept_mem_fn_darg0(double i, double j) const volatile && noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double const_volatile_rval_ref_noexcept_mem_fn_with_var_arg_list(double i, double j, ...) const volatile && noexcept { 
@@ -584,9 +679,11 @@ public:
   // CHECK: double const_volatile_rval_ref_noexcept_mem_fn_with_var_arg_list_darg0(double i, double j, ...) const volatile && noexcept {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
+  // CHECK-NEXT:     const volatile SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:     const volatile SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (0. + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return (_d_this->x + _d_this->y) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   double* arr[10];
@@ -600,9 +697,11 @@ public:
   // CHECK:   double use_mem_var_darg0(double i, double j) {
   // CHECK-NEXT:       double _d_i = 1;
   // CHECK-NEXT:       double _d_j = 0;
+  // CHECK-NEXT:       SimpleFunctions _d_this_obj;
+  // CHECK-NEXT:       SimpleFunctions *_d_this = &_d_this_obj;
   // CHECK-NEXT:       double *_d_p;
   // CHECK-NEXT:       double *p;
-  // CHECK-NEXT:       _d_p = 0;
+  // CHECK-NEXT:       _d_p = _d_this->arr[1];
   // CHECK-NEXT:       p = this->arr[1];
   // CHECK-NEXT:       return _d_i;
   // CHECK-NEXT:   }

--- a/test/ForwardMode/Pointers.C
+++ b/test/ForwardMode/Pointers.C
@@ -13,6 +13,8 @@ public:
 
   // CHECK: double memFn_darg0(double i) {
   // CHECK-NEXT:     double _d_i = 1;
+  // CHECK-NEXT:     Expression _d_this_obj;
+  // CHECK-NEXT:     Expression *_d_this = &_d_this_obj;
   // CHECK-NEXT:     return _d_i * i + i * _d_i;
   // CHECK-NEXT: }
 
@@ -157,7 +159,4 @@ int main() {
   NON_MEM_FN_TEST(d_nonMemFnReinterpretCast); // CHECK-EXEC: 5.00
 
   NON_MEM_FN_TEST(d_nonMemFnCStyleCast); // CHECK-EXEC: 5.00
-
-
-
 }

--- a/test/ForwardMode/TemplateFunctors.C
+++ b/test/ForwardMode/TemplateFunctors.C
@@ -6,6 +6,7 @@
 
 template <typename T> struct Experiment {
   mutable T x, y;
+  Experiment() : x(), y() {}
   Experiment(T p_x, T p_y) : x(p_x), y(p_y) {}
   T operator()(T i, T j) { return x * i * i + y * j; }
   void setX(T val) { x = val; }
@@ -14,6 +15,8 @@ template <typename T> struct Experiment {
 // CHECK: double operator_call_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     Experiment<double> _d_this_obj;
+// CHECK-NEXT:     Experiment<double> *_d_this = &_d_this_obj;
 // CHECK-NEXT:     double _d_x = 0;
 // CHECK-NEXT:     double _d_y = 0;
 // CHECK-NEXT:     double &_t0 = this->x;
@@ -24,6 +27,7 @@ template <typename T> struct Experiment {
 
 template <> struct Experiment<long double> {
   mutable long double x, y;
+  Experiment() : x(), y() {}
   Experiment(long double p_x, long double p_y) : x(p_x), y(p_y) {}
   long double operator()(long double i, long double j) { return x * i * i * j + y * j; }
   void setX(long double val) { x = val; }
@@ -32,6 +36,8 @@ template <> struct Experiment<long double> {
 // CHECK: long double operator_call_darg0(long double i, long double j) {
 // CHECK-NEXT:     long double _d_i = 1;
 // CHECK-NEXT:     long double _d_j = 0;
+// CHECK-NEXT:     Experiment<long double> _d_this_obj;
+// CHECK-NEXT:     Experiment<long double> *_d_this = &_d_this_obj;
 // CHECK-NEXT:     long double _d_x = 0;
 // CHECK-NEXT:     long double _d_y = 0;
 // CHECK-NEXT:     long double &_t0 = this->x;
@@ -43,6 +49,7 @@ template <> struct Experiment<long double> {
 
 template <typename T> struct ExperimentConstVolatile {
   mutable T x, y;
+  ExperimentConstVolatile() : x(), y() {}
   ExperimentConstVolatile(T p_x, T p_y) : x(p_x), y(p_y) {}
   T operator()(T i, T j) const volatile { return x * i * i + y * j; }
   void setX(T val) const volatile { x = val; }
@@ -51,6 +58,8 @@ template <typename T> struct ExperimentConstVolatile {
 // CHECK: double operator_call_darg0(double i, double j) const volatile {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     const volatile ExperimentConstVolatile<double> _d_this_obj;
+// CHECK-NEXT:     const volatile ExperimentConstVolatile<double> *_d_this = &_d_this_obj;
 // CHECK-NEXT:     double _d_x = 0;
 // CHECK-NEXT:     double _d_y = 0;
 // CHECK-NEXT:     volatile double &_t0 = this->x;
@@ -61,6 +70,7 @@ template <typename T> struct ExperimentConstVolatile {
 
 template <> struct ExperimentConstVolatile<long double> {
   mutable long double x, y;
+  ExperimentConstVolatile() : x(), y() {}
   ExperimentConstVolatile(long double p_x, long double p_y) : x(p_x), y(p_y) {}
   long double operator()(long double i, long double j) const volatile {
     return x * i * i * j + y * j;
@@ -71,6 +81,8 @@ template <> struct ExperimentConstVolatile<long double> {
 // CHECK: long double operator_call_darg0(long double i, long double j) const volatile {
 // CHECK-NEXT:     long double _d_i = 1;
 // CHECK-NEXT:     long double _d_j = 0;
+// CHECK-NEXT:     const volatile ExperimentConstVolatile<long double> _d_this_obj;
+// CHECK-NEXT:     const volatile ExperimentConstVolatile<long double> *_d_this = &_d_this_obj;
 // CHECK-NEXT:     long double _d_x = 0;
 // CHECK-NEXT:     long double _d_y = 0;
 // CHECK-NEXT:     volatile long double &_t0 = this->x;

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -178,6 +178,80 @@ TensorD5 fn7(double i, double j) {
 // CHECK-NEXT:     return _d_t;
 // CHECK-NEXT: }
 
+using complexD = std::complex<double>;
+
+complexD fn8(double i, TensorD5 t) {
+  t.updateTo(i*i);
+  complexD c;
+  c.real(7*t.sum());
+  c.imag(9*sum(t));
+  return c;
+}
+
+// CHECK: void real_pushforward({{.*}} [[__val:.*]], std{{(::__1)?}}::complex<double> *_d_this, {{.*}} [[_d___val:[a-zA-Z_]*]]){{.*}} {
+// CHECK-NEXT:     {{(__real)?}} _d_this->[[_M_value:.*]] = [[_d___val]];
+// CHECK-NEXT:     {{(__real)?}} this->[[_M_value]] = [[__val]];
+// CHECK-NEXT: }
+
+// CHECK: void imag_pushforward({{.*}} [[__val:.*]], std{{(::__1)?}}::complex<double> *_d_this, {{.*}} [[_d___val:[a-zA-Z_]*]]){{.*}} {
+// CHECK-NEXT:     {{(__imag)?}} _d_this->[[_M_value:.*]] = [[_d___val]];
+// CHECK-NEXT:     {{(__imag)?}} this->[[_M_value]] = [[__val]];
+// CHECK-NEXT: }
+
+// CHECK: complexD fn8_darg0(double i, TensorD5 t) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     TensorD5 _d_t;
+// CHECK-NEXT:     t.updateTo_pushforward(i * i, &_d_t, _d_i * i + i * _d_i);
+// CHECK-NEXT:     t.updateTo(i * i);
+// CHECK-NEXT:     complexD _d_c(0., 0.);
+// CHECK-NEXT:     complexD c(0., 0.);
+// CHECK-NEXT:     double _t0 = t.sum();
+// CHECK-NEXT:     c.real_pushforward(7 * _t0, &_d_c, 0 * _t0 + 7 * t.sum_pushforward(&_d_t));
+// CHECK-NEXT:     c.real(7 * _t0);
+// CHECK-NEXT:     double _t1 = sum(t);
+// CHECK-NEXT:     c.imag_pushforward(9 * _t1, &_d_c, 0 * _t1 + 9 * sum_pushforward(t, _d_t));
+// CHECK-NEXT:     c.imag(9 * _t1);
+// CHECK-NEXT:     return _d_c;
+// CHECK-NEXT: }
+
+complexD fn9(double i, complexD c) {
+  complexD r;
+  c.real(i*i);
+  c.imag(c.real()*c.real());
+  r.real(i*c.real());
+  r.imag(c.real()*c.imag());
+  return r;
+}
+
+// CHECK: constexpr double real_pushforward(const std{{(::__1)?}}::complex<double> *_d_this){{.*}} {
+// CHECK-NEXT:     return{{( __real)?}} _d_this->[[_M_value:.*]];
+// CHECK-NEXT: }
+
+// CHECK: constexpr double imag_pushforward(const std{{(::__1)?}}::complex<double> *_d_this){{.*}} {
+// CHECK-NEXT:     return{{( __imag)?}} _d_this->[[_M_value:.*]];
+// CHECK-NEXT: }
+
+// CHECK: complexD fn9_darg0(double i, complexD c) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     complexD _d_c;
+// CHECK-NEXT:     complexD _d_r(0., 0.);
+// CHECK-NEXT:     complexD r(0., 0.);
+// CHECK-NEXT:     c.real_pushforward(i * i, &_d_c, _d_i * i + i * _d_i);
+// CHECK-NEXT:     c.real(i * i);
+// CHECK-NEXT:     double _t0 = c.real();
+// CHECK-NEXT:     double _t1 = c.real();
+// CHECK-NEXT:     c.imag_pushforward(_t0 * _t1, &_d_c, c.real_pushforward(&_d_c) * _t1 + _t0 * c.real_pushforward(&_d_c));
+// CHECK-NEXT:     c.imag(_t0 * _t1);
+// CHECK-NEXT:     double _t2 = c.real();
+// CHECK-NEXT:     r.real_pushforward(i * _t2, &_d_r, _d_i * _t2 + i * c.real_pushforward(&_d_c));
+// CHECK-NEXT:     r.real(i * _t2);
+// CHECK-NEXT:     double _t3 = c.real();
+// CHECK-NEXT:     double _t4 = c.imag();
+// CHECK-NEXT:     r.imag_pushforward(_t3 * _t4, &_d_r, c.real_pushforward(&_d_c) * _t4 + _t3 * c.imag_pushforward(&_d_c));
+// CHECK-NEXT:     r.imag(_t3 * _t4);
+// CHECK-NEXT:     return _d_r;
+// CHECK-NEXT: }
+
 template<unsigned N>
 void print(const Tensor<double, N>& t) {
   for (int i=0; i<N; ++i) {
@@ -195,9 +269,12 @@ int main() {
   INIT_DIFFERENTIATE(fn5, "i");
   INIT_DIFFERENTIATE(fn6, "i");
   INIT_DIFFERENTIATE(fn7, "i");
+  INIT_DIFFERENTIATE(fn8, "i");
+  INIT_DIFFERENTIATE(fn9, "i");
 
   TensorD5 t;
   t.updateTo(5);
+  complexD c(3, 5);
 
   TEST_DIFFERENTIATE(fn1, 3, 5);  // CHECK-EXEC: {3.00, 3.00}
   TEST_DIFFERENTIATE(fn2, 3, 5);  // CHECK-EXEC: {0.00, 0.00}
@@ -206,4 +283,6 @@ int main() {
   TEST_DIFFERENTIATE(fn5, 3, 5);  // CHECK-EXEC: {1.00, 2.00, 3.00, 4.00, 5.00}
   TEST_DIFFERENTIATE(fn6, t, 3);  // CHECK-EXEC: {30.00}
   TEST_DIFFERENTIATE(fn7, 3, 5);  // CHECK-EXEC: {35.00, 35.00, 35.00, 35.00, 35.00}
+  TEST_DIFFERENTIATE(fn8, 3, t);  // CHECK-EXEC: {210.00, 270.00}
+  TEST_DIFFERENTIATE(fn9, 3, c);  // CHECK-EXEC: {27.00, 1458.00}
 }

--- a/test/Functors/Simple.C
+++ b/test/Functors/Simple.C
@@ -21,13 +21,14 @@ public:
 class Matcher {
   int target;
 public:
-  Matcher(int m) : target(m) {}
+  Matcher(int m=0) : target(m) {}
   int operator()(int x) { return x == target;}
 };
 
 class SimpleExpression {
   float x, y;
 public:
+  SimpleExpression() : x(), y() {}
   SimpleExpression(float x, float y) : x(x), y(y) {}
   float operator()(float x, float y) { return x * x + y * y;}
   float operator_call_darg0(float x, float y);
@@ -36,6 +37,8 @@ public:
 // CHECK: float operator_call_darg0(float x, float y) {
 // CHECK-NEXT: float _d_x = 1;
 // CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: SimpleExpression _d_this_obj;
+// CHECK-NEXT: SimpleExpression *_d_this = &_d_this_obj;
 // CHECK-NEXT: float _d_x0 = 0;
 // CHECK-NEXT: float _d_y0 = 0;
 // CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
@@ -44,6 +47,8 @@ public:
 // CHECK: float operator_call_darg1(float x, float y) {
 // CHECK-NEXT: float _d_x = 0;
 // CHECK-NEXT: float _d_y = 1;
+// CHECK-NEXT: SimpleExpression _d_this_obj;
+// CHECK-NEXT: SimpleExpression *_d_this = &_d_this_obj;
 // CHECK-NEXT: float _d_x0 = 0;
 // CHECK-NEXT: float _d_y0 = 0;
 // CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y;

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -3,9 +3,12 @@
 // CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"
-#include "../TestUtils.h"
+
 #include <utility>
 #include <complex>
+
+#include "../TestUtils.h"
+#include "../PrintOverloads.h"
 
 using pairdd = std::pair<double, double>;
 
@@ -569,11 +572,6 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
-
-namespace std {
-void print(const pairdd& p) { printf("%.2f, %.2f", p.first, p.second); }
-void print(const dcomplex& c) {printf("%.2f, %.2f", c.real(), c.imag());}
-} // namespace std
 
 void print(const Tangent& t) {
   for (int i = 0; i < 5; ++i) {

--- a/test/PrintOverloads.h
+++ b/test/PrintOverloads.h
@@ -1,0 +1,23 @@
+#ifndef TEST_PRINT_OVERLOADS_H
+#define TEST_PRINT_OVERLOADS_H
+
+#include <cstdio>
+#include <utility>
+#include <complex>
+
+namespace std {
+template <typename U, typename V> void print(const pair<U, V>& p) {
+  test_utils::print(p.first);
+  printf(", ");
+  test_utils::print(p.second);
+}
+
+template<typename T>
+void print(complex<T> c) {
+  test_utils::print(c.real());
+  printf(", ");
+  test_utils::print(c.imag());
+}
+} // namespace std
+
+#endif

--- a/test/TestUtils.h
+++ b/test/TestUtils.h
@@ -4,9 +4,13 @@
 
 #include <cstdio>
 #include <type_traits>
-#include <utility>
 
 namespace test_utils {
+
+template<typename T>
+void print(T t) {
+  fprintf(stderr, "Print method not defined for type: %s", typeid(t).name());
+}
 
 void print(const char* s) { printf("%s", s); }
 
@@ -96,7 +100,15 @@ void run_gradient(CF cf, Args&&... args) {
   run_gradient_impl(cf, DerivativeArgsRange(), std::forward<Args>(args)...);
 }
 
+template <class CF, class... Args>
+void run_differentiate(CF cf, Args&&... args) {
+  display(cf.execute(std::forward<Args>(args)...));
+}
+
 #define INIT_GRADIENT_ALL(fn) auto fn##_grad = clad::gradient(fn);
+
+#define INIT_DIFFERENTIATE(fn, ...)                                            \
+  auto fn##_diff = clad::differentiate(fn, __VA_ARGS__);
 
 #define INIT_GRADIENT_SPECIFIC(fn, args)                                       \
   auto fn##_grad = clad::gradient(fn, args);
@@ -109,6 +121,9 @@ void run_gradient(CF cf, Args&&... args) {
 
 #define TEST_GRADIENT(fn, numOfDerivativeArgs, ...)                            \
   test_utils::run_gradient<numOfDerivativeArgs>(fn##_grad, __VA_ARGS__);
+
+#define TEST_DIFFERENTIATE(fn, ...)                                            \
+  test_utils::run_differentiate(fn##_diff, __VA_ARGS__);
 
 #endif
 }


### PR DESCRIPTION
This PR adds support for differentiating calls to member functions in the forward mode AD.

The PR also adds cloning function for the node `SubstNonTypeTemplateParmExpr` and support for differentiating C99 language extensions `__real` and `__imag` unary operators. The support for these language extensions allow us to differentiate `std::complex` types. 

