### PR TITLE
Update readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,10 +5,12 @@ sphinx:
   builder: html
 
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
   apt_packages:
-    - clang-10
+    - clang-14
     - cmake
-    - libclang-10-dev
-    - llvm-10-dev
-    - llvm-10-tools
+    - libclang-14-dev
+    - llvm-14-dev
+    - llvm-14-tools

--- a/docs/internalDocs/sphinx/conf.py
+++ b/docs/internalDocs/sphinx/conf.py
@@ -56,8 +56,8 @@ CLAD_ROOT = '../../..'
 html_extra_path = [CLAD_ROOT + '/build/docs/internalDocs/doxygen/html']
 
 import subprocess
-command = 'mkdir {0}/build; cd {0}/build; cmake ../ -DClang_DIR=/usr/lib/llvm-10\
-          -DLLVM_DIR=/usr/lib/llvm-10 -DCLAD_ENABLE_DOXYGEN=ON\
+command = 'mkdir {0}/build; cd {0}/build; cmake ../ -DClang_DIR=/usr/lib/llvm-14\
+          -DLLVM_DIR=/usr/lib/llvm-14 -DCLAD_ENABLE_DOXYGEN=ON\
           -DCLAD_INCLUDE_DOCS=ON'.format(CLAD_ROOT)
 subprocess.call(command, shell=True)
 subprocess.call('doxygen {0}/build/docs/internalDocs/doxygen.cfg'.format(CLAD_ROOT), shell=True)

--- a/docs/userDocs/source/conf.py
+++ b/docs/userDocs/source/conf.py
@@ -85,8 +85,8 @@ if os.environ.get("CLAD_BUILD_INTERNAL_DOCS"):
 
     CMAKE_CONFIGURE_COMMAND = (
         "mkdir {0}/build; cd {0}/build; cmake ../ "
-        "-DClang_DIR=/usr/lib/llvm-10 -DLLVM_DIR="
-        "/usr/lib/llvm-10 -DCLAD_ENABLE_DOXYGEN=ON "
+        "-DClang_DIR=/usr/lib/llvm-14 -DLLVM_DIR="
+        "/usr/lib/llvm-14 -DCLAD_ENABLE_DOXYGEN=ON "
         "-DCLAD_INCLUDE_DOCS=ON"
     ).format(CLAD_ROOT)
     subprocess.call(CMAKE_CONFIGURE_COMMAND, shell=True)


### PR DESCRIPTION
As we have support up-to Clang-16, I have updated the build setup for readthedocs configuration.
The builder image are not used nowdays, I have updated it with latest build os versions.