### PR TITLE
 Fix reverse mode computation by adding missing gradient update during loop initialization.

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1093,6 +1093,7 @@ namespace clad {
     addToCurrentBlock(Forward, direction::forward);
     Forward = endBlock(direction::forward);
     addToCurrentBlock(loopCounter.getPop(), direction::reverse);
+    addToCurrentBlock(initResult.getStmt_dx(), direction::reverse);
     addToCurrentBlock(Reverse, direction::reverse);
     Reverse = endBlock(direction::reverse);
     endScope();

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -113,6 +113,7 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:                 _delta_sum += std::abs(_r_d0 * _r2 * {{.+}});
 //CHECK-NEXT:                 _d_sum -= _r_d0;
 //CHECK-NEXT:             }
+//CHECK-NEXT:             _d_j = 0;
 //CHECK-NEXT:             clad::pop(_t1);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }


### PR DESCRIPTION
This commit fixes gradient computation when fxn parameters are also used in the for-loop conditions. It does so by adding the gradient update statement for the initialisation statement in the for-loop.

Closes #474 