### PR TITLE
Enable differentiation wrt data members of parameters in forw mode

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -250,6 +250,48 @@ namespace clad {
     /// If `S` is `null`, then nothing happens.
     void AppendIndividualStmts(llvm::SmallVectorImpl<clang::Stmt*>& block,
                                clang::Stmt* S);
+    /// Builds a nested member expression that consist of base expression
+    /// specified by `base` argument and data members specified in `fields`
+    /// argument in the original sequence.
+    ///
+    /// For example, if `base` represents `b` -- an expression of a record type,
+    /// and `fields` is the sequence {'mem1', 'mem2', 'mem3'}, then the function
+    /// builds and returns the following expression:
+    /// ```
+    /// b.mem1.mem2.mem3
+    /// ```
+    clang::MemberExpr*
+    BuildMemberExpr(clang::Sema& semaRef, clang::Scope* S, clang::Expr* base,
+                    llvm::ArrayRef<llvm::StringRef> fields);
+
+    /// Returns true if member expression path specified by `fields` is correct;
+    /// otherwise returns false.
+    ///
+    /// For example, if `base` represents `b` -- an expression of a record type,
+    /// and `fields` is the sequence {'mem1', 'mem2', 'mem3'}, then the function
+    /// returns true if `b.mem1.mem2.mem3` is a valid data member reference
+    /// expression, otherwise returns false.
+    ///
+    /// \note This function returns true if `fields` is an empty sequence.
+    bool IsValidMemExprPath(clang::Sema& semaRef, clang::RecordDecl* RD,
+                     llvm::ArrayRef<llvm::StringRef> fields);
+
+    /// Perform lookup for data member with name `name`. If lookup finds a
+    /// declaration, then return the field declaration; otherwise returns
+    /// `nullptr`.
+    clang::FieldDecl* LookupDataMember(clang::Sema& semaRef,
+                                       clang::RecordDecl* RD,
+                                       llvm::StringRef name);
+
+    /// Computes the type of a data member of the record specified by `RD`
+    /// and nested fields specified in `fields` argument.
+    /// For example, if `RD` represents `std::pair<std::pair<std::complex,
+    /// double>, std::pair<double, double>`, and `fields` is the sequence
+    /// {'first', 'first'}, then the corresponding data member is
+    // of type `std::complex`.
+    clang::QualType
+    ComputeMemExprPathType(clang::Sema& semaRef, clang::RecordDecl* RD,
+                           llvm::ArrayRef<llvm::StringRef> fields);
   } // namespace utils
 }
 

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -53,9 +53,13 @@ namespace clad {
     /// differentiated, for example, when we are computing higher
     /// order derivatives.
     const clang::CXXRecordDecl* Functor = nullptr;
-    DiffParamsWithIndices DiffParamsInfo;
 
-    /// Recomputes `DiffParamsInfo` using the current values of data members.
+    /// Stores differentiation parameters information. Stored information
+    /// includes info on indices range for array parameters, and nested data
+    /// member information for record (class) type parameters.
+    DiffInputVarsInfo DVI;
+
+    /// Recomputes `DiffInputVarsInfo` using the current values of data members.
     ///
     /// Differentiation parameters info is computed by parsing the argument
     /// expression for the clad differentiation function calls. The argument is

--- a/include/clad/Differentiator/ParseDiffArgsTypes.h
+++ b/include/clad/Differentiator/ParseDiffArgsTypes.h
@@ -6,7 +6,9 @@
 #define CLAD_PARSE_DIFF_ARGS_TYPES_H
 
 #include "clang/AST/Decl.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 #include <cstddef>
 #include <utility>
@@ -34,10 +36,51 @@ namespace clad {
       return Start == rhs.Start && Finish == rhs.Finish;
     }
   };
