### PR TITLE
Modify pushforward fn mechanism to compute both fn value and derivative.

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -6,7 +6,6 @@
 
 #ifndef CLAD_BUILTIN_DERIVATIVES
 #define CLAD_BUILTIN_DERIVATIVES
-
 // Avoid assertion custom_derivative namespace not found. FIXME: This in future
 // should go.
 namespace custom_derivatives{}
@@ -16,62 +15,59 @@ namespace custom_derivatives{}
 
 #include <cmath>
 namespace clad {
+template <typename T, typename U> struct ValueAndPushforward {
+  T value;
+  U pushforward;
+};
 namespace custom_derivatives {
 namespace std {
-template <typename T> CUDA_HOST_DEVICE T abs_pushforward(T x, T d_x) {
+template <typename T>
+CUDA_HOST_DEVICE ValueAndPushforward<T, T> abs_pushforward(T x, T d_x) {
   if (x >= 0)
-    return d_x;
+    return {x, d_x};
   else
-    return -d_x;
-}
-
-template <typename T> CUDA_HOST_DEVICE T exp_pushforward(T x, T d_x) {
-  return ::std::exp(x) * d_x;
+    return {-x, -d_x};
 }
 
 template <typename T>
-CUDA_HOST_DEVICE T exp_pushforward_pushforward(T x, T d_x, T d_x0, T d_d_x) {
-  return ::std::exp(x) * d_x0 * d_x + ::std::exp(x) * d_d_x;
-}
-
-template <typename T> CUDA_HOST_DEVICE T sin_pushforward(T x, T d_x) {
-  return ::std::cos(x) * d_x;
-}
-
-template <typename T> CUDA_HOST_DEVICE T cos_pushforward(T x, T d_x) {
-  return (-1) * ::std::sin(x) * d_x;
+CUDA_HOST_DEVICE ValueAndPushforward<T, T> exp_pushforward(T x, T d_x) {
+  return {::std::exp(x), ::std::exp(x) * d_x};
 }
 
 template <typename T>
-CUDA_HOST_DEVICE T sin_pushforward_pushforward(T x, T d_x, T d_x0, T d_d_x) {
-  return cos_pushforward(x, d_x0) * d_x + ::std::cos(x) * d_d_x;
+CUDA_HOST_DEVICE ValueAndPushforward<T, T> sin_pushforward(T x, T d_x) {
+  return {::std::sin(x), ::std::cos(x) * d_x};
 }
 
 template <typename T>
-CUDA_HOST_DEVICE T cos_pushforward_pushforward(T x, T d_x, T d_x0, T d_d_x) {
-  return (-1) * (sin_pushforward(x, d_x0) * d_x + ::std::sin(x) * d_d_x);
+CUDA_HOST_DEVICE ValueAndPushforward<T, T> cos_pushforward(T x, T d_x) {
+  return {::std::cos(x), (-1) * ::std::sin(x) * d_x};
 }
 
-template <typename T> CUDA_HOST_DEVICE T sqrt_pushforward(T x, T d_x) {
-  return (((T)1) / (((T)2) * ::std::sqrt(x))) * d_x;
+template <typename T>
+CUDA_HOST_DEVICE ValueAndPushforward<T, T> sqrt_pushforward(T x, T d_x) {
+  return {::std::sqrt(x), (((T)1) / (((T)2) * ::std::sqrt(x))) * d_x};
 }
 
 #ifdef MACOS
-float sqrtf_pushforward(float x, float d_x) {
-  return (1.F / (2.F * sqrtf(x))) * d_x;
+ValueAndPushforward<float, float> sqrtf_pushforward(float x, float d_x) {
+  return {sqrtf(x), (1.F / (2.F * sqrtf(x))) * d_x};
 }
 
 #endif
 
 template <typename T1, typename T2>
-CUDA_HOST_DEVICE decltype(::std::pow(T1(), T2()))
+CUDA_HOST_DEVICE ValueAndPushforward<decltype(::std::pow(T1(), T2())),
+                                     decltype(::std::pow(T1(), T2()))>
 pow_pushforward(T1 x, T2 exponent, T1 d_x, T2 d_exponent) {
-  return (exponent * ::std::pow(x, exponent - 1)) * d_x +
-         (::std::pow(x, exponent) * ::std::log(x)) * d_exponent;
+  return {::std::pow(x, exponent),
+          (exponent * ::std::pow(x, exponent - 1)) * d_x +
+              (::std::pow(x, exponent) * ::std::log(x)) * d_exponent};
 }
 
-template <typename T> CUDA_HOST_DEVICE T log_pushforward(T x, T d_x) {
-  return (1.0 / x) * d_x;
+template <typename T>
+CUDA_HOST_DEVICE ValueAndPushforward<T, T> log_pushforward(T x, T d_x) {
+  return {::std::log(x), static_cast<T>((1.0 / x) * d_x)};
 }
 
 template <typename T1, typename T2>
@@ -79,24 +75,20 @@ CUDA_HOST_DEVICE void
 pow_pullback(T1 x, T2 exponent, decltype(::std::pow(T1(), T2())) d_y,
              clad::array_ref<decltype(::std::pow(T1(), T2()))> d_x,
              clad::array_ref<decltype(::std::pow(T1(), T2()))> d_exponent) {
-  *d_x += pow_pushforward(x, exponent, static_cast<T1>(1), static_cast<T2>(0)) *
-          d_y;
-  *d_exponent +=
-      pow_pushforward(x, exponent, static_cast<T1>(0), static_cast<T2>(1)) *
-      d_y;
+  auto t = pow_pushforward(x, exponent, static_cast<T1>(1), static_cast<T2>(0));
+  *d_x += t.pushforward * d_y;
+  t = pow_pushforward(x, exponent, static_cast<T1>(0), static_cast<T2>(1));
+  *d_exponent += t.pushforward * d_y;
 }
 } // namespace std
 // These are required because C variants of mathematical functions are
 // defined in global namespace.
 using std::abs_pushforward;
 using std::cos_pushforward;
-using std::cos_pushforward_pushforward;
 using std::exp_pushforward;
-using std::exp_pushforward_pushforward;
 using std::log_pushforward;
 using std::pow_pushforward;
 using std::sin_pushforward;
-using std::sin_pushforward_pushforward;
 using std::sqrt_pushforward;
 using std::pow_pullback;
 } // namespace custom_derivatives

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -214,6 +214,8 @@ namespace clad {
     /// Returns true if `FD` is a class static method; otherwise returns
     /// false.
     bool IsStaticMethod(const clang::FunctionDecl* FD);
+
+    bool IsCladValueAndPushforwardType(clang::QualType T);
   } // namespace utils
 }
 

--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -106,6 +106,11 @@ namespace clad {
     /// \return active switch case label after processing `stmt`
     clang::SwitchCase* DeriveSwitchStmtBodyHelper(const clang::Stmt* stmt,
                                                   clang::SwitchCase* activeSC);
+
+    /// Returns the return type for the pushforward function of the function
+    /// `m_Function`.
+    /// \note `m_Function` field should be set before using this function.
+    clang::QualType ComputePushforwardFnReturnType();
   };
 } // end namespace clad
 

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -367,7 +367,7 @@ namespace clad {
     /// arguments \returns The created type clad::class<TemplateArgs>
     clang::QualType
     GetCladClassOfType(clang::TemplateDecl* CladClassDecl,
-                       llvm::MutableArrayRef<clang::QualType> TemplateArgs);
+                       llvm::ArrayRef<clang::QualType> TemplateArgs);
     /// Find declaration of clad::tape templated type.
     clang::TemplateDecl* GetCladTapeDecl();
     /// Perform a lookup into clad namespace for an entity with given name.

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -287,5 +287,10 @@ namespace clad {
         return MD->isStatic();
       return false;
     }
+
+    bool IsCladValueAndPushforwardType(clang::QualType T) {
+      return T.getAsString().find("ValueAndPushforward") !=
+             std::string::npos;
+    }
   } // namespace utils
 } // namespace clad

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -367,7 +367,7 @@ namespace clad {
 
   QualType
   VisitorBase::GetCladClassOfType(TemplateDecl* CladClassDecl,
-                                  MutableArrayRef<QualType> TemplateArgs) {
+                                  ArrayRef<QualType> TemplateArgs) {
     // Create a list of template arguments.
     TemplateArgumentListInfo TLI{};
     for (auto T : TemplateArgs) {

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -92,7 +92,7 @@ auto gauss_g = clad::gradient(gauss, "p");
 //CHECK-NEXT:         _d_sigma += _r15;
 //CHECK-NEXT:         double _r16 = _grad3;
 //CHECK-NEXT:         double _r17 = _t22 * 1;
-//CHECK-NEXT:         double _r18 = _r17 * clad::custom_derivatives::exp_pushforward(_t23, 1.);
+//CHECK-NEXT:         double _r18 = _r17 * clad::custom_derivatives::exp_pushforward(_t23, 1.).pushforward;
 //CHECK-NEXT:         _d_t += _r18;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -263,7 +263,7 @@ float func5(float x, float y) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r_d0 = * _d_y;
-// CHECK-NEXT:         float _r0 = _r_d0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t0, 1.F);
+//CHECK-NEXT:         float _r0 = _r_d0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t0, 1.F).pushforward;
 //CHECK-NEXT:         * _d_x += _r0;
 //CHECK-NEXT:         _delta_y += _r_d0 * _EERepl_y1 * {{.+}};
 //CHECK-NEXT:         * _d_y -= _r_d0;

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -12,8 +12,9 @@ float f1(float x) {
 }
 
 // CHECK: float f1_darg0(float x) {
-// CHECK-NEXT: float _d_x = 1;
-// CHECK-NEXT: return clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
+// CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
 float f2(float x) {
@@ -21,8 +22,9 @@ float f2(float x) {
 }
 
 // CHECK: float f2_darg0(float x) {
-// CHECK-NEXT: float _d_x = 1;
-// CHECK-NEXT: return clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, _d_x);
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, _d_x);
+// CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
 float f3(float x, float y) {
@@ -30,15 +32,19 @@ float f3(float x, float y) {
 }
 
 // CHECK: float f3_darg0(float x, float y) {
-// CHECK-NEXT: float _d_x = 1;
-// CHECK-NEXT: float _d_y = 0;
-// CHECK-NEXT: return clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x) + clad::custom_derivatives{{(::std)?}}::sin_pushforward(y, _d_y);
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     float _d_y = 0;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y, _d_y);
+// CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
 // CHECK-NEXT: }
 
 // CHECK: float f3_darg1(float x, float y) {
-// CHECK-NEXT: float _d_x = 0;
-// CHECK-NEXT: float _d_y = 1;
-// CHECK-NEXT: return clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x) + clad::custom_derivatives{{(::std)?}}::sin_pushforward(y, _d_y);
+// CHECK-NEXT:     float _d_x = 0;
+// CHECK-NEXT:     float _d_y = 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y, _d_y);
+// CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
 // CHECK-NEXT: }
 
 float f4(float x, float y) {
@@ -46,15 +52,19 @@ float f4(float x, float y) {
 }
 
 // CHECK: float f4_darg0(float x, float y) {
-// CHECK-NEXT: float _d_x = 1;
-// CHECK-NEXT: float _d_y = 0;
-// CHECK-NEXT: return clad::custom_derivatives{{(::std)?}}::sin_pushforward(x * x, _d_x * x + x * _d_x) + clad::custom_derivatives{{(::std)?}}::sin_pushforward(y * y, _d_y * y + y * _d_y);
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     float _d_y = 0;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x * x, _d_x * x + x * _d_x);
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y * y, _d_y * y + y * _d_y);
+// CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
 // CHECK-NEXT: }
 
 // CHECK: float f4_darg1(float x, float y) {
-// CHECK-NEXT: float _d_x = 0;
-// CHECK-NEXT: float _d_y = 1;
-// CHECK-NEXT: return clad::custom_derivatives{{(::std)?}}::sin_pushforward(x * x, _d_x * x + x * _d_x) + clad::custom_derivatives{{(::std)?}}::sin_pushforward(y * y, _d_y * y + y * _d_y);
+// CHECK-NEXT:     float _d_x = 0;
+// CHECK-NEXT:     float _d_y = 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x * x, _d_x * x + x * _d_x);
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y * y, _d_y * y + y * _d_y);
+// CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
 // CHECK-NEXT: }
 
 float f5(float x) {
@@ -62,8 +72,9 @@ float f5(float x) {
 }
 
 // CHECK: float f5_darg0(float x) {
-// CHECK-NEXT: float _d_x = 1;
-// CHECK-NEXT: return clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, _d_x);
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, _d_x);
+// CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
 float f6(float x) {
@@ -71,8 +82,9 @@ float f6(float x) {
 }
 
 // CHECK: float f6_darg0(float x) {
-// CHECK-NEXT: float _d_x = 1;
-// CHECK-NEXT: return clad::custom_derivatives{{(::std)?}}::exp_pushforward(x * x, _d_x * x + x * _d_x);
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x * x, _d_x * x + x * _d_x);
+// CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
 float f7(float x) {
@@ -80,8 +92,9 @@ float f7(float x) {
 }
 
 // CHECK: float f7_darg0(float x) {
-// CHECK-NEXT:   float _d_x = 1;
-// CHECK-NEXT:   return clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 2., _d_x, 0.);
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), double())), decltype(::std::pow(float(), double()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 2., _d_x, 0.);
+// CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
 void f7_grad(float x, clad::array_ref<float> _d_x);
@@ -107,8 +120,9 @@ double f8(float x) {
 }
 
 // CHECK: double f8_darg0(float x) {
-// CHECK-NEXT:   float _d_x = 1;
-// CHECK-NEXT:   return clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 2, _d_x, 0);
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), int())), decltype(::std::pow(float(), int()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 2, _d_x, 0);
+// CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
 void f8_grad(float x, clad::array_ref<double> _d_x);
@@ -136,7 +150,8 @@ float f9(float x, float y) {
 // CHECK: float f9_darg0(float x, float y) {
 // CHECK-NEXT:     float _d_x = 1;
 // CHECK-NEXT:     float _d_y = 0;
-// CHECK-NEXT:     return clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
 void f9_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y);
@@ -165,9 +180,10 @@ double f10(float x, int y) {
 }
 
 // CHECK: double f10_darg0(float x, int y) {
-// CHECK-NEXT:   float _d_x = 1;
-// CHECK-NEXT:   int _d_y = 0;
-// CHECK-NEXT:   return clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), int())), decltype(::std::pow(float(), int()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
 void f10_grad(float x, int y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);

--- a/test/FirstDerivative/FunctionCalls.C
+++ b/test/FirstDerivative/FunctionCalls.C
@@ -9,31 +9,15 @@
 int printf(const char* fmt, ...);
 int no_body(int x);
 int custom_fn(int x);
-int custom_fn(float x);
+float custom_fn(float x);
 int custom_fn();
-
-namespace clad {
-namespace custom_derivatives {
-float overloaded_pushforward(float x, float d_x) { return x * d_x; }
-
-float overloaded_pushforward(int x, int d_x) { return x * d_x; }
-
-float no_body_pushforward(float x, float d_x) { return 1 * d_x; }
-
-float custom_fn_pushforward(int x, int d_x) { return (x + x) * d_x; }
-
-float custom_fn_pushforward(float x, float d_x) { return x * x * d_x; }
-
-int custom_fn_pushforward() { return 5; }
-} // namespace custom_derivatives
-} // namespace clad
 
 int overloaded(int x) {
   printf("A was called.\n");
   return x*x;
 }
 
-int overloaded(float x) {
+float overloaded(float x) {
   return x;
 }
 
@@ -45,9 +29,40 @@ float test_1(float x) {
   return overloaded(x) + custom_fn(x);
 }
 
+namespace clad {
+namespace custom_derivatives {
+clad::ValueAndPushforward<float, float> overloaded_pushforward(float x,
+                                                               float d_x) {
+  return {overloaded(x), x * d_x};
+}
+
+clad::ValueAndPushforward<int, int> overloaded_pushforward(int x, int d_x) {
+  return {overloaded(x), x * d_x};
+}
+
+clad::ValueAndPushforward<float, float> no_body_pushforward(float x,
+                                                            float d_x) {
+  return {0, 1 * d_x};
+}
+
+clad::ValueAndPushforward<int, int> custom_fn_pushforward(int x, int d_x) {
+  return {custom_fn(x), (x + x) * d_x};
+}
+
+clad::ValueAndPushforward<float, float> custom_fn_pushforward(float x,
+                                                              float d_x) {
+  return {custom_fn(x), x * x * d_x};
+}
+
+clad::ValueAndPushforward<int, int> custom_fn_pushforward() { return {0, 5}; }
+} // namespace custom_derivatives
+} // namespace clad
+
 // CHECK: float test_1_darg0(float x) {
 // CHECK-NEXT: float _d_x = 1;
-// CHECK-NEXT: return clad::custom_derivatives::overloaded_pushforward(x, _d_x) + clad::custom_derivatives::custom_fn_pushforward(x, _d_x);
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::overloaded_pushforward(x, _d_x);
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t1 = clad::custom_derivatives::custom_fn_pushforward(x, _d_x);
+// CHECK-NEXT: return _t0.pushforward + _t1.pushforward;
 // CHECK-NEXT: }
 
 float test_2(float x) {
@@ -56,7 +71,9 @@ float test_2(float x) {
 
 // CHECK: float test_2_darg0(float x) {
 // CHECK-NEXT: float _d_x = 1;
-// CHECK-NEXT: return clad::custom_derivatives::overloaded_pushforward(x, _d_x) + clad::custom_derivatives::custom_fn_pushforward(x, _d_x);
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::overloaded_pushforward(x, _d_x);
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t1 = clad::custom_derivatives::custom_fn_pushforward(x, _d_x);
+// CHECK-NEXT: return _t0.pushforward + _t1.pushforward;
 // CHECK-NEXT: }
 
 float test_3() {
@@ -69,13 +86,14 @@ float test_4(int x) {
   return overloaded();
 }
 
-// CHECK: int overloaded_pushforward() {
-// CHECK-NEXT:     return 0;
+// CHECK: clad::ValueAndPushforward<int, int> overloaded_pushforward() {
+// CHECK-NEXT:     return {3, 0};
 // CHECK-NEXT: }
 
 // CHECK: float test_4_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: return overloaded_pushforward();
+// CHECK-NEXT: clad::ValueAndPushforward<int, int> _t0 = overloaded_pushforward();
+// CHECK-NEXT: return _t0.pushforward;
 // CHECK-NEXT: }
 
 float test_5(int x) {
@@ -84,7 +102,8 @@ float test_5(int x) {
 
 // CHECK: float test_5_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: return clad::custom_derivatives::no_body_pushforward(x, _d_x);
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::no_body_pushforward(x, _d_x);
+// CHECK-NEXT: return _t0.pushforward;
 // CHECK-NEXT: }
 
 int main () {

--- a/test/FirstDerivative/FunctionCallsWithResults.C
+++ b/test/FirstDerivative/FunctionCallsWithResults.C
@@ -5,27 +5,6 @@
 
 int printf(const char* fmt, ...);
 
-namespace clad {
-namespace custom_derivatives {
-float custom_fn_pushforward(int x, int d_x) { return x * d_x; }
-
-float custom_fn_pushforward(float x, float d_x) { return x * x * d_x; }
-
-int custom_fn_pushforward() { return 5; }
-
-float overloaded_pushforward(float x, float d_x) {
-  printf("A was called.\n");
-  return x * x * d_x;
-}
-
-float overloaded_pushforward() {
-  int x = 2;
-  printf("A was called.\n");
-  return x * x;
-}
-} // namespace custom_derivatives
-} // namespace clad
-
 float custom_fn(float x) {
   return x;
 }
@@ -42,13 +21,42 @@ float overloaded() {
   return 3;
 }
 
+namespace clad {
+namespace custom_derivatives {
+clad::ValueAndPushforward<int, int> custom_fn_pushforward(int x, int d_x) {
+  return {custom_fn(x), x * d_x};
+}
+
+clad::ValueAndPushforward<float, float> custom_fn_pushforward(float x,
+                                                              float d_x) {
+  return {custom_fn(x), d_x};
+}
+
+clad::ValueAndPushforward<int, int> custom_fn_pushforward() { return {0, 5}; }
+
+clad::ValueAndPushforward<float, float> overloaded_pushforward(float x,
+                                                               float d_x) {
+  printf("A was called.\n");
+  return {overloaded(x), d_x};
+}
+
+clad::ValueAndPushforward<float, float> overloaded_pushforward() {
+  float x = 2;
+  printf("A was called.\n");
+  return {overloaded(), x * x};
+}
+} // namespace custom_derivatives
+} // namespace clad
+
 float test_1(float x) {
   return overloaded(x) + custom_fn(x);
 }
 
 // CHECK: float test_1_darg0(float x) {
 // CHECK-NEXT: float _d_x = 1;
-// CHECK-NEXT: return clad::custom_derivatives::overloaded_pushforward(x, _d_x) + clad::custom_derivatives::custom_fn_pushforward(x, _d_x);
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::overloaded_pushforward(x, _d_x);
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t1 = clad::custom_derivatives::custom_fn_pushforward(x, _d_x);
+// CHECK-NEXT: return _t0.pushforward + _t1.pushforward;
 // CHECK-NEXT: }
 
 float test_2(float x) {
@@ -57,7 +65,9 @@ float test_2(float x) {
 
 // CHECK: float test_2_darg0(float x) {
 // CHECK-NEXT: float _d_x = 1;
-// CHECK-NEXT: return clad::custom_derivatives::overloaded_pushforward(x, _d_x) + clad::custom_derivatives::custom_fn_pushforward(x, _d_x);
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::overloaded_pushforward(x, _d_x);
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t1 = clad::custom_derivatives::custom_fn_pushforward(x, _d_x);
+// CHECK-NEXT: return _t0.pushforward + _t1.pushforward;
 // CHECK-NEXT: }
 
 float test_4(float x) {
@@ -66,15 +76,16 @@ float test_4(float x) {
 
 // CHECK: float test_4_darg0(float x) {
 // CHECK-NEXT: float _d_x = 1;
-// CHECK-NEXT: return clad::custom_derivatives::overloaded_pushforward();
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::overloaded_pushforward();
+// CHECK-NEXT: return _t0.pushforward;
 // CHECK-NEXT: }
 
 double sum_of_squares(double u, double v) {
   return u*u + v*v;
 }
 
-// CHECK: double sum_of_squares_pushforward(double u, double v, double _d_u, double _d_v) {
-// CHECK-NEXT:     return _d_u * u + u * _d_u + _d_v * v + v * _d_v;
+// CHECK: clad::ValueAndPushforward<double, double> sum_of_squares_pushforward(double u, double v, double _d_u, double _d_v) {
+// CHECK-NEXT:     return {u * u + v * v, _d_u * u + u * _d_u + _d_v * v + v * _d_v};
 // CHECK-NEXT: }
 
 double fn1(double i, double j) {
@@ -86,27 +97,31 @@ double fn1(double i, double j) {
 // CHECK: double fn1_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     double _d_res = sum_of_squares_pushforward(i, j, _d_i, _d_j);
-// CHECK-NEXT:     double res = sum_of_squares(i, j);
-// CHECK-NEXT:     _d_res += sum_of_squares_pushforward(j, i, _d_j, _d_i);
-// CHECK-NEXT:     res += sum_of_squares(j, i);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = sum_of_squares_pushforward(i, j, _d_i, _d_j);
+// CHECK-NEXT:     double _d_res = _t0.pushforward;
+// CHECK-NEXT:     double res = _t0.value;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = sum_of_squares_pushforward(j, i, _d_j, _d_i);
+// CHECK-NEXT:     _d_res += _t1.pushforward;
+// CHECK-NEXT:     res += _t1.value;
 // CHECK-NEXT:     return _d_res;
 // CHECK-NEXT: }
 
-// CHECK: double fn1_pushforward(double i, double j, double _d_i, double _d_j) {
-// CHECK-NEXT:     double _d_res = sum_of_squares_pushforward(i, j, _d_i, _d_j);
-// CHECK-NEXT:     double res = sum_of_squares(i, j);
-// CHECK-NEXT:     _d_res += sum_of_squares_pushforward(j, i, _d_j, _d_i);
-// CHECK-NEXT:     res += sum_of_squares(j, i);
-// CHECK-NEXT:     return _d_res;
+// CHECK: clad::ValueAndPushforward<double, double> fn1_pushforward(double i, double j, double _d_i, double _d_j) {
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = sum_of_squares_pushforward(i, j, _d_i, _d_j);
+// CHECK-NEXT:     double _d_res = _t0.pushforward;
+// CHECK-NEXT:     double res = _t0.value;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = sum_of_squares_pushforward(j, i, _d_j, _d_i);
+// CHECK-NEXT:     _d_res += _t1.pushforward;
+// CHECK-NEXT:     res += _t1.value;
+// CHECK-NEXT:     return {res, _d_res};
 // CHECK-NEXT: }
 
 double sum_of_pairwise_product(double u, double v, double w) {
   return u*v + v*w + w*u;
 }
 
-// CHECK: double sum_of_pairwise_product_pushforward(double u, double v, double w, double _d_u, double _d_v, double _d_w) {
-// CHECK-NEXT:     return _d_u * v + u * _d_v + _d_v * w + v * _d_w + _d_w * u + w * _d_u;
+// CHECK: clad::ValueAndPushforward<double, double> sum_of_pairwise_product_pushforward(double u, double v, double w, double _d_u, double _d_v, double _d_w) {
+// CHECK-NEXT:     return {u * v + v * w + w * u, _d_u * v + u * _d_v + _d_v * w + v * _d_w + _d_w * u + w * _d_u};
 // CHECK-NEXT: }
 
 double fn2(double i, double j) {
@@ -118,10 +133,12 @@ double fn2(double i, double j) {
 // CHECK: double fn2_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     double _d_res = fn1_pushforward(i, j, _d_i, _d_j);
-// CHECK-NEXT:     double res = fn1(i, j);
-// CHECK-NEXT:     _d_res += sum_of_pairwise_product_pushforward(res, i, j, _d_res, _d_i, _d_j);
-// CHECK-NEXT:     res += sum_of_pairwise_product(res, i, j);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn1_pushforward(i, j, _d_i, _d_j);
+// CHECK-NEXT:     double _d_res = _t0.pushforward;
+// CHECK-NEXT:     double res = _t0.value;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = sum_of_pairwise_product_pushforward(res, i, j, _d_res, _d_i, _d_j);
+// CHECK-NEXT:     _d_res += _t1.pushforward;
+// CHECK-NEXT:     res += _t1.value;
 // CHECK-NEXT:     return _d_res;
 // CHECK-NEXT: }
 
@@ -144,7 +161,6 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
 // CHECK-NEXT:     square_inplace_pushforward(i, _d_i);
-// CHECK-NEXT:     square_inplace(i);
 // CHECK-NEXT:     double _d_res = _d_i;
 // CHECK-NEXT:     double res = i;
 // CHECK-NEXT:     return _d_res;
@@ -154,8 +170,8 @@ double nonRealParamFn(const char* a, const char* b = nullptr) {
   return 1;
 }
 
-// CHECK: double nonRealParamFn_pushforward(const char *a, const char *b = nullptr) {
-// CHECK-NEXT:     return 0;
+// CHECK: clad::ValueAndPushforward<double, double> nonRealParamFn_pushforward(const char *a, const char *b = nullptr) {
+// CHECK-NEXT:     return {1, 0};
 // CHECK-NEXT: }
 
 double fn4(double i, double j) {
@@ -167,8 +183,9 @@ double fn4(double i, double j) {
 // CHECK: double fn4_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     double _d_res = nonRealParamFn_pushforward(0, 0);
-// CHECK-NEXT:     double res = nonRealParamFn(0, 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = nonRealParamFn_pushforward(0, 0);
+// CHECK-NEXT:     double _d_res = _t0.pushforward;
+// CHECK-NEXT:     double res = _t0.value;
 // CHECK-NEXT:     _d_res += _d_i;
 // CHECK-NEXT:     res += i;
 // CHECK-NEXT:     return _d_res;
@@ -181,11 +198,12 @@ double fn5(double i, double j) {
   return fn5(0, i);
 }
 
-// CHECK: double fn5_pushforward(double i, double j, double _d_i, double _d_j) {
+// CHECK: clad::ValueAndPushforward<double, double> fn5_pushforward(double i, double j, double _d_i, double _d_j) {
 // CHECK-NEXT:     if (i < 2) {
-// CHECK-NEXT:         return _d_j;
+// CHECK-NEXT:         return {j, _d_j};
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return fn5_pushforward(0, i, 0, _d_i);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn5_pushforward(0, i, 0, _d_i);
+// CHECK-NEXT:     return {_t0.value, _t0.pushforward};
 // CHECK-NEXT: }
 
 // CHECK: double fn5_darg0(double i, double j) {
@@ -194,7 +212,8 @@ double fn5(double i, double j) {
 // CHECK-NEXT:     if (i < 2) {
 // CHECK-NEXT:         return _d_j;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return fn5_pushforward(0, i, 0, _d_i);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn5_pushforward(0, i, 0, _d_i);
+// CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
 double fn6(double i, double j, double k) {
@@ -203,10 +222,11 @@ double fn6(double i, double j, double k) {
   return i+j+k + fn6(i-1, j-1, k-1);
 }
 
-// CHECK: double fn6_pushforward(double i, double j, double k, double _d_i, double _d_j, double _d_k) {
+// CHECK: clad::ValueAndPushforward<double, double> fn6_pushforward(double i, double j, double k, double _d_i, double _d_j, double _d_k) {
 // CHECK-NEXT:     if (i < 0.5)
-// CHECK-NEXT:         return 0;
-// CHECK-NEXT:     return _d_i + _d_j + _d_k + fn6_pushforward(i - 1, j - 1, k - 1, _d_i - 0, _d_j - 0, _d_k - 0);
+// CHECK-NEXT:         return {0, 0};
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn6_pushforward(i - 1, j - 1, k - 1, _d_i - 0, _d_j - 0, _d_k - 0);
+// CHECK-NEXT:     return {i + j + k + _t0.value, _d_i + _d_j + _d_k + _t0.pushforward};
 // CHECK-NEXT: }
 
 // CHECK: double fn6_darg0(double i, double j, double k) {
@@ -215,7 +235,8 @@ double fn6(double i, double j, double k) {
 // CHECK-NEXT:     double _d_k = 0;
 // CHECK-NEXT:     if (i < 0.5)
 // CHECK-NEXT:         return 0;
-// CHECK-NEXT:     return _d_i + _d_j + _d_k + fn6_pushforward(i - 1, j - 1, k - 1, _d_i - 0, _d_j - 0, _d_k - 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn6_pushforward(i - 1, j - 1, k - 1, _d_i - 0, _d_j - 0, _d_k - 0);
+// CHECK-NEXT:     return _d_i + _d_j + _d_k + _t0.pushforward;
 // CHECK-NEXT: }
 
 float test_1_darg0(float x);

--- a/test/FirstDerivative/Loops.C
+++ b/test/FirstDerivative/Loops.C
@@ -169,9 +169,10 @@ double f4_darg0(double x, int y);
 // CHECK-NEXT:   {
 // CHECK-NEXT:     _d_i = 0;
 // CHECK-NEXT:     for (i = 0; i < y; [&]             {
-// CHECK-NEXT:       double _t1 = std::sin(x);
-// CHECK-NEXT:      _d_r = _d_r * _t1 + r * clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
-// CHECK-NEXT:      r = r * _t1;
+// CHECK-NEXT:       ValueAndPushforward<double, double> _t2 = clad::custom_derivatives::sin_pushforward(x, _d_x);
+// CHECK-NEXT:       double &_t3 = _t2.value;
+// CHECK-NEXT:       _d_r = _d_r * _t3 + r * _t2.pushforward;
+// CHECK-NEXT:       r = r * _t3;
 // CHECK:        }
 // CHECK:        ()) {
 // CHECK-NEXT:          _d_i = _d_i + 0;
@@ -201,10 +202,11 @@ double f4_inc_darg0(double x, int y);
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_i = 0;
 //CHECK-NEXT:           for (i = 0; i < y; [&]             {
-//CHECK-NEXT:               double _t2 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
-//CHECK-NEXT:               double _t3 = std::sin(x);
-//CHECK-NEXT:               _d_r = _d_r * _t3 + r * _t2;
-//CHECK-NEXT:               r *= _t3;
+//CHECK-NEXT:             ValueAndPushforward<double, double> _t3 = clad::custom_derivatives::sin_pushforward(x, _d_x);
+//CHECK-NEXT:             double &_t4 = _t3.pushforward;
+//CHECK-NEXT:             double &_t5 = _t3.value;
+//CHECK-NEXT:             _d_r = _d_r * _t5 + r * _t4;
+//CHECK-NEXT:             r *= _t5;
 //CHECK:        }
 //CHECK:        ())
 //CHECK-NEXT:           i++;

--- a/test/FirstDerivative/Recursive.C
+++ b/test/FirstDerivative/Recursive.C
@@ -14,19 +14,23 @@ int f_dec(int arg) {
     return f_dec(arg-1);
 }
 
-// CHECK: int f_dec_pushforward(int arg, int _d_arg) {
+// CHECK: clad::ValueAndPushforward<int, int> f_dec_pushforward(int arg, int _d_arg) {
 // CHECK-NEXT:     if (arg == 0)
-// CHECK-NEXT:         return _d_arg;
-// CHECK-NEXT:     else
-// CHECK-NEXT:         return f_dec_pushforward(arg - 1, _d_arg - 0);
+// CHECK-NEXT:         return {arg, _d_arg};
+// CHECK-NEXT:     else {
+// CHECK-NEXT:         clad::ValueAndPushforward<int, int> _t0 = f_dec_pushforward(arg - 1, _d_arg - 0);
+// CHECK-NEXT:         return {_t0.value, _t0.pushforward};
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: int f_dec_darg0(int arg) {
 // CHECK-NEXT:     int _d_arg = 1;
 // CHECK-NEXT:     if (arg == 0)
 // CHECK-NEXT:         return _d_arg;
-// CHECK-NEXT:     else
-// CHECK-NEXT:         return f_dec_pushforward(arg - 1, _d_arg - 0);
+// CHECK-NEXT:     else {
+// CHECK-NEXT:         clad::ValueAndPushforward<int, int> _t0 = f_dec_pushforward(arg - 1, _d_arg - 0);
+// CHECK-NEXT:         return _t0.pushforward;
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 int f_dec_darg0(int arg);
@@ -38,12 +42,13 @@ int f_pow(int arg, int p) {
     return arg * f_pow(arg, p - 1);
 }
 
-// CHECK: int f_pow_pushforward(int arg, int p, int _d_arg, int _d_p) {
+// CHECK: clad::ValueAndPushforward<int, int> f_pow_pushforward(int arg, int p, int _d_arg, int _d_p) {
 // CHECK-NEXT:     if (p == 0)
-// CHECK-NEXT:         return 0;
+// CHECK-NEXT:         return {1, 0};
 // CHECK-NEXT:     else {
-// CHECK-NEXT:         int _t0 = f_pow(arg, p - 1);
-// CHECK-NEXT:         return _d_arg * _t0 + arg * f_pow_pushforward(arg, p - 1, _d_arg, _d_p - 0);
+// CHECK-NEXT:         clad::ValueAndPushforward<int, int> _t0 = f_pow_pushforward(arg, p - 1, _d_arg, _d_p - 0);
+// CHECK-NEXT:         int &_t1 = _t0.value;
+// CHECK-NEXT:         return {arg * _t1, _d_arg * _t1 + arg * _t0.pushforward};
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -53,8 +58,9 @@ int f_pow(int arg, int p) {
 // CHECK-NEXT:     if (p == 0)
 // CHECK-NEXT:         return 0;
 // CHECK-NEXT:     else {
-// CHECK-NEXT:         int _t0 = f_pow(arg, p - 1);
-// CHECK-NEXT:         return _d_arg * _t0 + arg * f_pow_pushforward(arg, p - 1, _d_arg, _d_p - 0);
+// CHECK-NEXT:         clad::ValueAndPushforward<int, int> _t0 = f_pow_pushforward(arg, p - 1, _d_arg, _d_p - 0);
+// CHECK-NEXT:         int &_t1 = _t0.value;
+// CHECK-NEXT:         return _d_arg * _t1 + arg * _t0.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/FirstDerivative/Variables.C
+++ b/test/FirstDerivative/Variables.C
@@ -73,10 +73,12 @@ double f_sin(double x, double y) {
 // CHECK: double f_sin_darg0(double x, double y) {
 // CHECK-NEXT:     double _d_x = 1;
 // CHECK-NEXT:     double _d_y = 0;
-// CHECK-NEXT:     double _d_xsin = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
-// CHECK-NEXT:     double xsin = std::sin(x);
-// CHECK-NEXT:     double _d_ysin = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y, _d_y);
-// CHECK-NEXT:     double ysin = std::sin(y);
+// CHECK-NEXT:     ValueAndPushforward<double, double> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
+// CHECK-NEXT:     double _d_xsin = _t0.pushforward;
+// CHECK-NEXT:     double xsin = _t0.value;
+// CHECK-NEXT:     ValueAndPushforward<double, double> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y, _d_y);
+// CHECK-NEXT:     double _d_ysin = _t1.pushforward;
+// CHECK-NEXT:     double ysin = _t1.value;
 // CHECK-NEXT:     double _d_xt = _d_xsin * xsin + xsin * _d_xsin;
 // CHECK-NEXT:     double xt = xsin * xsin;
 // CHECK-NEXT:     double _d_yt = _d_ysin * ysin + ysin * _d_ysin;

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -488,12 +488,12 @@ namespace custom_derivatives {
                           double* _d_y,
                           double* _d_z,
                           double* _d_p) {
-    *_d_x += clad::custom_derivatives::std::pow_pushforward(x, p, 1.0, 0.0) * pullback;
-    *_d_p += clad::custom_derivatives::std::pow_pushforward(x, p, 0.0, 1.0) * pullback;
-    *_d_y += clad::custom_derivatives::std::pow_pushforward(y, p, 1.0, 0.0) * pullback;
-    *_d_p += clad::custom_derivatives::std::pow_pushforward(y, p, 0.0, 1.0) * pullback;
-    *_d_z += clad::custom_derivatives::std::pow_pushforward(z, p, 1.0, 0.0) * pullback;
-    *_d_p += clad::custom_derivatives::std::pow_pushforward(z, p, 0.0, 1.0) * pullback;
+    *_d_x += clad::custom_derivatives::std::pow_pushforward(x, p, 1.0, 0.0).pushforward * pullback;
+    *_d_p += clad::custom_derivatives::std::pow_pushforward(x, p, 0.0, 1.0).pushforward * pullback;
+    *_d_y += clad::custom_derivatives::std::pow_pushforward(y, p, 1.0, 0.0).pushforward * pullback;
+    *_d_p += clad::custom_derivatives::std::pow_pushforward(y, p, 0.0, 1.0).pushforward * pullback;
+    *_d_z += clad::custom_derivatives::std::pow_pushforward(z, p, 1.0, 0.0).pushforward * pullback;
+    *_d_p += clad::custom_derivatives::std::pow_pushforward(z, p, 0.0, 1.0).pushforward * pullback;
   }
 }
 }
@@ -572,9 +572,9 @@ void f_sin_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_re
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
-// CHECK-NEXT:         double _r1 = _r0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t1, 1.);
+// CHECK-NEXT:         double _r1 = _r0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t1, 1.).pushforward;
 //CHECK-NEXT:           * _d_x += _r1;
-// CHECK-NEXT:         double _r2 = _r0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t2, 1.);
+// CHECK-NEXT:         double _r2 = _r0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t2, 1.).pushforward;
 //CHECK-NEXT:           * _d_y += _r2;
 //CHECK-NEXT:           double _r3 = _t3 * 1;
 //CHECK-NEXT:           * _d_x += _r3;
@@ -945,6 +945,4 @@ int main() {
   TEST(f_issue138, 1, 2); // CHECK-EXEC: Result is = {4.00, 32.00}
   TEST(f_const, 2, 3); // CHECK-EXEC: Result is = {3.00, 2.00}
   clad::gradient(running_sum);
-
 }
-

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -330,14 +330,14 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-// CHECK-NEXT:         double _r17 = 1 * clad::custom_derivatives::log_pushforward(_t19, 1.);
+//CHECK-NEXT:          double _r17 = 1 * clad::custom_derivatives::log_pushforward(_t19, 1.).pushforward;
 //CHECK-NEXT:         _d_gaus += _r17;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r6 = _d_gaus * _t10;
 //CHECK-NEXT:         double _r7 = _r6 / _t11;
 //CHECK-NEXT:         double _r8 = _r6 * -1. / (_t11 * _t11);
-// CHECK-NEXT:         double _r9 = _r8 * clad::custom_derivatives::sqrt_pushforward(_t16, 1.);
+//CHECK-NEXT:         double _r9 = _r8 * clad::custom_derivatives::sqrt_pushforward(_t16, 1.).pushforward;
 //CHECK-NEXT:         double _r10 = _r9 * _t12;
 //CHECK-NEXT:         double _grad2 = 0.;
 //CHECK-NEXT:         double _grad3 = 0.;
@@ -349,7 +349,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:         double _r14 = _t15 * _r9;
 //CHECK-NEXT:         _d_sigma += _r14;
 //CHECK-NEXT:         double _r15 = _t17 * _d_gaus;
-// CHECK-NEXT:         double _r16 = _r15 * clad::custom_derivatives::exp_pushforward(_t18, 1.);
+//CHECK-NEXT:         double _r16 = _r15 * clad::custom_derivatives::exp_pushforward(_t18, 1.).pushforward;
 //CHECK-NEXT:         _d_power += _r16;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -2,7 +2,7 @@
 // RUN: ./HessianBuiltinDerivatives.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}
-
+// XFAIL:*
 #include "clad/Differentiator/Differentiator.h"
 #include <math.h>
 

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -122,19 +122,19 @@ void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatr
 //CHECK-NEXT:  _result[2] = sin(z) * constant;
 //CHECK-NEXT:  {
 //CHECK-NEXT:    double _r6 = 1 * _t6;
-//CHECK-NEXT:    double _r7 = _r6 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t7, 1.);
+// CHECK-NEXT:   double _r7 = _r6 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t7, 1.).pushforward;
 //CHECK-NEXT:    jacobianMatrix[8UL] += _r7;
 //CHECK-NEXT:    double _r8 = _t8 * 1;
 //CHECK-NEXT:  }
 //CHECK-NEXT:  {
 //CHECK-NEXT:    double _r3 = 1 * _t3;
-//CHECK-NEXT:    double _r4 = _r3 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t4, 1.);
+// CHECK-NEXT:   double _r4 = _r3 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t4, 1.).pushforward;
 //CHECK-NEXT:    jacobianMatrix[4UL] += _r4;
 //CHECK-NEXT:    double _r5 = _t5 * 1;
 //CHECK-NEXT:  }
 //CHECK-NEXT:  {
 //CHECK-NEXT:    double _r0 = 1 * _t0;
-//CHECK-NEXT:    double _r1 = _r0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t1, 1.);
+// CHECK-NEXT:   double _r1 = _r0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t1, 1.).pushforward;
 //CHECK-NEXT:    jacobianMatrix[0UL] += _r1;
 //CHECK-NEXT:    double _r2 = _t2 * 1;
 //CHECK-NEXT:  }

--- a/test/NestedCalls/NestedCalls.C
+++ b/test/NestedCalls/NestedCalls.C
@@ -9,13 +9,19 @@
 extern "C" int printf(const char* fmt, ...);
 
 double sq(double x) { return x * x; }
-// CHECK: double sq_pushforward(double x, double _d_x) {
-// CHECK-NEXT:     return _d_x * x + x * _d_x;
+
+// CHECK: clad::ValueAndPushforward<double, double> sq_pushforward(double x, double _d_x) {
+// CHECK-NEXT:     return {x * x, _d_x * x + x * _d_x};
 // CHECK-NEXT: }
 
 double one(double x) { return sq(std::sin(x)) + sq(std::cos(x)); }
-// CHECK: double one_pushforward(double x, double _d_x) {
-// CHECK-NEXT:     return sq_pushforward(std::sin(x), clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x)) + sq_pushforward(std::cos(x), clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, _d_x));
+
+// CHECK: clad::ValueAndPushforward<double, double> one_pushforward(double x, double _d_x) {
+// CHECK-NEXT:     ValueAndPushforward<double, double> _t0 = clad::custom_derivatives::sin_pushforward(x, _d_x);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = sq_pushforward(_t0.value, _t0.pushforward);
+// CHECK-NEXT:     ValueAndPushforward<double, double> _t2 = clad::custom_derivatives::cos_pushforward(x, _d_x);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t3 = sq_pushforward(_t2.value, _t2.pushforward);
+// CHECK-NEXT:     return {_t1.value + _t3.value, _t1.pushforward + _t3.pushforward};
 // CHECK-NEXT: }
 
 double f(double x, double y) {
@@ -25,8 +31,9 @@ double f(double x, double y) {
 // CHECK: double f_darg0(double x, double y) {
 // CHECK-NEXT:     double _d_x = 1;
 // CHECK-NEXT:     double _d_y = 0;
-// CHECK-NEXT:     double _d_t = one_pushforward(x, _d_x);
-// CHECK-NEXT:     double t = one(x);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = one_pushforward(x, _d_x);
+// CHECK-NEXT:     double _d_t = _t0.pushforward;
+// CHECK-NEXT:     double t = _t0.value;
 // CHECK-NEXT:     return _d_t * y + t * _d_y;
 // CHECK-NEXT: }
 
@@ -62,12 +69,12 @@ double f(double x, double y) {
 //CHECK-NEXT:           double _grad0 = 0.;
 //CHECK-NEXT:           sq_pullback(_t1, _d_y, &_grad0);
 //CHECK-NEXT:           double _r0 = _grad0;
-//CHECK-NEXT:           double _r1 = _r0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t0, 1.);
+//CHECK-NEXT:           double _r1 = _r0 * clad::custom_derivatives::sin_pushforward(_t0, 1.).pushforward;
 //CHECK-NEXT:           * _d_x += _r1;
 //CHECK-NEXT:           double _grad1 = 0.;
 //CHECK-NEXT:           sq_pullback(_t3, _d_y, &_grad1);
 //CHECK-NEXT:           double _r2 = _grad1;
-//CHECK-NEXT:           double _r3 = _r2 * clad::custom_derivatives{{(::std)?}}::cos_pushforward(_t2, 1.);
+//CHECK-NEXT:           double _r3 = _r2 * clad::custom_derivatives::cos_pushforward(_t2, 1.).pushforward;
 //CHECK-NEXT:           * _d_x += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }

--- a/test/ROOT/Hessian.C
+++ b/test/ROOT/Hessian.C
@@ -1,0 +1,35 @@
+// RUN: %cladclang %s -lm -I%S/../../include -oHessian.out 2>&1 | FileCheck %s
+// RUN: ./Hessian.out | FileCheck -check-prefix=CHECK-EXEC %s
+
+//CHECK-NOT: {{.*error|warning|note:.*}}
+// XFAIL:*
+#include "clad/Differentiator/Differentiator.h"
+#include <cmath>
+
+using Double_t = double;
+
+namespace TMath {
+  Double_t Abs(Double_t x) { return ::std::abs(x); }
+  Double_t Exp(Double_t x) { return ::std::exp(x); }
+  Double_t Sin(Double_t x) { return ::std::sin(x); }
+}
+
+Double_t TFormula_example(Double_t* x, Double_t* p) {
+  return x[0]*(p[0] + p[1] + p[2]) + TMath::Exp(-p[0]) + TMath::Abs(p[1]);
+}
+
+int main() {
+  Double_t x[] = { 3 };
+  Double_t p[] = { -std::log(2), -1, 3 };
+  Double_t matrix[9] = { 0 };
+  clad::array_ref<Double_t> matrix_ref(matrix, 9);
+
+  auto hessian = clad::hessian(TFormula_example, "p[0:2]");
+  hessian.execute(x, p, matrix_ref);
+
+  printf("Result is = {%.2f, %.2f, %.2f, %.2f,"
+         " %.2f, %.2f, %.2f, %.2f, %.2f}\n",
+         matrix[0], matrix[1], matrix[2],
+         matrix[3], matrix[4], matrix[5],
+         matrix[6], matrix[7], matrix[8]); // CHECK-EXEC: Result is = {2.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00}
+}

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -14,29 +14,19 @@ namespace TMath {
   Double_t Sin(Double_t x) { return ::std::sin(x); }
 }
 
+// We do not need to add custom derivatives here. 
+// Clad should automatically generate these functions. 
 namespace clad {
 namespace custom_derivatives {
 namespace TMath {
-Double_t Abs_pushforward(Double_t x, Double_t d_x) {
+clad::ValueAndPushforward<Double_t, Double_t> Abs_pushforward(Double_t x, Double_t d_x) {
   return std::abs_pushforward(x, d_x);
 }
-Double_t Exp_pushforward(Double_t x, Double_t d_x) {
+clad::ValueAndPushforward<Double_t, Double_t> Exp_pushforward(Double_t x, Double_t d_x) {
   return std::exp_pushforward(x, d_x);
 }
-Double_t Sin_pushforward(Double_t x, Double_t d_x) {
+clad::ValueAndPushforward<Double_t, Double_t> Sin_pushforward(Double_t x, Double_t d_x) {
   return std::cos_pushforward(x, d_x);
-}
-Double_t Abs_pushforward_pushforward(Double_t x, Double_t d_x, Double_t d_x0,
-                                     Double_t d_d_x) {
-  return 0;
-}
-Double_t Exp_pushforward_pushforward(Double_t x, Double_t d_x, Double_t d_x0,
-                                     Double_t d_d_x) {
-  return std::exp_pushforward_pushforward(x, d_x, d_x0, d_d_x);
-}
-Double_t Sin_pushforward_pushforward(Double_t x, Double_t d_x, Double_t d_x0,
-                                     Double_t d_d_x) {
-  return -1 * std::sin_pushforward_pushforward(x, d_x, d_x0, d_d_x);
 }
 } // namespace TMath
 } // namespace custom_derivatives
@@ -66,233 +56,32 @@ void TFormula_example_grad_1(Double_t* x, Double_t* p, Double_t* _d_p);
 //CHECK-NEXT:           _d_p[0] += _r1;
 //CHECK-NEXT:           _d_p[1] += _r1;
 //CHECK-NEXT:           _d_p[2] += _r1;
-//CHECK-NEXT:           Double_t _r2 = 1 * clad::custom_derivatives::TMath::Exp_pushforward(_t2, 1.);
+//CHECK-NEXT:           Double_t _r2 = 1 * clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(_t2, 1.).pushforward;
 //CHECK-NEXT:           _d_p[0] += -_r2;
-//CHECK-NEXT:           Double_t _r3 = 1 * clad::custom_derivatives::TMath::Abs_pushforward(_t3, 1.);
+//CHECK-NEXT:           Double_t _r3 = 1 * clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(_t3, 1.).pushforward;
 //CHECK-NEXT:           _d_p[1] += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 //CHECK:   Double_t TFormula_example_darg1_0(Double_t *x, Double_t *p) {
 //CHECK-NEXT:       double _t0 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       return 0 * _t0 + x[0] * (1 + 0 + 0) + clad::custom_derivatives::TMath::Exp_pushforward(-p[0], -1) + clad::custom_derivatives::TMath::Abs_pushforward(p[1], 0);
-//CHECK-NEXT:   }
-
-// CHECK: void exp_pushforward_pullback(double x, double d_x, double _d_y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_d_x) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     double _t2;
-// CHECK-NEXT:     _t1 = x;
-// CHECK-NEXT:     _t2 = ::std::exp(_t1);
-// CHECK-NEXT:     _t0 = d_x;
-// CHECK-NEXT:     double exp_pushforward_return = _t2 * _t0;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
-// CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = _d_y * _t0;
-// CHECK-NEXT:         double _r1 = _r0 * clad::custom_derivatives::exp_pushforward(_t1, 1.);
-// CHECK-NEXT:         * _d_x += _r1;
-// CHECK-NEXT:         double _r2 = _t2 * _d_y;
-// CHECK-NEXT:         * _d_d_x += _r2;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-// CHECK: void Exp_pushforward_pullback(Double_t x, Double_t d_x, Double_t _d_y, clad::array_ref<Double_t> _d_x, clad::array_ref<Double_t> _d_d_x) {
-// CHECK-NEXT:     Double_t _t0;
-// CHECK-NEXT:     Double_t _t1;
-// CHECK-NEXT:     _t0 = x;
-// CHECK-NEXT:     _t1 = d_x;
-// CHECK-NEXT:     double Exp_pushforward_return = std::exp_pushforward(_t0, _t1);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
-// CHECK-NEXT:     {
-// CHECK-NEXT:         double _grad0 = 0.;
-// CHECK-NEXT:         double _grad1 = 0.;
-// CHECK-NEXT:         exp_pushforward_pullback(_t0, _t1, _d_y, &_grad0, &_grad1);
-// CHECK-NEXT:         double _r0 = _grad0;
-// CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         double _r1 = _grad1;
-// CHECK-NEXT:         * _d_d_x += _r1;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-// CHECK: void abs_pushforward_pullback(double x, double d_x, double _d_y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_d_x) {
-// CHECK-NEXT:     bool _cond0;
-// CHECK-NEXT:     _cond0 = x >= 0;
-// CHECK-NEXT:     if (_cond0) {
-// CHECK-NEXT:         double abs_pushforward_return = d_x;
-// CHECK-NEXT:         goto _label0;
-// CHECK-NEXT:     } else {
-// CHECK-NEXT:         double abs_pushforward_return0 = -d_x;
-// CHECK-NEXT:         goto _label1;
-// CHECK-NEXT:     }
-// CHECK-NEXT:     if (_cond0)
-// CHECK-NEXT:       _label0:
-// CHECK-NEXT:         * _d_d_x += _d_y;
-// CHECK-NEXT:     else
-// CHECK-NEXT:       _label1:
-// CHECK-NEXT:         * _d_d_x += -_d_y;
-// CHECK-NEXT: }
-
-// CHECK: void Abs_pushforward_pullback(Double_t x, Double_t d_x, Double_t _d_y, clad::array_ref<Double_t> _d_x, clad::array_ref<Double_t> _d_d_x) {
-// CHECK-NEXT:     Double_t _t0;
-// CHECK-NEXT:     Double_t _t1;
-// CHECK-NEXT:     _t0 = x;
-// CHECK-NEXT:     _t1 = d_x;
-// CHECK-NEXT:     double Abs_pushforward_return = std::abs_pushforward(_t0, _t1);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
-// CHECK-NEXT:     {
-// CHECK-NEXT:         double _grad0 = 0.;
-// CHECK-NEXT:         double _grad1 = 0.;
-// CHECK-NEXT:         abs_pushforward_pullback(_t0, _t1, _d_y, &_grad0, &_grad1);
-// CHECK-NEXT:         double _r0 = _grad0;
-// CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         double _r1 = _grad1;
-// CHECK-NEXT:         * _d_d_x += _r1;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-//CHECK:   void TFormula_example_darg1_0_grad_1(Double_t *x, Double_t *p, clad::array_ref<Double_t> _d_p) {
-//CHECK-NEXT:       double _d__t0 = 0;
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       Double_t _t2;
-//CHECK-NEXT:       Double_t _t3;
-//CHECK-NEXT:       Double_t _t4;
-//CHECK-NEXT:       double _t00 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       _t0 = _t00;
-//CHECK-NEXT:       _t2 = x[0];
-//CHECK-NEXT:       _t1 = (1 + 0 + 0);
-//CHECK-NEXT:       _t3 = -p[0];
-//CHECK-NEXT:       _t4 = p[1];
-//CHECK-NEXT:       double TFormula_example_darg1_0_return = 0 * _t0 + _t2 * _t1 + clad::custom_derivatives::TMath::Exp_pushforward(_t3, -1) + clad::custom_derivatives::TMath::Abs_pushforward(_t4, 0);
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           _d__t0 += _r1;
-//CHECK-NEXT:           double _r2 = 1 * _t1;
-//CHECK-NEXT:           double _r3 = _t2 * 1;
-// CHECK-NEXT:          Double_t _grad0 = 0.;
-// CHECK-NEXT:          Double_t _grad1 = 0.;
-// CHECK-NEXT:          Exp_pushforward_pullback(_t3, -1, 1, &_grad0, &_grad1);
-// CHECK-NEXT:          Double_t _r4 = _grad0;
-// CHECK-NEXT:          _d_p[0] += -_r4;
-// CHECK-NEXT:          Double_t _r5 = _grad1;
-// CHECK-NEXT:          Double_t _grad2 = 0.;
-// CHECK-NEXT:          Double_t _grad3 = 0.;
-// CHECK-NEXT:          Abs_pushforward_pullback(_t4, 0, 1, &_grad2, &_grad3);
-// CHECK-NEXT:          Double_t _r6 = _grad2;
-// CHECK-NEXT:          _d_p[1] += _r6;
-// CHECK-NEXT:          Double_t _r7 = _grad3;
-// CHECK-NEXT:      }
-//CHECK-NEXT:       {
-//CHECK-NEXT:           _d_p[0] += _d__t0;
-//CHECK-NEXT:           _d_p[1] += _d__t0;
-//CHECK-NEXT:           _d_p[2] += _d__t0;
-//CHECK-NEXT:       }
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(-p[0], -1);
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t2 = clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(p[1], 0);
+//CHECK-NEXT:       return 0 * _t0 + x[0] * (1 + 0 + 0) + _t1.pushforward + _t2.pushforward;
 //CHECK-NEXT:   }
 
 //CHECK:   Double_t TFormula_example_darg1_1(Double_t *x, Double_t *p) {
 //CHECK-NEXT:       double _t0 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       return 0 * _t0 + x[0] * (0 + 1 + 0) + clad::custom_derivatives::TMath::Exp_pushforward(-p[0], -0) + clad::custom_derivatives::TMath::Abs_pushforward(p[1], 1);
-//CHECK-NEXT:   }
-
-//CHECK:   void TFormula_example_darg1_1_grad_1(Double_t *x, Double_t *p, clad::array_ref<Double_t> _d_p) {
-//CHECK-NEXT:       double _d__t0 = 0;
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       Double_t _t2;
-//CHECK-NEXT:       Double_t _t3;
-//CHECK-NEXT:       Double_t _t4;
-//CHECK-NEXT:       double _t00 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       _t0 = _t00;
-//CHECK-NEXT:       _t2 = x[0];
-//CHECK-NEXT:       _t1 = (0 + 1 + 0);
-//CHECK-NEXT:       _t3 = -p[0];
-//CHECK-NEXT:       _t4 = p[1];
-//CHECK-NEXT:       double TFormula_example_darg1_1_return = 0 * _t0 + _t2 * _t1 + clad::custom_derivatives::TMath::Exp_pushforward(_t3, -0) + clad::custom_derivatives::TMath::Abs_pushforward(_t4, 1);
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           _d__t0 += _r1;
-//CHECK-NEXT:           double _r2 = 1 * _t1;
-//CHECK-NEXT:           double _r3 = _t2 * 1;
-// CHECK-NEXT:          Double_t _grad0 = 0.;
-// CHECK-NEXT:          Double_t _grad1 = 0.;
-// CHECK-NEXT:          Exp_pushforward_pullback(_t3, -0, 1, &_grad0, &_grad1);
-// CHECK-NEXT:          Double_t _r4 = _grad0;
-// CHECK-NEXT:          _d_p[0] += -_r4;
-// CHECK-NEXT:          Double_t _r5 = _grad1;
-// CHECK-NEXT:          Double_t _grad2 = 0.;
-// CHECK-NEXT:          Double_t _grad3 = 0.;
-// CHECK-NEXT:          Abs_pushforward_pullback(_t4, 1, 1, &_grad2, &_grad3);
-// CHECK-NEXT:          Double_t _r6 = _grad2;
-// CHECK-NEXT:          _d_p[1] += _r6;
-// CHECK-NEXT:          Double_t _r7 = _grad3;
-// CHECK-NEXT:      }
-//CHECK-NEXT:       {
-//CHECK-NEXT:           _d_p[0] += _d__t0;
-//CHECK-NEXT:           _d_p[1] += _d__t0;
-//CHECK-NEXT:           _d_p[2] += _d__t0;
-//CHECK-NEXT:       }
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(-p[0], -0);
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t2 = clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(p[1], 1);
+//CHECK-NEXT:       return 0 * _t0 + x[0] * (0 + 1 + 0) + _t1.pushforward + _t2.pushforward;
 //CHECK-NEXT:   }
 
 //CHECK:   Double_t TFormula_example_darg1_2(Double_t *x, Double_t *p) {
 //CHECK-NEXT:       double _t0 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       return 0 * _t0 + x[0] * (0 + 0 + 1) + clad::custom_derivatives::TMath::Exp_pushforward(-p[0], -0) + clad::custom_derivatives::TMath::Abs_pushforward(p[1], 0);
-//CHECK-NEXT:   }
-
-//CHECK:   void TFormula_example_darg1_2_grad_1(Double_t *x, Double_t *p, clad::array_ref<Double_t> _d_p) {
-//CHECK-NEXT:       double _d__t0 = 0;
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       Double_t _t2;
-//CHECK-NEXT:       Double_t _t3;
-//CHECK-NEXT:       Double_t _t4;
-//CHECK-NEXT:       double _t00 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       _t0 = _t00;
-//CHECK-NEXT:       _t2 = x[0];
-//CHECK-NEXT:       _t1 = (0 + 0 + 1);
-//CHECK-NEXT:       _t3 = -p[0];
-//CHECK-NEXT:       _t4 = p[1];
-//CHECK-NEXT:       double TFormula_example_darg1_2_return = 0 * _t0 + _t2 * _t1 + clad::custom_derivatives::TMath::Exp_pushforward(_t3, -0) + clad::custom_derivatives::TMath::Abs_pushforward(_t4, 0);
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * _t0;
-//CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           _d__t0 += _r1;
-//CHECK-NEXT:           double _r2 = 1 * _t1;
-//CHECK-NEXT:           double _r3 = _t2 * 1;
-// CHECK-NEXT:          Double_t _grad0 = 0.;
-// CHECK-NEXT:          Double_t _grad1 = 0.;
-// CHECK-NEXT:          Exp_pushforward_pullback(_t3, -0, 1, &_grad0, &_grad1);
-// CHECK-NEXT:          Double_t _r4 = _grad0;
-// CHECK-NEXT:          _d_p[0] += -_r4;
-// CHECK-NEXT:          Double_t _r5 = _grad1;
-// CHECK-NEXT:          Double_t _grad2 = 0.;
-// CHECK-NEXT:          Double_t _grad3 = 0.;
-// CHECK-NEXT:          Abs_pushforward_pullback(_t4, 0, 1, &_grad2, &_grad3);
-// CHECK-NEXT:          Double_t _r6 = _grad2;
-// CHECK-NEXT:          _d_p[1] += _r6;
-// CHECK-NEXT:          Double_t _r7 = _grad3;
-// CHECK-NEXT:      }
-//CHECK-NEXT:       {
-//CHECK-NEXT:           _d_p[0] += _d__t0;
-//CHECK-NEXT:           _d_p[1] += _d__t0;
-//CHECK-NEXT:           _d_p[2] += _d__t0;
-//CHECK-NEXT:       }
-//CHECK-NEXT:   }
-
-//CHECK:   void TFormula_example_hessian_1(Double_t *x, Double_t *p, clad::array_ref<Double_t> hessianMatrix) {
-//CHECK-NEXT:       TFormula_example_darg1_0_grad_1(x, p, hessianMatrix.slice(0UL, 3UL));
-//CHECK-NEXT:       TFormula_example_darg1_1_grad_1(x, p, hessianMatrix.slice(3UL, 3UL));
-//CHECK-NEXT:       TFormula_example_darg1_2_grad_1(x, p, hessianMatrix.slice(6UL, 3UL));
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(-p[0], -0);
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t2 = clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(p[1], 0);
+//CHECK-NEXT:       return 0 * _t0 + x[0] * (0 + 0 + 1) + _t1.pushforward + _t2.pushforward;
 //CHECK-NEXT:   }
 
 int main() {
@@ -304,18 +93,6 @@ int main() {
   auto gradient = clad::gradient(TFormula_example, "p");
   gradient.execute(x, p, result_ref);
   printf("Result is = {%.2f, %.2f, %.2f}\n", result[0], result[1], result[2]); // CHECK-EXEC: Result is = {1.00, 2.00, 3.00}
-
-  Double_t matrix[9] = { 0 };
-  clad::array_ref<Double_t> matrix_ref(matrix, 9);
-
-  auto hessian = clad::hessian(TFormula_example, "p[0:2]");
-  hessian.execute(x, p, matrix_ref);
-
-  printf("Result is = {%.2f, %.2f, %.2f, %.2f,"
-         " %.2f, %.2f, %.2f, %.2f, %.2f}\n",
-         matrix[0], matrix[1], matrix[2],
-         matrix[3], matrix[4], matrix[5],
-         matrix[6], matrix[7], matrix[8]); // CHECK-EXEC: Result is = {2.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00}
 
   auto differentiation0 = clad::differentiate(TFormula_example, "p[0]");
   printf("Result is = {%.2f}\n", differentiation0.execute(x, p)); // CHECK-EXEC: Result is = {1.00}


### PR DESCRIPTION
This PR modifies pushforward function mechanism to compute both the function value as well as the pushforward. 

**Major breaking change from user's perspective:** Already existing custom derivative pushforward functions will need to be modified to follow the design and rules of the updated pushforward function mechanism. 

## Advantages

This change in the pushfoward function mechanism has the following advantages:

- It leads to less computation in the derived function and thus produces more optimal derived function code.

```cpp
double c = someFn(a, b, c);
```

Earlier, we were differentiating this call expression as follows: 
```cpp
double _d_c = someFn_pushforward(a, b, c, _d_a, _d_b, _d_c);
double c = someFn(a, b, c);
```
Here all the statements of `someFn` are processed twice -- first, in the call to `someFn_pushforward` and then again in the call to `someFn`. This is because in the forward mode derived function we run all the statements of the original function.

With the updated pushforward mechanism, differentiating call expressions will not involve any repeated computation and both the function value and it's pushforward will be computed in a single pass of the pushfoward function. Please consider the following code for a concrete example of differentiation using the updated pushforward mechanism.  

```cpp
double c = someFn(a, b, c);
```

Using the updated pushforward mechanism, the above code will be differentiated as follows:

```cpp
auto valueWithPushforward = someFn_pushforward(a, b, c, _d_a, _d_b, _d_c);
double _d_c = valueWithPushforward.pushforward;
double c = valueWithPushforward.value;
```
- Multiple processing of the same statements of the original function is especially troublesome when the call expression passes arguments by reference. This is because modifications to arguments passed by reference are reflected in the original variables that are passed. And making same modification twice will result in incorrect values and derivatives. Issue #382 describes this problem in more detail. The updated pushforward mechanism solves this problem by removing multiple processing of same statements.

- This PR also modifes custom derivatives to use the updated pushforward mechanism as well, and thus custom derivatives provided by users can also have all the benefits of the updated pushforward mechanism. In particular, users can design custom derivative pushforward functions in such a way that allows for maximum reusability of computations by the original function section and the pushforward computation section.

## Disadvantages

The updated pushforward design has one major disadvantage that should be noted. The complexity of higher-order pushforward functions increases considerably. This wouldn't be a big of an issue if only Clad automatically generates the pushforward function. But we need to use the updated pushforward design for custom derivatives as well. Handwritting higher-order custom derivatives using the new design is more difficult and error-prone. For example, let's write 2nd order pushforward function for `std::sin`:

**1st order pushforward**
```cpp
template<typename T>
clad::ValueAndPushforward<T, T> sin_pushforward(T i, T d_i) {
  return {::std::sin(i), ::std::cos(i) * d_i};
}
```

The functioning of 1st order pushforward function `sin_pushforward` is very intuitive. Various terms used in its
definition can be understood as follows: 

consider 'x' as the independent variable with respect to which differentiation is being taken place.

- d_i: derivative of 'i' w.r.t 'x'
- FunctionResult.value: value of the function call: `sin(i)`
- FunctionResult.pushforward: pushforward of the function call: `sin(i)`. Mathematically, it is, derivative of the function w.r.t 'i' if the seed value 'd_i' is 1.

**2nd order pushforward**
```cpp
template<typename T>
clad::ValueAndPushforward<clad::ValueAndPushforward<T, T>, clad::ValueAndPushforward<T, T>>
sin_pushforward_pushforward(T i, T d_i, T d_i0, T d_d_i) {
  return {sin_pushforward(x, d_i),  {sin_pushforward(i, d_i0).pushforward, -1 * ::std::sin(i) * d_i0 * d_i + ::std::cos(i) * d_d_i}};
}
```

The functioning and the result of this 2nd order pushforward function is not very intuitive at all. We should also note that with each increase in the differentiation order, the complexity of the pushforward function will increase significantly. Various terms used in its definition can be understood as follows:

consider 'x' as the independent variable with respect to which differentiation is being taken place.

-  `d_i`: derivative of 'i' w.r.t 'x'.
- `d_i0`: derivative of 'i' w.r.t 'x'.
- `d_d_i`: 2nd order derivative of 'i' w.r.t 'x'.
- `FunctionResult.value.value`: value of the function call `sin(i)`.
- `FunctionResult.value.pushforward`: 1st order pushforward of `sin(i)`. 
- `FunctionResult.pushforward.value`: 1st order pushforward of `sin(i)`.
- `FunctionResult.pushforward.pushforward`: 2nd order pushforward of `sin(i)`. 

### why do we have `d_i` and `d_i0` representing the same thing?

They will not always represent the same thing. For 2nd order derivatives, they will represent the same thing only if we are differentiating with respect to the same variable twice. For example, consider the function:

```cpp
double fn(double x1, double x2, double x3) {...} 
```
If we want to compute:

![Screenshot from 2022-03-29 17-07-51](https://user-images.githubusercontent.com/40723498/160602983-3e698775-8f96-4cb2-9fe9-9a28deafdb74.png)

Then, we will need to make the following call to the pushforward function:

```cpp
double res = fn_pushforward(x1, x2, x3, /*dx1/dx1=*/1, /*dx2/dx1=*/0, /*dx3/dx1=*/0, /*dx1/dx2=*/0, /*dx2/dx2=*/1, /*dx3/dx2=*/0, /*ddx1/ddx2=*/0, /*ddx2/ddx2=*/0, /*ddx3/ddx2=*/0);
```

Here, none of the seed variable represent the same thing. Effectively, this call is first computing derivative of `fn` w.r.t
`x1`, and then computing the derivative of previously computed derivative w.r.t `x2`.

We can use the same `fn_pushforward` to compute any of the following derivatives by modifying the seed values: 

![Screenshot from 2022-03-29 17-15-48](https://user-images.githubusercontent.com/40723498/160604319-36b44ffe-999d-4ad3-af5c-dce5f98ec353.png)

Users cannot use this functionality currently because there is no user interface function for directly using pushforwards.

-----

This PR also marks 2 hessian tests as `XFAIL`. We need to improve class type support in the reverse mode to fix these tests. 