### PR TITLE
Add initial support for pointers in reverse mode

### DIFF
--- a/include/clad/Differentiator/ArrayRef.h
+++ b/include/clad/Differentiator/ArrayRef.h
@@ -22,7 +22,7 @@ private:
 
 public:
   /// Delete default constructor
-  array_ref() = delete;
+  array_ref() = default;
   /// Constructor to store the pointer to and size of an array supplied by the
   /// user
   CUDA_HOST_DEVICE array_ref(T* arr, std::size_t size)
@@ -33,6 +33,9 @@ public:
   /// Constructor for clad::array types
   CUDA_HOST_DEVICE array_ref(array<T>& a) : m_arr(a.ptr()), m_size(a.size()) {}
 
+  /// Operator for conversion from array_ref<T> to T*.
+  CUDA_HOST_DEVICE operator T*() { return m_arr; }
+
   template <typename U>
   CUDA_HOST_DEVICE array_ref<T>& operator=(const array<U>& a) {
     assert(m_size == a.size());
@@ -40,9 +43,16 @@ public:
       m_arr[i] = a[i];
     return *this;
   }
+  template <typename U>
+  CUDA_HOST_DEVICE array_ref<T>& operator=(const array_ref<T>& a) {
+    m_arr = a.ptr();
+    m_size = a.size();
+    return *this;
+  }
   /// Returns the size of the underlying array
   CUDA_HOST_DEVICE std::size_t size() const { return m_size; }
   CUDA_HOST_DEVICE T* ptr() const { return m_arr; }
+  CUDA_HOST_DEVICE T*& ptr_ref() { return m_arr; }
   /// Returns an array_ref to a part of the underlying array starting at
   /// offset and having the specified size
   CUDA_HOST_DEVICE array_ref<T> slice(std::size_t offset, std::size_t size) {

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -527,6 +527,9 @@ namespace clad {
     /// Creates the expression Base.size() for the given Base expr. The Base
     /// expr must be of clad::array_ref<T> type
     clang::Expr* BuildArrayRefSizeExpr(clang::Expr* Base);
+    /// Creates the expression Base.ptr_ref() for the given Base expr. The Base
+    /// expr must be of clad::array_ref<T> type
+    clang::Expr* BuildArrayRefPtrRefExpr(clang::Expr* Base);
     /// Checks if the type is of clad::ValueAndPushforward<T,U> type
     bool isCladValueAndPushforwardType(clang::QualType QT);
     /// Creates the expression Base.slice(Args) for the given Base expr and Args
@@ -591,6 +594,40 @@ namespace clad {
     /// Cloning types is necessary since VariableArrayType
     /// store a pointer to their size expression.
     clang::QualType CloneType(clang::QualType T);
+
+    /// Computes effective derivative operands. It should be used when operands
+    /// might be of pointer types.
+    ///
+    /// In the trivial case, both operands are of non-pointer types, and the
+    /// effective derivative operands are `LDiff.getExpr_dx()` and
+    /// `RDiff.getExpr_dx()` respectively.
+    ///
+    /// Integers used in pointer arithmetic should be considered
+    /// non-differentiable entities. For example:
+    ///
+    /// ```
+    /// p + i;
+    /// ```
+    ///
+    /// Derived statement should be:
+    ///
+    /// ```
+    /// _d_p + i;
+    /// ```
+    ///
+    /// instead of:
+    ///
+    /// ```
+    /// _d_p + _d_i;
+    /// ```
+    ///
+    /// Therefore, effective derived expression of `i` is `i` instead of `_d_i`.
+    ///
+    /// This functions sets `derivedL` and `derivedR` arguments to effective
+    /// derived expressions.
+    void ComputeEffectiveDOperands(StmtDiff& LDiff, StmtDiff& RDiff,
+                                   clang::Expr*& derivedL,
+                                   clang::Expr*& derivedR);
   };
 } // end namespace clad
 

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1346,52 +1346,6 @@ StmtDiff BaseForwardModeVisitor::VisitUnaryOperator(const UnaryOperator* UnOp) {
   }
 }
 
