### PR TITLE
Remove Redundant Goto Statements

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -14,7 +14,7 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Sema/Sema.h"
-
+#include "clang/AST/ParentMapContext.h"  
 #include <array>
 #include <memory>
 #include <stack>
@@ -91,6 +91,9 @@ namespace clad {
 
     // Function to Differentiate with Enzyme as Backend
     void DifferentiateWithEnzyme();
+    
+    // Whether Stmt is Return and not inside any block;
+    bool OnlyReturn = false;
 
   public:
     using direction = rmv::direction;

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -13,7 +13,7 @@
 #include "clad/Differentiator/StmtClone.h"
 #include "clad/Differentiator/ExternalRMVSource.h"
 #include "clad/Differentiator/MultiplexExternalRMVSource.h"
-
+#include "clang/AST/ParentMapContext.h"  
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/TemplateBase.h"
@@ -744,6 +744,18 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     beginBlock(direction::forward);
     beginBlock(direction::reverse);
     for (Stmt* S : CS->body()) {
+      std::string cppString="ReturnStmt";
+      const char* cString = S->getStmtClassName();
+      if(cppString.compare(cString) == 0 ){
+        auto parents = m_Context.getParents(*CS);
+        if (!parents.empty()){
+          const Stmt* parentStmt =  parents[0].get<Stmt>();
+          if(parentStmt==nullptr)
+            OnlyReturn=true;
+          else
+            OnlyReturn=false;
+        }
+      }
       if (m_ExternalSource)
         m_ExternalSource->ActBeforeDifferentiatingStmtInVisitCompoundStmt();
       StmtDiff SDiff = DifferentiateSingleStmt(S);
@@ -1153,14 +1165,22 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     // If the original function returns at this point, some part of the reverse
     // pass (corresponding to other branches that do not return here) must be
     // skipped. We create a label in the reverse pass and jump to it via goto.
-    LabelDecl* LD = LabelDecl::Create(
-        m_Context, m_Sema.CurContext, noLoc, CreateUniqueIdentifier("_label"));
-    m_Sema.PushOnScopeChains(LD, m_DerivativeFnScope, true);
+    LabelDecl* LD = nullptr;
+    if (!OnlyReturn) {
+      LD = LabelDecl::Create(
+          m_Context, m_Sema.CurContext, noLoc, CreateUniqueIdentifier("_label"));
+      m_Sema.PushOnScopeChains(LD, m_DerivativeFnScope, true);      
+    }
     // Attach label to the last Stmt in the corresponding Reverse Stmt.
     if (!Reverse)
       Reverse = m_Sema.ActOnNullStmt(noLoc).get();
-    Stmt* LS = m_Sema.ActOnLabelStmt(noLoc, LD, noLoc, Reverse).get();
-    addToCurrentBlock(LS, direction::reverse);
+    if (!OnlyReturn) {
+      Stmt* LS = m_Sema.ActOnLabelStmt(noLoc, LD, noLoc, Reverse).get();
+      addToCurrentBlock(LS, direction::reverse);
+    }
+    else {
+      addToCurrentBlock(Reverse, direction::reverse);
+    }
     for (Stmt* S : cast<CompoundStmt>(ReturnDiff.getStmt())->body())
       addToCurrentBlock(S, direction::forward);
 
@@ -1175,7 +1195,10 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     }
 
     // Create goto to the label.
-    return m_Sema.ActOnGotoStmt(noLoc, noLoc, LD).get();
+    if (!OnlyReturn) 
+      return m_Sema.ActOnGotoStmt(noLoc, noLoc, LD).get();
+    
+    return nullptr;
   }
 
   StmtDiff ReverseModeVisitor::VisitParenExpr(const ParenExpr* PE) {

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -24,8 +24,6 @@ double addArr(double *arr, int n) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         ret += arr[clad::push(_t1, i)];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_ret += _d_y;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
@@ -45,8 +43,6 @@ double f(double *arr) {
 //CHECK:   void f_grad(double *arr, clad::array_ref<double> _d_arr) {
 //CHECK-NEXT:       double *_t0;
 //CHECK-NEXT:       _t0 = arr;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         int _grad1 = 0;
 //CHECK-NEXT:         addArr_pullback(_t0, 3, 1, _d_arr, &_grad1);
@@ -82,8 +78,6 @@ float func(float* a, float* b) {
 //CHECK-NEXT:         _ref0 *= clad::push(_t3, b[clad::push(_t5, i)]);
 //CHECK-NEXT:         sum += a[clad::push(_t7, i)];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
@@ -113,8 +107,6 @@ float helper(float x) {
 // CHECK: void helper_pullback(float x, float _d_y, clad::array_ref<float> _d_x) {
 // CHECK-NEXT:     float _t0;
 // CHECK-NEXT:     _t0 = x;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = _d_y * _t0;
 // CHECK-NEXT:         float _r1 = 2 * _d_y;
@@ -141,8 +133,6 @@ float func2(float* a) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         sum += helper(clad::push(_t3, a[clad::push(_t1, i)]));
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         float _r_d0 = _d_sum;
@@ -175,8 +165,6 @@ float func3(float* a, float* b) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         sum += (a[clad::push(_t1, i)] += b[clad::push(_t3, i)]);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         float _r_d0 = _d_sum;
@@ -221,8 +209,6 @@ double func4(double x) {
 //CHECK-NEXT:         clad::push(_t4, arr , 3UL);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t3; _t3--) {
 //CHECK-NEXT:         {
@@ -286,8 +272,6 @@ double func5(int k) {
 //CHECK-NEXT:         clad::push(_t4, arr , n);
 //CHECK-NEXT:         sum += addArr(arr, clad::push(_t5, n));
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t3; _t3--) {
 //CHECK-NEXT:         {
@@ -339,8 +323,6 @@ double func6(double seed) {
 //CHECK-NEXT:         clad::push(_t3, arr , 3UL);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {

--- a/test/Arrays/Arrays.C
+++ b/test/Arrays/Arrays.C
@@ -106,8 +106,6 @@ double const_dot_product(double x, double y, double z) {
 //CHECK-NEXT:       _t2 = consts[1];
 //CHECK-NEXT:       _t5 = vars[2];
 //CHECK-NEXT:       _t4 = consts[2];
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           _d_vars[0] += _r0;
@@ -193,8 +191,6 @@ double const_matmul_sum(double a, double b, double c, double d) {
 //:       _t15 = A[1][1];
 //:       _t14 = B[1][1];
 //:       double C[2][2] = {{[{][{]}}_t1 * _t0 + _t3 * _t2, _t5 * _t4 + _t7 * _t6}, {_t9 * _t8 + _t11 * _t10, _t13 * _t12 + _t15 * _t14}};
-//:       goto _label0;
-//:     _label0:
 //:       {
 //:           _d_C[0][0] += 1;
 //:           _d_C[0][1] += 1;

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -19,8 +19,6 @@ float func(float x, float y) {
 //CHECK-NEXT:     x = x + y;
 //CHECK-NEXT:     _EERepl_x1 = x;
 //CHECK-NEXT:     y = x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     * _d_y += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r_d1 = * _d_y;
@@ -61,8 +59,6 @@ float func2(float x, int y) {
 //CHECK-NEXT:     _t2 = x;
 //CHECK-NEXT:     x = _t1 * _t0 + _t3 * _t2;
 //CHECK-NEXT:     _EERepl_x1 = x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     * _d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r_d0 = * _d_x;
@@ -89,8 +85,6 @@ float func3(int x, int y) {
 
 //CHECK: void func3_grad(int x, int y, clad::array_ref<int> _d_x, clad::array_ref<int> _d_y, double &_final_error) {
 //CHECK-NEXT:     x = y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     * _d_y += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         int _r_d0 = * _d_x;
@@ -117,8 +111,6 @@ float func4(float x, float y) {
 //CHECK-NEXT:     _EERepl_z0 = z;
 //CHECK-NEXT:     x = z + y;
 //CHECK-NEXT:     _EERepl_x1 = x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     * _d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r_d0 = * _d_x;
@@ -149,8 +141,6 @@ float func5(float x, float y) {
 //CHECK-NEXT:     int z = 56;
 //CHECK-NEXT:     x = z + y;
 //CHECK-NEXT:     _EERepl_x1 = x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     * _d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r_d0 = * _d_x;
@@ -169,8 +159,6 @@ float func5(float x, float y) {
 float func6(float x) { return x; }
 
 //CHECK: void func6_grad(float x, clad::array_ref<float> _d_x, double &_final_error) {
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     * _d_x += 1;
 //CHECK-NEXT:     double _delta_x = 0;
 //CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
@@ -186,8 +174,6 @@ float func7(float x, float y) { return (x * y); }
 //CHECK-NEXT:     _t1 = x;
 //CHECK-NEXT:     _t0 = y;
 //CHECK-NEXT:     _ret_value0 = (_t1 * _t0);
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r0 = 1 * _t0;
 //CHECK-NEXT:         * _d_x += _r0;

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -35,8 +35,6 @@ float func(float x, float y) {
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     float z = _t1 * _t0;
 //CHECK-NEXT:     _EERepl_z0 = z;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r0 = _d_z * _t0;
@@ -95,8 +93,6 @@ float func2(float x, float y) {
 //CHECK-NEXT:     _t2 = x;
 //CHECK-NEXT:     float z = _t3 / _t2;
 //CHECK-NEXT:     _EERepl_z0 = z;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r2 = _d_z / _t2;
@@ -164,8 +160,6 @@ float func3(float x, float y) {
 //CHECK-NEXT:     float t = _t5 * _t2;
 //CHECK-NEXT:     _EERepl_t0 = t;
 //CHECK-NEXT:     _EERepl_y1 = y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_t += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r2 = _d_t * _t2;
@@ -210,8 +204,6 @@ float func4(float x, float y) { return std::pow(x, y); }
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     _t1 = y;
 //CHECK-NEXT:     _ret_value0 = std::pow(_t0, _t1);
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _grad0 = 0.F;
 //CHECK-NEXT:         float _grad1 = 0.F;
@@ -248,8 +240,6 @@ float func5(float x, float y) {
 //CHECK-NEXT:     _t2 = y;
 //CHECK-NEXT:     _t1 = y;
 //CHECK-NEXT:     _ret_value0 = _t2 * _t1;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r1 = 1 * _t1;
 //CHECK-NEXT:         * _d_y += _r1;
@@ -280,8 +270,6 @@ double helper(double x, double y) { return x * y; }
 //CHECK-NEXT:     _t1 = x;
 //CHECK-NEXT:     _t0 = y;
 //CHECK-NEXT:     _ret_value0 = _t1 * _t0;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = _d_y0 * _t0;
 //CHECK-NEXT:         * _d_x += _r0;
@@ -316,8 +304,6 @@ float func6(float x, float y) {
 //CHECK-NEXT:     _t4 = z;
 //CHECK-NEXT:     _t3 = z;
 //CHECK-NEXT:     _ret_value0 = _t4 * _t3;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r2 = 1 * _t3;
 //CHECK-NEXT:         _d_z += _r2;
@@ -350,8 +336,6 @@ float func7(float x) {
 //CHECK: void func7_grad(float x, clad::array_ref<float> _d_x, double &_final_error) {
 //CHECK-NEXT:     int _d_z = 0;
 //CHECK-NEXT:     int z = x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_z += 1;
 //CHECK-NEXT:         _d_z += 1;
@@ -372,8 +356,6 @@ double helper2(float& x) { return x * x; }
 //CHECK-NEXT:     _t1 = x;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     _ret_value0 = _t1 * _t0;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = _d_y * _t0;
 //CHECK-NEXT:         * _d_x += _r0;
@@ -400,8 +382,6 @@ float func8(float x, float y) {
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     z = y + helper2(x);
 //CHECK-NEXT:     _EERepl_z1 = z;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r_d0 = _d_z;
@@ -449,8 +429,6 @@ float func9(float x, float y) {
 //CHECK-NEXT:     _t5 = helper2(y);
 //CHECK-NEXT:     z += _t8 * _t5;
 //CHECK-NEXT:     _EERepl_z1 = z;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r_d0 = _d_z;

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -47,8 +47,6 @@ float func(float x, float y) {
 //CHECK-NEXT:         x = y;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _ret_value0 = x + y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_x += 1;
 //CHECK-NEXT:         * _d_y += 1;
@@ -160,8 +158,6 @@ float func3(float x, float y) { return x > 30 ? x * y : x + y; }
 //CHECK-NEXT:         _t0 = y;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _ret_value0 = _cond0 ? _t1 * _t0 : x + y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         float _r0 = 1 * _t0;
 //CHECK-NEXT:         * _d_x += _r0;
@@ -207,8 +203,6 @@ float func4(float x, float y) {
 //CHECK-NEXT:     _t3 = y;
 //CHECK-NEXT:     _t2 = x;
 //CHECK-NEXT:     _ret_value0 = _t3 / _t2;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r1 = 1 / _t2;
 //CHECK-NEXT:         * _d_y += _r1;

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -30,8 +30,6 @@ float func(float* p, int n) {
 //CHECK-NEXT:         sum += p[clad::push(_t1, i)];
 //CHECK-NEXT:         clad::push(_EERepl_sum1, sum);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
@@ -87,8 +85,6 @@ float func2(float x) {
 //CHECK-NEXT:         z = m + m;
 //CHECK-NEXT:         clad::push(_EERepl_z1, z);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
@@ -139,8 +135,6 @@ float func3(float x, float y) {
 //CHECK-NEXT:     _EERepl_arr1 = arr[1];
 //CHECK-NEXT:     arr[2] = arr[0] + arr[1];
 //CHECK-NEXT:     _EERepl_arr2 = arr[2];
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_arr[2] += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r_d2 = _d_arr[2];
@@ -213,8 +207,6 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:         sum += x[clad::push(_t5, i)];
 //CHECK-NEXT:         clad::push(_EERepl_sum1, sum);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
@@ -306,8 +298,6 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:     output[2] = _t9 * _t8 - _t11 * _t10;
 //CHECK-NEXT:     _EERepl_output3 = output[2];
 //CHECK-NEXT:     _ret_value0 = output[0] + output[1] + output[2];
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_output[0] += 1;
 //CHECK-NEXT:         _d_output[1] += 1;

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -32,8 +32,6 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:         sum += f[clad::push(_t1, i)] + f[clad::push(_t3, i - 1)];
 //CHECK-NEXT:         clad::push(_EERepl_sum1, sum);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
@@ -93,8 +91,6 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:             clad::push(_EERepl_sum1, sum);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
@@ -160,8 +156,6 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:         sum += clad::push(_t4, a[clad::push(_t2, i)]) / clad::push(_t1, b[clad::push(_t5, i)]);
 //CHECK-NEXT:         clad::push(_EERepl_sum1, sum);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -102,8 +102,6 @@ void f7_grad(float x, clad::array_ref<float> _d_x);
 // CHECK: void f7_grad(float x, clad::array_ref<float> _d_x) {
 // CHECK-NEXT:     float _t0;
 // CHECK-NEXT:     _t0 = x;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
 // CHECK-NEXT:         double _grad1 = 0.;
@@ -129,8 +127,6 @@ void f8_grad(float x, clad::array_ref<float> _d_x);
 // CHECK: void f8_grad(float x, clad::array_ref<float> _d_x) {
 // CHECK-NEXT:     float _t0;
 // CHECK-NEXT:     _t0 = x;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
 // CHECK-NEXT:         int _grad1 = 0;
@@ -159,8 +155,6 @@ void f9_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<floa
 // CHECK-NEXT:     float _t1;
 // CHECK-NEXT:     _t0 = x;
 // CHECK-NEXT:     _t1 = y;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
 // CHECK-NEXT:         float _grad1 = 0.F;
@@ -190,8 +184,6 @@ void f10_grad(float x, int y, clad::array_ref<float> _d_x, clad::array_ref<int> 
 // CHECK-NEXT:     int _t1;
 // CHECK-NEXT:     _t0 = x;
 // CHECK-NEXT:     _t1 = y;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
 // CHECK-NEXT:         int _grad1 = 0;
@@ -216,8 +208,6 @@ double f11(double x, double y) {
 // CHECK-NEXT:     _t2 = x;
 // CHECK-NEXT:     _t3 = y - std::pow(_t2, 2);
 // CHECK-NEXT:     _t1 = std::pow(_t3, 2);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _grad0 = 0.;
 // CHECK-NEXT:         int _grad1 = 0;

--- a/test/FirstDerivative/UnsupportedOpsWarn.C
+++ b/test/FirstDerivative/UnsupportedOpsWarn.C
@@ -19,8 +19,6 @@ int binOpWarn_1(int x){
 }
 
 // CHECK: void binOpWarn_1_grad(int x, clad::array_ref<int> _d_x) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     ;
 // CHECK-NEXT: }
 
@@ -41,8 +39,6 @@ int unOpWarn_1(int x){
 // CHECK: void unOpWarn_1_grad(int x, clad::array_ref<int> _d_x) {
 // CHECK-NEXT:     int *_d_pnt = 0;
 // CHECK-NEXT:     int *pnt = &x;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     * _d_x += 1;
 // CHECK-NEXT: }
 

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -13,8 +13,6 @@ double f1(double x, double y) {
 
 //CHECK:   void f1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       x = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       * _d_y += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d0 = * _d_x;
@@ -36,8 +34,6 @@ double f2(double x, double y) {
 //CHECK-NEXT:       _cond0 = x < y;
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:           x = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       * _d_x += 1;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           double _r_d0 = * _d_x;
@@ -69,8 +65,6 @@ double f3(double x, double y) {
 //CHECK-NEXT:       _t2 = x;
 //CHECK-NEXT:       y = _t3 * _t2;
 //CHECK-NEXT:       x = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       * _d_y += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d3 = * _d_x;
@@ -114,8 +108,6 @@ double f4(double x, double y) {
 //CHECK:   void f4_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       y = x;
 //CHECK-NEXT:       x = 0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       * _d_y += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d1 = * _d_x;
@@ -164,8 +156,6 @@ double f5(double x, double y) {
 //CHECK-NEXT:           double z = t;
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label1;
-//CHECK-NEXT:     _label1:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           {
@@ -226,8 +216,6 @@ double f6(double x, double y) {
 //CHECK-NEXT:           double z = t;
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label1;
-//CHECK-NEXT:     _label1:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           {
@@ -296,8 +284,6 @@ double f7(double x, double y) {
 //CHECK-NEXT:       t[0] /= _t4;
 //CHECK-NEXT:       t[0] -= t[1];
 //CHECK-NEXT:       x = ++t[0];
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t[0] += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d6 = * _d_x;
@@ -372,8 +358,6 @@ double f8(double x, double y) {
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       _t0 = (t[0] = t[1] = t[2]);
 //CHECK-NEXT:       t[3] = (y *= _t0);
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t[3] += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d0 = _d_t[3];
@@ -417,8 +401,6 @@ double f9(double x, double y) {
 //CHECK-NEXT:       _t3 = _ref0;
 //CHECK-NEXT:       _t2 = y;
 //CHECK-NEXT:       _ref0 *= _t2;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d1 = _d_t;
@@ -445,8 +427,6 @@ double f10(double x, double y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x;
 //CHECK-NEXT:       t = x = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d0 = _d_t;
@@ -469,8 +449,6 @@ double f11(double x, double y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x;
 //CHECK-NEXT:       (t = x) = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d1 = _d_t;
@@ -500,8 +478,6 @@ double f12(double x, double y) {
 //CHECK-NEXT:       _t1 = _ref0;
 //CHECK-NEXT:       _t0 = y;
 //CHECK-NEXT:       _ref0 *= _t0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d2 = (_cond0 ? _d_t : _d_t);
@@ -537,8 +513,6 @@ double f13(double x, double y) {
 //CHECK-NEXT:       double t = _t1 * _t0;
 //CHECK-NEXT:       _t3 = t;
 //CHECK-NEXT:       _t2 = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r2 = 1 * _t2;
 //CHECK-NEXT:           _d_t += _r2;
@@ -577,8 +551,6 @@ double f14(double i, double j) {
 // CHECK-NEXT:     _t2 = a;
 // CHECK-NEXT:     _t1 = i;
 // CHECK-NEXT:     a *= _t1;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     * _d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d2 = *_d_a;
@@ -648,8 +620,6 @@ double f15(double i, double j) {
 // CHECK-NEXT:     _t8 = j;
 // CHECK-NEXT:     _t6 = 3 * _t8;
 // CHECK-NEXT:     d *= _t6;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_a += 1;
 // CHECK-NEXT:         *_d_c += 1;
@@ -720,8 +690,6 @@ double f16(double i, double j) {
 // CHECK-NEXT:     _t2 = j;
 // CHECK-NEXT:     _t0 = 4 * _t2;
 // CHECK-NEXT:     c *= _t0;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     * _d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = *_d_c;
@@ -745,8 +713,6 @@ double f17(double i, double j, double k) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     _t0 = i;
 // CHECK-NEXT:     j = 2 * _t0;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_j += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_j;
@@ -771,8 +737,6 @@ double f18(double i, double j, double k) {
 // CHECK-NEXT:     _t1 = j;
 // CHECK-NEXT:     k = 2 * _t0 + 2 * _t1;
 // CHECK-NEXT:     k += i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_k += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d1 = _d_k;
@@ -803,8 +767,6 @@ double f19(double a, double b) {
 //CHECK-NEXT:     _t0 = a;
 //CHECK-NEXT:     _t1 = b;
 //CHECK-NEXT:     _t2 = b;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _grad0 = 0.;
 //CHECK-NEXT:         double _grad1 = 0.;

--- a/test/Gradient/DiffInterface.C
+++ b/test/Gradient/DiffInterface.C
@@ -19,8 +19,6 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       _t2 = z;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
@@ -44,8 +42,6 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       _t2 = z;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
@@ -69,8 +65,6 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       _t2 = z;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
@@ -94,8 +88,6 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       _t2 = z;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
@@ -118,8 +110,6 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       _t2 = z;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;
@@ -142,8 +132,6 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       _t2 = z;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 0 * 1;

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -8,8 +8,6 @@
 namespace A {
   template <typename T> T constantFn(T i) { return 3; }
   // CHECK: void constantFn_pullback(float i, float _d_y, clad::array_ref<float> _d_i) {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     ;
   // CHECK-NEXT: }
 } // namespace A
@@ -35,8 +33,6 @@ double fn1(float i) {
 // CHECK-NEXT:     _t2 = res;
 // CHECK-NEXT:     _t1 = i;
 // CHECK-NEXT:     double a = _t2 * _t1;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r1 = _d_a * _t1;
@@ -64,8 +60,6 @@ double modify1(double& i, double& j) {
 // CHECK-NEXT:     i += j;
 // CHECK-NEXT:     j += j;
 // CHECK-NEXT:     double res = i + j;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         * _d_i += _d_res;
@@ -107,8 +101,6 @@ double fn2(double i, double j) {
 // CHECK-NEXT:     _t2 = i;
 // CHECK-NEXT:     _t3 = j;
 // CHECK-NEXT:     temp = modify1(i, j);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     * _d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d1 = _d_temp;
@@ -167,8 +159,6 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     _t2 = i;
 // CHECK-NEXT:     _t3 = j;
 // CHECK-NEXT:     update1(i, j);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     * _d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         update1_pullback(_t2, _t3, &* _d_i, &* _d_j);
@@ -204,8 +194,6 @@ float sum(double* arr, int n) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _t3 = arr[0];
 // CHECK-NEXT:     arr[0] += 10 * _t3;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d1 = _d_arr[0];
@@ -274,8 +262,6 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:         twice(arr[clad::push(_t6, i)]);
 // CHECK-NEXT:         res += arr[clad::push(_t8, i)];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t2; _t2--) {
 // CHECK-NEXT:         {
@@ -314,8 +300,6 @@ double modify2(double* arr) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     _t0 = arr[0];
 // CHECK-NEXT:     arr[0] = 5 * _t0 + arr[1];
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_arr[0];
@@ -338,8 +322,6 @@ double fn5(double* arr, int n) {
 // CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     _t0 = arr;
 // CHECK-NEXT:     double temp = modify2(arr);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_arr[0] += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         modify2_pullback(_t0, _d_temp, _d_arr);

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -21,8 +21,6 @@ struct Experiment {
   // CHECK-NEXT:     _t1 = i;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
@@ -52,8 +50,6 @@ struct ExperimentConst {
   // CHECK-NEXT:     _t1 = i;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
@@ -88,8 +84,6 @@ struct ExperimentVolatile {
   // CHECK-NEXT:     _t1 = i;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
@@ -124,8 +118,6 @@ struct ExperimentConstVolatile {
   // CHECK-NEXT:     _t1 = i;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
@@ -157,8 +149,6 @@ struct ExperimentNNS {
   // CHECK-NEXT:     _t1 = i;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
@@ -215,8 +205,6 @@ int main() {
   // CHECK-NEXT:     _t1 = i;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;
@@ -239,8 +227,6 @@ int main() {
   // CHECK-NEXT:     _t1 = ii;
   // CHECK-NEXT:     _t3 = _t2 * _t1;
   // CHECK-NEXT:     _t0 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         double _r1 = _r0 * _t1;

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -15,8 +15,6 @@ __attribute__((always_inline)) double f_add1(double x, double y) {
 }
 
 //CHECK:   void f_add1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) __attribute__((always_inline)) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:           * _d_y += 1;
@@ -34,8 +32,6 @@ double f_add2(double x, double y) {
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       _t1 = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 3 * 1;
@@ -57,8 +53,6 @@ double f_add3(double x, double y) {
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       _t1 = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 3 * 1;
@@ -77,8 +71,6 @@ double f_sub1(double x, double y) {
 }
 
 //CHECK:   void f_sub1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:           * _d_y += -1;
@@ -95,8 +87,6 @@ double f_sub2(double x, double y) {
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       _t1 = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = 3 * 1;
@@ -118,8 +108,6 @@ double f_mult1(double x, double y) {
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       _t0 = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           * _d_x += _r0;
@@ -141,8 +129,6 @@ double f_mult2(double x, double y) {
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       _t2 = 3 * _t1 * 4;
 //CHECK-NEXT:       _t0 = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = _r0 * 4;
@@ -165,8 +151,6 @@ double f_div1(double x, double y) {
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       _t0 = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 / _t0;
 //CHECK-NEXT:           * _d_x += _r0;
@@ -190,8 +174,6 @@ double f_div2(double x, double y) {
 //CHECK-NEXT:       _t2 = 3 * _t1;
 //CHECK-NEXT:       _t3 = y;
 //CHECK-NEXT:       _t0 = (4 * _t3);
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 / _t0;
 //CHECK-NEXT:           double _r1 = _r0 * _t1;
@@ -227,8 +209,6 @@ double f_c(double x, double y) {
 //CHECK-NEXT:       _t2 = (_t5 / _t4);
 //CHECK-NEXT:       _t7 = x;
 //CHECK-NEXT:       _t6 = x;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           * _d_x += -_r0;
@@ -274,8 +254,6 @@ double f_rosenbrock(double x, double y) {
 //CHECK-NEXT:       _t8 = x;
 //CHECK-NEXT:       _t7 = x;
 //CHECK-NEXT:       _t2 = (y - _t8 * _t7);
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           * _d_x += _r0;
@@ -307,8 +285,6 @@ double f_cond1(double x, double y) {
 //CHECK:   void f_cond1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       _cond0 = x > y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:       else
@@ -329,8 +305,6 @@ double f_cond2(double x, double y) {
 //CHECK-NEXT:           ;
 //CHECK-NEXT:       else
 //CHECK-NEXT:           _cond1 = y > 0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:       else if (_cond1)
@@ -348,8 +322,6 @@ double f_cond3(double x, double c) {
 //CHECK:   void f_cond3_grad(double x, double c, clad::array_ref<double> _d_x, clad::array_ref<double> _d_c) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       _cond0 = c > 0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:           * _d_c += 1;
@@ -436,8 +408,6 @@ struct S {
   //CHECK-NEXT:       _t0 = x;
   //CHECK-NEXT:       _t3 = this->c2;
   //CHECK-NEXT:       _t2 = y;
-  //CHECK-NEXT:       goto _label0;
-  //CHECK-NEXT:     _label0:
   //CHECK-NEXT:       {
   //CHECK-NEXT:           double _r0 = 1 * _t0;
   //CHECK-NEXT:           (* _d_this).c1 += _r0;
@@ -505,8 +475,6 @@ void f_norm_grad(double x,
 //CHECK-NEXT:       _t4 = sum_of_powers(_t0, _t1, _t2, _t3);
 //CHECK-NEXT:       _t5 = d;
 //CHECK-NEXT:       _t6 = 1 / _t5;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _grad4 = 0.;
 //CHECK-NEXT:           double _grad5 = 0.;
@@ -546,8 +514,6 @@ void f_sin_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_re
 //CHECK-NEXT:       _t2 = y;
 //CHECK-NEXT:       _t3 = (std::sin(_t1) + std::sin(_t2));
 //CHECK-NEXT:       _t0 = (x + y);
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 // CHECK-NEXT:         double _r1 = _r0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(_t1, 1.).pushforward;
@@ -571,8 +537,6 @@ void f_types_grad(int x,
                   clad::array_ref<float> _d_y,
                   clad::array_ref<double> _d_z);
 //CHECK:   void f_types_grad(int x, float y, double z, clad::array_ref<int> _d_x, clad::array_ref<float> _d_y, clad::array_ref<double> _d_z) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:           * _d_y += 1;
@@ -601,8 +565,6 @@ void f_decls1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array
 //CHECK-NEXT:       double b = 5 * _t1;
 //CHECK-NEXT:       double c = a + b;
 //CHECK-NEXT:       _t2 = c;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r4 = 1 * _t2;
 //CHECK-NEXT:           double _r5 = 2 * 1;
@@ -653,8 +615,6 @@ void f_decls2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array
 //CHECK-NEXT:       _t4 = y;
 //CHECK-NEXT:       double c = _t5 * _t4;
 //CHECK-NEXT:       _t6 = b;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += 1;
 //CHECK-NEXT:           double _r6 = 1 * _t6;
@@ -724,8 +684,6 @@ void f_decls3_grad(double x, double y, clad::array_ref<double> _d_x, clad::array
 //CHECK-NEXT:       _t5 = a;
 //CHECK-NEXT:       _t4 = a;
 //CHECK-NEXT:       double b = _t5 * _t4;
-//CHECK-NEXT:       goto _label2;
-//CHECK-NEXT:     _label2:
 //CHECK-NEXT:       _d_b += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r8 = _d_b * _t4;
@@ -792,8 +750,6 @@ void f_issue138_grad(double x, double y, clad::array_ref<double> _d_x, clad::arr
 //CHECK-NEXT:       _t7 = y;
 //CHECK-NEXT:       _t12 = _t11 * _t7;
 //CHECK-NEXT:       _t6 = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           double _r1 = _r0 * _t1;
@@ -828,8 +784,6 @@ void f_const_grad(const double a, const double b, clad::array_ref<double> _d_a, 
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t1 = a;
 //CHECK-NEXT:       _t0 = b;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * _t0;
 //CHECK-NEXT:           * _d_a += _r0;
@@ -855,8 +809,6 @@ void f_const_reference_grad(double i, double j, clad::array_ref<double> _d_i, cl
 //CHECK-NEXT:    const double &ar = a;
 //CHECK-NEXT:    _t0 = ar;
 //CHECK-NEXT:    double res = 2 * _t0;
-//CHECK-NEXT:    goto _label0;
-//CHECK-NEXT:  _label0:
 //CHECK-NEXT:    _d_res += 1;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _r0 = _d_res * _t0;
@@ -876,8 +828,6 @@ void f_const02_grad(double i, double j, clad::array_ref<double> _d_i, clad::arra
 //CHECK-NEXT:       double _d_res = 0;
 //CHECK-NEXT:       const double a = i;
 //CHECK-NEXT:       double res = a;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_res += 1;
 //CHECK-NEXT:       _d_a += _d_res;
 //CHECK-NEXT:       * _d_i += _d_a;
@@ -902,8 +852,6 @@ float running_sum(float* p, int n) {
 // CHECK-NEXT:         p[clad::push(_t1, i)] += p[clad::push(_t3, i - 1)];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _t5 = n - 1;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_p[_t5] += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
@@ -932,8 +880,6 @@ double fn_global_var_use(double i, double j) {
 // CHECK-NEXT:     double &ref = global;
 // CHECK-NEXT:     _t1 = ref;
 // CHECK-NEXT:     _t0 = i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
 // CHECK-NEXT:         _d_ref += _r0;

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -27,8 +27,6 @@ double f1(double x) {
 //CHECK-NEXT:           clad::push(_t2, t);
 //CHECK-NEXT:           t *= clad::push(_t1, x);
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           double _r_d0 = _d_t;
@@ -66,8 +64,6 @@ double f2(double x) {
 //CHECK-NEXT:               t *= clad::push(_t2, x);
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           for (; clad::back(_t1); clad::back(_t1)--) {
@@ -112,8 +108,6 @@ double f3(double x) {
 //CHECK-NEXT:               clad::push(_t4, _t3);
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label1;
-//CHECK-NEXT:     _label1:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           if (clad::pop(_t4))
@@ -148,8 +142,6 @@ double f4(double x) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           i++;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           double _r_d0 = _d_t;
@@ -174,8 +166,6 @@ double f5(double x){
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           x++;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       * _d_x += 1;
 //CHECK-NEXT:       for (; _t0; _t0--)
 //CHECK-NEXT:           ;
@@ -200,8 +190,6 @@ double f_sum(double *p, int n) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         s += p[clad::push(_t1, i)];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_s += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         double _r_d0 = _d_s;
@@ -218,8 +206,6 @@ double sq(double x) { return x * x; }
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = _d_y * _t0;
 //CHECK-NEXT:           * _d_x += _r0;
@@ -248,8 +234,6 @@ double f_sum_squares(double *p, int n) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         s += sq(clad::push(_t3, p[clad::push(_t1, i)]));
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_s += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         double _r_d0 = _d_s;
@@ -319,8 +303,6 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:     _t10 = std::exp(_t18);
 //CHECK-NEXT:     double gaus = _t17 * _t10;
 //CHECK-NEXT:     _t19 = gaus;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:          double _r17 = 1 * clad::custom_derivatives::log_pushforward(_t19, 1.).pushforward;
 //CHECK-NEXT:         _d_gaus += _r17;
@@ -394,8 +376,6 @@ void f_const_grad(const double, const double, clad::array_ref<double>, clad::arr
 //CHECK-NEXT:           int sq0 = clad::push(_t2, b) * clad::push(_t1, b);
 //CHECK-NEXT:           r += sq0;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_r += 1;
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           {
@@ -444,8 +424,6 @@ double f6 (double i, double j) {
 // CHECK-NEXT:         b += j;
 // CHECK-NEXT:         a += b + c + i;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
@@ -501,8 +479,6 @@ double fn7(double i, double j) {
 // CHECK-NEXT:             _t0++;
 // CHECK-NEXT:             a += clad::push(_t2, i) * clad::push(_t1, i) + j;
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -549,8 +525,6 @@ double fn8(double i, double j) {
 // CHECK-NEXT:                 a += clad::push(_t3, i) * clad::push(_t2, i) + j;
 // CHECK-NEXT:             } while (--counter);
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -611,8 +585,6 @@ double fn9(double i, double j) {
 // CHECK-NEXT:                     a += clad::push(_t3, i) * clad::push(_t2, i) + j;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -680,8 +652,6 @@ double fn10(double i, double j) {
 // CHECK-NEXT:             a += b;
 // CHECK-NEXT:             counter -= 1;
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -740,8 +710,6 @@ double fn11(double i, double j) {
 // CHECK-NEXT:         a += clad::push(_t2, i) * clad::push(_t1, i) + j;
 // CHECK-NEXT:         counter -= 1;
 // CHECK-NEXT:     } while (counter);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         {
@@ -810,8 +778,6 @@ double fn12(double i, double j) {
 // CHECK-NEXT:         } while (counter_again);
 // CHECK-NEXT:         counter -= 1;
 // CHECK-NEXT:     } while (counter);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         {
@@ -888,8 +854,6 @@ double fn13(double i, double j) {
 // CHECK-NEXT:         double temp = k;
 // CHECK-NEXT:         res += temp;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
@@ -997,8 +961,6 @@ double fn14(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:             clad::push(_t3, 4UL);
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -1115,8 +1077,6 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             clad::push(_t3, 2UL);
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -1219,8 +1179,6 @@ double fn16(double i, double j) {
 // CHECK-NEXT:         res += i + j;
 // CHECK-NEXT:         clad::push(_t5, 3UL);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--)
 // CHECK-NEXT:         switch (clad::pop(_t5)) {
@@ -1339,8 +1297,6 @@ double fn17(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:         clad::push(_t3, 2UL);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--)
 // CHECK-NEXT:         switch (clad::pop(_t3)) {
@@ -1452,8 +1408,6 @@ double fn18(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         clad::push(_t5, 3UL);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--)
 // CHECK-NEXT:         switch (clad::pop(_t5)) {
@@ -1512,8 +1466,6 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:         double &ref = arr[clad::push(_t1, i)];
 // CHECK-NEXT:         res += ref;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         double *_t4 = clad::pop(_t3);
@@ -1559,8 +1511,6 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:         _t2++;
 // CHECK-NEXT:         sum += clad::push(_t6, clad::push(_t5, x) * clad::push(_t4, x)) * clad::push(_t3, interval);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         for (; _t2; _t2--) {

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -23,8 +23,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -49,8 +47,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -77,8 +73,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -105,8 +99,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -131,8 +123,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -159,8 +149,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -187,8 +175,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -215,8 +201,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -241,8 +225,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -269,8 +251,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -297,8 +277,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -325,8 +303,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -353,8 +329,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -381,8 +355,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -409,8 +381,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -437,8 +407,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -465,8 +433,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -493,8 +459,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -521,8 +485,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -549,8 +511,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -577,8 +537,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -605,8 +563,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -633,8 +589,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -661,8 +615,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -688,8 +640,6 @@ public:
   // CHECK-NEXT:     _t0 = i;
   // CHECK-NEXT:     _t3 = i;
   // CHECK-NEXT:     _t2 = j;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 1 * _t0;
   // CHECK-NEXT:         (* _d_this).x += _r0;
@@ -743,8 +693,6 @@ double fn(double i,double j) {
 // CHECK-NEXT:     _t1 = i;
 // CHECK-NEXT:     _t3 = _t2 * _t1;
 // CHECK-NEXT:     _t0 = j;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
 // CHECK-NEXT:         double _r1 = _r0 * _t1;
@@ -802,8 +750,6 @@ int main() {
   // CHECK-NEXT:       _t0 = i;
   // CHECK-NEXT:       _t3 = i;
   // CHECK-NEXT:       _t2 = j;
-  // CHECK-NEXT:       goto _label0;
-  // CHECK-NEXT:     _label0:
   // CHECK-NEXT:       {
   // CHECK-NEXT:           double _r0 = 1 * _t0;
   // CHECK-NEXT:           (* _d_this).x += _r0;
@@ -829,8 +775,6 @@ int main() {
   // CHECK-NEXT:       _t0 = i;
   // CHECK-NEXT:       _t3 = i;
   // CHECK-NEXT:       _t2 = j;
-  // CHECK-NEXT:       goto _label0;
-  // CHECK-NEXT:     _label0:
   // CHECK-NEXT:       {
   // CHECK-NEXT:           double _r0 = 1 * _t0;
   // CHECK-NEXT:           (* _d_this).x += _r0;

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -13,8 +13,6 @@ double nonMemFn(double i) {
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     _t1 = i;
 // CHECK-NEXT:     _t0 = i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
 // CHECK-NEXT:         * _d_i += _r0;

--- a/test/Gradient/TemplateFunctors.C
+++ b/test/Gradient/TemplateFunctors.C
@@ -25,8 +25,6 @@ template <typename T> struct Experiment {
 // CHECK-NEXT:     _t0 = i;
 // CHECK-NEXT:     _t5 = this->y;
 // CHECK-NEXT:     _t4 = j;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
 // CHECK-NEXT:         double _r1 = _r0 * _t1;
@@ -73,8 +71,6 @@ template <> struct Experiment<long double> {
 // CHECK-NEXT:     _t7 = j;
 // CHECK-NEXT:     _t9 = _t8 * _t7;
 // CHECK-NEXT:     _t6 = i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         long double _r0 = 1 * _t0;
 // CHECK-NEXT:         long double _r1 = _r0 * _t1;
@@ -117,8 +113,6 @@ template <typename T> struct ExperimentConstVolatile {
 // CHECK-NEXT:     _t0 = i;
 // CHECK-NEXT:     _t5 = this->y;
 // CHECK-NEXT:     _t4 = j;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
 // CHECK-NEXT:         double _r1 = _r0 * _t1;
@@ -165,8 +159,6 @@ template <> struct ExperimentConstVolatile<long double> {
 // CHECK-NEXT:     _t7 = j;
 // CHECK-NEXT:     _t9 = _t8 * _t7;
 // CHECK-NEXT:     _t6 = i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         long double _r0 = 1 * _t0;
 // CHECK-NEXT:         long double _r1 = _r0 * _t1;

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -26,8 +26,6 @@ void fn_type_conversion_grad(float z, int a, clad::array_ref<float> _d_z, clad::
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         z = clad::push(_t2, z) * clad::push(_t1, a);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     * _d_z += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -24,8 +24,6 @@ double fn1(pairdd p, double i) {
 // CHECK-NEXT:     _t0 = p.second;
 // CHECK-NEXT:     _t1 = i;
 // CHECK-NEXT:     double res = p.first + 2 * _t0 + 3 * _t1;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (* _d_p).first += _d_res;
@@ -72,8 +70,6 @@ double sum(Tangent& t) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         res += t.data[clad::push(_t1, i)];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         double _r_d0 = _d_res;
@@ -102,8 +98,6 @@ double sum(double *data) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         res += data[clad::push(_t1, i)];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         double _r_d0 = _d_res;
@@ -130,8 +124,6 @@ double fn2(Tangent t, double i) {
 // CHECK-NEXT:     _t1 = t.data;
 // CHECK-NEXT:     _t3 = t.data[0];
 // CHECK-NEXT:     res += sum(t.data) + i + 2 * _t3;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_res;
@@ -171,8 +163,6 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     _t2 = j;
 // CHECK-NEXT:     t.data[1] = 5 * _t1 + 3 * _t2;
 // CHECK-NEXT:     _t3 = t;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         sum_pullback(_t3, 1, &_d_t);
 // CHECK-NEXT:         Tangent _r6 = _d_t;
@@ -223,8 +213,6 @@ double fn4(double i, double j) {
 // CHECK-NEXT:     _t4 = i;
 // CHECK-NEXT:     _t7 = q.second;
 // CHECK-NEXT:     _t6 = j;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
 // CHECK-NEXT:         _d_p.first += _r0;
@@ -260,8 +248,6 @@ double fn4(double i, double j) {
 // CHECK-NEXT:     _t4 = this->data[2];
 // CHECK-NEXT:     _t6 = this->data[3];
 // CHECK-NEXT:     _t5 = this->data[4];
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 1 * _t0;
 // CHECK-NEXT:         (* _d_this).data[0] += _r0;
@@ -298,8 +284,6 @@ double fn5(const Tangent& t, double i) {
 // CHECK-NEXT:     _t3 = i;
 // CHECK-NEXT:     _t5 = _t4 * _t3;
 // CHECK-NEXT:     _t2 = j;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = _d_y * _t0;
 // CHECK-NEXT:         (* _d_this).data[0] += _r0;
@@ -322,8 +306,6 @@ double fn5(const Tangent& t, double i) {
 // CHECK-NEXT:     _t0 = i;
 // CHECK-NEXT:     _t1 = i;
 // CHECK-NEXT:     _t2 = t;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _grad0 = 0.;
 // CHECK-NEXT:         double _grad1 = 0.;
@@ -353,14 +335,10 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT: }
 
 // CHECK: constexpr void real_pullback(double _d_y, clad::array_ref<complex<double> > _d_this){{.*}} {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {{(__real)?}} (* _d_this).{{.*}} += _d_y;
 // CHECK-NEXT: }
 
 // CHECK: constexpr void imag_pullback(double _d_y, clad::array_ref<complex<double> > _d_this){{.*}} {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {{(__imag)?}} (* _d_this).{{.*}} += _d_y;
 // CHECK-NEXT: }
 
@@ -387,8 +365,6 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT:     _t8 = c;
 // CHECK-NEXT:     _t7 = c.real();
 // CHECK-NEXT:     res += 4 * _t7;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_res;
@@ -440,8 +416,6 @@ double fn7(dcomplex c1, dcomplex c2) {
 // CHECK-NEXT:     _t5 = c1;
 // CHECK-NEXT:     _t7 = c1;
 // CHECK-NEXT:     _t6 = c1.imag();
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t5.real_pullback(1, &(* _d_c1));
 // CHECK-NEXT:         double _r3 = 1 * _t6;
@@ -491,8 +465,6 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK-NEXT:     _t2 = t;
 // CHECK-NEXT:     t.updateTo(_t1);
 // CHECK-NEXT:     _t3 = t;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         sum_pullback(_t3, 1, &(* _d_t));
 // CHECK-NEXT:         Tangent _r1 = (* _d_t);
@@ -532,8 +504,6 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _t4 = t;
 // CHECK-NEXT:     res += sum(t);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d1 = _d_res;

--- a/test/Gradient/constexprTest.C
+++ b/test/Gradient/constexprTest.C
@@ -21,8 +21,6 @@ constexpr double mul (double a, double b, double c) {
 //CHECK-NEXT:    _t3 = _t2 * _t1;
 //CHECK-NEXT:    _t0 = c;
 //CHECK-NEXT:    double result = _t3 * _t0;
-//CHECK-NEXT:    goto _label0;
-//CHECK-NEXT:  _label0:
 //CHECK-NEXT:    _d_result += 1;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _r0 = _d_result * _t0;
@@ -58,8 +56,6 @@ constexpr double fn( double a, double b, double c) {
 //CHECK-NEXT:    _t5 = _t4 / _t1;
 //CHECK-NEXT:    _t0 = (a + b);
 //CHECK-NEXT:    double result = _t5 * _t0 * 100 + c;
-//CHECK-NEXT:    goto _label0;
-//CHECK-NEXT:  _label0:
 //CHECK-NEXT:    _d_result += 1;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _r0 = _d_result * 100;

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -oHessianBuiltinDerivatives.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oHessianBuiltinDerivatives.out 2>&1 
 // RUN: ./HessianBuiltinDerivatives.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -oHessians.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oHessians.out 2>&1 
 // RUN: ./Hessians.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -oNestedFunctionCalls.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oNestedFunctionCalls.out 2>&1 
 // RUN: ./NestedFunctionCalls.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 // CHECK-NOT: {{.*error|warning|note:.*}}
@@ -53,8 +53,6 @@ double f2(double x, double y){
 // CHECK-NEXT:     _t8 = y;
 // CHECK-NEXT:     _t11 = y;
 // CHECK-NEXT:     _t10 = _d_y;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = _d_y0.value * _t0;
 // CHECK-NEXT:         * _d_x += _r0;

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -oPointers.out 2>&1 | FileCheck %s
+// RUN: %cladclang %s -I%S/../../include -oPointers.out 2>&1 
 // RUN: ./Pointers.out | FileCheck -check-prefix=CHECK-EXEC %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -147,8 +147,6 @@ double multiply(double x, double y) { return x * y; }
 //CHECK-NEXT:    double _t1;
 //CHECK-NEXT:    _t1 = x;
 //CHECK-NEXT:    _t0 = y;
-//CHECK-NEXT:    goto _label0;
-//CHECK-NEXT:  _label0:
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _r0 = _d_y0 * _t0;
 //CHECK-NEXT:        * _d_x += _r0;

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -9,7 +9,7 @@
 //  Demo: Gradient.cpp
 //-----------------------------------------------------------------------------/
 
-// RUN: %cladclang %S/../../demos/Gradient.cpp -I%S/../../include -oGradient.out 2>&1 | FileCheck -check-prefix CHECK_GRADIENT %s
+// RUN: %cladclang %S/../../demos/Gradient.cpp -I%S/../../include -oGradient.out 2>&1 
 // CHECK_GRADIENT-NOT:{{.*error|warning|note:.*}}
 // CHECK_GRADIENT:float sphere_implicit_func_darg0(float x, float y, float z, float xc, float yc, float zc, float r) {
 // CHECK_GRADIENT: float _d_x = 1;

--- a/test/NestedCalls/NestedCalls.C
+++ b/test/NestedCalls/NestedCalls.C
@@ -42,8 +42,6 @@ double f(double x, double y) {
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       _t0 = x;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = _d_y * _t0;
 //CHECK-NEXT:           * _d_x += _r0;
@@ -61,8 +59,6 @@ double f(double x, double y) {
 //CHECK-NEXT:       _t1 = std::sin(_t0);
 //CHECK-NEXT:       _t2 = x;
 //CHECK-NEXT:       _t3 = std::cos(_t2);
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _grad0 = 0.;
 //CHECK-NEXT:           sq_pullback(_t1, _d_y, &_grad0);
@@ -86,8 +82,6 @@ double f(double x, double y) {
 //CHECK-NEXT:       double t = one(_t0);
 //CHECK-NEXT:       _t2 = t;
 //CHECK-NEXT:       _t1 = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r1 = 1 * _t1;
 //CHECK-NEXT:           _d_t += _r1;

--- a/test/NumericalDiff/GradientMultiArg.C
+++ b/test/NumericalDiff/GradientMultiArg.C
@@ -17,8 +17,6 @@ double test_1(double x, double y){
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     _t0 = x;
 // CHECK-NEXT:     _t1 = y;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _grad0 = 0.;
 // CHECK-NEXT:         double _grad1 = 0.;

--- a/test/NumericalDiff/NoNumDiff.C
+++ b/test/NumericalDiff/NoNumDiff.C
@@ -18,8 +18,6 @@ double func(double x) { return std::tanh(x); }
 //CHECK: void func_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     _t0 = x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _grad0 = 0.;
 //CHECK-NEXT:         double _r0;

--- a/test/NumericalDiff/NumDiff.C
+++ b/test/NumericalDiff/NumDiff.C
@@ -13,8 +13,6 @@ double test_1(double x){
 //CHECK: void test_1_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     _t0 = x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 1 * numerical_diff::forward_central_difference(tanh, _t0, 0, 0, _t0);
 //CHECK-NEXT:         * _d_x += _r0;

--- a/test/NumericalDiff/PrintErrorNumDiff.C
+++ b/test/NumericalDiff/PrintErrorNumDiff.C
@@ -17,8 +17,6 @@ double test_1(double x){
 //CHECK: void test_1_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     _t0 = x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 1 * numerical_diff::forward_central_difference(tanh, _t0, 0, 1, _t0);
 //CHECK-NEXT:         * _d_x += _r0;

--- a/test/ROOT/Interface.C
+++ b/test/ROOT/Interface.C
@@ -25,8 +25,6 @@ void f_grad_1(Double_t* x, Double_t* p, clad::array_ref<Double_t> _d_p);
 // CHECK-NEXT:     Double_t _t1;
 // CHECK-NEXT:     _t1 = x[0];
 // CHECK-NEXT:     _t0 = p[1];
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_p[0] += 1;
 // CHECK-NEXT:         {{double|Double_t}} _r0 = 1 * _t0;

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -47,8 +47,6 @@ void TFormula_example_grad_1(Double_t* x, Double_t* p, Double_t* _d_p);
 //CHECK-NEXT:       _t0 = (p[0] + p[1] + p[2]);
 //CHECK-NEXT:       _t2 = -p[0];
 //CHECK-NEXT:       _t3 = p[1];
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           {{double|Double_t}} _r0 = 1 * _t0;
 //CHECK-NEXT:           {{double|Double_t}} _r1 = _t1 * 1;


### PR DESCRIPTION
Solves issue #526. We can only remove the 'goto' label when the parent of the parent of the return statement is null.