### PR TITLE
Set derivative to 0 for fxn calls with literal arguments

### DIFF
--- a/test/FirstDerivative/FunctionCalls.C
+++ b/test/FirstDerivative/FunctionCalls.C
@@ -86,14 +86,9 @@ float test_4(int x) {
   return overloaded();
 }
 
-// CHECK: {{(clad::)?}}ValueAndPushforward<int, int> overloaded_pushforward() {
-// CHECK-NEXT:     return {3, 0};
-// CHECK-NEXT: }
-
 // CHECK: float test_4_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: {{(clad::)?}}ValueAndPushforward<int, int> _t0 = overloaded_pushforward();
-// CHECK-NEXT: return _t0.pushforward;
+// CHECK-NEXT: return 0;
 // CHECK-NEXT: }
 
 float test_5(int x) {

--- a/test/FirstDerivative/FunctionCallsWithResults.C
+++ b/test/FirstDerivative/FunctionCallsWithResults.C
@@ -297,7 +297,7 @@ double sum(double* arr, int n) {
 double fn8(double i, double j) {
   double arr[5] = {};
   modifyArr(arr, 5, i*j);
-  return sum(arr, 5);
+  return sum(arr, 5) * std::tanh(1.0);
 }
 
 // CHECK: double fn8_darg0(double i, double j) {
@@ -307,7 +307,9 @@ double fn8(double i, double j) {
 // CHECK-NEXT:     double arr[5] = {};
 // CHECK-NEXT:     modifyArr_pushforward(arr, 5, i * j, _d_arr, 0, _d_i * j + i * _d_j);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = sum_pushforward(arr, 5, _d_arr, 0);
-// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT:     double &_t1 = _t0.value; 
+// CHECK-NEXT:     double _t2 = std::tanh(1.); 
+// CHECK-NEXT:     return _t0.pushforward * _t2 + _t1 * 0; 
 // CHECK-NEXT: }
 
 float test_1_darg0(float x);
@@ -346,6 +348,6 @@ int main () {
   TEST(fn5, 3, 5);    // CHECK-EXEC: {1.00}
   TEST(fn6, 3, 5, 7); // CHECK-EXEC: {3.00}
   TEST(fn7, 3, 5);    // CHECK-EXEC: {8.00}
-  TEST(fn8, 3, 5);    // CHECK-EXEC: {25.00}
+  TEST(fn8, 3, 5);    // CHECK-EXEC: {19.04}
   return 0;
 }

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -460,6 +460,36 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
+double fn8(double x, double y) {
+  return x*y*std::tanh(1.0)*std::max(1.0, 2.0);
+}
+
+// CHECK: void fn8_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     double _t3;
+// CHECK-NEXT:     double _t4;
+// CHECK-NEXT:     double _t5;
+// CHECK-NEXT:     _t3 = x;
+// CHECK-NEXT:     _t2 = y;
+// CHECK-NEXT:     _t4 = _t3 * _t2;
+// CHECK-NEXT:     _t1 = std::tanh(1.);
+// CHECK-NEXT:     _t5 = _t4 * _t1;
+// CHECK-NEXT:     _t0 = std::max(1., 2.);
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 1 * _t0;
+// CHECK-NEXT:         double _r1 = _r0 * _t1;
+// CHECK-NEXT:         double _r2 = _r1 * _t2;
+// CHECK-NEXT:         * _d_x += _r2;
+// CHECK-NEXT:         double _r3 = _t3 * _r1;
+// CHECK-NEXT:         * _d_y += _r3;
+// CHECK-NEXT:         double _r4 = _t4 * _r0;
+// CHECK-NEXT:         double _r5 = _t5 * 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 template<typename T>
 void reset(T* arr, int n) {
@@ -513,6 +543,7 @@ int main() {
   INIT(fn5);
   INIT(fn6);
   INIT(fn7);
+  INIT(fn8);
 
   TEST1_float(fn1, 11);         // CHECK-EXEC: {3.00}
   TEST2(fn2, 3, 5);             // CHECK-EXEC: {1.00, 3.00}
@@ -522,4 +553,5 @@ int main() {
   TEST_ARR5(fn5, arr, 5);       // CHECK-EXEC: {5.00, 1.00, 0.00, 0.00, 0.00}
   TEST2(fn6, 3, 5);             // CHECK-EXEC: {5.00, 3.00}
   TEST2(fn7, 3, 5);             // CHECK-EXEC: {10.00, 71.00}
+  TEST2(fn8, 3, 5);             // CHECK-EXEC: {7.62, 4.57}
 }


### PR DESCRIPTION
Fixes #642.

Example taken from the issue - also added a similar one in the tests:
```cpp
double func(double x)
{
   return x * std::tanh(1.0);  // -----> tanh(1.0) is a const.
}
```