### PR TITLE
Add abs call over default error estimates.

### DIFF
--- a/include/clad/Differentiator/EstimationModel.h
+++ b/include/clad/Differentiator/EstimationModel.h
@@ -64,11 +64,6 @@ namespace clad {
                                  std::string nmspace = "");
 
     /// Helper to build a function call expression.
-    /// \note This function does not check if the parameters result in correct
-    /// overload resolution, this is done to avoid the overhead of checking
-    /// if the correct overload exists given this function will be called
-    /// multiple times for the same parameters types. The user has to ensure
-    /// the parameters correspond to a valid overload of the function.
     ///
     /// \param[in] lookupRes The result from \c GetFunctionCall , this param
     /// is used to build the final function call expression.

--- a/include/clad/Differentiator/EstimationModel.h
+++ b/include/clad/Differentiator/EstimationModel.h
@@ -48,33 +48,19 @@ namespace clad {
     /// \param[in] VD The declaration to track.
     void AddVarToEstimate(clang::VarDecl* VD, clang::Expr* VDRef);
 
-    /// Build a function lookup expression that can be later resolved to build
-    /// an actual function call expression with arguments. Implemented as a
-    /// separate function to save multiple calls to function/namespace lookup.
+    /// Helper to build a function call expression.
     ///
     /// \param[in] funcName The name of the function to build the expression
     /// for.
     /// \param[in] nmspace The name of the namespace for the function,
     /// currently does not support nested namespaces.
-    ///
-    /// \return The unresolved lookup expression that can be used to build
-    /// actual function call. This cannot be used directly to emit code, use
-    /// \c BuildFucntionCallExpr instead.
-    clang::Expr* GetFunctionCall(std::string funcName,
-                                 std::string nmspace = "");
-
-    /// Helper to build a function call expression.
-    ///
-    /// \param[in] lookupRes The result from \c GetFunctionCall , this param
-    /// is used to build the final function call expression.
     /// \param[in] callArgs A vector of \c clang::Expr of all the parameters
     /// to the function call.
     ///
     /// \return The function call expression that can be used to emit into
     /// code.
-    clang::Expr*
-    BuildFunctionCallExpr(clang::Expr* lookupRes,
-                          llvm::SmallVectorImpl<clang::Expr*>& callArgs);
+    clang::Expr* GetFunctionCall(std::string funcName, std::string nmspace,
+                                 llvm::SmallVectorImpl<clang::Expr*>& callArgs);
 
     /// User overridden function to return the error expression of a
     /// specific estimation model. The error expression is returned in the form
@@ -157,10 +143,6 @@ namespace clad {
 
   /// Example class for taylor series approximation based error estimation.
   class TaylorApprox : public FPErrorEstimationModel {
-    /// A variable to keep track of the function lookup expression for the
-    /// \c std::abs call
-    clang::Expr* absCallExpr = nullptr;
-
   public:
     TaylorApprox(DerivativeBuilder& builder)
         : FPErrorEstimationModel(builder) {}

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -1,8 +1,10 @@
-// RUN: %cladclang %s -x c++ -lstdc++ -I%S/../../include -oAssignments.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -x c++ -lstdc++ -lm -I%S/../../include -oAssignments.out 2>&1 | FileCheck %s
 // RUN: ./Assignments.out
 //CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"
+
+#include <cmath>
 
 float func(float x, float y) {
   x = x + y;
@@ -31,13 +33,13 @@ float func(float x, float y) {
 //CHECK-NEXT:         float _r_d0 = * _d_x;
 //CHECK-NEXT:         * _d_x += _r_d0;
 //CHECK-NEXT:         * _d_y += _r_d0;
-//CHECK-NEXT:         _delta_x += _r_d0 * _EERepl_x1 * {{.+}};
+//CHECK-NEXT:         _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
 //CHECK-NEXT:         * _d_x -= _r_d0;
 //CHECK-NEXT:         * _d_x;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _delta_x += * _d_x * _EERepl_x0 * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * _EERepl_x0 * {{.+}});
 //CHECK-NEXT:     double _delta_y = 0;
-//CHECK-NEXT:     _delta_y += * _d_y * y * {{.+}};
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
 //CHECK-NEXT:     _final_error += _delta_{{y|x}} + _delta_{{y|x}};
 //CHECK-NEXT: }
 
@@ -74,11 +76,11 @@ float func2(float x, int y) {
 //CHECK-NEXT:         * _d_x += _r2;
 //CHECK-NEXT:         float _r3 = _t3 * _r_d0;
 //CHECK-NEXT:         * _d_x += _r3;
-//CHECK-NEXT:         _delta_x += _r_d0 * _EERepl_x1 * {{.+}};
+//CHECK-NEXT:         _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
 //CHECK-NEXT:         * _d_x -= _r_d0;
 //CHECK-NEXT:         * _d_x;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _delta_x += * _d_x * _EERepl_x0 * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * _EERepl_x0 * {{.+}});
 //CHECK-NEXT:     _final_error += _delta_x;
 //CHECK-NEXT: }
 
@@ -126,14 +128,14 @@ float func4(float x, float y) {
 //CHECK-NEXT:         float _r_d0 = * _d_x;
 //CHECK-NEXT:         _d_z += _r_d0;
 //CHECK-NEXT:         * _d_y += _r_d0;
-//CHECK-NEXT:         _delta_x += _r_d0 * _EERepl_x1 * {{.+}};
+//CHECK-NEXT:         _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
 //CHECK-NEXT:         * _d_x -= _r_d0;
 //CHECK-NEXT:         * _d_x;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     * _d_y += _d_z;
-//CHECK-NEXT:     _delta_x += * _d_x * _EERepl_x0 * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * _EERepl_x0 * {{.+}});
 //CHECK-NEXT:     double _delta_y = 0;
-//CHECK-NEXT:     _delta_y += * _d_y * y * {{.+}};
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
 //CHECK-NEXT:     _final_error += _delta_{{x|y|z}} + _delta_{{x|y|z}} + _delta_{{x|y|z}};
 //CHECK-NEXT: }
 
@@ -159,13 +161,13 @@ float func5(float x, float y) {
 //CHECK-NEXT:         float _r_d0 = * _d_x;
 //CHECK-NEXT:         _d_z += _r_d0;
 //CHECK-NEXT:         * _d_y += _r_d0;
-//CHECK-NEXT:         _delta_x += _r_d0 * _EERepl_x1 * {{.+}};
+//CHECK-NEXT:         _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
 //CHECK-NEXT:         * _d_x -= _r_d0;
 //CHECK-NEXT:         * _d_x;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _delta_x += * _d_x * _EERepl_x0 * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * _EERepl_x0 * {{.+}});
 //CHECK-NEXT:     double _delta_y = 0;
-//CHECK-NEXT:     _delta_y += * _d_y * y * {{.+}};
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
 //CHECK-NEXT:     _final_error += _delta_{{x|y}} + _delta_{{x|y}};
 //CHECK-NEXT: }
 
@@ -177,7 +179,7 @@ float func6(float x) { return x; }
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     * _d_x += 1;
 //CHECK-NEXT:     double _delta_x = 0;
-//CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
 //CHECK-NEXT:     _final_error += _delta_x;
 //CHECK-NEXT: }
 
@@ -200,10 +202,10 @@ float func7(float x, float y) { return (x * y); }
 //CHECK-NEXT:         * _d_y += _r1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
-//CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
 //CHECK-NEXT:     double _delta_y = 0;
-//CHECK-NEXT:     _delta_y += * _d_y * y * {{.+}};
-//CHECK-NEXT:     _final_error += _delta_{{x|y}} + _delta_{{x|y}} + 1. * _ret_value0 * {{.+}};
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
+//CHECK-NEXT:     _final_error += _delta_{{x|y}} + _delta_{{x|y}} + std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 int main() {

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -44,15 +44,15 @@ float func(float x, float y) {
 //CHECK-NEXT:         * _d_y += _r0;
 //CHECK-NEXT:         float _r1 = _t1 * _d_z;
 //CHECK-NEXT:         * _d_x += _r1;
-//CHECK-NEXT:         _delta_z += _d_z * _EERepl_z0 * {{.+}};
+//CHECK-NEXT:         _delta_z += std::abs(_d_z * _EERepl_z0 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r_d1 = * _d_y;
 //CHECK-NEXT:         * _d_y += _r_d1;
 //CHECK-NEXT:         * _d_y += _r_d1;
-//CHECK-NEXT:         _delta_y += * _d_y * _EERepl_y1 * {{.+}};
+//CHECK-NEXT:         _delta_y += std::abs(* _d_y * _EERepl_y1 * {{.+}});
 //CHECK-NEXT:         * _d_y += _r_d1;
-//CHECK-NEXT:         _delta_y += _r_d1 * _EERepl_y2 * {{.+}};
+//CHECK-NEXT:         _delta_y += std::abs(_r_d1 * _EERepl_y2 * {{.+}});
 //CHECK-NEXT:         * _d_y -= _r_d1;
 //CHECK-NEXT:         * _d_y;
 //CHECK-NEXT:     }
@@ -60,12 +60,12 @@ float func(float x, float y) {
 //CHECK-NEXT:         float _r_d0 = * _d_x;
 //CHECK-NEXT:         * _d_x += _r_d0;
 //CHECK-NEXT:         * _d_y += _r_d0;
-//CHECK-NEXT:         _delta_x += _r_d0 * _EERepl_x1 * {{.+}};
+//CHECK-NEXT:         _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
 //CHECK-NEXT:         * _d_x -= _r_d0;
 //CHECK-NEXT:         * _d_x;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _delta_x += * _d_x * _EERepl_x0 * {{.+}};
-//CHECK-NEXT:     _delta_y += * _d_y * _EERepl_y0 * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * _EERepl_x0 * {{.+}});
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * _EERepl_y0 * {{.+}});
 //CHECK-NEXT:     _final_error += _delta_{{x|y|z}} + _delta_{{x|y|z}} + _delta_{{x|y|z}};
 //CHECK-NEXT: }
 
@@ -105,7 +105,7 @@ float func2(float x, float y) {
 //CHECK-NEXT:         * _d_y += _r2;
 //CHECK-NEXT:         float _r3 = _d_z * -_t3 / (_t2 * _t2);
 //CHECK-NEXT:         * _d_x += _r3;
-//CHECK-NEXT:         _delta_z += _d_z * _EERepl_z0 * {{.+}};
+//CHECK-NEXT:         _delta_z += std::abs(_d_z * _EERepl_z0 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r_d0 = * _d_x;
@@ -115,13 +115,13 @@ float func2(float x, float y) {
 //CHECK-NEXT:         * _d_y += _r0;
 //CHECK-NEXT:         float _r1 = _t1 * -_r_d0;
 //CHECK-NEXT:         * _d_y += _r1;
-//CHECK-NEXT:         _delta_x += _r_d0 * _EERepl_x1 * {{.+}};
+//CHECK-NEXT:         _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
 //CHECK-NEXT:         * _d_x -= _r_d0;
 //CHECK-NEXT:         * _d_x;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _delta_x += * _d_x * _EERepl_x0 * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * _EERepl_x0 * {{.+}});
 //CHECK-NEXT:     double _delta_y = 0;
-//CHECK-NEXT:     _delta_y += * _d_y * y * {{.+}};
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
 //CHECK-NEXT:     _final_error += _delta_{{x|y|z}} + _delta_{{x|y|z}} + _delta_{{x|y|z}};
 //CHECK-NEXT: }
 
@@ -181,9 +181,9 @@ float func3(float x, float y) {
 //CHECK-NEXT:         float _r_d1 = * _d_y;
 //CHECK-NEXT:         * _d_x += _r_d1;
 //CHECK-NEXT:         * _d_x += _r_d1;
-//CHECK-NEXT:         _delta_y += _r_d1 * _EERepl_y1 * {{.+}};
+//CHECK-NEXT:         _delta_y += std::abs(_r_d1 * _EERepl_y1 * {{.+}});
 //CHECK-NEXT:         * _d_y -= _r_d1;
-//CHECK-NEXT:         _delta_t += _d_t * _EERepl_t0 * {{.+}};
+//CHECK-NEXT:         _delta_t += std::abs(_d_t * _EERepl_t0 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     * _d_y += _d_z;
 //CHECK-NEXT:     {
@@ -194,12 +194,12 @@ float func3(float x, float y) {
 //CHECK-NEXT:         * _d_y += _r0;
 //CHECK-NEXT:         float _r1 = _t1 * -_r_d0;
 //CHECK-NEXT:         * _d_y += _r1;
-//CHECK-NEXT:         _delta_x += _r_d0 * _EERepl_x1 * {{.+}};
+//CHECK-NEXT:         _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
 //CHECK-NEXT:         * _d_x -= _r_d0;
 //CHECK-NEXT:         * _d_x;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _delta_x += * _d_x * _EERepl_x0 * {{.+}};
-//CHECK-NEXT:     _delta_y += * _d_y * _EERepl_y0 * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * _EERepl_x0 * {{.+}});
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * _EERepl_y0 * {{.+}});
 //CHECK-NEXT:     _final_error += _delta_{{t|x|y|z}} + _delta_{{t|x|y|z}} + _delta_{{t|x|y|z}} + _delta_{{t|x|y|z}};
 //CHECK-NEXT: }
 
@@ -226,10 +226,10 @@ float func4(float x, float y) { return std::pow(x, y); }
 //CHECK-NEXT:         * _d_y += _r1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
-//CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
 //CHECK-NEXT:     double _delta_y = 0;
-//CHECK-NEXT:     _delta_y += * _d_y * y * {{.+}};
-//CHECK-NEXT:     _final_error += _delta_{{x|y}} + _delta_{{x|y}} + 1. * _ret_value0 * {{.+}};
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
+//CHECK-NEXT:     _final_error += _delta_{{x|y}} + _delta_{{x|y}} + std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 // Function call custom derivative exists and is assigned
@@ -265,14 +265,14 @@ float func5(float x, float y) {
 //CHECK-NEXT:         float _r_d0 = * _d_y;
 //CHECK-NEXT:         float _r0 = _r_d0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t0, 1.F).pushforward;
 //CHECK-NEXT:         * _d_x += _r0;
-//CHECK-NEXT:         _delta_y += _r_d0 * _EERepl_y1 * {{.+}};
+//CHECK-NEXT:         _delta_y += std::abs(_r_d0 * _EERepl_y1 * {{.+}});
 //CHECK-NEXT:         * _d_y -= _r_d0;
 //CHECK-NEXT:         * _d_y;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
-//CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};
-//CHECK-NEXT:     _delta_y += * _d_y * _EERepl_y0 * {{.+}};
-//CHECK-NEXT:     _final_error += _delta_{{x|y}} + _delta_{{x|y}} + 1. * _ret_value0 * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * _EERepl_y0 * {{.+}});
+//CHECK-NEXT:     _final_error += _delta_{{x|y}} + _delta_{{x|y}} + std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 // Function call non custom derivative
@@ -332,13 +332,13 @@ float func6(float x, float y) {
 //CHECK-NEXT:         * _d_x += _r0;
 //CHECK-NEXT:         double _r1 = _grad1;
 //CHECK-NEXT:         * _d_y += _r1;
-//CHECK-NEXT:         _delta_z += _d_z * _EERepl_z0 * {{.+}};
+//CHECK-NEXT:         _delta_z += std::abs(_d_z * _EERepl_z0 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
-//CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
 //CHECK-NEXT:     double _delta_y = 0;
-//CHECK-NEXT:     _delta_y += * _d_y * y * {{.+}};
-//CHECK-NEXT:     _final_error += _delta_{{x|y|z}} + _delta_{{x|y|z}} + _delta_{{x|y|z}} + 1. * _ret_value0 * {{.+}};
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
+//CHECK-NEXT:     _final_error += _delta_{{x|y|z}} + _delta_{{x|y|z}} + _delta_{{x|y|z}} + std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 float func7(float x) {
@@ -358,7 +358,7 @@ float func7(float x) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     * _d_x += _d_z;
 //CHECK-NEXT:     double _delta_x = 0;
-//CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
 //CHECK-NEXT:     _final_error += _delta_x;
 //CHECK-NEXT: }
 
@@ -404,13 +404,13 @@ float func8(float x, float y) {
 //CHECK-NEXT:         helper2_pullback(_t0, _d_z, &_grad0);
 //CHECK-NEXT:         double _r0 = * _d_x;
 //CHECK-NEXT:         * _d_x = _grad0;
-//CHECK-NEXT:         _delta_z += _d_z * _EERepl_z0 * {{.+}};
-//CHECK-NEXT:         _final_error += _r0 * _t0 * {{.+}};
+//CHECK-NEXT:         _delta_z += std::abs(_d_z * _EERepl_z0 * {{.+}});
+//CHECK-NEXT:         _final_error += std::abs(_r0 * _t0 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
-//CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
 //CHECK-NEXT:     double _delta_y = 0;
-//CHECK-NEXT:     _delta_y += * _d_y * y * {{.+}};
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
 //CHECK-NEXT:     _final_error += _delta_{{x|y|z}} + _delta_{{x|y|z}} + _delta_{{x|y|z}};
 //CHECK-NEXT: }
 

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -1,7 +1,9 @@
-// RUN: %cladclang %s -x c++ -lstdc++ -I%S/../../include -oCondStmts.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -x c++ -lstdc++ -lm -I%S/../../include -oCondStmts.out 2>&1 | FileCheck %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"
+
+#include <cmath>
 
 // Single statement if/else
 float func(float x, float y) {
@@ -59,7 +61,7 @@ float func(float x, float y) {
 //CHECK-NEXT:             * _d_y += _r0;
 //CHECK-NEXT:             float _r1 = _t1 * _r_d0;
 //CHECK-NEXT:             * _d_x += _r1;
-//CHECK-NEXT:             _delta_y += _r_d0 * _EERepl_y1 * {{.+}};
+//CHECK-NEXT:             _delta_y += std::abs(_r_d0 * _EERepl_y1 * {{.+}});
 //CHECK-NEXT:             * _d_y -= _r_d0;
 //CHECK-NEXT:             * _d_y;
 //CHECK-NEXT:         }
@@ -76,15 +78,15 @@ float func(float x, float y) {
 //CHECK-NEXT:             * _d_y += _r2;
 //CHECK-NEXT:             float _r3 = _t3 * _r_d1;
 //CHECK-NEXT:             * _d_y += _r3;
-//CHECK-NEXT:             _delta_temp += _r_d1 * _EERepl_temp1 * {{.+}};
+//CHECK-NEXT:             _delta_temp += std::abs(_r_d1 * _EERepl_temp1 * {{.+}});
 //CHECK-NEXT:             _d_temp -= _r_d1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         * _d_y += _d_temp;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
-//CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};
-//CHECK-NEXT:     _delta_y += * _d_y * _EERepl_y0 * {{.+}};
-//CHECK-NEXT:     _final_error += _delta_{{x|y|temp}} + _delta_{{x|y|temp}} + _delta_{{x|y|temp}} + 1. * _ret_value0 * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * _EERepl_y0 * {{.+}});
+//CHECK-NEXT:     _final_error += _delta_{{x|y|temp}} + _delta_{{x|y|temp}} + _delta_{{x|y|temp}} + std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 // Single return statement if/else
@@ -141,11 +143,11 @@ float func2(float x) {
 //CHECK-NEXT:         * _d_x += _r0;
 //CHECK-NEXT:         float _r1 = _t1 * _d_z;
 //CHECK-NEXT:         * _d_x += _r1;
-//CHECK-NEXT:         _delta_z += _d_z * _EERepl_z0 * {{.+}};
+//CHECK-NEXT:         _delta_z += std::abs(_d_z * _EERepl_z0 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
-//CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};
-//CHECK-NEXT:     _final_error += _delta_{{x|z}} + _delta_{{x|z}} + 1. * _ret_value0 * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
+//CHECK-NEXT:     _final_error += _delta_{{x|z}} + _delta_{{x|z}} + std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 float func3(float x, float y) { return x > 30 ? x * y : x + y; }
@@ -174,10 +176,10 @@ float func3(float x, float y) { return x > 30 ? x * y : x + y; }
 //CHECK-NEXT:         * _d_y += 1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
-//CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
 //CHECK-NEXT:     double _delta_y = 0;
-//CHECK-NEXT:     _delta_y += * _d_y * y * {{.+}};
-//CHECK-NEXT:     _final_error += _delta_{{x|y}} + _delta_{{x|y}} + 1. * _ret_value0 * {{.+}};
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
+//CHECK-NEXT:     _final_error += _delta_{{x|y}} + _delta_{{x|y}} + std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 float func4(float x, float y) {
@@ -222,22 +224,22 @@ float func4(float x, float y) {
 //CHECK-NEXT:         if (_cond0) {
 //CHECK-NEXT:             float _r_d0 = * _d_x;
 //CHECK-NEXT:             * _d_x += _r_d0;
-//CHECK-NEXT:             _delta_x += _r_d0 * _EERepl_x1 * {{.+}};
+//CHECK-NEXT:             _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
 //CHECK-NEXT:             * _d_x -= _r_d0;
 //CHECK-NEXT:         } else {
 //CHECK-NEXT:             float _r_d1 = * _d_x;
 //CHECK-NEXT:             * _d_x += _r_d1 * _t0;
 //CHECK-NEXT:             float _r0 = _t1 * _r_d1;
 //CHECK-NEXT:             * _d_x += _r0;
-//CHECK-NEXT:             _delta_x += _r_d1 * _EERepl_x2 * {{.+}};
+//CHECK-NEXT:             _delta_x += std::abs(_r_d1 * _EERepl_x2 * {{.+}});
 //CHECK-NEXT:             * _d_x -= _r_d1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         _cond0 ? * _d_x : * _d_x;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _delta_x += * _d_x * _EERepl_x0 * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * _EERepl_x0 * {{.+}});
 //CHECK-NEXT:     double _delta_y = 0;
-//CHECK-NEXT:     _delta_y += * _d_y * y * {{.+}};
-//CHECK-NEXT:     _final_error += _delta_{{x|y}} + _delta_{{x|y}} + 1. * _ret_value0 * {{.+}};
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
+//CHECK-NEXT:     _final_error += _delta_{{x|y}} + _delta_{{x|y}} + std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 int main() {

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -1,7 +1,9 @@
-// RUN: %cladclang %s -x c++ -lstdc++ -I%S/../../include -oLoopsAndArrays.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -x c++ -lstdc++ -lm -I%S/../../include -oLoopsAndArrays.out 2>&1 | FileCheck %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"
+
+#include <cmath>
 
 // Arrays in loops
 float func(float* p, int n) {
@@ -39,15 +41,15 @@ float func(float* p, int n) {
 //CHECK-NEXT:             int _t2 = clad::pop(_t1);
 //CHECK-NEXT:             _d_p[_t2] += _r_d0;
 //CHECK-NEXT:             float _r0 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:             _delta_sum += _r_d0 * _r0 * {{.+}};
+//CHECK-NEXT:             _delta_sum += std::abs(_r_d0 * _r0 * {{.+}});
 //CHECK-NEXT:             _d_sum -= _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _delta_sum += _d_sum * _EERepl_sum0 * {{.+}};
+//CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_p(_d_p.size());
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i < _d_p.size(); i++) {
-//CHECK-NEXT:         double _t3 = _d_p[i] * p[i] * {{.+}};
+//CHECK-NEXT:         double _t3 = std::abs(_d_p[i] * p[i] * {{.+}});
 //CHECK-NEXT:         _delta_p[i] += _t3;
 //CHECK-NEXT:         _final_error += _t3;
 //CHECK-NEXT:     }
@@ -96,7 +98,7 @@ float func2(float x) {
 //CHECK-NEXT:             _d_m += _r_d0;
 //CHECK-NEXT:             _d_m += _r_d0;
 //CHECK-NEXT:             float _r3 = clad::pop(_EERepl_z1);
-//CHECK-NEXT:             _delta_z += _r_d0 * _r3 * {{.+}};
+//CHECK-NEXT:             _delta_z += std::abs(_r_d0 * _r3 * {{.+}});
 //CHECK-NEXT:             _d_z -= _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
@@ -106,11 +108,11 @@ float func2(float x) {
 //CHECK-NEXT:             * _d_x += _r1;
 //CHECK-NEXT:             _d_m = 0;
 //CHECK-NEXT:             float _r2 = clad::pop(_EERepl_m0);
-//CHECK-NEXT:             _delta_m += _d_m * _r2 * {{.+}};
+//CHECK-NEXT:             _delta_m += std::abs(_d_m * _r2 * {{.+}});
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
-//CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
 //CHECK-NEXT:     _final_error += _delta_{{x|z|m}} + _delta_{{x|z|m}} + _delta_{{x|z|m}};
 //CHECK-NEXT: }
 
@@ -147,7 +149,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:         double _r_d2 = _d_arr[2];
 //CHECK-NEXT:         _d_arr[0] += _r_d2;
 //CHECK-NEXT:         _d_arr[1] += _r_d2;
-//CHECK-NEXT:         _delta_arr[2] += _r_d2 * _EERepl_arr2 * {{.+}};
+//CHECK-NEXT:         _delta_arr[2] += std::abs(_r_d2 * _EERepl_arr2 * {{.+}});
 //CHECK-NEXT:         _final_error += _delta_arr[2];
 //CHECK-NEXT:         _d_arr[2] -= _r_d2;
 //CHECK-NEXT:         _d_arr[2];
@@ -158,7 +160,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:         * _d_x += _r0;
 //CHECK-NEXT:         double _r1 = _t1 * _r_d1;
 //CHECK-NEXT:         * _d_x += _r1;
-//CHECK-NEXT:         _delta_arr[1] += _r_d1 * _EERepl_arr1 * {{.+}};
+//CHECK-NEXT:         _delta_arr[1] += std::abs(_r_d1 * _EERepl_arr1 * {{.+}});
 //CHECK-NEXT:         _final_error += _delta_arr[1];
 //CHECK-NEXT:         _d_arr[1] -= _r_d1;
 //CHECK-NEXT:         _d_arr[1];
@@ -167,15 +169,15 @@ float func3(float x, float y) {
 //CHECK-NEXT:         double _r_d0 = _d_arr[0];
 //CHECK-NEXT:         * _d_x += _r_d0;
 //CHECK-NEXT:         * _d_y += _r_d0;
-//CHECK-NEXT:         _delta_arr[0] += _r_d0 * _EERepl_arr0 * {{.+}};
+//CHECK-NEXT:         _delta_arr[0] += std::abs(_r_d0 * _EERepl_arr0 * {{.+}});
 //CHECK-NEXT:         _final_error += _delta_arr[0];
 //CHECK-NEXT:         _d_arr[0] -= _r_d0;
 //CHECK-NEXT:         _d_arr[0];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
-//CHECK-NEXT:     _delta_x += * _d_x * x * {{.+}};
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
 //CHECK-NEXT:     double _delta_y = 0;
-//CHECK-NEXT:     _delta_y += * _d_y * y * {{.+}};
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
 //CHECK-NEXT:     _final_error += _delta_{{y|x}} + _delta_{{y|x}};
 //CHECK-NEXT: }
 
@@ -225,7 +227,7 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:             int _t6 = clad::pop(_t5);
 //CHECK-NEXT:             _d_x[_t6] += _r_d1;
 //CHECK-NEXT:             float _r2 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:             _delta_sum += _r_d1 * _r2 * {{.+}};
+//CHECK-NEXT:             _delta_sum += std::abs(_r_d1 * _r2 * {{.+}});
 //CHECK-NEXT:             _d_sum -= _r_d1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
@@ -236,23 +238,23 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:             _d_y[_t4] += _r_d0;
 //CHECK-NEXT:             float _r0 = clad::pop(_EERepl_x1);
 //CHECK-NEXT:             int _r1 = clad::pop(_t1);
-//CHECK-NEXT:             _delta_x[_r1] += _r_d0 * _r0 * {{.+}};
+//CHECK-NEXT:             _delta_x[_r1] += std::abs(_r_d0 * _r0 * {{.+}});
 //CHECK-NEXT:             _final_error += _delta_x[_r1];
 //CHECK-NEXT:             _d_x[_t2] -= _r_d0;
 //CHECK-NEXT:             _d_x[_t2];
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _delta_sum += _d_sum * _EERepl_sum0 * {{.+}};
+//CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i < _d_x.size(); i++) {
-//CHECK-NEXT:         double _t7 = _d_x[i] * _EERepl_x0[i] * {{.+}};
+//CHECK-NEXT:         double _t7 = std::abs(_d_x[i] * _EERepl_x0[i] * {{.+}});
 //CHECK-NEXT:         _delta_x[i] += _t7;
 //CHECK-NEXT:         _final_error += _t7;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     clad::array<float> _delta_y(_d_y.size());
 //CHECK-NEXT:     i = 0;
 //CHECK-NEXT:     for (; i < _d_y.size(); i++) {
-//CHECK-NEXT:         double _t8 = _d_y[i] * y[i] * {{.+}};
+//CHECK-NEXT:         double _t8 = std::abs(_d_y[i] * y[i] * {{.+}});
 //CHECK-NEXT:         _delta_y[i] += _t8;
 //CHECK-NEXT:         _final_error += _t8;
 //CHECK-NEXT:     }
@@ -326,7 +328,7 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         _d_y[0] += _r10;
 //CHECK-NEXT:         double _r11 = _t11 * -_r_d2;
 //CHECK-NEXT:         _d_x[1] += _r11;
-//CHECK-NEXT:         _delta_output[2] += _r_d2 * _EERepl_output3 * {{.+}};
+//CHECK-NEXT:         _delta_output[2] += std::abs(_r_d2 * _EERepl_output3 * {{.+}});
 //CHECK-NEXT:         _final_error += _delta_output[2];
 //CHECK-NEXT:         _d_output[2] -= _r_d2;
 //CHECK-NEXT:         _d_output[2];
@@ -341,7 +343,7 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         _d_x[0] += _r6;
 //CHECK-NEXT:         double _r7 = _t7 * -_r_d1;
 //CHECK-NEXT:         _d_y[2] += _r7;
-//CHECK-NEXT:         _delta_output[1] += _r_d1 * _EERepl_output2 * {{.+}};
+//CHECK-NEXT:         _delta_output[1] += std::abs(_r_d1 * _EERepl_output2 * {{.+}});
 //CHECK-NEXT:         _final_error += _delta_output[1];
 //CHECK-NEXT:         _d_output[1] -= _r_d1;
 //CHECK-NEXT:         _d_output[1];
@@ -356,7 +358,7 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         _d_x[2] += _r2;
 //CHECK-NEXT:         double _r3 = _t3 * -_r_d0;
 //CHECK-NEXT:         _d_y[1] += _r3;
-//CHECK-NEXT:         _delta_output[0] += _r_d0 * _EERepl_output1 * {{.+}};
+//CHECK-NEXT:         _delta_output[0] += std::abs(_r_d0 * _EERepl_output1 * {{.+}});
 //CHECK-NEXT:         _final_error += _delta_output[0];
 //CHECK-NEXT:         _d_output[0] -= _r_d0;
 //CHECK-NEXT:         _d_output[0];
@@ -364,24 +366,24 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:     clad::array<double> _delta_x(_d_x.size());
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i < _d_x.size(); i++) {
-//CHECK-NEXT:         double _t12 = _d_x[i] * x[i] * {{.+}};
+//CHECK-NEXT:         double _t12 = std::abs(_d_x[i] * x[i] * {{.+}});
 //CHECK-NEXT:         _delta_x[i] += _t12;
 //CHECK-NEXT:         _final_error += _t12;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     clad::array<double> _delta_y(_d_y.size());
 //CHECK-NEXT:     i = 0;
 //CHECK-NEXT:     for (; i < _d_y.size(); i++) {
-//CHECK-NEXT:         double _t13 = _d_y[i] * y[i] * {{.+}};
+//CHECK-NEXT:         double _t13 = std::abs(_d_y[i] * y[i] * {{.+}});
 //CHECK-NEXT:         _delta_y[i] += _t13;
 //CHECK-NEXT:         _final_error += _t13;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     i = 0;
 //CHECK-NEXT:     for (; i < _d_output.size(); i++) {
-//CHECK-NEXT:         double _t14 = _d_output[i] * _EERepl_output0[i] * {{.+}};
+//CHECK-NEXT:         double _t14 = std::abs(_d_output[i] * _EERepl_output0[i] * {{.+}});
 //CHECK-NEXT:         _delta_output[i] += _t14;
 //CHECK-NEXT:         _final_error += _t14;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += 1. * _ret_value0 * {{.+}};
+//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 int main() {

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -5,6 +5,8 @@
 
 #include "clad/Differentiator/Differentiator.h"
 
+#include <cmath>
+
 double runningSum(float* f, int n) {
   double sum = 0;
   for (int i = 1; i < n; i++) {
@@ -43,15 +45,15 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:             int _t4 = clad::pop(_t3);
 //CHECK-NEXT:             _d_f[_t4] += _r_d0;
 //CHECK-NEXT:             double _r0 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:             _delta_sum += _r_d0 * _r0 * {{.+}};
+//CHECK-NEXT:             _delta_sum += std::abs(_r_d0 * _r0 * {{.+}});
 //CHECK-NEXT:             _d_sum -= _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _delta_sum += _d_sum * _EERepl_sum0 * {{.+}};
+//CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_f(_d_f.size());
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i < _d_f.size(); i++) {
-//CHECK-NEXT:         double _t5 = _d_f[i] * f[i] * {{.+}};
+//CHECK-NEXT:         double _t5 = std::abs(_d_f[i] * f[i] * {{.+}});
 //CHECK-NEXT:         _delta_f[i] += _t5;
 //CHECK-NEXT:         _final_error += _t5;
 //CHECK-NEXT:     }
@@ -108,24 +110,24 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:                 int _t7 = clad::pop(_t6);
 //CHECK-NEXT:                 _d_b[_t7] += _r1;
 //CHECK-NEXT:                 double _r2 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:                 _delta_sum += _r_d0 * _r2 * {{.+}};
+//CHECK-NEXT:                 _delta_sum += std::abs(_r_d0 * _r2 * {{.+}});
 //CHECK-NEXT:                 _d_sum -= _r_d0;
 //CHECK-NEXT:             }
 //CHECK-NEXT:             clad::pop(_t1);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _delta_sum += _d_sum * _EERepl_sum0 * {{.+}};
+//CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_a(_d_a.size());
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i < _d_a.size(); i++) {
-//CHECK-NEXT:         double _t8 = _d_a[i] * a[i] * {{.+}};
+//CHECK-NEXT:         double _t8 = std::abs(_d_a[i] * a[i] * {{.+}});
 //CHECK-NEXT:         _delta_a[i] += _t8;
 //CHECK-NEXT:         _final_error += _t8;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     clad::array<float> _delta_b(_d_b.size());
 //CHECK-NEXT:     i = 0;
 //CHECK-NEXT:     for (; i < _d_b.size(); i++) {
-//CHECK-NEXT:         double _t9 = _d_b[i] * b[i] * {{.+}};
+//CHECK-NEXT:         double _t9 = std::abs(_d_b[i] * b[i] * {{.+}});
 //CHECK-NEXT:         _delta_b[i] += _t9;
 //CHECK-NEXT:         _final_error += _t9;
 //CHECK-NEXT:     }
@@ -175,22 +177,22 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:             int _t6 = clad::pop(_t5);
 //CHECK-NEXT:             _d_b[_t6] += _r2;
 //CHECK-NEXT:             double _r3 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:             _delta_sum += _r_d0 * _r3 * {{.+}};
+//CHECK-NEXT:             _delta_sum += std::abs(_r_d0 * _r3 * {{.+}});
 //CHECK-NEXT:             _d_sum -= _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _delta_sum += _d_sum * _EERepl_sum0 * {{.+}};
+//CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_a(_d_a.size());
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i < _d_a.size(); i++) {
-//CHECK-NEXT:         double _t7 = _d_a[i] * a[i] * {{.+}};
+//CHECK-NEXT:         double _t7 = std::abs(_d_a[i] * a[i] * {{.+}});
 //CHECK-NEXT:         _delta_a[i] += _t7;
 //CHECK-NEXT:         _final_error += _t7;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     clad::array<float> _delta_b(_d_b.size());
 //CHECK-NEXT:     i = 0;
 //CHECK-NEXT:     for (; i < _d_b.size(); i++) {
-//CHECK-NEXT:         double _t8 = _d_b[i] * b[i] * {{.+}};
+//CHECK-NEXT:         double _t8 = std::abs(_d_b[i] * b[i] * {{.+}});
 //CHECK-NEXT:         _delta_b[i] += _t8;
 //CHECK-NEXT:         _final_error += _t8;
 //CHECK-NEXT:     }

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -130,13 +130,13 @@
 //CHECK_FLOAT_SUM:             _d_sum += _r_d0;
 //CHECK_FLOAT_SUM:             * _d_x += _r_d0;
 //CHECK_FLOAT_SUM:             float _r0 = clad::pop(_EERepl_sum1);
-//CHECK_FLOAT_SUM:             _delta_sum += _r_d0 * _r0 * {{.+}};
+//CHECK_FLOAT_SUM:             _delta_sum += std::abs(_r_d0 * _r0 * {{.+}});
 //CHECK_FLOAT_SUM:             _d_sum -= _r_d0;
 //CHECK_FLOAT_SUM:         }
 //CHECK_FLOAT_SUM:     }
-//CHECK_FLOAT_SUM:     _delta_sum += _d_sum * _EERepl_sum0 * {{.+}};
+//CHECK_FLOAT_SUM:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK_FLOAT_SUM:     double _delta_x = 0;
-//CHECK_FLOAT_SUM:     _delta_x += * _d_x * x * {{.+}};
+//CHECK_FLOAT_SUM:     _delta_x += std::abs(* _d_x * x * {{.+}});
 //CHECK_FLOAT_SUM:     _final_error += _delta_{{x|sum}} + _delta_{{x|sum}};
 //CHECK_FLOAT_SUM: }
 


### PR DESCRIPTION
This PR introduces the following changes:
- Build a `std::abs` call over the error estimates from the Taylor approx model.
- Two helper functions for users to build their own function calls.
