### PR TITLE
Add support for specifying custom derivatives of class functions

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -14,6 +14,8 @@ namespace custom_derivatives{}
 #include "clad/Differentiator/CladConfig.h"
 
 #include <cmath>
+#include <vector>
+
 namespace clad {
 template <typename T, typename U> struct ValueAndPushforward {
   T value;
@@ -80,6 +82,7 @@ pow_pullback(T1 x, T2 exponent, decltype(::std::pow(T1(), T2())) d_y,
   t = pow_pushforward(x, exponent, static_cast<T1>(0), static_cast<T2>(1));
   *d_exponent += t.pushforward * d_y;
 }
+
 } // namespace std
 // These are required because C variants of mathematical functions are
 // defined in global namespace.

--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -14,7 +14,6 @@ namespace custom_derivatives{}
 #include "clad/Differentiator/CladConfig.h"
 
 #include <cmath>
-#include <vector>
 
 namespace clad {
 template <typename T, typename U> struct ValueAndPushforward {

--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -91,6 +91,7 @@ namespace clad {
     StmtDiff VisitCXXNewExpr(const clang::CXXNewExpr* CNE);
     StmtDiff VisitCXXDeleteExpr(const clang::CXXDeleteExpr* CDE);
     StmtDiff VisitCXXStaticCastExpr(const clang::CXXStaticCastExpr* CSE);
+    StmtDiff VisitCXXFunctionalCastExpr(const clang::CXXFunctionalCastExpr* FCE);
   private:
     /// Helper function for differentiating the switch statement body.
     ///

--- a/include/clad/Differentiator/STLBuiltinDerivatives.h
+++ b/include/clad/Differentiator/STLBuiltinDerivatives.h
@@ -1,0 +1,31 @@
+#ifndef CLAD_STL_BUILTIN_DERIVATIVES_H
+#define CLAD_STL_BUILTIN_DERIVATIVES_H
+
+namespace clad {
+namespace custom_derivatives {
+namespace class_functions {
+
+template <typename T>
+void clear_pushforward(::std::vector<T>* v, ::std::vector<T>* d_v) {
+  d_v->clear();
+  v->clear();
+}
+
+template <typename T>
+void resize_pushforward(::std::vector<T>* v, unsigned sz, ::std::vector<T>* d_v,
+                        unsigned d_sz) {
+  d_v->resize(sz, T());
+  v->resize(sz);
+}
+
+template <typename T, typename U>
+void resize_pushforward(::std::vector<T>* v, unsigned sz, U val,
+                        ::std::vector<T>* d_v, unsigned d_sz, U d_val) {
+  d_v->resize(sz, d_val);
+  v->resize(sz, val);
+}
+} // namespace class_functions
+} // namespace custom_derivatives
+} // namespace clad
+
+#endif

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -1,5 +1,7 @@
-#ifndef CLAD_STL_BUILTIN_DERIVATIVES_H
-#define CLAD_STL_BUILTIN_DERIVATIVES_H
+#ifndef CLAD_STL_BUILTINS_H
+#define CLAD_STL_BUILTINS_H
+
+#include <vector>
 
 namespace clad {
 namespace custom_derivatives {
@@ -28,4 +30,4 @@ void resize_pushforward(::std::vector<T>* v, unsigned sz, U val,
 } // namespace custom_derivatives
 } // namespace clad
 
-#endif
+#endif // CLAD_STL_BUILTINS_H

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -463,7 +463,8 @@ namespace clad {
                            llvm::MutableArrayRef<clang::Expr*> Args);
     clang::ParmVarDecl* CloneParmVarDecl(const clang::ParmVarDecl* PVD,
                                          clang::IdentifierInfo* II,
-                                         bool pushOnScopeChains = false);
+                                         bool pushOnScopeChains = false,
+                                         bool cloneDefaultArg = true);
     /// A function to get the single argument "forward_central_difference"
     /// call expression for the given arguments.
     ///

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -2011,4 +2011,20 @@ namespace clad {
             .get();
     return {clonedE, derivedE};
   }
+
+  StmtDiff ForwardModeVisitor::VisitCXXFunctionalCastExpr(
+      const clang::CXXFunctionalCastExpr* FCE) {
+    StmtDiff castExprDiff = Visit(FCE->getSubExpr());
+    Expr* clonedFCE = m_Sema
+                          .BuildCXXFunctionalCastExpr(
+                              FCE->getTypeInfoAsWritten(), FCE->getType(),
+                              noLoc, castExprDiff.getExpr(), noLoc)
+                          .get();
+    Expr* derivedFCE = m_Sema
+                           .BuildCXXFunctionalCastExpr(
+                               FCE->getTypeInfoAsWritten(), FCE->getType(),
+                               noLoc, castExprDiff.getExpr_dx(), noLoc)
+                           .get();
+    return {clonedFCE, derivedFCE};
+  }
 } // end namespace clad

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -83,10 +83,7 @@ namespace clad {
     for (auto* PVD : m_Function->parameters()) {
       paramTypes.push_back(PVD->getType());
 
-      // FIXME: Add support for pointer and array parameters in the
-      // forward mode.
-      if (utils::isDifferentiableType(PVD->getType()) &&
-          !utils::isArrayOrPointerType(PVD->getType()))
+      if (utils::isDifferentiableType(PVD->getType()))
         derivedParamTypes.push_back(PVD->getType());
     }
 
@@ -143,22 +140,22 @@ namespace clad {
         identifierMissing = true;
       }
       auto newPVD = CloneParmVarDecl(PVD, PVDII,
-                                     /*pushOnScopeChains=*/true);
+                                     /*pushOnScopeChains=*/true,
+                                     /*cloneDefaultArg=*/false);
       params.push_back(newPVD);
 
       if (identifierMissing)
         m_DeclReplacements[PVD] = newPVD;
 
       QualType nonRefParamType = PVD->getType().getNonReferenceType();
-      // FIXME: Add support for pointer and array parameters in the
-      // forward mode.
-      if (!utils::isDifferentiableType(PVD->getType()) ||
-          utils::isArrayOrPointerType(PVD->getType()))
+
+      if (!utils::isDifferentiableType(PVD->getType()))
         continue;
       auto derivedPVDName = "_d_" + std::string(PVDII->getName());
       IdentifierInfo* derivedPVDII = CreateUniqueIdentifier(derivedPVDName);
       auto derivedPVD = CloneParmVarDecl(PVD, derivedPVDII,
-                                         /*pushOnScopeChains=*/true);
+                                         /*pushOnScopeChains=*/true,
+                                         /*cloneDefaultArg=*/false);
       derivedParams.push_back(derivedPVD);
       m_Variables[newPVD] = BuildDeclRef(derivedPVD);
     }
@@ -1135,10 +1132,7 @@ namespace clad {
         }
       }
       CallArgs.push_back(argDiff.getExpr());
