### PR TITLE
Add support for Basic Forward Mode Differentiation with Enzyme

### DIFF
--- a/include/clad/Differentiator/ForwardModeVisitor.h
+++ b/include/clad/Differentiator/ForwardModeVisitor.h
@@ -13,6 +13,9 @@
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Sema/Sema.h"
 
+#include "clad/Differentiator/DiffPlanner.h"
+
+
 #include <array>
 #include <stack>
 #include <unordered_map>
@@ -28,6 +31,14 @@ namespace clad {
     unsigned m_IndependentVarIndex = ~0;
     unsigned m_DerivativeOrder = ~0;
     unsigned m_ArgIndex = ~0;
+    DiffInputVarsInfo m_DVI;
+    bool use_enzyme = false;
+
+    // Function to Differentiate with Clad as Backend
+    void DifferentiateWithClad();
+
+    // Function to Differentiate with Enzyme as Backend
+    void DifferentiateWithEnzyme();
     
   public:
     ForwardModeVisitor(DerivativeBuilder& builder);

--- a/test/Enzyme/ForwardMode.C
+++ b/test/Enzyme/ForwardMode.C
@@ -1,17 +1,22 @@
 // RUN: %cladclang %s -lstdc++ -I%S/../../include -oEnzyme.out 2>&1 | FileCheck %s
-// RUN: ./Enzyme.out
+// RUN: ./Enzyme.out | FileCheck -check-prefix=CHECK-EXEC %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 // REQUIRES: Enzyme
-// XFAIL:*
 // Forward mode is not implemented yet
 
 #include "clad/Differentiator/Differentiator.h"
 
-double f(double x, double y) { return x * y; }
+double f(double x, double y) {
+      return x * y; 
+}
 
-// CHECK:     double f_darg0_enzyme(double x, double y) {
-// CHECK-NEXT:}
+// CHECK: double f_darg0_enzyme(double x, double y) {
+// CHECK-NEXT:     double diff = __enzyme_fwddiff_f_x(f, x, 1., y, 0.);
+// CHECK-NEXT:     return diff;
+// CHECK-NEXT: }
 
 int main(){
      auto f_dx = clad::differentiate<clad::opts::use_enzyme>(f, "x");
+     double ans = f_dx.execute(3,4);
+     printf("Ans = %.2f\n",ans); // CHECK-EXEC: Ans = 4.00
 }


### PR DESCRIPTION
This commit adds support for differentiation of a function of type:
```cpp
double func(double x, double y){
	return x*y;
}
```