### PR TITLE
fix: use clang++ in compilation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,36 +211,27 @@ mamba create -n xeus-clad -c conda-forge clad xeus-cling jupyterlab
 conda activate xeus-clad
 ```
 
-Next, running ```jupyter notebook``` will show 3 new kernels for `C++ 11/14/17` with Clad attached. 
+Next, running `jupyter notebook` will show 3 new kernels for `C++ 11/14/17` with Clad attached.
 
 Try out a Clad [tutorial](https://compiler-research.org/tutorials/clad_jupyter/) interactively in your browser through binder: 
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/vgvassilev/clad/master?labpath=%2Fdemos%2FJupyter%2FIntro.ipynb)
 
 #### Using as a plugin for Clang
-Since Clad is a Clang plugin, it must be properly attached when Clang compiler is invoked. First, the plugin must be built to get `libclad.so` (or `.dylib`). To compile `SourceFile.cpp` with Clad enabled use:
-```
-clang -cc1 -x c++ -std=c++11 -load /full/path/to/lib/clad.so -plugin clad SourceFile.cpp
-```
+Since Clad is a Clang plugin, it must be properly attached when Clang compiler is invoked. First, the plugin must be built to get `libclad.so` (or `.dylib`).
 
-To compile using clang-9, use: 
-```
-clang-9 -I /full/path/to/include/  -x c++ -std=c++11 -fplugin=/full/path/to/lib/clad.so SourceFile.cpp -o sourcefile -lstdc++ -lm
-```
+To compile `SourceFile.cpp` with Clad enabled, use the following commands:
 
-To save the Clad generated derivative code to `Derivatives.cpp` add:
-```
--Xclang -plugin-arg-clad -Xclang -fgenerate-source-file
-```
+- Clang++: `clang++ -std=c++11 -I /full/path/to/include/ -fplugin=/full/path/to/lib/clad.so Sourcefile.cpp`
+- Clang: `clang -x c++ -std=c++11 -I /full/path/to/include/ -fplugin=/full/path/to/lib/clad.so SourceFile.cpp -lstdc++ -lm`
 
-To print the Clad generated derivative add:
-```
--Xclang -plugin-arg-clad -Xclang -fdump-derived-fn
-```
+Clad also provides certain flags to save and print the generated derivative code:
+
+- To save the Clad generated derivative code to `Derivatives.cpp`: `-Xclang -plugin-arg-clad -Xclang -fgenerate-source-file`
+- To print the Clad generated derivative: `-Xclang -plugin-arg-clad -Xclang -fdump-derived-fn`
 
 ## How to install
-At the moment, LLVM/Clang 5.0.x - 15.0.6 are supported.
-
+At the moment, LLVM/Clang 5.0.x - 15.0.7 are supported.
 
 ### Conda Installation
 
@@ -264,9 +255,12 @@ sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 sudo -H pip install lit
 git clone https://github.com/vgvassilev/clad.git clad
 mkdir build_dir inst; cd build_dir
-cmake ../clad -DClang_DIR=/usr/lib/llvm-11 -DLLVM_DIR=/usr/lib/llvm-11 -DCMAKE_INSTALL_PREFIX=../inst -DLLVM_EXTERNAL_LIT="``which lit``"
+cmake ../clad -DClang_DIR=/usr/lib/llvm-11 -DLLVM_DIR=/usr/lib/llvm-11 -DCMAKE_INSTALL_PREFIX=../inst -DLLVM_EXTERNAL_LIT="$(which lit)"
 make && make install
 ```
