### PR TITLE
Vector initialization improvements for vector forward mode AD

### DIFF
--- a/include/clad/Differentiator/Array.h
+++ b/include/clad/Differentiator/Array.h
@@ -41,6 +41,17 @@ public:
 
   CUDA_HOST_DEVICE array(const array<T>& arr) : array(arr.m_arr, arr.m_size) {}
 
+  CUDA_HOST_DEVICE array(std::size_t size, const clad::array<T>& arr)
+      : m_arr(new T[size]{static_cast<T>(T())}), m_size(size) {
+    for (std::size_t i = 0; i < size; ++i)
+      m_arr[i] = arr[i];
+  }
+
+  // initializing all entries using the same value
+  template <typename U>
+  CUDA_HOST_DEVICE array(std::size_t size, U val)
+      : m_arr(new T[size]{static_cast<T>(val)}), m_size(size) {}
+
   CUDA_HOST_DEVICE array(std::initializer_list<T> arr)
       : m_arr(new T[arr.size()]{static_cast<T>(T())}), m_size(arr.size()) {
     std::size_t i = 0;


### PR DESCRIPTION
Improved initialization of vectors while differentiating variable declarations and added test cases to demonstrate vector mode support for programs with loops.

New ways of initializing `clad::array` is added by passing `(size, expression...)`. 
This is done to allow initializing the array by all constant values or expressions which evaluate to a single value; 
- for ex: `clad::array<double> arr(5UL, 1)` can be used to initialize a vector of size 5 with all entries as 1.  