### PR TITLE
Use proper clang++ for testing

### DIFF
--- a/test/Arrays/ArrayInputsForwardMode.C
+++ b/test/Arrays/ArrayInputsForwardMode.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oArrayInputsForwardMode.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oArrayInputsForwardMode.out 2>&1 | FileCheck %s
 // RUN: ./ArrayInputsForwardMode.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -lstdc++ -I%S/../../include -Wno-unused-value -oArrayInputsReverseMode.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -Wno-unused-value -oArrayInputsReverseMode.out 2>&1 | FileCheck %s
 // RUN: ./ArrayInputsReverseMode.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Arrays/Arrays.C
+++ b/test/Arrays/Arrays.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -lstdc++ -I%S/../../include -oArrays.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oArrays.out 2>&1 | FileCheck %s
 // RUN: ./Arrays.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Enzyme/ForwardMode.C
+++ b/test/Enzyme/ForwardMode.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lstdc++ -I%S/../../include -oEnzyme.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oEnzyme.out 2>&1 | FileCheck %s
 // RUN: ./Enzyme.out
 // CHECK-NOT: {{.*error|warning|note:.*}}
 // REQUIRES: Enzyme

--- a/test/Enzyme/GradientsComparisonWithClad.C
+++ b/test/Enzyme/GradientsComparisonWithClad.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -lm -lstdc++ %s  -I%S/../../include -oEnzymeGradients.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s  -I%S/../../include -oEnzymeGradients.out 2>&1 | FileCheck %s
 // RUN: ./EnzymeGradients.out | FileCheck -check-prefix=CHECK-EXEC %s
 // REQUIRES: Enzyme
 // CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Enzyme/LoopsReverseModeComparisonWithClad.C
+++ b/test/Enzyme/LoopsReverseModeComparisonWithClad.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -oEnzymeLoops.out 2>&1 -lstdc++ -lm | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oEnzymeLoops.out 2>&1 | FileCheck %s
 // RUN: ./EnzymeLoops.out | FileCheck -check-prefix=CHECK-EXEC %s
 // REQUIRES: Enzyme
 // CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -x c++ -lstdc++ -lm -I%S/../../include -oAssignments.out %s 2>&1 | FileCheck %s
+// RUN: %cladclang -lstdc++ -lm -I%S/../../include -oAssignments.out %s 2>&1 | FileCheck %s
 // RUN: ./Assignments.out
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -lstdc++ -lm -I%S/../../include -oAssignments.out %s 2>&1 | FileCheck %s
+// RUN: %cladclang -I%S/../../include -oAssignments.out %s 2>&1 | FileCheck %s
 // RUN: ./Assignments.out
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -lstdc++ -lm -I%S/../../include -oCondStmts.out %s 2>&1 | FileCheck %s
+// RUN: %cladclang -I%S/../../include -oCondStmts.out %s 2>&1 | FileCheck %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -x c++ -lstdc++ -lm -I%S/../../include -oCondStmts.out %s 2>&1 | FileCheck %s
+// RUN: %cladclang -lstdc++ -lm -I%S/../../include -oCondStmts.out %s 2>&1 | FileCheck %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -lstdc++ -lm -I%S/../../include -oLoopsAndArrays.out %s 2>&1 | FileCheck %s
+// RUN: %cladclang -I%S/../../include -oLoopsAndArrays.out %s 2>&1 | FileCheck %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -x c++ -lstdc++ -lm -I%S/../../include -oLoopsAndArrays.out %s 2>&1 | FileCheck %s
+// RUN: %cladclang -lstdc++ -lm -I%S/../../include -oLoopsAndArrays.out %s 2>&1 | FileCheck %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -lstdc++ -I%S/../../include -oLoopsAndArraysExec.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oLoopsAndArraysExec.out 2>&1 | FileCheck %s
 // RUN: ./LoopsAndArraysExec.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 // CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/FirstDerivative/Assignments.C
