### PR TITLE
Enable CUDA constructs in forward mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
             compiler: gcc-6
             clang-runtime: '11'
             coverage: true
+            cuda: true
             #clang-format: true
 
           - name: ubu18-gcc6-runtime11-benchmarks

--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -21,6 +21,28 @@ template <typename T, typename U> struct ValueAndPushforward {
   U pushforward;
 };
 namespace custom_derivatives {
+#ifdef __CUDACC__
+template <typename T>
+ValueAndPushforward<cudaError_t, cudaError_t>
+cudaMalloc_pushforward(T** devPtr, size_t sz, T** d_devPtr, size_t d_sz)
+    __attribute__((host)) {
+  return {cudaMalloc(devPtr, sz), cudaMalloc(d_devPtr, sz)};
+}
+
+ValueAndPushforward<cudaError_t, cudaError_t>
+cudaMemcpy_pushforward(void* destPtr, void* srcPtr, size_t count,
+                       cudaMemcpyKind kind, void* d_destPtr, void* d_srcPtr,
+                       size_t d_count) __attribute__((host)) {
+  return {cudaMemcpy(destPtr, srcPtr, count, kind),
+          cudaMemcpy(d_destPtr, d_srcPtr, count, kind)};
+}
+
+ValueAndPushforward<int, int> cudaDeviceSynchronize_pushforward()
+    __attribute__((host)) {
+  return {cudaDeviceSynchronize(), 0};
+}
+#endif
+
 namespace std {
 template <typename T>
 CUDA_HOST_DEVICE ValueAndPushforward<T, T> abs_pushforward(T x, T d_x) {

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -168,8 +168,6 @@ namespace clad {
                                        clang::Expr* base,
                                        llvm::StringRef memberName);
 
-    bool isDifferentiableType(clang::QualType T);
-
     /// Returns a valid `SourceLocation` to be used in places where clang
     /// requires a valid `SourceLocation`.
     clang::SourceLocation GetValidSLoc(clang::Sema& semaRef);

--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -645,5 +645,13 @@ static inline bool IsPRValue(const Expr* E) { return E->isRValue(); }
 #else
 static inline bool IsPRValue(const Expr* E) { return E->isPRValue(); }
 #endif
+
+#if CLANG_VERSION_MAJOR >= 9
+#define CLAD_COMPAT_CLANG9_CXXDefaultArgExpr_getUsedContext_Param(Node)               \
+  , Node->getUsedContext()
+#else
+#define CLAD_COMPAT_CLANG9_CXXDefaultArgExpr_getUsedContext_Param(Node) /**/
+#endif
+
 } // namespace clad_compat
 #endif //CLAD_COMPATIBILITY

--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -93,6 +93,9 @@ namespace clad {
     StmtDiff VisitCXXStaticCastExpr(const clang::CXXStaticCastExpr* CSE);
     StmtDiff VisitCXXFunctionalCastExpr(const clang::CXXFunctionalCastExpr* FCE);
     StmtDiff VisitCXXBindTemporaryExpr(const clang::CXXBindTemporaryExpr* BTE);
+    StmtDiff VisitCXXNullPtrLiteralExpr(const clang::CXXNullPtrLiteralExpr* NPL);
+    StmtDiff VisitUnaryExprOrTypeTraitExpr(const clang::UnaryExprOrTypeTraitExpr* UE);
+    StmtDiff VisitPseudoObjectExpr(const clang::PseudoObjectExpr* POE);
   private:
     /// Helper function for differentiating the switch statement body.
     ///

--- a/include/clad/Differentiator/StmtClone.h
+++ b/include/clad/Differentiator/StmtClone.h
@@ -105,6 +105,7 @@ namespace utils {
     DECLARE_CLONE_FN(CXXDynamicCastExpr)
     DECLARE_CLONE_FN(CXXReinterpretCastExpr)
     DECLARE_CLONE_FN(CXXConstCastExpr)
+    DECLARE_CLONE_FN(CXXDefaultArgExpr)
     DECLARE_CLONE_FN(CXXFunctionalCastExpr)
     DECLARE_CLONE_FN(CXXBoolLiteralExpr)
     DECLARE_CLONE_FN(CXXNullPtrLiteralExpr)

--- a/include/clad/Differentiator/StmtClone.h
+++ b/include/clad/Differentiator/StmtClone.h
@@ -113,6 +113,7 @@ namespace utils {
     DECLARE_CLONE_FN(CXXConstructExpr)
     DECLARE_CLONE_FN(CXXTemporaryObjectExpr)
     DECLARE_CLONE_FN(MaterializeTemporaryExpr)
+    DECLARE_CLONE_FN(PseudoObjectExpr)
     DECLARE_CLONE_FN(SubstNonTypeTemplateParmExpr)
     // `ConstantExpr` node is only available after clang 7.
     #if CLANG_VERSION_MAJOR > 7

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -297,17 +297,6 @@ namespace clad {
       return ME;
     }
 
-    bool isDifferentiableType(QualType T) {
-      // FIXME: Handle arbitrary depth pointer types and arbitrary dimension
-      // array type as well.
-      if (isArrayOrPointerType(T))
-        T = T->getPointeeOrArrayElementType()->getCanonicalTypeInternal();
-      T = T.getNonReferenceType();
-      if (T->isRealType() || T->isStructureOrClassType())
-        return true;
-      return false;
-    }
-
     SourceLocation GetValidSLoc(Sema& semaRef) {
       auto& SM = semaRef.getSourceManager();
       return SM.getLocForStartOfFile(SM.getMainFileID());

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -1239,10 +1239,13 @@ namespace clad {
               BuildCallExprToMemFn(baseDiff.getExpr(), pushforwardFD->getName(),
                                    pushforwardFnArgs, pushforwardFD);
         } else {
+          Expr* execConfig = nullptr;
+          if (auto KCE = dyn_cast<CUDAKernelCallExpr>(CE))
+            execConfig = Clone(KCE->getConfig());
           callDiff =
               m_Sema
                   .ActOnCallExpr(getCurrentScope(), BuildDeclRef(pushforwardFD),
-                                 noLoc, pushforwardFnArgs, noLoc)
+                                 noLoc, pushforwardFnArgs, noLoc, execConfig)
                   .get();
         }
       }

--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -2066,4 +2066,20 @@ namespace clad {
     StmtDiff BTEDiff = Visit(BTE->getSubExpr());
     return BTEDiff;
   }
+
+  StmtDiff ForwardModeVisitor::VisitCXXNullPtrLiteralExpr(
+      const clang::CXXNullPtrLiteralExpr* NPL) {
+    return {Clone(NPL), Clone(NPL)};
+  }
+
+  StmtDiff ForwardModeVisitor::VisitUnaryExprOrTypeTraitExpr(
+      const clang::UnaryExprOrTypeTraitExpr* UE) {
+    return {Clone(UE), Clone(UE)};
+  }
+
+  StmtDiff ForwardModeVisitor::VisitPseudoObjectExpr(
+      const clang::PseudoObjectExpr* POE) {
+    return {Clone(POE),
+            ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, 0)};
+  }
 } // end namespace clad

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -76,6 +76,8 @@ DEFINE_CLONE_EXPR(CharacterLiteral, (Node->getValue(), Node->getKind(), Node->ge
 DEFINE_CLONE_EXPR(ImaginaryLiteral, (Clone(Node->getSubExpr()), Node->getType()))
 DEFINE_CLONE_EXPR(ParenExpr, (Node->getLParen(), Node->getRParen(), Clone(Node->getSubExpr())))
 DEFINE_CLONE_EXPR(ArraySubscriptExpr, (Clone(Node->getLHS()), Clone(Node->getRHS()), Node->getType(), Node->getValueKind(), Node->getObjectKind(), Node->getRBracketLoc()))
+DEFINE_CREATE_EXPR(CXXDefaultArgExpr, (Ctx, SourceLocation(), Node->getParam() CLAD_COMPAT_CLANG9_CXXDefaultArgExpr_getUsedContext_Param(Node)))
+
 Stmt* StmtClone::VisitMemberExpr(MemberExpr* Node) {
   TemplateArgumentListInfo TemplateArgs;
   if (Node->hasExplicitTemplateArgs())

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -133,6 +133,7 @@ DEFINE_CLONE_EXPR(CXXNullPtrLiteralExpr, (Node->getType(), Node->getSourceRange(
 DEFINE_CLONE_EXPR(CXXThisExpr, (Node->getSourceRange().getBegin(), Node->getType(), Node->isImplicit()))
 DEFINE_CLONE_EXPR(CXXThrowExpr, (Clone(Node->getSubExpr()), Node->getType(), Node->getThrowLoc(), Node->isThrownVariableInScope()))
 DEFINE_CLONE_EXPR(SubstNonTypeTemplateParmExpr, (Node->getType(), Node->getValueKind(), Node->getBeginLoc(), Node->getParameter(), CLAD_COMPAT_SubstNonTypeTemplateParmExpr_isReferenceParameter_ExtraParam(Node) Node->getReplacement()))
+DEFINE_CREATE_EXPR(PseudoObjectExpr, (Ctx, Node->getSyntacticForm(), llvm::SmallVector<Expr*, 4>(Node->semantics_begin(), Node->semantics_end()), Node->getResultExprIndex()))
 //BlockExpr
 //BlockDeclRefExpr
 

--- a/test/CUDA/ForwardMode.cu
+++ b/test/CUDA/ForwardMode.cu
@@ -1,0 +1,124 @@
+// RUN: %cladclang_cuda -I%S/../../include %s -xc++ %cudasmlevel \
+// RUN: --cuda-path=%cudapath -L/usr/local/cuda/lib64 -lcudart_static \
+// RUN: -ldl -lrt -pthread -lm -lstdc++ -oForwardMode.out 2>&1 | FileCheck %s
+
+// RUN: ./ForwardMode.out
+
+// REQUIRES: cuda-runtime
+
+// expected-no-diagnostics
+
+#include "clad/Differentiator/Differentiator.h"
+#include "../TestUtils.h"
+
+__global__ void add(double *a, double *b, double *c, int n) {
+  int idx = threadIdx.x;
+  if (idx < n)
+    c[idx] = a[idx] + b[idx];
+}
+
+// CHECK: void add_pushforward(double *a, double *b, double *c, int n, double *_d_a, double *_d_b, double *_d_c, int _d_n) __attribute__((global)) {
+// CHECK-NEXT:     int _d_idx = 0;
+// CHECK-NEXT:     int idx = threadIdx.x;
+// CHECK-NEXT:     if (idx < n) {
+// CHECK-NEXT:         _d_c[idx] = _d_a[idx] + _d_b[idx];
+// CHECK-NEXT:         c[idx] = a[idx] + b[idx];
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+double fn1(double i, double j) {
+  double a[500] = {};
+  double b[500] = {};
+  double c[500] = {};
+  int n = 500;
+
+  for (int idx=0; idx<500; ++idx) {
+    a[idx] = 7;
+    b[idx] = 9;
+  }
+
+  double *device_a = nullptr;
+  double *device_b = nullptr;
+  double *device_c = nullptr;
+
+  cudaMalloc(&device_a, n * sizeof(double));
+  cudaMalloc(&device_b, n * sizeof(double));
+  cudaMalloc(&device_c, n * sizeof(double));
+
+  cudaMemcpy(device_a, a, n * sizeof(double), cudaMemcpyHostToDevice);
+  cudaMemcpy(device_b, b, n * sizeof(double), cudaMemcpyHostToDevice);
+  cudaMemcpy(device_c, c, n * sizeof(double), cudaMemcpyHostToDevice);
+
+  add<<<1, 700>>>(device_a, device_b, device_c, n);
+
+  cudaDeviceSynchronize();
+
+  cudaMemcpy(c, device_c, n * sizeof(double), cudaMemcpyDeviceToHost);
+
+  double sum = 0;
+  for (int idx=0; idx<n; ++idx)
+    sum += c[idx];
+  
+  return sum * i + 2 * sum * j;
+}
+
+// CHECK: double fn1_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     double _d_a[500] = {};
+// CHECK-NEXT:     double a[500] = {};
+// CHECK-NEXT:     double _d_b[500] = {};
+// CHECK-NEXT:     double b[500] = {};
+// CHECK-NEXT:     double _d_c[500] = {};
+// CHECK-NEXT:     double c[500] = {};
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 500;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _d_idx = 0;
+// CHECK-NEXT:         for (int idx = 0; idx < 500; ++idx) {
+// CHECK-NEXT:             _d_a[idx] = 0;
+// CHECK-NEXT:             a[idx] = 7;
+// CHECK-NEXT:             _d_b[idx] = 0;
+// CHECK-NEXT:             b[idx] = 9;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     double *_d_device_a = nullptr;
+// CHECK-NEXT:     double *device_a = nullptr;
+// CHECK-NEXT:     double *_d_device_b = nullptr;
+// CHECK-NEXT:     double *device_b = nullptr;
+// CHECK-NEXT:     double *_d_device_c = nullptr;
+// CHECK-NEXT:     double *device_c = nullptr;
+// CHECK-NEXT:     unsigned long _t0 = sizeof(double);
+// CHECK-NEXT:     ValueAndPushforward<cudaError_t, cudaError_t> _t1 = clad::custom_derivatives::cudaMalloc_pushforward(&device_a, n * _t0, &_d_device_a, _d_n * _t0 + n * sizeof(double));
+// CHECK-NEXT:     unsigned long _t2 = sizeof(double);
+// CHECK-NEXT:     ValueAndPushforward<cudaError_t, cudaError_t> _t3 = clad::custom_derivatives::cudaMalloc_pushforward(&device_b, n * _t2, &_d_device_b, _d_n * _t2 + n * sizeof(double));
+// CHECK-NEXT:     unsigned long _t4 = sizeof(double);
+// CHECK-NEXT:     ValueAndPushforward<cudaError_t, cudaError_t> _t5 = clad::custom_derivatives::cudaMalloc_pushforward(&device_c, n * _t4, &_d_device_c, _d_n * _t4 + n * sizeof(double));
+// CHECK-NEXT:     unsigned long _t6 = sizeof(double);
+// CHECK-NEXT:     ValueAndPushforward<cudaError_t, cudaError_t> _t7 = clad::custom_derivatives::cudaMemcpy_pushforward(device_a, a, n * _t6, cudaMemcpyHostToDevice, _d_device_a, _d_a, _d_n * _t6 + n * sizeof(double));
+// CHECK-NEXT:     unsigned long _t8 = sizeof(double);
+// CHECK-NEXT:     ValueAndPushforward<cudaError_t, cudaError_t> _t9 = clad::custom_derivatives::cudaMemcpy_pushforward(device_b, b, n * _t8, cudaMemcpyHostToDevice, _d_device_b, _d_b, _d_n * _t8 + n * sizeof(double));
+// CHECK-NEXT:     unsigned long _t10 = sizeof(double);
+// CHECK-NEXT:     ValueAndPushforward<cudaError_t, cudaError_t> _t11 = clad::custom_derivatives::cudaMemcpy_pushforward(device_c, c, n * _t10, cudaMemcpyHostToDevice, _d_device_c, _d_c, _d_n * _t10 + n * sizeof(double));
+// CHECK-NEXT:     add_pushforward<<<1, 700>>>(device_a, device_b, device_c, n, _d_device_a, _d_device_b, _d_device_c, _d_n);
+// CHECK-NEXT:     ValueAndPushforward<int, int> _t12 = clad::custom_derivatives::cudaDeviceSynchronize_pushforward();
+// CHECK-NEXT:     unsigned long _t13 = sizeof(double);
+// CHECK-NEXT:     ValueAndPushforward<cudaError_t, cudaError_t> _t14 = clad::custom_derivatives::cudaMemcpy_pushforward(c, device_c, n * _t13, cudaMemcpyDeviceToHost, _d_c, _d_device_c, _d_n * _t13 + n * sizeof(double));
+// CHECK-NEXT:     double _d_sum = 0;
+// CHECK-NEXT:     double sum = 0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _d_idx = 0;
+// CHECK-NEXT:         for (int idx = 0; idx < n; ++idx) {
+// CHECK-NEXT:             _d_sum += _d_c[idx];
+// CHECK-NEXT:             sum += c[idx];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     double _t15 = 2 * sum;
+// CHECK-NEXT:     return _d_sum * i + sum * _d_i + (0 * sum + 2 * _d_sum) * j + _t15 * _d_j;
+// CHECK-NEXT: }
+
+int main() {
+  INIT_DIFFERENTIATE(fn1, "i");
+
+  TEST_DIFFERENTIATE(fn1, 3, 5);  // CHECK-EXEC: 8000.00
+}


### PR DESCRIPTION
This PR enables several CUDA constructs in the forward mode. In particular, the work done in this PR allows calling CUDA device functions in the function that needs to be differentiated.

Summary of the changes made in this PR: 

- Non CUDA related changes
  - Enable support of `nullptr` and `sizeof` expressions in the forward mode.
  - Enable cloning of `CXXDefaultArgExpr` node.
  - Enable creating derivatives of nested pointer objects in the forward mode.
 
- CUDA related changes
  -  Enable specifying execution configuration (`<<< >>>`) with function calls in the forward mode.
  - Add forward mode custom derivatives  for the following functions:
    - `cudaMalloc`
    - `cudaMemcpy`
    - `cudaDeviceSynchronize`