### PR TITLE
Fix for missing nested namespace identifier while declaring variables

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -76,6 +76,25 @@ namespace clad {
     void BuildNNS(clang::Sema& semaRef, clang::DeclContext* DC,
                   clang::CXXScopeSpec& CSS, bool addGlobalNS = false);
 
+    /// Add the namespace specifier to the type if it is not already an elaborated type.
+    /// For example, if the type is `SomeClass` and it is declared in namespace `A::B`,
+    /// as:
+    /// ```
+    /// namespace A {
+    ///  namespace B {
+    ///    struct SomeClass {};
+    ///  }
+    /// }
+    /// ```
+    /// then the function will return `A::B::SomeClass`.
+    /// If the type is already an elaborated type, then it is returned as is.
+    ///
+    /// \param semaRef
+    /// \param[in] C
+    /// \param[in] QT
+    /// \returns  type with namespace specifier added.
+    clang::QualType AddNamespaceSpecifier(clang::Sema& semaRef, clang::ASTContext& C, clang::QualType QT);
+
     /// Finds declaration context associated with the DC1::DC2.
     /// For example, consider DC1 corresponds to the following declaration
     /// context:

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -153,6 +153,20 @@ namespace clad {
       }
     }
 
+    // Adds a namespace specifier to the given type if the type is not already an elaborated type.
+    clang::QualType AddNamespaceSpecifier(clang::Sema& semaRef, clang::ASTContext &C, clang::QualType QT) {
+      auto typePtr = QT.getTypePtr();
+      if (typePtr->isRecordType() && !typePtr->getAs<clang::ElaboratedType>()) {
+        CXXScopeSpec CSS;
+        clang::CXXRecordDecl const* recordDecl = typePtr->getAsCXXRecordDecl();
+        clang::DeclContext const* declContext = static_cast<clang::DeclContext const*>(recordDecl);
+        utils::BuildNNS(semaRef, const_cast<clang::DeclContext*>(declContext), CSS);
+        NestedNameSpecifier* NS = CSS.getScopeRep();
+        return C.getElaboratedType(ETK_None, NS->getPrefix(), QT);
+      }
+      return QT;
+    }
+
     DeclContext* FindDeclContext(clang::Sema& semaRef, clang::DeclContext* DC1,
                                  clang::DeclContext* DC2) {
       // llvm::errs()<<"DC1 name: "<<DC1->getDeclKindName()<<"\n";

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -11,6 +11,7 @@
 #include "clad/Differentiator/DiffPlanner.h"
 #include "clad/Differentiator/ErrorEstimator.h"
 #include "clad/Differentiator/StmtClone.h"
+#include "clad/Differentiator/CladUtils.h"
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Expr.h"
@@ -63,6 +64,8 @@ namespace clad {
                                      TypeSourceInfo* TSI,
                                      VarDecl::InitializationStyle IS) {
 
+    // add namespace specifier in variable declaration if needed.
+    Type = utils::AddNamespaceSpecifier(m_Sema, m_Context, Type);
     auto VD =
         VarDecl::Create(m_Context, m_Sema.CurContext, m_Function->getLocation(),
                         m_Function->getLocation(), Identifier, Type, TSI,

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -13,7 +13,7 @@ float f1(float x) {
 
 // CHECK: float f1_darg0(float x) {
 // CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
@@ -23,7 +23,7 @@ float f2(float x) {
 
 // CHECK: float f2_darg0(float x) {
 // CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, _d_x);
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, _d_x);
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
@@ -34,16 +34,16 @@ float f3(float x, float y) {
 // CHECK: float f3_darg0(float x, float y) {
 // CHECK-NEXT:     float _d_x = 1;
 // CHECK-NEXT:     float _d_y = 0;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y, _d_y);
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y, _d_y);
 // CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
 // CHECK-NEXT: }
 
 // CHECK: float f3_darg1(float x, float y) {
 // CHECK-NEXT:     float _d_x = 0;
 // CHECK-NEXT:     float _d_y = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y, _d_y);
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y, _d_y);
 // CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
 // CHECK-NEXT: }
 
@@ -54,16 +54,16 @@ float f4(float x, float y) {
 // CHECK: float f4_darg0(float x, float y) {
 // CHECK-NEXT:     float _d_x = 1;
 // CHECK-NEXT:     float _d_y = 0;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x * x, _d_x * x + x * _d_x);
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y * y, _d_y * y + y * _d_y);
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x * x, _d_x * x + x * _d_x);
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y * y, _d_y * y + y * _d_y);
 // CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
 // CHECK-NEXT: }
 
 // CHECK: float f4_darg1(float x, float y) {
 // CHECK-NEXT:     float _d_x = 0;
 // CHECK-NEXT:     float _d_y = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x * x, _d_x * x + x * _d_x);
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y * y, _d_y * y + y * _d_y);
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x * x, _d_x * x + x * _d_x);
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(y * y, _d_y * y + y * _d_y);
 // CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
 // CHECK-NEXT: }
 
