### PR TITLE
Improve AD function interfaces with bitmasked options

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -42,3 +42,5 @@ CheckOptions:
     value:           aNy_CasE
   - key:             readability-identifier-naming.IgnoreMainLikeFunctions
     value:           1
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           1

--- a/docs/userDocs/source/user/UsingClad.rst
+++ b/docs/userDocs/source/user/UsingClad.rst
@@ -115,6 +115,14 @@ differentiation. The following examples demonstrate computation of higher-order 
 
 .. note::
 
+   For derivative orders upto 3, clad has specially defined enums that can be used
+   instead of the integer template parameter. For example, the following code is
+   equivalent to the code shown above::
+
+      auto d_fn_3 = clad::differentiate<clad::order::third>(fn, "i");
+
+.. note::
+
    Forward mode AD can only be used to differentiate with respect to a single 
    value. For differentiating with respect to multiple values (parameters), 
    reverse-mode AD must be used..

--- a/docs/userDocs/source/user/UsingEnzymeWithinClad.rst
+++ b/docs/userDocs/source/user/UsingEnzymeWithinClad.rst
@@ -1,52 +1,75 @@
 Using Enzyme within Clad
 *************************
 
-Like Clad, `Enzyme <https://enzyme.mit.edu/>`_ is also a library for Automatic Differentiation(AD). A major difference is that, Enzyme works at the LLVM Intermediate Representation(IR) level, while Clad works at the Clang Abstract Syntax Tree(AST) level.
-Clad analyses the Clang AST to generate the derivative of a function, while Enzyme analyses the LLVM IR of a function to generate the derivative of the same.
+Like Clad, `Enzyme <https://enzyme.mit.edu/>`_ is also a library for Automatic
+Differentiation(AD). A major difference is that, Enzyme works at the LLVM
+Intermediate Representation(IR) level, while Clad works at the Clang Abstract
+Syntax Tree(AST) level. Clad analyses the Clang AST to generate the derivative
+of a function, while Enzyme analyses the LLVM IR of a function to generate the
+derivative of the same.
 
-Languages such as Rust, C++, Julia and Swift output LLVM IR which makes Enzyme more interoperable as it can differentiate functions originally written in multiple languages.
-However, in Enzyme, interoperability comes at a cost. For example, while basic functions are supported across various languages; containers, classes and other language specific constructs require extra scaffolding to be supported by Enzyme.
-Clad is more tightly coupled with the Clang frontend and the C++ language. It has access to the high-level program structure and compile-only constructs such as `consteval`. That allows more coherency when differentiating C++.
-This includes first class support of Object Oriented Programs written in C++.
+Languages such as Rust, C++, Julia and Swift output LLVM IR which makes Enzyme
+more interoperable as it can differentiate functions originally written in
+multiple languages. However, in Enzyme, interoperability comes at a cost. For
+example, while basic functions are supported across various languages;
+containers, classes and other language specific constructs require extra
+scaffolding to be supported by Enzyme. Clad is more tightly coupled with the
+Clang frontend and the C++ language. It has access to the high-level program
+structure and compile-only constructs such as `consteval`. That allows more
+coherency when differentiating C++. This includes first class support of Object
+Oriented Programs written in C++.
 
-The initial integration of Enzyme in Clad is to enable cross validation of the produced code.
+The initial integration of Enzyme in Clad is to enable cross validation of the
+produced code.
 
-Currently, use of Enzyme for Reverse Mode AD is supported within Clad. This section describes how Enzyme can be used within Clad. 
+Currently, use of Enzyme for Reverse Mode AD is supported within Clad. This
+section describes how Enzyme can be used within Clad.
 
 
 Configuring Clad to use Enzyme
 =================================
-To enable the use of enzyme within Clad, one needs to configure Clad to use Enzyme. This can be done by adding the flag ``-DENABLE_ENZYME_BACKEND=On`` to cmake while configuring Clad build.
-Thus the overall cmake command should look something like this
+To enable the use of enzyme within Clad, one needs to configure Clad to use
+Enzyme. This can be done by adding the flag ``-DENABLE_ENZYME_BACKEND=On`` to
+cmake while configuring Clad build. Thus the overall cmake command should look
+something like this
 
 .. code-block:: bash
 