+
+> **NOTE**: On some Linux distributions (e.g. Arch Linux), the LLVM and Clang libraries are installed at `/usr/lib/cmake/llvm` and `/usr/lib/cmake/clang`. If compilation fails with the above provided command, ensure that you are using the correct path to the libraries.
+
 ###  Building from source (example was tested on macOS Big Sur 11.6)
 ```
 brew install llvm@12

--- a/demos/Arrays.cpp
+++ b/demos/Arrays.cpp
@@ -8,11 +8,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -std=c++11 Gradient.cpp
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -std=c++11 Gradient.cpp
 

--- a/demos/BasicUsage.cpp
+++ b/demos/BasicUsage.cpp
@@ -7,11 +7,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -std=c++11 BasicUsage.cpp
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -std=c++11 BasicUsage.cpp
 

--- a/demos/ComputerGraphics/smallpt/SmallPT.cpp
+++ b/demos/ComputerGraphics/smallpt/SmallPT.cpp
@@ -8,7 +8,7 @@
 //----------------------------------------------------------------------------//
 
 // To compile the demo please type:
-// path/to/clang -O3 -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++ -O3 -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so -I../../include/ -x c++ -std=c++11 -lstdc++ -lm SmallPT.cpp \
 // -fopenmp=libiomp5 -o SmallPT
 //
@@ -16,7 +16,7 @@
 // ./SmallPT 500 && xv image.ppm
 
 // A typical invocation would be:
-// ../../../../../obj/Debug+Asserts/bin/clang -O3 -Xclang -add-plugin -Xclang clad \
+// ../../../../../obj/Debug+Asserts/bin/clang++ -O3 -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../../obj/Debug+Asserts/lib/libclad.dylib \
 // -I../../include/ -x c++ -std=c++11 -lstdc++ -lm SmallPT.cpp -fopenmp=libiomp5 -o SmallPT
 // ./SmallPT 500 && xv image.ppm

--- a/demos/ControlFlow.cpp
+++ b/demos/ControlFlow.cpp
@@ -8,11 +8,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -std=c++11 ControlFlow.C
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -std=c++11 ControlFlow.C
 

--- a/demos/CustomTypeNumDiff.cpp
+++ b/demos/CustomTypeNumDiff.cpp
@@ -8,11 +8,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -std=c++11 CustomTypeNumDiff.cpp
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -std=c++11 CustomTypeNumDiff.cpp
 

--- a/demos/DebuggingClad.cpp
+++ b/demos/DebuggingClad.cpp
@@ -7,11 +7,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -std=c++11 DebuggingClad.cpp
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -std=c++11 DebuggingClad.cpp
 

--- a/demos/ErrorEstimation/CustomModel/README.md
+++ b/demos/ErrorEstimation/CustomModel/README.md
@@ -15,21 +15,19 @@ After building the code as specified in the [README.md](https://github.com/vgvas
 $ export CLAD_INST=$PWD/../inst;
 $ export CLAD_BASE=$PWD/../clad;
 ```
----
-**TIP:**
-You can put the above lines in your ~/.bashrc or equivalent shell "rc" file to maintain the same variables across multiple sessions.
----
+
+> **TIP**: You can put the above lines in your ~/.bashrc or equivalent shell "rc" file to maintain the same variables across multiple sessions.
 
 Now, in a terminal, run the following:
 
 ```bash
-$ clang -ICLAD_INST/include -fPIC -shared -fno-rtti -Wl,-undefined -Wl,suppress CLAD_BASE/demos/CustomModel/CustomModel.cpp -o libCustomModel.so
+$ clang++ -ICLAD_INST/include -fPIC -shared -fno-rtti -Wl,-undefined -Wl,suppress CLAD_BASE/demos/CustomModel/CustomModel.cpp -o libCustomModel.so
 ``` 
- The above should create a ```libCustomModel.so``` in the same directory you executed that command in. Once the shared object is created, we are ready to run it with clad.
+ The above should create a `libCustomModel.so` in the same directory you executed that command in. Once the shared object is created, we are ready to run it with clad.
 
 ## Running the demo
 
-Now, to use your custom estimation model, you can just specify the ```.so``` created in the previous section as an input to clad via CLI. The specific parameters you would need to add are given below:
+Now, to use your custom estimation model, you can just specify the `.so` created in the previous section as an input to clad via CLI. The specific parameters you would need to add are given below:
 
 ```bash
 -Xclang -plugin-arg-clad -Xclang -fcustom-estimation-model -Xclang -plugin-arg-clad -Xclang ./libCustomModel.so
@@ -37,11 +35,11 @@ Now, to use your custom estimation model, you can just specify the ```.so``` cre
 So a typical invocation to clad would then look like the following:
 
 ```bash
