### PR TITLE
Restore args passed by reference and arg of increment/decrement

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1884,6 +1884,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
   StmtDiff ReverseModeVisitor::VisitUnaryOperator(const UnaryOperator* UnOp) {
     auto opCode = UnOp->getOpcode();
     StmtDiff diff{};
+    Expr* E = UnOp->getSubExpr();
     // If it is a post-increment/decrement operator, its result is a reference
     // and we should return it.
     Expr* ResultRef = nullptr;
@@ -1891,23 +1892,35 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
       // xi = +xj
       // dxi/dxj = +1.0
       // df/dxj += df/dxi * dxi/dxj = df/dxi
-      diff = Visit(UnOp->getSubExpr(), dfdx());
+      diff = Visit(E, dfdx());
     else if (opCode == UO_Minus) {
       // xi = -xj
       // dxi/dxj = -1.0
       // df/dxj += df/dxi * dxi/dxj = -df/dxi
       auto d = BuildOp(UO_Minus, dfdx());
-      diff = Visit(UnOp->getSubExpr(), d);
+      diff = Visit(E, d);
     } else if (opCode == UO_PostInc || opCode == UO_PostDec) {
-      diff = Visit(UnOp->getSubExpr(), dfdx());
+      auto EStored = GlobalStoreAndRef(E, "_t", /*force=*/true);
+      auto assign = BuildOp(BinaryOperatorKind::BO_Assign, E, EStored.getExpr_dx());
+      if (isInsideLoop)
+          addToCurrentBlock(EStored.getExpr(), direction::forward);
+      addToCurrentBlock(assign, direction::reverse);
+
+      diff = Visit(E, dfdx());
       ResultRef = diff.getExpr_dx();
       if (m_ExternalSource)
         m_ExternalSource->ActBeforeFinalisingPostIncDecOp(diff);
     } else if (opCode == UO_PreInc || opCode == UO_PreDec) {
-      diff = Visit(UnOp->getSubExpr(), dfdx());
+      auto EStored = GlobalStoreAndRef(E, "_t", /*force=*/true);
+      auto assign = BuildOp(BinaryOperatorKind::BO_Assign, E, EStored.getExpr_dx());
+      if (isInsideLoop)
+          addToCurrentBlock(EStored.getExpr(), direction::forward);
+      addToCurrentBlock(assign, direction::reverse);
+
+      diff = Visit(E, dfdx());
     } else if (opCode == UnaryOperatorKind::UO_Real ||
                opCode == UnaryOperatorKind::UO_Imag) {
-      diff = VisitWithExplicitNoDfDx(UnOp->getSubExpr());
+      diff = VisitWithExplicitNoDfDx(E);
       ResultRef = BuildOp(opCode, diff.getExpr_dx());
       /// Create and add `__real r += dfdx()` expression.
       if (dfdx()) {
@@ -1931,7 +1944,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
           if (MD->isInstance()) {
             auto thisType = clad_compat::CXXMethodDecl_getThisType(m_Sema, MD);
             if (utils::SameCanonicalType(thisType, UnOp->getType())) {
-              diff = Visit(UnOp->getSubExpr());
+              diff = Visit(E);
               Expr* cloneE =
                   BuildOp(UnaryOperatorKind::UO_AddrOf, diff.getExpr());
               Expr* derivedE =
@@ -1947,11 +1960,10 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
       if (opCode != UO_LNot)
         unsupportedOpWarn(UnOp->getEndLoc());
 
-      Expr* subExpr = UnOp->getSubExpr();
-      if (isa<DeclRefExpr>(subExpr))
-        diff = Visit(subExpr);
+      if (isa<DeclRefExpr>(E))
+        diff = Visit(E);
       else
-        diff = StmtDiff(subExpr);
+        diff = StmtDiff(E);
     }
     Expr* op = BuildOp(opCode, diff.getExpr());
     return StmtDiff(op, ResultRef);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1491,7 +1491,10 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
       CallArgDx.push_back(argDiff.getExpr_dx());
       // Save cloned arg in a "global" variable, so that it is accessible from
       // the reverse pass.
-      StmtDiff argDiffStore = GlobalStoreAndRef(argDiff.getExpr(), "_t");
+      // FIXME: At this point, we assume all the variables passed by reference
+      // may be changed since we have no way to determine otherwise.
+      StmtDiff argDiffStore =
+        GlobalStoreAndRef(argDiff.getExpr(), "_t", /*force=*/ passByRef);
       // We need to pass the actual argument in the cloned call expression,
       // instead of a temporary, for arguments passed by reference. This is
       // because, callee function may modify the argument passed as reference
@@ -1536,11 +1539,17 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
           auto& block = getCurrentBlock(direction::reverse);
           block.insert(block.begin() + insertionPoint,
                        BuildDeclStmt(argDiffLocalVD));
+          // Restore agrs
+          auto op = BuildOp(BinaryOperatorKind::BO_Assign,
+             argDiff.getExpr(), BuildDeclRef(argDiffLocalVD));
+          block.insert(block.begin() + insertionPoint + 1, op);
+
           Expr* argDiffLocalE = BuildDeclRef(argDiffLocalVD);
 
-          // We added local variable to store result of `clad::pop(...)`. Thus
-          // we need to correspondingly adjust the insertion point.
-          insertionPoint += 1;
+          // We added local variable to store result of `clad::pop(...)` and
+          // restoration of the original arg. Thus we need to correspondingly
+          // adjust the insertion point.
+          insertionPoint += 2;
           // We cannot use the already existing `argDiff.getExpr()` here because
           // it will cause inconsistent pushes and pops to the clad tape.
           // FIXME: Modify `GlobalStoreAndRef` such that its functioning is
@@ -1549,6 +1558,15 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
           Expr* newArgE = Visit(arg).getExpr();
           argDiffStore = {newArgE, argDiffLocalE};
         } else {
+          // Restore args
+          auto& block = getCurrentBlock(direction::reverse);
+          auto op = BuildOp(BinaryOperatorKind::BO_Assign,
+             argDiff.getExpr(), argDiffStore.getExpr());
+          block.insert(block.begin() + insertionPoint, op);
+          // We added restoration of the original arg. Thus we need to
+          // correspondingly adjust the insertion point.
+          insertionPoint += 1;
+
           argDiffStore = {argDiff.getExpr(), argDiffStore.getExpr_dx()};
         }
       }


### PR DESCRIPTION
If an argument is passed to a function by reference it might be changed. Therefore, we have to restore it on the backward pass. The same applies to increments/decrements.
Note: 
1) Restoring reference type parameters still doesn't work with pointer-array type variables with indices that have to be stored (or without indices).
2) Storing variables before they are incremented/decremented may seem like an overkill since we can insert decrement/increment respectively in the backward pass. However, this approach can easily cause bugs: For `x = x++', we would restore x first and then decrement it by one (due to the order of assignment and increment), which is not correct. Moreover, it would be preferable to have a central point for storing variables (which GlobalStoreAndRef() already is).
