### PR TITLE
Fix issue #322 which takes into -DCLAD_BUILD_STATIC_ONLY=On

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,15 @@ option(CLAD_BUILD_STATIC_ONLY "Does not build shared libraries. Useful when we h
 if (NOT CLAD_BUILD_STATIC_ONLY AND NOT LLVM_ENABLE_PLUGINS)
   message(FATAL_ERROR "LLVM_ENABLE_PLUGINS is set to OFF. Please build clad with -DCLAD_BUILD_STATIC_ONLY=ON.")
 endif()
+
+# Add clad deps if we build together with clang.
+if (TARGET intrinsics_gen)
+  list(APPEND LLVM_COMMON_DEPENDS intrinsics_gen)
+endif()
+if (TARGET clang-headers)
+  list(APPEND LLVM_COMMON_DEPENDS clang-headers)
+endif()
+
 add_subdirectory(lib)
 add_subdirectory(tools)
 
@@ -302,9 +311,3 @@ if( CLAD_BUILT_STANDALONE AND MSVC_VERSION EQUAL 1600 )
     file(APPEND "${CLAD_SLN_FILENAME}" "\n# This should be regenerated!\n")
   endif()
 endif()
-
-# Add clad deps
-if (TARGET clangBasic)
-  add_dependencies(clad clangBasic)
-endif()
-

--- a/demos/ErrorEstimation/CustomModel/CMakeLists.txt
+++ b/demos/ErrorEstimation/CustomModel/CMakeLists.txt
@@ -6,11 +6,6 @@ if (TARGET check-clad)
   add_dependencies(check-clad cladCustomModelPlugin)
 endif()
 
-if (TARGET clangBasic)
-  add_dependencies(cladCustomModelPlugin clangBasic)
-endif()
-
-
 # Sometimes it seems that even if we do not specify -frtti some compilers
 # generate it by default. Then the library requires _ZTIN4clad22FPErrorEstimationModelE
 # but it does not find it and fails to load.

--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -45,7 +45,3 @@ add_llvm_library(cladDifferentiator
   VisitorBase.cpp
   ${version_inc}
   )
-
-if (TARGET clangBasic)
-  add_dependencies(cladDifferentiator clangBasic)
-endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -7,11 +7,6 @@ add_llvm_library(cladPlugin
   DerivedFnInfo.cpp
   RequiredSymbols.cpp
   )
-
-if (TARGET clangBasic)
-  add_dependencies(cladPlugin clangBasic)
-endif()
-
 if (NOT CLAD_BUILD_STATIC_ONLY)
   add_llvm_loadable_module(clad
     ClangPlugin.cpp


### PR DESCRIPTION
We should use the LLVM_COMMON_DEPENDS variable which tells LLVM to insert the dependencies to each subsequent target.

This patch fixes an error we see when embedding in the ROOT project that uses -DCLAD_BUILD_STATIC_ONLY=On and complained about not finding the CMake target clad which is only added in that mode.