### PR TITLE
Add support for diff overloaded operators in the forw mode

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -231,6 +231,16 @@ namespace clad {
                                        clang::Expr* initializer,
                                        clang::TypeSourceInfo* TSI = nullptr);
 
+    /// Builds a static cast to RValue expression for the expression `E`.
+    ///
+    /// If type of `E` is `T`. Then this function effectively creates:
+    // ```
+    // static_cast<T&&>(E)
+    // ```
+    clang::Expr* BuildStaticCastToRValue(clang::Sema& semaRef, clang::Expr* E);
+
+    /// Returns true if expression `E` is PRValue or XValue.
+    bool IsRValue(const clang::Expr* E);
   } // namespace utils
 }
 

--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -51,7 +51,6 @@ namespace clad {
     StmtDiff VisitConditionalOperator(const clang::ConditionalOperator* CO);
     StmtDiff VisitCXXBoolLiteralExpr(const clang::CXXBoolLiteralExpr* BL);
     StmtDiff VisitCXXDefaultArgExpr(const clang::CXXDefaultArgExpr* DE);
-    StmtDiff VisitCXXOperatorCallExpr(const clang::CXXOperatorCallExpr* OpCall);
     StmtDiff VisitDeclRefExpr(const clang::DeclRefExpr* DRE);
     StmtDiff VisitDeclStmt(const clang::DeclStmt* DS);
     StmtDiff VisitFloatingLiteral(const clang::FloatingLiteral* FL);
@@ -91,7 +90,7 @@ namespace clad {
     StmtDiff VisitCXXThisExpr(const clang::CXXThisExpr* CTE);
     StmtDiff VisitCXXNewExpr(const clang::CXXNewExpr* CNE);
     StmtDiff VisitCXXDeleteExpr(const clang::CXXDeleteExpr* CDE);
-
+    StmtDiff VisitCXXStaticCastExpr(const clang::CXXStaticCastExpr* CSE);
   private:
     /// Helper function for differentiating the switch statement body.
     ///

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -46,6 +46,9 @@ namespace clad {
     clang::Expr* getExpr_dx() {
       return llvm::cast_or_null<clang::Expr>(getStmt_dx());
     }
+    
+    void updateStmt(clang::Stmt* S) { data[1] = S; }
+    void updateStmtDx(clang::Stmt* S) { data[0] = S; }
     // Stmt_dx goes first!
     std::array<clang::Stmt*, 2>& getBothStmts() { return data; }
   };

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -14,12 +14,91 @@ using namespace clang;
 namespace clad {
   namespace utils {
     static SourceLocation noLoc{};
-    
+
     std::string ComputeEffectiveFnName(const FunctionDecl* FD) {
-      // TODO: Add cases for more operators
       switch (FD->getOverloadedOperator()) {
-        case OverloadedOperatorKind::OO_Call: return "operator_call";
-        default: return FD->getNameAsString();
+      case OverloadedOperatorKind::OO_Plus:
+        return "operator_plus";
+      case OverloadedOperatorKind::OO_Minus:
+        return "operator_minus";
+      case OverloadedOperatorKind::OO_Star:
+        return "operator_star";
+      case OverloadedOperatorKind::OO_Slash:
+        return "operator_slash";
+      case OverloadedOperatorKind::OO_Percent:
+        return "operator_percent";
+      case OverloadedOperatorKind::OO_Caret:
+        return "operator_caret";
+      case OverloadedOperatorKind::OO_Amp:
+        return "operator_amp";
+      case OverloadedOperatorKind::OO_Pipe:
+        return "operator_pipe";
+      case OverloadedOperatorKind::OO_Tilde:
+        return "operator_tilde";
+      case OverloadedOperatorKind::OO_Exclaim:
+        return "operator_exclaim";
+      case OverloadedOperatorKind::OO_Equal:
+        return "operator_equal";
+      case OverloadedOperatorKind::OO_Less:
+        return "operator_less";
+      case OverloadedOperatorKind::OO_Greater:
+        return "operator_greater";
+      case OverloadedOperatorKind::OO_PlusEqual:
+        return "operator_plus_equal";
+      case OverloadedOperatorKind::OO_MinusEqual:
+        return "operator_minus_equal";
+      case OverloadedOperatorKind::OO_StarEqual:
+        return "operator_star_equal";
+      case OverloadedOperatorKind::OO_SlashEqual:
+        return "operator_slash_equal";
+      case OverloadedOperatorKind::OO_PercentEqual:
+        return "operator_percent_equal";
+      case OverloadedOperatorKind::OO_CaretEqual:
+        return "operator_caret_equal";
+      case OverloadedOperatorKind::OO_AmpEqual:
+        return "operator_amp_equal";
+      case OverloadedOperatorKind::OO_PipeEqual:
+        return "operator_pipe_equal";
+      case OverloadedOperatorKind::OO_LessLess:
+        return "operator_less_less";
+      case OverloadedOperatorKind::OO_GreaterGreater:
+        return "operator_greater_greater";
+      case OverloadedOperatorKind::OO_GreaterGreaterEqual:
+        return "operator_greater_greater_equal";
+      case OverloadedOperatorKind::OO_LessLessEqual:
+        return "operator_less_less_equal";
+      case OverloadedOperatorKind::OO_EqualEqual:
+        return "operator_equal_equal";
+      case OverloadedOperatorKind::OO_ExclaimEqual:
+        return "operator_exclaim_equal";
+      case OverloadedOperatorKind::OO_LessEqual:
+        return "operator_less_equal";
+      case OverloadedOperatorKind::OO_GreaterEqual:
+        return "operator_greater_equal";
+#if CLANG_VERSION_MAJOR > 5
+      case OverloadedOperatorKind::OO_Spaceship:
+        return "operator_spaceship";
+#endif
+      case OverloadedOperatorKind::OO_AmpAmp:
+        return "operator_AmpAmp";
+      case OverloadedOperatorKind::OO_PipePipe:
+        return "operator_pipe_pipe";
+      case OverloadedOperatorKind::OO_PlusPlus:
+        return "operator_plus_plus";
+      case OverloadedOperatorKind::OO_MinusMinus:
+        return "operator_minus_minus";
+      case OverloadedOperatorKind::OO_Comma:
+        return "operator_comma";
+      case OverloadedOperatorKind::OO_ArrowStar:
+        return "operator_arrow_star";
+      case OverloadedOperatorKind::OO_Arrow:
+        return "operator_arrow";
+      case OverloadedOperatorKind::OO_Call:
+        return "operator_call";
+      case OverloadedOperatorKind::OO_Subscript:
+        return "operator_subscript";
+      default:
+        return FD->getNameAsString();
       }
     }
 
@@ -313,6 +392,24 @@ namespace clad {
                   GetValidSRange(semaRef), initializer)
               .getAs<CXXNewExpr>();
       return newExpr;
+    }
+
+    clang::Expr* BuildStaticCastToRValue(clang::Sema& semaRef, clang::Expr* E) {
+      ASTContext& C = semaRef.getASTContext();
+      QualType T = E->getType();
+      T = T.getNonReferenceType();
+      T = C.getRValueReferenceType(T);
+      TypeSourceInfo* TSI = C.getTrivialTypeSourceInfo(T);
+      Expr* rvalueCastE =
+          semaRef
+              .BuildCXXNamedCast(noLoc, tok::TokenKind::kw_static_cast, TSI, E,
+                                 noLoc, noLoc)
+              .get();
+      return rvalueCastE;
+    }
+
+    bool IsRValue(const clang::Expr* E) {
+      return E->isRValue() || E->isXValue();
     }
   } // namespace utils
 } // namespace clad

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -235,16 +235,16 @@ Stmt* StmtClone::VisitUnresolvedLookupExpr(UnresolvedLookupExpr* Node) {
 }
 
 Stmt* StmtClone::VisitCXXOperatorCallExpr(CXXOperatorCallExpr* Node) {
-  CXXOperatorCallExpr* result
-    = clad_compat::CXXOperatorCallExpr_Create(Ctx, Node->getOperator(),
-                                    Clone(Node->getCallee()), 0,
-                                    Node->getType(),
-                                    Node->getValueKind(),
-                                    Node->getRParenLoc(),
-                                    Node->getFPFeatures()
-                                    CLAD_COMPAT_CLANG11_CXXOperatorCallExpr_Create_ExtraParams
-                                    );
-//###  result->setNumArgs(Ctx, Node->getNumArgs());
+  llvm::SmallVector<Expr*, 4> clonedArgs;
+  for (Expr* arg : Node->arguments()) {
+    clonedArgs.push_back(Clone(arg));
+  }
+  CXXOperatorCallExpr* result = clad_compat::CXXOperatorCallExpr_Create(
+      Ctx, Node->getOperator(), Clone(Node->getCallee()), clonedArgs,
+      Node->getType(), Node->getValueKind(), Node->getRParenLoc(),
+      Node->getFPFeatures()
+          CLAD_COMPAT_CLANG11_CXXOperatorCallExpr_Create_ExtraParams);
+  //###  result->setNumArgs(Ctx, Node->getNumArgs());
   result->setNumArgsUnsafe(Node->getNumArgs());
   for (unsigned i = 0, e = Node->getNumArgs(); i < e; ++i)
     result->setArg(i, Clone(Node->getArg(i)));

--- a/test/ForwardMode/Casts.C
+++ b/test/ForwardMode/Casts.C
@@ -1,0 +1,19 @@
+// RUN: %cladclang %s -I%S/../../include -oCasts.out 2>&1 | FileCheck %s
+// RUN: ./Casts.out | FileCheck -check-prefix=CHECK-EXEC %s
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include "../TestUtils.h"
+
+long double fn1(double i, double j) {
+  long double res =
+      static_cast<long double>(7 * i) + static_cast<long double>(i * j);
+  return res;
+}
+
+int main() {
+  INIT_DIFFERENTIATE(fn1, "i");
+
+  TEST_DIFFERENTIATE(fn1, 3, 5);  // CHECK-EXEC: {12.00}
+}

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -oUserDefinedTypes.out 2>&1 | FileCheck %s
+// RUN: %cladclang -lm -lstdc++ %s -I%S/../../include -oUserDefinedTypes.out 2>&1 | FileCheck %s
 // RUN: ./UserDefinedTypes.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 // CHECK-NOT: {{.*error|warning|note:.*}}
@@ -95,17 +95,307 @@ std::pair<double, double> fn4(double i, double j) {
 template<typename T, unsigned N>
 struct Tensor {
   T data[N] = {};
+
+  Tensor() : data() {}
+
   void updateTo(T val) {
     for (int i=0; i<N; ++i)
       data[i] = val;
   }
+
   T sum() {
     T res = 0;
     for (int i=0; i<N; ++i)
       res += data[i];
     return res;
   }
+
+  Tensor& operator=(const Tensor& t) {
+    for (unsigned i=0; i<N; ++i)
+      data[i] = t.data[i];
+    return *this;
+  }
+
+  T& operator[](std::size_t idx) {
+    return data[idx];
+  }
+
+  const T& operator[](std::size_t idx) const {
+    return data[idx];
+  }
+
+  void operator()(T val) {
+    for (unsigned i=0; i<N; ++i)
+      data[i] = val;
+  }
+  
+  Tensor& operator++() {
+    for (unsigned i=0; i<N; ++i)
+      data[i]+=1;
+    return *this;
+  }
+  
+  Tensor operator++(int) {
+    Tensor temp;
+    for (unsigned i=0; i<N; ++i)
+      temp.data[i] += 1;
+    return temp;
+  }
+  
+  Tensor& operator--() {
+    for (unsigned i=0; i<N; ++i)
+      data[i] += 1;
+    return *this;
+  }
+
+  Tensor operator--(int) {
+    Tensor temp;
+    for (unsigned i=0; i<N; ++i)
+      temp.data[i] -= 1;
+    return temp;
+  }
+
+  Tensor* operator->() { return this; }
+  Tensor* operator&() { return this; }
 };
+
+template<typename T, unsigned N>
+Tensor<T, N> operator-(const Tensor<T, N>& t) {
+  Tensor<T, N> res;
+  for (unsigned i=0; i<N; ++i)
+    res.data[i] = -t.data[i];
+  return res;
+};
+
+template<typename T, unsigned N>
+Tensor<T, N> operator+(const Tensor<T, N>& t) {
+  Tensor<T, N> res;
+  for (unsigned i=0; i<N; ++i)
+    res.data[i] = +t.data[i];
+  return res;
+};
+
+template<typename T, unsigned N>
+Tensor<T, N> operator+(const Tensor<T, N>& a, const Tensor<T, N>& b) {
+  Tensor<T, N> res;
+  for (unsigned i=0; i<N; ++i)
+    res.data[i] = a.data[i] + b.data[i];
+  return res;
+};
+
+template<typename T, unsigned N>
+Tensor<T, N> operator-(const Tensor<T, N>& a, const Tensor<T, N>& b) {
+  Tensor<T, N> res;
+  for (unsigned i=0; i<N; ++i)
+    res.data[i] = a.data[i] - b.data[i];
+  return res;
+};
+
+template<typename T, unsigned N>
+Tensor<T, N> operator*(const Tensor<T, N>& a, const Tensor<T, N>& b) {
+  Tensor<T, N> res;
+  for (unsigned i=0; i<N; ++i)
+    res.data[i] = a.data[i] * b.data[i];
+  return res;
+};
+
+template<typename T, unsigned N>
+Tensor<T, N> operator*(double val, const Tensor<T, N>& b) {
+  Tensor<T, N> res;
+  for (unsigned i=0; i<N; ++i)
+    res.data[i] = val * b.data[i];
+  return res;
+};
+
+template<typename T, unsigned N>
+Tensor<T, N> operator/(const Tensor<T, N>& a, const Tensor<T, N>& b) {
+  Tensor<T, N> res;
+  for (unsigned i=0; i<N; ++i)
+    res.data[i] = a.data[i] / b.data[i];
+  return res;
+};
+
+template<typename T, unsigned N>
+Tensor<T, N> operator^(const Tensor<T, N>& a, const Tensor<T, N>& b) {
+  Tensor<T, N> res;
+  for (unsigned i=0; i<N; ++i)
+    res.data[i] = std::pow(a.data[i], b.data[i]);
+  return res;
+};
+
+template<typename T, unsigned N>
+Tensor<T, N>& operator+=(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  lhs = lhs + rhs;
+  return lhs;
+}
+
+template<typename T, unsigned N>
+Tensor<T, N>& operator-=(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  lhs = lhs - rhs;
+  return lhs;
+}
+
+template<typename T, unsigned N>
+Tensor<T, N>& operator*=(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  lhs = lhs * rhs;
+  return lhs;
+}
+
+template<typename T, unsigned N>
+Tensor<T, N>& operator/=(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  lhs = lhs / rhs;
+  return lhs;
+}
+
+template<typename T, unsigned N>
+Tensor<T, N>& operator^=(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  lhs = lhs / rhs;
+  return lhs;
+}
+
+template<typename T, unsigned N>
+Tensor<T, N> operator%(const Tensor<T, N>& a, const Tensor<T, N>& b) {
+  return a;
+};
+
+template<typename T, unsigned N>
+Tensor<T, N>& operator%=(Tensor<T, N>& a, const Tensor<T, N>& b) {
+  return a;
+};
+
+template<typename T, unsigned N>
+void operator~(const Tensor<T, N>& a) {};
+
+template<typename T, unsigned N>
+bool operator<(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  T lsum, rsum;
+  lsum = rsum = 0;
+  for (unsigned i=0; i<N; ++i) {
+    lsum += lhs.data[i];
+    rsum += lhs.data[i];
+  }
+  // FIXME: Add support for differentiating comparison operators.
+  // return lsum < rsum;
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator>(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  T lsum, rsum;
+  lsum = rsum = 0;
+  for (unsigned i=0; i<N; ++i) {
+    lsum += lhs.data[i];
+    rsum += lhs.data[i];
+  }
+  // FIXME: Add support for differentiating comparison operators.
+  // return lsum > rsum;
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator==(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return !(lhs < rhs) && !(lhs > rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator<=(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return (lhs < rhs) || (lhs == rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator>=(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return (lhs > rhs) || (lhs == rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator!=(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return !(lhs == rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator<<(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return !(lhs == rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator>>(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return !(lhs == rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator<<=(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return !(lhs == rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator>>=(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return !(lhs == rhs);
+  return 1;
+}
+
+
+template<typename T, unsigned N>
+bool operator&&(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return !(lhs == rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator||(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return !(lhs == rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator&(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return !(lhs == rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator|(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return !(lhs == rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator&=(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return !(lhs == rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+bool operator|=(Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+  // FIXME: Add support for differentiating comparison operators.
+  // return !(lhs == rhs);
+  return 1;
+}
+
+template<typename T, unsigned N>
+void operator,(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {}
+
+template<typename T, unsigned N>
+void operator!(const Tensor<T, N>& lhs) {}
 
 template<typename T, unsigned N>
 T sum(Tensor<T, N>& t) {
@@ -186,11 +476,11 @@ double fn6(TensorD5 t, double i) {
 // CHECK: double fn6_darg1(TensorD5 t, double i) {
 // CHECK-NEXT:     TensorD5 _d_t;
 // CHECK-NEXT:     double _d_i = 1;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = t.sum_pushforward(&_d_t);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = t.sum_pushforward(& _d_t);
 // CHECK-NEXT:     double &_t1 = _t0.value;
 // CHECK-NEXT:     double _d_res = 0 * _t1 + 3 * _t0.pushforward;
 // CHECK-NEXT:     double res = 3 * _t1;
-// CHECK-NEXT:     t.updateTo_pushforward(i * i, &_d_t, _d_i * i + i * _d_i);
+// CHECK-NEXT:     t.updateTo_pushforward(i * i, & _d_t, _d_i * i + i * _d_i);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t2 = sum_pushforward(t, _d_t);
 // CHECK-NEXT:     _d_res += _t2.pushforward;
 // CHECK-NEXT:     res += _t2.value;
@@ -209,7 +499,7 @@ TensorD5 fn7(double i, double j) {
 // CHECK-NEXT:     TensorD5 _d_t;
 // CHECK-NEXT:     TensorD5 t;
 // CHECK-NEXT:     double _t0 = 7 * i;
-// CHECK-NEXT:     t.updateTo_pushforward(_t0 * j, &_d_t, (0 * i + 7 * _d_i) * j + _t0 * _d_j);
+// CHECK-NEXT:     t.updateTo_pushforward(_t0 * j, & _d_t, (0 * i + 7 * _d_i) * j + _t0 * _d_j);
 // CHECK-NEXT:     return _d_t;
 // CHECK-NEXT: }
 
@@ -233,14 +523,13 @@ complexD fn8(double i, TensorD5 t) {
 // CHECK-NEXT:     {{(__imag)?}} this->[[_M_value]] = [[__val]];
 // CHECK-NEXT: }
 
-
 // CHECK: complexD fn8_darg0(double i, TensorD5 t) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     TensorD5 _d_t;
-// CHECK-NEXT:     t.updateTo_pushforward(i * i, &_d_t, _d_i * i + i * _d_i);
+// CHECK-NEXT:     t.updateTo_pushforward(i * i, & _d_t, _d_i * i + i * _d_i);
 // CHECK-NEXT:     complexD _d_c(0., 0.);
 // CHECK-NEXT:     complexD c(0., 0.);
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = t.sum_pushforward(&_d_t);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = t.sum_pushforward(& _d_t);
 // CHECK-NEXT:     double &_t1 = _t0.value;
 // CHECK-NEXT:     c.real_pushforward(7 * _t1, &_d_c, 0 * _t1 + 7 * _t0.pushforward);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t2 = sum_pushforward(t, _d_t);
@@ -288,6 +577,532 @@ complexD fn9(double i, complexD c) {
 // CHECK-NEXT:     return _d_r;
 // CHECK-NEXT: }
 
+std::complex<double> fn10(double i, double j) {
+  std::complex<double> c1, c2;
+  c1.real(2 * i);
+  c1.imag(5 * i);
+  c2.real(5 * i);
+  c2.imag(2 * i);
+  c1 = c1 + c2;
+  c1 += c2;
+  return c1 + c1;
+}
+
+// CHECK: std::complex<double> fn10_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     std::complex<double> _d_c1(0., 0.), _d_c2(0., 0.);
+// CHECK-NEXT:     std::complex<double> c1(0., 0.), c2(0., 0.);
+// CHECK-NEXT:     c1.real_pushforward(2 * i, &_d_c1, 0 * i + 2 * _d_i);
+// CHECK-NEXT:     c1.imag_pushforward(5 * i, &_d_c1, 0 * i + 5 * _d_i);
+// CHECK-NEXT:     c2.real_pushforward(5 * i, &_d_c2, 0 * i + 5 * _d_i);
+// CHECK-NEXT:     c2.imag_pushforward(2 * i, &_d_c2, 0 * i + 2 * _d_i);
+// CHECK-NEXT:     clad::ValueAndPushforward<complex<double>, complex<double> > _t0 = operator_plus_pushforward(c1, c2, _d_c1, _d_c2);
+// CHECK-NEXT:     clad::ValueAndPushforward<complex<double> &, complex<double> &> _t1 = c1.operator_equal_pushforward({{(static_cast<std(::__1)?::complex<double> &&>\(_t0.value\))|(_t0.value)}}, &_d_c1, {{(static_cast<std(::__1)?::complex<double> &&>\(_t0.pushforward\))|(_t0.pushforward)}});
+// CHECK-NEXT:     clad::ValueAndPushforward<complex<double> &, complex<double> &> _t2 = c1.operator_plus_equal_pushforward(c2, &_d_c1, _d_c2);
+// CHECK-NEXT:     clad::ValueAndPushforward<complex<double>, complex<double> > _t3 = operator_plus_pushforward(c1, c1, _d_c1, _d_c1);
+// CHECK-NEXT:     return _t3.pushforward;
+// CHECK-NEXT: }
+
+TensorD5 fn11(double i, double j) {
+  TensorD5 a, b;
+  a(7*i);
+  b(9*i);
+  a[0] += 11*i;
+  b[0] += 13*i;
+  TensorD5 res1, res2;
+  res1 = a + b + (a*b) + (-a) - b + a/a;
+  TensorD5 one;
+  one(1);
+  res2 = (a+b)^(one);
+  res1 += res2;
+  res1 -= a*b;
+  ++res1;
+  ++res2;
+  --res1;
+  --res2;
+  res1++;
+  res2++;
+  return res1;
+}
+
+// CHECK: void operator_call_pushforward(double val, Tensor<double, 5> *_d_this, double _d_val) {
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_this->data[i] = _d_val;
+// CHECK-NEXT:             this->data[i] = val;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<double &, double &> operator_subscript_pushforward(std::size_t idx, Tensor<double, 5> *_d_this, std::size_t _d_idx) {
+// CHECK-NEXT:     return {this->data[idx], _d_this->data[idx]};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_plus_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5U> _d_res;
+// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_res.data[i] = _d_a.data[i] + _d_b.data[i];
+// CHECK-NEXT:             res.data[i] = a.data[i] + b.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_star_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5U> _d_res;
+// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             const double _t0 = a.data[i];
+// CHECK-NEXT:             const double _t1 = b.data[i];
+// CHECK-NEXT:             _d_res.data[i] = _d_a.data[i] * _t1 + _t0 * _d_b.data[i];
+// CHECK-NEXT:             res.data[i] = _t0 * _t1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_minus_pushforward(const Tensor<double, 5U> &t, const Tensor<double, 5U> &_d_t) {
+// CHECK-NEXT:     Tensor<double, 5U> _d_res;
+// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_res.data[i] = -_d_t.data[i];
+// CHECK-NEXT:             res.data[i] = -t.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_minus_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5U> _d_res;
+// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_res.data[i] = _d_a.data[i] - _d_b.data[i];
+// CHECK-NEXT:             res.data[i] = a.data[i] - b.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_slash_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5U> _d_res;
+// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             const double _t0 = a.data[i];
+// CHECK-NEXT:             const double _t1 = b.data[i];
+// CHECK-NEXT:             _d_res.data[i] = (_d_a.data[i] * _t1 - _t0 * _d_b.data[i]) / (_t1 * _t1);
+// CHECK-NEXT:             res.data[i] = _t0 / _t1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_equal_pushforward(const Tensor<double, 5> &t, Tensor<double, 5> *_d_this, const Tensor<double, 5> &_d_t) {
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_this->data[i] = _d_t.data[i];
+// CHECK-NEXT:             this->data[i] = t.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {*this, *_d_this};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_caret_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5U> _d_res;
+// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             ValueAndPushforward<decltype(::std::pow(double(), double())), decltype(::std::pow(double(), double()))> _t0 = clad::custom_derivatives::pow_pushforward(a.data[i], b.data[i], _d_a.data[i], _d_b.data[i]);
+// CHECK-NEXT:             _d_res.data[i] = _t0.pushforward;
+// CHECK-NEXT:             res.data[i] = _t0.value;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_plus_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_plus_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
+// CHECK-NEXT:     return {lhs, _d_lhs};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_minus_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_minus_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
+// CHECK-NEXT:     return {lhs, _d_lhs};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_plus_plus_pushforward(Tensor<double, 5> *_d_this) {
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_this->data[i] += 0;
+// CHECK-NEXT:             this->data[i] += 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {*this, *_d_this};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_minus_minus_pushforward(Tensor<double, 5> *_d_this) {
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_this->data[i] += 0;
+// CHECK-NEXT:             this->data[i] += 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {*this, *_d_this};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5>, Tensor<double, 5> > operator_plus_plus_pushforward(int param, Tensor<double, 5> *_d_this, int _d_param) {
+// CHECK-NEXT:     Tensor<double, 5> _d_temp;
+// CHECK-NEXT:     Tensor<double, 5> temp;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_temp.data[i] += 0;
+// CHECK-NEXT:             temp.data[i] += 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {temp, _d_temp};
+// CHECK-NEXT: }
+
+// CHECK: TensorD5 fn11_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     TensorD5 _d_a, _d_b;
+// CHECK-NEXT:     TensorD5 a, b;
+// CHECK-NEXT:     a.operator_call_pushforward(7 * i, & _d_a, 0 * i + 7 * _d_i);
+// CHECK-NEXT:     b.operator_call_pushforward(9 * i, & _d_b, 0 * i + 9 * _d_i);
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t0 = a.operator_subscript_pushforward(0, & _d_a, 0);
+// CHECK-NEXT:     _t0.pushforward += 0 * i + 11 * _d_i;
+// CHECK-NEXT:     _t0.value += 11 * i;
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t1 = b.operator_subscript_pushforward(0, & _d_b, 0);
+// CHECK-NEXT:     _t1.pushforward += 0 * i + 13 * _d_i;
+// CHECK-NEXT:     _t1.value += 13 * i;
+// CHECK-NEXT:     TensorD5 _d_res1, _d_res2;
+// CHECK-NEXT:     TensorD5 res1, res2;
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t2 = operator_plus_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t3 = operator_star_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t4 = operator_plus_pushforward(_t2.value, _t3.value, _t2.pushforward, _t3.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t5 = operator_minus_pushforward(a, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t6 = operator_plus_pushforward(_t4.value, _t5.value, _t4.pushforward, _t5.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t7 = operator_minus_pushforward(_t6.value, b, _t6.pushforward, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t8 = operator_slash_pushforward(a, a, _d_a, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t9 = operator_plus_pushforward(_t7.value, _t8.value, _t7.pushforward, _t8.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t10 = res1.operator_equal_pushforward(_t9.value, & _d_res1, _t9.pushforward);
+// CHECK-NEXT:     TensorD5 _d_one;
+// CHECK-NEXT:     TensorD5 one;
+// CHECK-NEXT:     one.operator_call_pushforward(1, & _d_one, 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t11 = operator_plus_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t12 = operator_caret_pushforward(_t11.value, one, _t11.pushforward, _d_one);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t13 = res2.operator_equal_pushforward(_t12.value, & _d_res2, _t12.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t14 = operator_plus_equal_pushforward(res1, res2, _d_res1, _d_res2);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t15 = operator_star_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t16 = operator_minus_equal_pushforward(res1, _t15.value, _d_res1, _t15.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t17 = res1.operator_plus_plus_pushforward(& _d_res1);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t18 = res2.operator_plus_plus_pushforward(& _d_res2);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t19 = res1.operator_minus_minus_pushforward(& _d_res1);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t20 = res2.operator_minus_minus_pushforward(& _d_res2);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5>, Tensor<double, 5> > _t21 = res1.operator_plus_plus_pushforward(0, & _d_res1, 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5>, Tensor<double, 5> > _t22 = res2.operator_plus_plus_pushforward(0, & _d_res2, 0);
+// CHECK-NEXT:     return _d_res1;
+// CHECK-NEXT: }
+
+TensorD5 fn12(double i, double j) {
+  TensorD5 a, b;
+  a(7*i);
+  b(9*i);
+  a[0] += 11*i;
+  b[0] += 13*i;
+  TensorD5 res1;
+  TensorD5 one;
+  one(1);
+  res1(0);
+  res1 += a;
+  res1 *= b;
+  res1 /= a;
+  res1 -= b;
+  res1 += a*a/a;
+  res1[1] += 17*i;
+  res1 ^= one;
+  res1 = res1 = res1;
+  return res1;
+}
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_star_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_star_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
+// CHECK-NEXT:     return {lhs, _d_lhs};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_slash_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_slash_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
+// CHECK-NEXT:     return {lhs, _d_lhs};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_caret_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_slash_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
+// CHECK-NEXT:     return {lhs, _d_lhs};
+// CHECK-NEXT: }
+
+// CHECK: TensorD5 fn12_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     TensorD5 _d_a, _d_b;
+// CHECK-NEXT:     TensorD5 a, b;
+// CHECK-NEXT:     a.operator_call_pushforward(7 * i, & _d_a, 0 * i + 7 * _d_i);
+// CHECK-NEXT:     b.operator_call_pushforward(9 * i, & _d_b, 0 * i + 9 * _d_i);
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t0 = a.operator_subscript_pushforward(0, & _d_a, 0);
+// CHECK-NEXT:     _t0.pushforward += 0 * i + 11 * _d_i;
+// CHECK-NEXT:     _t0.value += 11 * i;
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t1 = b.operator_subscript_pushforward(0, & _d_b, 0);
+// CHECK-NEXT:     _t1.pushforward += 0 * i + 13 * _d_i;
+// CHECK-NEXT:     _t1.value += 13 * i;
+// CHECK-NEXT:     TensorD5 _d_res1;
+// CHECK-NEXT:     TensorD5 res1;
+// CHECK-NEXT:     TensorD5 _d_one;
+// CHECK-NEXT:     TensorD5 one;
+// CHECK-NEXT:     one.operator_call_pushforward(1, & _d_one, 0);
+// CHECK-NEXT:     res1.operator_call_pushforward(0, & _d_res1, 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t2 = operator_plus_equal_pushforward(res1, a, _d_res1, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t3 = operator_star_equal_pushforward(res1, b, _d_res1, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t4 = operator_slash_equal_pushforward(res1, a, _d_res1, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t5 = operator_minus_equal_pushforward(res1, b, _d_res1, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t6 = operator_star_pushforward(a, a, _d_a, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t7 = operator_slash_pushforward(_t6.value, a, _t6.pushforward, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t8 = operator_plus_equal_pushforward(res1, _t7.value, _d_res1, _t7.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t9 = res1.operator_subscript_pushforward(1, & _d_res1, 0);
+// CHECK-NEXT:     _t9.pushforward += 0 * i + 17 * _d_i;
+// CHECK-NEXT:     _t9.value += 17 * i;
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t10 = operator_caret_equal_pushforward(res1, one, _d_res1, _d_one);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t11 = res1.operator_equal_pushforward(res1, & _d_res1, _d_res1);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t12 = res1.operator_equal_pushforward(_t11.value, & _d_res1, _t11.pushforward);
+// CHECK-NEXT:     return _d_res1;
+// CHECK-NEXT: }
+
+TensorD5 fn13(double i, double j) {
+  TensorD5 a, b;
+  a[0] = i*j;
+  b[0] = i*i;
+  a[0] += (a<b) + (a>b);
+  b[0] += (a<=b) + (a>=b);
+  a[0] += (a==b) + (a != b);
+  a, b;
+  !a;
+  auto ap = &a;
+  ap->data[1] = 7*i;
+  auto b_data = b->data;
+  b_data[1] = i*j;
+  a = a % b;
+  a %= b;
+  ~a;
+  a[2] = (a<<b) + (a>>b);
+  b[2] = (a&&b) + (a||b);
+  a <<= b;
+  b >>= a;
+  a[3] = (a&b) + (a|b);
+  a |= b;
+  b &= a;
+  return a + b;
+}
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     double _d_lsum, _d_rsum;
+// CHECK-NEXT:     double lsum, rsum;
+// CHECK-NEXT:     _d_lsum = _d_rsum = 0;
+// CHECK-NEXT:     lsum = rsum = 0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_lsum += _d_lhs.data[i];
+// CHECK-NEXT:             lsum += lhs.data[i];
+// CHECK-NEXT:             _d_rsum += _d_lhs.data[i];
+// CHECK-NEXT:             rsum += lhs.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     double _d_lsum, _d_rsum;
+// CHECK-NEXT:     double lsum, rsum;
+// CHECK-NEXT:     _d_lsum = _d_rsum = 0;
+// CHECK-NEXT:     lsum = rsum = 0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_lsum += _d_lhs.data[i];
+// CHECK-NEXT:             lsum += lhs.data[i];
+// CHECK-NEXT:             _d_rsum += _d_lhs.data[i];
+// CHECK-NEXT:             rsum += lhs.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_equal_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_exclaim_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: void operator_comma_pushforward(const Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, const Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT: }
+
+// CHECK: void operator_exclaim_pushforward(const Tensor<double, 5U> &lhs, const Tensor<double, 5U> &_d_lhs) {
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5> *, Tensor<double, 5> *> operator_amp_pushforward(Tensor<double, 5> *_d_this) {
+// CHECK-NEXT:     return {this, _d_this};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5> *, Tensor<double, 5> *> operator_arrow_pushforward(Tensor<double, 5> *_d_this) {
+// CHECK-NEXT:     return {this, _d_this};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_percent_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     return {a, _d_a};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_percent_equal_pushforward(Tensor<double, 5U> &a, const Tensor<double, 5U> &b, Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     return {a, _d_a};
+// CHECK-NEXT: }
+
+// CHECK: void operator_tilde_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &_d_a) {
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_less_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_greater_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_AmpAmp_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_pipe_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_less_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_greater_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_amp_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_amp_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {1, 0};
+// CHECK-NEXT: }
+
+// CHECK: TensorD5 fn13_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     TensorD5 _d_a, _d_b;
+// CHECK-NEXT:     TensorD5 a, b;
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t0 = a.operator_subscript_pushforward(0, & _d_a, 0);
+// CHECK-NEXT:     _t0.pushforward = _d_i * j + i * _d_j;
+// CHECK-NEXT:     _t0.value = i * j;
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t1 = b.operator_subscript_pushforward(0, & _d_b, 0);
+// CHECK-NEXT:     _t1.pushforward = _d_i * i + i * _d_i;
+// CHECK-NEXT:     _t1.value = i * i;
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t2 = a.operator_subscript_pushforward(0, & _d_a, 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t3 = operator_less_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t4 = operator_greater_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     _t2.pushforward += _t3.pushforward + _t4.pushforward;
+// CHECK-NEXT:     _t2.value += _t3.value + _t4.value;
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t5 = b.operator_subscript_pushforward(0, & _d_b, 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t6 = operator_less_equal_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t7 = operator_greater_equal_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     _t5.pushforward += _t6.pushforward + _t7.pushforward;
+// CHECK-NEXT:     _t5.value += _t6.value + _t7.value;
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t8 = a.operator_subscript_pushforward(0, & _d_a, 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t9 = operator_equal_equal_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t10 = operator_exclaim_equal_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     _t8.pushforward += _t9.pushforward + _t10.pushforward;
+// CHECK-NEXT:     _t8.value += _t9.value + _t10.value;
+// CHECK-NEXT:     operator_comma_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     operator_exclaim_pushforward(a, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> *, Tensor<double, 5> *> _t11 = a.operator_amp_pushforward(& _d_a);
+// CHECK-NEXT:     Tensor<double, 5> *_d_ap = _t11.pushforward;
+// CHECK-NEXT:     Tensor<double, 5> *ap = _t11.value;
+// CHECK-NEXT:     _d_ap->data[1] = 0 * i + 7 * _d_i;
+// CHECK-NEXT:     ap->data[1] = 7 * i;
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> *, Tensor<double, 5> *> _t12 = b.operator_arrow_pushforward(& _d_b);
+// CHECK-NEXT:     double *_d_b_data = _t12.pushforward->data;
+// CHECK-NEXT:     double *b_data = _t12.value->data;
+// CHECK-NEXT:     _d_b_data[1] = _d_i * j + i * _d_j;
+// CHECK-NEXT:     b_data[1] = i * j;
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t13 = operator_percent_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t14 = a.operator_equal_pushforward(_t13.value, & _d_a, _t13.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t15 = operator_percent_equal_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     operator_tilde_pushforward(a, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t16 = a.operator_subscript_pushforward(2, & _d_a, 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t17 = operator_less_less_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t18 = operator_greater_greater_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     _t16.pushforward = _t17.pushforward + _t18.pushforward;
+// CHECK-NEXT:     _t16.value = _t17.value + _t18.value;
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t19 = b.operator_subscript_pushforward(2, & _d_b, 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t20 = operator_AmpAmp_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t21 = operator_pipe_pipe_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     _t19.pushforward = _t20.pushforward + _t21.pushforward;
+// CHECK-NEXT:     _t19.value = _t20.value + _t21.value;
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t22 = operator_less_less_equal_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t23 = operator_greater_greater_equal_pushforward(b, a, _d_b, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t24 = a.operator_subscript_pushforward(3, & _d_a, 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t25 = operator_amp_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t26 = operator_pipe_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     _t24.pushforward = _t25.pushforward + _t26.pushforward;
+// CHECK-NEXT:     _t24.value = _t25.value + _t26.value;
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t27 = operator_pipe_equal_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t28 = operator_amp_equal_pushforward(b, a, _d_b, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t29 = operator_plus_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     return _t29.pushforward;
+// CHECK-NEXT: }
+
 template<unsigned N>
 void print(const Tensor<double, N>& t) {
   for (int i=0; i<N; ++i) {
@@ -307,7 +1122,11 @@ int main() {
   INIT_DIFFERENTIATE(fn7, "i");
   INIT_DIFFERENTIATE(fn8, "i");
   INIT_DIFFERENTIATE(fn9, "i");
-
+  INIT_DIFFERENTIATE(fn10, "i");
+  INIT_DIFFERENTIATE(fn11, "i");
+  INIT_DIFFERENTIATE(fn12, "i");
+  INIT_DIFFERENTIATE(fn13, "i");
+  
   TensorD5 t;
   t.updateTo(5);
   complexD c(3, 5);
@@ -321,4 +1140,8 @@ int main() {
   TEST_DIFFERENTIATE(fn7, 3, 5);  // CHECK-EXEC: {35.00, 35.00, 35.00, 35.00, 35.00}
   TEST_DIFFERENTIATE(fn8, 3, t);  // CHECK-EXEC: {210.00, 270.00}
   TEST_DIFFERENTIATE(fn9, 3, c);  // CHECK-EXEC: {27.00, 1458.00}
+  TEST_DIFFERENTIATE(fn10, 3, 5); // CHECK-EXEC: {24.00, 18.00}
+  TEST_DIFFERENTIATE(fn11, 3, 5); // CHECK-EXEC: {40.00, 16.00, 16.00, 16.00, 16.00}
+  TEST_DIFFERENTIATE(fn12, 3, 5); // CHECK-EXEC: {18.00, 24.00, 7.00, 7.00, 7.00}
+  TEST_DIFFERENTIATE(fn13, 3, 5); // CHECK-EXEC: {11.00, 12.00, 0.00, 0.00, 0.00}
 }

--- a/test/TestUtils.h
+++ b/test/TestUtils.h
@@ -7,8 +7,7 @@
 
 namespace test_utils {
 
-template<typename T>
-void print(T t) {
+template <typename T> void print(T t) {
   fprintf(stderr, "Print method not defined for type: %s", typeid(t).name());
 }
 
@@ -17,6 +16,8 @@ void print(const char* s) { printf("%s", s); }
 void print(double d) { printf("%.2f", d); }
 
 void print(int i) { printf("%d", i); }
+
+void print(long double ld) { printf("%.2Lf", ld); }
 
 void print() {}
 


### PR DESCRIPTION
This PR adds support for differentiating overloaded operators in the forward mode. 

It also fixes the cloning of `CXXOperatorCallExpr` node.