### PR TITLE
Rename executable in TestTypeConversion

### DIFF
--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -1,5 +1,5 @@
-// RUN: %cladnumdiffclang -lm -lstdc++ %s  -I%S/../../include -oGradients.out 2>&1 | FileCheck %s
-// RUN: ./Gradients.out | FileCheck -check-prefix=CHECK-EXEC %s
+// RUN: %cladnumdiffclang -lm -lstdc++ %s  -I%S/../../include -oTestTypeConversion.out 2>&1 | FileCheck %s
+// RUN: ./TestTypeConversion.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}
 


### PR DESCRIPTION
It clashed with `test/Gradient/Gradients.C` which resulted in frequent failures during parallel testing.

*Note:* Ideally the executable would be placed in a temporary directory, maybe based on `%t`?