-    cmake ../clad -DClang_DIR=/usr/lib/llvm-11 -DLLVM_DIR=/usr/lib/llvm-11 -DCMAKE_INSTALL_PREFIX=../inst -DLLVM_EXTERNAL_LIT="``which lit``" -DENABLE_ENZYME_BACKEND=On
+    cmake ../clad -DClang_DIR=/usr/lib/llvm-11 -DLLVM_DIR=/usr/lib/llvm-11
+    -DCMAKE_INSTALL_PREFIX=../inst -DLLVM_EXTERNAL_LIT="``which lit``"
+    -DENABLE_ENZYME_BACKEND=On
 
-This flag instructs the build system to download and build Enzyme. Then it is linked as a static library to Clad.
+This flag instructs the build system to download and build Enzyme. Then it is
+linked as a static library to Clad.
 
 Asking Clad to generate gradients with Enzyme
 ================================================
 
-The following code snippet shows how one can request Clad to generate gradients with Enzyme::
+The following code snippet shows how one can request Clad to generate gradients
+with Enzyme::
 
     #include "clad/Differentiator/Differentiator.h"
 
-    double foo(double* arr) { return arr[0] * arr[1]; }
+    double array_product(double* arr) { return arr[0] * arr[1]; }
 
     int main(){
-        auto grad = clad::gradient<clad::opts::use_enzyme>(f1);
+        auto grad = clad::gradient<clad::opts::use_enzyme>(array_product);
         double v[2] = {3, 4};
         double g[2] = {0};
         grad.execute(v, g);
-        printf("d_x = %.2f, d_y = %.2f\n", g[0], g[1]); 
+        printf("d_x = %.2f, d_y = %.2f\n", g[0], g[1]);
     }
 
-Thus, the calling convention is to use ``clad::gradient<clad::opts::use_enzyme>(...)`` instead of the usual calling convention, ``clad::gradient(...)``.
-Calling ``execute``, ``dump`` and other functionalities remain same as that of Clad.
+Thus, the calling convention is to use
+``clad::gradient<clad::opts::use_enzyme>(...)`` instead of the usual calling
+convention, ``clad::gradient(...)``. Calling ``execute``, ``dump`` and other
+functionalities remain same as that of Clad.
 
 Extent of support for Enzyme within Clad
 =========================================
 
-Currently functions that take in arrays, pointers and primitive types(integer and real) as parameters are supported for differentiation with Enzyme within Clad.
-For more ideas on the type of functions supported, please have a look at ``test/Enzyme/ReverseMode.C`` for examples that can be differentiated within Clad.
+Currently functions that take in arrays, pointers and primitive types(integer
+and real) as parameters are supported for differentiation with Enzyme within
+Clad. For more ideas on the type of functions supported, please have a look at
+``test/Enzyme/ReverseMode.C`` for examples that can be differentiated within
+Clad.

--- a/docs/userDocs/source/user/UsingVectorMode.rst
+++ b/docs/userDocs/source/user/UsingVectorMode.rst
@@ -1,0 +1,51 @@
+Using Vector Mode for Differentiation
+**************************************
+
+For forward mode AD, the restriction is that the function can be only be
+differentiated with respect to a single input variable. However, in many cases,
+it is desirable to differentiate a function with respect to multiple input
+variables. One way to do this is to use a vectorized version of forward mode AD.
+
+Without vector mode, for computing derivative of a function with n-dimensional
+input - forward mode requires n forward passes, i.e. one for each input
+variable. In vector mode, all these computations are batched together and
+computed in a single forward pass and the function is differentiated with
+respect to multiple input variables. This can help in reducing the overhead of
+computing an expensive operation in multiple forward passes. This can also help
+in utilizing the vectorization capabilities of the hardware.
+
+The output of the function is a vector of partial derivatives with respect to
+each input variable.
+
+Currently, Clad only supports vectorized version of forward mode AD.
+
+Asking Clad to differentiate using Vector mode
+================================================
+
+The following code snippet shows how one can request Clad to use vector mode for
+differentiation::
+
+    #include "clad/Differentiator/Differentiator.h"
+
+    double prod(double x, double y, double z) { return x*y*z; }
+
+    int main(){
+        auto grad = clad::differentiate<clad::opts::vector_mode>(prod, "x,y");
+        double x = 3.0, y = 4.0, z = 5.0;
+        double dx = 0.0, dy = 0.0;
+        grad.execute(x, y, z, &dx, &dy);
+        printf("d_x = %.2f, d_y = %.2f\n", dx, dy);
+    }
+
+Thus, the calling convention is to use
+``clad::differentiate<clad::opts::vector_mode>(...)`` instead of the usual
+calling convention, ``clad::differentiate(...)``.
+
+Extent of support for Vector Mode within Clad
+================================================
+
+Currently only forward mode AD (using ``clad::differentiate``) has support for
+vector mode with features being added incrementally for various cases. For more
+ideas on the type of functions supported, please have a look at
+``test/ForwardMode/VectorMode.C`` for examples that can be differentiated within
+Clad.

