### PR TITLE
Resolve some GCC warnings

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -667,7 +667,7 @@ BaseForwardModeVisitor::VisitArraySubscriptExpr(const ArraySubscriptExpr* ASE) {
   auto cloned = BuildArraySubscript(clonedBase, clonedIndices);
 
   auto zero = ConstantFolder::synthesizeLiteral(ExprTy, m_Context, 0);
-  ValueDecl* VD;
+  ValueDecl* VD = nullptr;
   // Derived variables for member variables are also created when we are
   // differentiating a call operator.
   if (m_Functor) {

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -387,12 +387,22 @@ namespace clad {
           if (lastStr.empty()) {
             // The string is not a range just a single index
             size_t index;
-            firstStr.getAsInteger(10, index);
+            if (firstStr.getAsInteger(10, index)) {
+                utils::EmitDiag(semaRef, DiagnosticsEngine::Error,
+                                diffArgs->getEndLoc(),
+                                "Could not parse index '%0'", {diffSpec});
+                return;
+            }
             dVarInfo.paramIndexInterval = IndexInterval(index);
           } else {
             size_t first, last;
-            firstStr.getAsInteger(10, first);
-            lastStr.getAsInteger(10, last);
+            if (firstStr.getAsInteger(10, first) ||
+                lastStr.getAsInteger(10, last)) {
+                utils::EmitDiag(semaRef, DiagnosticsEngine::Error,
+                                diffArgs->getEndLoc(),
+                                "Could not parse range '%0'", {diffSpec});
+                return;
+            }
             if (first >= last) {
               utils::EmitDiag(semaRef, DiagnosticsEngine::Error,
                               diffArgs->getEndLoc(),

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -384,10 +384,11 @@ namespace clad {
           llvm::StringRef firstStr, lastStr;
           std::tie(firstStr, lastStr) = interval.split(':');
 
+          static constexpr unsigned Radix = 10;
           if (lastStr.empty()) {
             // The string is not a range just a single index
             size_t index;
-            if (firstStr.getAsInteger(10, index)) {
+            if (firstStr.getAsInteger(Radix, index)) {
                 utils::EmitDiag(semaRef, DiagnosticsEngine::Error,
                                 diffArgs->getEndLoc(),
                                 "Could not parse index '%0'", {diffSpec});
@@ -396,8 +397,8 @@ namespace clad {
             dVarInfo.paramIndexInterval = IndexInterval(index);
           } else {
             size_t first, last;
-            if (firstStr.getAsInteger(10, first) ||
-                lastStr.getAsInteger(10, last)) {
+            if (firstStr.getAsInteger(Radix, first) ||
+                lastStr.getAsInteger(Radix, last)) {
                 utils::EmitDiag(semaRef, DiagnosticsEngine::Error,
                                 diffArgs->getEndLoc(),
                                 "Could not parse range '%0'", {diffSpec});

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -466,11 +466,12 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     DiffParams args{};
     std::copy(FD->param_begin(), FD->param_end(), std::back_inserter(args));
 
+#ifndef NDEBUG
     bool isStaticMethod = utils::IsStaticMethod(FD);
-
     assert((!args.empty() || !isStaticMethod) &&
            "Cannot generate pullback function of a function "
            "with no differentiable arguments");
+#endif
 
     if (m_ExternalSource)
       m_ExternalSource->ActAfterParsingDiffArgs(request, args);
@@ -1212,10 +1213,12 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
       // FIXME: This is a makeshift arrangement to differentiate an InitListExpr
       // that represents a ValueAndPushforward type. Ideally this must be
       // differentiated at VisitCXXConstructExpr
+#ifndef NDEBUG
       bool isValueAndPushforward = isCladValueAndPushforwardType(ILEType);
       assert(isValueAndPushforward &&
              "Only InitListExpr that represents arrays or ValueAndPushforward "
              "Object initialization is supported");
+#endif
 
       // Here we assume that the adjoint expression of the first element in
       // InitList is dfdx().value and the adjoint for the second element is

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -78,8 +78,10 @@ namespace clad {
           PP.Diag(PragmaTok, diag::warn_pragma_diagnostic_invalid);
           return;
         }
+#ifndef NDEBUG
         IdentifierInfo* II = PragmaTok.getIdentifierInfo();
         assert(II->isStr("clad"));
+#endif
 
         tok::OnOffSwitch OOS;
         if (PP.LexOnOffSwitch(OOS))


### PR DESCRIPTION
`maybe-uninitialized` and `unused-variable` by GCC 8.5.0.