+  
+  using IndexIntervalTable = llvm::SmallVector<IndexInterval, 16>;
+
+  /// `DiffInputVarInfo` is designed to store all the essential information about a
+  /// differentiation input variable. Please note that here input variable corresponds
+  /// to mathematical variable, not a programming one. 
+  // FIXME: 'DiffInputVarInfo' name is probably not accurate, since we can have multiple
+  // differentiation input variables for same parameter as well. 'DiffInputVarInfo' 
+  // name implicitly guides that there would be at most one `DiffInputVarInfo` object for
+  // one parameter, but that is not strictly true.
+  struct DiffInputVarInfo {
+    /// Source string specified by user that defines differentiation
+    /// specification for the input variable.
+    /// For example, if complete input string specified by user is:
+    /// 'u, v.first, arr[3]'
+    /// then `source` data member value for 2nd input variable should be
+    /// 'v.first'
+    std::string source;
+    /// Parameter associated with the input variable.
+    const clang::ValueDecl* param = nullptr;
+    /// array index range associated with the parameter.
+    IndexInterval paramIndexInterval;
+    /// Nested field information.
+    llvm::SmallVector<std::string, 4> fields;
+    // FIXME: Add support for differentiating with respect to array fields.
+    // llvm::SmallVector<IndexInterval> fieldIndexIntervals;
+
+    DiffInputVarInfo(const clang::ValueDecl* pParam = nullptr,
+                     IndexInterval pParamIndexInterval = {},
+                     llvm::SmallVector<std::string, 4> pFields = {})
+        : param(pParam), paramIndexInterval(pParamIndexInterval),
+          fields(pFields) {}
+
+    // FIXME: Move function definitions to ParseDiffArgTypes.cpp
+    bool operator==(const DiffInputVarInfo& rhs) const {
+      return param == rhs.param &&
+             paramIndexInterval == rhs.paramIndexInterval &&
+             fields == rhs.fields;
+    }
+  };
+
+  using DiffInputVarsInfo = llvm::SmallVector<DiffInputVarInfo, 16>;
 
   using DiffParams = llvm::SmallVector<const clang::ValueDecl*, 16>;
-  using IndexIntervalTable = llvm::SmallVector<IndexInterval, 16>;
   using DiffParamsWithIndices = std::pair<DiffParams, IndexIntervalTable>;
