### PR TITLE
Modified the dump function to print a more readable output.

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -219,7 +219,7 @@ namespace clad {
     }
  
     void dump() const {
-      printf("The code is: %s\n", getCode());
+      printf("The code is: \n%s\n", getCode());
     }
 
     /// Set object pointed by the functor as the default object for

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -152,7 +152,8 @@
 
 // RUN: ./CustomModelTest.out | FileCheck -check-prefix CHECK_CUSTOM_MODEL_EXEC %s
 // CHECK_CUSTOM_MODEL_EXEC-NOT:{{.*error|warning|note:.*}}
-// CHECK_CUSTOM_MODEL_EXEC: The code is: void func_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
+// CHECK_CUSTOM_MODEL_EXEC: The code is:
+// CHECK_CUSTOM_MODEL_EXEC-NEXT: void func_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    double _delta_z = 0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _EERepl_z0;


### PR DESCRIPTION
Previously the dump function printed the code immediately after "The code is"
which made the actual code less readable. Now a '\n' character has been added
after "The code is" so that the actual code starts from a new line, making it more
readable.

closes #377