--- a/include/clad/Differentiator/CladConfig.h
+++ b/include/clad/Differentiator/CladConfig.h
@@ -6,6 +6,37 @@
 #include <cstdlib>
 #include <memory>
 
+namespace clad {
+// The aim is to have a single unsigned integer for storing both, the
+// differentiation order and the options. The differentiation order is
+// stored in the lower 8 bits, and the options are stored in the upper
+// 24 bits. The differentiation order is stored in the lower 8 bits
+// thus allowing for a maximum differentiation order of 2^8 - 1 = 255.
+constexpr unsigned ORDER_BITS = 8;
+constexpr unsigned ORDER_MASK = (1 << ORDER_BITS) - 1;
+
+enum opts {
+  use_enzyme = 1 << ORDER_BITS,
+  vector_mode = 1 << (ORDER_BITS + 1),
+}; // enum opts
+
+constexpr unsigned GetDerivativeOrder(unsigned const bitmasked_opts) {
+  return bitmasked_opts & ORDER_MASK;
+}
+
+constexpr bool HasOption(unsigned const bitmasked_opts, unsigned const option) {
+  return (bitmasked_opts & option) == option;
+}
+
+constexpr unsigned GetBitmaskedOpts() { return 0; }
+constexpr unsigned GetBitmaskedOpts(unsigned const first) { return first; }
+template <typename... Opts>
+constexpr unsigned GetBitmaskedOpts(unsigned const first, Opts... opts) {
+  return first | GetBitmaskedOpts(opts...);
+}
+
+} // namespace clad
+
 // Define CUDA_HOST_DEVICE attribute for adding CUDA support to
 // clad functions
 #ifdef __CUDACC__