+++ b/test/FirstDerivative/Assignments.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oAssignments.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oAssignments.out 2>&1 | FileCheck %s
 // RUN: ./Assignments.out
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -Xclang -verify -oBuiltinDerivatives.out -lm -lstdc++ 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -Xclang -verify -oBuiltinDerivatives.out 2>&1 | FileCheck %s
 // RUN: ./BuiltinDerivatives.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/FirstDerivative/CallArguments.C
+++ b/test/FirstDerivative/CallArguments.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -Xclang -verify -oCallArguments.out -lm 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -Xclang -verify -oCallArguments.out 2>&1 | FileCheck %s
 // RUN: ./CallArguments.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/FirstDerivative/ClassMethodCall.C
+++ b/test/FirstDerivative/ClassMethodCall.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -lstdc++ -oClassMethods.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oClassMethods.out 2>&1 | FileCheck %s
 // RUN: ./ClassMethods.out | FileCheck -check-prefix=CHECK-EXEC %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/FirstDerivative/CompoundAssignments.C
+++ b/test/FirstDerivative/CompoundAssignments.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oCompoundAssignments.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oCompoundAssignments.out 2>&1 | FileCheck %s
 // RUN: ./CompoundAssignments.out
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/FirstDerivative/Loops.C
+++ b/test/FirstDerivative/Loops.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -std=c++17 -lm -I%S/../../include -oLoops.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -std=c++17 -I%S/../../include -oLoops.out 2>&1 | FileCheck %s
 // RUN: ./Loops.out | FileCheck -check-prefix=CHECK-EXEC %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/FirstDerivative/Namespaces.C
+++ b/test/FirstDerivative/Namespaces.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oNamespaces.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oNamespaces.out 2>&1 | FileCheck %s
 // RUN: ./Namespaces.out
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/FirstDerivative/Overloads.C
+++ b/test/FirstDerivative/Overloads.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -lstdc++ -oOverloads.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oOverloads.out 2>&1 | FileCheck %s
 // RUN: ./Overloads.out | FileCheck -check-prefix=CHECK-EXEC %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/FirstDerivative/Switch.C
+++ b/test/FirstDerivative/Switch.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oSwitch.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oSwitch.out 2>&1 | FileCheck %s
 // RUN: ./Switch.out | FileCheck -check-prefix=CHECK-EXEC %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/FirstDerivative/SwitchInit.C
+++ b/test/FirstDerivative/SwitchInit.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -std=c++17 -oSwitchInit.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -std=c++17 -oSwitchInit.out 2>&1 | FileCheck %s
 // RUN: ./SwitchInit.out | FileCheck -check-prefix=CHECK-EXEC %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/FirstDerivative/Variables.C
+++ b/test/FirstDerivative/Variables.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oVariables.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oVariables.out 2>&1 | FileCheck %s
 // RUN: ./Variables.out
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/FirstDerivative/VirtualMethodsCall.C
+++ b/test/FirstDerivative/VirtualMethodsCall.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -lstdc++ -oVirtualMethodsCall.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oVirtualMethodsCall.out 2>&1 | FileCheck %s
 // RUN: ./VirtualMethodsCall.out | FileCheck -check-prefix=CHECK-EXEC %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/ForwardMode/Pointer.C
+++ b/test/ForwardMode/Pointer.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lstdc++ -I%S/../../include -oPointer.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oPointer.out 2>&1 | FileCheck %s
 // RUN: ./Pointer.out | FileCheck -check-prefix=CHECK-EXEC %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -lm -lstdc++ %s -I%S/../../include -oUserDefinedTypes.out | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oUserDefinedTypes.out | FileCheck %s
 // RUN: ./UserDefinedTypes.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 // CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/ForwardMode/VectorMode.C
