### PR TITLE
Add default definition for SetError.

### DIFF
--- a/demos/ErrorEstimation/CustomModel/CustomModel.cpp
+++ b/demos/ErrorEstimation/CustomModel/CustomModel.cpp
@@ -8,8 +8,6 @@ clang::Expr* CustomModel::AssignError(clad::StmtDiff refExpr) {
   return BuildOp(clang::BO_Mul, refExpr.getExpr_dx(), refExpr.getExpr());
 }
 
-clang::Expr* CustomModel::SetError(clang::VarDecl* decl) { return nullptr; }
-
 // We need this statement to register our model with clad. Without this, clad
 // will NOT be able to resolve to our overidden functions properly.
 static clad::ErrorEstimationModelRegistry::Add<

--- a/demos/ErrorEstimation/CustomModel/CustomModel.h
+++ b/demos/ErrorEstimation/CustomModel/CustomModel.h
@@ -20,7 +20,4 @@ public:
   // Return an expression of the following kind:
   //  dfdx * delta_x
   clang::Expr* AssignError(clad::StmtDiff refExpr);
-
-  // Return a nullptr here, clad will interpret that as a 0 literal.
-  clang::Expr* SetError(clang::VarDecl* decl);
 };

--- a/include/clad/Differentiator/EstimationModel.h
+++ b/include/clad/Differentiator/EstimationModel.h
@@ -76,7 +76,7 @@ namespace clad {
     /// variables. This function is separate from AssignError to keep
     /// implementation of different estimation models more flexible.
     ///
-    /// Following the example above, a possible override is:
+    /// The default definition is as follows:
     /// \n \code
     /// clang::Expr* SetError(clang::VarDecl* declStmt) {
     ///      return nullptr;
@@ -88,7 +88,7 @@ namespace clad {
     /// \param[in] decl The declaration to which the error has to be assigned.
     ///
     /// \returns The error expression for declaration statements.
-    virtual clang::Expr* SetError(clang::VarDecl* decl) = 0;
+    virtual clang::Expr* SetError(clang::VarDecl* decl);
 
     /// Calculate aggregate error from m_EstimateVar.
     ///
@@ -135,9 +135,6 @@ namespace clad {
     // Return an expression of the following kind:
     //  dfdx * delta_x * Em
     clang::Expr* AssignError(StmtDiff refExpr) override;
-
-    // For now, we can just return null.
-    clang::Expr* SetError(clang::VarDecl* decl) override;
   };
 
   /// Register any custom error estimation model a user provides

--- a/lib/Differentiator/EstimationModel.cpp
+++ b/lib/Differentiator/EstimationModel.cpp
@@ -45,6 +45,11 @@ namespace clad {
     return addExpr;
   }
 
+  // Return nullptr here, this is interpreted as 0 internally.
+  Expr* FPErrorEstimationModel::SetError(VarDecl* declStmt) { 
+    return nullptr; 
+  }
+
   Expr* TaylorApprox::AssignError(StmtDiff refExpr) {
     // Get the machine epsilon value.
     double val = std::numeric_limits<float>::epsilon();
@@ -59,9 +64,6 @@ namespace clad {
     return BuildOp(BO_Mul, refExpr.getExpr_dx(),
                    BuildOp(BO_Mul, refExpr.getExpr(), epsExpr));
   }
-
-  // return nullptr here, this is interpreted as 0 internally.
-  Expr* TaylorApprox::SetError(VarDecl* declStmt) { return nullptr; }
 
 } // namespace clad
 


### PR DESCRIPTION
This is helpful as most people will not require explicitly overloading SetError with a definition different than the default.