### PR TITLE
Add `VisitCXXBindTemporaryExpr` function in forw visitor

### DIFF
--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -92,6 +92,7 @@ namespace clad {
     StmtDiff VisitCXXDeleteExpr(const clang::CXXDeleteExpr* CDE);
     StmtDiff VisitCXXStaticCastExpr(const clang::CXXStaticCastExpr* CSE);
     StmtDiff VisitCXXFunctionalCastExpr(const clang::CXXFunctionalCastExpr* FCE);
+    StmtDiff VisitCXXBindTemporaryExpr(const clang::CXXBindTemporaryExpr* BTE);
   private:
     /// Helper function for differentiating the switch statement body.
     ///

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -2024,4 +2024,12 @@ namespace clad {
                            .get();
     return {clonedFCE, derivedFCE};
   }
+
+  StmtDiff ForwardModeVisitor::VisitCXXBindTemporaryExpr(
+      const clang::CXXBindTemporaryExpr* BTE) {
+    // `CXXBindTemporaryExpr` node will be created automatically, if it is
+    // required, by `ActOn`/`Build` Sema functions.
+    StmtDiff BTEDiff = Visit(BTE->getSubExpr());
+    return BTEDiff;
+  }
 } // end namespace clad

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -100,6 +100,8 @@ struct Tensor {
   T data[N] = {};
 
   Tensor() : data() {}
+  
+  ~Tensor() {}
 
   void updateTo(T val) {
     for (int i=0; i<N; ++i)


### PR DESCRIPTION
If a class has a non-trivial or user-defined destructor then AST uses `CXXBindTemporaryExpr` node to represent the binding of an expression to a temporary. This node ensures the destructor is called for the temporary.