+++ b/test/ForwardMode/VectorMode.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -lstdc++ -I%S/../../include -oVectorMode.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oVectorMode.out 2>&1 | FileCheck %s
 // RUN: ./VectorMode.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/ForwardMode/constexprTest.C
+++ b/test/ForwardMode/constexprTest.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -lm -lstdc++ %s -I%S/../../include -oconstexprTest.out | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oconstexprTest.out | FileCheck %s
 // RUN: ./constexprTest.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -lstdc++ -lm -oReverseAssignments.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oReverseAssignments.out 2>&1 | FileCheck %s
 // RUN: ./ReverseAssignments.out | FileCheck -check-prefix=CHECK-EXEC %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/Gradient/DiffInterface.C
+++ b/test/Gradient/DiffInterface.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oGradientDiffInterface.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oGradientDiffInterface.out 2>&1 | FileCheck %s
 // RUN: ./GradientDiffInterface.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -1,4 +1,4 @@
-// RUN: %cladnumdiffclang -lm -lstdc++ %s  -I%S/../../include -oFunctionCalls.out 2>&1 | FileCheck %s
+// RUN: %cladnumdiffclang %s  -I%S/../../include -oFunctionCalls.out 2>&1 | FileCheck %s
 // RUN: ./FunctionCalls.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -1,4 +1,4 @@
-// RUN: %cladnumdiffclang -lm -lstdc++ %s  -I%S/../../include -oGradients.out 2>&1 | FileCheck %s
+// RUN: %cladnumdiffclang %s  -I%S/../../include -oGradients.out 2>&1 | FileCheck %s
 // RUN: ./Gradients.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -oReverseLoops.out 2>&1 -lstdc++ -lm | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oReverseLoops.out 2>&1 | FileCheck %s
 // RUN: ./ReverseLoops.out | FileCheck -check-prefix=CHECK-EXEC %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -1,8 +1,8 @@
-// RUN: %cladclang %s -lm -fno-exceptions -I%S/../../include -oMemberFunctions.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -fno-exceptions -I%S/../../include -oMemberFunctions.out 2>&1 | FileCheck %s
 // RUN: ./MemberFunctions.out | FileCheck -check-prefix=CHECK-EXEC %s
-// RUN: %cladclang -std=c++14 %s -lm -fno-exceptions -I%S/../../include -oMemberFunctions-cpp14.out 2>&1 | FileCheck %s
+// RUN: %cladclang -std=c++14 %s -fno-exceptions -I%S/../../include -oMemberFunctions-cpp14.out 2>&1 | FileCheck %s
 // RUN: ./MemberFunctions-cpp14.out | FileCheck -check-prefix=CHECK-EXEC %s
-// RUN: %cladclang -std=c++17 %s -lm -fno-exceptions -I%S/../../include -oMemberFunctions-cpp17.out 2>&1 | FileCheck %s
+// RUN: %cladclang -std=c++17 %s -fno-exceptions -I%S/../../include -oMemberFunctions-cpp17.out 2>&1 | FileCheck %s
 // RUN: ./MemberFunctions-cpp17.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -1,4 +1,4 @@
-// RUN: %cladnumdiffclang -lm -lstdc++ %s  -I%S/../../include -oTestTypeConversion.out 2>&1 | FileCheck %s
+// RUN: %cladnumdiffclang %s  -I%S/../../include -oTestTypeConversion.out 2>&1 | FileCheck %s
 // RUN: ./TestTypeConversion.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -oUserDefinedTypes.out 2>&1 -lstdc++ -lm | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oUserDefinedTypes.out 2>&1 | FileCheck %s
 // RUN: ./UserDefinedTypes.out | FileCheck -check-prefix=CHECK-EXEC %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/Gradient/constexprTest.C
+++ b/test/Gradient/constexprTest.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -lm -lstdc++ %s -I%S/../../include -oconstexprTest.out | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oconstexprTest.out | FileCheck %s
 // RUN: ./constexprTest.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Hessian/Arrays.C
