### PR TITLE
Change return type of `*::Derive` fns to `DerivativeAndOverload`

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -51,10 +51,15 @@ namespace clad {
   // instead would lead to unnecessarily returning a nullptr in the overloaded
   // FD
   using DeclWithContext = std::pair<clang::FunctionDecl*, clang::Decl*>;
-  /// A tuple which consists of a FunctionDecl, it's potential enclosing context
-  /// and optionally it's overload FunctionDecl
-  using OverloadedDeclWithContext =
-      std::tuple<clang::FunctionDecl*, clang::Decl*, clang::FunctionDecl*>;
+  /// Stores derivative and the corresponding overload. If no overload exist
+  /// then `second` data member should be `nullptr`.
+  struct DerivativeAndOverload {
+    clang::FunctionDecl* derivative = nullptr;
+    clang::FunctionDecl* overload = nullptr;
+    DerivativeAndOverload(clang::FunctionDecl* p_derivative = nullptr,
+                          clang::FunctionDecl* p_overload = nullptr)
+        : derivative(p_derivative), overload(p_overload) {}
+  };
 
   using VectorOutputs =
       std::vector<std::unordered_map<const clang::ValueDecl*, clang::Expr*>>;
@@ -153,7 +158,7 @@ namespace clad {
     ///\returns The differentiated function and potentially created enclosing
     /// context.
     ///
-    OverloadedDeclWithContext Derive(const DiffRequest& request);
+    DerivativeAndOverload Derive(const DiffRequest& request);
   };
 
 } // end namespace clad

