### PR TITLE
Provide a fake source location used for instantiations.

### DIFF
--- a/lib/Differentiator/ForwardModeVisitor.cpp
+++ b/lib/Differentiator/ForwardModeVisitor.cpp
@@ -773,9 +773,15 @@ namespace clad {
     } else {
       llvm::SmallVector<Expr*, 2> returnValues = {retValDiff.getExpr(),
                                                   retValDiff.getExpr_dx()};
-      Expr* initList = m_Sema.ActOnInitList(noLoc, returnValues, noLoc).get();
+      SourceLocation fakeInitLoc = utils::GetValidSLoc(m_Sema);
+      // This can instantiate as part of the move or copy initialization and
+      // needs a fake source location.
+      Expr* initList =
+          m_Sema.ActOnInitList(fakeInitLoc, returnValues, noLoc).get();
+
+      SourceLocation fakeRetLoc = utils::GetValidSLoc(m_Sema);
       returnStmt =
-          m_Sema.ActOnReturnStmt(noLoc, initList, getCurrentScope()).get();
+          m_Sema.ActOnReturnStmt(fakeRetLoc, initList, getCurrentScope()).get();
     }
     return StmtDiff(returnStmt);
   }

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3001,8 +3001,10 @@ namespace clad {
           m_Sema.PushOnScopeChains(thisDerivativePVD, getCurrentScope(),
                                    /*AddToContext=*/false);
 
+        // This can instantiate an array_ref and needs a fake source location.
+        SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
         Expr* deref = BuildOp(UnaryOperatorKind::UO_Deref,
-                              BuildDeclRef(thisDerivativePVD));
+                              BuildDeclRef(thisDerivativePVD), fakeLoc);
         m_ThisExprDerivative = utils::BuildParenExpr(m_Sema, deref);
         ++dParamTypesIdx;
       }


### PR DESCRIPTION
Template instantiations rely on valid points of instantiations. The generated code does not have one which makes the template instantiator trigger assertions if clang is build with asserts enabled. This patch fixes the asserts by providing pseudo-valid source locations.