### PR TITLE
Modified UpdateDiffParamsInfo to not add result as a parameter in jacobian mode

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -262,17 +262,25 @@ namespace clad {
     std::string gradientName = derivativeBaseName + funcPostfix();
     // To be consistent with older tests, nothing is appended to 'f_grad' if
     // we differentiate w.r.t. all the parameters at once.
-    if (!(args.size() == FD->getNumParams() &&
-          std::equal(FD->param_begin(), FD->param_end(), std::begin(args)))) {
-      for (auto arg : args) {
-        auto it = std::find(FD->param_begin(), FD->param_end(), arg);
-        auto idx = std::distance(FD->param_begin(), it);
-        gradientName += ('_' + std::to_string(idx));
+    if(isVectorValued){
+      // If Jacobian is asked, the last parameter is the result parameter
+      // and should be ignored
+      if (args.size() != FD->getNumParams()-1){
+        for (auto arg : args) {
+          auto it = std::find(FD->param_begin(), FD->param_end()-1, arg);
+          auto idx = std::distance(FD->param_begin(), it);
+          gradientName += ('_' + std::to_string(idx));
+        }
+      }
+    }else{
+      if (args.size() != FD->getNumParams()){
+        for (auto arg : args) {
+          auto it = std::find(FD->param_begin(), FD->param_end(), arg);
+          auto idx = std::distance(FD->param_begin(), it);
+          gradientName += ('_' + std::to_string(idx));
+        }
       }
     }
-
-    if (isVectorValued)
-      args.pop_back();
 
     IdentifierInfo* II = &m_Context.Idents.get(gradientName);
     DeclarationNameInfo name(II, noLoc);

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -87,6 +87,7 @@ void f_1_jac(double a, double b, double c, double output[], double *_result);
 //CHECK-NEXT:  }
 //CHECK-NEXT:}
 
+
 void f_3(double x, double y, double z, double *_result) {
   double constant = 42;
 
@@ -231,6 +232,77 @@ void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatr
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
+void f_1_jac_0(double a, double b, double c, double output[], double *jacobianMatrix);
+// CHECK: void f_1_jac_0(double a, double b, double c, double output[], double *jacobianMatrix) {
+// CHECK-NEXT:  double _d_b = 0;
+// CHECK-NEXT:  double _d_c = 0;
+// CHECK-NEXT:  double _t0;
+// CHECK-NEXT:  double _t1;
+// CHECK-NEXT:  double _t2;
+// CHECK-NEXT:  double _t3;
+// CHECK-NEXT:  double _t4;
+// CHECK-NEXT:  double _t5;
+// CHECK-NEXT:  double _t6;
+// CHECK-NEXT:  double _t7;
+// CHECK-NEXT:  double _t8;
+// CHECK-NEXT:  double _t9;
+// CHECK-NEXT:  double _t10;
+// CHECK-NEXT:  double _t11;
+// CHECK-NEXT:  double _t12;
+// CHECK-NEXT:  double _t13;
+// CHECK-NEXT:  double _t14;
+// CHECK-NEXT:  double _t15;
+// CHECK-NEXT:  _t2 = a;
+// CHECK-NEXT:  _t1 = a;
+// CHECK-NEXT:  _t3 = _t2 * _t1;
+// CHECK-NEXT:  _t0 = a;
+// CHECK-NEXT:  output[0] = a * a * a;
+// CHECK-NEXT:  _t6 = a;
+// CHECK-NEXT:  _t5 = a;
+// CHECK-NEXT:  _t7 = _t6 * _t5;
+// CHECK-NEXT:  _t4 = a;
+// CHECK-NEXT:  _t10 = b;
+// CHECK-NEXT:  _t9 = b;
+// CHECK-NEXT:  _t11 = _t10 * _t9;
+// CHECK-NEXT:  _t8 = b;
+// CHECK-NEXT:  output[1] = a * a * a + b * b * b;
+// CHECK-NEXT:  _t13 = c;
+// CHECK-NEXT:  _t12 = c;
+// CHECK-NEXT:  _t15 = a;
+// CHECK-NEXT:  _t14 = a;
+// CHECK-NEXT:  output[2] = c * c * 10 - a * a;
+// CHECK-NEXT:  {
+// CHECK-NEXT:    double _r12 = 1 * 10;
+// CHECK-NEXT:    double _r13 = _r12 * _t12;
+// CHECK-NEXT:    double _r14 = _t13 * _r12;
+// CHECK-NEXT:    double _r15 = -1 * _t14;
+// CHECK-NEXT:    jacobianMatrix[2UL] += _r15;
+// CHECK-NEXT:    double _r16 = _t15 * -1;
+// CHECK-NEXT:    jacobianMatrix[2UL] += _r16;
+// CHECK-NEXT:  }
+// CHECK-NEXT:  {
+// CHECK-NEXT:    double _r4 = 1 * _t4;
+// CHECK-NEXT:    double _r5 = _r4 * _t5;
+// CHECK-NEXT:    jacobianMatrix[1UL] += _r5;
+// CHECK-NEXT:    double _r6 = _t6 * _r4;
+// CHECK-NEXT:    jacobianMatrix[1UL] += _r6;
+// CHECK-NEXT:    double _r7 = _t7 * 1;
+// CHECK-NEXT:    jacobianMatrix[1UL] += _r7;
+// CHECK-NEXT:    double _r8 = 1 * _t8;
+// CHECK-NEXT:    double _r9 = _r8 * _t9;
+// CHECK-NEXT:    double _r10 = _t10 * _r8;
+// CHECK-NEXT:    double _r11 = _t11 * 1;
+// CHECK-NEXT:  }
+// CHECK-NEXT:  {
+// CHECK-NEXT:    double _r0 = 1 * _t0;
+// CHECK-NEXT:    double _r1 = _r0 * _t1;
+// CHECK-NEXT:    jacobianMatrix[0UL] += _r1;
+// CHECK-NEXT:    double _r2 = _t2 * _r0;
+// CHECK-NEXT:    jacobianMatrix[0UL] += _r2;
+// CHECK-NEXT:    double _r3 = _t3 * 1;
+// CHECK-NEXT:    jacobianMatrix[0UL] += _r3;
+// CHECK-NEXT:  }
+// CHECK-NEXT:}
 
 #define TEST(F, x, y, z) { \
   result[0] = 0; result[1] = 0; result[2] = 0;\
@@ -246,10 +318,21 @@ void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatr
   F##_jac(x, y, z, outputarr, result);\
 }
 
+#define TEST_F_1_SINGLE_PARAM(x, y, z) { \
+  result[0] = 0; result[1] = 0; result[2] = 0;\
+  outputarr[0] = 0; outputarr[1] = 1; outputarr[2] = 0;\
+  auto j = clad::jacobian(f_1,"a");\
+  j.execute(x, y, z, outputarr, result);\
+  printf("Result is = {%.2f, %.2f, %.2f}\n",\
+  result[0], result[1], result[2]);\
+}
+
+
 int main() {
   double result[10];
   double outputarr[9];
   TEST(f_1, 1, 2, 3); // CHECK-EXEC: Result is = {3.00, 0.00, 0.00, 3.00, 12.00, 0.00, -2.00, 0.00, 60.00}
   TEST(f_3, 1, 2, 3); // CHECK-EXEC: Result is = {22.69, 0.00, 0.00, 0.00, -17.48, 0.00, 0.00, 0.00, -41.58}
   TEST(f_4, 1, 2, 3); // CHECK-EXEC: Result is = {84.00, 42.00, 0.00, 0.00, 126.00, 84.00, 126.00, 0.00, 42.00}
+  TEST_F_1_SINGLE_PARAM(1, 2, 3); // CHECK-EXEC: Result is = {3.00, 3.00, -2.00}
 }


### PR DESCRIPTION
I have modified ```DiffRequest::UpdateDiffParamsInfo``` to ignore the last parameter(which is the result parameter), if the Mode is jacobian. Accordingly I have changed the ```ReverseModeVisitor::Derive``` to not pop the last element in jacobian mode.

As far as I understand the codebase, the changes I have made must only affect Jacobian mode of Differentiation. Please let me know if you feel that there are some other dependencies that I must consider.

closes #408 