-      // FIXME: Add support for pointer and array arguments in the
-      // pushforward mode.
-      if (utils::isDifferentiableType(arg->getType()) &&
-          !utils::isArrayOrPointerType(arg->getType()))
+      if (utils::isDifferentiableType(arg->getType()))
         diffArgs.push_back(argDiff.getExpr_dx());
     }
 

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -1264,7 +1264,10 @@ namespace clad {
       return StmtDiff(op, BuildOp(opKind, diff.getExpr_dx()));
     else if (opKind == UO_PostInc || opKind == UO_PostDec ||
              opKind == UO_PreInc || opKind == UO_PreDec) {
-      return StmtDiff(op, diff.getExpr_dx());
+      Expr* derivedOp = diff.getExpr_dx();
+      if (diff.getExpr_dx()->getType()->isPointerType())
+        derivedOp = BuildOp(opKind, diff.getExpr_dx());
+      return StmtDiff(op, derivedOp);
     } /* For supporting complex types */
     else if (opKind == UnaryOperatorKind::UO_Real ||
              opKind == UnaryOperatorKind::UO_Imag) {

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -689,9 +689,10 @@ namespace clad {
 
   ParmVarDecl* VisitorBase::CloneParmVarDecl(const ParmVarDecl* PVD,
                                              IdentifierInfo* II,
-                                             bool pushOnScopeChains) {
+                                             bool pushOnScopeChains,
+                                             bool cloneDefaultArg) {
     Expr* newPVDDefaultArg = nullptr;
-    if (PVD->hasDefaultArg()) {
+    if (PVD->hasDefaultArg() && cloneDefaultArg) {
       newPVDDefaultArg = Clone(PVD->getDefaultArg());
     }
     auto newPVD = ParmVarDecl::Create(

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -4,7 +4,7 @@
 // CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"
-#include "clad/Differentiator/STLBuiltinDerivatives.h"
+#include "clad/Differentiator/STLBuiltins.h"
 
 #include <complex>
 #include <numeric>
@@ -1118,6 +1118,30 @@ double fn14(double i, double j) {
   auto res = std::accumulate(b, e, 0.00);
   return res;
 }
+
+// CHECK: double fn14_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     vectorD _d_v;
+// CHECK-NEXT:     vectorD v;
+// CHECK-NEXT:     clad::custom_derivatives::class_functions::resize_pushforward(&v, 5, 0, &_d_v, 0, 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<{{.*}}, {{.*}}> _t0 = v.operator_subscript_pushforward(0, &_d_v, 0);
+// CHECK-NEXT:     _t0.pushforward = 0 * i + 9 * _d_i;
+// CHECK-NEXT:     _t0.value = 9 * i;
+// CHECK-NEXT:     clad::ValueAndPushforward<{{.*}}, {{.*}}> _t1 = v.operator_subscript_pushforward(1, &_d_v, 0);
+// CHECK-NEXT:     _t1.pushforward = 0 * i + 11 * _d_i;
+// CHECK-NEXT:     _t1.value = 11 * i;
+// CHECK-NEXT:     clad::ValueAndPushforward<decltype({{.*}}.begin()), decltype({{.*}}.begin())> _t2 = begin_pushforward(v, _d_v);
+// CHECK-NEXT:     {{.*}} _d_b = _t2.pushforward;
+// CHECK-NEXT:     {{.*}} b = _t2.value;
+// CHECK-NEXT:     clad::ValueAndPushforward<decltype({{.*}}.end()), decltype({{.*}}.end())> _t3 = end_pushforward(v, _d_v);
+// CHECK-NEXT:     {{.*}} _d_e = _t3.pushforward;
+// CHECK-NEXT:     {{.*}} e = _t3.value;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t4 = accumulate_pushforward(b, e, 0., _d_b, _d_e, 0.);
+// CHECK-NEXT:     double _d_res = _t4.pushforward;
+// CHECK-NEXT:     double res = _t4.value;
+// CHECK-NEXT:     return _d_res;
+// CHECK-NEXT: }
 
 template<unsigned N>
 void print(const Tensor<double, N>& t) {

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -lm -lstdc++ %s -I%S/../../include -oUserDefinedTypes.out 2>&1 | FileCheck %s
+// RUN: %cladclang -lm -lstdc++ %s -I%S/../../include -oUserDefinedTypes.out | FileCheck %s
 // RUN: ./UserDefinedTypes.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 // CHECK-NOT: {{.*error|warning|note:.*}}
@@ -7,6 +7,8 @@
 #include "clad/Differentiator/STLBuiltinDerivatives.h"
 
 #include <complex>
+#include <numeric>
+#include <vector>
 
 #include "../TestUtils.h"
 #include "../PrintOverloads.h"
@@ -1104,6 +1106,19 @@ TensorD5 fn13(double i, double j) {
 // CHECK-NEXT:     return _t29.pushforward;
 // CHECK-NEXT: }
 
+using vectorD = std::vector<double>;
+
+double fn14(double i, double j) {
+  vectorD v;
+  v.resize(5, 0);
+  v[0] = 9 * i;
+  v[1] = 11 * i;
+  auto b = std::begin(v);
+  auto e = std::end(v);
+  auto res = std::accumulate(b, e, 0.00);
+  return res;
+}
+
 template<unsigned N>
 void print(const Tensor<double, N>& t) {
   for (int i=0; i<N; ++i) {
@@ -1127,6 +1142,7 @@ int main() {
   INIT_DIFFERENTIATE(fn11, "i");
   INIT_DIFFERENTIATE(fn12, "i");
   INIT_DIFFERENTIATE(fn13, "i");
+  INIT_DIFFERENTIATE(fn14, "i");
   
   TensorD5 t;
   t.updateTo(5);
@@ -1145,4 +1161,5 @@ int main() {
   TEST_DIFFERENTIATE(fn11, 3, 5); // CHECK-EXEC: {40.00, 16.00, 16.00, 16.00, 16.00}
   TEST_DIFFERENTIATE(fn12, 3, 5); // CHECK-EXEC: {18.00, 24.00, 7.00, 7.00, 7.00}
   TEST_DIFFERENTIATE(fn13, 3, 5); // CHECK-EXEC: {11.00, 12.00, 0.00, 0.00, 0.00}
+  TEST_DIFFERENTIATE(fn14, 3, 5); // CHECK-EXEC: {20.00}
 }

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -4,6 +4,7 @@
 // CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltinDerivatives.h"
 
 #include <complex>
 


### PR DESCRIPTION
This PR adds support for specifying custom derivatives of class functions. It also solves a number of other issues (each in separate PR) that were required to enable differentiation of `std::accumulate`, `std::begin` and `std::end` without any custom derivative.