+++ b/test/Hessian/Arrays.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oArrays.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oArrays.out 2>&1 | FileCheck %s
 // RUN: ./Arrays.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 // CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oHessianBuiltinDerivatives.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oHessianBuiltinDerivatives.out 2>&1 | FileCheck %s
 // RUN: ./HessianBuiltinDerivatives.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oHessians.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oHessians.out 2>&1 | FileCheck %s
 // RUN: ./Hessians.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oNestedFunctionCalls.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oNestedFunctionCalls.out 2>&1 | FileCheck %s
 // RUN: ./NestedFunctionCalls.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 // CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Hessian/constexprTest.C
+++ b/test/Hessian/constexprTest.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -std=c++14 -oconstexprTest.out 2>&1 -lstdc++ -lm | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -std=c++14 -oconstexprTest.out 2>&1 | FileCheck %s
 // RUN: ./constexprTest.out | FileCheck -check-prefix=CHECK-EXEC %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/Hessian/testhessUtility.C
+++ b/test/Hessian/testhessUtility.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -otesthessUtility.out 2>&1 -lstdc++ -lm | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -otesthessUtility.out 2>&1 | FileCheck %s
 // RUN: ./testhessUtility.out | FileCheck -check-prefix=CHECK-EXEC %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/Jacobian/FunctionCalls.C
+++ b/test/Jacobian/FunctionCalls.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oFunctionCalls.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oFunctionCalls.out 2>&1 | FileCheck %s
 // RUN: ./FunctionCalls.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oJacobian.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oJacobian.out 2>&1 | FileCheck %s
 // RUN: ./Jacobian.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Jacobian/constexprTest.C
+++ b/test/Jacobian/constexprTest.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -std=c++14 -oconstexprTest.out 2>&1 -lstdc++ -lm | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -std=c++14 -oconstexprTest.out 2>&1 | FileCheck %s
 // RUN: ./constexprTest.out | FileCheck -check-prefix=CHECK-EXEC %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/Jacobian/testUtility.C
+++ b/test/Jacobian/testUtility.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -otestUtility.out 2>&1 -lstdc++ -lm | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -otestUtility.out 2>&1 | FileCheck %s
 // RUN: ./testUtility.out | FileCheck -check-prefix=CHECK-EXEC %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/Misc/CladArray.C
+++ b/test/Misc/CladArray.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -x c++ -lstdc++ -I%S/../../include -oCladArray.out 2>&1
+// RUN: %cladclang %s -lstdc++ -I%S/../../include -oCladArray.out 2>&1
 // RUN: ./CladArray.out
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/Misc/CladArray.C
+++ b/test/Misc/CladArray.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lstdc++ -I%S/../../include -oCladArray.out 2>&1
+// RUN: %cladclang %s -I%S/../../include -oCladArray.out 2>&1
 // RUN: ./CladArray.out
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -2,7 +2,7 @@
 // RUN: %cladclang %S/../../demos/ControlFlow.cpp -I%S/../../include 2>&1
 // RUN: %cladclang %S/../../demos/DebuggingClad.cpp -I%S/../../include 2>&1
 // RUN: %cladclang %S/../../demos/RosenbrockFunction.cpp -I%S/../../include 2>&1
-// RUN: %cladclang -lstdc++ -lm %S/../../demos/ComputerGraphics/smallpt/SmallPT.cpp -I%S/../../include 2>&1
+// RUN: %cladclang %S/../../demos/ComputerGraphics/smallpt/SmallPT.cpp -I%S/../../include 2>&1
 
 
 //-----------------------------------------------------------------------------/
@@ -96,13 +96,13 @@
 //-----------------------------------------------------------------------------/
 // Demo: ODE Solver Sensitivity
 //-----------------------------------------------------------------------------/