-clang -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang CLAD_INST/lib/clad.so -ICLAD_INST/include -x c++ -lstdc++ -Xclang -plugin-arg-clad -Xclang -fcustom-estimation-model -Xclang -plugin-arg-clad -Xclang ./libCustomModel.so CLAD_BASE/demos/CustomModel/test.cpp
+clang++ -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang CLAD_INST/lib/clad.so -ICLAD_INST/include -x c++ -lstdc++ -Xclang -plugin-arg-clad -Xclang -fcustom-estimation-model -Xclang -plugin-arg-clad -Xclang ./libCustomModel.so CLAD_BASE/demos/CustomModel/test.cpp
 ```
 ## Verifying results
 
-To verify your results, you can build the dummy ```test.cpp``` file with the commands shown above. Once you compile and run the test file correctly, you will notice the generated code is as follows:
+To verify your results, you can build the dummy `test.cpp` file with the commands shown above. Once you compile and run the test file correctly, you will notice the generated code is as follows:
 
 ```cpp
 The code is: void func_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
@@ -72,6 +70,6 @@ The code is: void func_grad(float x, float y, clad::array_ref<float> _d_x, clad:
 }
 ```
 
-Here, notice that the result in the ```_delta_z``` variable  now reflects the error expression defined in the custom model we just compiled!
+Here, notice that the result in the `_delta_z` variable  now reflects the error expression defined in the custom model we just compiled!
 
-This demo is also a runnable test under ```CLAD_BASE/test/Misc/RunDemos.C``` and will run as a part of the lit test suite. Thus, the same can be verified by running ```make check-clad```.
+This demo is also a runnable test under `CLAD_BASE/test/Misc/RunDemos.C` and will run as a part of the lit test suite. Thus, the same can be verified by running `make check-clad`.

--- a/demos/ErrorEstimation/FloatSum.cpp
+++ b/demos/ErrorEstimation/FloatSum.cpp
@@ -7,11 +7,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -std=c++11 FloatSum.cpp
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -std=c++11 FloatSum.cpp
 //

--- a/demos/ErrorEstimation/PrintModel/README.md
+++ b/demos/ErrorEstimation/PrintModel/README.md
@@ -15,21 +15,18 @@ After building the code as specified in the [README.md](https://github.com/vgvas
 $ export CLAD_INST=$PWD/../inst;
 $ export CLAD_BASE=$PWD/../clad;
 ```
----
-**TIP:**
-You can put the above lines in your ~/.bashrc or equivalent shell "rc" file to maintain the same variables across multiple sessions.
----
+> **TIP**: You can put the above lines in your ~/.bashrc or equivalent shell "rc" file to maintain the same variables across multiple sessions.
 
 Now, in a terminal, run the following:
 
 ```bash
-$ clang -ICLAD_INST/include -fPIC -shared -fno-rtti -Wl,-undefined -Wl,suppress CLAD_BASE/demos/PrintModel/PrintModel.cpp -o libPrintModel.so
+$ clang++ -ICLAD_INST/include -fPIC -shared -fno-rtti -Wl,-undefined -Wl,suppress CLAD_BASE/demos/PrintModel/PrintModel.cpp -o libPrintModel.so
 ``` 
- The above should create a ```libPrintModel.so``` in the same directory you executed that command in. Once the shared object is created, we are ready to run it with clad.
+ The above should create a `libPrintModel.so` in the same directory you executed that command in. Once the shared object is created, we are ready to run it with clad.
 
 ## Running the demo
 
-Now, to use your custom estimation model, you can just specify the ```.so``` created in the previous section as an input to clad via CLI. The specific parameters you would need to add are given below:
+Now, to use your custom estimation model, you can just specify the `.so` created in the previous section as an input to clad via CLI. The specific parameters you would need to add are given below:
 
 ```bash
 -Xclang -plugin-arg-clad -Xclang -fcustom-estimation-model -Xclang -plugin-arg-clad -Xclang ./libPrintModel.so
@@ -41,7 +38,7 @@ clang -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang CLAD_INST/lib/clad.
 ```
 ## Verifying results
 
