### PR TITLE
Add fix for const parameters

### DIFF
--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -352,6 +352,7 @@ namespace clad {
       else if (T->isArrayType()) 
         valueType =
             T->getPointeeOrArrayElementType()->getCanonicalTypeInternal();
+      valueType.removeLocalConst();
       return valueType;
     }
 

--- a/test/Arrays/ArrayInputsForwardMode.C
+++ b/test/Arrays/ArrayInputsForwardMode.C
@@ -5,23 +5,23 @@
 
 #include "clad/Differentiator/Differentiator.h"
 
-double multiply(double *arr) {
+double multiply(const double *arr) {
   return arr[0] * arr[1];
 }
 
-//CHECK:   double multiply_darg0_1(double *arr) {
+//CHECK:   double multiply_darg0_1(const double *arr) {
 //CHECK-NEXT:       return 0. * arr[1] + arr[0] * 1.;
 //CHECK-NEXT:   }
 
-double divide(double *arr) {
+double divide(const double *arr) {
   return arr[0] / arr[1];
 }
 
-//CHECK:   double divide_darg0_1(double *arr) {
+//CHECK:   double divide_darg0_1(const double *arr) {
 //CHECK-NEXT:       return (0. * arr[1] - arr[0] * 1.) / (arr[1] * arr[1]);
 //CHECK-NEXT:   }
 
-double addArr(double *arr, int n) {
+double addArr(const double *arr, int n) {
   double ret = 0;
   for (int i = 0; i < n; i++) {
     ret += arr[i];
@@ -29,7 +29,7 @@ double addArr(double *arr, int n) {
   return ret;
 }
 
-//CHECK:   double addArr_darg0_1(double *arr, int n) {
+//CHECK:   double addArr_darg0_1(const double *arr, int n) {
 //CHECK-NEXT:       int _d_n = 0;
 //CHECK-NEXT:       double _d_ret = 0;
 //CHECK-NEXT:       double ret = 0;

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -5,7 +5,7 @@
 
 #include "clad/Differentiator/Differentiator.h"
 
-double addArr(double *arr, int n) {
+double addArr(const double *arr, int n) {
   double ret = 0;
   for (int i = 0; i < n; i++) {
     ret += arr[i];
@@ -13,7 +13,7 @@ double addArr(double *arr, int n) {
   return ret;
 }
 
-//CHECK: void addArr_pullback(double *arr, int n, double _d_y, clad::array_ref<double> _d_arr, clad::array_ref<int> _d_n) {
+//CHECK: void addArr_pullback(const double *arr, int n, double _d_y, clad::array_ref<double> _d_arr, clad::array_ref<int> _d_n) {
 //CHECK-NEXT:     double _d_ret = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;

--- a/test/Arrays/ArrayInputsVectorForwardMode.C
+++ b/test/Arrays/ArrayInputsVectorForwardMode.C
@@ -5,11 +5,11 @@
 
 #include "clad/Differentiator/Differentiator.h"
 
-double multiply(double *arr) {
+double multiply(const double *arr) {
   return arr[0] * arr[1];
 }
 
-// CHECK: void multiply_dvec(double *arr, clad::array_ref<double> _d_arr) {
+// CHECK: void multiply_dvec(const double *arr, clad::array_ref<double> _d_arr) {
 // CHECK-NEXT:   unsigned long indepVarCount = _d_arr.size();
 // CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, 0UL);
 // CHECK-NEXT:   {
@@ -33,7 +33,7 @@ double divide(double *arr) {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
-double addArr(double *arr, int n) {
+double addArr(const double *arr, int n) {
   double ret = 0;
   for (int i = 0; i < n; i++) {
     ret += arr[i];
@@ -41,7 +41,7 @@ double addArr(double *arr, int n) {
   return ret;
 }
 
-// CHECK: void addArr_dvec_0(double *arr, int n, clad::array_ref<double> _d_arr) {
+// CHECK: void addArr_dvec_0(const double *arr, int n, clad::array_ref<double> _d_arr) {
 // CHECK-NEXT:   unsigned long indepVarCount = _d_arr.size();
 // CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, 0UL);
 // CHECK-NEXT:   clad::array<int> _d_vector_n = clad::zero_vector(indepVarCount);
@@ -61,7 +61,7 @@ double addArr(double *arr, int n) {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
-double maskedSum(double *arr, int n, int *signedMask, double alpha, double beta) {
+double maskedSum(const double *arr, int n, int *signedMask, double alpha, double beta) {
   double ret = 0;
   for (int i = 0; i < n; i++) {
     if (signedMask[i] > 0) {
@@ -73,7 +73,7 @@ double maskedSum(double *arr, int n, int *signedMask, double alpha, double beta)
   return ret;
 }
 
-// CHECK: void maskedSum_dvec_0_3_4(double *arr, int n, int *signedMask, double alpha, double beta, clad::array_ref<double> _d_arr, double *_d_alpha, double *_d_beta) {
+// CHECK: void maskedSum_dvec_0_3_4(const double *arr, int n, int *signedMask, double alpha, double beta, clad::array_ref<double> _d_arr, double *_d_alpha, double *_d_beta) {
 // CHECK-NEXT:   unsigned long indepVarCount = _d_arr.size() + 2UL;
 // CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, 0UL);
 // CHECK-NEXT:   clad::array<int> _d_vector_n = clad::zero_vector(indepVarCount);


### PR DESCRIPTION
This was troublesome when we created `clad::array<const double>` type arrays when the parameter was `const double` type, for example.

This was reported in the [discussion here](https://github.com/vgvassilev/clad/discussions/618).