-// RUN: %cladclang -lstdc++ %S/../../demos/ODESolverSensitivity.cpp -I%S/../../include -oODESolverSensitivity.out
+// RUN: %cladclang %S/../../demos/ODESolverSensitivity.cpp -I%S/../../include -oODESolverSensitivity.out
 
 //-----------------------------------------------------------------------------/
 // Demo: Error Estimation Float Sum
 //-----------------------------------------------------------------------------/
 
-// RUN: %cladclang -lm -lstdc++ %S/../../demos/ErrorEstimation/FloatSum.cpp -I%S/../../include 2>&1  | FileCheck -check-prefix CHECK_FLOAT_SUM %s
+// RUN: %cladclang %S/../../demos/ErrorEstimation/FloatSum.cpp -I%S/../../include 2>&1  | FileCheck -check-prefix CHECK_FLOAT_SUM %s
 //CHECK_FLOAT_SUM-NOT: {{.*error|warning|note:.*}}
 
 //CHECK_FLOAT_SUM: void vanillaSum_grad(float x, unsigned int n, clad::array_ref<float> _d_x, clad::array_ref<unsigned int> _d_n, double &_final_error) {
@@ -183,7 +183,7 @@
 //-----------------------------------------------------------------------------/
 // Demo: Print Error Estimation Plugin
 //-----------------------------------------------------------------------------/
-// RUN: %cladclang -lstdc++ -Xclang -plugin-arg-clad -Xclang -fcustom-estimation-model \
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fcustom-estimation-model \
 // RUN:  -Xclang -plugin-arg-clad -Xclang %clad_obj_root/demos/ErrorEstimation/PrintModel/libcladPrintModelPlugin%shlibext \
 // RUN:   %S/../../demos/ErrorEstimation/PrintModel/test.cpp \
 // RUN: -I%S/../../include -oPrintModelTest.out | FileCheck -check-prefix CHECK_PRINT_MODEL %s
@@ -226,7 +226,7 @@
 //-----------------------------------------------------------------------------/
 // Demo: Gradient Descent
 //-----------------------------------------------------------------------------/
-// RUN: %cladclang -lstdc++ %S/../../demos/GradientDescent.cpp -I%S/../../include -oGradientDescent.out | FileCheck -check-prefix CHECK_GRADIENT_DESCENT %s
+// RUN: %cladclang %S/../../demos/GradientDescent.cpp -I%S/../../include -oGradientDescent.out | FileCheck -check-prefix CHECK_GRADIENT_DESCENT %s
 
 //CHECK_GRADIENT_DESCENT: void f_pullback(double theta_0, double theta_1, double x, double _d_y, clad::array_ref<double> _d_theta_0, clad::array_ref<double> _d_theta_1, clad::array_ref<double> _d_x) {
 //CHECK_GRADIENT_DESCENT-NEXT:     double _t0;
@@ -286,7 +286,7 @@
 //-----------------------------------------------------------------------------/
 // Demo: Custom Type Numerical Diff
 //-----------------------------------------------------------------------------/
-// RUN: %cladnumdiffclang -lm -lstdc++ %S/../../demos/CustomTypeNumDiff.cpp -I%S/../../include -oCustomTypeNumDiff.out
+// RUN: %cladnumdiffclang %S/../../demos/CustomTypeNumDiff.cpp -I%S/../../include -oCustomTypeNumDiff.out
 // RUN: ./CustomTypeNumDiff.out | FileCheck -check-prefix CHECK_CUSTOM_NUM_DIFF_EXEC %s
 // CHECK_CUSTOM_NUM_DIFF_EXEC: Result of df/dx is = 0.07
 // CHECK_CUSTOM_NUM_DIFF_EXEC: Result of df/dx is = 0.003
@@ -294,7 +294,7 @@
 //-----------------------------------------------------------------------------/
 // Demo: Arrays.cpp
 //-----------------------------------------------------------------------------/
