### PR TITLE
Detect Request for use of Enzyme as Backend by user

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -59,6 +59,9 @@ namespace clad {
     /// member information for record (class) type parameters.
     DiffInputVarsInfo DVI;
 
+    // A flag to enable the use of enzyme for backend instead of clad
+    bool use_enzyme = false;
+
     /// Recomputes `DiffInputVarsInfo` using the current values of data members.
     ///
     /// Differentiation parameters info is computed by parsing the argument

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -35,7 +35,9 @@ namespace clad {
     #endif
     return count;
   }
-  
+
+  enum opts { use_enzyme = -1 }; // enum opts
+
   /// Tape type used for storing values in reverse-mode AD inside loops.
   template <typename T>
   using tape = tape_impl<T>;
@@ -286,16 +288,13 @@ namespace clad {
   /// \param[in] fn function to differentiate 
   /// \param[in] args independent parameter information 
   /// \returns `CladFunction` object to access the corresponding derived function.
-  template <unsigned N = 1,
-            typename ArgSpec = const char*,
-            typename F,
+  template <signed N = 1, typename ArgSpec = const char*, typename F,
             typename DerivedFnType = ExtractDerivedFnTraitsForwMode_t<F>,
             typename = typename std::enable_if<
                 !std::is_class<remove_reference_and_pointer_t<F>>::value>::type>
   CladFunction<DerivedFnType, ExtractFunctorTraits_t<F>> __attribute__((
       annotate("D")))
-  differentiate(F fn,
-                ArgSpec args = "",
+  differentiate(F fn, ArgSpec args = "",
                 DerivedFnType derivedFn = static_cast<DerivedFnType>(nullptr),
                 const char* code = "") {
     assert(fn && "Must pass in a non-0 argument");
@@ -306,15 +305,13 @@ namespace clad {
   /// Specialization for differentiating functors.
   /// The specialization is needed because objects have to be passed
   /// by reference whereas functions have to be passed by value.
-  template <unsigned N = 1,
-            typename ArgSpec = const char*,
-            typename F,
+  template <signed N = 1, typename ArgSpec = const char*, typename F,
             typename DerivedFnType = ExtractDerivedFnTraitsForwMode_t<F>,
             typename = typename std::enable_if<
                 std::is_class<remove_reference_and_pointer_t<F>>::value>::type>
-  CladFunction<DerivedFnType, ExtractFunctorTraits_t<F>> __attribute__((annotate("D")))
-  differentiate(F&& f,
-                ArgSpec args = "",
+  CladFunction<DerivedFnType, ExtractFunctorTraits_t<F>> __attribute__((
+      annotate("D")))
+  differentiate(F&& f, ArgSpec args = "",
                 DerivedFnType derivedFn = static_cast<DerivedFnType>(nullptr),
                 const char* code = "") {
     return CladFunction<DerivedFnType, ExtractFunctorTraits_t<F>>(derivedFn, code, f);
@@ -327,7 +324,8 @@ namespace clad {
   /// \param[in] args independent parameters information
   /// \returns `CladFunction` object to access the corresponding derived
   /// function.
-  template <typename ArgSpec = const char*, typename F,
+  template <signed E = 1 /*To check for enzyme*/,
+            typename ArgSpec = const char*, typename F,
             typename DerivedFnType = GradientDerivedFnTraits_t<F>,
             typename = typename std::enable_if<
                 !std::is_class<remove_reference_and_pointer_t<F>>::value>::type>
@@ -344,7 +342,8 @@ namespace clad {
   /// Specialization for differentiating functors.
   /// The specialization is needed because objects have to be passed
   /// by reference whereas functions have to be passed by value.
-  template <typename ArgSpec = const char*, typename F,
+  template <signed E = 1 /*To check for enzyme*/,
+            typename ArgSpec = const char*, typename F,
             typename DerivedFnType = GradientDerivedFnTraits_t<F>,
             typename = typename std::enable_if<
                 std::is_class<remove_reference_and_pointer_t<F>>::value>::type>

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -63,6 +63,7 @@ namespace clad {
     unsigned outputArrayCursor = 0;
     unsigned numParams = 0;
     bool isVectorValued = false;
+    bool use_enzyme = false;
     // FIXME: Should we make this an object instead of a pointer?
     // Downside of making it an object: We will need to include
     // 'MultiplexExternalRMVSource.h' file
@@ -71,6 +72,8 @@ namespace clad {
     const char* funcPostfix() const {
       if (isVectorValued)
         return "_jac";
+      else if (use_enzyme)
+        return "_grad_enzyme";
       else
         return "_grad";
     }

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -536,13 +536,25 @@ namespace clad {
         return true;
       DiffRequest request{};
 
+      // Check if enzyme is requested in case of Forward Mode or reverse Mode
+      if (A->getAnnotation().equals("D") || A->getAnnotation().equals("G")) {
+        signed enzyme_request = FD->getTemplateSpecializationArgs()
+                                    ->get(0)
+                                    .getAsIntegral()
+                                    .getZExtValue();
+
+        if (enzyme_request == -1)
+          request.use_enzyme = true;
+      }
+
       if (A->getAnnotation().equals("D")) {
         request.Mode = DiffMode::forward;
         llvm::APSInt derivativeOrderAPSInt
           = FD->getTemplateSpecializationArgs()->get(0).getAsIntegral();
-        // We know the first template spec argument is of unsigned type
-        assert(derivativeOrderAPSInt.isUnsigned() && "Must be unsigned");
-        unsigned derivativeOrder = derivativeOrderAPSInt.getZExtValue();
+
+        unsigned derivativeOrder = 1;
+        if (!request.use_enzyme)
+          derivativeOrder = derivativeOrderAPSInt.getZExtValue();
         request.RequestedDerivativeOrder = derivativeOrder;
       } else if (A->getAnnotation().equals("H")) {
         request.Mode = DiffMode::hessian;

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -261,6 +261,10 @@ namespace clad {
       outputArrayStr = m_Function->getParamDecl(lastArgN)->getNameAsString();
     }
 
+    // Check if DiffRequest asks for use of enzyme as backend
+    if (request.use_enzyme)
+      use_enzyme = true;
+
     auto derivativeBaseName = request.BaseFunctionName;
     std::string gradientName = derivativeBaseName + funcPostfix();
     // To be consistent with older tests, nothing is appended to 'f_grad' if
@@ -403,53 +407,71 @@ namespace clad {
     if (m_ExternalSource)
       m_ExternalSource->ActOnStartOfDerivedFnBody(request);
 
+    Stmt* gradientBody = nullptr;
+
     // create derived variables for parameters which are not part of
     // independent variables (args).
-    for (std::size_t i=0; i<m_Function->getNumParams(); ++i) {
-      ParmVarDecl* param = params[i];
-      // derived variables are already created for independent variables.
-      if (m_Variables.count(param))
-        continue;
-      // in vector mode last non diff parameter is output parameter.
-      if (isVectorValued && i == m_Function->getNumParams()-1)
-        continue;
-      auto VDDerivedType = param->getType();
-      // We cannot initialize derived variable for pointer types because
-      // we do not know the correct size.
-      if (utils::isArrayOrPointerType(VDDerivedType))
-        continue;
-      auto VDDerived =
-          BuildVarDecl(VDDerivedType, "_d_" + param->getNameAsString(),
-                       getZeroInit(VDDerivedType));
-      m_Variables[param] = BuildDeclRef(VDDerived);
-      addToBlock(BuildDeclStmt(VDDerived), m_Globals);
+    if (!use_enzyme) {
+      for (std::size_t i = 0; i < m_Function->getNumParams(); ++i) {
+        ParmVarDecl* param = params[i];
+        // derived variables are already created for independent variables.
+        if (m_Variables.count(param))
+          continue;
+        // in vector mode last non diff parameter is output parameter.
+        if (isVectorValued && i == m_Function->getNumParams() - 1)
+          continue;
+        auto VDDerivedType = param->getType();
+        // We cannot initialize derived variable for pointer types because
+        // we do not know the correct size.
+        if (utils::isArrayOrPointerType(VDDerivedType))
+          continue;
+        auto VDDerived =
+            BuildVarDecl(VDDerivedType, "_d_" + param->getNameAsString(),
+                         getZeroInit(VDDerivedType));
+        m_Variables[param] = BuildDeclRef(VDDerived);
+        addToBlock(BuildDeclStmt(VDDerived), m_Globals);
+      }
+      // Start the visitation process which outputs the statements in the
+      // current block.
+      StmtDiff BodyDiff = Visit(FD->getBody());
+      Stmt* Forward = BodyDiff.getStmt();
+      Stmt* Reverse = BodyDiff.getStmt_dx();
+      // Create the body of the function.
+      // Firstly, all "global" Stmts are put into fn's body.
+      for (Stmt* S : m_Globals)
+        addToCurrentBlock(S, direction::forward);
+      // Forward pass.
+      if (auto CS = dyn_cast<CompoundStmt>(Forward))
+        for (Stmt* S : CS->body())
+          addToCurrentBlock(S, direction::forward);
+      else
+        addToCurrentBlock(Forward, direction::forward);
+      // Reverse pass.
+      if (auto RCS = dyn_cast<CompoundStmt>(Reverse))
+        for (Stmt* S : RCS->body())
+          addToCurrentBlock(S, direction::forward);
+      else
+        addToCurrentBlock(Reverse, direction::forward);
+
+      if (m_ExternalSource)
+        m_ExternalSource->ActOnEndOfDerivedFnBody();
+
+      gradientBody = endBlock();
+    } else {
+      // TODO: Write code to generate code that enzyme can work on
+      /*
+        Two if cases ought to come here
+        a. How to deal with functions of form - double function(double z, double
+        y, double z...); This is not straight forward as of now because Enzyme
+        does not have support for this yet, we will need to setup data
+        structures that can deal with this easily
+
+        b. How to deal with functions of the form - double function(double*
+        arrayOfParams); This is straightforward to deal in enzyme
+      */
+      gradientBody = endBlock();
     }
-    // Start the visitation process which outputs the statements in the current
-    // block.
-    StmtDiff BodyDiff = Visit(FD->getBody());
-    Stmt* Forward = BodyDiff.getStmt();
-    Stmt* Reverse = BodyDiff.getStmt_dx();
-    // Create the body of the function.
-    // Firstly, all "global" Stmts are put into fn's body.
-    for (Stmt* S : m_Globals)
-      addToCurrentBlock(S, direction::forward);
-    // Forward pass.
-    if (auto CS = dyn_cast<CompoundStmt>(Forward))
-      for (Stmt* S : CS->body())
-        addToCurrentBlock(S, direction::forward);
-    else
-      addToCurrentBlock(Forward, direction::forward);
-    // Reverse pass.
-    if (auto RCS = dyn_cast<CompoundStmt>(Reverse))
-      for (Stmt* S : RCS->body())
-        addToCurrentBlock(S, direction::forward);
-    else
-      addToCurrentBlock(Reverse, direction::forward);
 
-    if (m_ExternalSource)
-      m_ExternalSource->ActOnEndOfDerivedFnBody();
-
-    Stmt* gradientBody = endBlock();
     m_Derivative->setBody(gradientBody);
     endScope(); // Function body scope
     m_Sema.PopFunctionScopeInfo();

--- a/test/ForwardMode/Enzyme.C
+++ b/test/ForwardMode/Enzyme.C
@@ -1,0 +1,15 @@
+// RUN: %cladclang %s -lstdc++ -I%S/../../include -oEnzyme.out 2>&1 | FileCheck %s
+// RUN: ./Enzyme.out
+// CHECK-NOT: {{.*error|warning|note:.*}}
+// XFAIL:*
+
+#include "clad/Differentiator/Differentiator.h"
+
+double f(double x, double y) { return x * y; }
+
+// CHECK:     void f_diff_enzyme() {
+// CHECK-NEXT:}
+
+int main(){
+     auto f_dx = clad::differentiate<clad::opts::use_enzyme>(f, "x");
+}

--- a/test/Gradient/Enzyme.C
+++ b/test/Gradient/Enzyme.C
@@ -1,0 +1,15 @@
+
+// RUN: %cladclang %s -lstdc++ -I%S/../../include -oEnzyme.out 2>&1 | FileCheck %s
+// RUN: ./Enzyme.out
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+double f(double x, double y) { return x * y; }
+
+// CHECK:  void f_grad_enzyme(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
+// CHECK-NEXT:}
+
+int main(){
+     auto f_dx = clad::gradient<clad::opts::use_enzyme>(f);
+}


### PR DESCRIPTION
This patch is the first step towards integrating enzyme AD with Clad. The user can now mention that he/she wants to use enzyme for AD instead of clad by using the API calls:
           ```clad::differentiate<clad::opts::use_enzyme>(func,"...");```
and     ```clad::gradient<clad::opts::use_enzyme>(func);```
Via this patch one can successfully recognise the request for Enzyme AD backend. It is implemented via Overloading the function templates for differentiate and gradient. Currently after successfully recognising a Enzyme request, an empty function is created to show that we have identified the request for enzyme. That is,
    
```clad::gradient<clad::opts::use_enzyme>(func);```
generates the function:
```
        void func_grad_enzyme(...function arguments... , ...arguments to store derivatives...){
        }
```
Currently generation of dummy function for clad::differentiate<clad::opts::use_enzyme>(...) is not implemented.
These functions must be modified in future patches to insert valid code for enzyme to work on.