@@ -73,7 +73,7 @@ float f5(float x) {
 
 // CHECK: float f5_darg0(float x) {
 // CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, _d_x);
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, _d_x);
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
@@ -83,7 +83,7 @@ float f6(float x) {
 
 // CHECK: float f6_darg0(float x) {
 // CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x * x, _d_x * x + x * _d_x);
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x * x, _d_x * x + x * _d_x);
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
@@ -93,7 +93,7 @@ float f7(float x) {
 
 // CHECK: float f7_darg0(float x) {
 // CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), double())), decltype(::std::pow(float(), double()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 2., _d_x, 0.);
+// CHECK-NEXT:     clad::ValueAndPushforward<decltype(::std::pow(float(), double())), decltype(::std::pow(float(), double()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 2., _d_x, 0.);
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
@@ -121,7 +121,7 @@ double f8(float x) {
 
 // CHECK: double f8_darg0(float x) {
 // CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), int())), decltype(::std::pow(float(), int()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 2, _d_x, 0);
+// CHECK-NEXT:     clad::ValueAndPushforward<decltype(::std::pow(float(), int())), decltype(::std::pow(float(), int()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 2, _d_x, 0);
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
@@ -150,7 +150,7 @@ float f9(float x, float y) {
 // CHECK: float f9_darg0(float x, float y) {
 // CHECK-NEXT:     float _d_x = 1;
 // CHECK-NEXT:     float _d_y = 0;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     clad::ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x, _d_y);
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
@@ -182,7 +182,7 @@ double f10(float x, int y) {
 // CHECK: double f10_darg0(float x, int y) {
 // CHECK-NEXT:     float _d_x = 1;
 // CHECK-NEXT:     int _d_y = 0;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), int())), decltype(::std::pow(float(), int()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     clad::ValueAndPushforward<decltype(::std::pow(float(), int())), decltype(::std::pow(float(), int()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x, _d_y);
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
@@ -252,7 +252,7 @@ double f12(double a, double b) { return std::fma(a, b, b); }
 //CHECK: double f12_darg1(double a, double b) {
 //CHECK-NEXT:     double _d_a = 0;
 //CHECK-NEXT:     double _d_b = 1;
-//CHECK-NEXT:     ValueAndPushforward<decltype(::std::fma(double(), double(), double())), decltype(::std::fma(double(), double(), double()))> _t0 = clad::custom_derivatives::fma_pushforward(a, b, b, _d_a, _d_b, _d_b);
+//CHECK-NEXT:     clad::ValueAndPushforward<decltype(::std::fma(double(), double(), double())), decltype(::std::fma(double(), double(), double()))> _t0 = clad::custom_derivatives::fma_pushforward(a, b, b, _d_a, _d_b, _d_b);
 //CHECK-NEXT:     return _t0.pushforward;
 //CHECK-NEXT: }
 

--- a/test/FirstDerivative/FunctionCalls.C
+++ b/test/FirstDerivative/FunctionCalls.C
@@ -4,7 +4,7 @@
 
 #include "clad/Differentiator/Differentiator.h"
 
-#include <math.h>
+#include <cmath>
 
 int printf(const char* fmt, ...);
 int no_body(int x);
@@ -106,11 +106,25 @@ float test_5(int x) {
 // CHECK-NEXT: return _t0.pushforward;
 // CHECK-NEXT: }
 
+float test_6(float x, float y) {
+  return std::sin(x) + std::cos(y);
+}
+
+// CHECK: float test_6_darg0(float x, float y) {
+// CHECK-NEXT: float _d_x = 1;
+// CHECK-NEXT: float _d_y = 0;
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::cos_pushforward(y, _d_y);
+// CHECK-NEXT: return _t0.pushforward + _t1.pushforward;
+// CHECK-NEXT: }
+
+
 int main () {
   clad::differentiate(test_1, 0);
   clad::differentiate(test_2, 0);
   clad::differentiate(test_3, 0); //expected-error {{Invalid argument index '0' of '0' argument(s)}}
   clad::differentiate(test_4, 0);
   clad::differentiate(test_5, 0);
+  clad::differentiate(test_6, "x");
   return 0;
 }


### PR DESCRIPTION
Add the missing nested namespace identifier from the code generated in forward mode using custom derivatives.

closes #521 