### PR TITLE
Add initial support for differentiating pointers in forw mode

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -216,6 +216,21 @@ namespace clad {
     bool IsStaticMethod(const clang::FunctionDecl* FD);
 
     bool IsCladValueAndPushforwardType(clang::QualType T);
+
+    /// Returns a valid `SourceRange` to be used in places where clang 
+    /// requires a valid `SourceRange`.
+    clang::SourceRange GetValidSRange(clang::Sema& semaRef);
+
+    /// Builds and returns `new` expression.
+    ///
+    /// This function is just a convenient routine that internally calls
+    /// `clang::Sema::BuildCXXNew`.
+    clang::CXXNewExpr* BuildCXXNewExpr(clang::Sema& semaRef,
+                                       clang::QualType qType,
+                                       clang::Expr* arraySize,
+                                       clang::Expr* initializer,
+                                       clang::TypeSourceInfo* TSI = nullptr);
+
   } // namespace utils
 }
 

--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -614,5 +614,13 @@ template <typename T> llvm::Optional<T> EmptyOptional() {
     Node)                                                                         \
   Node->isReferenceParameter(),
 #endif
+
+#if CLANG_VERSION_MAJOR < 9
+template <typename T> const T& Optional_GetValue(const T& val) { return val; }
+#else
+template <typename T> const T& Optional_GetValue(const llvm::Optional<T>& opt) {
+  return opt.getValue();
+}
+#endif
 } // namespace clad_compat
 #endif //CLAD_COMPATIBILITY

--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -89,6 +89,9 @@ namespace clad {
     StmtDiff
     VisitCXXTemporaryObjectExpr(const clang::CXXTemporaryObjectExpr* TOE);
     StmtDiff VisitCXXThisExpr(const clang::CXXThisExpr* CTE);
+    StmtDiff VisitCXXNewExpr(const clang::CXXNewExpr* CNE);
+    StmtDiff VisitCXXDeleteExpr(const clang::CXXDeleteExpr* CDE);
+
   private:
     /// Helper function for differentiating the switch statement body.
     ///

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -292,5 +292,27 @@ namespace clad {
       return T.getAsString().find("ValueAndPushforward") !=
              std::string::npos;
     }
+
+    clang::SourceRange GetValidSRange(clang::Sema& semaRef) {
+      SourceLocation validSL = GetValidSLoc(semaRef);
+      return SourceRange(validSL, validSL);
+    }
+
+    CXXNewExpr* BuildCXXNewExpr(Sema& semaRef, QualType qType,
+                                clang::Expr* arraySize, Expr* initializer,
+                                clang::TypeSourceInfo* TSI) {
+      auto& C = semaRef.getASTContext();
+      if (!TSI)
+        TSI = C.getTrivialTypeSourceInfo(qType);
+      auto newExpr =
+          semaRef
+              .BuildCXXNew(
+                  SourceRange(), false, noLoc, MultiExprArg(), noLoc,
+                  SourceRange(), qType, TSI,
+                  (arraySize ? arraySize : clad_compat::EmptyOptional<Expr*>()),
+                  GetValidSRange(semaRef), initializer)
+              .getAs<CXXNewExpr>();
+      return newExpr;
+    }
   } // namespace utils
 } // namespace clad

