### PR TITLE
Recover the testsuite run with clang built in debug mode

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -99,8 +99,8 @@ namespace clad {
                                   clang::QualType functionType);
     /// Looks for a suitable overload for a given function.
     ///
-    /// \param[in] DNI The identification information of the function overload
-    /// to be found.
+    /// \param[in] Name The identification information of the function
+    /// overload to be found.
     /// \param[in] CallArgs The call args to be used to resolve to the
     /// correct overload.
     /// \param[in] forCustomDerv A flag to keep track of which
@@ -112,10 +112,9 @@ namespace clad {
     /// \returns The call expression if a suitable function overload was found,
     /// null otherwise.
     clang::Expr* BuildCallToCustomDerivativeOrNumericalDiff(
-        clang::DeclarationNameInfo DNI,
-        llvm::SmallVectorImpl<clang::Expr*>& CallArgs, clang::Scope* S,
-        clang::DeclContext* originalFnDC, bool forCustomDerv = true,
-        bool namespaceShouldExist = true);
+        const std::string& Name, llvm::SmallVectorImpl<clang::Expr*>& CallArgs,
+        clang::Scope* S, clang::DeclContext* originalFnDC,
+        bool forCustomDerv = true, bool namespaceShouldExist = true);
     bool noOverloadExists(clang::Expr* UnresolvedLookup,
                           llvm::MutableArrayRef<clang::Expr*> ARargs);
     /// Shorthand to issues a warning or error.

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -138,8 +138,8 @@ namespace clad {
 
       if (auto ND = dyn_cast<NamespaceDecl>(DC)) {
         CSS.Extend(C, ND,
-                   /*NamespaceLoc=*/noLoc,
-                   /*ColonColonLoc=*/noLoc);
+                   /*NamespaceLoc=*/utils::GetValidSLoc(semaRef),
+                   /*ColonColonLoc=*/utils::GetValidSLoc(semaRef));
       } else if (auto RD = dyn_cast<CXXRecordDecl>(DC)) {
         auto RDQType = RD->getTypeForDecl()->getCanonicalTypeInternal();
         auto RDTypeSourceInfo = C.getTrivialTypeSourceInfo(RDQType);

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -17,6 +17,8 @@ QualType getUnderlyingArrayType(QualType baseType, ASTContext& C) {
   } else if (auto PTType = baseType->getAs<PointerType>()) {
     return PTType->getPointeeType();
   }
+  assert(0 && "Unreachable");
+  return {};
 }
 
 Expr* UpdateErrorForFuncCallAssigns(ErrorEstimationHandler* handler,

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1403,17 +1403,13 @@ namespace clad {
 
     if (NArgs == 1 && !utils::HasAnyReferenceOrPointerArgument(FD) &&
         !isa<CXXMethodDecl>(FD)) {
-      IdentifierInfo* II =
-          &m_Context.Idents.get(FD->getNameAsString() + "_pushforward");
-      // Try to find it in builtin derivatives
-      DeclarationName name(II);
-      DeclarationNameInfo DNInfo(name, noLoc);
+      std::string customPushforward = FD->getNameAsString() + "_pushforward";
       auto pushforwardCallArgs = DerivedCallArgs;
       pushforwardCallArgs.push_back(ConstantFolder::synthesizeLiteral(
           DerivedCallArgs.front()->getType(), m_Context, 1));
       OverloadedDerivedFn =
           m_Builder.BuildCallToCustomDerivativeOrNumericalDiff(
-              DNInfo, pushforwardCallArgs, getCurrentScope(),
+              customPushforward, pushforwardCallArgs, getCurrentScope(),
               const_cast<DeclContext*>(FD->getDeclContext()));
       if (OverloadedDerivedFn)
         asGrad = false;
@@ -1433,11 +1429,6 @@ namespace clad {
     // If it has more args or f_darg0 was not found, we look for its pullback
     // function.
     if (!OverloadedDerivedFn) {
-      IdentifierInfo* II =
-          &m_Context.Idents.get(FD->getNameAsString() + "_pullback");
-      DeclarationName name(II);
-      DeclarationNameInfo DNInfo(name, noLoc);
-
       unsigned size_type_bits = m_Context.getIntWidth(m_Context.getSizeType());
 
       size_t idx = 0;
@@ -1537,9 +1528,10 @@ namespace clad {
                                 dfdx());
 
       // Try to find it in builtin derivatives
+      std::string customPullback = FD->getNameAsString() + "_pullback";
       OverloadedDerivedFn =
           m_Builder.BuildCallToCustomDerivativeOrNumericalDiff(
-              DNInfo, pullbackCallArgs, getCurrentScope(),
+              customPullback, pullbackCallArgs, getCurrentScope(),
               const_cast<DeclContext*>(FD->getDeclContext()));
     }
 

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -597,9 +597,6 @@ namespace clad {
     bool isSupported = argType->isArithmeticType();
     if (!isSupported)
       return nullptr;
-    IdentifierInfo* II = &m_Context.Idents.get("forward_central_difference");
-    DeclarationName name(II);
-    DeclarationNameInfo DNInfo(name, noLoc);
     // Build function args.
     llvm::SmallVector<Expr*, 16U> NumDiffArgs;
     NumDiffArgs.push_back(targetFuncCall);
@@ -612,8 +609,9 @@ namespace clad {
                                                             printErrorInf));
     NumDiffArgs.insert(NumDiffArgs.end(), args.begin(), args.begin() + numArgs);
     // Return the found overload.
+    std::string Name = "forward_central_difference";
     return m_Builder.BuildCallToCustomDerivativeOrNumericalDiff(
-        DNInfo, NumDiffArgs, getCurrentScope(), /*OriginalFnDC=*/nullptr,
+        Name, NumDiffArgs, getCurrentScope(), /*OriginalFnDC=*/nullptr,
         /*forCustomDerv=*/false,
         /*namespaceShouldExist=*/false);
   }
@@ -624,9 +622,6 @@ namespace clad {
       llvm::SmallVectorImpl<Expr*>& args,
       llvm::SmallVectorImpl<Expr*>& outputArgs) {
     int printErrorInf = m_Builder.shouldPrintNumDiffErrs();
-    IdentifierInfo* II = &m_Context.Idents.get("central_difference");
-    DeclarationName name(II);
-    DeclarationNameInfo DNInfo(name, noLoc);
     llvm::SmallVector<Expr*, 16U> NumDiffArgs = {};
     NumDiffArgs.push_back(targetFuncCall);
     // build the clad::tape<clad::array_ref>> = {};
@@ -660,8 +655,9 @@ namespace clad {
       NumericalDiffMultiArg.push_back(PushExpr);
       NumDiffArgs.push_back(args[i]);
     }
+    std::string Name = "central_difference";
     return m_Builder.BuildCallToCustomDerivativeOrNumericalDiff(
-        DNInfo, NumDiffArgs, getCurrentScope(), /*OriginalFnDC=*/nullptr,
+        Name, NumDiffArgs, getCurrentScope(), /*OriginalFnDC=*/nullptr,
         /*forCustomDerv=*/false,
         /*namespaceShouldExist=*/false);
   }

--- a/test/Arrays/ArrayInputsForwardMode.C
+++ b/test/Arrays/ArrayInputsForwardMode.C
@@ -18,8 +18,8 @@ double divide(double *arr) {
 }
 
 //CHECK:   double divide_darg0_1(double *arr) {
-//CHECK_NEXT:       return (0 * arr[1] - arr[0] * 1) / (arr[1] * arr[1]);
-//CHECK_NEXT:   }
+//CHECK-NEXT:       return (0 * arr[1] - arr[0] * 1) / (arr[1] * arr[1]);
+//CHECK-NEXT:   }
 
 double addArr(double *arr, int n) {
   double ret = 0;

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang %s -x c++ -lstdc++ -lm -I%S/../../include -oAssignments.out 2>&1 | FileCheck %s
+// RUN: %cladclang -x c++ -lstdc++ -lm -I%S/../../include -oAssignments.out %s 2>&1 | FileCheck %s
 // RUN: ./Assignments.out
-//CHECK-NOT: {{.*error|warning|note:.*}}
+// CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"
 

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -1,5 +1,5 @@
-// RUN: %cladclang %s -x c++ -lstdc++ -lm -I%S/../../include -oCondStmts.out 2>&1 | FileCheck %s
-//CHECK-NOT: {{.*error|warning|note:.*}}
+// RUN: %cladclang -x c++ -lstdc++ -lm -I%S/../../include -oCondStmts.out %s 2>&1 | FileCheck %s
+// CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"
 

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -1,5 +1,5 @@
-// RUN: %cladclang %s -x c++ -lstdc++ -lm -I%S/../../include -oLoopsAndArrays.out 2>&1 | FileCheck %s
-//CHECK-NOT: {{.*error|warning|note:.*}}
+// RUN: %cladclang -x c++ -lstdc++ -lm -I%S/../../include -oLoopsAndArrays.out %s 2>&1 | FileCheck %s
+// CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"
 


### PR DESCRIPTION
This PR fixes several problems with clad's testsuite when ran with clang built in debug mode.