### PR TITLE
demos: Use C++ std::abs for floating point values

### DIFF
--- a/demos/GradientDescent.cpp
+++ b/demos/GradientDescent.cpp
@@ -110,8 +110,8 @@ std::vector<double> optimize(std::vector<double> theta, Dataset dt,
     std::cout << "Steps #" << currentStep << " Theta 0: " << theta[0]
               << " Theta 1: " << theta[1] << std::endl;
 
-    hasConverged = abs(diff[0] - theta[0]) <= eps &&
-                   abs(diff[1] - theta[1]) <= eps;
+    hasConverged = std::abs(diff[0] - theta[0]) <= eps &&
+                   std::abs(diff[1] - theta[1]) <= eps;
 
     diff = theta;
   } while (currentStep++ < maxSteps && !hasConverged);

--- a/demos/ODESolverSensitivity.cpp
+++ b/demos/ODESolverSensitivity.cpp
@@ -84,7 +84,7 @@ int main() {
     double x = x0 + h * i;
     double db = bSensitivity(x);
 
-    out << x << "\t" << abs(db) << std::endl;
+    out << x << "\t" << std::abs(db) << std::endl;
   }
   out.close();
 


### PR DESCRIPTION
Clang warns that `abs` from C takes an integer argument. `std::abs` has overloads for floating point arguments that work as expected.