--- a/test/ForwardMode/Pointer.C
+++ b/test/ForwardMode/Pointer.C
@@ -1,0 +1,89 @@
+// RUN: %cladclang %s -lstdc++ -I%S/../../include -oPointer.out 2>&1 | FileCheck %s
+// RUN: ./Pointer.out | FileCheck -check-prefix=CHECK-EXEC %s
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include "../TestUtils.h"
+
+double fn1(double i, double j) {
+  double *p = &i;
+  double **q = new double *;
+  *q = new double;
+  **q = j;
+  return *p * **q;
+}
+
+// CHECK: double fn1_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     double *_d_p = &_d_i;
+// CHECK-NEXT:     double *p = &i;
+// CHECK-NEXT:     double **_d_q = new double *(/*implicit*/(double *)0);
+// CHECK-NEXT:     double **q = new double *(/*implicit*/(double *)0);
+// CHECK-NEXT:     *_d_q = new double(/*implicit*/(double)0);
+// CHECK-NEXT:     *q = new double(/*implicit*/(double)0);
+// CHECK-NEXT:     **_d_q = _d_j;
+// CHECK-NEXT:     **q = j;
+// CHECK-NEXT:     return *_d_p * **q + *p * **_d_q;
+// CHECK-NEXT: }
+
+double fn2(double i, double j) {
+  return *(&i) * *(&(*(&j)));
+}
+
+// CHECK: double fn2_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     return *&_d_i * *&*&j + *&i * *&*&_d_j;
+// CHECK-NEXT: }
+
+double fn3(double i, double j) {
+  double *p = new double[2];
+  p[0] = i + j;
+  p[1] = i*j;
+  return p[0] + p[1];
+}
+
+// CHECK: double fn3_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     double *_d_p = new double [2](/*implicit*/(double [2])0);
+// CHECK-NEXT:     double *p = new double [2](/*implicit*/(double [2])0);
+// CHECK-NEXT:     _d_p[0] = _d_i + _d_j;
+// CHECK-NEXT:     p[0] = i + j;
+// CHECK-NEXT:     _d_p[1] = _d_i * j + i * _d_j;
+// CHECK-NEXT:     p[1] = i * j;
+// CHECK-NEXT:     return _d_p[0] + _d_p[1];
+// CHECK-NEXT: }
+
+double fn4(double i, double j) {
+  double *p = new double(7*i + j);
+  double q = *p + 9*i;
+  delete p;
+  return q;
+}
+
+// CHECK: double fn4_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     double *_d_p = new double(0 * i + 7 * _d_i + _d_j);
+// CHECK-NEXT:     double *p = new double(7 * i + j);
+// CHECK-NEXT:     double _d_q = *_d_p + 0 * i + 9 * _d_i;
+// CHECK-NEXT:     double q = *p + 9 * i;
+// CHECK-NEXT:     delete _d_p;
+// CHECK-NEXT:     delete p;
+// CHECK-NEXT:     return _d_q;
+// CHECK-NEXT: }
+
+int main() {
+  INIT_DIFFERENTIATE(fn1, "i");
+  INIT_DIFFERENTIATE(fn2, "i");
+  INIT_DIFFERENTIATE(fn3, "i");
+  INIT_DIFFERENTIATE(fn4, "i");
+
+  TEST_DIFFERENTIATE(fn1, 3, 5);  // CHECK-EXEC: {5.00}
+  TEST_DIFFERENTIATE(fn2, 3, 5);  // CHECK-EXEC: {5.00}
+  TEST_DIFFERENTIATE(fn3, 3, 5);  // CHECK-EXEC: {6.00}
+  TEST_DIFFERENTIATE(fn4, 3, 5);  // CHECK-EXEC: {16.00}
+}

--- a/test/ForwardMode/SourceFnArg.C
+++ b/test/ForwardMode/SourceFnArg.C
@@ -1,5 +1,5 @@
-// RUN: %cladclang %s -I%S/../../include -oPointers.out 2>&1 | FileCheck %s
-// RUN: ./Pointers.out | FileCheck -check-prefix=CHECK-EXEC %s
+// RUN: %cladclang %s -I%S/../../include -oSourceFnArg.out 2>&1 | FileCheck %s
+// RUN: ./SourceFnArg.out | FileCheck -check-prefix=CHECK-EXEC %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"


### PR DESCRIPTION
This PR adds initial support for differentiating pointers in the forward mode AD. 

This PR adds support for the following features:

- Address of operator (`&`) 
- Dereference operator (`*`)
- `new` operator
- `delete` operator

This PR does not add support for differentiating functions with pointers as arguments, because in that case, there is no way of determining if the pointer points to a single element or an array of elements.