### PR TITLE
Fix differentiation of pointer arithmetic in forward mode

### DIFF
--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -1214,6 +1214,52 @@ namespace clad {
     }
   }
 
+  /// Computes effective derivative operands. It should be used when operands
+  /// might be of pointer types.
+  ///
+  /// In the trivial case, both operands are of non-pointer types, and the
+  /// effective derivative operands are `LDiff.getExpr_dx()` and
+  /// `RDiff.getExpr_dx()` respectively.
+  ///
+  /// Integers used in pointer arithmetic should be considered
+  /// non-differentiable entities. For example:
+  ///
+  /// ```
+  /// p + i;
+  /// ```
+  ///
+  /// Derived statement should be:
+  ///
+  /// ```
+  /// _d_p + i;
+  /// ```
+  ///
+  /// instead of:
+  ///
+  /// ```
+  /// _d_p + _d_i;
+  /// ```
+  ///
+  /// Therefore, effective derived expression of `i` is `i` instead of `_d_i`.
+  ///
+  /// This functions sets `derivedL` and `derivedR` arguments to effective
+  /// derived expressions.
+  static void ComputeEffectiveDOperands(StmtDiff& LDiff, StmtDiff& RDiff,
+                                        clang::Expr*& derivedL,
+                                        clang::Expr*& derivedR) {
+    derivedL = LDiff.getExpr_dx();
+    derivedR = RDiff.getExpr_dx();
+    if (utils::isArrayOrPointerType(LDiff.getExpr_dx()->getType()) &&
+        !utils::isArrayOrPointerType(RDiff.getExpr_dx()->getType())) {
+      derivedL = LDiff.getExpr_dx();
+      derivedR = RDiff.getExpr();
+    } else if (utils::isArrayOrPointerType(RDiff.getExpr_dx()->getType()) &&
+               !utils::isArrayOrPointerType(LDiff.getExpr_dx()->getType())) {
+      derivedL = LDiff.getExpr();
+      derivedR = RDiff.getExpr_dx();
+    }
+  }
+
   StmtDiff
   ForwardModeVisitor::VisitBinaryOperator(const BinaryOperator* BinOp) {
     StmtDiff Ldiff = Visit(BinOp->getLHS());
@@ -1264,11 +1310,14 @@ namespace clad {
       Rdiff = {StoreAndRef(Rdiff.getExpr()), Rdiff.getExpr_dx()};
 
       opDiff = deriveDiv(Ldiff, Rdiff);
-    } else if (opCode == BO_Add)
-      opDiff = BuildOp(BO_Add, Ldiff.getExpr_dx(), Rdiff.getExpr_dx());
-    else if (opCode == BO_Sub)
-      opDiff =
-          BuildOp(BO_Sub, Ldiff.getExpr_dx(), BuildParens(Rdiff.getExpr_dx()));
+    } else if (opCode == BO_Add || opCode == BO_Sub) {
+      Expr* derivedL = nullptr;
+      Expr* derivedR = nullptr;
+      ComputeEffectiveDOperands(Ldiff, Rdiff, derivedL, derivedR);
+      if (opCode == BO_Sub)
+        derivedR = BuildParens(derivedR);
+      opDiff = BuildOp(opCode, derivedL, derivedR);
+    }
     else if (BinOp->isAssignmentOp()) {
       if (Ldiff.getExpr_dx()->isModifiableLvalue(m_Context) !=
           Expr::MLV_Valid) {
@@ -1279,9 +1328,12 @@ namespace clad {
         opDiff =
             ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, 0);
       } else if (opCode == BO_Assign || opCode == BO_AddAssign ||
-                 opCode == BO_SubAssign)
-        opDiff = BuildOp(opCode, Ldiff.getExpr_dx(), Rdiff.getExpr_dx());
-      else if (opCode == BO_MulAssign || opCode == BO_DivAssign) {
+                 opCode == BO_SubAssign) {
+        Expr* derivedL = nullptr;
+        Expr* derivedR = nullptr;
+        ComputeEffectiveDOperands(Ldiff, Rdiff, derivedL, derivedR);
+        opDiff = BuildOp(opCode, derivedL, derivedR);
+      } else if (opCode == BO_MulAssign || opCode == BO_DivAssign) {
         // if both original expression and derived expression and evaluatable,
         // then derived expression reference needs to be stored before
         // the original expression reference to correctly evaluate

--- a/test/ForwardMode/Pointer.C
+++ b/test/ForwardMode/Pointer.C
@@ -76,14 +76,50 @@ double fn4(double i, double j) {
 // CHECK-NEXT:     return _d_q;
 // CHECK-NEXT: }
 
+double fn5(double i, double j) {
+  double arr[2] = {7*i, 9*i};
+  *(arr + 1) += 11*i;
+  int idx1 = 0, idx2 = 1;
+  double *p = arr;
+  p += 1;
+  p = 0 + p;
+  *p += 13*i;
+  *(p-1) += 17*i;
+  return *(arr+idx1) + *(arr+idx2);
+}
+
+// CHECK: double fn5_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     double _d_arr[2] = {0 * i + 7 * _d_i, 0 * i + 9 * _d_i};
+// CHECK-NEXT:     double arr[2] = {7 * i, 9 * i};
+// CHECK-NEXT:     *(_d_arr + 1) += 0 * i + 11 * _d_i;
+// CHECK-NEXT:     *(arr + 1) += 11 * i;
+// CHECK-NEXT:     int _d_idx1 = 0, _d_idx2 = 0;
+// CHECK-NEXT:     int idx1 = 0, idx2 = 1;
+// CHECK-NEXT:     double *_d_p = _d_arr;
+// CHECK-NEXT:     double *p = arr;
+// CHECK-NEXT:     _d_p += 1;
+// CHECK-NEXT:     p += 1;
+// CHECK-NEXT:     _d_p = 0 + _d_p;
+// CHECK-NEXT:     p = 0 + p;
+// CHECK-NEXT:     *_d_p += 0 * i + 13 * _d_i;
+// CHECK-NEXT:     *p += 13 * i;
+// CHECK-NEXT:     *(_d_p - 1) += 0 * i + 17 * _d_i;
+// CHECK-NEXT:     *(p - 1) += 17 * i;
+// CHECK-NEXT:     return *(_d_arr + idx1) + *(_d_arr + idx2);
+// CHECK-NEXT: }
+
 int main() {
   INIT_DIFFERENTIATE(fn1, "i");
   INIT_DIFFERENTIATE(fn2, "i");
   INIT_DIFFERENTIATE(fn3, "i");
   INIT_DIFFERENTIATE(fn4, "i");
+  INIT_DIFFERENTIATE(fn5, "i");
 
   TEST_DIFFERENTIATE(fn1, 3, 5);  // CHECK-EXEC: {5.00}
   TEST_DIFFERENTIATE(fn2, 3, 5);  // CHECK-EXEC: {5.00}
   TEST_DIFFERENTIATE(fn3, 3, 5);  // CHECK-EXEC: {6.00}
   TEST_DIFFERENTIATE(fn4, 3, 5);  // CHECK-EXEC: {16.00}
+  TEST_DIFFERENTIATE(fn5, 3, 5);  // CHECK-EXEC: {57.00}
 }


### PR DESCRIPTION
Integers used in pointer arithmetic should be considered
non-differentiable entities. For example:

```
p + i;
```

Derived statement should be:

```
_d_p + i;
```

instead of:

```
_d_p + _d_i;
```

Therefore, effective derived expression of `i` is `i` instead of `_d_i`.