### PR TITLE
Fix assertions seen in clang13 due to type mismatches.

### DIFF
--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -325,10 +325,14 @@ namespace clad {
   }
 
   Expr* VisitorBase::getZeroInit(QualType T) {
-    if (T->isScalarType())
-      return ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, 0);
-    else
-      return m_Sema.ActOnInitList(noLoc, {}, noLoc).get();
+    // FIXME: Consolidate other uses of synthesizeLiteral for creation 0 or 1.
+    if (T->isScalarType()) {
+      ExprResult Zero =
+          ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, 0);
+      CastKind CK = m_Sema.PrepareScalarCast(Zero, T);
+      return m_Sema.ImpCastExprToType(Zero.get(), T, CK).get();
+    }
+    return m_Sema.ActOnInitList(noLoc, {}, noLoc).get();
   }
 
   std::pair<const clang::Expr*, llvm::SmallVector<const clang::Expr*, 4>>


### PR DESCRIPTION
When we synthesize the 0 constant we do not take into account if the corresponding type matches to IntTy. In case it does not match we need to add the necessary implicit casts.

This patch fixes an issue that became visible after landing PR #655.