### PR TITLE
Add Support for calculating FP error estimates of nested function calls.

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -82,13 +82,14 @@ namespace clad {
     std::unique_ptr<utils::StmtClone> m_NodeCloner;
     clang::NamespaceDecl* m_BuiltinDerivativesNSD;
     /// A reference to the model to use for error estimation (if any).
-    std::unique_ptr<FPErrorEstimationModel> m_EstModel = nullptr;
+    llvm::SmallVector<std::unique_ptr<FPErrorEstimationModel>, 4> m_EstModel;
     clang::NamespaceDecl* m_NumericalDiffNSD;
     /// A flag to keep track of whether error diagnostics are requested by user
     /// for numerical differentiation.
     bool m_PrintNumericalDiffErrorDiag = false;
     // A pointer to a the handler to be used for estimation requests.
-    std::unique_ptr<ErrorEstimationHandler> m_ErrorEstHandler;
+    llvm::SmallVector<std::unique_ptr<ErrorEstimationHandler>, 4>
+        m_ErrorEstHandler;
     DeclWithContext cloneFunction(const clang::FunctionDecl* FD,
                                   clad::VisitorBase VB, clang::DeclContext* DC,
                                   clang::Sema& m_Sema,
@@ -136,7 +137,7 @@ namespace clad {
     /// \param[in] estModel The error estimation model, can be either
     /// an in-built one (TaylorApprox) or one provided by the user.
     void
-    SetErrorEstimationModel(std::unique_ptr<FPErrorEstimationModel> estModel);
+    AddErrorEstimationModel(std::unique_ptr<FPErrorEstimationModel> estModel);
     /// Fuction to set the error diagnostic printing value for numerical
     /// differentiation.
     ///

--- a/include/clad/Differentiator/ErrorEstimator.h
+++ b/include/clad/Differentiator/ErrorEstimator.h
@@ -44,6 +44,9 @@ class ErrorEstimationHandler : public ExternalRMVSource {
   clang::Expr* m_IdxExpr;
   /// A set of declRefExprs for parameter value replacements.
   std::unordered_map<const clang::VarDecl*, clang::Expr*> m_ParamRepls;
+  /// An expression to match nested function call errors with their
+  /// assignee (if any exists).
+  clang::Expr* m_NestedFuncError = nullptr;
 
   std::stack<bool> m_ShouldEmit;
   ReverseModeVisitor* m_RMV;
@@ -270,6 +273,10 @@ public:
   void ActBeforeFinalisingAssignOp(clang::Expr*&, clang::Expr*&) override;
   void ActBeforeFinalizingDifferentiateSingleStmt(const direction& d) override;
   void ActBeforeFinalizingDifferentiateSingleExpr(const direction& d) override;
+  void ActBeforeDifferentiatingCallExpr(
+      llvm::SmallVectorImpl<clang::Expr*>& pullbackArgs,
+      llvm::SmallVectorImpl<clang::DeclStmt*>& ArgDecls,
+      bool hasAssignee) override;
   void ActBeforeFinalizingVisitDeclStmt(
       llvm::SmallVectorImpl<clang::Decl*>& decls,
       llvm::SmallVectorImpl<clang::Decl*>& declsDiff);

--- a/include/clad/Differentiator/ExternalRMVSource.h
+++ b/include/clad/Differentiator/ExternalRMVSource.h
@@ -153,6 +153,10 @@ public:
   /// `ReverseModeVisitor::DifferentiateSingleExpr`.
   virtual void ActBeforeFinalizingDifferentiateSingleExpr(const direction& d) {}
 
+  virtual void ActBeforeDifferentiatingCallExpr(
+      llvm::SmallVectorImpl<clang::Expr*>& pullbackArgs,
+      llvm::SmallVectorImpl<clang::DeclStmt*>& ArgDecls, bool hasAssignee) {}
+
   virtual void ActBeforeFinalizingVisitDeclStmt(
       llvm::SmallVectorImpl<clang::Decl*>& decls,
       llvm::SmallVectorImpl<clang::Decl*>& declsDiff) {}

--- a/include/clad/Differentiator/MultiplexExternalRMVSource.h
+++ b/include/clad/Differentiator/MultiplexExternalRMVSource.h
@@ -58,6 +58,10 @@ public:
   void ActOnStartOfDifferentiateSingleStmt() override;
   void ActBeforeFinalizingDifferentiateSingleStmt(const direction& d) override;
   void ActBeforeFinalizingDifferentiateSingleExpr(const direction& d) override;
+  void ActBeforeDifferentiatingCallExpr(
+      llvm::SmallVectorImpl<clang::Expr*>& pullbackArgs,
+      llvm::SmallVectorImpl<clang::DeclStmt*>& ArgDecls,
+      bool hasAssignee) override;
   void ActBeforeFinalizingVisitDeclStmt(
       llvm::SmallVectorImpl<clang::Decl*>& decls,
       llvm::SmallVectorImpl<clang::Decl*>& declsDiff) override;

--- a/lib/Differentiator/MultiplexExternalRMVSource.cpp
+++ b/lib/Differentiator/MultiplexExternalRMVSource.cpp
@@ -192,6 +192,14 @@ void MultiplexExternalRMVSource::ActBeforeFinalizingDifferentiateSingleExpr(
   }
 }
 
+void MultiplexExternalRMVSource::ActBeforeDifferentiatingCallExpr(
+    llvm::SmallVectorImpl<clang::Expr*>& pullbackArgs,
+    llvm::SmallVectorImpl<clang::DeclStmt*>& ArgDecls, bool hasAssignee) {
+  for (auto source : m_Sources)
+    source->ActBeforeDifferentiatingCallExpr(pullbackArgs, ArgDecls,
+                                             hasAssignee);
+}
+
 void MultiplexExternalRMVSource::ActBeforeFinalizingVisitDeclStmt(
     llvm::SmallVectorImpl<clang::Decl*>& decls,
     llvm::SmallVectorImpl<clang::Decl*>& declsDiff) {

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -278,26 +278,33 @@ float func5(float x, float y) {
 // Function call non custom derivative
 double helper(double x, double y) { return x * y; }
 
+//CHECK: void helper_pullback(double x, double y, double _d_y0, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y, double &_final_error) {
+//CHECK-NEXT:     double _t0;
+//CHECK-NEXT:     double _t1;
+//CHECK-NEXT:     double _ret_value0 = 0;
+//CHECK-NEXT:     _t1 = x;
+//CHECK-NEXT:     _t0 = y;
+//CHECK-NEXT:     double helper_return = _t1 * _t0;
+//CHECK-NEXT:     _ret_value0 = helper_return;
+//CHECK-NEXT:     goto _label0;
+//CHECK-NEXT:   _label0:
+//CHECK-NEXT:     {
+//CHECK-NEXT:         double _r0 = _d_y0 * _t0;
+//CHECK-NEXT:         * _d_x += _r0;
+//CHECK-NEXT:         double _r1 = _t1 * _d_y0;
+//CHECK-NEXT:         * _d_y += _r1;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     double _delta_x = 0;
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
+//CHECK-NEXT:     double _delta_y = 0;
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
+//CHECK-NEXT:     _final_error += _delta_{{y|x}} + _delta_{{y|x}} + std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT: }
+
 float func6(float x, float y) {
   float z = helper(x, y);
   return z * z;
 }
-
-// CHECK: void helper_pullback(double x, double y, double _d_y0, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     _t1 = x;
-// CHECK-NEXT:     _t0 = y;
-// CHECK-NEXT:     double helper_return = _t1 * _t0;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
-// CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = _d_y0 * _t0;
-// CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         double _r1 = _t1 * _d_y0;
-// CHECK-NEXT:         * _d_y += _r1;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
 
 //CHECK: void func6_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
 //CHECK-NEXT:     float _t0;
@@ -305,40 +312,41 @@ float func6(float x, float y) {
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _delta_z = 0;
 //CHECK-NEXT:     float _EERepl_z0;
-//CHECK-NEXT:     float _t2;
 //CHECK-NEXT:     float _t3;
+//CHECK-NEXT:     float _t4;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     _t1 = y;
 //CHECK-NEXT:     float z = helper(_t0, _t1);
 //CHECK-NEXT:     _EERepl_z0 = z;
+//CHECK-NEXT:     _t4 = z;
 //CHECK-NEXT:     _t3 = z;
-//CHECK-NEXT:     _t2 = z;
-//CHECK-NEXT:     float func6_return = _t3 * _t2;
+//CHECK-NEXT:     float func6_return = _t4 * _t3;
 //CHECK-NEXT:     _ret_value0 = func6_return;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         float _r2 = 1 * _t2;
+//CHECK-NEXT:         float _r2 = 1 * _t3;
 //CHECK-NEXT:         _d_z += _r2;
-//CHECK-NEXT:         float _r3 = _t3 * 1;
+//CHECK-NEXT:         float _r3 = _t4 * 1;
 //CHECK-NEXT:         _d_z += _r3;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _grad0 = 0.;
 //CHECK-NEXT:         double _grad1 = 0.;
-//CHECK-NEXT:         helper_pullback(_t0, _t1, _d_z, &_grad0, &_grad1);
+//CHECK-NEXT:         double _t2 = 0;
+//CHECK-NEXT:         helper_pullback(_t0, _t1, _d_z, &_grad0, &_grad1, _t2);
 //CHECK-NEXT:         double _r0 = _grad0;
 //CHECK-NEXT:         * _d_x += _r0;
 //CHECK-NEXT:         double _r1 = _grad1;
 //CHECK-NEXT:         * _d_y += _r1;
-//CHECK-NEXT:         _delta_z += std::abs(_d_z * _EERepl_z0 * {{.+}});
+//CHECK-NEXT:         _delta_z += _t2;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
 //CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
 //CHECK-NEXT:     double _delta_y = 0;
 //CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
-//CHECK-NEXT:     _final_error += _delta_{{x|y|z}} + _delta_{{x|y|z}} + _delta_{{x|y|z}} + std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     _final_error += _delta_{{y|x|z}} + _delta_{{y|x|z}} + _delta_{{y|x|z}} + std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 float func7(float x) {
@@ -365,45 +373,126 @@ float func7(float x) {
 
 double helper2(float& x) { return x * x; }
 
-// CHECK: void helper2_pullback(float &x, double _d_y, clad::array_ref<float> _d_x) {
-// CHECK-NEXT:     float _t0;
-// CHECK-NEXT:     float _t1;
-// CHECK-NEXT:     _t1 = x;
-// CHECK-NEXT:     _t0 = x;
-// CHECK-NEXT:     float helper2_return = _t1 * _t0;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
-// CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = _d_y * _t0;
-// CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         double _r1 = _t1 * _d_y;
-// CHECK-NEXT:         * _d_x += _r1;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
+//CHECK: void helper2_pullback(float &x, double _d_y, clad::array_ref<float> _d_x, double &_final_error) {
+//CHECK-NEXT:     float _t0;
+//CHECK-NEXT:     float _t1;
+//CHECK-NEXT:     double _ret_value0 = 0;
+//CHECK-NEXT:     _t1 = x;
+//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     float helper2_return = _t1 * _t0;
+//CHECK-NEXT:     _ret_value0 = helper2_return;
+//CHECK-NEXT:     goto _label0;
+//CHECK-NEXT:   _label0:
+//CHECK-NEXT:     {
+//CHECK-NEXT:         double _r0 = _d_y * _t0;
+//CHECK-NEXT:         * _d_x += _r0;
+//CHECK-NEXT:         double _r1 = _t1 * _d_y;
+//CHECK-NEXT:         * _d_x += _r1;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT: }
 
 float func8(float x, float y) {
-  float z = y + helper2(x);
+  float z;
+  z = y + helper2(x);
   return z;
 }
 
 //CHECK: void func8_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
-//CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _delta_z = 0;
 //CHECK-NEXT:     float _EERepl_z0;
-//CHECK-NEXT:     _t0 = x;
-//CHECK-NEXT:     float z = y + helper2(x);
+//CHECK-NEXT:     float _t0;
+//CHECK-NEXT:     float _EERepl_z1;
+//CHECK-NEXT:     float z;
 //CHECK-NEXT:     _EERepl_z0 = z;
+//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     z = y + helper2(x);
+//CHECK-NEXT:     _EERepl_z1 = z;
 //CHECK-NEXT:     float func8_return = z;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         * _d_y += _d_z;
-//CHECK-NEXT:         helper2_pullback(_t0, _d_z, &* _d_x);
+//CHECK-NEXT:         float _r_d0 = _d_z;
+//CHECK-NEXT:         * _d_y += _r_d0;
+//CHECK-NEXT:         double _t1 = 0;
+//CHECK-NEXT:         helper2_pullback(_t0, _r_d0, &* _d_x, _t1);
 //CHECK-NEXT:         float _r0 = * _d_x;
-//CHECK-NEXT:         _delta_z += std::abs(_d_z * _EERepl_z0 * {{.+}});
+//CHECK-NEXT:         _delta_z += _t1;
 //CHECK-NEXT:         _final_error += std::abs(_r0 * _t0 * {{.+}});
+//CHECK-NEXT:         _d_z -= _r_d0;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     double _delta_x = 0;
+//CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
+//CHECK-NEXT:     double _delta_y = 0;
+//CHECK-NEXT:     _delta_y += std::abs(* _d_y * y * {{.+}});
+//CHECK-NEXT:     _final_error += _delta_{{x|y|z}} + _delta_{{x|y|z}} + _delta_{{x|y|z}};
+//CHECK-NEXT: }
+
+float func9(float x, float y) {
+  float z = helper(x, y) + helper2(x);
+  z += helper2(x) * helper2(y);
+  return z;
+}
+
+//CHECK: void func9_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
+//CHECK-NEXT:     float _t0;
+//CHECK-NEXT:     float _t1;
+//CHECK-NEXT:     float _t3;
+//CHECK-NEXT:     float _d_z = 0;
+//CHECK-NEXT:     double _delta_z = 0;
+//CHECK-NEXT:     float _EERepl_z0;
+//CHECK-NEXT:     double _t5;
+//CHECK-NEXT:     float _t6;
+//CHECK-NEXT:     double _t8;
+//CHECK-NEXT:     float _t9;
+//CHECK-NEXT:     float _EERepl_z1;
+//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     _t1 = y;
+//CHECK-NEXT:     _t3 = x;
+//CHECK-NEXT:     float z = helper(_t0, _t1) + helper2(x);
+//CHECK-NEXT:     _EERepl_z0 = z;
+//CHECK-NEXT:     _t6 = x;
+//CHECK-NEXT:     _t8 = helper2(x);
+//CHECK-NEXT:     _t9 = y;
+//CHECK-NEXT:     _t5 = helper2(y);
+//CHECK-NEXT:     z += _t8 * _t5;
+//CHECK-NEXT:     _EERepl_z1 = z;
+//CHECK-NEXT:     float func9_return = z;
+//CHECK-NEXT:     goto _label0;
+//CHECK-NEXT:   _label0:
+//CHECK-NEXT:     _d_z += 1;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         float _r_d0 = _d_z;
+//CHECK-NEXT:         _d_z += _r_d0;
+//CHECK-NEXT:         double _r3 = _r_d0 * _t5;
+//CHECK-NEXT:         double _t7 = 0;
+//CHECK-NEXT:         helper2_pullback(_t6, _r3, &* _d_x, _t7);
+//CHECK-NEXT:         float _r4 = * _d_x;
+//CHECK-NEXT:         double _r5 = _t8 * _r_d0;
+//CHECK-NEXT:         double _t10 = 0;
+//CHECK-NEXT:         helper2_pullback(_t9, _r5, &* _d_y, _t10);
+//CHECK-NEXT:         float _r6 = * _d_y;
+//CHECK-NEXT:         _delta_z += _t7 + _t10;
+//CHECK-NEXT:         _final_error += std::abs(_r6 * _t9 * {{.+}});
+//CHECK-NEXT:         _final_error += std::abs(_r4 * _t6 * {{.+}});
+//CHECK-NEXT:         _d_z -= _r_d0;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     {
+//CHECK-NEXT:         double _grad0 = 0.;
+//CHECK-NEXT:         double _grad1 = 0.;
+//CHECK-NEXT:         double _t2 = 0;
+//CHECK-NEXT:         helper_pullback(_t0, _t1, _d_z, &_grad0, &_grad1, _t2);
+//CHECK-NEXT:         double _r0 = _grad0;
+//CHECK-NEXT:         * _d_x += _r0;
+//CHECK-NEXT:         double _r1 = _grad1;
+//CHECK-NEXT:         * _d_y += _r1;
+//CHECK-NEXT:         double _t4 = 0;
+//CHECK-NEXT:         helper2_pullback(_t3, _d_z, &* _d_x, _t4);
+//CHECK-NEXT:         float _r2 = * _d_x;
+//CHECK-NEXT:         _delta_z += _t2 + _t4;
+//CHECK-NEXT:         _final_error += std::abs(_r2 * _t3 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
 //CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
@@ -421,4 +510,5 @@ int main() {
   clad::estimate_error(func6);
   clad::estimate_error(func7);
   clad::estimate_error(func8);
+  clad::estimate_error(func9);
 }

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -183,7 +183,7 @@ namespace clad {
                   ie = ErrorEstimationModelRegistry::end();
              it != ie; ++it) {
           auto estimationPlugin = it->instantiate();
-          m_DerivativeBuilder->SetErrorEstimationModel(
+          m_DerivativeBuilder->AddErrorEstimationModel(
               estimationPlugin->InstantiateCustomModel(*m_DerivativeBuilder));
         }
       }


### PR DESCRIPTION
This PR covers the following cases:

1) Nested function calls with a return value (with and without pass-by-reference inputs). Currently, reference inputs will work correctly in the case they are not being assigned to. Otherwise, the error in those inputs is added to the final error twice. Needs a bit of discussion to resolve.
2) Functions with no return, no reference inputs.
3) Functions with no return but reference inputs.