### PR TITLE
Initial support for expression templates in array and array_ref class

### DIFF
--- a/include/clad/Differentiator/ArrayExpression.h
+++ b/include/clad/Differentiator/ArrayExpression.h
@@ -1,0 +1,150 @@
+#ifndef CLAD_DIFFERENTIATOR_ARRAYEXPRESSION_H
+#define CLAD_DIFFERENTIATOR_ARRAYEXPRESSION_H
+
+#include <algorithm>
+#include <type_traits>
+
+// This is a helper class to implement expression templates for clad::array.
+
+// NOLINTBEGIN(*-pointer-arithmetic)
+namespace clad {
+
+// Operator to add two elements.
+struct BinaryAdd {
+  template <typename T, typename U>
+  static auto apply(T const& t, U const& u) -> decltype(t + u) {
+    return t + u;
+  }
+};
+
+// Operator to add two elements.
+struct BinaryMul {
+  template <typename T, typename U>
+  static auto apply(T const& t, U const& u) -> decltype(t * u) {
+    return t * u;
+  }
+};
+
+// Operator to divide two elements.
+struct BinaryDiv {
+  template <typename T, typename U>
+  static auto apply(T const& t, U const& u) -> decltype(t / u) {
+    return t / u;
+  }
+};
+
+// Operator to subtract two elements.
+struct BinarySub {
+  template <typename T, typename U>
+  static auto apply(T const& t, U const& u) -> decltype(t - u) {
+    return t - u;
+  }
+};
+
+// Class to represent an array expression using templates.
+template <typename LeftExp, typename BinaryOp, typename RightExp>
+class array_expression {
+  LeftExp l;
+  RightExp r;
+
+public:
+  array_expression(LeftExp const& l, RightExp const& r) : l(l), r(r) {}
+
+  // for scalars
+  template <typename T, typename std::enable_if<std::is_arithmetic<T>::value,
+                                                int>::type = 0>
+  std::size_t get_size(T const& t) const {
+    return 1;
+  }
+  template <typename T, typename std::enable_if<std::is_arithmetic<T>::value,
+                                                int>::type = 0>
+  T get(T const& t, std::size_t i) const {
+    return t;
+  }
+
+  // for vectors
+  template <typename T, typename std::enable_if<!std::is_arithmetic<T>::value,
+                                                int>::type = 0>
+  std::size_t get_size(T const& t) const {
+    return t.size();
+  }
+  template <typename T, typename std::enable_if<!std::is_arithmetic<T>::value,
+                                                int>::type = 0>
+  auto get(T const& t, std::size_t i) const -> decltype(t[i]) {
+    return t[i];
+  }
+
+  // We also need to handle the case when any of the operands is a scalar.
+  auto operator[](std::size_t i) const
+      -> decltype(BinaryOp::apply(get(l, i), get(r, i))) {
+    return BinaryOp::apply(get(l, i), get(r, i));
+  }
+
+  std::size_t size() const { return std::max(get_size(l), get_size(r)); }
+
+  // Operator overload for addition.
+  template <typename RE>
+  array_expression<array_expression<LeftExp, BinaryOp, RightExp>, BinaryAdd, RE>
+  operator+(RE const& r) const {
+    return array_expression<array_expression<LeftExp, BinaryOp, RightExp>,
+                            BinaryAdd, RE>(*this, r);
+  }
+
+  // Operator overload for multiplication.
+  template <typename RE>
+  array_expression<array_expression<LeftExp, BinaryOp, RightExp>, BinaryMul, RE>
+  operator*(RE const& r) const {
+    return array_expression<array_expression<LeftExp, BinaryOp, RightExp>,
+                            BinaryMul, RE>(*this, r);
+  }
+
+  // Operator overload for subtraction.
+  template <typename RE>
+  array_expression<array_expression<LeftExp, BinaryOp, RightExp>, BinarySub, RE>
+  operator-(RE const& r) const {
+    return array_expression<array_expression<LeftExp, BinaryOp, RightExp>,
+                            BinarySub, RE>(*this, r);
+  }
+
+  // Operator overload for division.
+  template <typename RE>
+  array_expression<array_expression<LeftExp, BinaryOp, RightExp>, BinaryDiv, RE>
+  operator/(RE const& r) const {
+    return array_expression<array_expression<LeftExp, BinaryOp, RightExp>,
+                            BinaryDiv, RE>(*this, r);
+  }
+};
+
+// Operator overload for addition, when the right operand is an array_expression
+// and the left operand is a scalar.
+template <typename T, typename LeftExp, typename BinaryOp, typename RightExp,
+          typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
+array_expression<T, BinaryAdd, array_expression<LeftExp, BinaryOp, RightExp>>
+operator+(T const& l, array_expression<LeftExp, BinaryOp, RightExp> const& r) {
+  return array_expression<T, BinaryAdd,
+                          array_expression<LeftExp, BinaryOp, RightExp>>(l, r);
+}
+
+// Operator overload for multiplication, when the right operand is an
+// array_expression and the left operand is a scalar.
+template <typename T, typename LeftExp, typename BinaryOp, typename RightExp,
+          typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
+array_expression<T, BinaryMul, array_expression<LeftExp, BinaryOp, RightExp>>
+operator*(T const& l, array_expression<LeftExp, BinaryOp, RightExp> const& r) {
+  return array_expression<T, BinaryMul,
+                          array_expression<LeftExp, BinaryOp, RightExp>>(l, r);
+}
+
+// Operator overload for subtraction, when the right operand is an
+// array_expression and the left operand is a scalar.
+template <typename T, typename LeftExp, typename BinaryOp, typename RightExp,
+          typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
+array_expression<T, BinarySub, array_expression<LeftExp, BinaryOp, RightExp>>
+operator-(T const& l, array_expression<LeftExp, BinaryOp, RightExp> const& r) {
+  return array_expression<T, BinarySub,
+                          array_expression<LeftExp, BinaryOp, RightExp>>(l, r);
+}
+} // namespace clad
+// NOLINTEND(*-pointer-arithmetic)
+
+#endif // CLAD_DIFFERENTIATOR_ARRAYEXPRESSION_H