-// RUN: %cladclang %S/../../demos/Arrays.cpp -I%S/../../include -oArrays.out 2>&1 -lstdc++ -lm
+// RUN: %cladclang %S/../../demos/Arrays.cpp -I%S/../../include -oArrays.out 2>&1
 // RUN: ./Arrays.out | FileCheck -check-prefix CHECK_ARRAYS_EXEC %s
 // CHECK_ARRAYS_EXEC: Forward Mode w.r.t. arr:
 // CHECK_ARRAYS_EXEC:  res_arr = 0.17, 0.2, 0.1

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -102,7 +102,7 @@
 // Demo: Error Estimation Float Sum
 //-----------------------------------------------------------------------------/
 
-// RUN: %cladclang -x c++ -lm -lstdc++ %S/../../demos/ErrorEstimation/FloatSum.cpp -I%S/../../include 2>&1  | FileCheck -check-prefix CHECK_FLOAT_SUM %s
+// RUN: %cladclang -lm -lstdc++ %S/../../demos/ErrorEstimation/FloatSum.cpp -I%S/../../include 2>&1  | FileCheck -check-prefix CHECK_FLOAT_SUM %s
 //CHECK_FLOAT_SUM-NOT: {{.*error|warning|note:.*}}
 
 //CHECK_FLOAT_SUM: void vanillaSum_grad(float x, unsigned int n, clad::array_ref<float> _d_x, clad::array_ref<unsigned int> _d_n, double &_final_error) {

--- a/test/Misc/TapeMemory.C
+++ b/test/Misc/TapeMemory.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -x c++ -lstdc++ -I%S/../../include -oTapeMemory.out 2>&1
+// RUN: %cladclang %s -lstdc++ -I%S/../../include -oTapeMemory.out 2>&1
 // RUN: ./TapeMemory.out
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/Misc/TapeMemory.C
+++ b/test/Misc/TapeMemory.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lstdc++ -I%S/../../include -oTapeMemory.out 2>&1
+// RUN: %cladclang %s -I%S/../../include -oTapeMemory.out 2>&1
 // RUN: ./TapeMemory.out
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/NestedCalls/NestedCalls.C
+++ b/test/NestedCalls/NestedCalls.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oNestedCalls.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oNestedCalls.out 2>&1 | FileCheck %s
 // RUN: ./NestedCalls.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/NumericalDiff/GradientMultiArg.C
+++ b/test/NumericalDiff/GradientMultiArg.C
@@ -1,4 +1,4 @@
-// RUN: %cladnumdiffclang -lm -lstdc++ %s -I%S/../../include -oGradientMultiArg.out 2>&1 | FileCheck -check-prefix=CHECK %s
+// RUN: %cladnumdiffclang %s -I%S/../../include -oGradientMultiArg.out 2>&1 | FileCheck -check-prefix=CHECK %s
 // RUN: ./GradientMultiArg.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/NumericalDiff/NoNumDiff.C
+++ b/test/NumericalDiff/NoNumDiff.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oNoNumDiff.out 2>&1 | FileCheck -check-prefix=CHECK %s
+// RUN: %cladclang %s -I%S/../../include -oNoNumDiff.out 2>&1 | FileCheck -check-prefix=CHECK %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/NumericalDiff/NumDiff.C
+++ b/test/NumericalDiff/NumDiff.C
@@ -1,4 +1,4 @@
-// RUN: %cladnumdiffclang -lm -lstdc++ %s -I%S/../../include -oNumDiff.out 2>&1 | FileCheck -check-prefix=CHECK %s
+// RUN: %cladnumdiffclang %s -I%S/../../include -oNumDiff.out 2>&1 | FileCheck -check-prefix=CHECK %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/NumericalDiff/PrintErrorNumDiff.C
+++ b/test/NumericalDiff/PrintErrorNumDiff.C
@@ -1,4 +1,4 @@
-// RUN: %cladnumdiffclang -lm -lstdc++ -Xclang -plugin-arg-clad -Xclang -fprint-num-diff-errors %s -I%S/../../include -oPrintErrorNumDiff.out 2>&1 | FileCheck -check-prefix=CHECK %s
+// RUN: %cladnumdiffclang -Xclang -plugin-arg-clad -Xclang -fprint-num-diff-errors %s -I%S/../../include -oPrintErrorNumDiff.out 2>&1 | FileCheck -check-prefix=CHECK %s
 // -Xclang -verify 2>&1 RUN: ./PrintErrorNumDiff.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/NumericalDiff/PureCentralDiffCalls.C
