### PR TITLE
Fix isUnusedResult to work with clad::array

### DIFF
--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -39,8 +39,8 @@ namespace clad {
     const Expr* ignoreExpr;
     SourceLocation ignoreLoc;
     SourceRange ignoreRange;
-    if(auto array = dyn_cast<clad::array>(E))
-    	return false;
+    if (auto array = dyn_cast<ArraySubscriptExpr>(E))
+    	return !array->getBase()->isLValue();
     return E->isUnusedResultAWarning(
         ignoreExpr, ignoreLoc, ignoreRange, ignoreRange, m_Context);
   }

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -39,6 +39,8 @@ namespace clad {
     const Expr* ignoreExpr;
     SourceLocation ignoreLoc;
     SourceRange ignoreRange;
+    if(auto array = dyn_cast<clad::array>(E))
+    	return false;
     return E->isUnusedResultAWarning(
         ignoreExpr, ignoreLoc, ignoreRange, ignoreRange, m_Context);
   }


### PR DESCRIPTION
Fixes #350 

This pull request addresses an issue with the isUnusedResult function in CLAD, which currently does not correctly identify unused results for clad::array expressions. 

To fix this issue , I have made some minor changes to the isUnusedResult function from  the clad/Differentiator/VisitorBase.cpp file which explicity checks whether the passed  expression is an instance of 'clad::array'.