--- a/include/clad/Differentiator/ArrayRef.h
+++ b/include/clad/Differentiator/ArrayRef.h
@@ -158,114 +158,104 @@ public:
   }
 };
 
-/// Overloaded operators for clad::array_ref which returns a new clad::array
-/// object.
+/// Overloaded operators for clad::array_ref which returns an array
+/// expression.
 
 /// Multiplies the arrays element wise
 template <typename T, typename U>
-CUDA_HOST_DEVICE array<T> operator*(const array_ref<T>& Ar,
-                                    const array_ref<U>& Br) {
+CUDA_HOST_DEVICE array_expression<array_ref<T>, BinaryMul, array_ref<U>>
+operator*(const array_ref<T>& Ar, const array_ref<U>& Br) {
   assert(Ar.size() == Br.size() &&
-         "Size of both the array_refs must be equal for carrying out addition "
-         "assignment");
-  array<T> C(Ar);
-  C *= Br;
-  return C;
+         "Size of both the array_refs must be equal for carrying out "
+         "multiplication assignment");
+  return array_expression<array_ref<T>, BinaryMul, array_ref<U>>(Ar, Br);
 }
 
 /// Adds the arrays element wise
 template <typename T, typename U>
-CUDA_HOST_DEVICE array<T> operator+(const array_ref<T>& Ar,
-                                    const array_ref<U>& Br) {
+CUDA_HOST_DEVICE array_expression<array_ref<T>, BinaryAdd, array_ref<U>>
+operator+(const array_ref<T>& Ar, const array_ref<U>& Br) {
   assert(Ar.size() == Br.size() &&
          "Size of both the array_refs must be equal for carrying out addition "
          "assignment");
-  array<T> C(Ar);
-  C += Br;
-  return C;
+  return array_expression<array_ref<T>, BinaryAdd, array_ref<U>>(Ar, Br);
 }
 
 /// Subtracts the arrays element wise
 template <typename T, typename U>
-CUDA_HOST_DEVICE array<T> operator-(const array_ref<T>& Ar,
-                                    const array_ref<U>& Br) {
-  assert(Ar.size() == Br.size() &&
-         "Size of both the array_refs must be equal for carrying out addition "
-         "assignment");
-  array<T> C(Ar);
-  C -= Br;
-  return C;
+CUDA_HOST_DEVICE array_expression<array_ref<T>, BinarySub, array_ref<U>>
+operator-(const array_ref<T>& Ar, const array_ref<U>& Br) {
+  assert(
+      Ar.size() == Br.size() &&
+      "Size of both the array_refs must be equal for carrying out subtraction "
+      "assignment");
+  return array_expression<array_ref<T>, BinarySub, array_ref<U>>(Ar, Br);
 }
 
 /// Divides the arrays element wise
 template <typename T, typename U>
-CUDA_HOST_DEVICE array<T> operator/(const array_ref<T>& Ar,
-                                    const array_ref<U>& Br) {
+CUDA_HOST_DEVICE array_expression<array_ref<T>, BinaryDiv, array_ref<U>>
+operator/(const array_ref<T>& Ar, const array_ref<U>& Br) {
   assert(Ar.size() == Br.size() &&
-         "Size of both the array_refs must be equal for carrying out addition "
+         "Size of both the array_refs must be equal for carrying out division "
          "assignment");
-  array<T> C(Ar);
-  C /= Br;
-  return C;
+  return array_expression<array_ref<T>, BinaryDiv, array_ref<U>>(Ar, Br);
 }
 
 /// Multiplies array_ref by a scalar
 template <typename T, typename U,
           typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
-CUDA_HOST_DEVICE array<T> operator*(const array_ref<T>& Ar, U a) {
-  array<T> C(Ar);
-  C *= a;
-  return C;
+CUDA_HOST_DEVICE array_expression<array_ref<T>, BinaryMul, U>
+operator*(const array_ref<T>& Ar, U a) {
+  return array_expression<array_ref<T>, BinaryMul, U>(Ar, a);
 }
 
 /// Multiplies array_ref by a scalar (reverse order)
 template <typename T, typename U,
           typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
-CUDA_HOST_DEVICE array<T> operator*(U a, const array_ref<T>& Ar) {
-  return Ar * a;
+CUDA_HOST_DEVICE array_expression<array_ref<T>, BinaryMul, U>
+operator*(U a, const array_ref<T>& Ar) {
+  return array_expression<array_ref<T>, BinaryMul, U>(Ar, a);
 }
 
 /// Divides array_ref by a scalar
 template <typename T, typename U,
           typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
-CUDA_HOST_DEVICE array<T> operator/(const array_ref<T>& Ar, U a) {
-  array<T> C(Ar);
-  C /= a;
-  return C;
+CUDA_HOST_DEVICE array_expression<array_ref<T>, BinaryDiv, U>
+operator/(const array_ref<T>& Ar, U a) {
+  return array_expression<array_ref<T>, BinaryDiv, U>(Ar, a);
 }
 
 /// Adds array_ref by a scalar
 template <typename T, typename U,
           typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
-CUDA_HOST_DEVICE array<T> operator+(const array_ref<T>& Ar, U a) {
-  array<T> C(Ar);
-  C += a;
-  return C;
+CUDA_HOST_DEVICE array_expression<array_ref<T>, BinaryAdd, U>
+operator+(const array_ref<T>& Ar, U a) {
+  return array_expression<array_ref<T>, BinaryAdd, U>(Ar, a);
 }
 
 /// Adds array_ref by a scalar (reverse order)
 template <typename T, typename U,
           typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
-CUDA_HOST_DEVICE array<T> operator+(U a, const array_ref<T>& Ar) {
-  return Ar + a;
+CUDA_HOST_DEVICE array_expression<array_ref<T>, BinaryAdd, U>
+operator+(U a, const array_ref<T>& Ar) {
+  return array_expression<array_ref<T>, BinaryAdd, U>(Ar, a);
 }
 
 /// Subtracts array_ref by a scalar
 template <typename T, typename U,
           typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
-CUDA_HOST_DEVICE array<T> operator-(const array_ref<T>& Ar, U a) {
-  array<T> C(Ar);
-  C -= a;
-  return C;
+CUDA_HOST_DEVICE array_expression<array_ref<T>, BinarySub, U>
+operator-(const array_ref<T>& Ar, U a) {
+  return array_expression<array_ref<T>, BinarySub, U>(Ar, a);
 }
 
 /// Subtracts array_ref by a scalar (reverse order)
 template <typename T, typename U,
           typename std::enable_if<std::is_arithmetic<U>::value, int>::type = 0>
-CUDA_HOST_DEVICE array<T> operator-(U a, const array_ref<T>& Ar) {
-  array<T> C(Ar.size(), a);
-  C -= Ar;
-  return C;
+CUDA_HOST_DEVICE array_expression<U, BinarySub, array_ref<T>>
+operator-(U a, const array_ref<T>& Ar) {
+  return array_expression<U, BinarySub, array_ref<T>>(a, Ar);
 }
 
   /// `array_ref<void>` specialisation is created to be used as a placeholder


### PR DESCRIPTION
This is to speed up the operations for vector mode by ensuring that temporary array objects are not created when performing arithmetic operations of vectors.
Reference used: https://indico.cern.ch/event/450743/contributions/1116430/attachments/1224060/1790963/out-iCSC2016-L1.pdf