+++ b/test/NumericalDiff/PureCentralDiffCalls.C
@@ -1,4 +1,4 @@
-// RUN: %cladnumdiffclang -lm -lstdc++ %s -I%S/../../include -oPureCentralDiffCalls.out
+// RUN: %cladnumdiffclang %s -I%S/../../include -oPureCentralDiffCalls.out
 // -Xclang -verify 2>&1 RUN: ./PureCentralDiffCalls.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 // CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/NumericalDiff/UserDefinedPointers.C
+++ b/test/NumericalDiff/UserDefinedPointers.C
@@ -1,4 +1,4 @@
-// RUN: %cladnumdiffclang -lm -lstdc++ %s -I%S/../../include -oUserDefinedPointers.out -Xclang -verify 2>&1
+// RUN: %cladnumdiffclang %s -I%S/../../include -oUserDefinedPointers.out -Xclang -verify 2>&1
 // RUN: ./UserDefinedPointers.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/ROOT/Hessian.C
+++ b/test/ROOT/Hessian.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oHessian.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oHessian.out 2>&1 | FileCheck %s
 // RUN: ./Hessian.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/ROOT/Interface.C
+++ b/test/ROOT/Interface.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oInterface.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oInterface.out 2>&1 | FileCheck %s
 // RUN: ./Interface.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -lm -I%S/../../include -oTFormula.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oTFormula.out 2>&1 | FileCheck %s
 // RUN: ./TFormula.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -249,7 +249,7 @@ if not lit_config.quiet:
 lit.util.usePlatformSdkOnDarwin(config, lit_config)
 
 #Start clad forwarding to:
-#clang -x c++ -std=c++11 some-input-file.c -Xclang -add-plugin -Xclang ad -Xclang
+#clang -std=c++11 some-input-file.c -Xclang -add-plugin -Xclang ad -Xclang
 #\ -plugin-arg-ad -Xclang -fdump-derived-fn -Xclang -load -Xclang../../Debug+Asserts/lib/libclad.so
 #FIXME: we need to introduce a better way to check compatible version of clang, propagating
 #-fvalidate-clang-version flag is not enough.
@@ -259,11 +259,11 @@ flags = ' -std=c++11 -Xclang -add-plugin -Xclang clad -Xclang \
 
 config.substitutions.append( ('%cladclang_cuda', config.clang + flags) )
 
-config.substitutions.append( ('%cladclang', config.clang + ' -DCLAD_NO_NUM_DIFF -x c++ ' + flags) )
+config.substitutions.append( ('%cladclang', config.clang + '++ -DCLAD_NO_NUM_DIFF ' + flags) )
 
 config.substitutions.append( ('%cladlib', config.cladlib) )
 
-config.substitutions.append( ('%cladnumdiffclang', config.clang + ' -x c++ ' + flags) )
+config.substitutions.append( ('%cladnumdiffclang', config.clang + '++ ' + flags) )
 
 # When running under valgrind, we mangle '-vg' onto the end of the triple so we
 # can check it with XFAIL and XTARGET.


### PR DESCRIPTION
This solves a problem on EL8 where Clang uses `libstdc++` from the Developer Toolset and linking requires some extra care, which only `clang++` does but not `clang -x c++`.

@vgvassilev was there an explicit reason to use `clang -x c++`?