### PR TITLE
Remove Redundant Goto

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -14,7 +14,7 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Sema/Sema.h"
-
+#include "clang/AST/ParentMapContext.h"  
 #include <array>
 #include <memory>
 #include <stack>
@@ -91,6 +91,9 @@ namespace clad {
 
     // Function to Differentiate with Enzyme as Backend
     void DifferentiateWithEnzyme();
+    
+    // Whether Stmt is Return and not inside any block;
+    bool OnlyReturn = false;
 
   public:
     using direction = rmv::direction;


### PR DESCRIPTION
Solves issue #526.  We can only remove the 'goto' label when the parent of the parent of the return statement is null. 