### PR TITLE
Fixes for overloaded arithmetic operations on clad::array

### DIFF
--- a/include/clad/Differentiator/Array.h
+++ b/include/clad/Differentiator/Array.h
@@ -173,31 +173,35 @@ public:
     return *this;
   }
   /// Performs element wise addition
-  CUDA_HOST_DEVICE array<T>& operator+=(array<T>& arr) {
+  template <typename U>
+  CUDA_HOST_DEVICE array<T>& operator+=(array<U>& arr) {
     assert(arr.size() == m_size);
     for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] += arr[i];
+      m_arr[i] += static_cast<T>(arr[i]);
     return *this;
   }
   /// Performs element wise subtraction
-  CUDA_HOST_DEVICE array<T>& operator-=(array<T>& arr) {
+  template <typename U>
+  CUDA_HOST_DEVICE array<T>& operator-=(array<U>& arr) {
     assert(arr.size() == m_size);
     for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] -= arr[i];
+      m_arr[i] -= static_cast<T>(arr[i]);
     return *this;
   }
   /// Performs element wise multiplication
-  CUDA_HOST_DEVICE array<T>& operator*=(array<T>& arr) {
+  template <typename U>
+  CUDA_HOST_DEVICE array<T>& operator*=(array<U>& arr) {
     assert(arr.size() == m_size);
     for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] *= arr[i];
+      m_arr[i] *= static_cast<T>(arr[i]);
     return *this;
   }
   /// Performs element wise division
-  CUDA_HOST_DEVICE array<T>& operator/=(array<T>& arr) {
+  template <typename U>
+  CUDA_HOST_DEVICE array<T>& operator/=(array<U>& arr) {
     assert(arr.size() == m_size);
     for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] /= arr[i];
+      m_arr[i] /= static_cast<T>(arr[i]);
     return *this;
   }
   /// Implicitly converts from clad::array to pointer to an array of type T

--- a/include/clad/Differentiator/Array.h
+++ b/include/clad/Differentiator/Array.h
@@ -60,25 +60,33 @@ public:
 
   // Arithmetic overloads
   /// Divides the number from every element in the array
-  CUDA_HOST_DEVICE array<T>& operator/=(T n) {
+  template <typename U, typename std::enable_if<std::is_arithmetic<U>::value,
+                                                int>::type = 0>
+  CUDA_HOST_DEVICE array<T>& operator/=(U n) {
     for (std::size_t i = 0; i < m_size; i++)
       m_arr[i] /= n;
     return *this;
   }
   /// Multiplies the number to every element in the array
-  CUDA_HOST_DEVICE array<T>& operator*=(T n) {
+  template <typename U, typename std::enable_if<std::is_arithmetic<U>::value,
+                                                int>::type = 0>
+  CUDA_HOST_DEVICE array<T>& operator*=(U n) {
     for (std::size_t i = 0; i < m_size; i++)
       m_arr[i] *= n;
     return *this;
   }
   /// Adds the number to every element in the array
-  CUDA_HOST_DEVICE array<T>& operator+=(T n) {
+  template <typename U, typename std::enable_if<std::is_arithmetic<U>::value,
+                                                int>::type = 0>
+  CUDA_HOST_DEVICE array<T>& operator+=(U n) {
     for (std::size_t i = 0; i < m_size; i++)
       m_arr[i] += n;
     return *this;
   }
   /// Subtracts the number from every element in the array
-  CUDA_HOST_DEVICE array<T>& operator-=(T n) {
+  template <typename U, typename std::enable_if<std::is_arithmetic<U>::value,
+                                                int>::type = 0>
+  CUDA_HOST_DEVICE array<T>& operator-=(U n) {
     for (std::size_t i = 0; i < m_size; i++)
       m_arr[i] -= n;
     return *this;

--- a/test/Misc/CladArray.C
+++ b/test/Misc/CladArray.C
@@ -7,12 +7,14 @@
 int main() {
   clad::array<int> test_arr(3);
   clad::array<int> clad_arr(3);
+  clad::array<double> double_test_arr(3);
   int arr[] = {2, 2, 2};
   clad::array_ref<int> arr_ref(arr, 3);
 
   for (int i = 0; i < 3; i++) {
     test_arr[i] = 0;
     clad_arr[i] = i + 1;
+    double_test_arr[i] = 0;
   }
 
   for (int i = 0; i < 3; i++) {
@@ -143,4 +145,20 @@ int main() {
   //CHECK-EXEC: 0 : 2
   //CHECK-EXEC: 1 : 2
   //CHECK-EXEC: 2 : 2
+
+  double_test_arr += 0;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %.2f\n", i, double_test_arr[i]);
+  }
+  //CHECK-EXEC: 0 : 0.00
+  //CHECK-EXEC: 1 : 0.00
+  //CHECK-EXEC: 2 : 0.00
+
+  double_test_arr += test_arr;
+  for (int i = 0; i < 3; i++) {
+    printf("%d : %.2f\n", i, double_test_arr[i]);
+  }
+  // CHECK-EXEC: 0 : 2.00
+  // CHECK-EXEC: 1 : 2.00
+  // CHECK-EXEC: 2 : 2.00
 }


### PR DESCRIPTION
A minimal example which failed earlier:
```cpp
clad::array<double> arr(5UL);
arr += 0;
```
This resulted in: 
```sh
error: use of overloaded operator '+=' is ambiguous (with operand types 'clad::array<double>' and 'int')
```