--- a/include/clad/Differentiator/CladConfig.h
+++ b/include/clad/Differentiator/CladConfig.h
@@ -15,6 +15,12 @@ namespace clad {
 constexpr unsigned ORDER_BITS = 8;
 constexpr unsigned ORDER_MASK = (1 << ORDER_BITS) - 1;
 
+enum order {
+  first = 1,
+  second = 2,
+  third = 3,
+}; // enum order
+
 enum opts {
   use_enzyme = 1 << ORDER_BITS,
   vector_mode = 1 << (ORDER_BITS + 1),

--- a/test/FirstDerivative/Assignments.C
+++ b/test/FirstDerivative/Assignments.C
@@ -102,7 +102,7 @@ int main() {
   clad::differentiate(f2, 1);
   clad::differentiate(f3, 0);
   clad::differentiate(f3, 1);
-  clad::differentiate(f4, 0);
+  clad::differentiate <clad::order::first> (f4, 0); // testing order template parameter
 }
 
 

--- a/test/ForwardMode/VectorMode.C
+++ b/test/ForwardMode/VectorMode.C
@@ -183,7 +183,7 @@ double f5(double x, double y, double z) {
   {                                                                            \
     result[0] = 0;                                                             \
     result[1] = 0;                                                             \
-    clad::vector_forward_differentiate(F);                                     \
+    clad::differentiate<clad::opts::vector_mode>(F);                        \
     F##_dvec(x, y, &result[0], &result[1]);                                    \
     printf("Result is = {%.2f, %.2f}\n", result[0], result[1]);                \
   }
@@ -197,26 +197,26 @@ int main() {
   TEST(f4, 1, 2); // CHECK-EXEC: Result is = {-1.00, 4.00}
 
   // Testing derivatives of partial parameters.
-  auto f_dvec_x_y_z = clad::vector_forward_differentiate(f5, "x, y, z");
+  auto f_dvec_x_y_z = clad::differentiate<clad::opts::vector_mode>(f5, "x, y, z");
   f_dvec_x_y_z.execute(1, 2, 3, &result[0], &result[1], &result[2]);
   printf("Result is = {%.2f, %.2f, %.2f}\n", result[0], result[1], result[2]); // CHECK-EXEC: Result is = {1.00, 2.00, 3.00}
 
-  auto f_dvec_x_y = clad::vector_forward_differentiate(f5, "x, y");
+  auto f_dvec_x_y = clad::differentiate<clad::opts::vector_mode>(f5, "x, y");
   f_dvec_x_y.execute(1, 2, 3, &result[0], &result[1]);
   printf("Result is = {%.2f, %.2f}\n", result[0], result[1]); // CHECK-EXEC: Result is = {1.00, 2.00}
 
-  auto f_dvec_x_z = clad::vector_forward_differentiate(f5, "x, z");
+  auto f_dvec_x_z = clad::differentiate<clad::opts::vector_mode>(f5, "x, z");
   f_dvec_x_z.execute(1, 2, 3, &result[0], &result[1]);
   printf("Result is = {%.2f, %.2f}\n", result[0], result[1]); // CHECK-EXEC: Result is = {1.00, 3.00}
 
-  auto f_dvec_y_z = clad::vector_forward_differentiate(f5, "y, z");
+  auto f_dvec_y_z = clad::differentiate<clad::opts::vector_mode>(f5, "y, z");
   f_dvec_y_z.execute(1, 2, 3, &result[0], &result[1]);
   printf("Result is = {%.2f, %.2f}\n", result[0], result[1]); // CHECK-EXEC: Result is = {2.00, 3.00}
 
-  auto f_dvec_y_x = clad::vector_forward_differentiate(f5, "y, x");
+  auto f_dvec_y_x = clad::differentiate<clad::opts::vector_mode>(f5, "y, x");
   f_dvec_y_x.execute(1, 2, 3, &result[0], &result[1]);
 
-  auto f_dvec_z = clad::vector_forward_differentiate(f5, "z");
+  auto f_dvec_z = clad::differentiate<clad::opts::vector_mode>(f5, "z");
   f_dvec_z.execute(1, 2, 3, &result[0]);
   printf("Result is = {%.2f}\n", result[0]); // CHECK-EXEC: Result is = {3.00}
 }

--- a/test/ForwardMode/VectorModeInterface.C
+++ b/test/ForwardMode/VectorModeInterface.C
@@ -55,8 +55,12 @@ double f_try_catch(double x, double y)
 // CHECK-NEXT: }
 
 int main() {
-  clad::vector_forward_differentiate(f1);
-  clad::vector_forward_differentiate(f2);
-  clad::vector_forward_differentiate(f_try_catch);
+  clad::differentiate<clad::opts::vector_mode>(f1);
+  clad::differentiate<clad::opts::vector_mode>(f2);
+  clad::differentiate<clad::opts::vector_mode>(f_try_catch);
+  clad::differentiate<2, clad::opts::vector_mode>(f_try_catch); // expected-error {{Only first order derivative is supported for now in vector forward mode}}
+  clad::differentiate<clad::opts::use_enzyme, clad::opts::vector_mode>(f1); // expected-error {{Enzyme's vector mode is not yet supported}}
+  
+  clad::gradient<clad::opts::vector_mode>(f1, "x, y, z"); // expected-error {{Reverse vector mode is not yet supported.}}
   return 0;
 }


### PR DESCRIPTION
This will extend existing functions to have support for options like vector mode.

A current working example is:
- `clad::differentiate <clad::opts::vector_mode> (fn)` - first-order differentiation of the function `fn` using vector forward mode

Another example which is not yet supported but may be helpful for the future:
- `clad::gradient <clad::opts::use_enzyme, clad::opts::vector_mode> (fn)` - first-order gradient computation (reverse mode AD) using enzyme's vector mode.
