### PR TITLE
Fix version and permissions for clang-tidy-review-post workflow

### DIFF
--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+permissions:
+  checks: write
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -17,7 +21,7 @@ jobs:
     steps:
       - name: Post review comments
         id: post-review
-        uses: ZedThree/clang-tidy-review/post@v0.12.0
+        uses: ZedThree/clang-tidy-review/post@v0.13.1
         with:
           max_comments: 10
 


### PR DESCRIPTION
The earlier version had an error fetching the PR number and working with forks. Also, permissions needed to be set correctly. This is why the action on one of the PR failed: https://github.com/vgvassilev/clad/actions/runs/5506327012, although clang-tidy reported some warnings.

I took reference from this issue of the github action we are using: https://github.com/ZedThree/clang-tidy-review/issues/82.