### PR TITLE
Fix failure on 32-bit machines due to ambigious cast.

### DIFF
--- a/include/clad/Differentiator/Array.h
+++ b/include/clad/Differentiator/Array.h
@@ -54,7 +54,7 @@ public:
   CUDA_HOST_DEVICE T* ptr() { return m_arr; }
   /// Returns the reference to the location at the index of the underlying
   /// array
-  CUDA_HOST_DEVICE T& operator[](std::size_t i) { return m_arr[i]; }
+  CUDA_HOST_DEVICE T& operator[](std::ptrdiff_t i) { return m_arr[i]; }
   /// Returns the reference to the underlying array
   CUDA_HOST_DEVICE T& operator*() { return *m_arr; }
 


### PR DESCRIPTION
Using `clad::array`'s `[]` operator causes an ambiguity error on 32-bit machines when using a non-`std::size_t` type as the subscript expression. This happens because `clad::array` can be implicitly cast to `double*` through the overloaded dereference operator. Changing the subscript expression type in `clad::array` to `std::ptrdiff_t` solves this issue.