### PR TITLE
Fix two asserts in Clang

### DIFF
--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -395,7 +395,8 @@ namespace clad {
                   SourceRange(), false, noLoc, MultiExprArg(), noLoc,
                   SourceRange(), qType, TSI,
                   (arraySize ? arraySize : clad_compat::ArraySize_None()),
-                  GetValidSRange(semaRef), initializer)
+                  initializer ? GetValidSRange(semaRef) : SourceRange(),
+                  initializer)
               .getAs<CXXNewExpr>();
       return newExpr;
     }

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -162,7 +162,8 @@ namespace clad {
         clang::DeclContext const* declContext = static_cast<clang::DeclContext const*>(recordDecl);
         utils::BuildNNS(semaRef, const_cast<clang::DeclContext*>(declContext), CSS);
         NestedNameSpecifier* NS = CSS.getScopeRep();
-        return C.getElaboratedType(ETK_None, NS->getPrefix(), QT);
+        if (auto* Prefix = NS->getPrefix())
+          return C.getElaboratedType(ETK_None, Prefix, QT);
       }
       return QT;
     }

--- a/test/ForwardMode/Pointer.C
+++ b/test/ForwardMode/Pointer.C
@@ -19,10 +19,10 @@ double fn1(double i, double j) {
 // CHECK-NEXT:     double _d_j = 0;
 // CHECK-NEXT:     double *_d_p = &_d_i;
 // CHECK-NEXT:     double *p = &i;
-// CHECK-NEXT:     double **_d_q = new double *(/*implicit*/(double *)0);
-// CHECK-NEXT:     double **q = new double *(/*implicit*/(double *)0);
-// CHECK-NEXT:     *_d_q = new double(/*implicit*/(double)0);
-// CHECK-NEXT:     *q = new double(/*implicit*/(double)0);
+// CHECK-NEXT:     double **_d_q = new double *;
+// CHECK-NEXT:     double **q = new double *;
+// CHECK-NEXT:     *_d_q = new double;
+// CHECK-NEXT:     *q = new double;
 // CHECK-NEXT:     **_d_q = _d_j;
 // CHECK-NEXT:     **q = j;
 // CHECK-NEXT:     return *_d_p * **q + *p * **_d_q;
@@ -48,8 +48,8 @@ double fn3(double i, double j) {
 // CHECK: double fn3_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     double *_d_p = new double [2](/*implicit*/(double{{ ?}}[2])0);
-// CHECK-NEXT:     double *p = new double [2](/*implicit*/(double{{ ?}}[2])0);
+// CHECK-NEXT:     double *_d_p = new double [2];
+// CHECK-NEXT:     double *p = new double [2];
 // CHECK-NEXT:     _d_p[0] = _d_i + _d_j;
 // CHECK-NEXT:     p[0] = i + j;
 // CHECK-NEXT:     _d_p[1] = _d_i * j + i * _d_j;


### PR DESCRIPTION
This reduces the number of tests failures when using a LLVM build with `assert`s enabled from 21 to 8:
```
Failed Tests (8):
  clad :: Arrays/ArrayInputsReverseMode.C
  clad :: FirstDerivative/Overloads.C
  clad :: FirstDerivative/VirtualMethodsCall.C
  clad :: ForwardMode/UserDefinedTypes.C
  clad :: ForwardMode/VectorMode.C
  clad :: ForwardMode/VectorModeInterface.C
  clad :: Gradient/UserDefinedTypes.C
  clad :: Misc/RunDemos.C
```

Of these:
 * 4x "point of instantiation must be valid"
 * 2x `VTableBuilder.cpp`, "Should not have method info for this method yet!"
 * 1x `CGCall.cpp`, "type mismatch in call argument!"
 * 1x `SourceManager.cpp`, "Can't get file characteristic of invalid loc!"