### PR TITLE
Fix cuda test invocation

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -17,19 +17,7 @@
 
 #include <assert.h>
 #include <stddef.h>
-
-extern "C" {
-  int printf(const char* fmt, ...);
-#if defined(__APPLE__) || defined(_MSC_VER)
-  extern size_t strlen(const char*);
-  void* malloc(size_t);
-  void free(void *ptr);
-#else
-  extern size_t strlen(const char*) __THROW __attribute_pure__ __nonnull ((1));
-  void* malloc(size_t) __THROW __attribute_malloc__ __wur;
-  void free(void *ptr) __THROW;
-#endif
-}
+#include <cstring>
 
 namespace clad {
   /// \returns the size of a c-style string

--- a/include/clad/Differentiator/NumericalDiff.h
+++ b/include/clad/Differentiator/NumericalDiff.h
@@ -11,16 +11,6 @@
 #include <memory>
 #include <utility>
 
-extern "C" {
-#if defined(__APPLE__) || defined(_MSC_VER)
-void* malloc(size_t);
-void free(void* ptr);
-#else
-void* malloc(size_t) __THROW __attribute_malloc__ __wur;
-void free(void* ptr) __THROW;
-#endif
-}
-
 namespace numerical_diff {
 
   /// A class to keep track of the memory we allocate to make sure it is

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -2,10 +2,11 @@
 // the device having all the dependencies also as device functions.
 
 // RUN: %cladclang_cuda -I%S/../../include  %s -fsyntax-only \
-// RUN:     --cuda-path=%cudapath  -Xclang -verify 2>&1 | FileCheck %s
+// RUN: %cudasmlevel --cuda-path=%cudapath  -Xclang -verify 2>&1 | FileCheck %s
 
-// R: %cladclang_cuda -I%S/../../include  -xc++  --cuda-path=%cudapath  \
-// R: -L/usr/local/cuda/lib64 -lcudart_static -ldl -lrt -pthread -lm -lstdc++ %s
+// RUN: %cladclang_cuda -I%S/../../include %s -xc++ %cudasmlevel \
+// RUN: --cuda-path=%cudapath -L/usr/local/cuda/lib64 -lcudart_static \
+// RUN: -ldl -lrt -pthread -lm -lstdc++
 
 // REQUIRES: cuda-runtime
 


### PR DESCRIPTION
This PR makes the following changes to correctly run CUDA programs and tests: 
1) Remove explicit `extern "C" { ... }` definitions, thus making the code more portable and easier to maintain. 
2) Modify test invocation to use `CLING_TEST_CUDA_SM_LEVEL` environment variable value as defined in lit configuration file. 
3) Add `RUN` invocations to actually compile the test. 