### PR TITLE
Add declarations for variables reused in the reverse pass

### DIFF
--- a/include/clad/Differentiator/ErrorEstimator.h
+++ b/include/clad/Differentiator/ErrorEstimator.h
@@ -255,6 +255,7 @@ public:
   void ActOnEndOfDerivedFnBody() override;
   void ActBeforeDifferentiatingStmtInVisitCompoundStmt() override;
   void ActAfterProcessingStmtInVisitCompoundStmt() override;
+  void ActBeforeDifferentiatingLoopCondition() override;
   void ActBeforeDifferentiatingSingleStmtBranchInVisitIfStmt() override;
   void ActBeforeFinalisingVisitBranchSingleStmtInIfVisitStmt() override;
   void ActBeforeDifferentiatingLoopInitStmt() override;

--- a/include/clad/Differentiator/ExternalRMVSource.h
+++ b/include/clad/Differentiator/ExternalRMVSource.h
@@ -106,6 +106,9 @@ public:
   /// branch in `VisitBranch` lambda in
   virtual void ActBeforeFinalisingVisitBranchSingleStmtInIfVisitStmt() {}
 
+  /// This is called just before differentiating loop conditions.
+  virtual void ActBeforeDifferentiatingLoopCondition() {}
+
   /// This is called just before differentiating init statement of loops.
   virtual void ActBeforeDifferentiatingLoopInitStmt() {}
 

--- a/include/clad/Differentiator/MultiplexExternalRMVSource.h
+++ b/include/clad/Differentiator/MultiplexExternalRMVSource.h
@@ -41,6 +41,7 @@ public:
   void ActAfterProcessingStmtInVisitCompoundStmt() override;
   void ActBeforeDifferentiatingSingleStmtBranchInVisitIfStmt() override;
   void ActBeforeFinalisingVisitBranchSingleStmtInIfVisitStmt() override;