-/// Computes effective derivative operands. It should be used when operands
-/// might be of pointer types.
-///
-/// In the trivial case, both operands are of non-pointer types, and the
-/// effective derivative operands are `LDiff.getExpr_dx()` and
-/// `RDiff.getExpr_dx()` respectively.
-///
-/// Integers used in pointer arithmetic should be considered
-/// non-differentiable entities. For example:
-///
-/// ```
-/// p + i;
-/// ```
-///
-/// Derived statement should be:
-///
-/// ```
-/// _d_p + i;
-/// ```
-///
-/// instead of:
-///
-/// ```
-/// _d_p + _d_i;
-/// ```
-///
-/// Therefore, effective derived expression of `i` is `i` instead of `_d_i`.
-///
-/// This functions sets `derivedL` and `derivedR` arguments to effective
-/// derived expressions.
-static void ComputeEffectiveDOperands(StmtDiff& LDiff, StmtDiff& RDiff,
-                                      clang::Expr*& derivedL,
-                                      clang::Expr*& derivedR) {
-  derivedL = LDiff.getExpr_dx();
-  derivedR = RDiff.getExpr_dx();
-  if (utils::isArrayOrPointerType(LDiff.getExpr_dx()->getType()) &&
-      !utils::isArrayOrPointerType(RDiff.getExpr_dx()->getType())) {
-    derivedL = LDiff.getExpr_dx();
-    derivedR = RDiff.getExpr();
-  } else if (utils::isArrayOrPointerType(RDiff.getExpr_dx()->getType()) &&
-             !utils::isArrayOrPointerType(LDiff.getExpr_dx()->getType())) {
-    derivedL = LDiff.getExpr();
-    derivedR = RDiff.getExpr_dx();
-  }
-}
-
 StmtDiff
 BaseForwardModeVisitor::VisitBinaryOperator(const BinaryOperator* BinOp) {
   StmtDiff Ldiff = Visit(BinOp->getLHS());

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -584,7 +584,8 @@ namespace clad {
             /// be more complex than just a DeclRefExpr.
             /// (e.g. `__real (n++ ? z1 : z2)`)
             m_Exprs.push_back(UnOp);
-          }
+          } else if (opCode == UnaryOperatorKind::UO_Deref)
+            m_Exprs.push_back(UnOp);
         }
 
         void VisitDeclRefExpr(clang::DeclRefExpr* DRE) {

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -713,6 +713,10 @@ namespace clad {
     return BuildCallExprToMemFn(Base, /*MemberFunctionName=*/"slice", Args);
   }
 
+  Expr* VisitorBase::BuildArrayRefPtrRefExpr(Expr* Base) {
+    return BuildCallExprToMemFn(Base, /*MemberFunctionName=*/"ptr_ref", {});
+  }
+
   bool VisitorBase::isCladArrayType(QualType QT) {
     // FIXME: Replace this check with a clang decl check
     return QT.getAsString().find("clad::array") != std::string::npos ||
@@ -842,5 +846,31 @@ namespace clad {
         cast<ClassTemplateSpecializationDecl>(T->getAsCXXRecordDecl());
     auto& TAL = specialization->getTemplateArgs();
     return TAL.get(0).getAsType();
+  }
+
+  void VisitorBase::ComputeEffectiveDOperands(StmtDiff& LDiff, StmtDiff& RDiff,
+                                              clang::Expr*& derivedL,
+                                              clang::Expr*& derivedR) {
+    derivedL = LDiff.getExpr_dx();
+    derivedR = RDiff.getExpr_dx();
+    if (utils::isArrayOrPointerType(LDiff.getExpr()->getType()) &&
+        utils::isArrayOrPointerType(RDiff.getExpr()->getType())) {
+      if (isCladArrayType(derivedL->getType()))
+        derivedL = BuildArrayRefPtrRefExpr(derivedL);
+      if (isCladArrayType(derivedR->getType()))
+        derivedR = BuildArrayRefPtrRefExpr(derivedR);
+    } else if (utils::isArrayOrPointerType(LDiff.getExpr()->getType()) &&
+               !utils::isArrayOrPointerType(RDiff.getExpr()->getType())) {
+      derivedL = LDiff.getExpr_dx();
+      if (isCladArrayType(derivedL->getType()))
+        derivedL = BuildArrayRefPtrRefExpr(derivedL);
+      derivedR = RDiff.getExpr();
+    } else if (utils::isArrayOrPointerType(RDiff.getExpr()->getType()) &&
+               !utils::isArrayOrPointerType(LDiff.getExpr()->getType())) {
+      derivedL = LDiff.getExpr();
+      derivedR = RDiff.getExpr_dx();
+      if (isCladArrayType(derivedR->getType()))
+        derivedR = BuildArrayRefPtrRefExpr(derivedR);
+    }
   }
 } // end namespace clad

--- a/test/FirstDerivative/UnsupportedOpsWarn.C
+++ b/test/FirstDerivative/UnsupportedOpsWarn.C
@@ -34,23 +34,9 @@ int unOpWarn_0(int x){
 // CHECK-NEXT:   return 0;
 // CHECK-NEXT: }
 
-int unOpWarn_1(int x){
-    auto pnt = &x;  // expected-warning {{attempt to differentiate unsupported operator, ignored.}}
-    return x;
-}
-
-// CHECK: void unOpWarn_1_grad(int x, clad::array_ref<int> _d_x) {
-// CHECK-NEXT:     int *_d_pnt = 0;
-// CHECK-NEXT:     int *pnt = &x;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
-// CHECK-NEXT:     * _d_x += 1;
-// CHECK-NEXT: }
-
 int main(){
 
     clad::differentiate(binOpWarn_0, 0);
     clad::gradient(binOpWarn_1);
     clad::differentiate(unOpWarn_0, 0);
-    clad::gradient(unOpWarn_1);
 }

--- a/test/Gradient/PointersWithTBR.C
+++ b/test/Gradient/PointersWithTBR.C
@@ -1,0 +1,41 @@
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-tbr %s -I%S/../../include -oPointersWithTBR.out
+// RUN: ./PointersWithTBR.out | FileCheck -check-prefix=CHECK-EXEC %s
+// XFAIL: *
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+// FIXME: This is currently marked XFAIL because of lack of pointer support in
+// TBR analysis. Once TBR supports pointers, this test should be enabled
+// and possibily combined with Pointer.C
+
+#include "clad/Differentiator/Differentiator.h"
+
+double minimalPointer(double x) {
+  double* const p = &x;
+  *p = (*p)*(*p);
+  return *p; // x*x
+}
+
+double pointerParam(const double* arr, size_t n) {
+  double sum = 0;
+  for (size_t i=0; i < n; ++i) {
+    size_t* j = &i;
+    sum += arr[0] * (*j);
+    arr = arr + 1;
+  }
+  return sum;
+}
+
+int main() {
+    auto d_minimalPointer = clad::gradient(minimalPointer, "x");
+    double x = 5;
+    double dx = 0;
+    d_minimalPointer.execute(x, &dx);
+    printf("%.2f\n", dx); // CHECK-EXEC: 10.00
+
+    auto d_pointerParam = clad::gradient(pointerParam, "arr");
+    double arr[5] = {1, 2, 3, 4, 5};
+    double d_arr[5] = {0, 0, 0, 0, 0};
+    clad::array_ref<double> d_arr_ref(d_arr, 5);
+    d_pointerParam.execute(arr, 5, d_arr_ref);
+    printf("%.2f %.2f %.2f %.2f %.2f\n", d_arr[0], d_arr[1], d_arr[2], d_arr[3], d_arr[4]); // CHECK-EXEC: 0.00 1.00 2.00 3.00 4.00
+}


### PR DESCRIPTION
This commit adds support for pointer operation in reverse mode. The technique is to maintain a corresponding derivative pointer variable, which gets updated (and stored/restored) in the exact same way as the primal pointer variable in both forward and reverse passes.
Added a workaround (with a FIXME comment) in the UsefulToStoreGlobal method to essentially bypass TBR analysis results for pointer expr.

Fixes #195, Fixes #197 