-} // namespace clad
+  } // namespace clad
 
 #endif

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -80,8 +80,14 @@ namespace clad {
                              const DiffRequest& request) {
     DiffParams args{};
     IndexIntervalTable indexIntervalTable{};
-    if (request.Args)
-      std::tie(args, indexIntervalTable) = request.DiffParamsInfo;
+    DiffInputVarsInfo DVI;
+    if (request.Args) {
+      DVI = request.DVI;
+      for (auto dParam : DVI) {
+        args.push_back(dParam.param);
+        indexIntervalTable.push_back(dParam.paramIndexInterval);
+      }
+    }
     else
       std::copy(FD->param_begin(), FD->param_end(), std::back_inserter(args));
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -240,8 +240,11 @@ namespace clad {
     assert(m_Function && "Must not be null.");
 
     DiffParams args{};
+    DiffInputVarsInfo DVI;
     if (request.Args) {
-      std::tie(args, std::ignore) = request.DiffParamsInfo;
+      DVI = request.DVI;
+      for (auto dParam : DVI)
+        args.push_back(dParam.param);
     }
     else
       std::copy(FD->param_begin(), FD->param_end(), std::back_inserter(args));

--- a/test/FirstDerivative/DiffInterface.C
+++ b/test/FirstDerivative/DiffInterface.C
@@ -89,6 +89,25 @@ double fn_with_no_params() {
   return 11;
 }
 
+struct Complex {
+  double real, im;
+  double getReal() {
+    return real;
+  }
+};
+
+double fn_with_Complex_type_param(Complex c) {
+  return c.real + c.im;
+}
+
+struct ComplexPair {
+  Complex c1, c2;
+};
+
+double fn_with_ComplexPair_type_param(ComplexPair cp) {
+  return 11;
+};
+
 int main () {
   int x = 4 * 5;
   clad::differentiate(f_1, 0);
@@ -133,5 +152,10 @@ int main () {
   clad::differentiate(f_2, ""); // expected-error {{No parameters were provided}}
   clad::differentiate(fn_with_no_params); // expected-error {{Attempted to differentiate a function without parameters}}
 
+  clad::differentiate(f_2, "x.mem1");                                   // expected-error {{Fields can only be provided for class type parameters. Field information is incorrectly specified in 'x.mem1' for non-class type parameter 'x'}}
+  clad::differentiate(fn_with_Complex_type_param, "c.real.im");         // expected-error {{Path specified by fields in 'c.real.im' is invalid.}}
+  clad::differentiate(fn_with_ComplexPair_type_param, "cp.c1");         // expected-error {{Attempted differentiation w.r.t. member 'cp.c1' which is not of real type.}}
+  clad::differentiate(fn_with_Complex_type_param, "c.getReal");         // expected-error {{Path specified by fields in 'c.getReal' is invalid.}}
+  clad::differentiate(fn_with_Complex_type_param, "c.invalidField");    // expected-error {{Path specified by fields in 'c.invalidField' is invalid.}}
   return 0;
 }

--- a/test/FirstDerivative/Recursive.C
+++ b/test/FirstDerivative/Recursive.C
@@ -1,5 +1,5 @@
-// RUN: %cladclang %s -I%S/../../include -oBasicArithmeticAddSub.out 2>&1 | FileCheck %s
-// RUN: ./BasicArithmeticAddSub.out | FileCheck -check-prefix=CHECK-EXEC %s
+// RUN: %cladclang %s -I%S/../../include -oRecursive.out 2>&1 | FileCheck %s
+// RUN: ./Recursive.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/ROOT/Interface.C
+++ b/test/ROOT/Interface.C
@@ -1,5 +1,5 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oTFormula.out 2>&1 | FileCheck %s
-// RUN: ./TFormula.out | FileCheck -check-prefix=CHECK-EXEC %s
+// RUN: %cladclang %s -lm -I%S/../../include -oInterface.out 2>&1 | FileCheck %s
+// RUN: ./Interface.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/tools/DerivedFnInfo.cpp
+++ b/tools/DerivedFnInfo.cpp
@@ -11,12 +11,12 @@ namespace clad {
       : m_OriginalFn(request.Function), m_DerivedFn(derivedFn),
         m_OverloadedDerivedFn(overloadedDerivedFn), m_Mode(request.Mode),
         m_DerivativeOrder(request.CurrentDerivativeOrder),
-        m_DiffParamsInfo(request.DiffParamsInfo) {}
+        m_DiffVarsInfo(request.DVI) {}
 
   bool DerivedFnInfo::SatisfiesRequest(const DiffRequest& request) const {
     return (request.Function == m_OriginalFn && request.Mode == m_Mode &&
             request.CurrentDerivativeOrder == m_DerivativeOrder &&
-            request.DiffParamsInfo == m_DiffParamsInfo);
+            request.DVI == m_DiffVarsInfo);
   }
 
   bool DerivedFnInfo::IsValid() const { return m_OriginalFn && m_DerivedFn; }
@@ -26,6 +26,6 @@ namespace clad {
     return lhs.m_OriginalFn == rhs.m_OriginalFn &&
            lhs.m_DerivativeOrder == rhs.m_DerivativeOrder &&
            lhs.m_Mode == rhs.m_Mode &&
-           lhs.m_DiffParamsInfo == rhs.m_DiffParamsInfo;
+           lhs.m_DiffVarsInfo == rhs.m_DiffVarsInfo;
   }
 } // namespace clad

--- a/tools/DerivedFnInfo.h
+++ b/tools/DerivedFnInfo.h
@@ -16,7 +16,7 @@ namespace clad {
     clang::FunctionDecl* m_OverloadedDerivedFn = nullptr;
     DiffMode m_Mode = DiffMode::unknown;
     unsigned m_DerivativeOrder = 0;
-    DiffParamsWithIndices m_DiffParamsInfo;
+    DiffInputVarsInfo m_DiffVarsInfo;
 
     DerivedFnInfo() {}
     DerivedFnInfo(const DiffRequest& request, clang::FunctionDecl* derivedFn,


### PR DESCRIPTION
This PR adds initial support for differentiation with respect to data members in Forward Mode AD. Functions can be differentiated with respect to a data member by specifying the data member in the differentiation args. For example: 

```cpp
double fn(std::pair<double, double> u, std::pair<double, double> v) {
  return u.first + v.second;
}

auto d_fn = clad::differentiate(fn, "u.first"); 
```

This PR does not add support for differentiating with respect to array data members. 

This PR also fixes the test invocation of `FirstDerivative/Recursive` and `ROOT/Interface` tests. These tests were using clashing names for output file and that was causing failed tests due to race conditions. 