+  void ActBeforeDifferentiatingLoopCondition() override;
   void ActBeforeDifferentiatingLoopInitStmt() override;
   void ActBeforeDifferentiatingSingleStmtLoopBody() override;
   void ActAfterProcessingSingleStmtBodyInVisitForLoop() override;

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -289,12 +289,14 @@ namespace clad {
     /// C style initalization.
     /// \param[in] TSI The type source information of the variable declaration.
     /// \returns The newly built variable declaration.
-    clang::VarDecl*
-    BuildVarDecl(clang::QualType Type, clang::IdentifierInfo* Identifier,
-                 clang::Expr* Init = nullptr, bool DirectInit = false,
-                 clang::TypeSourceInfo* TSI = nullptr,
-                 clang::VarDecl::InitializationStyle IS =
-                     clang::VarDecl::InitializationStyle::CInit);
+    clang::VarDecl* BuildVarDecl(clang::QualType Type,
+                                 clang::IdentifierInfo* Identifier,
+                                 clang::Expr* Init = nullptr,
+                                 bool DirectInit = false,
+                                 clang::TypeSourceInfo* TSI = nullptr,
+                                 clang::VarDecl::InitializationStyle IS =
+                                     clang::VarDecl::InitializationStyle::CInit,
+                                 bool pushOnScopeChains = true);
     /// Builds variable declaration to be used inside the derivative
     /// body.
     /// \param[in] Type The type of variable declaration to build.

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -119,11 +119,11 @@ namespace clad {
     CompoundStmt* AppendAndCreateCompoundStmt(ASTContext& C, Stmt* initial,
                                               Stmt* S) {
       llvm::SmallVector<Stmt*, 16> block;
-      assert(isa<CompoundStmt>(initial) &&
-             "initial should be of type `clang::CompoundStmt`");
       CompoundStmt* CS = dyn_cast<CompoundStmt>(initial);
       if (CS)
         block.append(CS->body_begin(), CS->body_end());
+      else
+        block.push_back(initial);
       block.push_back(S);
       auto stmtsRef = clad_compat::makeArrayRef(block.begin(), block.end());
       return clad_compat::CompoundStmt_Create(C, stmtsRef /**/ CLAD_COMPAT_CLANG15_CompoundStmt_Create_ExtraParam1(CS), noLoc, noLoc);

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -562,6 +562,10 @@ void ErrorEstimationHandler::ActAfterProcessingStmtInVisitCompoundStmt() {
   EmitErrorEstimationStmts(direction::reverse);
 }
 
+void ErrorEstimationHandler::ActBeforeDifferentiatingLoopCondition() {
+  m_ShouldEmit.push(true);
+}
+
 void ErrorEstimationHandler::
     ActBeforeDifferentiatingSingleStmtBranchInVisitIfStmt() {
   m_ShouldEmit.push(true);

--- a/lib/Differentiator/MultiplexExternalRMVSource.cpp
+++ b/lib/Differentiator/MultiplexExternalRMVSource.cpp
@@ -120,6 +120,11 @@ void MultiplexExternalRMVSource::
   }
 }
 
+void MultiplexExternalRMVSource::ActBeforeDifferentiatingLoopCondition() {
+  for (auto* source : m_Sources)
+    source->ActBeforeDifferentiatingLoopCondition();
+}
+
 void MultiplexExternalRMVSource::ActBeforeDifferentiatingLoopInitStmt() {
   for (auto source : m_Sources) {
     source->ActBeforeDifferentiatingLoopInitStmt();

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -127,7 +127,8 @@ namespace clad {
   VarDecl* VisitorBase::BuildVarDecl(QualType Type, IdentifierInfo* Identifier,
                                      Expr* Init, bool DirectInit,
                                      TypeSourceInfo* TSI,
-                                     VarDecl::InitializationStyle IS) {
+                                     VarDecl::InitializationStyle IS,
+                                     bool pushOnScopeChains) {
 
     // add namespace specifier in variable declaration if needed.
     Type = utils::AddNamespaceSpecifier(m_Sema, m_Context, Type);
@@ -144,7 +145,8 @@ namespace clad {
     }
     m_Sema.FinalizeDeclaration(VD);
     // Add the identifier to the scope and IdResolver
-    m_Sema.PushOnScopeChains(VD, getCurrentScope(), /*AddToContext*/ false);
+    if (pushOnScopeChains)
+      m_Sema.PushOnScopeChains(VD, getCurrentScope(), /*AddToContext*/ false);
     return VD;
   }
 

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -20,22 +20,31 @@ double addArr(const double *arr, int n) {
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     int _t2;
 //CHECK-NEXT:     double ret = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, ret);
-//CHECK-NEXT:         ret += arr[i];
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < n; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, ret);
+//CHECK-NEXT:             ret += arr[i];
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t2 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_ret += _d_y;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             ret = clad::pop(_t1);
-//CHECK-NEXT:             double _r_d0 = _d_ret;
-//CHECK-NEXT:             _d_arr[i] += _r_d0;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t2;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 ret = clad::pop(_t1);
+//CHECK-NEXT:                 double _r_d0 = _d_ret;
+//CHECK-NEXT:                 _d_arr[i] += _r_d0;
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -49,6 +58,7 @@ double f(double *arr) {
 //CHECK-NEXT:       _t0 = arr;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         arr = _t0;
 //CHECK-NEXT:         int _grad1 = 0;
@@ -73,32 +83,41 @@ float func(float* a, float* b) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
+//CHECK-NEXT:     int _t3;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 3; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, a[i]);
-//CHECK-NEXT:         a[i] *= b[i];
-//CHECK-NEXT:         clad::push(_t2, sum);
-//CHECK-NEXT:         sum += a[i];
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < 3; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, a[i]);
+//CHECK-NEXT:             a[i] *= b[i];
+//CHECK-NEXT:             clad::push(_t2, sum);
+//CHECK-NEXT:             sum += a[i];
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t3 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t2);
-//CHECK-NEXT:             float _r_d1 = _d_sum;
-//CHECK-NEXT:             _d_a[i] += _r_d1;
-//CHECK-NEXT:         }
-//CHECK-NEXT:         {
-//CHECK-NEXT:             a[i] = clad::pop(_t1);
-//CHECK-NEXT:             float _r_d0 = _d_a[i];
-//CHECK-NEXT:             _d_a[i] += _r_d0 * b[i];
-//CHECK-NEXT:             _d_b[i] += a[i] * _r_d0;
-//CHECK-NEXT:             _d_a[i] -= _r_d0;
-//CHECK-NEXT:             _d_a[i];
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t3;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 sum = clad::pop(_t2);
+//CHECK-NEXT:                 float _r_d1 = _d_sum;
+//CHECK-NEXT:                 _d_a[i] += _r_d1;
+//CHECK-NEXT:             }
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 a[i] = clad::pop(_t1);
+//CHECK-NEXT:                 float _r_d0 = _d_a[i];
+//CHECK-NEXT:                 _d_a[i] += _r_d0 * b[i];
+//CHECK-NEXT:                 _d_b[i] += a[i] * _r_d0;
+//CHECK-NEXT:                 _d_a[i] -= _r_d0;
+//CHECK-NEXT:                 _d_a[i];
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -110,6 +129,7 @@ float helper(float x) {
 // CHECK: void helper_pullback(float x, float _d_y, clad::array_ref<float> _d_x) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     * _d_x += 2 * _d_y;
 // CHECK-NEXT: }
 
@@ -125,24 +145,33 @@ float func2(float* a) {
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
+//CHECK-NEXT:     int _t2;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 3; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, sum);
-//CHECK-NEXT:         sum += helper(a[i]);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < 3; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, sum);
+//CHECK-NEXT:             sum += helper(a[i]);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t2 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         sum = clad::pop(_t1);
-//CHECK-NEXT:         float _r_d0 = _d_sum;
-//CHECK-NEXT:         float _grad0 = 0.F;
-//CHECK-NEXT:         helper_pullback(a[i], _r_d0, &_grad0);
-//CHECK-NEXT:         float _r0 = _grad0;
-//CHECK-NEXT:         _d_a[i] += _r0;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t2;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             sum = clad::pop(_t1);
+//CHECK-NEXT:             float _r_d0 = _d_sum;
+//CHECK-NEXT:             float _grad0 = 0.F;
+//CHECK-NEXT:             helper_pullback(a[i], _r_d0, &_grad0);
+//CHECK-NEXT:             float _r0 = _grad0;
+//CHECK-NEXT:             _d_a[i] += _r0;
+//CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -159,25 +188,34 @@ float func3(float* a, float* b) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
+//CHECK-NEXT:     int _t3;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 3; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, sum);
-//CHECK-NEXT:         clad::push(_t2, a[i]);
-//CHECK-NEXT:         sum += (a[i] += b[i]);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < 3; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, sum);
+//CHECK-NEXT:             clad::push(_t2, a[i]);
+//CHECK-NEXT:             sum += (a[i] += b[i]);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t3 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         sum = clad::pop(_t1);
-//CHECK-NEXT:         float _r_d0 = _d_sum;
-//CHECK-NEXT:         _d_a[i] += _r_d0;
-//CHECK-NEXT:         a[i] = clad::pop(_t2);
-//CHECK-NEXT:         float _r_d1 = _d_a[i];
-//CHECK-NEXT:         _d_b[i] += _r_d1;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t3;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             sum = clad::pop(_t1);
+//CHECK-NEXT:             float _r_d0 = _d_sum;
+//CHECK-NEXT:             _d_a[i] += _r_d0;
+//CHECK-NEXT:             a[i] = clad::pop(_t2);
+//CHECK-NEXT:             float _r_d1 = _d_a[i];
+//CHECK-NEXT:             _d_b[i] += _r_d1;
+//CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -196,26 +234,35 @@ double func4(double x) {
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     int _t2;
 //CHECK-NEXT:     double arr[3] = {x, 2 * x, x * x};
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 3; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, sum);
-//CHECK-NEXT:         sum += addArr(arr, 3);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < 3; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, sum);
+//CHECK-NEXT:             sum += addArr(arr, 3);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t2 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t1);
-//CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             int _grad1 = 0;
-//CHECK-NEXT:             addArr_pullback(arr, 3, _r_d0, _d_arr, &_grad1);
-//CHECK-NEXT:             clad::array<double> _r0(_d_arr);
-//CHECK-NEXT:             int _r1 = _grad1;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t2;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 sum = clad::pop(_t1);
+//CHECK-NEXT:                 double _r_d0 = _d_sum;
+//CHECK-NEXT:                 int _grad1 = 0;
+//CHECK-NEXT:                 addArr_pullback(arr, 3, _r_d0, _d_arr, &_grad1);
+//CHECK-NEXT:                 clad::array<double> _r0(_d_arr);
+//CHECK-NEXT:                 int _r1 = _grad1;
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
@@ -244,49 +291,66 @@ double func5(int k) {
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     int _t2;
 //CHECK-NEXT:     double _d_sum = 0;
-//CHECK-NEXT:     unsigned long _t2;
+//CHECK-NEXT:     unsigned long _t3;
 //CHECK-NEXT:     int _d_i = 0;
-//CHECK-NEXT:     clad::tape<double> _t3 = {};
+//CHECK-NEXT:     clad::tape<double> _t4 = {};
+//CHECK-NEXT:     int _t5;
 //CHECK-NEXT:     int n = k;
 //CHECK-NEXT:     clad::array<double> _d_arr(n);
 //CHECK-NEXT:     double arr[n];
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, arr[i]);
-//CHECK-NEXT:         arr[i] = k;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < n; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, arr[i]);
+//CHECK-NEXT:             arr[i] = k;
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t2 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t2 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 3; i++) {
-//CHECK-NEXT:         _t2++;
-//CHECK-NEXT:         clad::push(_t3, sum);
-//CHECK-NEXT:         sum += addArr(arr, n);
+//CHECK-NEXT:     _t3 = 0;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < 3; i++) {
+//CHECK-NEXT:             _t3++;
+//CHECK-NEXT:             clad::push(_t4, sum);
+//CHECK-NEXT:             sum += addArr(arr, n);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t5 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t2; _t2--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t3);
-//CHECK-NEXT:             double _r_d1 = _d_sum;
-//CHECK-NEXT:             int _grad1 = 0;
-//CHECK-NEXT:             addArr_pullback(arr, n, _r_d1, _d_arr, &_grad1);
-//CHECK-NEXT:             clad::array<double> _r0(_d_arr);
-//CHECK-NEXT:             int _r1 = _grad1;
-//CHECK-NEXT:             _d_n += _r1;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t5;
+//CHECK-NEXT:         for (; _t3; _t3--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 sum = clad::pop(_t4);
+//CHECK-NEXT:                 double _r_d1 = _d_sum;
+//CHECK-NEXT:                 int _grad1 = 0;
+//CHECK-NEXT:                 addArr_pullback(arr, n, _r_d1, _d_arr, &_grad1);
+//CHECK-NEXT:                 clad::array<double> _r0(_d_arr);
+//CHECK-NEXT:                 int _r1 = _grad1;
+//CHECK-NEXT:                 _d_n += _r1;
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             arr[i] = clad::pop(_t1);
-//CHECK-NEXT:             double _r_d0 = _d_arr[i];
-//CHECK-NEXT:             * _d_k += _r_d0;
-//CHECK-NEXT:             _d_arr[i] -= _r_d0;
-//CHECK-NEXT:             _d_arr[i];
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t2;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 arr[i] = clad::pop(_t1);
+//CHECK-NEXT:                 double _r_d0 = _d_arr[i];
+//CHECK-NEXT:                 * _d_k += _r_d0;
+//CHECK-NEXT:                 _d_arr[i] -= _r_d0;
+//CHECK-NEXT:                 _d_arr[i];
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     * _d_k += _d_n;
@@ -307,34 +371,46 @@ double func6(double seed) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::array<double> _d_arr(3UL);
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     clad::tape<double *> _t2 = {};
+//CHECK-NEXT:     int _t3;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 3; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         double arr[3] = {seed, seed * i, seed + i};
-//CHECK-NEXT:         clad::push(_t1, sum);
-//CHECK-NEXT:         sum += addArr(arr, 3);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < 3; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             double arr[3] = {seed, seed * i, seed + i};
+//CHECK-NEXT:             clad::push(_t1, sum);
+//CHECK-NEXT:             sum += addArr(arr, 3);
+//CHECK-NEXT:             clad::push(_t2, arr);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t3 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t1);
-//CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             int _grad1 = 0;
-//CHECK-NEXT:             addArr_pullback(arr, 3, _r_d0, _d_arr, &_grad1);
-//CHECK-NEXT:             clad::array<double> _r0(_d_arr);
-//CHECK-NEXT:             int _r1 = _grad1;
-//CHECK-NEXT:         }
-//CHECK-NEXT:         {
-//CHECK-NEXT:             * _d_seed += _d_arr[0];
-//CHECK-NEXT:             * _d_seed += _d_arr[1] * i;
-//CHECK-NEXT:             _d_i += seed * _d_arr[1];
-//CHECK-NEXT:             * _d_seed += _d_arr[2];
-//CHECK-NEXT:             _d_i += _d_arr[2];
-//CHECK-NEXT:             _d_arr = {};
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t3;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             double *arr = clad::pop(_t2);
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 sum = clad::pop(_t1);
+//CHECK-NEXT:                 double _r_d0 = _d_sum;
+//CHECK-NEXT:                 int _grad1 = 0;
+//CHECK-NEXT:                 addArr_pullback(arr, 3, _r_d0, _d_arr, &_grad1);
+//CHECK-NEXT:                 clad::array<double> _r0(_d_arr);
+//CHECK-NEXT:                 int _r1 = _grad1;
+//CHECK-NEXT:             }
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 * _d_seed += _d_arr[0];
+//CHECK-NEXT:                 * _d_seed += _d_arr[1] * i;
+//CHECK-NEXT:                 _d_i += seed * _d_arr[1];
+//CHECK-NEXT:                 * _d_seed += _d_arr[2];
+//CHECK-NEXT:                 _d_i += _d_arr[2];
+//CHECK-NEXT:                 _d_arr = {};
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -348,6 +424,7 @@ double inv_square(double *params) {
 //CHECK-NEXT:     _t0 = (params[0] * params[0]);
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = _d_y * -1 / (_t0 * _t0);
 //CHECK-NEXT:         _d_params[0] += _r0 * params[0];
@@ -370,30 +447,42 @@ double func7(double *params) {
 //CHECK-NEXT:     std::size_t _d_i = 0;
 //CHECK-NEXT:     clad::array<double> _d_paramsPrime(1UL);
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     clad::tape<double *> _t2 = {};
+//CHECK-NEXT:     std::size_t _t3;
 //CHECK-NEXT:     double out = 0.;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (std::size_t i = 0; i < 1; ++i) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         double paramsPrime[1] = {params[0]};
-//CHECK-NEXT:         clad::push(_t1, out);
-//CHECK-NEXT:         out = out + inv_square(paramsPrime);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         std::size_t i = 0;
+//CHECK-NEXT:         for (; i < 1; ++i) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             double paramsPrime[1] = {params[0]};
+//CHECK-NEXT:             clad::push(_t1, out);
+//CHECK-NEXT:             out = out + inv_square(paramsPrime);
+//CHECK-NEXT:             clad::push(_t2, paramsPrime);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t3 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_out += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         --i;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             out = clad::pop(_t1);
-//CHECK-NEXT:             double _r_d0 = _d_out;
-//CHECK-NEXT:             _d_out += _r_d0;
-//CHECK-NEXT:             inv_square_pullback(paramsPrime, _r_d0, _d_paramsPrime);
-//CHECK-NEXT:             clad::array<double> _r0(_d_paramsPrime);
-//CHECK-NEXT:             _d_out -= _r_d0;
-//CHECK-NEXT:         }
-//CHECK-NEXT:         {
-//CHECK-NEXT:             _d_params[0] += _d_paramsPrime[0];
-//CHECK-NEXT:             _d_paramsPrime = {};
+//CHECK-NEXT:     {
+//CHECK-NEXT:         std::size_t i = _t3;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             --i;
+//CHECK-NEXT:             double *paramsPrime = clad::pop(_t2);
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 out = clad::pop(_t1);
+//CHECK-NEXT:                 double _r_d0 = _d_out;
+//CHECK-NEXT:                 _d_out += _r_d0;
+//CHECK-NEXT:                 inv_square_pullback(paramsPrime, _r_d0, _d_paramsPrime);
+//CHECK-NEXT:                 clad::array<double> _r0(_d_paramsPrime);
+//CHECK-NEXT:                 _d_out -= _r_d0;
+//CHECK-NEXT:             }
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 _d_params[0] += _d_paramsPrime[0];
+//CHECK-NEXT:                 _d_paramsPrime = {};
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -405,6 +494,7 @@ double helper2(double i, double *arr, int n) {
 //CHECK: void helper2_pullback(double i, double *arr, int n, double _d_y, clad::array_ref<double> _d_i, clad::array_ref<double> _d_arr, clad::array_ref<int> _d_n) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_arr[0] += _d_y * i;
 //CHECK-NEXT:         * _d_i += arr[0] * _d_y;
@@ -435,6 +525,7 @@ double func8(double i, double *arr, int n) {
 //CHECK-NEXT:     arr[0] = 5;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_res += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         arr[0] = _t3;
@@ -495,15 +586,21 @@ double func9(double i, double j) {
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_idx = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     int _t2;
 //CHECK-NEXT:     double arr[5] = {};
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int idx = 0; idx < 5; ++idx) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, arr[idx]);
-//CHECK-NEXT:         modify(arr[idx], i);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int idx = 0;
+//CHECK-NEXT:         for (; idx < 5; ++idx) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, arr[idx]);
+//CHECK-NEXT:             modify(arr[idx], i);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t2 = idx;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_arr[0] += 1;
 //CHECK-NEXT:         _d_arr[1] += 1;
@@ -511,16 +608,19 @@ double func9(double i, double j) {
 //CHECK-NEXT:         _d_arr[3] += 1;
 //CHECK-NEXT:         _d_arr[4] += 1;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         --idx;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             double _r1 = clad::pop(_t1);
-//CHECK-NEXT:             arr[idx] = _r1;
-//CHECK-NEXT:             double _grad1 = 0.;
-//CHECK-NEXT:             modify_pullback(_r1, i, &_d_arr[idx], &_grad1);
-//CHECK-NEXT:             double _r0 = _d_arr[idx];
-//CHECK-NEXT:             double _r2 = _grad1;
-//CHECK-NEXT:             * _d_i += _r2;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int idx = _t2;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             --idx;
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 double _r1 = clad::pop(_t1);
+//CHECK-NEXT:                 arr[idx] = _r1;
+//CHECK-NEXT:                 double _grad1 = 0.;
+//CHECK-NEXT:                 modify_pullback(_r1, i, &_d_arr[idx], &_grad1);
+//CHECK-NEXT:                 double _r0 = _d_arr[idx];
+//CHECK-NEXT:                 double _r2 = _grad1;
+//CHECK-NEXT:                 * _d_i += _r2;
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -536,6 +636,7 @@ double sq(double& elem) {
 //CHECK-NEXT:     elem = elem * elem;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     * _d_elem += _d_y;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         elem = _t0;
@@ -562,26 +663,35 @@ double func10(double *arr, int n) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
+//CHECK-NEXT:     int _t3;
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; ++i) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, res);
-//CHECK-NEXT:         clad::push(_t2, arr[i]);
-//CHECK-NEXT:         res += sq(arr[i]);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < n; ++i) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, res);
+//CHECK-NEXT:             clad::push(_t2, arr[i]);
+//CHECK-NEXT:             res += sq(arr[i]);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t3 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_res += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         --i;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             res = clad::pop(_t1);
-//CHECK-NEXT:             double _r_d0 = _d_res;
-//CHECK-NEXT:             double _r1 = clad::pop(_t2);
-//CHECK-NEXT:             arr[i] = _r1;
-//CHECK-NEXT:             sq_pullback(_r1, _r_d0, &_d_arr[i]);
-//CHECK-NEXT:             double _r0 = _d_arr[i];
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t3;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             --i;
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 res = clad::pop(_t1);
+//CHECK-NEXT:                 double _r_d0 = _d_res;
+//CHECK-NEXT:                 double _r1 = clad::pop(_t2);
+//CHECK-NEXT:                 arr[i] = _r1;
+//CHECK-NEXT:                 sq_pullback(_r1, _r_d0, &_d_arr[i]);
+//CHECK-NEXT:                 double _r0 = _d_arr[i];
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }

--- a/test/Arrays/Arrays.C
+++ b/test/Arrays/Arrays.C
@@ -98,6 +98,7 @@ double const_dot_product(double x, double y, double z) {
 //CHECK-NEXT:       double consts[3] = {1, 2, 3};
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_vars[0] += 1 * consts[0];
 //CHECK-NEXT:           _d_consts[0] += vars[0] * 1;

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -35,57 +35,66 @@ auto gauss_g = clad::gradient(gauss, "p");
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
-//CHECK-NEXT:     double _t2;
+//CHECK-NEXT:     int _t2;
 //CHECK-NEXT:     double _t3;
 //CHECK-NEXT:     double _t4;
 //CHECK-NEXT:     double _t5;
 //CHECK-NEXT:     double _t6;
+//CHECK-NEXT:     double _t7;
 //CHECK-NEXT:     double t = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < dim; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, t);
-//CHECK-NEXT:         t += (x[i] - p[i]) * (x[i] - p[i]);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < dim; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, t);
+//CHECK-NEXT:             t += (x[i] - p[i]) * (x[i] - p[i]);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t2 = i;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _t2 = t;
-//CHECK-NEXT:     _t3 = (2 * sigma * sigma);
-//CHECK-NEXT:     t = -t / _t3;
-//CHECK-NEXT:     _t6 = std::pow(2 * 3.1415926535897931, -dim / 2.);
-//CHECK-NEXT:     _t5 = std::pow(sigma, -0.5);
-//CHECK-NEXT:     _t4 = std::exp(t);
+//CHECK-NEXT:     _t3 = t;
+//CHECK-NEXT:     _t4 = (2 * sigma * sigma);
+//CHECK-NEXT:     t = -t / _t4;
+//CHECK-NEXT:     _t7 = std::pow(2 * 3.1415926535897931, -dim / 2.);
+//CHECK-NEXT:     _t6 = std::pow(sigma, -0.5);
+//CHECK-NEXT:     _t5 = std::exp(t);
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _grad0 = 0.;
 //CHECK-NEXT:         double _grad1 = 0.;
-//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(2 * 3.1415926535897931, -dim / 2., 1 * _t4 * _t5, &_grad0, &_grad1);
+//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(2 * 3.1415926535897931, -dim / 2., 1 * _t5 * _t6, &_grad0, &_grad1);
 //CHECK-NEXT:         double _r1 = _grad0;
 //CHECK-NEXT:         double _r2 = _grad1;
 //CHECK-NEXT:         _d_dim += -_r2 / 2.;
 //CHECK-NEXT:         double _grad2 = 0.;
 //CHECK-NEXT:         double _grad3 = 0.;
-//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(sigma, -0.5, _t6 * 1 * _t4, &_grad2, &_grad3);
+//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(sigma, -0.5, _t7 * 1 * _t5, &_grad2, &_grad3);
 //CHECK-NEXT:         double _r3 = _grad2;
 //CHECK-NEXT:         _d_sigma += _r3;
 //CHECK-NEXT:         double _r4 = _grad3;
-//CHECK-NEXT:         double _r5 = _t6 * _t5 * 1 * clad::custom_derivatives::exp_pushforward(t, 1.).pushforward;
+//CHECK-NEXT:         double _r5 = _t7 * _t6 * 1 * clad::custom_derivatives::exp_pushforward(t, 1.).pushforward;
 //CHECK-NEXT:         _d_t += _r5;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         t = _t2;
+//CHECK-NEXT:         t = _t3;
 //CHECK-NEXT:         double _r_d1 = _d_t;
-//CHECK-NEXT:         _d_t += -_r_d1 / _t3;
-//CHECK-NEXT:         double _r0 = _r_d1 * --t / (_t3 * _t3);
+//CHECK-NEXT:         _d_t += -_r_d1 / _t4;
+//CHECK-NEXT:         double _r0 = _r_d1 * --t / (_t4 * _t4);
 //CHECK-NEXT:         _d_sigma += 2 * _r0 * sigma;
 //CHECK-NEXT:         _d_sigma += 2 * sigma * _r0;
 //CHECK-NEXT:         _d_t -= _r_d1;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         t = clad::pop(_t1);
-//CHECK-NEXT:         double _r_d0 = _d_t;
-//CHECK-NEXT:         _d_p[i] += -_r_d0 * (x[i] - p[i]);
-//CHECK-NEXT:         _d_p[i] += -(x[i] - p[i]) * _r_d0;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t2;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             t = clad::pop(_t1);
+//CHECK-NEXT:             double _r_d0 = _d_t;
+//CHECK-NEXT:             _d_p[i] += -_r_d0 * (x[i] - p[i]);
+//CHECK-NEXT:             _d_p[i] += -(x[i] - p[i]) * _r_d0;
+//CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 

--- a/test/Enzyme/DifferentCladEnzymeDerivatives.C
+++ b/test/Enzyme/DifferentCladEnzymeDerivatives.C
@@ -13,6 +13,7 @@ double foo(double x, double y){
 // CHECK: void foo_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         * _d_x += 1 * y;
 // CHECK-NEXT:         * _d_y += x * 1;

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -25,6 +25,7 @@ float func(float x, float y) {
 //CHECK-NEXT:     y = x;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     * _d_y += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t1;
@@ -63,6 +64,7 @@ float func2(float x, int y) {
 //CHECK-NEXT:     _EERepl_x1 = x;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     * _d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
@@ -90,6 +92,7 @@ float func3(int x, int y) {
 //CHECK-NEXT:     x = y;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     * _d_y += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
@@ -121,6 +124,7 @@ float func4(float x, float y) {
 //CHECK-NEXT:     _EERepl_x1 = x;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     * _d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
@@ -156,6 +160,7 @@ float func5(float x, float y) {
 //CHECK-NEXT:     _EERepl_x1 = x;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     * _d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
@@ -177,6 +182,7 @@ float func6(float x) { return x; }
 //CHECK: void func6_grad(float x, clad::array_ref<float> _d_x, double &_final_error) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     * _d_x += 1;
 //CHECK-NEXT:     double _delta_x = 0;
 //CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
@@ -190,6 +196,7 @@ float func7(float x, float y) { return (x * y); }
 //CHECK-NEXT:     _ret_value0 = (x * y);
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_x += 1 * y;
 //CHECK-NEXT:         * _d_y += x * 1;

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -37,6 +37,7 @@ float func(float x, float y) {
 //CHECK-NEXT:     _EERepl_z0 = z;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_y += _d_z * x;
@@ -92,6 +93,7 @@ float func2(float x, float y) {
 //CHECK-NEXT:     _EERepl_z0 = z;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_y += _d_z / x;
@@ -153,6 +155,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:     _EERepl_y1 = y;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_t += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_x += _d_t * _t1 * z;
@@ -191,6 +194,7 @@ float func4(float x, float y) { return std::pow(x, y); }
 //CHECK-NEXT:     _ret_value0 = std::pow(x, y);
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _grad0 = 0.F;
 //CHECK-NEXT:         float _grad1 = 0.F;
@@ -225,6 +229,7 @@ float func5(float x, float y) {
 //CHECK-NEXT:     _ret_value0 = y * y;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_y += 1 * y;
 //CHECK-NEXT:         * _d_y += y * 1;
@@ -252,6 +257,7 @@ double helper(double x, double y) { return x * y; }
 //CHECK-NEXT:     _ret_value0 = x * y;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_x += _d_y0 * y;
 //CHECK-NEXT:         * _d_y += x * _d_y0;
@@ -278,6 +284,7 @@ float func6(float x, float y) {
 //CHECK-NEXT:     _ret_value0 = z * z;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_z += 1 * z;
 //CHECK-NEXT:         _d_z += z * 1;
@@ -310,6 +317,7 @@ float func7(float x) {
 //CHECK-NEXT:     int z = x;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_z += 1;
 //CHECK-NEXT:         _d_z += 1;
@@ -328,6 +336,7 @@ double helper2(float& x) { return x * x; }
 //CHECK-NEXT:     _ret_value0 = x * x;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_x += _d_y * x;
 //CHECK-NEXT:         * _d_x += x * _d_y;
@@ -356,6 +365,7 @@ float func8(float x, float y) {
 //CHECK-NEXT:     _EERepl_z1 = z;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         z = _t0;
@@ -405,6 +415,7 @@ float func9(float x, float y) {
 //CHECK-NEXT:     _EERepl_z1 = z;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         z = _t3;

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -29,6 +29,7 @@ float func(float x, float y) {
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _EERepl_temp1;
 //CHECK-NEXT:     float _t2;
+//CHECK-NEXT:     float _t3;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _cond0 = x > y;
 //CHECK-NEXT:     if (_cond0) {
@@ -43,10 +44,12 @@ float func(float x, float y) {
 //CHECK-NEXT:         _EERepl_temp1 = temp;
 //CHECK-NEXT:         _t2 = x;
 //CHECK-NEXT:         x = y;
+//CHECK-NEXT:         _t3 = temp;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _ret_value0 = x + y;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_x += 1;
 //CHECK-NEXT:         * _d_y += 1;
@@ -62,6 +65,7 @@ float func(float x, float y) {
 //CHECK-NEXT:             * _d_y;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     } else {
+//CHECK-NEXT:         float temp = _t3;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             x = _t2;
 //CHECK-NEXT:             float _r_d2 = * _d_x;
@@ -110,18 +114,21 @@ float func2(float x) {
 //CHECK-NEXT:         _ret_value0 = x * x;
 //CHECK-NEXT:         goto _label1;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     if (_cond0)
+//CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:       _label0:
+//CHECK-NEXT:         ;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             * _d_x += 1;
 //CHECK-NEXT:             * _d_x += 1;
 //CHECK-NEXT:         }
-//CHECK-NEXT:     else
+//CHECK-NEXT:     } else {
 //CHECK-NEXT:       _label1:
+//CHECK-NEXT:         ;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             * _d_x += 1 * x;
 //CHECK-NEXT:             * _d_x += x * 1;
 //CHECK-NEXT:         }
+//CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_x += _d_z * x;
 //CHECK-NEXT:         * _d_x += x * _d_z;
@@ -141,6 +148,7 @@ float func3(float x, float y) { return x > 30 ? x * y : x + y; }
 //CHECK-NEXT:     _ret_value0 = _cond0 ? x * y : x + y;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         * _d_x += 1 * y;
 //CHECK-NEXT:         * _d_y += x * 1;
@@ -180,6 +188,7 @@ float func4(float x, float y) {
 //CHECK-NEXT:     _ret_value0 = y / x;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_y += 1 / x;
 //CHECK-NEXT:         float _r0 = 1 * -y / (x * x);

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -22,35 +22,44 @@ float func(float* p, int n) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _EERepl_sum1 = {};
+//CHECK-NEXT:     int _t2;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _EERepl_sum0 = sum;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, sum);
-//CHECK-NEXT:         sum += p[i];
-//CHECK-NEXT:         clad::push(_EERepl_sum1, sum);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < n; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, sum);
+//CHECK-NEXT:             sum += p[i];
+//CHECK-NEXT:             clad::push(_EERepl_sum1, sum);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t2 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t1);
-//CHECK-NEXT:             float _r_d0 = _d_sum;
-//CHECK-NEXT:             _d_p[i] += _r_d0;
-//CHECK-NEXT:             float _r0 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:             _delta_sum += std::abs(_r_d0 * _r0 * {{.+}});
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t2;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 sum = clad::pop(_t1);
+//CHECK-NEXT:                 float _r_d0 = _d_sum;
+//CHECK-NEXT:                 _d_p[i] += _r_d0;
+//CHECK-NEXT:                 float _r0 = clad::pop(_EERepl_sum1);
+//CHECK-NEXT:                 _delta_sum += std::abs(_r_d0 * _r0 * {{.+}});
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_p(_d_p.size());
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i < _d_p.size(); i++) {
-//CHECK-NEXT:         double _t2 = std::abs(_d_p[i] * p[i] * {{.+}});
-//CHECK-NEXT:         _delta_p[i] += _t2;
-//CHECK-NEXT:         _final_error += _t2;
+//CHECK-NEXT:         double _t3 = std::abs(_d_p[i] * p[i] * {{.+}});
+//CHECK-NEXT:         _delta_p[i] += _t3;
+//CHECK-NEXT:         _final_error += _t3;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += _delta_sum;
 //CHECK-NEXT: }
@@ -71,45 +80,54 @@ float func2(float x) {
 //CHECK-NEXT:     float _EERepl_z0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
-//CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     float _d_m = 0;
 //CHECK-NEXT:     double _delta_m = 0;
 //CHECK-NEXT:     clad::tape<float> _EERepl_m0 = {};
-//CHECK-NEXT:     float m = 0;
-//CHECK-NEXT:     clad::tape<float> _t2 = {};
+//CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _EERepl_z1 = {};
+//CHECK-NEXT:     clad::tape<float> _t2 = {};
+//CHECK-NEXT:     int _t3;
 //CHECK-NEXT:     float z;
 //CHECK-NEXT:     _EERepl_z0 = z;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 9; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, m) , m = x * x;
-//CHECK-NEXT:         clad::push(_EERepl_m0, m);
-//CHECK-NEXT:         clad::push(_t2, z);
-//CHECK-NEXT:         z = m + m;
-//CHECK-NEXT:         clad::push(_EERepl_z1, z);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < 9; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             float m = x * x;
+//CHECK-NEXT:             clad::push(_EERepl_m0, m);
+//CHECK-NEXT:             clad::push(_t1, z);
+//CHECK-NEXT:             z = m + m;
+//CHECK-NEXT:             clad::push(_EERepl_z1, z);
+//CHECK-NEXT:             clad::push(_t2, m);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t3 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_z += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             z = clad::pop(_t2);
-//CHECK-NEXT:             float _r_d0 = _d_z;
-//CHECK-NEXT:             _d_m += _r_d0;
-//CHECK-NEXT:             _d_m += _r_d0;
-//CHECK-NEXT:             float _r1 = clad::pop(_EERepl_z1);
-//CHECK-NEXT:             _delta_z += std::abs(_r_d0 * _r1 * {{.+}});
-//CHECK-NEXT:             _d_z -= _r_d0;
-//CHECK-NEXT:         }
-//CHECK-NEXT:         {
-//CHECK-NEXT:             * _d_x += _d_m * x;
-//CHECK-NEXT:             * _d_x += x * _d_m;
-//CHECK-NEXT:             _d_m = 0;
-//CHECK-NEXT:             m = clad::pop(_t1);
-//CHECK-NEXT:             float _r0 = clad::pop(_EERepl_m0);
-//CHECK-NEXT:             _delta_m += std::abs(_d_m * _r0 * {{.+}});
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t3;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             float m = clad::pop(_t2);
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 z = clad::pop(_t1);
+//CHECK-NEXT:                 float _r_d0 = _d_z;
+//CHECK-NEXT:                 _d_m += _r_d0;
+//CHECK-NEXT:                 _d_m += _r_d0;
+//CHECK-NEXT:                 float _r1 = clad::pop(_EERepl_z1);
+//CHECK-NEXT:                 _delta_z += std::abs(_r_d0 * _r1 * {{.+}});
+//CHECK-NEXT:                 _d_z -= _r_d0;
+//CHECK-NEXT:             }
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 * _d_x += _d_m * x;
+//CHECK-NEXT:                 * _d_x += x * _d_m;
+//CHECK-NEXT:                 _d_m = 0;
+//CHECK-NEXT:                 float _r0 = clad::pop(_EERepl_m0);
+//CHECK-NEXT:                 _delta_m += std::abs(_d_m * _r0 * {{.+}});
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
@@ -146,6 +164,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:     _EERepl_arr2 = arr[2];
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_arr[2] += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         arr[2] = _t2;
@@ -208,53 +227,62 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:     clad::tape<float> _EERepl_x1 = {};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     clad::tape<float> _EERepl_sum1 = {};
+//CHECK-NEXT:     int _t3;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _EERepl_sum0 = sum;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 10; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, x[i]);
-//CHECK-NEXT:         x[i] += y[i];
-//CHECK-NEXT:         clad::push(_EERepl_x1, x[i]);
-//CHECK-NEXT:         clad::push(_t2, sum);
-//CHECK-NEXT:         sum += x[i];
-//CHECK-NEXT:         clad::push(_EERepl_sum1, sum);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < 10; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, x[i]);
+//CHECK-NEXT:             x[i] += y[i];
+//CHECK-NEXT:             clad::push(_EERepl_x1, x[i]);
+//CHECK-NEXT:             clad::push(_t2, sum);
+//CHECK-NEXT:             sum += x[i];
+//CHECK-NEXT:             clad::push(_EERepl_sum1, sum);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t3 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t2);
-//CHECK-NEXT:             float _r_d1 = _d_sum;
-//CHECK-NEXT:             _d_x[i] += _r_d1;
-//CHECK-NEXT:             float _r1 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:             _delta_sum += std::abs(_r_d1 * _r1 * {{.+}});
-//CHECK-NEXT:         }
-//CHECK-NEXT:         {
-//CHECK-NEXT:             x[i] = clad::pop(_t1);
-//CHECK-NEXT:             float _r_d0 = _d_x[i];
-//CHECK-NEXT:             _d_y[i] += _r_d0;
-//CHECK-NEXT:             float _r0 = clad::pop(_EERepl_x1);
-//CHECK-NEXT:             _delta_x[i] += std::abs(_r_d0 * _r0 * {{.+}});
-//CHECK-NEXT:             _final_error += _delta_x[i];
-//CHECK-NEXT:             _d_x[i];
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t3;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 sum = clad::pop(_t2);
+//CHECK-NEXT:                 float _r_d1 = _d_sum;
+//CHECK-NEXT:                 _d_x[i] += _r_d1;
+//CHECK-NEXT:                 float _r1 = clad::pop(_EERepl_sum1);
+//CHECK-NEXT:                 _delta_sum += std::abs(_r_d1 * _r1 * {{.+}});
+//CHECK-NEXT:             }
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 x[i] = clad::pop(_t1);
+//CHECK-NEXT:                 float _r_d0 = _d_x[i];
+//CHECK-NEXT:                 _d_y[i] += _r_d0;
+//CHECK-NEXT:                 float _r0 = clad::pop(_EERepl_x1);
+//CHECK-NEXT:                 _delta_x[i] += std::abs(_r_d0 * _r0 * {{.+}});
+//CHECK-NEXT:                 _final_error += _delta_x[i];
+//CHECK-NEXT:                 _d_x[i];
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i < _d_x.size(); i++) {
-//CHECK-NEXT:         double _t3 = std::abs(_d_x[i] * _EERepl_x0[i] * {{.+}});
-//CHECK-NEXT:         _delta_x[i] += _t3;
-//CHECK-NEXT:         _final_error += _t3;
+//CHECK-NEXT:         double _t4 = std::abs(_d_x[i] * _EERepl_x0[i] * {{.+}});
+//CHECK-NEXT:         _delta_x[i] += _t4;
+//CHECK-NEXT:         _final_error += _t4;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     clad::array<float> _delta_y(_d_y.size());
 //CHECK-NEXT:     i = 0;
 //CHECK-NEXT:     for (; i < _d_y.size(); i++) {
-//CHECK-NEXT:         double _t4 = std::abs(_d_y[i] * y[i] * {{.+}});
-//CHECK-NEXT:         _delta_y[i] += _t4;
-//CHECK-NEXT:         _final_error += _t4;
+//CHECK-NEXT:         double _t5 = std::abs(_d_y[i] * y[i] * {{.+}});
+//CHECK-NEXT:         _delta_y[i] += _t5;
+//CHECK-NEXT:         _final_error += _t5;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += _delta_sum;
 //CHECK-NEXT: }
@@ -292,6 +320,7 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:     _ret_value0 = output[0] + output[1] + output[2];
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_output[0] += 1;
 //CHECK-NEXT:         _d_output[1] += 1;

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -23,36 +23,45 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _EERepl_sum1 = {};
+//CHECK-NEXT:     int _t2;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _EERepl_sum0 = sum;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 1; i < n; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, sum);
-//CHECK-NEXT:         sum += f[i] + f[i - 1];
-//CHECK-NEXT:         clad::push(_EERepl_sum1, sum);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 1;
+//CHECK-NEXT:         for (; i < n; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, sum);
+//CHECK-NEXT:             sum += f[i] + f[i - 1];
+//CHECK-NEXT:             clad::push(_EERepl_sum1, sum);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t2 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t1);
-//CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             _d_f[i] += _r_d0;
-//CHECK-NEXT:             _d_f[i - 1] += _r_d0;
-//CHECK-NEXT:             double _r0 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:             _delta_sum += std::abs(_r_d0 * _r0 * {{.+}});
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t2;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 sum = clad::pop(_t1);
+//CHECK-NEXT:                 double _r_d0 = _d_sum;
+//CHECK-NEXT:                 _d_f[i] += _r_d0;
+//CHECK-NEXT:                 _d_f[i - 1] += _r_d0;
+//CHECK-NEXT:                 double _r0 = clad::pop(_EERepl_sum1);
+//CHECK-NEXT:                 _delta_sum += std::abs(_r_d0 * _r0 * {{.+}});
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_f(_d_f.size());
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i < _d_f.size(); i++) {
-//CHECK-NEXT:         double _t2 = std::abs(_d_f[i] * f[i] * {{.+}});
-//CHECK-NEXT:         _delta_f[i] += _t2;
-//CHECK-NEXT:         _final_error += _t2;
+//CHECK-NEXT:         double _t3 = std::abs(_d_f[i] * f[i] * {{.+}});
+//CHECK-NEXT:         _delta_f[i] += _t3;
+//CHECK-NEXT:         _final_error += _t3;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += _delta_sum;
 //CHECK-NEXT: }
@@ -73,60 +82,70 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<unsigned long> _t1 = {};
-//CHECK-NEXT:     clad::tape<int> _t2 = {};
 //CHECK-NEXT:     int _d_j = 0;
-//CHECK-NEXT:     int j = 0;
-//CHECK-NEXT:     clad::tape<double> _t3 = {};
+//CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     clad::tape<double> _EERepl_sum1 = {};
+//CHECK-NEXT:     clad::tape<int> _t3 = {};
+//CHECK-NEXT:     int _t4;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _EERepl_sum0 = sum;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, 0UL);
-//CHECK-NEXT:         for (clad::push(_t2, j) , j = 0; j < n; j++) {
-//CHECK-NEXT:             clad::back(_t1)++;
-//CHECK-NEXT:             clad::push(_t3, sum);
-//CHECK-NEXT:             sum += a[i] * b[j];
-//CHECK-NEXT:             clad::push(_EERepl_sum1, sum);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < n; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, 0UL);
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 int j = 0;
+//CHECK-NEXT:                 for (; j < n; j++) {
+//CHECK-NEXT:                     clad::back(_t1)++;
+//CHECK-NEXT:                     clad::push(_t2, sum);
+//CHECK-NEXT:                     sum += a[i] * b[j];
+//CHECK-NEXT:                     clad::push(_EERepl_sum1, sum);
+//CHECK-NEXT:                 }
+//CHECK-NEXT:                 clad::push(_t3, j);
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
+//CHECK-NEXT:         _t4 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             for (; clad::back(_t1); clad::back(_t1)--) {
-//CHECK-NEXT:                 j--;
-//CHECK-NEXT:                 sum = clad::pop(_t3);
-//CHECK-NEXT:                 double _r_d0 = _d_sum;
-//CHECK-NEXT:                 _d_a[i] += _r_d0 * b[j];
-//CHECK-NEXT:                 _d_b[j] += a[i] * _r_d0;
-//CHECK-NEXT:                 double _r0 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:                 _delta_sum += std::abs(_r_d0 * _r0 * {{.+}});
-//CHECK-NEXT:             }
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t4;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
 //CHECK-NEXT:             {
+//CHECK-NEXT:                 int j = clad::pop(_t3);
+//CHECK-NEXT:                 for (; clad::back(_t1); clad::back(_t1)--) {
+//CHECK-NEXT:                     j--;
+//CHECK-NEXT:                     sum = clad::pop(_t2);
+//CHECK-NEXT:                     double _r_d0 = _d_sum;
+//CHECK-NEXT:                     _d_a[i] += _r_d0 * b[j];
+//CHECK-NEXT:                     _d_b[j] += a[i] * _r_d0;
+//CHECK-NEXT:                     double _r0 = clad::pop(_EERepl_sum1);
+//CHECK-NEXT:                     _delta_sum += std::abs(_r_d0 * _r0 * {{.+}});
+//CHECK-NEXT:                 }
 //CHECK-NEXT:                 _d_j = 0;
-//CHECK-NEXT:                 j = clad::pop(_t2);
+//CHECK-NEXT:                 clad::pop(_t1);
 //CHECK-NEXT:             }
-//CHECK-NEXT:             clad::pop(_t1);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_a(_d_a.size());
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i < _d_a.size(); i++) {
-//CHECK-NEXT:         double _t4 = std::abs(_d_a[i] * a[i] * {{.+}});
-//CHECK-NEXT:         _delta_a[i] += _t4;
-//CHECK-NEXT:         _final_error += _t4;
+//CHECK-NEXT:         double _t5 = std::abs(_d_a[i] * a[i] * {{.+}});
+//CHECK-NEXT:         _delta_a[i] += _t5;
+//CHECK-NEXT:         _final_error += _t5;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     clad::array<float> _delta_b(_d_b.size());
 //CHECK-NEXT:     i = 0;
 //CHECK-NEXT:     for (; i < _d_b.size(); i++) {
-//CHECK-NEXT:         double _t5 = std::abs(_d_b[i] * b[i] * {{.+}});
-//CHECK-NEXT:         _delta_b[i] += _t5;
-//CHECK-NEXT:         _final_error += _t5;
+//CHECK-NEXT:         double _t6 = std::abs(_d_b[i] * b[i] * {{.+}});
+//CHECK-NEXT:         _delta_b[i] += _t6;
+//CHECK-NEXT:         _final_error += _t6;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += _delta_sum;
 //CHECK-NEXT: }
@@ -147,44 +166,53 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _EERepl_sum1 = {};
+//CHECK-NEXT:     int _t2;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _EERepl_sum0 = sum;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, sum);
-//CHECK-NEXT:         sum += a[i] / b[i];
-//CHECK-NEXT:         clad::push(_EERepl_sum1, sum);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < n; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, sum);
+//CHECK-NEXT:             sum += a[i] / b[i];
+//CHECK-NEXT:             clad::push(_EERepl_sum1, sum);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t2 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t1);
-//CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             _d_a[i] += _r_d0 / b[i];
-//CHECK-NEXT:             double _r0 = _r_d0 * -a[i] / (b[i] * b[i]);
-//CHECK-NEXT:             _d_b[i] += _r0;
-//CHECK-NEXT:             double _r1 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:             _delta_sum += std::abs(_r_d0 * _r1 * {{.+}});
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t2;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 sum = clad::pop(_t1);
+//CHECK-NEXT:                 double _r_d0 = _d_sum;
+//CHECK-NEXT:                 _d_a[i] += _r_d0 / b[i];
+//CHECK-NEXT:                 double _r0 = _r_d0 * -a[i] / (b[i] * b[i]);
+//CHECK-NEXT:                 _d_b[i] += _r0;
+//CHECK-NEXT:                 double _r1 = clad::pop(_EERepl_sum1);
+//CHECK-NEXT:                 _delta_sum += std::abs(_r_d0 * _r1 * {{.+}});
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_a(_d_a.size());
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i < _d_a.size(); i++) {
-//CHECK-NEXT:         double _t2 = std::abs(_d_a[i] * a[i] * {{.+}});
-//CHECK-NEXT:         _delta_a[i] += _t2;
-//CHECK-NEXT:         _final_error += _t2;
+//CHECK-NEXT:         double _t3 = std::abs(_d_a[i] * a[i] * {{.+}});
+//CHECK-NEXT:         _delta_a[i] += _t3;
+//CHECK-NEXT:         _final_error += _t3;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     clad::array<float> _delta_b(_d_b.size());
 //CHECK-NEXT:     i = 0;
 //CHECK-NEXT:     for (; i < _d_b.size(); i++) {
-//CHECK-NEXT:         double _t3 = std::abs(_d_b[i] * b[i] * {{.+}});
-//CHECK-NEXT:         _delta_b[i] += _t3;
-//CHECK-NEXT:         _final_error += _t3;
+//CHECK-NEXT:         double _t4 = std::abs(_d_b[i] * b[i] * {{.+}});
+//CHECK-NEXT:         _delta_b[i] += _t4;
+//CHECK-NEXT:         _final_error += _t4;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += _delta_sum;
 //CHECK-NEXT: }

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -104,6 +104,7 @@ void f7_grad(float x, clad::array_ref<float> _d_x);
 // CHECK: void f7_grad(float x, clad::array_ref<float> _d_x) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
 // CHECK-NEXT:         double _grad1 = 0.;
@@ -129,6 +130,7 @@ void f8_grad(float x, clad::array_ref<float> _d_x);
 // CHECK: void f8_grad(float x, clad::array_ref<float> _d_x) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
 // CHECK-NEXT:         int _grad1 = 0;
@@ -155,6 +157,7 @@ void f9_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<floa
 // CHECK: void f9_grad(float x, float y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_y) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
 // CHECK-NEXT:         float _grad1 = 0.F;
@@ -182,6 +185,7 @@ void f10_grad(float x, int y, clad::array_ref<float> _d_x, clad::array_ref<int> 
 // CHECK: void f10_grad(float x, int y, clad::array_ref<float> _d_x, clad::array_ref<int> _d_y) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
 // CHECK-NEXT:         int _grad1 = 0;
@@ -202,6 +206,7 @@ double f11(double x, double y) {
 // CHECK-NEXT:     _t0 = std::pow(y - std::pow(x, 2), 2);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _grad0 = 0.;
 // CHECK-NEXT:         int _grad1 = 0;

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -1,6 +1,8 @@
-// RUN: %cladclang %s -I%S/../../include -oReverseAssignments.out 2>&1 | FileCheck %s
+/// FIXME: `-Wno-unused-value` is needed to suppress the warning
+/// produced by `f21`. We have to figure out where it comes from.
+// RUN: %cladclang %s -Wno-unused-value -I%S/../../include -oReverseAssignments.out 2>&1 | FileCheck %s
 // RUN: ./ReverseAssignments.out | FileCheck -check-prefix=CHECK-EXEC %s
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-tbr %s -I%S/../../include -oReverseAssignments.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-tbr %s -Wno-unused-value -I%S/../../include -oReverseAssignments.out
 // RUN: ./ReverseAssignments.out | FileCheck -check-prefix=CHECK-EXEC %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
 
@@ -19,6 +21,7 @@ double f1(double x, double y) {
 //CHECK-NEXT:       x = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       * _d_y += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t0;
@@ -46,6 +49,7 @@ double f2(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       * _d_x += 1;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           x = _t0;
@@ -80,6 +84,7 @@ double f3(double x, double y) {
 //CHECK-NEXT:       x = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       * _d_y += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t3;
@@ -129,6 +134,7 @@ double f4(double x, double y) {
 //CHECK-NEXT:       x = 0;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       * _d_y += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t1;
@@ -166,6 +172,7 @@ double f5(double x, double y) {
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       double _d_z = 0;
 //CHECK-NEXT:       double _t1;
+//CHECK-NEXT:       double _t2;
 //CHECK-NEXT:       double t = x * x;
 //CHECK-NEXT:       _cond0 = x < 0;
 //CHECK-NEXT:       if (_cond0) {
@@ -178,11 +185,14 @@ double f5(double x, double y) {
 //CHECK-NEXT:           double z = t;
 //CHECK-NEXT:           _t1 = t;
 //CHECK-NEXT:           t = -t;
+//CHECK-NEXT:           _t2 = z;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label1;
 //CHECK-NEXT:     _label1:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       if (_cond1) {
+//CHECK-NEXT:           double z = _t2;
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = _t1;
 //CHECK-NEXT:               double _r_d1 = _d_t;
@@ -193,6 +203,7 @@ double f5(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:         _label0:
+//CHECK-NEXT:           ;
 //CHECK-NEXT:           _d_t += 1;
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = _t0;
@@ -228,6 +239,7 @@ double f6(double x, double y) {
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       double _d_z = 0;
 //CHECK-NEXT:       double _t1;
+//CHECK-NEXT:       double _t2;
 //CHECK-NEXT:       double t = x * x;
 //CHECK-NEXT:       _cond0 = x < 0;
 //CHECK-NEXT:       if (_cond0) {
@@ -240,11 +252,14 @@ double f6(double x, double y) {
 //CHECK-NEXT:           double z = t;
 //CHECK-NEXT:           _t1 = t;
 //CHECK-NEXT:           t = -t;
+//CHECK-NEXT:           _t2 = z;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label1;
 //CHECK-NEXT:     _label1:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       if (_cond1) {
+//CHECK-NEXT:           double z = _t2;
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = _t1;
 //CHECK-NEXT:               double _r_d1 = _d_t;
@@ -255,6 +270,7 @@ double f6(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:         _label0:
+//CHECK-NEXT:           ;
 //CHECK-NEXT:           _d_t += 1;
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = _t0;
@@ -315,6 +331,7 @@ double f7(double x, double y) {
 //CHECK-NEXT:       x = ++t[0];
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_t[0] += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t6;
@@ -404,6 +421,7 @@ double f8(double x, double y) {
 //CHECK-NEXT:       t[3] = (y *= (t[0] = t[1] = t[2]));
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:       _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_t[3] += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[3] = _t0;
@@ -411,7 +429,7 @@ double f8(double x, double y) {
 //CHECK-NEXT:           * _d_y += _r_d0;
 //CHECK-NEXT:           y = _t1;
 //CHECK-NEXT:           double _r_d1 = * _d_y;
-//CHECK-NEXT:           * _d_y += _r_d1 * t[2];
+//CHECK-NEXT:           * _d_y += _r_d1 * t[0];
 //CHECK-NEXT:           _d_t[0] += y * _r_d1;
 //CHECK-NEXT:           t[0] = _t2;
 //CHECK-NEXT:           double _r_d2 = _d_t[0];
@@ -444,10 +462,11 @@ double f9(double x, double y) {
 //CHECK-NEXT:       double t = x;
 //CHECK-NEXT:       _t0 = t;
 //CHECK-NEXT:       double &_t1 = (t *= x);
-//CHECK-NEXT:       _t2 = t;
+//CHECK-NEXT:       _t2 = _t1;
 //CHECK-NEXT:       _t1 *= y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:       _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t2;
@@ -480,6 +499,7 @@ double f10(double x, double y) {
 //CHECK-NEXT:       t = x = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:       _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t0;
@@ -507,10 +527,11 @@ double f11(double x, double y) {
 //CHECK-NEXT:       double t = x;
 //CHECK-NEXT:       _t0 = t;
 //CHECK-NEXT:       double &_t1 = (t = x);
-//CHECK-NEXT:       _t2 = t;
+//CHECK-NEXT:       _t2 = _t1;
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:       _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t2;
@@ -537,7 +558,6 @@ double f12(double x, double y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t3;
-//CHECK-NEXT:       double _t4;
 //CHECK-NEXT:       double t;
 //CHECK-NEXT:       _cond0 = x > y;
 //CHECK-NEXT:       if (_cond0)
@@ -545,15 +565,14 @@ double f12(double x, double y) {
 //CHECK-NEXT:       else
 //CHECK-NEXT:           _t1 = t;
 //CHECK-NEXT:       double &_t2 = (_cond0 ? (t = x) : (t = y));
-//CHECK-NEXT:       _t3 = t;
-//CHECK-NEXT:       _t4 = t;
+//CHECK-NEXT:       _t3 = _t2;
 //CHECK-NEXT:       _t2 *= y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:       _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           t = _t3;
-//CHECK-NEXT:           t = _t4;
+//CHECK-NEXT:           (_cond0 ? (t = x) : (t = y)) = _t3;
 //CHECK-NEXT:           double _r_d2 = (_cond0 ? _d_t : _d_t);
 //CHECK-NEXT:           (_cond0 ? _d_t : _d_t) += _r_d2 * y;
 //CHECK-NEXT:           * _d_y += _t2 * _r_d2;
@@ -586,6 +605,7 @@ double f13(double x, double y) {
 //CHECK-NEXT:       double t = x * _t0;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:       _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_t += 1 * y;
 //CHECK-NEXT:           * _d_y += t * 1;
@@ -623,6 +643,7 @@ double f14(double i, double j) {
 // CHECK-NEXT:     a *= i;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:     _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     * _d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t2;
@@ -682,6 +703,7 @@ double f15(double i, double j) {
 // CHECK-NEXT:     d *= 3 * j;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_a += 1;
 // CHECK-NEXT:         *_d_c += 1;
@@ -740,6 +762,7 @@ double f16(double i, double j) {
 // CHECK-NEXT:     c *= 4 * j;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:     _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     * _d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         c = _t0;
@@ -763,6 +786,7 @@ double f17(double i, double j, double k) {
 // CHECK-NEXT:     j = 2 * i;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:     _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_j += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         j = _t0;
@@ -788,6 +812,7 @@ double f18(double i, double j, double k) {
 // CHECK-NEXT:     k += i;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:     _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_k += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         k = _t1;
@@ -810,6 +835,7 @@ double f19(double a, double b) {
 //CHECK: void f19_grad(double a, double b, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _grad0 = 0.;
 //CHECK-NEXT:         double _grad1 = 0.;
@@ -843,6 +869,7 @@ double f20(double x, double y) {
 //CHECK-NEXT:     x = r * y;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     * _d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t1;
@@ -870,6 +897,7 @@ double f21 (double x, double y) {
 //CHECK-NEXT:     y = (y++ , x);
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     * _d_y += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t0;
@@ -879,6 +907,43 @@ double f21 (double x, double y) {
 //CHECK-NEXT:         * _d_x += _r_d0;
 //CHECK-NEXT:         * _d_y -= _r_d0;
 //CHECK-NEXT:         * _d_y;
+//CHECK-NEXT:     }
+//CHECK-NEXT: }
+
+double f22(double x, double y) {
+    if (x > 0) {
+        double& ref = x;
+        ref *= y;
+    }
+    return x;
+}
+
+//CHECK: void f22_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
+//CHECK-NEXT:     bool _cond0;
+//CHECK-NEXT:     double *_d_ref = 0;
+//CHECK-NEXT:     double _t0;
+//CHECK-NEXT:     double *_t1;
+//CHECK-NEXT:     _cond0 = x > 0;
+//CHECK-NEXT:     if (_cond0) {
+//CHECK-NEXT:         _d_ref = &* _d_x;
+//CHECK-NEXT:         double &ref = x;
+//CHECK-NEXT:         _t0 = ref;
+//CHECK-NEXT:         ref *= y;
+//CHECK-NEXT:         _t1 = &ref;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     goto _label0;
+//CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
+//CHECK-NEXT:     * _d_x += 1;
+//CHECK-NEXT:     if (_cond0) {
+//CHECK-NEXT:         double &ref = *_t1;
+//CHECK-NEXT:         {
+//CHECK-NEXT:             ref = _t0;
+//CHECK-NEXT:             double _r_d0 = *_d_ref;
+//CHECK-NEXT:             *_d_ref += _r_d0 * y;
+//CHECK-NEXT:             * _d_y += ref * _r_d0;
+//CHECK-NEXT:             *_d_ref -= _r_d0;
+//CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -945,4 +1010,5 @@ int main() {
   TEST(f19, 1, 2); // CHECK-EXEC: {2.00, 2.00}
   TEST(f20, 1, 2); // CHECK-EXEC: {0.00, 3.00}
   TEST(f21, 6, 4); // CHECK-EXEC: {1.00, 0.00}
+  TEST(f22, 1, 2); // CHECK-EXEC: {2.00, 1.00}
 }

--- a/test/Gradient/DiffInterface.C
+++ b/test/Gradient/DiffInterface.C
@@ -17,6 +17,7 @@ double f_1(double x, double y, double z) {
 //CHECK:   void f_1_grad(double x, double y, double z, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y, clad::array_ref<double> _d_z) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 0 * 1;
 //CHECK-NEXT:           * _d_y += 1 * 1;
@@ -30,6 +31,7 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       double _d_z = 0;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 0 * 1;
 //CHECK-NEXT:           _d_y += 1 * 1;
@@ -43,6 +45,7 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       double _d_z = 0;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_x += 0 * 1;
 //CHECK-NEXT:           * _d_y += 1 * 1;
@@ -56,6 +59,7 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       double _d_y = 0;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_x += 0 * 1;
 //CHECK-NEXT:           _d_y += 1 * 1;
@@ -68,6 +72,7 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       double _d_z = 0;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 0 * 1;
 //CHECK-NEXT:           * _d_y += 1 * 1;
@@ -80,6 +85,7 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       double _d_x = 0;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_x += 0 * 1;
 //CHECK-NEXT:           * _d_y += 1 * 1;

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -33,6 +33,7 @@ double fn1(float i) {
 // CHECK-NEXT:     double a = res * i;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_res += _d_a * i;
@@ -64,6 +65,7 @@ double modify1(double& i, double& j) {
 // CHECK-NEXT:     double res = i + j;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         * _d_i += _d_res;
@@ -109,6 +111,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:     temp = modify1(i, j);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     * _d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         temp = _t3;
@@ -177,6 +180,7 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     update1(i, j);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     * _d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         i = _t2;
@@ -207,30 +211,39 @@ float sum(double* arr, int n) {
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
-// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     int _t2;
+// CHECK-NEXT:     double _t3;
 // CHECK-NEXT:     float res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 0; i < n; ++i) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, res);
-// CHECK-NEXT:         res += arr[i];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = 0;
+// CHECK-NEXT:         for (; i < n; ++i) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             clad::push(_t1, res);
+// CHECK-NEXT:             res += arr[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t2 = i;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _t2 = arr[0];
+// CHECK-NEXT:     _t3 = arr[0];
 // CHECK-NEXT:     arr[0] += 10 * arr[0];
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         arr[0] = _t2;
+// CHECK-NEXT:         arr[0] = _t3;
 // CHECK-NEXT:         double _r_d1 = _d_arr[0];
 // CHECK-NEXT:         _d_arr[0] += 10 * _r_d1;
 // CHECK-NEXT:         _d_arr[0];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --i;
-// CHECK-NEXT:         res = clad::pop(_t1);
-// CHECK-NEXT:         float _r_d0 = _d_res;
-// CHECK-NEXT:         _d_arr[i] += _r_d0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = _t2;
+// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:             --i;
+// CHECK-NEXT:             res = clad::pop(_t1);
+// CHECK-NEXT:             float _r_d0 = _d_res;
+// CHECK-NEXT:             _d_arr[i] += _r_d0;
+// CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -269,33 +282,42 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
+// CHECK-NEXT:     int _t5;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = res;
 // CHECK-NEXT:     _t1 = arr;
 // CHECK-NEXT:     res += sum(arr, n);
 // CHECK-NEXT:     _t2 = 0;
-// CHECK-NEXT:     for (int i = 0; i < n; ++i) {
-// CHECK-NEXT:         _t2++;
-// CHECK-NEXT:         clad::push(_t3, arr[i]);
-// CHECK-NEXT:         twice(arr[i]);
-// CHECK-NEXT:         clad::push(_t4, res);
-// CHECK-NEXT:         res += arr[i];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = 0;
+// CHECK-NEXT:         for (; i < n; ++i) {
+// CHECK-NEXT:             _t2++;
+// CHECK-NEXT:             clad::push(_t3, arr[i]);
+// CHECK-NEXT:             twice(arr[i]);
+// CHECK-NEXT:             clad::push(_t4, res);
+// CHECK-NEXT:             res += arr[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t5 = i;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t2; _t2--) {
-// CHECK-NEXT:         --i;
-// CHECK-NEXT:         {
-// CHECK-NEXT:             res = clad::pop(_t4);
-// CHECK-NEXT:             double _r_d1 = _d_res;
-// CHECK-NEXT:             _d_arr[i] += _r_d1;
-// CHECK-NEXT:         }
-// CHECK-NEXT:         {
-// CHECK-NEXT:             double _r3 = clad::pop(_t3);
-// CHECK-NEXT:             arr[i] = _r3;
-// CHECK-NEXT:             twice_pullback(_r3, &_d_arr[i]);
-// CHECK-NEXT:             double _r2 = _d_arr[i];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = _t5;
+// CHECK-NEXT:         for (; _t2; _t2--) {
+// CHECK-NEXT:             --i;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 res = clad::pop(_t4);
+// CHECK-NEXT:                 double _r_d1 = _d_res;
+// CHECK-NEXT:                 _d_arr[i] += _r_d1;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 double _r3 = clad::pop(_t3);
+// CHECK-NEXT:                 arr[i] = _r3;
+// CHECK-NEXT:                 twice_pullback(_r3, &_d_arr[i]);
+// CHECK-NEXT:                 double _r2 = _d_arr[i];
+// CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -344,6 +366,7 @@ double fn5(double* arr, int n) {
 // CHECK-NEXT:     double temp = modify2(arr);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_arr[0] += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         arr = _t0;
@@ -378,6 +401,7 @@ double fn7(double i, double j) {
 // CHECK: void fn6_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         * _d_i += 1 * j;
 // CHECK-NEXT:         * _d_j += i * 1;
@@ -393,6 +417,7 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     _d_i0 += 1;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     * _d_i += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_i0 = _t0;
@@ -432,6 +457,7 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     l += 9 * i;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         * _d_i += 1;
 // CHECK-NEXT:         * _d_j += 1;
@@ -469,6 +495,7 @@ double fn8(double x, double y) {
 // CHECK-NEXT:     _t0 = std::max(1., 2.);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         * _d_x += 1 * _t0 * _t1 * y;
 // CHECK-NEXT:         * _d_y += x * 1 * _t0 * _t1;
@@ -484,6 +511,7 @@ double custom_max(const double& a, const double& b) {
 // CHECK-NEXT:     _cond0 = a > b;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     if (_cond0)
 // CHECK-NEXT:         * _d_a += _d_y;
 // CHECK-NEXT:     else
@@ -499,6 +527,7 @@ double fn9(double x, double y) {
 // CHECK-NEXT:    _t0 = y;
 // CHECK-NEXT:    goto _label0;
 // CHECK-NEXT:  _label0:
+// CHECK-NEXT:    ;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        y = _t0;
 // CHECK-NEXT:        double _grad0 = 0.;
@@ -538,6 +567,7 @@ double fn10(double x, double y) {
 // CHECK-NEXT:    out = std::clamp(out, 3., 7.);
 // CHECK-NEXT:    goto _label0;
 // CHECK-NEXT:  _label0:
+// CHECK-NEXT:    ;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        _d_out += 1 * y;
 // CHECK-NEXT:        * _d_y += out * 1;
@@ -609,6 +639,7 @@ double fn11(double x, double y) {
 // CHECK-NEXT:    _t1 = y;
 // CHECK-NEXT:    goto _label0;
 // CHECK-NEXT:  _label0:
+// CHECK-NEXT:    ;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        x = _t0;
 // CHECK-NEXT:        y = _t1;

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -17,6 +17,7 @@ struct Experiment {
   // CHECK: void operator_call_grad(double i, double j, clad::array_ref<Experiment> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * j * i;
   // CHECK-NEXT:         * _d_i += this->x * 1 * j;
@@ -35,6 +36,7 @@ struct ExperimentConst {
   // CHECK: void operator_call_grad(double i, double j, clad::array_ref<ExperimentConst> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * j * i;
   // CHECK-NEXT:         * _d_i += this->x * 1 * j;
@@ -61,6 +63,7 @@ struct ExperimentVolatile {
   // CHECK-NEXT:     _t0 = this->x * i;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * j * i;
   // CHECK-NEXT:         * _d_i += this->x * 1 * j;
@@ -87,6 +90,7 @@ struct ExperimentConstVolatile {
   // CHECK-NEXT:     _t0 = this->x * i;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * j * i;
   // CHECK-NEXT:         * _d_i += this->x * 1 * j;
@@ -108,6 +112,7 @@ struct ExperimentNNS {
   // CHECK: void operator_call_grad(double i, double j, clad::array_ref<ExperimentNNS> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * j * i;
   // CHECK-NEXT:         * _d_i += this->x * 1 * j;
@@ -172,6 +177,7 @@ int main() {
   // CHECK: inline void operator_call_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         * _d_i += 1 * j * i;
   // CHECK-NEXT:         * _d_i += i * 1 * j;
@@ -184,6 +190,7 @@ int main() {
   // CHECK: inline void operator_call_grad(double ii, double j, clad::array_ref<double> _d_ii, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         * _d_ii += x * 1 * j;
   // CHECK-NEXT:         * _d_j += x * ii * 1;
@@ -245,6 +252,7 @@ int main() {
   // CHECK-NEXT:     _t0 = E;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _grad0 = 0.;
   // CHECK-NEXT:         double _grad1 = 0.;
@@ -267,6 +275,7 @@ int main() {
   // CHECK-NEXT:     _t0 = fn;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _grad0 = 0.;
   // CHECK-NEXT:         double _grad1 = 0.;
@@ -290,6 +299,7 @@ int main() {
   // CHECK-NEXT:     _t0 = fn;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _grad0 = 0.;
   // CHECK-NEXT:         double _grad1 = 0.;
@@ -306,6 +316,7 @@ int main() {
   // CHECK-NEXT:     Experiment E(3, 5);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         Experiment _grad0;
   // CHECK-NEXT:         double _grad1 = 0.;

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -19,6 +19,7 @@ __attribute__((always_inline)) double f_add1(double x, double y) {
 //CHECK:   void f_add1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) __attribute__((always_inline)) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:           * _d_y += 1;
@@ -34,6 +35,7 @@ double f_add2(double x, double y) {
 //CHECK:   void f_add2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 3 * 1;
 //CHECK-NEXT:           * _d_y += 4 * 1;
@@ -49,6 +51,7 @@ double f_add3(double x, double y) {
 //CHECK:   void f_add3_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 3 * 1;
 //CHECK-NEXT:           * _d_y += 4 * 1 * 4;
@@ -64,6 +67,7 @@ double f_sub1(double x, double y) {
 //CHECK:   void f_sub1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:           * _d_y += -1;
@@ -78,6 +82,7 @@ double f_sub2(double x, double y) {
 //CHECK:   void f_sub2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 3 * 1;
 //CHECK-NEXT:           * _d_y += 4 * -1;
@@ -93,6 +98,7 @@ double f_mult1(double x, double y) {
 //CHECK:   void f_mult1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 1 * y;
 //CHECK-NEXT:           * _d_y += x * 1;
@@ -108,6 +114,7 @@ double f_mult2(double x, double y) {
 //CHECK:   void f_mult2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 3 * 1 * y * 4;
 //CHECK-NEXT:           * _d_y += 3 * x * 4 * 1;
@@ -123,6 +130,7 @@ double f_div1(double x, double y) {
 //CHECK:   void f_div1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 1 / y;
 //CHECK-NEXT:           double _r0 = 1 * -x / (y * y);
@@ -141,6 +149,7 @@ double f_div2(double x, double y) {
 //CHECK-NEXT:       _t0 = (4 * y);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 3 * 1 / _t0;
 //CHECK-NEXT:           double _r0 = 1 * -3 * x / (_t0 * _t0);
@@ -163,6 +172,7 @@ double f_div3(double x, double y) {
 //CHECK-NEXT:     _t0 = (y * y);
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_x += 1 / _t0;
 //CHECK-NEXT:         x = _t1;
@@ -184,6 +194,7 @@ double f_c(double x, double y) {
 //CHECK:   void f_c_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += -1 * y;
 //CHECK-NEXT:           * _d_y += -x * 1;
@@ -206,6 +217,7 @@ double f_rosenbrock(double x, double y) {
 //CHECK:   void f_rosenbrock_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 1 * (x - 1);
 //CHECK-NEXT:           * _d_x += (x - 1) * 1;
@@ -229,6 +241,7 @@ double f_cond1(double x, double y) {
 //CHECK-NEXT:       _cond0 = x > y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:       else
@@ -251,6 +264,7 @@ double f_cond2(double x, double y) {
 //CHECK-NEXT:           _cond1 = y > 0;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:       else if (_cond1)
@@ -270,6 +284,7 @@ double f_cond3(double x, double c) {
 //CHECK-NEXT:       _cond0 = c > 0;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:           * _d_c += 1;
@@ -304,6 +319,7 @@ double f_cond4(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       * _d_y += 1;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           {
@@ -339,9 +355,11 @@ double f_if1(double x, double y) {
 //CHECK-NEXT:           goto _label1;
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:         _label0:
+//CHECK-NEXT:           ;
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:       else
 //CHECK-NEXT:         _label1:
+//CHECK-NEXT:           ;
 //CHECK-NEXT:           * _d_y += 1;
 //CHECK-NEXT:   }
 
@@ -369,15 +387,19 @@ double f_if2(double x, double y) {
 //CHECK-NEXT:           else
 //CHECK-NEXT:               goto _label2;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       if (_cond0)
+//CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:         _label0:
+//CHECK-NEXT:           ;
 //CHECK-NEXT:           * _d_x += 1;
-//CHECK-NEXT:       else if (_cond1)
+//CHECK-NEXT:       } else if (_cond1) {
 //CHECK-NEXT:         _label1:
+//CHECK-NEXT:           ;
 //CHECK-NEXT:           * _d_y += 1;
-//CHECK-NEXT:       else
+//CHECK-NEXT:       } else
 //CHECK-NEXT:         _label2:
+//CHECK-NEXT:           ;
 //CHECK-NEXT:           * _d_y += -1;
+//CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 void f_if2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
@@ -392,6 +414,7 @@ struct S {
   //CHECK:   void f_grad(double x, double y, clad::array_ref<S> _d_this, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
   //CHECK-NEXT:       goto _label0;
   //CHECK-NEXT:     _label0:
+  //CHECK-NEXT:       ;
   //CHECK-NEXT:       {
   //CHECK-NEXT:           (* _d_this).c1 += 1 * x;
   //CHECK-NEXT:           * _d_x += this->c1 * 1;
@@ -443,6 +466,7 @@ void f_norm_grad(double x,
 //CHECK:   void f_norm_grad(double x, double y, double z, double d, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y, clad::array_ref<double> _d_z, clad::array_ref<double> _d_d) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _grad4 = 0.;
 //CHECK-NEXT:           double _grad5 = 0.;
@@ -477,6 +501,7 @@ void f_sin_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_re
 //CHECK-NEXT:       _t0 = (std::sin(x) + std::sin(y));
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 1 * (x + y) * clad::custom_derivatives::sin_pushforward(x, 1.).pushforward;
 //CHECK-NEXT:           * _d_x += _r0;
@@ -500,6 +525,7 @@ void f_types_grad(int x,
 //CHECK:   void f_types_grad(int x, float y, double z, clad::array_ref<int> _d_x, clad::array_ref<float> _d_y, clad::array_ref<double> _d_z) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 1;
 //CHECK-NEXT:           * _d_y += 1;
@@ -524,6 +550,7 @@ void f_decls1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array
 //CHECK-NEXT:       double c = a + b;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_c += 2 * 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += _d_c;
@@ -550,6 +577,7 @@ void f_decls2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array
 //CHECK-NEXT:       double c = y * y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += 1;
 //CHECK-NEXT:           _d_b += 2 * 1;
@@ -600,17 +628,21 @@ void f_decls3_grad(double x, double y, clad::array_ref<double> _d_x, clad::array
 //CHECK-NEXT:       double b = a * a;
 //CHECK-NEXT:       goto _label2;
 //CHECK-NEXT:     _label2:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_b += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += _d_b * a;
 //CHECK-NEXT:           _d_a += a * _d_b;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       if (_cond0)
+//CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:         _label0:
+//CHECK-NEXT:           ;
 //CHECK-NEXT:           _d_a += 2 * 1;
-//CHECK-NEXT:       else if (_cond1)
+//CHECK-NEXT:       } else if (_cond1) {
 //CHECK-NEXT:         _label1:
+//CHECK-NEXT:           ;
 //CHECK-NEXT:           _d_a += -2 * 1;
+//CHECK-NEXT:       }
 //CHECK-NEXT:       * _d_y += 333 * _d_c;
 //CHECK-NEXT:       * _d_x += 3 * _d_a;
 //CHECK-NEXT:   }
@@ -626,6 +658,7 @@ void f_issue138_grad(double x, double y, clad::array_ref<double> _d_x, clad::arr
 //CHECK-NEXT:       double _t10 = 1;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += 1 * x * x * x;
 //CHECK-NEXT:           * _d_x += x * 1 * x * x;
@@ -646,6 +679,7 @@ void f_const_grad(const double a, const double b, clad::array_ref<double> _d_a, 
 //CHECK:   void f_const_grad(const double a, const double b, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_a += 1 * b;
 //CHECK-NEXT:           * _d_b += a * 1;
@@ -669,6 +703,7 @@ void f_const_reference_grad(double i, double j, clad::array_ref<double> _d_i, cl
 //CHECK-NEXT:    double res = 2 * ar;
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
+//CHECK-NEXT:    ;
 //CHECK-NEXT:    _d_res += 1;
 //CHECK-NEXT:    *_d_ar += 2 * _d_res;
 //CHECK-NEXT:    * _d_i += _d_a;
@@ -686,6 +721,7 @@ void f_const02_grad(double i, double j, clad::array_ref<double> _d_i, clad::arra
 //CHECK-NEXT:       double res = a;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_res += 1;
 //CHECK-NEXT:       _d_a += _d_res;
 //CHECK-NEXT:       * _d_i += _d_a;
@@ -702,22 +738,31 @@ float running_sum(float* p, int n) {
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
+// CHECK-NEXT:     int _t2;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 1; i < n; i++) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, p[i]);
-// CHECK-NEXT:         p[i] += p[i - 1];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = 1;
+// CHECK-NEXT:         for (; i < n; i++) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             clad::push(_t1, p[i]);
+// CHECK-NEXT:             p[i] += p[i - 1];
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t2 = i;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_p[n - 1] += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         i--;
-// CHECK-NEXT:         {
-// CHECK-NEXT:             p[i] = clad::pop(_t1);
-// CHECK-NEXT:             float _r_d0 = _d_p[i];
-// CHECK-NEXT:             _d_p[i - 1] += _r_d0;
-// CHECK-NEXT:             _d_p[i];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = _t2;
+// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:             i--;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 p[i] = clad::pop(_t1);
+// CHECK-NEXT:                 float _r_d0 = _d_p[i];
+// CHECK-NEXT:                 _d_p[i - 1] += _r_d0;
+// CHECK-NEXT:                 _d_p[i];
+// CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -734,6 +779,7 @@ double fn_global_var_use(double i, double j) {
 // CHECK-NEXT:     double &ref = global;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_ref += 1 * i;
 // CHECK-NEXT:         * _d_i += ref * 1;
@@ -753,6 +799,7 @@ void fn_increment_in_return_grad(double i, double j, clad::array_ref<double> _d_
 // CHECK-NEXT:     _t0 = ++i;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         * _d_i += 1 * temp;
 // CHECK-NEXT:         --i;
@@ -777,6 +824,7 @@ double fn_template_non_type(double x) {
 // CHECK-NEXT:     const size_t m = _cond0 ? maxN : 15UL;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     * _d_x += 1 * m;
 // CHECK-NEXT:     if (_cond0)
 // CHECK-NEXT:         _d_maxN += _d_m;

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -21,23 +21,32 @@ double f1(double x) {
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
 //CHECK-NEXT:       clad::tape<double> _t1 = {};
+//CHECK-NEXT:       int _t2;
 //CHECK-NEXT:       double t = 1;
 //CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < 3; i++) {
-//CHECK-NEXT:           _t0++;
-//CHECK-NEXT:           clad::push(_t1, t);
-//CHECK-NEXT:           t *= x;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int i = 0;
+//CHECK-NEXT:           for (; i < 3; i++) {
+//CHECK-NEXT:               _t0++;
+//CHECK-NEXT:               clad::push(_t1, t);
+//CHECK-NEXT:               t *= x;
+//CHECK-NEXT:           }
+//CHECK-NEXT:           _t2 = i;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_t += 1;
-//CHECK-NEXT:       for (; _t0; _t0--) {
-//CHECK-NEXT:           i--;
-//CHECK-NEXT:           t = clad::pop(_t1);
-//CHECK-NEXT:           double _r_d0 = _d_t;
-//CHECK-NEXT:           _d_t += _r_d0 * x;
-//CHECK-NEXT:           * _d_x += t * _r_d0;
-//CHECK-NEXT:           _d_t -= _r_d0;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int i = _t2;
+//CHECK-NEXT:           for (; _t0; _t0--) {
+//CHECK-NEXT:               i--;
+//CHECK-NEXT:               t = clad::pop(_t1);
+//CHECK-NEXT:               double _r_d0 = _d_t;
+//CHECK-NEXT:               _d_t += _r_d0 * x;
+//CHECK-NEXT:               * _d_x += t * _r_d0;
+//CHECK-NEXT:               _d_t -= _r_d0;
+//CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -54,39 +63,49 @@ double f2(double x) {
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
 //CHECK-NEXT:       clad::tape<unsigned long> _t1 = {};
-//CHECK-NEXT:       clad::tape<int> _t2 = {};
 //CHECK-NEXT:       int _d_j = 0;
-//CHECK-NEXT:       int j = 0;
-//CHECK-NEXT:       clad::tape<double> _t3 = {};
+//CHECK-NEXT:       clad::tape<double> _t2 = {};
+//CHECK-NEXT:       clad::tape<int> _t3 = {};
+//CHECK-NEXT:       int _t4;
 //CHECK-NEXT:       double t = 1;
 //CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < 3; i++) {
-//CHECK-NEXT:           _t0++;
-//CHECK-NEXT:           clad::push(_t1, 0UL);
-//CHECK-NEXT:           for (clad::push(_t2, j) , j = 0; j < 3; j++) {
-//CHECK-NEXT:               clad::back(_t1)++;
-//CHECK-NEXT:               clad::push(_t3, t);
-//CHECK-NEXT:               t *= x;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int i = 0;
+//CHECK-NEXT:           for (; i < 3; i++) {
+//CHECK-NEXT:               _t0++;
+//CHECK-NEXT:               clad::push(_t1, 0UL);
+//CHECK-NEXT:               {
+//CHECK-NEXT:                   int j = 0;
+//CHECK-NEXT:                   for (; j < 3; j++) {
+//CHECK-NEXT:                       clad::back(_t1)++;
+//CHECK-NEXT:                       clad::push(_t2, t);
+//CHECK-NEXT:                       t *= x;
+//CHECK-NEXT:                   }
+//CHECK-NEXT:                   clad::push(_t3, j);
+//CHECK-NEXT:               }
 //CHECK-NEXT:           }
+//CHECK-NEXT:           _t4 = i;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_t += 1;
-//CHECK-NEXT:       for (; _t0; _t0--) {
-//CHECK-NEXT:           i--;
-//CHECK-NEXT:           for (; clad::back(_t1); clad::back(_t1)--) {
-//CHECK-NEXT:               j--;
-//CHECK-NEXT:               t = clad::pop(_t3);
-//CHECK-NEXT:               double _r_d0 = _d_t;
-//CHECK-NEXT:               _d_t += _r_d0 * x;
-//CHECK-NEXT:               * _d_x += t * _r_d0;
-//CHECK-NEXT:               _d_t -= _r_d0;
-//CHECK-NEXT:           }
-//CHECK-NEXT:           {
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int i = _t4;
+//CHECK-NEXT:           for (; _t0; _t0--) {
+//CHECK-NEXT:               i--;
+//CHECK-NEXT:               int j = clad::pop(_t3);
+//CHECK-NEXT:               for (; clad::back(_t1); clad::back(_t1)--) {
+//CHECK-NEXT:                   j--;
+//CHECK-NEXT:                   t = clad::pop(_t2);
+//CHECK-NEXT:                   double _r_d0 = _d_t;
+//CHECK-NEXT:                   _d_t += _r_d0 * x;
+//CHECK-NEXT:                   * _d_x += t * _r_d0;
+//CHECK-NEXT:                   _d_t -= _r_d0;
+//CHECK-NEXT:               }
 //CHECK-NEXT:               _d_j = 0;
-//CHECK-NEXT:               j = clad::pop(_t2);
+//CHECK-NEXT:               clad::pop(_t1);
 //CHECK-NEXT:           }
-//CHECK-NEXT:           clad::pop(_t1);
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -106,33 +125,44 @@ double f3(double x) {
 //CHECK-NEXT:       int _d_i = 0;
 //CHECK-NEXT:       clad::tape<double> _t1 = {};
 //CHECK-NEXT:       clad::tape<bool> _t3 = {};
+//CHECK-NEXT:       int _t4;
 //CHECK-NEXT:       double t = 1;
 //CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < 3; i++) {
-//CHECK-NEXT:           _t0++;
-//CHECK-NEXT:           clad::push(_t1, t);
-//CHECK-NEXT:           t *= x;
-//CHECK-NEXT:           bool _t2 = i == 1;
-//CHECK-NEXT:           {
-//CHECK-NEXT:               if (_t2)
-//CHECK-NEXT:                   goto _label0;
-//CHECK-NEXT:               clad::push(_t3, _t2);
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int i = 0;
+//CHECK-NEXT:           for (; i < 3; i++) {
+//CHECK-NEXT:               _t0++;
+//CHECK-NEXT:               clad::push(_t1, t);
+//CHECK-NEXT:               t *= x;
+//CHECK-NEXT:               bool _t2 = i == 1;
+//CHECK-NEXT:               {
+//CHECK-NEXT:                   if (_t2)
+//CHECK-NEXT:                       goto _label0;
+//CHECK-NEXT:                   clad::push(_t3, _t2);
+//CHECK-NEXT:               }
 //CHECK-NEXT:           }
+//CHECK-NEXT:           _t4 = i;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label1;
 //CHECK-NEXT:     _label1:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_t += 1;
-//CHECK-NEXT:       for (; _t0; _t0--) {
-//CHECK-NEXT:           i--;
-//CHECK-NEXT:           if (clad::pop(_t3))
-//CHECK-NEXT:             _label0:
-//CHECK-NEXT:               _d_t += 1;
-//CHECK-NEXT:           {
-//CHECK-NEXT:               t = clad::pop(_t1);
-//CHECK-NEXT:               double _r_d0 = _d_t;
-//CHECK-NEXT:               _d_t += _r_d0 * x;
-//CHECK-NEXT:               * _d_x += t * _r_d0;
-//CHECK-NEXT:               _d_t -= _r_d0;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int i = _t4;
+//CHECK-NEXT:           for (; _t0; _t0--) {
+//CHECK-NEXT:               i--;
+//CHECK-NEXT:               if (clad::pop(_t3)) {
+//CHECK-NEXT:                 _label0:
+//CHECK-NEXT:                   ;
+//CHECK-NEXT:                   _d_t += 1;
+//CHECK-NEXT:               }
+//CHECK-NEXT:               {
+//CHECK-NEXT:                   t = clad::pop(_t1);
+//CHECK-NEXT:                   double _r_d0 = _d_t;
+//CHECK-NEXT:                   _d_t += _r_d0 * x;
+//CHECK-NEXT:                   * _d_x += t * _r_d0;
+//CHECK-NEXT:                   _d_t -= _r_d0;
+//CHECK-NEXT:               }
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -149,24 +179,33 @@ double f4(double x) {
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
 //CHECK-NEXT:       clad::tape<double> _t1 = {};
+//CHECK-NEXT:       int _t2;
 //CHECK-NEXT:       double t = 1;
 //CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < 3; clad::push(_t1, t) , (t *= x)) {
-//CHECK-NEXT:           _t0++;
-//CHECK-NEXT:           i++;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int i = 0;
+//CHECK-NEXT:           for (; i < 3; clad::push(_t1, t) , (t *= x)) {
+//CHECK-NEXT:               _t0++;
+//CHECK-NEXT:               i++;
+//CHECK-NEXT:           }
+//CHECK-NEXT:           _t2 = i;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_t += 1;
-//CHECK-NEXT:       for (; _t0; _t0--) {
-//CHECK-NEXT:           {
-//CHECK-NEXT:               t = clad::pop(_t1);
-//CHECK-NEXT:               double _r_d0 = _d_t;
-//CHECK-NEXT:               _d_t += _r_d0 * x;
-//CHECK-NEXT:               * _d_x += t * _r_d0;
-//CHECK-NEXT:               _d_t -= _r_d0;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int i = _t2;
+//CHECK-NEXT:           for (; _t0; _t0--) {
+//CHECK-NEXT:               {
+//CHECK-NEXT:                   t = clad::pop(_t1);
+//CHECK-NEXT:                   double _r_d0 = _d_t;
+//CHECK-NEXT:                   _d_t += _r_d0 * x;
+//CHECK-NEXT:                   * _d_x += t * _r_d0;
+//CHECK-NEXT:                   _d_t -= _r_d0;
+//CHECK-NEXT:               }
+//CHECK-NEXT:               i--;
 //CHECK-NEXT:           }
-//CHECK-NEXT:           i--;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -179,18 +218,27 @@ double f5(double x){
 //CHECK:   void f5_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
+//CHECK-NEXT:       int _t1;
 //CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < 10; i++) {
-//CHECK-NEXT:           _t0++;
-//CHECK-NEXT:           x++;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int i = 0;
+//CHECK-NEXT:           for (; i < 10; i++) {
+//CHECK-NEXT:               _t0++;
+//CHECK-NEXT:               x++;
+//CHECK-NEXT:           }
+//CHECK-NEXT:           _t1 = i;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       * _d_x += 1;
-//CHECK-NEXT:       for (; _t0; _t0--) {
-//CHECK-NEXT:           i--;
-//CHECK-NEXT:           x--;
-//CHECK-NEXT:           * _d_x;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int i = _t1;
+//CHECK-NEXT:           for (; _t0; _t0--) {
+//CHECK-NEXT:               i--;
+//CHECK-NEXT:               x--;
+//CHECK-NEXT:               * _d_x;
+//CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -207,34 +255,43 @@ double f_const_local(double x) {
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    unsigned long _t0;
 //CHECK-NEXT:    int _d_i = 0;
-//CHECK-NEXT:    clad::tape<double> _t1 = {};
 //CHECK-NEXT:    double _d_n = 0;
-//CHECK-NEXT:    double n = 0;
+//CHECK-NEXT:    clad::tape<double> _t1 = {};
 //CHECK-NEXT:    clad::tape<double> _t2 = {};
+//CHECK-NEXT:    int _t3;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    _t0 = 0;
-//CHECK-NEXT:    for (int i = 0; i < 3; ++i) {
-//CHECK-NEXT:        _t0++;
-//CHECK-NEXT:        clad::push(_t1, n) , n = x + i;
-//CHECK-NEXT:        clad::push(_t2, res);
-//CHECK-NEXT:        res += x * n;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        int i = 0;
+//CHECK-NEXT:        for (; i < 3; ++i) {
+//CHECK-NEXT:            _t0++;
+//CHECK-NEXT:            const double n = x + i;
+//CHECK-NEXT:            clad::push(_t1, res);
+//CHECK-NEXT:            res += x * n;
+//CHECK-NEXT:            clad::push(_t2, n);
+//CHECK-NEXT:        }
+//CHECK-NEXT:        _t3 = i;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
+//CHECK-NEXT:    ;
 //CHECK-NEXT:    _d_res += 1;
-//CHECK-NEXT:    for (; _t0; _t0--) {
-//CHECK-NEXT:        --i;
-//CHECK-NEXT:        {
-//CHECK-NEXT:            res = clad::pop(_t2);
-//CHECK-NEXT:            double _r_d0 = _d_res;
-//CHECK-NEXT:            * _d_x += _r_d0 * n;
-//CHECK-NEXT:            _d_n += x * _r_d0;
-//CHECK-NEXT:        }
-//CHECK-NEXT:        {
-//CHECK-NEXT:            * _d_x += _d_n;
-//CHECK-NEXT:            _d_i += _d_n;
-//CHECK-NEXT:            _d_n = 0;
-//CHECK-NEXT:            n = clad::pop(_t1);
+//CHECK-NEXT:    {
+//CHECK-NEXT:        int i = _t3;
+//CHECK-NEXT:        for (; _t0; _t0--) {
+//CHECK-NEXT:            --i;
+//CHECK-NEXT:            const double n = clad::pop(_t2);
+//CHECK-NEXT:            {
+//CHECK-NEXT:                res = clad::pop(_t1);
+//CHECK-NEXT:                double _r_d0 = _d_res;
+//CHECK-NEXT:                * _d_x += _r_d0 * n;
+//CHECK-NEXT:                _d_n += x * _r_d0;
+//CHECK-NEXT:            }
+//CHECK-NEXT:            {
+//CHECK-NEXT:                * _d_x += _d_n;
+//CHECK-NEXT:                _d_i += _d_n;
+//CHECK-NEXT:                _d_n = 0;
+//CHECK-NEXT:            }
 //CHECK-NEXT:        }
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
@@ -252,21 +309,30 @@ double f_sum(double *p, int n) {
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     int _t2;
 //CHECK-NEXT:     double s = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, s);
-//CHECK-NEXT:         s += p[i];
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < n; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, s);
+//CHECK-NEXT:             s += p[i];
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t2 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_s += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         s = clad::pop(_t1);
-//CHECK-NEXT:         double _r_d0 = _d_s;
-//CHECK-NEXT:         _d_p[i] += _r_d0;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t2;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             s = clad::pop(_t1);
+//CHECK-NEXT:             double _r_d0 = _d_s;
+//CHECK-NEXT:             _d_p[i] += _r_d0;
+//CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -274,6 +340,7 @@ double sq(double x) { return x * x; }
 //CHECK:   void sq_pullback(double x, double _d_y, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += _d_y * x;
 //CHECK-NEXT:           * _d_x += x * _d_y;
@@ -293,24 +360,33 @@ double f_sum_squares(double *p, int n) {
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     int _t2;
 //CHECK-NEXT:     double s = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, s);
-//CHECK-NEXT:         s += sq(p[i]);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < n; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, s);
+//CHECK-NEXT:             s += sq(p[i]);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t2 = i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     _d_s += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         s = clad::pop(_t1);
-//CHECK-NEXT:         double _r_d0 = _d_s;
-//CHECK-NEXT:         double _grad0 = 0.;
-//CHECK-NEXT:         sq_pullback(p[i], _r_d0, &_grad0);
-//CHECK-NEXT:         double _r0 = _grad0;
-//CHECK-NEXT:         _d_p[i] += _r0;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t2;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             s = clad::pop(_t1);
+//CHECK-NEXT:             double _r_d0 = _d_s;
+//CHECK-NEXT:             double _grad0 = 0.;
+//CHECK-NEXT:             sq_pullback(p[i], _r_d0, &_grad0);
+//CHECK-NEXT:             double _r0 = _grad0;
+//CHECK-NEXT:             _d_p[i] += _r0;
+//CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -330,66 +406,75 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
-//CHECK-NEXT:     double _t2;
+//CHECK-NEXT:     int _t2;
 //CHECK-NEXT:     double _t3;
 //CHECK-NEXT:     double _t4;
 //CHECK-NEXT:     double _t5;
 //CHECK-NEXT:     double _t6;
 //CHECK-NEXT:     double _t7;
+//CHECK-NEXT:     double _t8;
 //CHECK-NEXT:     double _d_gaus = 0;
 //CHECK-NEXT:     double power = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, power);
-//CHECK-NEXT:         power += sq(x[i] - p[i]);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = 0;
+//CHECK-NEXT:         for (; i < n; i++) {
+//CHECK-NEXT:             _t0++;
+//CHECK-NEXT:             clad::push(_t1, power);
+//CHECK-NEXT:             power += sq(x[i] - p[i]);
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _t2 = i;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _t2 = power;
-//CHECK-NEXT:     _t4 = sq(sigma);
-//CHECK-NEXT:     _t3 = (2 * _t4);
-//CHECK-NEXT:     power = -power / _t3;
-//CHECK-NEXT:     _t7 = std::pow(2 * 3.1415926535897931, n);
-//CHECK-NEXT:     _t6 = std::sqrt(_t7 * sigma);
-//CHECK-NEXT:     _t5 = std::exp(power);
-//CHECK-NEXT:     double gaus = 1. / _t6 * _t5;
+//CHECK-NEXT:     _t3 = power;
+//CHECK-NEXT:     _t5 = sq(sigma);
+//CHECK-NEXT:     _t4 = (2 * _t5);
+//CHECK-NEXT:     power = -power / _t4;
+//CHECK-NEXT:     _t8 = std::pow(2 * 3.1415926535897931, n);
+//CHECK-NEXT:     _t7 = std::sqrt(_t8 * sigma);
+//CHECK-NEXT:     _t6 = std::exp(power);
+//CHECK-NEXT:     double gaus = 1. / _t7 * _t6;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r8 = 1 * clad::custom_derivatives::log_pushforward(gaus, 1.).pushforward;
 //CHECK-NEXT:         _d_gaus += _r8;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r3 = _d_gaus * _t5 * -1. / (_t6 * _t6);
-//CHECK-NEXT:         double _r4 = _r3 * clad::custom_derivatives::sqrt_pushforward(_t7 * sigma, 1.).pushforward;
+//CHECK-NEXT:         double _r3 = _d_gaus * _t6 * -1. / (_t7 * _t7);
+//CHECK-NEXT:         double _r4 = _r3 * clad::custom_derivatives::sqrt_pushforward(_t8 * sigma, 1.).pushforward;
 //CHECK-NEXT:         double _grad2 = 0.;
 //CHECK-NEXT:         double _grad3 = 0.;
 //CHECK-NEXT:         clad::custom_derivatives::pow_pullback(2 * 3.1415926535897931, n, _r4 * sigma, &_grad2, &_grad3);
 //CHECK-NEXT:         double _r5 = _grad2;
 //CHECK-NEXT:         double _r6 = _grad3;
 //CHECK-NEXT:         _d_n += _r6;
-//CHECK-NEXT:         _d_sigma += _t7 * _r4;
-//CHECK-NEXT:         double _r7 = 1. / _t6 * _d_gaus * clad::custom_derivatives::exp_pushforward(power, 1.).pushforward;
+//CHECK-NEXT:         _d_sigma += _t8 * _r4;
+//CHECK-NEXT:         double _r7 = 1. / _t7 * _d_gaus * clad::custom_derivatives::exp_pushforward(power, 1.).pushforward;
 //CHECK-NEXT:         _d_power += _r7;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         power = _t2;
+//CHECK-NEXT:         power = _t3;
 //CHECK-NEXT:         double _r_d1 = _d_power;
-//CHECK-NEXT:         _d_power += -_r_d1 / _t3;
-//CHECK-NEXT:         double _r1 = _r_d1 * --power / (_t3 * _t3);
+//CHECK-NEXT:         _d_power += -_r_d1 / _t4;
+//CHECK-NEXT:         double _r1 = _r_d1 * --power / (_t4 * _t4);
 //CHECK-NEXT:         double _grad1 = 0.;
 //CHECK-NEXT:         sq_pullback(sigma, 2 * _r1, &_grad1);
 //CHECK-NEXT:         double _r2 = _grad1;
 //CHECK-NEXT:         _d_sigma += _r2;
 //CHECK-NEXT:         _d_power -= _r_d1;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
-//CHECK-NEXT:         power = clad::pop(_t1);
-//CHECK-NEXT:         double _r_d0 = _d_power;
-//CHECK-NEXT:         double _grad0 = 0.;
-//CHECK-NEXT:         sq_pullback(x[i] - p[i], _r_d0, &_grad0);
-//CHECK-NEXT:         double _r0 = _grad0;
-//CHECK-NEXT:         _d_p[i] += -_r0;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         int i = _t2;
+//CHECK-NEXT:         for (; _t0; _t0--) {
+//CHECK-NEXT:             i--;
+//CHECK-NEXT:             power = clad::pop(_t1);
+//CHECK-NEXT:             double _r_d0 = _d_power;
+//CHECK-NEXT:             double _grad0 = 0.;
+//CHECK-NEXT:             sq_pullback(x[i] - p[i], _r_d0, &_grad0);
+//CHECK-NEXT:             double _r0 = _grad0;
+//CHECK-NEXT:             _d_p[i] += -_r0;
+//CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -407,33 +492,42 @@ void f_const_grad(const double, const double, clad::array_ref<double>, clad::arr
 //CHECK-NEXT:       int _d_r = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
-//CHECK-NEXT:       clad::tape<int> _t1 = {};
 //CHECK-NEXT:       int _d_sq = 0;
-//CHECK-NEXT:       int sq0 = 0;
+//CHECK-NEXT:       clad::tape<int> _t1 = {};
 //CHECK-NEXT:       clad::tape<int> _t2 = {};
+//CHECK-NEXT:       int _t3;
 //CHECK-NEXT:       int r = 0;
 //CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < a; i++) {
-//CHECK-NEXT:           _t0++;
-//CHECK-NEXT:           clad::push(_t1, sq0) , sq0 = b * b;
-//CHECK-NEXT:           clad::push(_t2, r);
-//CHECK-NEXT:           r += sq0;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int i = 0;
+//CHECK-NEXT:           for (; i < a; i++) {
+//CHECK-NEXT:               _t0++;
+//CHECK-NEXT:               int sq0 = b * b;
+//CHECK-NEXT:               clad::push(_t1, r);
+//CHECK-NEXT:               r += sq0;
+//CHECK-NEXT:               clad::push(_t2, sq0);
+//CHECK-NEXT:           }
+//CHECK-NEXT:           _t3 = i;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       _d_r += 1;
-//CHECK-NEXT:       for (; _t0; _t0--) {
-//CHECK-NEXT:           i--;
-//CHECK-NEXT:           {
-//CHECK-NEXT:               r = clad::pop(_t2);
-//CHECK-NEXT:               int _r_d0 = _d_r;
-//CHECK-NEXT:               _d_sq += _r_d0;
-//CHECK-NEXT:           }
-//CHECK-NEXT:           {
-//CHECK-NEXT:               * _d_b += _d_sq * b;
-//CHECK-NEXT:               * _d_b += b * _d_sq;
-//CHECK-NEXT:               _d_sq = 0;
-//CHECK-NEXT:               sq0 = clad::pop(_t1);
+//CHECK-NEXT:       {
+//CHECK-NEXT:           int i = _t3;
+//CHECK-NEXT:           for (; _t0; _t0--) {
+//CHECK-NEXT:               i--;
+//CHECK-NEXT:               int sq = clad::pop(_t2);
+//CHECK-NEXT:               {
+//CHECK-NEXT:                   r = clad::pop(_t1);
+//CHECK-NEXT:                   int _r_d0 = _d_r;
+//CHECK-NEXT:                   _d_sq += _r_d0;
+//CHECK-NEXT:               }
+//CHECK-NEXT:               {
+//CHECK-NEXT:                   * _d_b += _d_sq * b;
+//CHECK-NEXT:                   * _d_b += b * _d_sq;
+//CHECK-NEXT:                   _d_sq = 0;
+//CHECK-NEXT:               }
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -453,53 +547,62 @@ double f6 (double i, double j) {
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_counter = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_b = 0;
-// CHECK-NEXT:     double b = 0;
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_c = 0;
-// CHECK-NEXT:     double c = 0;
+// CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
+// CHECK-NEXT:     int _t5;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int counter = 0; counter < 3; ++counter) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, b) , b = i * i;
-// CHECK-NEXT:         clad::push(_t2, c) , c = j * j;
-// CHECK-NEXT:         clad::push(_t3, b);
-// CHECK-NEXT:         b += j;
-// CHECK-NEXT:         clad::push(_t4, a);
-// CHECK-NEXT:         a += b + c + i;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int counter = 0;
+// CHECK-NEXT:         for (; counter < 3; ++counter) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             double b = i * i;
+// CHECK-NEXT:             double c = j * j;
+// CHECK-NEXT:             clad::push(_t1, b);
+// CHECK-NEXT:             b += j;
+// CHECK-NEXT:             clad::push(_t2, a);
+// CHECK-NEXT:             a += b + c + i;
+// CHECK-NEXT:             clad::push(_t3, c);
+// CHECK-NEXT:             clad::push(_t4, b);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t5 = counter;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_a += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --counter;
-// CHECK-NEXT:         {
-// CHECK-NEXT:             a = clad::pop(_t4);
-// CHECK-NEXT:             double _r_d1 = _d_a;
-// CHECK-NEXT:             _d_b += _r_d1;
-// CHECK-NEXT:             _d_c += _r_d1;
-// CHECK-NEXT:             * _d_i += _r_d1;
-// CHECK-NEXT:         }
-// CHECK-NEXT:         {
-// CHECK-NEXT:             b = clad::pop(_t3);
-// CHECK-NEXT:             double _r_d0 = _d_b;
-// CHECK-NEXT:             * _d_j += _r_d0;
-// CHECK-NEXT:         }
-// CHECK-NEXT:         {
-// CHECK-NEXT:             * _d_j += _d_c * j;
-// CHECK-NEXT:             * _d_j += j * _d_c;
-// CHECK-NEXT:             _d_c = 0;
-// CHECK-NEXT:             c = clad::pop(_t2);
-// CHECK-NEXT:         }
-// CHECK-NEXT:         {
-// CHECK-NEXT:             * _d_i += _d_b * i;
-// CHECK-NEXT:             * _d_i += i * _d_b;
-// CHECK-NEXT:             _d_b = 0;
-// CHECK-NEXT:             b = clad::pop(_t1);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int counter = _t5;
+// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:             --counter;
+// CHECK-NEXT:             double b = clad::pop(_t4);
+// CHECK-NEXT:             double c = clad::pop(_t3);
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 a = clad::pop(_t2);
+// CHECK-NEXT:                 double _r_d1 = _d_a;
+// CHECK-NEXT:                 _d_b += _r_d1;
+// CHECK-NEXT:                 _d_c += _r_d1;
+// CHECK-NEXT:                 * _d_i += _r_d1;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 b = clad::pop(_t1);
+// CHECK-NEXT:                 double _r_d0 = _d_b;
+// CHECK-NEXT:                 * _d_j += _r_d0;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 * _d_j += _d_c * j;
+// CHECK-NEXT:                 * _d_j += j * _d_c;
+// CHECK-NEXT:                 _d_c = 0;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 * _d_i += _d_b * i;
+// CHECK-NEXT:                 * _d_i += i * _d_b;
+// CHECK-NEXT:                 _d_b = 0;
+// CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -528,16 +631,16 @@ double fn7(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 a = clad::pop(_t1);
-// CHECK-NEXT:                 double _r_d0 = _d_a;
-// CHECK-NEXT:                 * _d_i += _r_d0 * i;
-// CHECK-NEXT:                 * _d_i += i * _r_d0;
-// CHECK-NEXT:                 * _d_j += _r_d0;
-// CHECK-NEXT:             }
+// CHECK-NEXT:             a = clad::pop(_t1);
+// CHECK-NEXT:             double _r_d0 = _d_a;
+// CHECK-NEXT:             * _d_i += _r_d0 * i;
+// CHECK-NEXT:             * _d_i += i * _r_d0;
+// CHECK-NEXT:             * _d_j += _r_d0;
+// CHECK-NEXT:             counter++;
 // CHECK-NEXT:             _t0--;
 // CHECK-NEXT:         }
 // CHECK-NEXT: }
@@ -573,24 +676,22 @@ double fn8(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 do {
-// CHECK-NEXT:                     {
-// CHECK-NEXT:                         {
-// CHECK-NEXT:                             a = clad::pop(_t2);
-// CHECK-NEXT:                             double _r_d0 = _d_a;
-// CHECK-NEXT:                             * _d_i += _r_d0 * i;
-// CHECK-NEXT:                             * _d_i += i * _r_d0;
-// CHECK-NEXT:                             * _d_j += _r_d0;
-// CHECK-NEXT:                         }
-// CHECK-NEXT:                     }
-// CHECK-NEXT:                     clad::back(_t1)--;
-// CHECK-NEXT:                 } while (clad::back(_t1));
-// CHECK-NEXT:                 clad::pop(_t1);
-// CHECK-NEXT:             }
+// CHECK-NEXT:             do {
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     a = clad::pop(_t2);
+// CHECK-NEXT:                     double _r_d0 = _d_a;
+// CHECK-NEXT:                     * _d_i += _r_d0 * i;
+// CHECK-NEXT:                     * _d_i += i * _r_d0;
+// CHECK-NEXT:                     * _d_j += _r_d0;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 ++counter;
+// CHECK-NEXT:                 clad::back(_t1)--;
+// CHECK-NEXT:             } while (clad::back(_t1));
+// CHECK-NEXT:             clad::pop(_t1);
 // CHECK-NEXT:             _t0--;
 // CHECK-NEXT:         }
 // CHECK-NEXT: }
@@ -638,32 +739,31 @@ double fn9(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t2)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     while (clad::back(_t4))
+// CHECK-NEXT:                 while (clad::back(_t4))
+// CHECK-NEXT:                     {
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             {
-// CHECK-NEXT:                                 {
-// CHECK-NEXT:                                     a = clad::pop(_t5);
-// CHECK-NEXT:                                     double _r_d3 = _d_a;
-// CHECK-NEXT:                                     * _d_i += _r_d3 * i;
-// CHECK-NEXT:                                     * _d_i += i * _r_d3;
-// CHECK-NEXT:                                     * _d_j += _r_d3;
-// CHECK-NEXT:                                 }
-// CHECK-NEXT:                             }
-// CHECK-NEXT:                             clad::back(_t4)--;
+// CHECK-NEXT:                             a = clad::pop(_t5);
+// CHECK-NEXT:                             double _r_d3 = _d_a;
+// CHECK-NEXT:                             * _d_i += _r_d3 * i;
+// CHECK-NEXT:                             * _d_i += i * _r_d3;
+// CHECK-NEXT:                             * _d_j += _r_d3;
 // CHECK-NEXT:                         }
-// CHECK-NEXT:                     clad::pop(_t4);
-// CHECK-NEXT:                 }
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     counter_again = clad::pop(_t3);
-// CHECK-NEXT:                     int _r_d2 = _d_counter_again;
-// CHECK-NEXT:                     _d_counter_again -= _r_d2;
-// CHECK-NEXT:                 }
+// CHECK-NEXT:                         counter_again++;
+// CHECK-NEXT:                         clad::back(_t4)--;
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                 clad::pop(_t4);
 // CHECK-NEXT:             }
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 counter_again = clad::pop(_t3);
+// CHECK-NEXT:                 int _r_d2 = _d_counter_again;
+// CHECK-NEXT:                 _d_counter_again -= _r_d2;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             counter++;
 // CHECK-NEXT:             _t2--;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     {
@@ -692,52 +792,51 @@ double fn10(double i, double j) {
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     unsigned long _t0;
-// CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_b = 0;
-// CHECK-NEXT:     int b = 0;
-// CHECK-NEXT:     clad::tape<int> _t2 = {};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     clad::tape<int> _t1 = {};
+// CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     clad::tape<int> _t3 = {};
 // CHECK-NEXT:     clad::tape<int> _t4 = {};
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     while (clad::push(_t1, b) , b = counter)
+// CHECK-NEXT:     while (int b = counter)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
-// CHECK-NEXT:             clad::push(_t2, b);
+// CHECK-NEXT:             clad::push(_t1, b);
 // CHECK-NEXT:             b += i * i + j;
-// CHECK-NEXT:             clad::push(_t3, a);
+// CHECK-NEXT:             clad::push(_t2, a);
 // CHECK-NEXT:             a += b;
-// CHECK-NEXT:             clad::push(_t4, counter);
+// CHECK-NEXT:             clad::push(_t3, counter);
 // CHECK-NEXT:             counter -= 1;
+// CHECK-NEXT:             clad::push(_t4, b);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
+// CHECK-NEXT:             int b = clad::pop(_t4);
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     counter = clad::pop(_t4);
-// CHECK-NEXT:                     int _r_d2 = _d_counter;
-// CHECK-NEXT:                 }
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     a = clad::pop(_t3);
-// CHECK-NEXT:                     double _r_d1 = _d_a;
-// CHECK-NEXT:                     _d_b += _r_d1;
-// CHECK-NEXT:                 }
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     b = clad::pop(_t2);
-// CHECK-NEXT:                     int _r_d0 = _d_b;
-// CHECK-NEXT:                     * _d_i += _r_d0 * i;
-// CHECK-NEXT:                     * _d_i += i * _r_d0;
-// CHECK-NEXT:                     * _d_j += _r_d0;
-// CHECK-NEXT:                 }
+// CHECK-NEXT:                 counter = clad::pop(_t3);
+// CHECK-NEXT:                 int _r_d2 = _d_counter;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 a = clad::pop(_t2);
+// CHECK-NEXT:                 double _r_d1 = _d_a;
+// CHECK-NEXT:                 _d_b += _r_d1;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 b = clad::pop(_t1);
+// CHECK-NEXT:                 int _r_d0 = _d_b;
+// CHECK-NEXT:                 * _d_i += _r_d0 * i;
+// CHECK-NEXT:                 * _d_i += i * _r_d0;
+// CHECK-NEXT:                 * _d_j += _r_d0;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 _d_counter += _d_b;
 // CHECK-NEXT:                 _d_b = 0;
-// CHECK-NEXT:                 b = clad::pop(_t1);
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _t0--;
 // CHECK-NEXT:         }
@@ -771,20 +870,19 @@ double fn11(double i, double j) {
 // CHECK-NEXT:     } while (counter);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 counter = clad::pop(_t2);
-// CHECK-NEXT:                 int _r_d1 = _d_counter;
-// CHECK-NEXT:             }
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 a = clad::pop(_t1);
-// CHECK-NEXT:                 double _r_d0 = _d_a;
-// CHECK-NEXT:                 * _d_i += _r_d0 * i;
-// CHECK-NEXT:                 * _d_i += i * _r_d0;
-// CHECK-NEXT:                 * _d_j += _r_d0;
-// CHECK-NEXT:             }
+// CHECK-NEXT:             counter = clad::pop(_t2);
+// CHECK-NEXT:             int _r_d1 = _d_counter;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             a = clad::pop(_t1);
+// CHECK-NEXT:             double _r_d0 = _d_a;
+// CHECK-NEXT:             * _d_i += _r_d0 * i;
+// CHECK-NEXT:             * _d_i += i * _r_d0;
+// CHECK-NEXT:             * _d_j += _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0--;
 // CHECK-NEXT:     } while (_t0);
@@ -811,82 +909,75 @@ double fn12(double i, double j) {
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     unsigned long _t0;
-// CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_counter_again = 0;
-// CHECK-NEXT:     int counter_again = 0;
-// CHECK-NEXT:     clad::tape<unsigned long> _t2 = {};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<int> _t4 = {};
-// CHECK-NEXT:     clad::tape<unsigned long> _t5 = {};
-// CHECK-NEXT:     clad::tape<double> _t6 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t1 = {};
+// CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     clad::tape<int> _t3 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t4 = {};
+// CHECK-NEXT:     clad::tape<double> _t5 = {};
+// CHECK-NEXT:     clad::tape<int> _t6 = {};
 // CHECK-NEXT:     clad::tape<int> _t7 = {};
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     _t0 = 0;
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, counter_again) , counter_again = 3;
-// CHECK-NEXT:         clad::push(_t2, 0UL);
+// CHECK-NEXT:         int counter_again = 3;
+// CHECK-NEXT:         clad::push(_t1, 0UL);
 // CHECK-NEXT:         do {
-// CHECK-NEXT:             clad::back(_t2)++;
-// CHECK-NEXT:             clad::push(_t3, a);
+// CHECK-NEXT:             clad::back(_t1)++;
+// CHECK-NEXT:             clad::push(_t2, a);
 // CHECK-NEXT:             a += i * i + j;
-// CHECK-NEXT:             clad::push(_t4, counter_again);
+// CHECK-NEXT:             clad::push(_t3, counter_again);
 // CHECK-NEXT:             counter_again -= 1;
-// CHECK-NEXT:             clad::push(_t5, 0UL);
+// CHECK-NEXT:             clad::push(_t4, 0UL);
 // CHECK-NEXT:             do {
-// CHECK-NEXT:                 clad::back(_t5)++;
-// CHECK-NEXT:                 clad::push(_t6, a);
+// CHECK-NEXT:                 clad::back(_t4)++;
+// CHECK-NEXT:                 clad::push(_t5, a);
 // CHECK-NEXT:                 a += j;
 // CHECK-NEXT:             } while (0);
 // CHECK-NEXT:         } while (counter_again);
-// CHECK-NEXT:         clad::push(_t7, counter);
+// CHECK-NEXT:         clad::push(_t6, counter);
 // CHECK-NEXT:         counter -= 1;
+// CHECK-NEXT:         clad::push(_t7, counter_again);
 // CHECK-NEXT:     } while (counter);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     do {
+// CHECK-NEXT:         int counter_again = clad::pop(_t7);
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 counter = clad::pop(_t7);
-// CHECK-NEXT:                 int _r_d3 = _d_counter;
-// CHECK-NEXT:             }
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 do {
-// CHECK-NEXT:                     {
-// CHECK-NEXT:                         {
-// CHECK-NEXT:                             do {
-// CHECK-NEXT:                                 {
-// CHECK-NEXT:                                     a = clad::pop(_t6);
-// CHECK-NEXT:                                     double _r_d2 = _d_a;
-// CHECK-NEXT:                                     * _d_j += _r_d2;
-// CHECK-NEXT:                                 }
-// CHECK-NEXT:                                 clad::back(_t5)--;
-// CHECK-NEXT:                             } while (clad::back(_t5));
-// CHECK-NEXT:                             clad::pop(_t5);
-// CHECK-NEXT:                         }
-// CHECK-NEXT:                         {
-// CHECK-NEXT:                             counter_again = clad::pop(_t4);
-// CHECK-NEXT:                             int _r_d1 = _d_counter_again;
-// CHECK-NEXT:                         }
-// CHECK-NEXT:                         {
-// CHECK-NEXT:                             a = clad::pop(_t3);
-// CHECK-NEXT:                             double _r_d0 = _d_a;
-// CHECK-NEXT:                             * _d_i += _r_d0 * i;
-// CHECK-NEXT:                             * _d_i += i * _r_d0;
-// CHECK-NEXT:                             * _d_j += _r_d0;
-// CHECK-NEXT:                         }
-// CHECK-NEXT:                     }
-// CHECK-NEXT:                     clad::back(_t2)--;
-// CHECK-NEXT:                 } while (clad::back(_t2));
-// CHECK-NEXT:                 clad::pop(_t2);
-// CHECK-NEXT:             }
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 _d_counter_again = 0;
-// CHECK-NEXT:                 counter_again = clad::pop(_t1);
-// CHECK-NEXT:             }
+// CHECK-NEXT:             counter = clad::pop(_t6);
+// CHECK-NEXT:             int _r_d3 = _d_counter;
 // CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             do {
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     do {
+// CHECK-NEXT:                         a = clad::pop(_t5);
+// CHECK-NEXT:                         double _r_d2 = _d_a;
+// CHECK-NEXT:                         * _d_j += _r_d2;
+// CHECK-NEXT:                         clad::back(_t4)--;
+// CHECK-NEXT:                     } while (clad::back(_t4));
+// CHECK-NEXT:                     clad::pop(_t4);
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     counter_again = clad::pop(_t3);
+// CHECK-NEXT:                     int _r_d1 = _d_counter_again;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     a = clad::pop(_t2);
+// CHECK-NEXT:                     double _r_d0 = _d_a;
+// CHECK-NEXT:                     * _d_i += _r_d0 * i;
+// CHECK-NEXT:                     * _d_i += i * _r_d0;
+// CHECK-NEXT:                     * _d_j += _r_d0;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 clad::back(_t1)--;
+// CHECK-NEXT:             } while (clad::back(_t1));
+// CHECK-NEXT:             clad::pop(_t1);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _d_counter_again = 0;
 // CHECK-NEXT:         _t0--;
 // CHECK-NEXT:     } while (_t0);
 // CHECK-NEXT: }
@@ -908,54 +999,53 @@ double fn13(double i, double j) {
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_k = 0;
-// CHECK-NEXT:     int k = 0;
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
-// CHECK-NEXT:     clad::tape<int> _t3 = {};
-// CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     double _d_temp = 0;
-// CHECK-NEXT:     double temp = 0;
-// CHECK-NEXT:     clad::tape<double> _t5 = {};
+// CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     clad::tape<double> _t4 = {};
+// CHECK-NEXT:     clad::tape<int> _t5 = {};
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (; clad::push(_t1, k) , k = counter; clad::push(_t2, counter) , (counter -= 1)) {
+// CHECK-NEXT:     for (; {{int k = counter|k}}; clad::push(_t1, counter) , (counter -= 1)) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t3, k);
+// CHECK-NEXT:         clad::push(_t2, k);
 // CHECK-NEXT:         k += i + 2 * j;
-// CHECK-NEXT:         clad::push(_t4, temp) , temp = k;
-// CHECK-NEXT:         clad::push(_t5, res);
+// CHECK-NEXT:         double temp = k;
+// CHECK-NEXT:         clad::push(_t3, res);
 // CHECK-NEXT:         res += temp;
+// CHECK-NEXT:         clad::push(_t4, temp);
+// CHECK-NEXT:         clad::push(_t5, k);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         int k = clad::pop(_t5);
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 counter = clad::pop(_t2);
-// CHECK-NEXT:                 int _r_d0 = _d_counter;
-// CHECK-NEXT:             }
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 res = clad::pop(_t5);
-// CHECK-NEXT:                 double _r_d2 = _d_res;
-// CHECK-NEXT:                 _d_temp += _r_d2;
-// CHECK-NEXT:             }
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 _d_k += _d_temp;
-// CHECK-NEXT:                 _d_temp = 0;
-// CHECK-NEXT:                 temp = clad::pop(_t4);
-// CHECK-NEXT:             }
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 k = clad::pop(_t3);
-// CHECK-NEXT:                 int _r_d1 = _d_k;
-// CHECK-NEXT:                 * _d_i += _r_d1;
-// CHECK-NEXT:                 * _d_j += 2 * _r_d1;
-// CHECK-NEXT:             }
+// CHECK-NEXT:             counter = clad::pop(_t1);
+// CHECK-NEXT:             int _r_d0 = _d_counter;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         double temp = clad::pop(_t4);
+// CHECK-NEXT:         {
+// CHECK-NEXT:             res = clad::pop(_t3);
+// CHECK-NEXT:             double _r_d2 = _d_res;
+// CHECK-NEXT:             _d_temp += _r_d2;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             _d_k += _d_temp;
+// CHECK-NEXT:             _d_temp = 0;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             k = clad::pop(_t2);
+// CHECK-NEXT:             int _r_d1 = _d_k;
+// CHECK-NEXT:             * _d_i += _r_d1;
+// CHECK-NEXT:             * _d_j += 2 * _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _d_counter += _d_k;
 // CHECK-NEXT:             _d_k = 0;
-// CHECK-NEXT:             k = clad::pop(_t1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -1038,6 +1128,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -1072,6 +1163,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                         * _d_i += _r_d0;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
+// CHECK-NEXT:                 choice++;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _t0--;
 // CHECK-NEXT:         }
@@ -1103,15 +1195,14 @@ double fn15(double i, double j) {
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     clad::tape<bool> _t2 = {};
 // CHECK-NEXT:     clad::tape<unsigned long> _t3 = {};
-// CHECK-NEXT:     clad::tape<int> _t4 = {};
 // CHECK-NEXT:     int _d_another_choice = 0;
-// CHECK-NEXT:     int another_choice = 0;
-// CHECK-NEXT:     clad::tape<unsigned long> _t5 = {};
-// CHECK-NEXT:     clad::tape<bool> _t7 = {};
-// CHECK-NEXT:     clad::tape<double> _t8 = {};
-// CHECK-NEXT:     clad::tape<unsigned long> _t9 = {};
-// CHECK-NEXT:     clad::tape<bool> _t11 = {};
-// CHECK-NEXT:     clad::tape<double> _t12 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t4 = {};
+// CHECK-NEXT:     clad::tape<bool> _t6 = {};
+// CHECK-NEXT:     clad::tape<double> _t7 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t8 = {};
+// CHECK-NEXT:     clad::tape<bool> _t10 = {};
+// CHECK-NEXT:     clad::tape<double> _t11 = {};
+// CHECK-NEXT:     clad::tape<int> _t12 = {};
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
@@ -1126,77 +1217,79 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 clad::push(_t2, _t1);
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t4, another_choice) , another_choice = 3;
-// CHECK-NEXT:             clad::push(_t5, 0UL);
+// CHECK-NEXT:             int another_choice = 3;
+// CHECK-NEXT:             clad::push(_t4, 0UL);
 // CHECK-NEXT:             while (another_choice--)
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::back(_t5)++;
-// CHECK-NEXT:                     bool _t6 = another_choice > 1;
+// CHECK-NEXT:                     clad::back(_t4)++;
+// CHECK-NEXT:                     bool _t5 = another_choice > 1;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         if (_t6) {
-// CHECK-NEXT:                             clad::push(_t8, res);
+// CHECK-NEXT:                         if (_t5) {
+// CHECK-NEXT:                             clad::push(_t7, res);
 // CHECK-NEXT:                             res += i;
 // CHECK-NEXT:                             {
-// CHECK-NEXT:                                 clad::push(_t9, 1UL);
+// CHECK-NEXT:                                 clad::push(_t8, 1UL);
 // CHECK-NEXT:                                 continue;
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                         }
-// CHECK-NEXT:                         clad::push(_t7, _t6);
+// CHECK-NEXT:                         clad::push(_t6, _t5);
 // CHECK-NEXT:                     }
-// CHECK-NEXT:                     bool _t10 = another_choice > 0;
+// CHECK-NEXT:                     bool _t9 = another_choice > 0;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         if (_t10) {
-// CHECK-NEXT:                             clad::push(_t12, res);
+// CHECK-NEXT:                         if (_t9) {
+// CHECK-NEXT:                             clad::push(_t11, res);
 // CHECK-NEXT:                             res += j;
 // CHECK-NEXT:                         }
-// CHECK-NEXT:                         clad::push(_t11, _t10);
+// CHECK-NEXT:                         clad::push(_t10, _t9);
 // CHECK-NEXT:                     }
-// CHECK-NEXT:                     clad::push(_t9, 2UL);
+// CHECK-NEXT:                     clad::push(_t8, 2UL);
 // CHECK-NEXT:                 }
+// CHECK-NEXT:             clad::push(_t12, another_choice);
 // CHECK-NEXT:             clad::push(_t3, 2UL);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             switch (clad::pop(_t3)) {
 // CHECK-NEXT:               case 2UL:
 // CHECK-NEXT:                 ;
+// CHECK-NEXT:                 int another_choice = clad::pop(_t12);
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     while (clad::back(_t5))
+// CHECK-NEXT:                     while (clad::back(_t4))
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             switch (clad::pop(_t9)) {
+// CHECK-NEXT:                             switch (clad::pop(_t8)) {
 // CHECK-NEXT:                               case 2UL:
 // CHECK-NEXT:                                 ;
-// CHECK-NEXT:                                 if (clad::pop(_t11)) {
+// CHECK-NEXT:                                 if (clad::pop(_t10)) {
 // CHECK-NEXT:                                     {
-// CHECK-NEXT:                                         res = clad::pop(_t12);
+// CHECK-NEXT:                                         res = clad::pop(_t11);
 // CHECK-NEXT:                                         double _r_d1 = _d_res;
 // CHECK-NEXT:                                         * _d_j += _r_d1;
 // CHECK-NEXT:                                     }
 // CHECK-NEXT:                                 }
-// CHECK-NEXT:                                 if (clad::pop(_t7)) {
+// CHECK-NEXT:                                 if (clad::pop(_t6)) {
 // CHECK-NEXT:                                   case 1UL:
 // CHECK-NEXT:                                     ;
 // CHECK-NEXT:                                     {
-// CHECK-NEXT:                                         res = clad::pop(_t8);
+// CHECK-NEXT:                                         res = clad::pop(_t7);
 // CHECK-NEXT:                                         double _r_d0 = _d_res;
 // CHECK-NEXT:                                         * _d_i += _r_d0;
 // CHECK-NEXT:                                     }
 // CHECK-NEXT:                                 }
+// CHECK-NEXT:                                 another_choice++;
 // CHECK-NEXT:                             }
-// CHECK-NEXT:                             clad::back(_t5)--;
+// CHECK-NEXT:                             clad::back(_t4)--;
 // CHECK-NEXT:                         }
-// CHECK-NEXT:                     clad::pop(_t5);
+// CHECK-NEXT:                     clad::pop(_t4);
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     _d_another_choice = 0;
-// CHECK-NEXT:                     another_choice = clad::pop(_t4);
-// CHECK-NEXT:                 }
+// CHECK-NEXT:                 _d_another_choice = 0;
 // CHECK-NEXT:                 if (clad::pop(_t2))
 // CHECK-NEXT:                   case 1UL:
 // CHECK-NEXT:                     ;
+// CHECK-NEXT:                 choice++;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _t0--;
 // CHECK-NEXT:         }
@@ -1230,73 +1323,82 @@ double fn16(double i, double j) {
 // CHECK-NEXT:     clad::tape<bool> _t6 = {};
 // CHECK-NEXT:     clad::tape<double> _t7 = {};
 // CHECK-NEXT:     clad::tape<double> _t8 = {};
+// CHECK-NEXT:     int _t9;
 // CHECK-NEXT:     int counter = 5;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int ii = 0; ii < counter; ++ii) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         bool _t1 = ii == 4;
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (_t1) {
-// CHECK-NEXT:                 clad::push(_t3, res);
-// CHECK-NEXT:                 res += i * j;
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_t4, 1UL);
-// CHECK-NEXT:                     break;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int ii = 0;
+// CHECK-NEXT:         for (; ii < counter; ++ii) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             bool _t1 = ii == 4;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (_t1) {
+// CHECK-NEXT:                     clad::push(_t3, res);
+// CHECK-NEXT:                     res += i * j;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         clad::push(_t4, 1UL);
+// CHECK-NEXT:                         break;
+// CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
+// CHECK-NEXT:                 clad::push(_t2, _t1);
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t2, _t1);
-// CHECK-NEXT:         }
-// CHECK-NEXT:         bool _t5 = ii > 2;
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (_t5) {
-// CHECK-NEXT:                 clad::push(_t7, res);
-// CHECK-NEXT:                 res += 2 * i;
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_t4, 2UL);
-// CHECK-NEXT:                     continue;
+// CHECK-NEXT:             bool _t5 = ii > 2;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (_t5) {
+// CHECK-NEXT:                     clad::push(_t7, res);
+// CHECK-NEXT:                     res += 2 * i;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         clad::push(_t4, 2UL);
+// CHECK-NEXT:                         continue;
+// CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
+// CHECK-NEXT:                 clad::push(_t6, _t5);
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t6, _t5);
+// CHECK-NEXT:             clad::push(_t8, res);
+// CHECK-NEXT:             res += i + j;
+// CHECK-NEXT:             clad::push(_t4, 3UL);
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t8, res);
-// CHECK-NEXT:         res += i + j;
-// CHECK-NEXT:         clad::push(_t4, 3UL);
+// CHECK-NEXT:         _t9 = ii;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t0; _t0--)
-// CHECK-NEXT:         switch (clad::pop(_t4)) {
-// CHECK-NEXT:           case 3UL:
-// CHECK-NEXT:             ;
-// CHECK-NEXT:             --ii;
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 res = clad::pop(_t8);
-// CHECK-NEXT:                 double _r_d2 = _d_res;
-// CHECK-NEXT:                 * _d_i += _r_d2;
-// CHECK-NEXT:                 * _d_j += _r_d2;
-// CHECK-NEXT:             }
-// CHECK-NEXT:             if (clad::pop(_t6)) {
-// CHECK-NEXT:               case 2UL:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int ii = _t9;
+// CHECK-NEXT:         for (; _t0; _t0--)
+// CHECK-NEXT:             switch (clad::pop(_t4)) {
+// CHECK-NEXT:               case 3UL:
 // CHECK-NEXT:                 ;
+// CHECK-NEXT:                 --ii;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     res = clad::pop(_t7);
-// CHECK-NEXT:                     double _r_d1 = _d_res;
-// CHECK-NEXT:                     * _d_i += 2 * _r_d1;
+// CHECK-NEXT:                     res = clad::pop(_t8);
+// CHECK-NEXT:                     double _r_d2 = _d_res;
+// CHECK-NEXT:                     * _d_i += _r_d2;
+// CHECK-NEXT:                     * _d_j += _r_d2;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 if (clad::pop(_t6)) {
+// CHECK-NEXT:                   case 2UL:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         res = clad::pop(_t7);
+// CHECK-NEXT:                         double _r_d1 = _d_res;
+// CHECK-NEXT:                         * _d_i += 2 * _r_d1;
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 if (clad::pop(_t2)) {
+// CHECK-NEXT:                   case 1UL:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         res = clad::pop(_t3);
+// CHECK-NEXT:                         double _r_d0 = _d_res;
+// CHECK-NEXT:                         * _d_i += _r_d0 * j;
+// CHECK-NEXT:                         * _d_j += i * _r_d0;
+// CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
-// CHECK-NEXT:             if (clad::pop(_t2)) {
-// CHECK-NEXT:               case 1UL:
-// CHECK-NEXT:                 ;
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     res = clad::pop(_t3);
-// CHECK-NEXT:                     double _r_d0 = _d_res;
-// CHECK-NEXT:                     * _d_i += _r_d0 * j;
-// CHECK-NEXT:                     * _d_j += i * _r_d0;
-// CHECK-NEXT:                 }
-// CHECK-NEXT:             }
-// CHECK-NEXT:         }
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 double fn17(double i, double j) {
@@ -1324,106 +1426,116 @@ double fn17(double i, double j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_ii = 0;
-// CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_jj = 0;
-// CHECK-NEXT:     int jj = 0;
-// CHECK-NEXT:     clad::tape<bool> _t3 = {};
+// CHECK-NEXT:     clad::tape<bool> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t3 = {};
 // CHECK-NEXT:     clad::tape<unsigned long> _t4 = {};
-// CHECK-NEXT:     clad::tape<unsigned long> _t5 = {};
-// CHECK-NEXT:     clad::tape<bool> _t7 = {};
-// CHECK-NEXT:     clad::tape<double> _t8 = {};
-// CHECK-NEXT:     clad::tape<unsigned long> _t9 = {};
-// CHECK-NEXT:     clad::tape<double> _t10 = {};
+// CHECK-NEXT:     clad::tape<bool> _t6 = {};
+// CHECK-NEXT:     clad::tape<double> _t7 = {};
+// CHECK-NEXT:     clad::tape<unsigned long> _t8 = {};
+// CHECK-NEXT:     clad::tape<double> _t9 = {};
+// CHECK-NEXT:     clad::tape<int> _t10 = {};
+// CHECK-NEXT:     int _t11;
 // CHECK-NEXT:     int counter = 5;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int ii = 0; ii < counter; ++ii) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, jj) , jj = ii;
-// CHECK-NEXT:         bool _t2 = ii < 2;
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (_t2) {
-// CHECK-NEXT:                 clad::push(_t4, 1UL);
-// CHECK-NEXT:                 continue;
-// CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t3, _t2);
-// CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t5, 0UL);
-// CHECK-NEXT:         while (jj--)
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int ii = 0;
+// CHECK-NEXT:         for (; ii < counter; ++ii) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             int jj = ii;
+// CHECK-NEXT:             bool _t1 = ii < 2;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::back(_t5)++;
-// CHECK-NEXT:                 bool _t6 = jj < 3;
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     if (_t6) {
-// CHECK-NEXT:                         clad::push(_t8, res);
-// CHECK-NEXT:                         res += i * j;
-// CHECK-NEXT:                         {
-// CHECK-NEXT:                             clad::push(_t9, 1UL);
-// CHECK-NEXT:                             break;
-// CHECK-NEXT:                         }
-// CHECK-NEXT:                     } else {
-// CHECK-NEXT:                         {
-// CHECK-NEXT:                             clad::push(_t9, 2UL);
-// CHECK-NEXT:                             continue;
-// CHECK-NEXT:                         }
-// CHECK-NEXT:                     }
-// CHECK-NEXT:                     clad::push(_t7, _t6);
+// CHECK-NEXT:                 if (_t1) {
+// CHECK-NEXT:                     clad::push(_t3, 1UL);
+// CHECK-NEXT:                     continue;
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 clad::push(_t10, res);
-// CHECK-NEXT:                 res += i * i * j * j;
-// CHECK-NEXT:                 clad::push(_t9, 3UL);
+// CHECK-NEXT:                 clad::push(_t2, _t1);
 // CHECK-NEXT:             }
-// CHECK-NEXT:         clad::push(_t4, 2UL);
+// CHECK-NEXT:             clad::push(_t4, 0UL);
+// CHECK-NEXT:             while (jj--)
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     clad::back(_t4)++;
+// CHECK-NEXT:                     bool _t5 = jj < 3;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         if (_t5) {
+// CHECK-NEXT:                             clad::push(_t7, res);
+// CHECK-NEXT:                             res += i * j;
+// CHECK-NEXT:                             {
+// CHECK-NEXT:                                 clad::push(_t8, 1UL);
+// CHECK-NEXT:                                 break;
+// CHECK-NEXT:                             }
+// CHECK-NEXT:                         } else {
+// CHECK-NEXT:                             {
+// CHECK-NEXT:                                 clad::push(_t8, 2UL);
+// CHECK-NEXT:                                 continue;
+// CHECK-NEXT:                             }
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                         clad::push(_t6, _t5);
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                     clad::push(_t9, res);
+// CHECK-NEXT:                     res += i * i * j * j;
+// CHECK-NEXT:                     clad::push(_t8, 3UL);
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             clad::push(_t10, jj);
+// CHECK-NEXT:             clad::push(_t3, 2UL);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t11 = ii;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t0; _t0--)
-// CHECK-NEXT:         switch (clad::pop(_t4)) {
-// CHECK-NEXT:           case 2UL:
-// CHECK-NEXT:             ;
-// CHECK-NEXT:             --ii;
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 while (clad::back(_t5))
-// CHECK-NEXT:                     {
-// CHECK-NEXT:                         switch (clad::pop(_t9)) {
-// CHECK-NEXT:                           case 3UL:
-// CHECK-NEXT:                             ;
-// CHECK-NEXT:                             {
-// CHECK-NEXT:                                 res = clad::pop(_t10);
-// CHECK-NEXT:                                 double _r_d1 = _d_res;
-// CHECK-NEXT:                                 * _d_i += _r_d1 * j * j * i;
-// CHECK-NEXT:                                 * _d_i += i * _r_d1 * j * j;
-// CHECK-NEXT:                                 * _d_j += i * i * _r_d1 * j;
-// CHECK-NEXT:                                 * _d_j += i * i * j * _r_d1;
-// CHECK-NEXT:                             }
-// CHECK-NEXT:                             if (clad::pop(_t7)) {
-// CHECK-NEXT:                               case 1UL:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int ii = _t11;
+// CHECK-NEXT:         for (; _t0; _t0--)
+// CHECK-NEXT:             switch (clad::pop(_t3)) {
+// CHECK-NEXT:               case 2UL:
+// CHECK-NEXT:                 ;
+// CHECK-NEXT:                 --ii;
+// CHECK-NEXT:                 int jj = clad::pop(_t10);
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     while (clad::back(_t4))
+// CHECK-NEXT:                         {
+// CHECK-NEXT:                             switch (clad::pop(_t8)) {
+// CHECK-NEXT:                               case 3UL:
 // CHECK-NEXT:                                 ;
 // CHECK-NEXT:                                 {
-// CHECK-NEXT:                                     res = clad::pop(_t8);
-// CHECK-NEXT:                                     double _r_d0 = _d_res;
-// CHECK-NEXT:                                     * _d_i += _r_d0 * j;
-// CHECK-NEXT:                                     * _d_j += i * _r_d0;
+// CHECK-NEXT:                                     res = clad::pop(_t9);
+// CHECK-NEXT:                                     double _r_d1 = _d_res;
+// CHECK-NEXT:                                     * _d_i += _r_d1 * j * j * i;
+// CHECK-NEXT:                                     * _d_i += i * _r_d1 * j * j;
+// CHECK-NEXT:                                     * _d_j += i * i * _r_d1 * j;
+// CHECK-NEXT:                                     * _d_j += i * i * j * _r_d1;
 // CHECK-NEXT:                                 }
-// CHECK-NEXT:                             } else {
-// CHECK-NEXT:                               case 2UL:
-// CHECK-NEXT:                                 ;
+// CHECK-NEXT:                                 if (clad::pop(_t6)) {
+// CHECK-NEXT:                                   case 1UL:
+// CHECK-NEXT:                                     ;
+// CHECK-NEXT:                                     {
+// CHECK-NEXT:                                         res = clad::pop(_t7);
+// CHECK-NEXT:                                         double _r_d0 = _d_res;
+// CHECK-NEXT:                                         * _d_i += _r_d0 * j;
+// CHECK-NEXT:                                         * _d_j += i * _r_d0;
+// CHECK-NEXT:                                     }
+// CHECK-NEXT:                                 } else {
+// CHECK-NEXT:                                   case 2UL:
+// CHECK-NEXT:                                     ;
+// CHECK-NEXT:                                 }
+// CHECK-NEXT:                                 jj++;
 // CHECK-NEXT:                             }
+// CHECK-NEXT:                             clad::back(_t4)--;
 // CHECK-NEXT:                         }
-// CHECK-NEXT:                         clad::back(_t5)--;
-// CHECK-NEXT:                     }
-// CHECK-NEXT:                 clad::pop(_t5);
+// CHECK-NEXT:                     clad::pop(_t4);
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 if (clad::pop(_t2))
+// CHECK-NEXT:                   case 1UL:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     _d_ii += _d_jj;
+// CHECK-NEXT:                     _d_jj = 0;
+// CHECK-NEXT:                 }
 // CHECK-NEXT:             }
-// CHECK-NEXT:             if (clad::pop(_t3))
-// CHECK-NEXT:               case 1UL:
-// CHECK-NEXT:                 ;
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 _d_ii += _d_jj;
-// CHECK-NEXT:                 _d_jj = 0;
-// CHECK-NEXT:                 jj = clad::pop(_t1);
-// CHECK-NEXT:             }
-// CHECK-NEXT:         }
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 double fn18(double i, double j) {
@@ -1451,64 +1563,73 @@ double fn18(double i, double j) {
 // CHECK-NEXT:     clad::tape<bool> _t5 = {};
 // CHECK-NEXT:     clad::tape<unsigned long> _t6 = {};
 // CHECK-NEXT:     clad::tape<double> _t7 = {};
+// CHECK-NEXT:     int _t8;
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int counter = 0; counter < choice; ++counter) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         bool _t1 = counter < 2;
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (_t1) {
-// CHECK-NEXT:                 clad::push(_t3, res);
-// CHECK-NEXT:                 res += i + j;
-// CHECK-NEXT:             } else {
-// CHECK-NEXT:                 bool _t4 = counter < 4;
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     if (_t4) {
-// CHECK-NEXT:                         clad::push(_t6, 1UL);
-// CHECK-NEXT:                         continue;
-// CHECK-NEXT:                     } else {
-// CHECK-NEXT:                         clad::push(_t7, res);
-// CHECK-NEXT:                         res += 2 * i + 2 * j;
-// CHECK-NEXT:                         {
-// CHECK-NEXT:                             clad::push(_t6, 2UL);
-// CHECK-NEXT:                             break;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int counter = 0;
+// CHECK-NEXT:         for (; counter < choice; ++counter) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             bool _t1 = counter < 2;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (_t1) {
+// CHECK-NEXT:                     clad::push(_t3, res);
+// CHECK-NEXT:                     res += i + j;
+// CHECK-NEXT:                 } else {
+// CHECK-NEXT:                     bool _t4 = counter < 4;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         if (_t4) {
+// CHECK-NEXT:                             clad::push(_t6, 1UL);
+// CHECK-NEXT:                             continue;
+// CHECK-NEXT:                         } else {
+// CHECK-NEXT:                             clad::push(_t7, res);
+// CHECK-NEXT:                             res += 2 * i + 2 * j;
+// CHECK-NEXT:                             {
+// CHECK-NEXT:                                 clad::push(_t6, 2UL);
+// CHECK-NEXT:                                 break;
+// CHECK-NEXT:                             }
 // CHECK-NEXT:                         }
+// CHECK-NEXT:                         clad::push(_t5, _t4);
 // CHECK-NEXT:                     }
-// CHECK-NEXT:                     clad::push(_t5, _t4);
 // CHECK-NEXT:                 }
+// CHECK-NEXT:                 clad::push(_t2, _t1);
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t2, _t1);
+// CHECK-NEXT:             clad::push(_t6, 3UL);
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t6, 3UL);
+// CHECK-NEXT:         _t8 = counter;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t0; _t0--)
-// CHECK-NEXT:         switch (clad::pop(_t6)) {
-// CHECK-NEXT:           case 3UL:
-// CHECK-NEXT:             ;
-// CHECK-NEXT:             --counter;
-// CHECK-NEXT:             if (clad::pop(_t2)) {
-// CHECK-NEXT:                 res = clad::pop(_t3);
-// CHECK-NEXT:                 double _r_d0 = _d_res;
-// CHECK-NEXT:                 * _d_i += _r_d0;
-// CHECK-NEXT:                 * _d_j += _r_d0;
-// CHECK-NEXT:             } else if (clad::pop(_t5))
-// CHECK-NEXT:               case 1UL:
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int counter = _t8;
+// CHECK-NEXT:         for (; _t0; _t0--)
+// CHECK-NEXT:             switch (clad::pop(_t6)) {
+// CHECK-NEXT:               case 3UL:
 // CHECK-NEXT:                 ;
-// CHECK-NEXT:             else {
-// CHECK-NEXT:               case 2UL:
-// CHECK-NEXT:                 ;
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     res = clad::pop(_t7);
-// CHECK-NEXT:                     double _r_d1 = _d_res;
-// CHECK-NEXT:                     * _d_i += 2 * _r_d1;
-// CHECK-NEXT:                     * _d_j += 2 * _r_d1;
+// CHECK-NEXT:                 --counter;
+// CHECK-NEXT:                 if (clad::pop(_t2)) {
+// CHECK-NEXT:                     res = clad::pop(_t3);
+// CHECK-NEXT:                     double _r_d0 = _d_res;
+// CHECK-NEXT:                     * _d_i += _r_d0;
+// CHECK-NEXT:                     * _d_j += _r_d0;
+// CHECK-NEXT:                 } else if (clad::pop(_t5))
+// CHECK-NEXT:                   case 1UL:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                 else {
+// CHECK-NEXT:                   case 2UL:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         res = clad::pop(_t7);
+// CHECK-NEXT:                         double _r_d1 = _d_res;
+// CHECK-NEXT:                         * _d_i += 2 * _r_d1;
+// CHECK-NEXT:                         * _d_j += 2 * _r_d1;
+// CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
-// CHECK-NEXT:         }
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 double fn19(double* arr, int n) {
@@ -1528,26 +1649,38 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:     clad::tape<double *> _t1 = {};
 // CHECK-NEXT:     double *_d_ref = 0;
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     clad::tape<double *> _t4 = {};
+// CHECK-NEXT:     int _t5;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 0; i < n; ++i) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         _d_ref = &_d_arr[i];
-// CHECK-NEXT:         clad::push(_t1, _d_ref);
-// CHECK-NEXT:         double &ref = arr[i];
-// CHECK-NEXT:         clad::push(_t3, res);
-// CHECK-NEXT:         res += ref;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = 0;
+// CHECK-NEXT:         for (; i < n; ++i) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             _d_ref = &_d_arr[i];
+// CHECK-NEXT:             clad::push(_t1, _d_ref);
+// CHECK-NEXT:             double &ref = arr[i];
+// CHECK-NEXT:             clad::push(_t3, res);
+// CHECK-NEXT:             res += ref;
+// CHECK-NEXT:             clad::push(_t4, &ref);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t5 = i;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --i;
-// CHECK-NEXT:         double *_t2 = clad::pop(_t1);
-// CHECK-NEXT:         {
-// CHECK-NEXT:             res = clad::pop(_t3);
-// CHECK-NEXT:             double _r_d0 = _d_res;
-// CHECK-NEXT:             *_t2 += _r_d0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = _t5;
+// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:             double *_t2 = clad::pop(_t1);
+// CHECK-NEXT:             --i;
+// CHECK-NEXT:             double &ref = *clad::pop(_t4);
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 res = clad::pop(_t3);
+// CHECK-NEXT:                 double _r_d0 = _d_res;
+// CHECK-NEXT:                 *_t2 += _r_d0;
+// CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -1570,19 +1703,26 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:     double _d_x = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     double _t3;
 // CHECK-NEXT:     double sum = 0;
 // CHECK-NEXT:     double num_points = 10000;
 // CHECK-NEXT:     double interval = (upper - lower) / num_points;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (double x = lower; x <= upper; clad::push(_t1, x) , (x += interval)) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t2, sum);
-// CHECK-NEXT:         sum += x * x * interval;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double x = lower;
+// CHECK-NEXT:         for (; x <= upper; clad::push(_t1, x) , (x += interval)) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             clad::push(_t2, sum);
+// CHECK-NEXT:             sum += x * x * interval;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t3 = x;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
+// CHECK-NEXT:         double x = _t3;
 // CHECK-NEXT:         for (; _t0; _t0--) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 x = clad::pop(_t1);

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -27,6 +27,7 @@ public:
   // CHECK: void mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -41,6 +42,7 @@ public:
   // CHECK: void const_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -59,6 +61,7 @@ public:
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -77,6 +80,7 @@ public:
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -91,6 +95,7 @@ public:
   // CHECK: void lval_ref_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) & {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -107,6 +112,7 @@ public:
   // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const & {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -125,6 +131,7 @@ public:
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -143,6 +150,7 @@ public:
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -157,6 +165,7 @@ public:
   // CHECK: void rval_ref_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) && {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -173,6 +182,7 @@ public:
   // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const && {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -191,6 +201,7 @@ public:
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -209,6 +220,7 @@ public:
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -225,6 +237,7 @@ public:
   // CHECK: void noexcept_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) noexcept {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -241,6 +254,7 @@ public:
   // CHECK: void const_noexcept_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const noexcept {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -259,6 +273,7 @@ public:
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -277,6 +292,7 @@ public:
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -293,6 +309,7 @@ public:
   // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) & noexcept {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -309,6 +326,7 @@ public:
   // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const & noexcept {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -327,6 +345,7 @@ public:
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -345,6 +364,7 @@ public:
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -361,6 +381,7 @@ public:
   // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) && noexcept {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -377,6 +398,7 @@ public:
   // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const && noexcept {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -395,6 +417,7 @@ public:
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -413,6 +436,7 @@ public:
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -428,6 +452,7 @@ public:
   // CHECK-NEXT:     double _d_j = 0;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
+  // CHECK-NEXT:     ;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
@@ -485,6 +510,7 @@ double fn(double i,double j) {
 // CHECK: void fn_grad(double i, double j, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         * _d_i += 1 * j * i;
 // CHECK-NEXT:         * _d_i += i * 1 * j;
@@ -505,6 +531,7 @@ double fn2(SimpleFunctions& sf, double i) {
 // CHECK-NEXT:     this->x = -i;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     (* _d_this).x += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t1;
@@ -536,6 +563,7 @@ double fn2(SimpleFunctions& sf, double i) {
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = _t0.ref_mem_fn_forw(i, &(* _d_sf), nullptr);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _grad0 = 0.;
 // CHECK-NEXT:         _t0.ref_mem_fn_pullback(i, 1, &(* _d_sf), &_grad0);
@@ -581,6 +609,7 @@ double fn5(SimpleFunctions& v, double value) {
 // CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = _t0.operator_plus_equal_forw(value, &(* _d_v), nullptr);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     (* _d_v).x += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _grad0 = 0.;
@@ -621,6 +650,7 @@ double fn4(SimpleFunctions& v) {
 // CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = _t0.operator_plus_plus_forw(&(* _d_v));
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     (* _d_v).x += 1;
 // CHECK-NEXT:     _t0.operator_plus_plus_pullback({}, &(* _d_v));
 // CHECK-NEXT: }
@@ -682,6 +712,7 @@ int main() {
   // CHECK-NEXT:       _t0 = (this->x + this->y);
   // CHECK-NEXT:       goto _label0;
   // CHECK-NEXT:       _label0:
+  // CHECK-NEXT:       ;
   // CHECK-NEXT:       {
   // CHECK-NEXT:           (* _d_this).x += 1 * i;
   // CHECK-NEXT:           (* _d_this).y += 1 * i;
@@ -699,6 +730,7 @@ int main() {
   // CHECK-NEXT:       _t0 = (this->x + this->y);
   // CHECK-NEXT:       goto _label0;
   // CHECK-NEXT:       _label0:
+  // CHECK-NEXT:       ;
   // CHECK-NEXT:       {
   // CHECK-NEXT:           (* _d_this).x += 1 * i;
   // CHECK-NEXT:           (* _d_this).y += 1 * i;
@@ -722,6 +754,7 @@ int main() {
 // CHECK-NEXT:     _t0 = sf;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _grad0 = 0.;
 // CHECK-NEXT:         double _grad1 = 0.;

--- a/test/Gradient/TemplateFunctors.C
+++ b/test/Gradient/TemplateFunctors.C
@@ -17,6 +17,7 @@ template <typename T> struct Experiment {
 // CHECK: void operator_call_grad(double i, double j, clad::array_ref<Experiment<double> > _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (* _d_this).x += 1 * i * i;
 // CHECK-NEXT:         * _d_i += this->x * 1 * i;
@@ -39,6 +40,7 @@ template <> struct Experiment<long double> {
 // CHECK: void operator_call_grad(long double i, long double j, clad::array_ref<Experiment<long double> > _d_this, clad::array_ref<long double> _d_i, clad::array_ref<long double> _d_j) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (* _d_this).x += 1 * j * i * i;
 // CHECK-NEXT:         * _d_i += this->x * 1 * j * i;
@@ -63,6 +65,7 @@ template <typename T> struct ExperimentConstVolatile {
 // CHECK-NEXT:     _t0 = this->x * i;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (* _d_this).x += 1 * i * i;
 // CHECK-NEXT:         * _d_i += this->x * 1 * i;
@@ -89,6 +92,7 @@ template <> struct ExperimentConstVolatile<long double> {
 // CHECK-NEXT:     _t1 = this->y * j;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (* _d_this).x += 1 * j * i * i;
 // CHECK-NEXT:         * _d_i += this->x * 1 * j * i;

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -22,24 +22,33 @@ void fn_type_conversion_grad(float z, int a, clad::array_ref<float> _d_z, clad::
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
+// CHECK-NEXT:     int _t2;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 1; i < a; i++) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, z);
-// CHECK-NEXT:         z = z * a;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = 1;
+// CHECK-NEXT:         for (; i < a; i++) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             clad::push(_t1, z);
+// CHECK-NEXT:             z = z * a;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t2 = i;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     * _d_z += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         i--;
-// CHECK-NEXT:         {
-// CHECK-NEXT:             z = clad::pop(_t1);
-// CHECK-NEXT:             float _r_d0 = * _d_z;
-// CHECK-NEXT:             * _d_z += _r_d0 * a;
-// CHECK-NEXT:             * _d_a += z * _r_d0;
-// CHECK-NEXT:             * _d_z -= _r_d0;
-// CHECK-NEXT:             * _d_z;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = _t2;
+// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:             i--;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 z = clad::pop(_t1);
+// CHECK-NEXT:                 float _r_d0 = * _d_z;
+// CHECK-NEXT:                 * _d_z += _r_d0 * a;
+// CHECK-NEXT:                 * _d_a += z * _r_d0;
+// CHECK-NEXT:                 * _d_z -= _r_d0;
+// CHECK-NEXT:                 * _d_z;
+// CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -25,6 +25,7 @@ double fn1(pairdd p, double i) {
 // CHECK-NEXT:     double res = p.first + 2 * p.second + 3 * i;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (* _d_p).first += _d_res;
@@ -61,21 +62,30 @@ double sum(Tangent& t) {
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     int _t2;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 0; i < 5; ++i) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, res);
-// CHECK-NEXT:         res += t.data[i];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = 0;
+// CHECK-NEXT:         for (; i < 5; ++i) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             clad::push(_t1, res);
+// CHECK-NEXT:             res += t.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t2 = i;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += _d_y;
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --i;
-// CHECK-NEXT:         res = clad::pop(_t1);
-// CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         (* _d_t).data[i] += _r_d0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = _t2;
+// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:             --i;
+// CHECK-NEXT:             res = clad::pop(_t1);
+// CHECK-NEXT:             double _r_d0 = _d_res;
+// CHECK-NEXT:             (* _d_t).data[i] += _r_d0;
+// CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -91,21 +101,30 @@ double sum(double *data) {
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     int _t2;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 0; i < 5; ++i) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, res);
-// CHECK-NEXT:         res += data[i];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = 0;
+// CHECK-NEXT:         for (; i < 5; ++i) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             clad::push(_t1, res);
+// CHECK-NEXT:             res += data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t2 = i;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += _d_y;
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --i;
-// CHECK-NEXT:         res = clad::pop(_t1);
-// CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         _d_data[i] += _r_d0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = _t2;
+// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:             --i;
+// CHECK-NEXT:             res = clad::pop(_t1);
+// CHECK-NEXT:             double _r_d0 = _d_res;
+// CHECK-NEXT:             _d_data[i] += _r_d0;
+// CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -125,6 +144,7 @@ double fn2(Tangent t, double i) {
 // CHECK-NEXT:     res += sum(t.data) + i + 2 * t.data[0];
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t1;
@@ -162,6 +182,7 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     _t2 = t;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t = _t2;
 // CHECK-NEXT:         sum_pullback(_t2, 1, &_d_t);
@@ -195,6 +216,7 @@ double fn4(double i, double j) {
 // CHECK-NEXT:     pairdd q({7, 5});
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_p.first += 1 * i;
 // CHECK-NEXT:         * _d_i += p.first * 1;
@@ -210,6 +232,7 @@ double fn4(double i, double j) {
 // CHECK: void someMemFn_grad(double i, double j, clad::array_ref<Tangent> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (* _d_this).data[0] += 1 * i;
 // CHECK-NEXT:         * _d_i += this->data[0] * 1;
@@ -228,6 +251,7 @@ double fn5(const Tangent& t, double i) {
 // CHECK: void someMemFn2_pullback(double i, double j, double _d_y, clad::array_ref<Tangent> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (* _d_this).data[0] += _d_y * i;
 // CHECK-NEXT:         * _d_i += this->data[0] * _d_y;
@@ -242,6 +266,7 @@ double fn5(const Tangent& t, double i) {
 // CHECK-NEXT:     _t0 = t;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _grad0 = 0.;
 // CHECK-NEXT:         double _grad1 = 0.;
@@ -276,12 +301,14 @@ double fn6(dcomplex c, double i) {
 // CHECK: constexpr void real_pullback(double _d_y, clad::array_ref<complex<double> > _d_this){{.*}} {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {{(__real)?}} (* _d_this).{{.*}} += _d_y;
 // CHECK-NEXT: }
 
 // CHECK: constexpr void imag_pullback(double _d_y, clad::array_ref<complex<double> > _d_this){{.*}} {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {{(__imag)?}} (* _d_this).{{.*}} += _d_y;
 // CHECK-NEXT: }
 
@@ -306,6 +333,7 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT:     res += 4 * _t5;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t4;
@@ -348,6 +376,7 @@ double fn7(dcomplex c1, dcomplex c2) {
 // CHECK-NEXT:     _t5 = c1.imag();
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t4.real_pullback(1, &(* _d_c1));
 // CHECK-NEXT:         _t6.imag_pullback(3 * 1, &(* _d_c1));
@@ -370,18 +399,26 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     int _t2;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 0; i < 5; ++i) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, this->data[i]);
-// CHECK-NEXT:         this->data[i] = d;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = 0;
+// CHECK-NEXT:         for (; i < 5; ++i) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             clad::push(_t1, this->data[i]);
+// CHECK-NEXT:             this->data[i] = d;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t2 = i;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --i;
-// CHECK-NEXT:         this->data[i] = clad::pop(_t1);
-// CHECK-NEXT:         double _r_d0 = (* _d_this).data[i];
-// CHECK-NEXT:         * _d_d += _r_d0;
-// CHECK-NEXT:         (* _d_this).data[i] -= _r_d0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = _t2;
+// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:             --i;
+// CHECK-NEXT:             this->data[i] = clad::pop(_t1);
+// CHECK-NEXT:             double _r_d0 = (* _d_this).data[i];
+// CHECK-NEXT:             * _d_d += _r_d0;
+// CHECK-NEXT:             (* _d_this).data[i] -= _r_d0;
+// CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -395,6 +432,7 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK-NEXT:     _t2 = t;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t = _t2;
 // CHECK-NEXT:         sum_pullback(_t2, 1, &(* _d_t));
@@ -425,39 +463,48 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     clad::tape<dcomplex> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<dcomplex> _t4 = {};
-// CHECK-NEXT:     double _t5;
-// CHECK-NEXT:     Tangent _t6;
+// CHECK-NEXT:     int _t5;
+// CHECK-NEXT:     double _t6;
+// CHECK-NEXT:     Tangent _t7;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 0; i < 5; ++i) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, res);
-// CHECK-NEXT:         clad::push(_t2, c);
-// CHECK-NEXT:         clad::push(_t4, c);
-// CHECK-NEXT:         res += c.real() + 2 * clad::push(_t3, c.imag());
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = 0;
+// CHECK-NEXT:         for (; i < 5; ++i) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             clad::push(_t1, res);
+// CHECK-NEXT:             clad::push(_t2, c);
+// CHECK-NEXT:             clad::push(_t4, c);
+// CHECK-NEXT:             res += c.real() + 2 * clad::push(_t3, c.imag());
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t5 = i;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _t5 = res;
-// CHECK-NEXT:     _t6 = t;
+// CHECK-NEXT:     _t6 = res;
+// CHECK-NEXT:     _t7 = t;
 // CHECK-NEXT:     res += sum(t);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         res = _t5;
+// CHECK-NEXT:         res = _t6;
 // CHECK-NEXT:         double _r_d1 = _d_res;
-// CHECK-NEXT:         t = _t6;
-// CHECK-NEXT:         sum_pullback(_t6, _r_d1, &(* _d_t));
+// CHECK-NEXT:         t = _t7;
+// CHECK-NEXT:         sum_pullback(_t7, _r_d1, &(* _d_t));
 // CHECK-NEXT:         Tangent _r2 = (* _d_t);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --i;
-// CHECK-NEXT:         {
-// CHECK-NEXT:             res = clad::pop(_t1);
-// CHECK-NEXT:             double _r_d0 = _d_res;
-// CHECK-NEXT:             std{{(::__1)?}}::complex<double> _r0 = clad::pop(_t2);
-// CHECK-NEXT:             _r0.real_pullback(_r_d0, &(* _d_c));
-// CHECK-NEXT:             std{{(::__1)?}}::complex<double> _r1 = clad::pop(_t4);
-// CHECK-NEXT:             _r1.imag_pullback(2 * _r_d0, &(* _d_c));
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int i = _t5;
+// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:             --i;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 res = clad::pop(_t1);
+// CHECK-NEXT:                 double _r_d0 = _d_res;
+// CHECK-NEXT:                 std{{(::__1)?}}::complex<double> _r0 = clad::pop(_t2);
+// CHECK-NEXT:                 _r0.real_pullback(_r_d0, &(* _d_c));
+// CHECK-NEXT:                 std{{(::__1)?}}::complex<double> _r1 = clad::pop(_t4);
+// CHECK-NEXT:                 _r1.imag_pullback(2 * _r_d0, &(* _d_c));
+// CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Gradient/constexprTest.C
+++ b/test/Gradient/constexprTest.C
@@ -17,6 +17,7 @@ constexpr double mul (double a, double b, double c) {
 //CHECK-NEXT:    double result = a * b * c;
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
+//CHECK-NEXT:    ;
 //CHECK-NEXT:    _d_result += 1;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        * _d_a += _d_result * c * b;
@@ -38,6 +39,7 @@ constexpr double fn( double a, double b, double c) {
 //CHECK-NEXT:    double result = a * b / c * (a + b) * 100 + c;
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
+//CHECK-NEXT:    ;
 //CHECK-NEXT:    _d_result += 1;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        * _d_a += _d_result * 100 * (a + b) / c * b;

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -25,6 +25,7 @@ float f1(float x) {
 // CHECK-NEXT:     _t0 = ::std::cos(x);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = _d_y.value * clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         * _d_x += _r0;
@@ -39,6 +40,7 @@ float f1(float x) {
 // CHECK-NEXT:     _t0 = ::std::sin(x);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = _d_y.value * clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         * _d_x += _r0;
@@ -57,6 +59,7 @@ float f1(float x) {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t10 = clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, _d_x0);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d__t0.pushforward += 1;
 // CHECK-NEXT:         _d__t1.pushforward += 1;
@@ -100,6 +103,7 @@ float f2(float x) {
 // CHECK-NEXT:     _t0 = ::std::exp(x);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = _d_y.value * clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         * _d_x += _r0;
@@ -116,6 +120,7 @@ float f2(float x) {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, _d_x0);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
@@ -146,6 +151,7 @@ float f3(float x) {
 // CHECK: void log_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_d_x) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = _d_y.value * clad::custom_derivatives{{(::std)?}}::log_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         * _d_x += _r0;
@@ -162,6 +168,7 @@ float f3(float x) {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::log_pushforward(x, _d_x0);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
@@ -209,6 +216,7 @@ float f4(float x) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_val += _d_y.value;
 // CHECK-NEXT:         _d_derivative += _d_y.pushforward;
@@ -256,6 +264,7 @@ float f4(float x) {
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 4.F, _d_x0, 0.F);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
@@ -294,6 +303,7 @@ float f5(float x) {
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(2.F, x, 0.F, _d_x0);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
@@ -335,6 +345,7 @@ float f6(float x, float y) {
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y0);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
@@ -369,6 +380,7 @@ float f6(float x, float y) {
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y0);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -23,6 +23,7 @@ void f_cubed_add1_darg0_grad(double a, double b, clad::array_ref<double> _d_a, c
 //CHECK-NEXT:    double _t10 = b * b;
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
+//CHECK-NEXT:    ;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _d__d_a += 1 * a * a;
 //CHECK-NEXT:        * _d_a += _d_a0 * 1 * a;
@@ -61,6 +62,7 @@ void f_cubed_add1_darg1_grad(double a, double b, clad::array_ref<double> _d_a, c
 //CHECK-NEXT:    double _t10 = b * b;
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
+//CHECK-NEXT:    ;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _d__d_a += 1 * a * a;
 //CHECK-NEXT:        * _d_a += _d_a0 * 1 * a;

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -33,6 +33,7 @@ double f2(double x, double y){
 // CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y, clad::array_ref<double> _d__d_x, clad::array_ref<double> _d__d_y) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:    ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         * _d_x += _d_y0.value * x;
 // CHECK-NEXT:         * _d_x += x * _d_y0.value;
@@ -62,6 +63,7 @@ double f2(double x, double y){
 // CHECK-NEXT:     double ans = _t00.value;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d__d_ans += 1;
 // CHECK-NEXT:     _d__t0.value += _d_ans0;
 // CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
@@ -104,6 +106,7 @@ double f2(double x, double y){
 // CHECK-NEXT:     double ans = _t00.value;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     _d__d_ans += 1;
 // CHECK-NEXT:     _d__t0.value += _d_ans0;
 // CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -23,6 +23,7 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:     double _d_j0 = 0;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d__d_i += 1 * j;
 // CHECK-NEXT:         * _d_j += _d_i0 * 1;
@@ -44,6 +45,7 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:     double _d_j0 = 1;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d__d_i += 1 * j;
 // CHECK-NEXT:         * _d_j += _d_i0 * 1;

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -80,6 +80,7 @@ double multiply(double x, double y) { return x * y; }
 //CHECK: void multiply_pullback(double x, double y, double _d_y0, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
+//CHECK-NEXT:    ;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        * _d_x += _d_y0 * y;
 //CHECK-NEXT:        * _d_y += x * _d_y0;

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -114,28 +114,37 @@
 //CHECK_FLOAT_SUM:     unsigned int _d_i = 0;
 //CHECK_FLOAT_SUM:     clad::tape<float> _t1 = {};
 //CHECK_FLOAT_SUM:     clad::tape<float> _EERepl_sum1 = {};
+//CHECK_FLOAT_SUM:     unsigned int _t2;
 //CHECK_FLOAT_SUM:     float sum = 0.;
 //CHECK_FLOAT_SUM:     _EERepl_sum0 = sum;
 //CHECK_FLOAT_SUM:     _t0 = 0;
-//CHECK_FLOAT_SUM:     for (unsigned int i = 0; i < n; i++) {
-//CHECK_FLOAT_SUM:         _t0++;
-//CHECK_FLOAT_SUM:         clad::push(_t1, sum);
-//CHECK_FLOAT_SUM:         sum = sum + x;
-//CHECK_FLOAT_SUM:         clad::push(_EERepl_sum1, sum);
+//CHECK_FLOAT_SUM:     {
+//CHECK_FLOAT_SUM:         unsigned int i = 0;
+//CHECK_FLOAT_SUM:         for (; i < n; i++) {
+//CHECK_FLOAT_SUM:             _t0++;
+//CHECK_FLOAT_SUM:             clad::push(_t1, sum);
+//CHECK_FLOAT_SUM:             sum = sum + x;
+//CHECK_FLOAT_SUM:             clad::push(_EERepl_sum1, sum);
+//CHECK_FLOAT_SUM:         }
+//CHECK_FLOAT_SUM:         _t2 = i;
 //CHECK_FLOAT_SUM:     }
 //CHECK_FLOAT_SUM:     goto _label0;
 //CHECK_FLOAT_SUM:   _label0:
+//CHECK_FLOAT_SUM:     ;
 //CHECK_FLOAT_SUM:     _d_sum += 1;
-//CHECK_FLOAT_SUM:     for (; _t0; _t0--) {
-//CHECK_FLOAT_SUM:         i--;
-//CHECK_FLOAT_SUM:         {
-//CHECK_FLOAT_SUM:             sum = clad::pop(_t1);
-//CHECK_FLOAT_SUM:             float _r_d0 = _d_sum;
-//CHECK_FLOAT_SUM:             _d_sum += _r_d0;
-//CHECK_FLOAT_SUM:             * _d_x += _r_d0;
-//CHECK_FLOAT_SUM:             float _r0 = clad::pop(_EERepl_sum1);
-//CHECK_FLOAT_SUM:             _delta_sum += std::abs(_r_d0 * _r0 * 1.1920928955078125E-7);
-//CHECK_FLOAT_SUM:             _d_sum -= _r_d0;
+//CHECK_FLOAT_SUM:     {
+//CHECK_FLOAT_SUM:         unsigned int i = _t2;
+//CHECK_FLOAT_SUM:         for (; _t0; _t0--) {
+//CHECK_FLOAT_SUM:             i--;
+//CHECK_FLOAT_SUM:             {
+//CHECK_FLOAT_SUM:                 sum = clad::pop(_t1);
+//CHECK_FLOAT_SUM:                 float _r_d0 = _d_sum;
+//CHECK_FLOAT_SUM:                 _d_sum += _r_d0;
+//CHECK_FLOAT_SUM:                 * _d_x += _r_d0;
+//CHECK_FLOAT_SUM:                 float _r0 = clad::pop(_EERepl_sum1);
+//CHECK_FLOAT_SUM:                 _delta_sum += std::abs(_r_d0 * _r0 * 1.1920928955078125E-7);
+//CHECK_FLOAT_SUM:                 _d_sum -= _r_d0;
+//CHECK_FLOAT_SUM:             }
 //CHECK_FLOAT_SUM:         }
 //CHECK_FLOAT_SUM:     }
 //CHECK_FLOAT_SUM:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * 1.1920928955078125E-7);
@@ -170,6 +179,7 @@
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    _EERepl_z1 = z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    goto _label0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:  _label0:
+// CHECK_CUSTOM_MODEL_EXEC-NEXT:    ;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    _d_z += 1;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    {
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        z = _t0;
@@ -212,6 +222,7 @@
 // CHECK_PRINT_MODEL_EXEC-NEXT:    _EERepl_z1 = z;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    goto _label0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:  _label0:
+// CHECK_PRINT_MODEL_EXEC-NEXT:    ;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    _d_z += 1;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    {
 // CHECK_PRINT_MODEL_EXEC-NEXT:        z = _t0;
@@ -239,6 +250,7 @@
 //CHECK_GRADIENT_DESCENT: void f_pullback(double theta_0, double theta_1, double x, double _d_y, clad::array_ref<double> _d_theta_0, clad::array_ref<double> _d_theta_1, clad::array_ref<double> _d_x) {
 //CHECK_GRADIENT_DESCENT-NEXT:     goto _label0;
 //CHECK_GRADIENT_DESCENT-NEXT:   _label0:
+//CHECK_GRADIENT_DESCENT-NEXT:     ;
 //CHECK_GRADIENT_DESCENT-NEXT:     {
 //CHECK_GRADIENT_DESCENT-NEXT:         * _d_theta_0 += _d_y;
 //CHECK_GRADIENT_DESCENT-NEXT:         * _d_theta_1 += _d_y * x;
@@ -251,6 +263,7 @@
 //CHECK_GRADIENT_DESCENT-NEXT:     double f_x = f(theta_0, theta_1, x);
 //CHECK_GRADIENT_DESCENT-NEXT:     goto _label0;
 //CHECK_GRADIENT_DESCENT-NEXT:   _label0:
+//CHECK_GRADIENT_DESCENT-NEXT:     ;
 //CHECK_GRADIENT_DESCENT-NEXT:     {
 //CHECK_GRADIENT_DESCENT-NEXT:         _d_f_x += 1 * (f_x - y);
 //CHECK_GRADIENT_DESCENT-NEXT:         * _d_y += -1 * (f_x - y);

--- a/test/NestedCalls/NestedCalls.C
+++ b/test/NestedCalls/NestedCalls.C
@@ -42,6 +42,7 @@ double f(double x, double y) {
 //CHECK:   void sq_pullback(double x, double _d_y, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += _d_y * x;
 //CHECK-NEXT:           * _d_x += x * _d_y;
@@ -51,6 +52,7 @@ double f(double x, double y) {
 //CHECK:   void one_pullback(double x, double _d_y, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _grad0 = 0.;
 //CHECK-NEXT:           sq_pullback(std::sin(x), _d_y, &_grad0);
@@ -70,6 +72,7 @@ double f(double x, double y) {
 //CHECK-NEXT:       double t = one(x);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_t += 1 * y;
 //CHECK-NEXT:           * _d_y += t * 1;

--- a/test/NumericalDiff/GradientMultiArg.C
+++ b/test/NumericalDiff/GradientMultiArg.C
@@ -17,6 +17,7 @@ double test_1(double x, double y){
 // CHECK: void test_1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _grad0 = 0.;
 // CHECK-NEXT:         double _grad1 = 0.;

--- a/test/NumericalDiff/NoNumDiff.C
+++ b/test/NumericalDiff/NoNumDiff.C
@@ -18,6 +18,7 @@ double func(double x) { return std::tanh(x); }
 //CHECK: void func_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _grad0 = 0.;
 //CHECK-NEXT:         double _r0;

--- a/test/NumericalDiff/NumDiff.C
+++ b/test/NumericalDiff/NumDiff.C
@@ -13,6 +13,7 @@ double test_1(double x){
 //CHECK: void test_1_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 1 * numerical_diff::forward_central_difference(tanh, x, 0, 0, x);
 //CHECK-NEXT:         * _d_x += _r0;

--- a/test/NumericalDiff/PrintErrorNumDiff.C
+++ b/test/NumericalDiff/PrintErrorNumDiff.C
@@ -19,6 +19,7 @@ double test_1(double x){
 //CHECK: void test_1_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
+//CHECK-NEXT:     ;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 1 * numerical_diff::forward_central_difference(tanh, x, 0, 1, x);
 //CHECK-NEXT:         * _d_x += _r0;

--- a/test/ROOT/Interface.C
+++ b/test/ROOT/Interface.C
@@ -25,6 +25,7 @@ void f_grad_1(Double_t* x, Double_t* p, clad::array_ref<Double_t> _d_p);
 // CHECK: void f_grad_1(Double_t *x, Double_t *p, clad::array_ref<Double_t> _d_p) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
+// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_p[0] += 1;
 // CHECK-NEXT:         _d_p[1] += x[0] * 1;

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -43,6 +43,7 @@ void TFormula_example_grad_1(Double_t* x, Double_t* p, Double_t* _d_p);
 //CHECK:   void TFormula_example_grad_1(Double_t *x, Double_t *p, clad::array_ref<Double_t> _d_p) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
+//CHECK-NEXT:       ;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_p[0] += x[0] * 1;
 //CHECK-NEXT:           _d_p[1] += x[0] * 1;


### PR DESCRIPTION
The problem this PR attempts to fix is described in #659 (which in turn caused #681). Also, this PR introduces placeholders to ``DelayedGlobalStoreAndRef`` to rewrite expressions after they are added to the current block if there is no point in storing them. This is done to avoid cloning while handling multiplication differentiation.

Fixes #659. Fixes #681.