-To verify your results, you can build the dummy ```test.cpp``` file with the commands shown above. Once you compile and run the test file correctly, you will notice the generated code is as follows:
+To verify your results, you can build the dummy `test.cpp` file with the commands shown above. Once you compile and run the test file correctly, you will notice the generated code is as follows:
 
 ```cpp
 The code is: void func_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y, double &_final_error) {
@@ -72,6 +69,6 @@ The code is: void func_grad(float x, float y, clad::array_ref<float> _d_x, clad:
 }
 ```
 
-Here, notice that the result in the ```_delta_z``` variable  now reflects the error expression defined in the custom model we just compiled!
+Here, notice that the result in the `_delta_z` variable  now reflects the error expression defined in the custom model we just compiled!
 
-This demo is also a runnable test under ```CLAD_BASE/test/Misc/RunDemos.C``` and will run as a part of the lit test suite. Thus, the same can be verified by running ```make check-clad```.
+This demo is also a runnable test under `CLAD_BASE/test/Misc/RunDemos.C` and will run as a part of the lit test suite. Thus, the same can be verified by running `make check-clad`.

--- a/demos/Functor.cpp
+++ b/demos/Functor.cpp
@@ -7,11 +7,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -std=c++11 Functor.cpp
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -std=c++11 Functor.cpp
 

--- a/demos/Gradient.cpp
+++ b/demos/Gradient.cpp
@@ -8,11 +8,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -std=c++11 Gradient.cpp
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -std=c++11 Gradient.cpp
 

--- a/demos/GradientDescent.cpp
+++ b/demos/GradientDescent.cpp
@@ -8,11 +8,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -lstdc++ -lm GradientDescent.cpp
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -lstdc++ -lm GradientDescent.cpp
 //

--- a/demos/Hessian.cpp
+++ b/demos/Hessian.cpp
@@ -8,11 +8,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -std=c++11 Hessian.cpp
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -std=c++11 Hessian.cpp
 

--- a/demos/ODESolverSensitivity.cpp
+++ b/demos/ODESolverSensitivity.cpp
@@ -11,11 +11,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -lstdc++ -lm ODESolverSensitivity.cpp
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -lstdc++ -lm ODESolverSensitivity.cpp
 //

--- a/demos/OpenCL/RosenbrockFunction.cpp
+++ b/demos/OpenCL/RosenbrockFunction.cpp
@@ -7,11 +7,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -framework opencl -x c++ -std=c++11 RosenbrockFunction.cpp
 //
 // A typical invocation would be:
-// ../../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../../include/ -framework opencl -x c++ -std=c++11 RosenbrockFunction.cpp
 

--- a/demos/RosenbrockFunction.cpp
+++ b/demos/RosenbrockFunction.cpp
@@ -7,11 +7,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -std=c++11 RosenbrockFunction.cpp
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -std=c++11 RosenbrockFunction.cpp
 

--- a/demos/Templates.cpp
+++ b/demos/Templates.cpp
@@ -7,11 +7,11 @@
 //----------------------------------------------------------------------------//
 
 // To run the demo please type:
-// path/to/clang  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
+// path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
 // path/to/libclad.so  -I../include/ -x c++ -std=c++11 Templates.cpp
 //
 // A typical invocation would be:
-// ../../../../obj/Debug+Asserts/bin/clang  -Xclang -add-plugin -Xclang clad \
+// ../../../../obj/Debug+Asserts/bin/clang++  -Xclang -add-plugin -Xclang clad \
 // -Xclang -load -Xclang ../../../../obj/Debug+Asserts/lib/libclad.dylib     \
 // -I../include/ -x c++ -std=c++11 Templates.cpp
 


### PR DESCRIPTION
`clang` does not link the C++ standard libraries by default, causing it to fail on C++ files. Using `clang++` fixes this issue. The READMEs and examples in the `/demos` directory have been changed accordingly. There are also a couple of minor formatting fixes.

Edit: Fixes #530 