### PR TITLE
Fix tape push expr for clad array in reverse mode

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -95,7 +95,12 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     Expr* exprToPush = E;
     if (auto AT = dyn_cast<ArrayType>(E->getType())) {
       Expr* init = getArraySizeExpr(AT, m_Context, *this);
-      exprToPush = BuildOp(BO_Comma, E, init);
+      llvm::SmallVector<Expr*, 2> pushArgs{E, init};
+      SourceLocation loc = E->getExprLoc();
+      TypeSourceInfo* TSI = m_Context.getTrivialTypeSourceInfo(EQt, loc);
+      exprToPush =
+          m_Sema.BuildCXXTypeConstructExpr(TSI, loc, pushArgs, loc, false)
+              .get();
     }
     Expr* CallArgs[] = {TapeRef, exprToPush};
     Expr* PushExpr =


### PR DESCRIPTION
Using comma expressions for pushing a clad array onto a tape generated a warning and also resulted in invalid results in some cases.

Fixes #635 