--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -40,10 +40,10 @@ namespace clad {
     ///\returns The differentiated and potentially created enclosing
     /// context.
     ///
-    OverloadedDeclWithContext Derive(const clang::FunctionDecl* FD,
-                                     const DiffRequest& request);
-    OverloadedDeclWithContext DerivePushforward(const clang::FunctionDecl* FD,
-                                                const DiffRequest& request);
+    DerivativeAndOverload Derive(const clang::FunctionDecl* FD,
+                                 const DiffRequest& request);
+    DerivativeAndOverload DerivePushforward(const clang::FunctionDecl* FD,
+                                            const DiffRequest& request);
     StmtDiff VisitArraySubscriptExpr(const clang::ArraySubscriptExpr* ASE);
     StmtDiff VisitBinaryOperator(const clang::BinaryOperator* BinOp);
     StmtDiff VisitCallExpr(const clang::CallExpr* CE);

--- a/include/clad/Differentiator/HessianModeVisitor.h
+++ b/include/clad/Differentiator/HessianModeVisitor.h
@@ -27,7 +27,7 @@ namespace clad {
     /// A helper method that combines all the generated second derivatives
     /// (contained within a vector) obtained from Derive
     /// into a single FunctionDecl f_hessian
-    OverloadedDeclWithContext
+    DerivativeAndOverload
     Merge(std::vector<clang::FunctionDecl*> secDerivFuncs,
           llvm::SmallVector<size_t, 16> IndependentArgsSize,
           size_t TotalIndependentArgsSize, std::string hessianFuncName);
@@ -48,7 +48,7 @@ namespace clad {
     /// ReverseModeVisitor to generate second derivatives that correspond to
     /// columns of the Hessian. uses Merge to return a FunctionDecl
     /// containing CallExprs to the generated second derivatives.
-    OverloadedDeclWithContext Derive(const clang::FunctionDecl* FD,
+    DerivativeAndOverload Derive(const clang::FunctionDecl* FD,
                                      const DiffRequest& request);
   };
 } // end namespace clad

--- a/include/clad/Differentiator/JacobianModeVisitor.h
+++ b/include/clad/Differentiator/JacobianModeVisitor.h
@@ -36,8 +36,8 @@ namespace clad {
     ///
     ///\returns A function containing jacobian matrix.
     ///
-    OverloadedDeclWithContext Derive(const clang::FunctionDecl* FD,
-                                     const DiffRequest& request);
+    DerivativeAndOverload Derive(const clang::FunctionDecl* FD,
+                                 const DiffRequest& request);
   };
 } // end namespace clad
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -305,10 +305,10 @@ namespace clad {
     /// Improved naming scheme is required. Hence, we append the indices to of
     /// the requested parameters to 'f_grad', i.e. in the previous example "x,
     /// y" will give 'f_grad_0_1' and "x, z" will give 'f_grad_0_2'.
-    OverloadedDeclWithContext Derive(const clang::FunctionDecl* FD,
-                                     const DiffRequest& request);
-    OverloadedDeclWithContext DerivePullback(const clang::FunctionDecl* FD,
-                                             const DiffRequest& request);
+    DerivativeAndOverload Derive(const clang::FunctionDecl* FD,
+                                 const DiffRequest& request);
+    DerivativeAndOverload DerivePullback(const clang::FunctionDecl* FD,
+                                         const DiffRequest& request);
     StmtDiff VisitArraySubscriptExpr(const clang::ArraySubscriptExpr* ASE);
     StmtDiff VisitBinaryOperator(const clang::BinaryOperator* BinOp);
     StmtDiff VisitCallExpr(const clang::CallExpr* CE);

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -51,7 +51,7 @@ namespace clad {
     return RT;
   }
 
-  OverloadedDeclWithContext
+  DerivativeAndOverload
   ForwardModeVisitor::DerivePushforward(const FunctionDecl* FD,
                                         const DiffRequest& request) {
     m_Function = FD;
@@ -182,16 +182,14 @@ namespace clad {
     endScope(); // Function decl scope
 
     m_DerivativeInFlight = false;
-    return OverloadedDeclWithContext{cloneFunctionResult.first,
-                                     cloneFunctionResult.second,
-                                     /*OverloadFunctionDecl=*/nullptr};
+    return DerivativeAndOverload{cloneFunctionResult.first};
   }
 
   bool IsRealNonReferenceType(QualType T) {
     return T.getNonReferenceType()->isRealType();
   }
 
-  OverloadedDeclWithContext ForwardModeVisitor::Derive(
+  DerivativeAndOverload ForwardModeVisitor::Derive(
       const FunctionDecl* FD, const DiffRequest& request) {
     silenceDiags = !request.VerboseDiags;
     m_Function = FD;
@@ -469,8 +467,8 @@ namespace clad {
 
     m_DerivativeInFlight = false;
 
-    return OverloadedDeclWithContext{result.first, result.second,
-                                     /*OverloadFunctionDecl=*/nullptr};
+    return DerivativeAndOverload{result.first,
+                                 /*OverloadFunctionDecl=*/nullptr};
   }
 
   StmtDiff ForwardModeVisitor::VisitStmt(const Stmt* S) {

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -75,7 +75,7 @@ namespace clad {
     return secondDerivative;
   }
 
-  OverloadedDeclWithContext
+  DerivativeAndOverload
   HessianModeVisitor::Derive(const clang::FunctionDecl* FD,
                              const DiffRequest& request) {
     DiffParams args{};
@@ -190,7 +190,7 @@ namespace clad {
   // Combines all generated second derivative functions into a
   // single hessian function by creating CallExprs to each individual
   // secon derivative function in FunctionBody.
-  OverloadedDeclWithContext
+  DerivativeAndOverload
   HessianModeVisitor::Merge(std::vector<FunctionDecl*> secDerivFuncs,
                             SmallVector<size_t, 16> IndependentArgsSize,
                             size_t TotalIndependentArgsSize,
@@ -371,7 +371,7 @@ namespace clad {
     m_Sema.PopDeclContext();
     endScope(); // Function decl scope
 
-    return OverloadedDeclWithContext{result.first, result.second,
-                                     /*OverloadFunctionDecl=*/nullptr};
+    return DerivativeAndOverload{result.first,
+                                 /*OverloadFunctionDecl=*/nullptr};
   }
 } // end namespace clad

--- a/lib/Differentiator/JacobianModeVisitor.cpp
+++ b/lib/Differentiator/JacobianModeVisitor.cpp
@@ -32,11 +32,11 @@ namespace clad {
 
   JacobianModeVisitor::~JacobianModeVisitor() {}
 
-  OverloadedDeclWithContext
+  DerivativeAndOverload
   JacobianModeVisitor::Derive(const clang::FunctionDecl* FD,
                               const DiffRequest& request) {
     FD = FD->getDefinition();
-    OverloadedDeclWithContext result{};
+    DerivativeAndOverload result{};
 
     ReverseModeVisitor V(this->builder);
     result = V.Derive(FD, request);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -221,7 +221,7 @@ namespace clad {
     return gradientOverloadFD;
   }
 
-  OverloadedDeclWithContext
+  DerivativeAndOverload
   ReverseModeVisitor::Derive(const FunctionDecl* FD,
                              const DiffRequest& request) {
     if (m_ExternalSource)
@@ -459,11 +459,10 @@ namespace clad {
           CreateGradientOverload();
     }
 
-    return OverloadedDeclWithContext{result.first, result.second,
-                                     gradientOverloadFD};
+    return DerivativeAndOverload{result.first, gradientOverloadFD};
   }
 
-  OverloadedDeclWithContext
+  DerivativeAndOverload
   ReverseModeVisitor::DerivePullback(const clang::FunctionDecl* FD,
                                      const DiffRequest& request) {
     silenceDiags = !request.VerboseDiags;
@@ -537,8 +536,7 @@ namespace clad {
     m_Sema.PopDeclContext();
     endScope(); // Function decl scope
 
-    return OverloadedDeclWithContext(fnBuildRes.first, fnBuildRes.second,
-                                     nullptr);
+    return DerivativeAndOverload{fnBuildRes.first, nullptr};
   }
 
   StmtDiff ReverseModeVisitor::VisitStmt(const Stmt* S) {

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -34,8 +34,6 @@ namespace clang {
 } // namespace clang
 
 namespace clad {
-  struct DiffRequest;
-
   /// This class is designed to store collection of `DerivedFnInfo` objects.
   /// It's purpose is to avoid repeated generation of same derivatives by
   /// making it possible to reuse previously computed derivatives.


### PR DESCRIPTION
`*::Derive` functions were returning function declaration context as well that was not being used anywhere. Moreover, we can access the derived function declaration context using `derivative->getDeclContext()`. 