### PR TITLE
fix missing comma in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ matrix. *The caller is responsible for allocating and zeroing-out the jacobian s
 #include "clad/Differentiator/Differentiator.h"
 #include <iostream>
 
-void h(double a, double b double output[]) {
+void h(double a, double b, double output[]) {
     output[0] = a * a * a;
     output[1] = a * a * a + b * b * b;
     output[2] = 2 * (a + b);


### PR DESCRIPTION
Changes I didn't make - but perhaps could.. this example could also benefit from an explicit build recipe, which for me was something like
```
clang -x c++ -std=c++11 -fplugin=../inst/lib64/clad.so -I../inst/include/ -lstdc++ -lm clad_test.cc
```

Relative to recipes in this README, I needed the include path to clads headers and to include libstdc++ and libm in the linking. If those are expected to be required, they should be included in the documentation as well 