### PR TITLE
Simplify derivative statements in VisitBinaryOperator

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -218,6 +218,10 @@ namespace clad {
     /// to avoid recomputiation.
     bool UsefulToStoreGlobal(clang::Expr* E);
 
+    /// For an expr E, decides if we should recompute it or store it.
+    /// This is the central point for checkpointing.
+    bool ShouldRecompute(const clang::Expr* E);
+
     /// Builds a variable declaration and stores it in the function
     /// global scope.
     ///

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -353,6 +353,10 @@ namespace clad {
                              bool forceDeclCreation = false,
                              clang::VarDecl::InitializationStyle IS =
                                  clang::VarDecl::InitializationStyle::CInit);
+    /// For an expr E, decides if it is useful to store it in a temporary
+    /// variable and replace E's further usage by a reference to that variable
+    /// to avoid recomputation.
+    static bool UsefulToStore(clang::Expr* E);
     /// A flag for silencing warnings/errors output by diag function.
     bool silenceDiags = false;
     /// Shorthand to issues a warning or error.

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2164,7 +2164,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
       StmtDiff RResult;
       // If R has no side effects, it can be just cloned
       // (no need to store it).
-      if (utils::ContainsFunctionCalls(R) || R->HasSideEffects(m_Context)) {
+      if (!ShouldRecompute(R)) {
         RDelayed = std::unique_ptr<DelayedStoreResult>(
             new DelayedStoreResult(DelayedGlobalStoreAndRef(R)));
         RResult = RDelayed->Result;
@@ -2179,30 +2179,39 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
       // dxi/xr = xl
       // df/dxr += df/dxi * dxi/xr = df/dxi * xl
       // Store left multiplier and assign it with L.
-      Expr* LStored = Ldiff.getExpr();
+      StmtDiff LStored = Ldiff;
+      if (!ShouldRecompute(LStored.getExpr()))
+        LStored = GlobalStoreAndRef(LStored.getExpr(), /*prefix=*/"_t",
+                                    /*force=*/true);
       Expr::EvalResult dummy;
       if (RDelayed ||
           !clad_compat::Expr_EvaluateAsConstantExpr(R, dummy, m_Context)) {
         Expr* dr = nullptr;
         if (dfdx())
-          dr = BuildOp(BO_Mul, Ldiff.getRevSweepAsExpr(), dfdx());
+          dr = BuildOp(BO_Mul, LStored.getRevSweepAsExpr(), dfdx());
         Rdiff = Visit(R, dr);
         // Assign right multiplier's variable with R.
         if (RDelayed)
           RDelayed->Finalize(Rdiff.getExpr());
       }
-      std::tie(Ldiff, Rdiff) = std::make_pair(LStored, RResult.getExpr());
+      std::tie(Ldiff, Rdiff) =
+          std::make_pair(LStored.getExpr(), RResult.getExpr());
     } else if (opCode == BO_Div) {
       // xi = xl / xr
       // dxi/xl = 1 / xr
       // df/dxl += df/dxi * dxi/xl = df/dxi * (1/xr)
       auto RDelayed = DelayedGlobalStoreAndRef(R);
       StmtDiff RResult = RDelayed.Result;
-      Expr* RStored = StoreAndRef(RResult.getExpr_dx(), direction::reverse);
+      Expr* RStored =
+          StoreAndRef(RResult.getRevSweepAsExpr(), direction::reverse);
       Expr* dl = nullptr;
       if (dfdx())
         dl = BuildOp(BO_Div, dfdx(), RStored);
       Ldiff = Visit(L, dl);
+      StmtDiff LStored = Ldiff;
+      if (!ShouldRecompute(LStored.getExpr()))
+        LStored = GlobalStoreAndRef(LStored.getExpr(), /*prefix=*/"_t",
+                                    /*force=*/true);
       // dxi/xr = -xl / (xr * xr)
       // df/dxl += df/dxi * dxi/xr = df/dxi * (-xl /(xr * xr))
       // Wrap R * R in parentheses: (R * R). otherwise code like 1 / R * R is
@@ -2211,17 +2220,17 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
         Expr* dr = nullptr;
         if (dfdx()) {
           Expr* RxR = BuildParens(BuildOp(BO_Mul, RStored, RStored));
-          dr =
-              BuildOp(BO_Mul, dfdx(),
-                      BuildOp(UO_Minus,
-                              BuildOp(BO_Div, Ldiff.getRevSweepAsExpr(), RxR)));
+          dr = BuildOp(
+              BO_Mul, dfdx(),
+              BuildOp(UO_Minus,
+                      BuildOp(BO_Div, LStored.getRevSweepAsExpr(), RxR)));
           dr = StoreAndRef(dr, direction::reverse);
         }
         Rdiff = Visit(R, dr);
         RDelayed.Finalize(Rdiff.getExpr());
       }
       std::tie(Ldiff, Rdiff) =
-          std::make_pair(Ldiff.getExpr(), RResult.getExpr());
+          std::make_pair(LStored.getExpr(), RResult.getExpr());
     } else if (BinOp->isAssignmentOp()) {
       if (L->isModifiableLvalue(m_Context) != Expr::MLV_Valid) {
         diag(DiagnosticsEngine::Warning,
@@ -2394,7 +2403,8 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
       } else if (opCode == BO_DivAssign) {
         auto RDelayed = DelayedGlobalStoreAndRef(R);
         StmtDiff RResult = RDelayed.Result;
-        Expr* RStored = StoreAndRef(RResult.getExpr_dx(), direction::reverse);
+        Expr* RStored =
+            StoreAndRef(RResult.getRevSweepAsExpr(), direction::reverse);
         addToCurrentBlock(BuildOp(BO_AddAssign, AssignedDiff,
                                   BuildOp(BO_Div, oldValue, RStored)),
                           direction::reverse);
@@ -2787,6 +2797,10 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     return StmtDiff(subExprDiff.getExpr(), subExprDiff.getExpr_dx());
   }
 
+  bool ReverseModeVisitor::ShouldRecompute(const Expr* E) {
+    return !(utils::ContainsFunctionCalls(E) || E->HasSideEffects(m_Context));
+  }
+
   bool ReverseModeVisitor::UsefulToStoreGlobal(Expr* E) {
     if (!E)
       return false;
@@ -2946,12 +2960,12 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
   ReverseModeVisitor::DelayedGlobalStoreAndRef(Expr* E,
                                                llvm::StringRef prefix) {
     assert(E && "must be provided");
-    if (isa<DeclRefExpr>(E) /*!UsefulToStoreGlobal(E)*/) {
-      Expr* Cloned = Clone(E);
+    if (!UsefulToStore(E)) {
+      StmtDiff Ediff = Visit(E);
       Expr::EvalResult evalRes;
       bool isConst =
           clad_compat::Expr_EvaluateAsConstantExpr(E, evalRes, m_Context);
-      return DelayedStoreResult{*this, StmtDiff{Cloned, Cloned},
+      return DelayedStoreResult{*this, Ediff,
                                 /*isConstant*/ isConst,
                                 /*isInsideLoop*/ false,
                                 /*pNeedsUpdate=*/false};
@@ -2961,14 +2975,14 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
       auto CladTape = MakeCladTapeFor(dummy);
       Expr* Push = CladTape.Push;
       Expr* Pop = CladTape.Pop;
-      return DelayedStoreResult{*this, StmtDiff{Push, Pop, nullptr, Pop},
+      return DelayedStoreResult{*this, StmtDiff{Push, nullptr, nullptr, Pop},
                                 /*isConstant*/ false,
                                 /*isInsideLoop*/ true, /*pNeedsUpdate=*/true};
     }
     Expr* Ref = BuildDeclRef(GlobalStoreImpl(
         getNonConstType(E->getType(), m_Context, m_Sema), prefix));
     // Return reference to the declaration instead of original expression.
-    return DelayedStoreResult{*this, StmtDiff{Ref, Ref},
+    return DelayedStoreResult{*this, StmtDiff{Ref, nullptr, nullptr, Ref},
                               /*isConstant*/ false,
                               /*isInsideLoop*/ false, /*pNeedsUpdate=*/true};
   }

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -247,10 +247,7 @@ namespace clad {
     return StoreAndRef(E, Type, block, prefix, forceDeclCreation, IS);
   }
 
-  /// For an expr E, decides if it is useful to store it in a temporary variable
-  /// and replace E's further usage by a reference to that variable to avoid
-  /// recomputiation.
-  static bool UsefulToStore(Expr* E) {
+  bool VisitorBase::UsefulToStore(Expr* E) {
     if (!E)
       return false;
     Expr* B = E->IgnoreParenImpCasts();

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -35,9 +35,7 @@ double addArr(const double *arr, int n) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             ret = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_ret;
-//CHECK-NEXT:             _d_ret += _r_d0;
 //CHECK-NEXT:             _d_arr[i] += _r_d0;
-//CHECK-NEXT:             _d_ret -= _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -92,16 +90,13 @@ float func(float* a, float* b) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t2);
 //CHECK-NEXT:             float _r_d1 = _d_sum;
-//CHECK-NEXT:             _d_sum += _r_d1;
 //CHECK-NEXT:             _d_a[i] += _r_d1;
-//CHECK-NEXT:             _d_sum -= _r_d1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             a[i] = clad::pop(_t1);
 //CHECK-NEXT:             float _r_d0 = _d_a[i];
 //CHECK-NEXT:             _d_a[i] += _r_d0 * b[i];
-//CHECK-NEXT:             float _r0 = a[i] * _r_d0;
-//CHECK-NEXT:             _d_b[i] += _r0;
+//CHECK-NEXT:             _d_b[i] += a[i] * _r_d0;
 //CHECK-NEXT:             _d_a[i] -= _r_d0;
 //CHECK-NEXT:             _d_a[i];
 //CHECK-NEXT:         }
@@ -115,11 +110,7 @@ float helper(float x) {
 // CHECK: void helper_pullback(float x, float _d_y, clad::array_ref<float> _d_x) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
-// CHECK-NEXT:     {
-// CHECK-NEXT:         float _r0 = _d_y * x;
-// CHECK-NEXT:         float _r1 = 2 * _d_y;
-// CHECK-NEXT:         * _d_x += _r1;
-// CHECK-NEXT:     }
+// CHECK-NEXT:     * _d_x += 2 * _d_y;
 // CHECK-NEXT: }
 
 float func2(float* a) {
@@ -148,12 +139,10 @@ float func2(float* a) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         sum = clad::pop(_t1);
 //CHECK-NEXT:         float _r_d0 = _d_sum;
-//CHECK-NEXT:         _d_sum += _r_d0;
 //CHECK-NEXT:         float _grad0 = 0.F;
 //CHECK-NEXT:         helper_pullback(a[i], _r_d0, &_grad0);
 //CHECK-NEXT:         float _r0 = _grad0;
 //CHECK-NEXT:         _d_a[i] += _r0;
-//CHECK-NEXT:         _d_sum -= _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -185,14 +174,10 @@ float func3(float* a, float* b) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         sum = clad::pop(_t1);
 //CHECK-NEXT:         float _r_d0 = _d_sum;
-//CHECK-NEXT:         _d_sum += _r_d0;
 //CHECK-NEXT:         _d_a[i] += _r_d0;
 //CHECK-NEXT:         a[i] = clad::pop(_t2);
 //CHECK-NEXT:         float _r_d1 = _d_a[i];
-//CHECK-NEXT:         _d_a[i] += _r_d1;
 //CHECK-NEXT:         _d_b[i] += _r_d1;
-//CHECK-NEXT:         _d_a[i] -= _r_d1;
-//CHECK-NEXT:         _d_sum -= _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -227,23 +212,17 @@ double func4(double x) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             _d_sum += _r_d0;
 //CHECK-NEXT:             int _grad1 = 0;
 //CHECK-NEXT:             addArr_pullback(arr, 3, _r_d0, _d_arr, &_grad1);
-//CHECK-NEXT:             clad::array<double> _r4(_d_arr);
-//CHECK-NEXT:             int _r5 = _grad1;
-//CHECK-NEXT:             _d_sum -= _r_d0;
+//CHECK-NEXT:             clad::array<double> _r0(_d_arr);
+//CHECK-NEXT:             int _r1 = _grad1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         * _d_x += _d_arr[0];
-//CHECK-NEXT:         double _r0 = _d_arr[1] * x;
-//CHECK-NEXT:         double _r1 = 2 * _d_arr[1];
-//CHECK-NEXT:         * _d_x += _r1;
-//CHECK-NEXT:         double _r2 = _d_arr[2] * x;
-//CHECK-NEXT:         * _d_x += _r2;
-//CHECK-NEXT:         double _r3 = x * _d_arr[2];
-//CHECK-NEXT:         * _d_x += _r3;
+//CHECK-NEXT:         * _d_x += 2 * _d_arr[1];
+//CHECK-NEXT:         * _d_x += _d_arr[2] * x;
+//CHECK-NEXT:         * _d_x += x * _d_arr[2];
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -293,13 +272,11 @@ double func5(int k) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t3);
 //CHECK-NEXT:             double _r_d1 = _d_sum;
-//CHECK-NEXT:             _d_sum += _r_d1;
 //CHECK-NEXT:             int _grad1 = 0;
 //CHECK-NEXT:             addArr_pullback(arr, n, _r_d1, _d_arr, &_grad1);
 //CHECK-NEXT:             clad::array<double> _r0(_d_arr);
 //CHECK-NEXT:             int _r1 = _grad1;
 //CHECK-NEXT:             _d_n += _r1;
-//CHECK-NEXT:             _d_sum -= _r_d1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     for (; _t0; _t0--) {
@@ -346,19 +323,15 @@ double func6(double seed) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             _d_sum += _r_d0;
 //CHECK-NEXT:             int _grad1 = 0;
 //CHECK-NEXT:             addArr_pullback(arr, 3, _r_d0, _d_arr, &_grad1);
-//CHECK-NEXT:             clad::array<double> _r2(_d_arr);
-//CHECK-NEXT:             int _r3 = _grad1;
-//CHECK-NEXT:             _d_sum -= _r_d0;
+//CHECK-NEXT:             clad::array<double> _r0(_d_arr);
+//CHECK-NEXT:             int _r1 = _grad1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             * _d_seed += _d_arr[0];
-//CHECK-NEXT:             double _r0 = _d_arr[1] * i;
-//CHECK-NEXT:             * _d_seed += _r0;
-//CHECK-NEXT:             double _r1 = seed * _d_arr[1];
-//CHECK-NEXT:             _d_i += _r1;
+//CHECK-NEXT:             * _d_seed += _d_arr[1] * i;
+//CHECK-NEXT:             _d_i += seed * _d_arr[1];
 //CHECK-NEXT:             * _d_seed += _d_arr[2];
 //CHECK-NEXT:             _d_i += _d_arr[2];
 //CHECK-NEXT:             _d_arr = {};
@@ -376,12 +349,9 @@ double inv_square(double *params) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r0 = _d_y / _t0;
-//CHECK-NEXT:         double _r1 = _d_y * -1 / (_t0 * _t0);
-//CHECK-NEXT:         double _r2 = _r1 * params[0];
-//CHECK-NEXT:         _d_params[0] += _r2;
-//CHECK-NEXT:         double _r3 = params[0] * _r1;
-//CHECK-NEXT:         _d_params[0] += _r3;
+//CHECK-NEXT:         double _r0 = _d_y * -1 / (_t0 * _t0);
+//CHECK-NEXT:         _d_params[0] += _r0 * params[0];
+//CHECK-NEXT:         _d_params[0] += params[0] * _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -436,10 +406,8 @@ double helper2(double i, double *arr, int n) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r0 = _d_y * i;
-//CHECK-NEXT:         _d_arr[0] += _r0;
-//CHECK-NEXT:         double _r1 = arr[0] * _d_y;
-//CHECK-NEXT:         * _d_i += _r1;
+//CHECK-NEXT:         _d_arr[0] += _d_y * i;
+//CHECK-NEXT:         * _d_i += arr[0] * _d_y;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -572,10 +540,8 @@ double sq(double& elem) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         elem = _t0;
 //CHECK-NEXT:         double _r_d0 = * _d_elem;
-//CHECK-NEXT:         double _r0 = _r_d0 * elem;
-//CHECK-NEXT:         * _d_elem += _r0;
-//CHECK-NEXT:         double _r1 = elem * _r_d0;
-//CHECK-NEXT:         * _d_elem += _r1;
+//CHECK-NEXT:         * _d_elem += _r_d0 * elem;
+//CHECK-NEXT:         * _d_elem += elem * _r_d0;
 //CHECK-NEXT:         * _d_elem -= _r_d0;
 //CHECK-NEXT:         * _d_elem;
 //CHECK-NEXT:     }
@@ -612,12 +578,10 @@ double func10(double *arr, int n) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             res = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_res;
-//CHECK-NEXT:             _d_res += _r_d0;
 //CHECK-NEXT:             double _r1 = clad::pop(_t2);
 //CHECK-NEXT:             arr[i] = _r1;
 //CHECK-NEXT:             sq_pullback(_r1, _r_d0, &_d_arr[i]);
 //CHECK-NEXT:             double _r0 = _d_arr[i];
-//CHECK-NEXT:             _d_res -= _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }

--- a/test/Arrays/Arrays.C
+++ b/test/Arrays/Arrays.C
@@ -99,18 +99,12 @@ double const_dot_product(double x, double y, double z) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * consts[0];
-//CHECK-NEXT:           _d_vars[0] += _r0;
-//CHECK-NEXT:           double _r1 = vars[0] * 1;
-//CHECK-NEXT:           _d_consts[0] += _r1;
-//CHECK-NEXT:           double _r2 = 1 * consts[1];
-//CHECK-NEXT:           _d_vars[1] += _r2;
-//CHECK-NEXT:           double _r3 = vars[1] * 1;
-//CHECK-NEXT:           _d_consts[1] += _r3;
-//CHECK-NEXT:           double _r4 = 1 * consts[2];
-//CHECK-NEXT:           _d_vars[2] += _r4;
-//CHECK-NEXT:           double _r5 = vars[2] * 1;
-//CHECK-NEXT:           _d_consts[2] += _r5;
+//CHECK-NEXT:           _d_vars[0] += 1 * consts[0];
+//CHECK-NEXT:           _d_consts[0] += vars[0] * 1;
+//CHECK-NEXT:           _d_vars[1] += 1 * consts[1];
+//CHECK-NEXT:           _d_consts[1] += vars[1] * 1;
+//CHECK-NEXT:           _d_vars[2] += 1 * consts[2];
+//CHECK-NEXT:           _d_consts[2] += vars[2] * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += _d_vars[0];

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -56,52 +56,37 @@ auto gauss_g = clad::gradient(gauss, "p");
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r8 = 1 * _t4;
-//CHECK-NEXT:         double _r9 = _r8 * _t5;
 //CHECK-NEXT:         double _grad0 = 0.;
 //CHECK-NEXT:         double _grad1 = 0.;
-//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(2 * 3.1415926535897931, -dim / _t6, _r9, &_grad0, &_grad1);
-//CHECK-NEXT:         double _r10 = _grad0;
-//CHECK-NEXT:         double _r11 = _r10 * 3.1415926535897931;
-//CHECK-NEXT:         double _r12 = _grad1;
-//CHECK-NEXT:         double _r13 = _r12 / _t6;
-//CHECK-NEXT:         _d_dim += -_r13;
-//CHECK-NEXT:         double _r14 = _r12 * --dim / (_t6 * _t6);
-//CHECK-NEXT:         double _r15 = std::pow(2 * 3.1415926535897931, -dim / _t6) * _r8;
+//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(2 * 3.1415926535897931, -dim / _t6, 1 * _t4 * _t5, &_grad0, &_grad1);
+//CHECK-NEXT:         double _r1 = _grad0;
+//CHECK-NEXT:         double _r2 = _grad1;
+//CHECK-NEXT:         _d_dim += -_r2 / _t6;
+//CHECK-NEXT:         double _r3 = _r2 * --dim / (_t6 * _t6);
 //CHECK-NEXT:         double _grad2 = 0.;
 //CHECK-NEXT:         double _grad3 = 0.;
-//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(sigma, -0.5, _r15, &_grad2, &_grad3);
-//CHECK-NEXT:         double _r16 = _grad2;
-//CHECK-NEXT:         _d_sigma += _r16;
-//CHECK-NEXT:         double _r17 = _grad3;
-//CHECK-NEXT:         double _r18 = std::pow(2 * 3.1415926535897931, -dim / _t6) * _t5 * 1;
-//CHECK-NEXT:         double _r19 = _r18 * clad::custom_derivatives::exp_pushforward(t, 1.).pushforward;
-//CHECK-NEXT:         _d_t += _r19;
+//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(sigma, -0.5, std::pow(2 * 3.1415926535897931, -dim / _t6) * 1 * _t4, &_grad2, &_grad3);
+//CHECK-NEXT:         double _r4 = _grad2;
+//CHECK-NEXT:         _d_sigma += _r4;
+//CHECK-NEXT:         double _r5 = _grad3;
+//CHECK-NEXT:         double _r6 = std::pow(2 * 3.1415926535897931, -dim / _t6) * _t5 * 1 * clad::custom_derivatives::exp_pushforward(t, 1.).pushforward;
+//CHECK-NEXT:         _d_t += _r6;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         t = _t2;
 //CHECK-NEXT:         double _r_d1 = _d_t;
-//CHECK-NEXT:         double _r2 = _r_d1 / _t3;
-//CHECK-NEXT:         _d_t += -_r2;
-//CHECK-NEXT:         double _r3 = _r_d1 * --t / (_t3 * _t3);
-//CHECK-NEXT:         double _r4 = _r3 * sigma;
-//CHECK-NEXT:         double _r5 = _r4 * sigma;
-//CHECK-NEXT:         double _r6 = 2 * _r4;
-//CHECK-NEXT:         _d_sigma += _r6;
-//CHECK-NEXT:         double _r7 = 2 * sigma * _r3;
-//CHECK-NEXT:         _d_sigma += _r7;
+//CHECK-NEXT:         _d_t += -_r_d1 / _t3;
+//CHECK-NEXT:         double _r0 = _r_d1 * --t / (_t3 * _t3);
+//CHECK-NEXT:         _d_sigma += 2 * _r0 * sigma;
+//CHECK-NEXT:         _d_sigma += 2 * sigma * _r0;
 //CHECK-NEXT:         _d_t -= _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         t = clad::pop(_t1);
 //CHECK-NEXT:         double _r_d0 = _d_t;
-//CHECK-NEXT:         _d_t += _r_d0;
-//CHECK-NEXT:         double _r0 = _r_d0 * (x[i] - p[i]);
-//CHECK-NEXT:         _d_p[i] += -_r0;
-//CHECK-NEXT:         double _r1 = (x[i] - p[i]) * _r_d0;
-//CHECK-NEXT:         _d_p[i] += -_r1;
-//CHECK-NEXT:         _d_t -= _r_d0;
+//CHECK-NEXT:         _d_p[i] += -_r_d0 * (x[i] - p[i]);
+//CHECK-NEXT:         _d_p[i] += -(x[i] - p[i]) * _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -50,7 +50,7 @@ auto gauss_g = clad::gradient(gauss, "p");
 //CHECK-NEXT:     _t2 = t;
 //CHECK-NEXT:     _t3 = (2 * sigma * sigma);
 //CHECK-NEXT:     t = -t / _t3;
-//CHECK-NEXT:     _t6 = 2.;
+//CHECK-NEXT:     _t6 = std::pow(2 * 3.1415926535897931, -dim / 2.);
 //CHECK-NEXT:     _t5 = std::pow(sigma, -0.5);
 //CHECK-NEXT:     _t4 = std::exp(t);
 //CHECK-NEXT:     goto _label0;
@@ -58,19 +58,18 @@ auto gauss_g = clad::gradient(gauss, "p");
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _grad0 = 0.;
 //CHECK-NEXT:         double _grad1 = 0.;
-//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(2 * 3.1415926535897931, -dim / _t6, 1 * _t4 * _t5, &_grad0, &_grad1);
+//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(2 * 3.1415926535897931, -dim / 2., 1 * _t4 * _t5, &_grad0, &_grad1);
 //CHECK-NEXT:         double _r1 = _grad0;
 //CHECK-NEXT:         double _r2 = _grad1;
-//CHECK-NEXT:         _d_dim += -_r2 / _t6;
-//CHECK-NEXT:         double _r3 = _r2 * --dim / (_t6 * _t6);
+//CHECK-NEXT:         _d_dim += -_r2 / 2.;
 //CHECK-NEXT:         double _grad2 = 0.;
 //CHECK-NEXT:         double _grad3 = 0.;
-//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(sigma, -0.5, std::pow(2 * 3.1415926535897931, -dim / _t6) * 1 * _t4, &_grad2, &_grad3);
-//CHECK-NEXT:         double _r4 = _grad2;
-//CHECK-NEXT:         _d_sigma += _r4;
-//CHECK-NEXT:         double _r5 = _grad3;
-//CHECK-NEXT:         double _r6 = std::pow(2 * 3.1415926535897931, -dim / _t6) * _t5 * 1 * clad::custom_derivatives::exp_pushforward(t, 1.).pushforward;
-//CHECK-NEXT:         _d_t += _r6;
+//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(sigma, -0.5, _t6 * 1 * _t4, &_grad2, &_grad3);
+//CHECK-NEXT:         double _r3 = _grad2;
+//CHECK-NEXT:         _d_sigma += _r3;
+//CHECK-NEXT:         double _r4 = _grad3;
+//CHECK-NEXT:         double _r5 = _t6 * _t5 * 1 * clad::custom_derivatives::exp_pushforward(t, 1.).pushforward;
+//CHECK-NEXT:         _d_t += _r5;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         t = _t2;

--- a/test/Enzyme/DifferentCladEnzymeDerivatives.C
+++ b/test/Enzyme/DifferentCladEnzymeDerivatives.C
@@ -14,10 +14,8 @@ double foo(double x, double y){
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * y;
-// CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         double _r1 = x * 1;
-// CHECK-NEXT:         * _d_y += _r1;
+// CHECK-NEXT:         * _d_x += 1 * y;
+// CHECK-NEXT:         * _d_y += x * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -67,14 +67,10 @@ float func2(float x, int y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = * _d_x;
-//CHECK-NEXT:         float _r0 = _r_d0 * x;
-//CHECK-NEXT:         * _d_y += _r0;
-//CHECK-NEXT:         float _r1 = y * _r_d0;
-//CHECK-NEXT:         * _d_x += _r1;
-//CHECK-NEXT:         float _r2 = _r_d0 * x;
-//CHECK-NEXT:         * _d_x += _r2;
-//CHECK-NEXT:         float _r3 = x * _r_d0;
-//CHECK-NEXT:         * _d_x += _r3;
+//CHECK-NEXT:         * _d_y += _r_d0 * x;
+//CHECK-NEXT:         * _d_x += y * _r_d0;
+//CHECK-NEXT:         * _d_x += _r_d0 * x;
+//CHECK-NEXT:         * _d_x += x * _r_d0;
 //CHECK-NEXT:         _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
 //CHECK-NEXT:         * _d_x -= _r_d0;
 //CHECK-NEXT:         * _d_x;
@@ -195,10 +191,8 @@ float func7(float x, float y) { return (x * y); }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         float _r0 = 1 * y;
-//CHECK-NEXT:         * _d_x += _r0;
-//CHECK-NEXT:         float _r1 = x * 1;
-//CHECK-NEXT:         * _d_y += _r1;
+//CHECK-NEXT:         * _d_x += 1 * y;
+//CHECK-NEXT:         * _d_y += x * 1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
 //CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -82,22 +82,20 @@ float func2(float x, float y) {
 //CHECK-NEXT:     double _delta_x = 0;
 //CHECK-NEXT:     float _EERepl_x0 = x;
 //CHECK-NEXT:     float _EERepl_x1;
-//CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _delta_z = 0;
 //CHECK-NEXT:     float _EERepl_z0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = x - y - y * y;
 //CHECK-NEXT:     _EERepl_x1 = x;
-//CHECK-NEXT:     _t1 = x;
-//CHECK-NEXT:     float z = y / _t1;
+//CHECK-NEXT:     float z = y / x;
 //CHECK-NEXT:     _EERepl_z0 = z;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         * _d_y += _d_z / _t1;
-//CHECK-NEXT:         float _r0 = _d_z * -y / (_t1 * _t1);
+//CHECK-NEXT:         * _d_y += _d_z / x;
+//CHECK-NEXT:         float _r0 = _d_z * -y / (x * x);
 //CHECK-NEXT:         * _d_x += _r0;
 //CHECK-NEXT:         _delta_z += std::abs(_d_z * _EERepl_z0 * {{.+}});
 //CHECK-NEXT:     }
@@ -392,16 +390,18 @@ float func9(float x, float y) {
 //CHECK-NEXT:     float _t3;
 //CHECK-NEXT:     double _t4;
 //CHECK-NEXT:     float _t5;
-//CHECK-NEXT:     float _t7;
+//CHECK-NEXT:     double _t7;
+//CHECK-NEXT:     float _t8;
 //CHECK-NEXT:     float _EERepl_z1;
 //CHECK-NEXT:     _t1 = x;
 //CHECK-NEXT:     float z = helper(x, y) + helper2(x);
 //CHECK-NEXT:     _EERepl_z0 = z;
 //CHECK-NEXT:     _t3 = z;
 //CHECK-NEXT:     _t5 = x;
-//CHECK-NEXT:     _t7 = y;
+//CHECK-NEXT:     _t7 = helper2(x);
+//CHECK-NEXT:     _t8 = y;
 //CHECK-NEXT:     _t4 = helper2(y);
-//CHECK-NEXT:     z += helper2(x) * _t4;
+//CHECK-NEXT:     z += _t7 * _t4;
 //CHECK-NEXT:     _EERepl_z1 = z;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
@@ -413,12 +413,12 @@ float func9(float x, float y) {
 //CHECK-NEXT:         double _t6 = 0;
 //CHECK-NEXT:         helper2_pullback(_t5, _r_d0 * _t4, &* _d_x, _t6);
 //CHECK-NEXT:         float _r3 = * _d_x;
-//CHECK-NEXT:         y = _t7;
-//CHECK-NEXT:         double _t8 = 0;
-//CHECK-NEXT:         helper2_pullback(_t7, helper2(x) * _r_d0, &* _d_y, _t8);
+//CHECK-NEXT:         y = _t8;
+//CHECK-NEXT:         double _t9 = 0;
+//CHECK-NEXT:         helper2_pullback(_t8, _t7 * _r_d0, &* _d_y, _t9);
 //CHECK-NEXT:         float _r4 = * _d_y;
-//CHECK-NEXT:         _delta_z += _t6 + _t8;
-//CHECK-NEXT:         _final_error += std::abs(_r4 * _t7 * {{.+}});
+//CHECK-NEXT:         _delta_z += _t6 + _t9;
+//CHECK-NEXT:         _final_error += std::abs(_r4 * _t8 * {{.+}});
 //CHECK-NEXT:         _final_error += std::abs(_r3 * _t5 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -39,10 +39,8 @@ float func(float x, float y) {
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         float _r0 = _d_z * x;
-//CHECK-NEXT:         * _d_y += _r0;
-//CHECK-NEXT:         float _r1 = y * _d_z;
-//CHECK-NEXT:         * _d_x += _r1;
+//CHECK-NEXT:         * _d_y += _d_z * x;
+//CHECK-NEXT:         * _d_x += y * _d_z;
 //CHECK-NEXT:         _delta_z += std::abs(_d_z * _EERepl_z0 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
@@ -98,10 +96,9 @@ float func2(float x, float y) {
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         float _r2 = _d_z / _t1;
-//CHECK-NEXT:         * _d_y += _r2;
-//CHECK-NEXT:         float _r3 = _d_z * -y / (_t1 * _t1);
-//CHECK-NEXT:         * _d_x += _r3;
+//CHECK-NEXT:         * _d_y += _d_z / _t1;
+//CHECK-NEXT:         float _r0 = _d_z * -y / (_t1 * _t1);
+//CHECK-NEXT:         * _d_x += _r0;
 //CHECK-NEXT:         _delta_z += std::abs(_d_z * _EERepl_z0 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
@@ -109,10 +106,8 @@ float func2(float x, float y) {
 //CHECK-NEXT:         float _r_d0 = * _d_x;
 //CHECK-NEXT:         * _d_x += _r_d0;
 //CHECK-NEXT:         * _d_y += -_r_d0;
-//CHECK-NEXT:         float _r0 = -_r_d0 * y;
-//CHECK-NEXT:         * _d_y += _r0;
-//CHECK-NEXT:         float _r1 = y * -_r_d0;
-//CHECK-NEXT:         * _d_y += _r1;
+//CHECK-NEXT:         * _d_y += -_r_d0 * y;
+//CHECK-NEXT:         * _d_y += y * -_r_d0;
 //CHECK-NEXT:         _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
 //CHECK-NEXT:         * _d_x -= _r_d0;
 //CHECK-NEXT:         * _d_x;
@@ -162,13 +157,9 @@ float func3(float x, float y) {
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_t += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         float _r2 = _d_t * _t1;
-//CHECK-NEXT:         float _r3 = _r2 * z;
-//CHECK-NEXT:         * _d_x += _r3;
-//CHECK-NEXT:         float _r4 = x * _r2;
-//CHECK-NEXT:         _d_z += _r4;
-//CHECK-NEXT:         float _r5 = x * z * _d_t;
-//CHECK-NEXT:         * _d_y += _r5;
+//CHECK-NEXT:         * _d_x += _d_t * _t1 * z;
+//CHECK-NEXT:         _d_z += x * _d_t * _t1;
+//CHECK-NEXT:         * _d_y += x * z * _d_t;
 //CHECK-NEXT:         y = _t2;
 //CHECK-NEXT:         float _r_d1 = * _d_y;
 //CHECK-NEXT:         * _d_x += _r_d1;
@@ -183,10 +174,8 @@ float func3(float x, float y) {
 //CHECK-NEXT:         float _r_d0 = * _d_x;
 //CHECK-NEXT:         * _d_x += _r_d0;
 //CHECK-NEXT:         * _d_y += -_r_d0;
-//CHECK-NEXT:         float _r0 = -_r_d0 * y;
-//CHECK-NEXT:         * _d_y += _r0;
-//CHECK-NEXT:         float _r1 = y * -_r_d0;
-//CHECK-NEXT:         * _d_y += _r1;
+//CHECK-NEXT:         * _d_y += -_r_d0 * y;
+//CHECK-NEXT:         * _d_y += y * -_r_d0;
 //CHECK-NEXT:         _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
 //CHECK-NEXT:         * _d_x -= _r_d0;
 //CHECK-NEXT:         * _d_x;
@@ -239,10 +228,8 @@ float func5(float x, float y) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         float _r1 = 1 * y;
-//CHECK-NEXT:         * _d_y += _r1;
-//CHECK-NEXT:         float _r2 = y * 1;
-//CHECK-NEXT:         * _d_y += _r2;
+//CHECK-NEXT:         * _d_y += 1 * y;
+//CHECK-NEXT:         * _d_y += y * 1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t0;
@@ -268,10 +255,8 @@ double helper(double x, double y) { return x * y; }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r0 = _d_y0 * y;
-//CHECK-NEXT:         * _d_x += _r0;
-//CHECK-NEXT:         double _r1 = x * _d_y0;
-//CHECK-NEXT:         * _d_y += _r1;
+//CHECK-NEXT:         * _d_x += _d_y0 * y;
+//CHECK-NEXT:         * _d_y += x * _d_y0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
 //CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});
@@ -296,10 +281,8 @@ float func6(float x, float y) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         float _r2 = 1 * z;
-//CHECK-NEXT:         _d_z += _r2;
-//CHECK-NEXT:         float _r3 = z * 1;
-//CHECK-NEXT:         _d_z += _r3;
+//CHECK-NEXT:         _d_z += 1 * z;
+//CHECK-NEXT:         _d_z += z * 1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _grad0 = 0.;
@@ -348,10 +331,8 @@ double helper2(float& x) { return x * x; }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r0 = _d_y * x;
-//CHECK-NEXT:         * _d_x += _r0;
-//CHECK-NEXT:         double _r1 = x * _d_y;
-//CHECK-NEXT:         * _d_x += _r1;
+//CHECK-NEXT:         * _d_x += _d_y * x;
+//CHECK-NEXT:         * _d_x += x * _d_y;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
@@ -428,21 +409,17 @@ float func9(float x, float y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         z = _t3;
 //CHECK-NEXT:         float _r_d0 = _d_z;
-//CHECK-NEXT:         _d_z += _r_d0;
-//CHECK-NEXT:         double _r3 = _r_d0 * _t4;
 //CHECK-NEXT:         x = _t5;
 //CHECK-NEXT:         double _t6 = 0;
-//CHECK-NEXT:         helper2_pullback(_t5, _r3, &* _d_x, _t6);
-//CHECK-NEXT:         float _r4 = * _d_x;
-//CHECK-NEXT:         double _r5 = helper2(x) * _r_d0;
+//CHECK-NEXT:         helper2_pullback(_t5, _r_d0 * _t4, &* _d_x, _t6);
+//CHECK-NEXT:         float _r3 = * _d_x;
 //CHECK-NEXT:         y = _t7;
 //CHECK-NEXT:         double _t8 = 0;
-//CHECK-NEXT:         helper2_pullback(_t7, _r5, &* _d_y, _t8);
-//CHECK-NEXT:         float _r6 = * _d_y;
+//CHECK-NEXT:         helper2_pullback(_t7, helper2(x) * _r_d0, &* _d_y, _t8);
+//CHECK-NEXT:         float _r4 = * _d_y;
 //CHECK-NEXT:         _delta_z += _t6 + _t8;
-//CHECK-NEXT:         _final_error += std::abs(_r6 * _t7 * {{.+}});
-//CHECK-NEXT:         _final_error += std::abs(_r4 * _t5 * {{.+}});
-//CHECK-NEXT:         _d_z -= _r_d0;
+//CHECK-NEXT:         _final_error += std::abs(_r4 * _t7 * {{.+}});
+//CHECK-NEXT:         _final_error += std::abs(_r3 * _t5 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _grad0 = 0.;

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -168,7 +168,6 @@ float func4(float x, float y) {
 //CHECK-NEXT:     float _EERepl_x1;
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _EERepl_x2;
-//CHECK-NEXT:     float _t2;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _cond0 = !x;
 //CHECK-NEXT:     if (_cond0)
@@ -178,13 +177,12 @@ float func4(float x, float y) {
 //CHECK-NEXT:     _cond0 ? (x += 1) : (x *= x);
 //CHECK-NEXT:     _EERepl_x2 = x;
 //CHECK-NEXT:     _EERepl_x1 = x;
-//CHECK-NEXT:     _t2 = x;
-//CHECK-NEXT:     _ret_value0 = y / _t2;
+//CHECK-NEXT:     _ret_value0 = y / x;
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         * _d_y += 1 / _t2;
-//CHECK-NEXT:         float _r0 = 1 * -y / (_t2 * _t2);
+//CHECK-NEXT:         * _d_y += 1 / x;
+//CHECK-NEXT:         float _r0 = 1 * -y / (x * x);
 //CHECK-NEXT:         * _d_x += _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -55,10 +55,8 @@ float func(float x, float y) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             y = _t0;
 //CHECK-NEXT:             float _r_d0 = * _d_y;
-//CHECK-NEXT:             float _r0 = _r_d0 * x;
-//CHECK-NEXT:             * _d_y += _r0;
-//CHECK-NEXT:             float _r1 = y * _r_d0;
-//CHECK-NEXT:             * _d_x += _r1;
+//CHECK-NEXT:             * _d_y += _r_d0 * x;
+//CHECK-NEXT:             * _d_x += y * _r_d0;
 //CHECK-NEXT:             _delta_y += std::abs(_r_d0 * _EERepl_y1 * {{.+}});
 //CHECK-NEXT:             * _d_y -= _r_d0;
 //CHECK-NEXT:             * _d_y;
@@ -74,10 +72,8 @@ float func(float x, float y) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             temp = _t1;
 //CHECK-NEXT:             float _r_d1 = _d_temp;
-//CHECK-NEXT:             float _r2 = _r_d1 * y;
-//CHECK-NEXT:             * _d_y += _r2;
-//CHECK-NEXT:             float _r3 = y * _r_d1;
-//CHECK-NEXT:             * _d_y += _r3;
+//CHECK-NEXT:             * _d_y += _r_d1 * y;
+//CHECK-NEXT:             * _d_y += y * _r_d1;
 //CHECK-NEXT:             _delta_temp += std::abs(_r_d1 * _EERepl_temp1 * {{.+}});
 //CHECK-NEXT:             _d_temp -= _r_d1;
 //CHECK-NEXT:         }
@@ -123,16 +119,12 @@ float func2(float x) {
 //CHECK-NEXT:     else
 //CHECK-NEXT:       _label1:
 //CHECK-NEXT:         {
-//CHECK-NEXT:             float _r2 = 1 * x;
-//CHECK-NEXT:             * _d_x += _r2;
-//CHECK-NEXT:             float _r3 = x * 1;
-//CHECK-NEXT:             * _d_x += _r3;
+//CHECK-NEXT:             * _d_x += 1 * x;
+//CHECK-NEXT:             * _d_x += x * 1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         float _r0 = _d_z * x;
-//CHECK-NEXT:         * _d_x += _r0;
-//CHECK-NEXT:         float _r1 = x * _d_z;
-//CHECK-NEXT:         * _d_x += _r1;
+//CHECK-NEXT:         * _d_x += _d_z * x;
+//CHECK-NEXT:         * _d_x += x * _d_z;
 //CHECK-NEXT:         _delta_z += std::abs(_d_z * _EERepl_z0 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
@@ -150,10 +142,8 @@ float func3(float x, float y) { return x > 30 ? x * y : x + y; }
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     if (_cond0) {
-//CHECK-NEXT:         float _r0 = 1 * y;
-//CHECK-NEXT:         * _d_x += _r0;
-//CHECK-NEXT:         float _r1 = x * 1;
-//CHECK-NEXT:         * _d_y += _r1;
+//CHECK-NEXT:         * _d_x += 1 * y;
+//CHECK-NEXT:         * _d_y += x * 1;
 //CHECK-NEXT:     } else {
 //CHECK-NEXT:         * _d_x += 1;
 //CHECK-NEXT:         * _d_y += 1;
@@ -193,24 +183,20 @@ float func4(float x, float y) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         float _r1 = 1 / _t2;
-//CHECK-NEXT:         * _d_y += _r1;
-//CHECK-NEXT:         float _r2 = 1 * -y / (_t2 * _t2);
-//CHECK-NEXT:         * _d_x += _r2;
+//CHECK-NEXT:         * _d_y += 1 / _t2;
+//CHECK-NEXT:         float _r0 = 1 * -y / (_t2 * _t2);
+//CHECK-NEXT:         * _d_x += _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         if (_cond0) {
 //CHECK-NEXT:             x = _t0;
 //CHECK-NEXT:             float _r_d0 = * _d_x;
-//CHECK-NEXT:             * _d_x += _r_d0;
 //CHECK-NEXT:             _delta_x += std::abs(_r_d0 * _EERepl_x1 * {{.+}});
-//CHECK-NEXT:             * _d_x -= _r_d0;
 //CHECK-NEXT:         } else {
 //CHECK-NEXT:             x = _t1;
 //CHECK-NEXT:             float _r_d1 = * _d_x;
 //CHECK-NEXT:             * _d_x += _r_d1 * x;
-//CHECK-NEXT:             float _r0 = x * _r_d1;
-//CHECK-NEXT:             * _d_x += _r0;
+//CHECK-NEXT:             * _d_x += x * _r_d1;
 //CHECK-NEXT:             _delta_x += std::abs(_r_d1 * _EERepl_x2 * {{.+}});
 //CHECK-NEXT:             * _d_x -= _r_d1;
 //CHECK-NEXT:         }

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -39,11 +39,9 @@ float func(float* p, int n) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             float _r_d0 = _d_sum;
-//CHECK-NEXT:             _d_sum += _r_d0;
 //CHECK-NEXT:             _d_p[i] += _r_d0;
 //CHECK-NEXT:             float _r0 = clad::pop(_EERepl_sum1);
 //CHECK-NEXT:             _delta_sum += std::abs(_r_d0 * _r0 * {{.+}});
-//CHECK-NEXT:             _d_sum -= _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
@@ -101,19 +99,17 @@ float func2(float x) {
 //CHECK-NEXT:             float _r_d0 = _d_z;
 //CHECK-NEXT:             _d_m += _r_d0;
 //CHECK-NEXT:             _d_m += _r_d0;
-//CHECK-NEXT:             float _r3 = clad::pop(_EERepl_z1);
-//CHECK-NEXT:             _delta_z += std::abs(_r_d0 * _r3 * {{.+}});
+//CHECK-NEXT:             float _r1 = clad::pop(_EERepl_z1);
+//CHECK-NEXT:             _delta_z += std::abs(_r_d0 * _r1 * {{.+}});
 //CHECK-NEXT:             _d_z -= _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
-//CHECK-NEXT:             float _r0 = _d_m * x;
-//CHECK-NEXT:             * _d_x += _r0;
-//CHECK-NEXT:             float _r1 = x * _d_m;
-//CHECK-NEXT:             * _d_x += _r1;
+//CHECK-NEXT:             * _d_x += _d_m * x;
+//CHECK-NEXT:             * _d_x += x * _d_m;
 //CHECK-NEXT:             _d_m = 0;
 //CHECK-NEXT:             m = clad::pop(_t1);
-//CHECK-NEXT:             float _r2 = clad::pop(_EERepl_m0);
-//CHECK-NEXT:             _delta_m += std::abs(_d_m * _r2 * {{.+}});
+//CHECK-NEXT:             float _r0 = clad::pop(_EERepl_m0);
+//CHECK-NEXT:             _delta_m += std::abs(_d_m * _r0 * {{.+}});
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
@@ -164,10 +160,8 @@ float func3(float x, float y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         arr[1] = _t1;
 //CHECK-NEXT:         double _r_d1 = _d_arr[1];
-//CHECK-NEXT:         double _r0 = _r_d1 * x;
-//CHECK-NEXT:         * _d_x += _r0;
-//CHECK-NEXT:         double _r1 = x * _r_d1;
-//CHECK-NEXT:         * _d_x += _r1;
+//CHECK-NEXT:         * _d_x += _r_d1 * x;
+//CHECK-NEXT:         * _d_x += x * _r_d1;
 //CHECK-NEXT:         _delta_arr[1] += std::abs(_r_d1 * _EERepl_arr1 * {{.+}});
 //CHECK-NEXT:         _final_error += _delta_arr[1];
 //CHECK-NEXT:         _d_arr[1] -= _r_d1;
@@ -234,21 +228,17 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t2);
 //CHECK-NEXT:             float _r_d1 = _d_sum;
-//CHECK-NEXT:             _d_sum += _r_d1;
 //CHECK-NEXT:             _d_x[i] += _r_d1;
 //CHECK-NEXT:             float _r1 = clad::pop(_EERepl_sum1);
 //CHECK-NEXT:             _delta_sum += std::abs(_r_d1 * _r1 * {{.+}});
-//CHECK-NEXT:             _d_sum -= _r_d1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             x[i] = clad::pop(_t1);
 //CHECK-NEXT:             float _r_d0 = _d_x[i];
-//CHECK-NEXT:             _d_x[i] += _r_d0;
 //CHECK-NEXT:             _d_y[i] += _r_d0;
 //CHECK-NEXT:             float _r0 = clad::pop(_EERepl_x1);
 //CHECK-NEXT:             _delta_x[i] += std::abs(_r_d0 * _r0 * {{.+}});
 //CHECK-NEXT:             _final_error += _delta_x[i];
-//CHECK-NEXT:             _d_x[i] -= _r_d0;
 //CHECK-NEXT:             _d_x[i];
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
@@ -310,14 +300,10 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         output[2] = _t2;
 //CHECK-NEXT:         double _r_d2 = _d_output[2];
-//CHECK-NEXT:         double _r8 = _r_d2 * y[1];
-//CHECK-NEXT:         _d_x[0] += _r8;
-//CHECK-NEXT:         double _r9 = x[0] * _r_d2;
-//CHECK-NEXT:         _d_y[1] += _r9;
-//CHECK-NEXT:         double _r10 = -_r_d2 * x[1];
-//CHECK-NEXT:         _d_y[0] += _r10;
-//CHECK-NEXT:         double _r11 = y[0] * -_r_d2;
-//CHECK-NEXT:         _d_x[1] += _r11;
+//CHECK-NEXT:         _d_x[0] += _r_d2 * y[1];
+//CHECK-NEXT:         _d_y[1] += x[0] * _r_d2;
+//CHECK-NEXT:         _d_y[0] += -_r_d2 * x[1];
+//CHECK-NEXT:         _d_x[1] += y[0] * -_r_d2;
 //CHECK-NEXT:         _delta_output[2] += std::abs(_r_d2 * _EERepl_output3 * {{.+}});
 //CHECK-NEXT:         _final_error += _delta_output[2];
 //CHECK-NEXT:         _d_output[2] -= _r_d2;
@@ -326,14 +312,10 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         output[1] = _t1;
 //CHECK-NEXT:         double _r_d1 = _d_output[1];
-//CHECK-NEXT:         double _r4 = _r_d1 * y[0];
-//CHECK-NEXT:         _d_x[2] += _r4;
-//CHECK-NEXT:         double _r5 = x[2] * _r_d1;
-//CHECK-NEXT:         _d_y[0] += _r5;
-//CHECK-NEXT:         double _r6 = -_r_d1 * y[2];
-//CHECK-NEXT:         _d_x[0] += _r6;
-//CHECK-NEXT:         double _r7 = x[0] * -_r_d1;
-//CHECK-NEXT:         _d_y[2] += _r7;
+//CHECK-NEXT:         _d_x[2] += _r_d1 * y[0];
+//CHECK-NEXT:         _d_y[0] += x[2] * _r_d1;
+//CHECK-NEXT:         _d_x[0] += -_r_d1 * y[2];
+//CHECK-NEXT:         _d_y[2] += x[0] * -_r_d1;
 //CHECK-NEXT:         _delta_output[1] += std::abs(_r_d1 * _EERepl_output2 * {{.+}});
 //CHECK-NEXT:         _final_error += _delta_output[1];
 //CHECK-NEXT:         _d_output[1] -= _r_d1;
@@ -342,14 +324,10 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         output[0] = _t0;
 //CHECK-NEXT:         double _r_d0 = _d_output[0];
-//CHECK-NEXT:         double _r0 = _r_d0 * y[2];
-//CHECK-NEXT:         _d_x[1] += _r0;
-//CHECK-NEXT:         double _r1 = x[1] * _r_d0;
-//CHECK-NEXT:         _d_y[2] += _r1;
-//CHECK-NEXT:         double _r2 = -_r_d0 * y[1];
-//CHECK-NEXT:         _d_x[2] += _r2;
-//CHECK-NEXT:         double _r3 = x[2] * -_r_d0;
-//CHECK-NEXT:         _d_y[1] += _r3;
+//CHECK-NEXT:         _d_x[1] += _r_d0 * y[2];
+//CHECK-NEXT:         _d_y[2] += x[1] * _r_d0;
+//CHECK-NEXT:         _d_x[2] += -_r_d0 * y[1];
+//CHECK-NEXT:         _d_y[1] += x[2] * -_r_d0;
 //CHECK-NEXT:         _delta_output[0] += std::abs(_r_d0 * _EERepl_output1 * {{.+}});
 //CHECK-NEXT:         _final_error += _delta_output[0];
 //CHECK-NEXT:         _d_output[0] -= _r_d0;

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -40,12 +40,10 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             _d_sum += _r_d0;
 //CHECK-NEXT:             _d_f[i] += _r_d0;
 //CHECK-NEXT:             _d_f[i - 1] += _r_d0;
 //CHECK-NEXT:             double _r0 = clad::pop(_EERepl_sum1);
 //CHECK-NEXT:             _delta_sum += std::abs(_r_d0 * _r0 * {{.+}});
-//CHECK-NEXT:             _d_sum -= _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
@@ -103,14 +101,10 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:                 j--;
 //CHECK-NEXT:                 sum = clad::pop(_t3);
 //CHECK-NEXT:                 double _r_d0 = _d_sum;
-//CHECK-NEXT:                 _d_sum += _r_d0;
-//CHECK-NEXT:                 double _r0 = _r_d0 * b[j];
-//CHECK-NEXT:                 _d_a[i] += _r0;
-//CHECK-NEXT:                 double _r1 = a[i] * _r_d0;
-//CHECK-NEXT:                 _d_b[j] += _r1;
-//CHECK-NEXT:                 double _r2 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:                 _delta_sum += std::abs(_r_d0 * _r2 * {{.+}});
-//CHECK-NEXT:                 _d_sum -= _r_d0;
+//CHECK-NEXT:                 _d_a[i] += _r_d0 * b[j];
+//CHECK-NEXT:                 _d_b[j] += a[i] * _r_d0;
+//CHECK-NEXT:                 double _r0 = clad::pop(_EERepl_sum1);
+//CHECK-NEXT:                 _delta_sum += std::abs(_r_d0 * _r0 * {{.+}});
 //CHECK-NEXT:             }
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 _d_j = 0;
@@ -171,15 +165,12 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             _d_sum += _r_d0;
 //CHECK-NEXT:             float _r0 = clad::pop(_t2);
-//CHECK-NEXT:             double _r1 = _r_d0 / _r0;
-//CHECK-NEXT:             _d_a[i] += _r1;
-//CHECK-NEXT:             double _r2 = _r_d0 * -a[i] / (_r0 * _r0);
-//CHECK-NEXT:             _d_b[i] += _r2;
-//CHECK-NEXT:             double _r3 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:             _delta_sum += std::abs(_r_d0 * _r3 * {{.+}});
-//CHECK-NEXT:             _d_sum -= _r_d0;
+//CHECK-NEXT:             _d_a[i] += _r_d0 / _r0;
+//CHECK-NEXT:             double _r1 = _r_d0 * -a[i] / (_r0 * _r0);
+//CHECK-NEXT:             _d_b[i] += _r1;
+//CHECK-NEXT:             double _r2 = clad::pop(_EERepl_sum1);
+//CHECK-NEXT:             _delta_sum += std::abs(_r_d0 * _r2 * {{.+}});
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -146,7 +146,6 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
-//CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     clad::tape<double> _EERepl_sum1 = {};
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _EERepl_sum0 = sum;
@@ -154,7 +153,7 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:     for (int i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
-//CHECK-NEXT:         sum += a[i] / clad::push(_t2, b[i]);
+//CHECK-NEXT:         sum += a[i] / b[i];
 //CHECK-NEXT:         clad::push(_EERepl_sum1, sum);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
@@ -165,28 +164,27 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             float _r0 = clad::pop(_t2);
-//CHECK-NEXT:             _d_a[i] += _r_d0 / _r0;
-//CHECK-NEXT:             double _r1 = _r_d0 * -a[i] / (_r0 * _r0);
-//CHECK-NEXT:             _d_b[i] += _r1;
-//CHECK-NEXT:             double _r2 = clad::pop(_EERepl_sum1);
-//CHECK-NEXT:             _delta_sum += std::abs(_r_d0 * _r2 * {{.+}});
+//CHECK-NEXT:             _d_a[i] += _r_d0 / b[i];
+//CHECK-NEXT:             double _r0 = _r_d0 * -a[i] / (b[i] * b[i]);
+//CHECK-NEXT:             _d_b[i] += _r0;
+//CHECK-NEXT:             double _r1 = clad::pop(_EERepl_sum1);
+//CHECK-NEXT:             _delta_sum += std::abs(_r_d0 * _r1 * {{.+}});
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_a(_d_a.size());
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i < _d_a.size(); i++) {
-//CHECK-NEXT:         double _t3 = std::abs(_d_a[i] * a[i] * {{.+}});
-//CHECK-NEXT:         _delta_a[i] += _t3;
-//CHECK-NEXT:         _final_error += _t3;
+//CHECK-NEXT:         double _t2 = std::abs(_d_a[i] * a[i] * {{.+}});
+//CHECK-NEXT:         _delta_a[i] += _t2;
+//CHECK-NEXT:         _final_error += _t2;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     clad::array<float> _delta_b(_d_b.size());
 //CHECK-NEXT:     i = 0;
 //CHECK-NEXT:     for (; i < _d_b.size(); i++) {
-//CHECK-NEXT:         double _t4 = std::abs(_d_b[i] * b[i] * {{.+}});
-//CHECK-NEXT:         _delta_b[i] += _t4;
-//CHECK-NEXT:         _final_error += _t4;
+//CHECK-NEXT:         double _t3 = std::abs(_d_b[i] * b[i] * {{.+}});
+//CHECK-NEXT:         _delta_b[i] += _t3;
+//CHECK-NEXT:         _final_error += _t3;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += _delta_sum;
 //CHECK-NEXT: }

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -209,20 +209,18 @@ double f11(double x, double y) {
 // CHECK-NEXT:         double _r0 = _grad0;
 // CHECK-NEXT:         * _d_x += -_r0;
 // CHECK-NEXT:         int _r1 = _grad1;
-// CHECK-NEXT:         double _r2 = 1 * _t0;
-// CHECK-NEXT:         double _r3 = 100. * 1;
 // CHECK-NEXT:         double _grad4 = 0.;
 // CHECK-NEXT:         int _grad5 = 0;
-// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(y - std::pow(x, 2), 2, _r3, &_grad4, &_grad5);
-// CHECK-NEXT:         double _r4 = _grad4;
-// CHECK-NEXT:         * _d_y += _r4;
+// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(y - std::pow(x, 2), 2, 100. * 1, &_grad4, &_grad5);
+// CHECK-NEXT:         double _r2 = _grad4;
+// CHECK-NEXT:         * _d_y += _r2;
 // CHECK-NEXT:         double _grad2 = 0.;
 // CHECK-NEXT:         int _grad3 = 0;
-// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(x, 2, -_r4, &_grad2, &_grad3);
-// CHECK-NEXT:         double _r5 = _grad2;
-// CHECK-NEXT:         * _d_x += _r5;
-// CHECK-NEXT:         int _r6 = _grad3;
-// CHECK-NEXT:         int _r7 = _grad5;
+// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(x, 2, -_r2, &_grad2, &_grad3);
+// CHECK-NEXT:         double _r3 = _grad2;
+// CHECK-NEXT:         * _d_x += _r3;
+// CHECK-NEXT:         int _r4 = _grad3;
+// CHECK-NEXT:         int _r5 = _grad5;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -91,20 +91,16 @@ double f3(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           y = _t2;
 //CHECK-NEXT:           double _r_d2 = * _d_y;
-//CHECK-NEXT:           double _r2 = _r_d2 * x;
-//CHECK-NEXT:           * _d_x += _r2;
-//CHECK-NEXT:           double _r3 = x * _r_d2;
-//CHECK-NEXT:           * _d_x += _r3;
+//CHECK-NEXT:           * _d_x += _r_d2 * x;
+//CHECK-NEXT:           * _d_x += x * _r_d2;
 //CHECK-NEXT:           * _d_y -= _r_d2;
 //CHECK-NEXT:           * _d_y;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t1;
 //CHECK-NEXT:           double _r_d1 = * _d_x;
-//CHECK-NEXT:           double _r0 = _r_d1 * x;
-//CHECK-NEXT:           * _d_x += _r0;
-//CHECK-NEXT:           double _r1 = x * _r_d1;
-//CHECK-NEXT:           * _d_x += _r1;
+//CHECK-NEXT:           * _d_x += _r_d1 * x;
+//CHECK-NEXT:           * _d_x += x * _r_d1;
 //CHECK-NEXT:           * _d_x -= _r_d1;
 //CHECK-NEXT:           * _d_x;
 //CHECK-NEXT:       }
@@ -206,10 +202,8 @@ double f5(double x, double y) {
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = _d_t * x;
-//CHECK-NEXT:           * _d_x += _r0;
-//CHECK-NEXT:           double _r1 = x * _d_t;
-//CHECK-NEXT:           * _d_x += _r1;
+//CHECK-NEXT:           * _d_x += _d_t * x;
+//CHECK-NEXT:           * _d_x += x * _d_t;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -270,10 +264,8 @@ double f6(double x, double y) {
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = _d_t * x;
-//CHECK-NEXT:           * _d_x += _r0;
-//CHECK-NEXT:           double _r1 = x * _d_t;
-//CHECK-NEXT:           * _d_x += _r1;
+//CHECK-NEXT:           * _d_x += _d_t * x;
+//CHECK-NEXT:           * _d_x += x * _d_t;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -337,17 +329,15 @@ double f7(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[0] = _t6;
 //CHECK-NEXT:           double _r_d5 = _d_t[0];
-//CHECK-NEXT:           _d_t[0] += _r_d5;
 //CHECK-NEXT:           _d_t[1] += -_r_d5;
-//CHECK-NEXT:           _d_t[0] -= _r_d5;
 //CHECK-NEXT:           _d_t[0];
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[0] = _t4;
 //CHECK-NEXT:           double _r_d4 = _d_t[0];
 //CHECK-NEXT:           _d_t[0] += _r_d4 / _t5;
-//CHECK-NEXT:           double _r3 = _r_d4 * -t[0] / (_t5 * _t5);
-//CHECK-NEXT:           _d_t[1] += _r3;
+//CHECK-NEXT:           double _r0 = _r_d4 * -t[0] / (_t5 * _t5);
+//CHECK-NEXT:           _d_t[1] += _r0;
 //CHECK-NEXT:           _d_t[0] -= _r_d4;
 //CHECK-NEXT:           _d_t[0];
 //CHECK-NEXT:       }
@@ -355,17 +345,14 @@ double f7(double x, double y) {
 //CHECK-NEXT:           t[0] = _t3;
 //CHECK-NEXT:           double _r_d3 = _d_t[0];
 //CHECK-NEXT:           _d_t[0] += _r_d3 * t[1];
-//CHECK-NEXT:           double _r2 = t[0] * _r_d3;
-//CHECK-NEXT:           _d_t[1] += _r2;
+//CHECK-NEXT:           _d_t[1] += t[0] * _r_d3;
 //CHECK-NEXT:           _d_t[0] -= _r_d3;
 //CHECK-NEXT:           _d_t[0];
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[0] = _t2;
 //CHECK-NEXT:           double _r_d2 = _d_t[0];
-//CHECK-NEXT:           _d_t[0] += _r_d2;
 //CHECK-NEXT:           _d_t[1] += _r_d2;
-//CHECK-NEXT:           _d_t[0] -= _r_d2;
 //CHECK-NEXT:           _d_t[0];
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
@@ -394,10 +381,8 @@ double f7(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           * _d_x += _d_t[1];
-//CHECK-NEXT:           double _r0 = _d_t[2] * x;
-//CHECK-NEXT:           * _d_x += _r0;
-//CHECK-NEXT:           double _r1 = x * _d_t[2];
-//CHECK-NEXT:           * _d_x += _r1;
+//CHECK-NEXT:           * _d_x += _d_t[2] * x;
+//CHECK-NEXT:           * _d_x += x * _d_t[2];
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -429,8 +414,7 @@ double f8(double x, double y) {
 //CHECK-NEXT:           y = _t1;
 //CHECK-NEXT:           double _r_d1 = * _d_y;
 //CHECK-NEXT:           * _d_y += _r_d1 * t[2];
-//CHECK-NEXT:           double _r0 = y * _r_d1;
-//CHECK-NEXT:           _d_t[0] += _r0;
+//CHECK-NEXT:           _d_t[0] += y * _r_d1;
 //CHECK-NEXT:           t[0] = _t2;
 //CHECK-NEXT:           double _r_d2 = _d_t[0];
 //CHECK-NEXT:           _d_t[1] += _r_d2;
@@ -471,14 +455,12 @@ double f9(double x, double y) {
 //CHECK-NEXT:           t = _t2;
 //CHECK-NEXT:           double _r_d1 = _d_t;
 //CHECK-NEXT:           _d_t += _r_d1 * y;
-//CHECK-NEXT:           double _r1 = _t1 * _r_d1;
-//CHECK-NEXT:           * _d_y += _r1;
+//CHECK-NEXT:           * _d_y += _t1 * _r_d1;
 //CHECK-NEXT:           _d_t -= _r_d1;
 //CHECK-NEXT:           t = _t0;
 //CHECK-NEXT:           double _r_d0 = _d_t;
 //CHECK-NEXT:           _d_t += _r_d0 * x;
-//CHECK-NEXT:           double _r0 = t * _r_d0;
-//CHECK-NEXT:           * _d_x += _r0;
+//CHECK-NEXT:           * _d_x += t * _r_d0;
 //CHECK-NEXT:           _d_t -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       * _d_x += _d_t;
@@ -576,8 +558,7 @@ double f12(double x, double y) {
 //CHECK-NEXT:           t = _t4;
 //CHECK-NEXT:           double _r_d2 = (_cond0 ? _d_t : _d_t);
 //CHECK-NEXT:           (_cond0 ? _d_t : _d_t) += _r_d2 * y;
-//CHECK-NEXT:           double _r0 = _t2 * _r_d2;
-//CHECK-NEXT:           * _d_y += _r0;
+//CHECK-NEXT:           * _d_y += _t2 * _r_d2;
 //CHECK-NEXT:           (_cond0 ? _d_t : _d_t) -= _r_d2;
 //CHECK-NEXT:           if (_cond0) {
 //CHECK-NEXT:               t = _t0;
@@ -608,16 +589,12 @@ double f13(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:       _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r2 = 1 * y;
-//CHECK-NEXT:           _d_t += _r2;
-//CHECK-NEXT:           double _r3 = t * 1;
-//CHECK-NEXT:           * _d_y += _r3;
+//CHECK-NEXT:           _d_t += 1 * y;
+//CHECK-NEXT:           * _d_y += t * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = _d_t * _t0;
-//CHECK-NEXT:           * _d_x += _r0;
-//CHECK-NEXT:           double _r1 = x * _d_t;
-//CHECK-NEXT:           * _d_y += _r1;
+//CHECK-NEXT:           * _d_x += _d_t * _t0;
+//CHECK-NEXT:           * _d_y += x * _d_t;
 //CHECK-NEXT:           y = _t1;
 //CHECK-NEXT:           double _r_d0 = * _d_y;
 //CHECK-NEXT:           * _d_x += _r_d0;
@@ -653,23 +630,18 @@ double f14(double i, double j) {
 // CHECK-NEXT:         a = _t2;
 // CHECK-NEXT:         double _r_d2 = *_d_a;
 // CHECK-NEXT:         *_d_a += _r_d2 * i;
-// CHECK-NEXT:         double _r2 = a * _r_d2;
-// CHECK-NEXT:         * _d_i += _r2;
+// CHECK-NEXT:         * _d_i += a * _r_d2;
 // CHECK-NEXT:         *_d_a -= _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t1;
 // CHECK-NEXT:         double _r_d1 = *_d_a;
-// CHECK-NEXT:         *_d_a += _r_d1;
 // CHECK-NEXT:         * _d_i += _r_d1;
-// CHECK-NEXT:         *_d_a -= _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_a;
-// CHECK-NEXT:         double _r0 = _r_d0 * i;
-// CHECK-NEXT:         double _r1 = 2 * _r_d0;
-// CHECK-NEXT:         * _d_i += _r1;
+// CHECK-NEXT:         * _d_i += 2 * _r_d0;
 // CHECK-NEXT:         *_d_a -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -721,43 +693,29 @@ double f15(double i, double j) {
 // CHECK-NEXT:         d = _t3;
 // CHECK-NEXT:         double _r_d3 = *_d_d;
 // CHECK-NEXT:         *_d_d += _r_d3 * 3 * j;
-// CHECK-NEXT:         double _r7 = d * _r_d3;
-// CHECK-NEXT:         double _r8 = _r7 * j;
-// CHECK-NEXT:         double _r9 = 3 * _r7;
-// CHECK-NEXT:         * _d_j += _r9;
+// CHECK-NEXT:         * _d_j += 3 * d * _r_d3;
 // CHECK-NEXT:         *_d_d -= _r_d3;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         c = _t2;
 // CHECK-NEXT:         double _r_d2 = *_d_c;
-// CHECK-NEXT:         *_d_c += _r_d2;
-// CHECK-NEXT:         double _r5 = _r_d2 * i;
-// CHECK-NEXT:         double _r6 = 3 * _r_d2;
-// CHECK-NEXT:         * _d_i += _r6;
-// CHECK-NEXT:         *_d_c -= _r_d2;
+// CHECK-NEXT:         * _d_i += 3 * _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         b = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_b;
-// CHECK-NEXT:         _d_b += _r_d1;
-// CHECK-NEXT:         double _r3 = _r_d1 * i;
-// CHECK-NEXT:         double _r4 = 2 * _r_d1;
-// CHECK-NEXT:         * _d_i += _r4;
-// CHECK-NEXT:         _d_b -= _r_d1;
+// CHECK-NEXT:         * _d_i += 2 * _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_a;
 // CHECK-NEXT:         *_d_a += _r_d0 * i;
-// CHECK-NEXT:         double _r2 = a * _r_d0;
-// CHECK-NEXT:         * _d_i += _r2;
+// CHECK-NEXT:         * _d_i += a * _r_d0;
 // CHECK-NEXT:         *_d_a -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = _d_b * j;
-// CHECK-NEXT:         * _d_i += _r0;
-// CHECK-NEXT:         double _r1 = i * _d_b;
-// CHECK-NEXT:         * _d_j += _r1;
+// CHECK-NEXT:         * _d_i += _d_b * j;
+// CHECK-NEXT:         * _d_j += i * _d_b;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -789,10 +747,7 @@ double f16(double i, double j) {
 // CHECK-NEXT:         c = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_c;
 // CHECK-NEXT:         *_d_c += _r_d0 * 4 * j;
-// CHECK-NEXT:         double _r0 = c * _r_d0;
-// CHECK-NEXT:         double _r1 = _r0 * j;
-// CHECK-NEXT:         double _r2 = 4 * _r0;
-// CHECK-NEXT:         * _d_j += _r2;
+// CHECK-NEXT:         * _d_j += 4 * c * _r_d0;
 // CHECK-NEXT:         *_d_c -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -814,9 +769,7 @@ double f17(double i, double j, double k) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         j = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_j;
-// CHECK-NEXT:         double _r0 = _r_d0 * i;
-// CHECK-NEXT:         double _r1 = 2 * _r_d0;
-// CHECK-NEXT:         * _d_i += _r1;
+// CHECK-NEXT:         * _d_i += 2 * _r_d0;
 // CHECK-NEXT:         _d_j -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -841,19 +794,13 @@ double f18(double i, double j, double k) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         k = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_k;
-// CHECK-NEXT:         _d_k += _r_d1;
 // CHECK-NEXT:         * _d_i += _r_d1;
-// CHECK-NEXT:         _d_k -= _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         k = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_k;
-// CHECK-NEXT:         double _r0 = _r_d0 * i;
-// CHECK-NEXT:         double _r1 = 2 * _r_d0;
-// CHECK-NEXT:         * _d_i += _r1;
-// CHECK-NEXT:         double _r2 = _r_d0 * j;
-// CHECK-NEXT:         double _r3 = 2 * _r_d0;
-// CHECK-NEXT:         * _d_j += _r3;
+// CHECK-NEXT:         * _d_i += 2 * _r_d0;
+// CHECK-NEXT:         * _d_j += 2 * _r_d0;
 // CHECK-NEXT:         _d_k -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -902,10 +849,8 @@ double f20(double x, double y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _r_d1 = * _d_x;
-//CHECK-NEXT:         double _r0 = _r_d1 * y;
-//CHECK-NEXT:         *_d_r += _r0;
-//CHECK-NEXT:         double _r1 = r * _r_d1;
-//CHECK-NEXT:         * _d_y += _r1;
+//CHECK-NEXT:         *_d_r += _r_d1 * y;
+//CHECK-NEXT:         * _d_y += r * _r_d1;
 //CHECK-NEXT:         * _d_x -= _r_d1;
 //CHECK-NEXT:         * _d_x;
 //CHECK-NEXT:     }

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -294,7 +294,6 @@ double f7(double x, double y) {
 //CHECK-NEXT:       double _t4;
 //CHECK-NEXT:       double _t5;
 //CHECK-NEXT:       double _t6;
-//CHECK-NEXT:       double _t7;
 //CHECK-NEXT:       double t[3] = {1, x, x * x};
 //CHECK-NEXT:       t[0]++;
 //CHECK-NEXT:       t[0]--;
@@ -309,17 +308,16 @@ double f7(double x, double y) {
 //CHECK-NEXT:       _t3 = t[0];
 //CHECK-NEXT:       t[0] *= t[1];
 //CHECK-NEXT:       _t4 = t[0];
-//CHECK-NEXT:       _t5 = t[1];
-//CHECK-NEXT:       t[0] /= _t5;
-//CHECK-NEXT:       _t6 = t[0];
+//CHECK-NEXT:       t[0] /= t[1];
+//CHECK-NEXT:       _t5 = t[0];
 //CHECK-NEXT:       t[0] -= t[1];
-//CHECK-NEXT:       _t7 = x;
+//CHECK-NEXT:       _t6 = x;
 //CHECK-NEXT:       x = ++t[0];
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t[0] += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           x = _t7;
+//CHECK-NEXT:           x = _t6;
 //CHECK-NEXT:           double _r_d6 = * _d_x;
 //CHECK-NEXT:           _d_t[0] += _r_d6;
 //CHECK-NEXT:           --t[0];
@@ -327,7 +325,7 @@ double f7(double x, double y) {
 //CHECK-NEXT:           * _d_x;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           t[0] = _t6;
+//CHECK-NEXT:           t[0] = _t5;
 //CHECK-NEXT:           double _r_d5 = _d_t[0];
 //CHECK-NEXT:           _d_t[1] += -_r_d5;
 //CHECK-NEXT:           _d_t[0];
@@ -335,8 +333,8 @@ double f7(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[0] = _t4;
 //CHECK-NEXT:           double _r_d4 = _d_t[0];
-//CHECK-NEXT:           _d_t[0] += _r_d4 / _t5;
-//CHECK-NEXT:           double _r0 = _r_d4 * -t[0] / (_t5 * _t5);
+//CHECK-NEXT:           _d_t[0] += _r_d4 / t[1];
+//CHECK-NEXT:           double _r0 = _r_d4 * -t[0] / (t[1] * t[1]);
 //CHECK-NEXT:           _d_t[1] += _r0;
 //CHECK-NEXT:           _d_t[0] -= _r_d4;
 //CHECK-NEXT:           _d_t[0];

--- a/test/Gradient/DiffInterface.C
+++ b/test/Gradient/DiffInterface.C
@@ -18,15 +18,9 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * x;
-//CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           * _d_x += _r1;
-//CHECK-NEXT:           double _r2 = 1 * y;
-//CHECK-NEXT:           double _r3 = 1 * 1;
-//CHECK-NEXT:           * _d_y += _r3;
-//CHECK-NEXT:           double _r4 = 1 * z;
-//CHECK-NEXT:           double _r5 = 2 * 1;
-//CHECK-NEXT:           * _d_z += _r5;
+//CHECK-NEXT:           * _d_x += 0 * 1;
+//CHECK-NEXT:           * _d_y += 1 * 1;
+//CHECK-NEXT:           * _d_z += 2 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -37,15 +31,9 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * x;
-//CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           * _d_x += _r1;
-//CHECK-NEXT:           double _r2 = 1 * y;
-//CHECK-NEXT:           double _r3 = 1 * 1;
-//CHECK-NEXT:           _d_y += _r3;
-//CHECK-NEXT:           double _r4 = 1 * z;
-//CHECK-NEXT:           double _r5 = 2 * 1;
-//CHECK-NEXT:           _d_z += _r5;
+//CHECK-NEXT:           * _d_x += 0 * 1;
+//CHECK-NEXT:           _d_y += 1 * 1;
+//CHECK-NEXT:           _d_z += 2 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -56,15 +44,9 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * x;
-//CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           _d_x += _r1;
-//CHECK-NEXT:           double _r2 = 1 * y;
-//CHECK-NEXT:           double _r3 = 1 * 1;
-//CHECK-NEXT:           * _d_y += _r3;
-//CHECK-NEXT:           double _r4 = 1 * z;
-//CHECK-NEXT:           double _r5 = 2 * 1;
-//CHECK-NEXT:           _d_z += _r5;
+//CHECK-NEXT:           _d_x += 0 * 1;
+//CHECK-NEXT:           * _d_y += 1 * 1;
+//CHECK-NEXT:           _d_z += 2 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -75,15 +57,9 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * x;
-//CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           _d_x += _r1;
-//CHECK-NEXT:           double _r2 = 1 * y;
-//CHECK-NEXT:           double _r3 = 1 * 1;
-//CHECK-NEXT:           _d_y += _r3;
-//CHECK-NEXT:           double _r4 = 1 * z;
-//CHECK-NEXT:           double _r5 = 2 * 1;
-//CHECK-NEXT:           * _d_z += _r5;
+//CHECK-NEXT:           _d_x += 0 * 1;
+//CHECK-NEXT:           _d_y += 1 * 1;
+//CHECK-NEXT:           * _d_z += 2 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -93,15 +69,9 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * x;
-//CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           * _d_x += _r1;
-//CHECK-NEXT:           double _r2 = 1 * y;
-//CHECK-NEXT:           double _r3 = 1 * 1;
-//CHECK-NEXT:           * _d_y += _r3;
-//CHECK-NEXT:           double _r4 = 1 * z;
-//CHECK-NEXT:           double _r5 = 2 * 1;
-//CHECK-NEXT:           _d_z += _r5;
+//CHECK-NEXT:           * _d_x += 0 * 1;
+//CHECK-NEXT:           * _d_y += 1 * 1;
+//CHECK-NEXT:           _d_z += 2 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -111,15 +81,9 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * x;
-//CHECK-NEXT:           double _r1 = 0 * 1;
-//CHECK-NEXT:           _d_x += _r1;
-//CHECK-NEXT:           double _r2 = 1 * y;
-//CHECK-NEXT:           double _r3 = 1 * 1;
-//CHECK-NEXT:           * _d_y += _r3;
-//CHECK-NEXT:           double _r4 = 1 * z;
-//CHECK-NEXT:           double _r5 = 2 * 1;
-//CHECK-NEXT:           * _d_z += _r5;
+//CHECK-NEXT:           _d_x += 0 * 1;
+//CHECK-NEXT:           * _d_y += 1 * 1;
+//CHECK-NEXT:           * _d_z += 2 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -35,10 +35,8 @@ double fn1(float i) {
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r1 = _d_a * i;
-// CHECK-NEXT:         _d_res += _r1;
-// CHECK-NEXT:         double _r2 = res * _d_a;
-// CHECK-NEXT:         * _d_i += _r2;
+// CHECK-NEXT:         _d_res += _d_a * i;
+// CHECK-NEXT:         * _d_i += res * _d_a;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;
@@ -75,16 +73,12 @@ double modify1(double& i, double& j) {
 // CHECK-NEXT:         j = _t1;
 // CHECK-NEXT:         double _r_d1 = * _d_j;
 // CHECK-NEXT:         * _d_j += _r_d1;
-// CHECK-NEXT:         * _d_j += _r_d1;
-// CHECK-NEXT:         * _d_j -= _r_d1;
 // CHECK-NEXT:         * _d_j;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         i = _t0;
 // CHECK-NEXT:         double _r_d0 = * _d_i;
-// CHECK-NEXT:         * _d_i += _r_d0;
 // CHECK-NEXT:         * _d_j += _r_d0;
-// CHECK-NEXT:         * _d_i -= _r_d0;
 // CHECK-NEXT:         * _d_i;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -154,16 +148,12 @@ void update1(double& i, double& j) {
 // CHECK-NEXT:         j = _t1;
 // CHECK-NEXT:         double _r_d1 = * _d_j;
 // CHECK-NEXT:         * _d_j += _r_d1;
-// CHECK-NEXT:         * _d_j += _r_d1;
-// CHECK-NEXT:         * _d_j -= _r_d1;
 // CHECK-NEXT:         * _d_j;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         i = _t0;
 // CHECK-NEXT:         double _r_d0 = * _d_i;
-// CHECK-NEXT:         * _d_i += _r_d0;
 // CHECK-NEXT:         * _d_j += _r_d0;
-// CHECK-NEXT:         * _d_i -= _r_d0;
 // CHECK-NEXT:         * _d_i;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -233,20 +223,14 @@ float sum(double* arr, int n) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         arr[0] = _t2;
 // CHECK-NEXT:         double _r_d1 = _d_arr[0];
-// CHECK-NEXT:         _d_arr[0] += _r_d1;
-// CHECK-NEXT:         double _r0 = _r_d1 * arr[0];
-// CHECK-NEXT:         double _r1 = 10 * _r_d1;
-// CHECK-NEXT:         _d_arr[0] += _r1;
-// CHECK-NEXT:         _d_arr[0] -= _r_d1;
+// CHECK-NEXT:         _d_arr[0] += 10 * _r_d1;
 // CHECK-NEXT:         _d_arr[0];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         res = clad::pop(_t1);
 // CHECK-NEXT:         float _r_d0 = _d_res;
-// CHECK-NEXT:         _d_res += _r_d0;
 // CHECK-NEXT:         _d_arr[i] += _r_d0;
-// CHECK-NEXT:         _d_res -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -261,9 +245,7 @@ void twice(double& d) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         d = _t0;
 // CHECK-NEXT:         double _r_d0 = * _d_d;
-// CHECK-NEXT:         double _r0 = _r_d0 * d;
-// CHECK-NEXT:         double _r1 = 2 * _r_d0;
-// CHECK-NEXT:         * _d_d += _r1;
+// CHECK-NEXT:         * _d_d += 2 * _r_d0;
 // CHECK-NEXT:         * _d_d -= _r_d0;
 // CHECK-NEXT:         * _d_d;
 // CHECK-NEXT:     }
@@ -307,9 +289,7 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t4);
 // CHECK-NEXT:             double _r_d1 = _d_res;
-// CHECK-NEXT:             _d_res += _r_d1;
 // CHECK-NEXT:             _d_arr[i] += _r_d1;
-// CHECK-NEXT:             _d_res -= _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r3 = clad::pop(_t3);
@@ -321,14 +301,12 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         _d_res += _r_d0;
 // CHECK-NEXT:         arr = _t1;
 // CHECK-NEXT:         int _grad1 = 0;
 // CHECK-NEXT:         sum_pullback(_t1, n, _r_d0, _d_arr, &_grad1);
 // CHECK-NEXT:         clad::array<double> _r0(_d_arr);
 // CHECK-NEXT:         int _r1 = _grad1;
 // CHECK-NEXT:         * _d_n += _r1;
-// CHECK-NEXT:         _d_res -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -347,9 +325,7 @@ double modify2(double* arr) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         arr[0] = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_arr[0];
-// CHECK-NEXT:         double _r0 = _r_d0 * arr[0];
-// CHECK-NEXT:         double _r1 = 5 * _r_d0;
-// CHECK-NEXT:         _d_arr[0] += _r1;
+// CHECK-NEXT:         _d_arr[0] += 5 * _r_d0;
 // CHECK-NEXT:         _d_arr[1] += _r_d0;
 // CHECK-NEXT:         _d_arr[0] -= _r_d0;
 // CHECK-NEXT:         _d_arr[0];
@@ -403,10 +379,8 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * j;
-// CHECK-NEXT:         * _d_i += _r0;
-// CHECK-NEXT:         double _r1 = i * 1;
-// CHECK-NEXT:         * _d_j += _r1;
+// CHECK-NEXT:         * _d_i += 1 * j;
+// CHECK-NEXT:         * _d_j += i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -423,8 +397,6 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_i0 = _t0;
 // CHECK-NEXT:         double _r_d0 = _d__d_i;
-// CHECK-NEXT:         _d__d_i += _r_d0;
-// CHECK-NEXT:         _d__d_i -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     * _d_i += _d__d_i;
 // CHECK-NEXT: }
@@ -467,20 +439,12 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         l = _t5;
 // CHECK-NEXT:         double _r_d1 = *_d_l;
-// CHECK-NEXT:         *_d_l += _r_d1;
-// CHECK-NEXT:         double _r4 = _r_d1 * i;
-// CHECK-NEXT:         double _r5 = 9 * _r_d1;
-// CHECK-NEXT:         * _d_i += _r5;
-// CHECK-NEXT:         *_d_l -= _r_d1;
+// CHECK-NEXT:         * _d_i += 9 * _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         k = _t4;
 // CHECK-NEXT:         double _r_d0 = *_d_k;
-// CHECK-NEXT:         *_d_k += _r_d0;
-// CHECK-NEXT:         double _r2 = _r_d0 * j;
-// CHECK-NEXT:         double _r3 = 7 * _r_d0;
-// CHECK-NEXT:         * _d_j += _r3;
-// CHECK-NEXT:         *_d_k -= _r_d0;
+// CHECK-NEXT:         * _d_j += 7 * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         j = _t2;
@@ -506,14 +470,8 @@ double fn8(double x, double y) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * _t0;
-// CHECK-NEXT:         double _r1 = _r0 * _t1;
-// CHECK-NEXT:         double _r2 = _r1 * y;
-// CHECK-NEXT:         * _d_x += _r2;
-// CHECK-NEXT:         double _r3 = x * _r1;
-// CHECK-NEXT:         * _d_y += _r3;
-// CHECK-NEXT:         double _r4 = x * y * _r0;
-// CHECK-NEXT:         double _r5 = x * y * _t1 * 1;
+// CHECK-NEXT:         * _d_x += 1 * _t0 * _t1 * y;
+// CHECK-NEXT:         * _d_y += x * 1 * _t0 * _t1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -546,11 +504,9 @@ double fn9(double x, double y) {
 // CHECK-NEXT:        double _grad0 = 0.;
 // CHECK-NEXT:        custom_max_pullback(x * y, _t0, 1, &_grad0, &* _d_y);
 // CHECK-NEXT:        double _r0 = _grad0;
-// CHECK-NEXT:        double _r1 = _r0 * y;
-// CHECK-NEXT:        * _d_x += _r1;
-// CHECK-NEXT:        double _r2 = x * _r0;
-// CHECK-NEXT:        * _d_y += _r2;
-// CHECK-NEXT:        double _r3 = * _d_y;
+// CHECK-NEXT:        * _d_x += _r0 * y;
+// CHECK-NEXT:        * _d_y += x * _r0;
+// CHECK-NEXT:        double _r1 = * _d_y;
 // CHECK-NEXT:    }
 // CHECK-NEXT: }
 
@@ -583,10 +539,8 @@ double fn10(double x, double y) {
 // CHECK-NEXT:    goto _label0;
 // CHECK-NEXT:  _label0:
 // CHECK-NEXT:    {
-// CHECK-NEXT:        double _r7 = 1 * y;
-// CHECK-NEXT:        _d_out += _r7;
-// CHECK-NEXT:        double _r8 = out * 1;
-// CHECK-NEXT:        * _d_y += _r8;
+// CHECK-NEXT:        _d_out += 1 * y;
+// CHECK-NEXT:        * _d_y += out * 1;
 // CHECK-NEXT:    }
 // CHECK-NEXT:    {
 // CHECK-NEXT:        out = _t4;

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -18,13 +18,9 @@ struct Experiment {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * j;
-  // CHECK-NEXT:         double _r1 = _r0 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r1;
-  // CHECK-NEXT:         double _r2 = this->x * _r0;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = this->x * i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * j * i;
+  // CHECK-NEXT:         * _d_i += this->x * 1 * j;
+  // CHECK-NEXT:         * _d_j += this->x * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -40,13 +36,9 @@ struct ExperimentConst {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * j;
-  // CHECK-NEXT:         double _r1 = _r0 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r1;
-  // CHECK-NEXT:         double _r2 = this->x * _r0;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = this->x * i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * j * i;
+  // CHECK-NEXT:         * _d_i += this->x * 1 * j;
+  // CHECK-NEXT:         * _d_j += this->x * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -68,13 +60,9 @@ struct ExperimentVolatile {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * j;
-  // CHECK-NEXT:         double _r1 = _r0 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r1;
-  // CHECK-NEXT:         double _r2 = this->x * _r0;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = this->x * i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * j * i;
+  // CHECK-NEXT:         * _d_i += this->x * 1 * j;
+  // CHECK-NEXT:         * _d_j += this->x * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -96,13 +84,9 @@ struct ExperimentConstVolatile {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * j;
-  // CHECK-NEXT:         double _r1 = _r0 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r1;
-  // CHECK-NEXT:         double _r2 = this->x * _r0;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = this->x * i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * j * i;
+  // CHECK-NEXT:         * _d_i += this->x * 1 * j;
+  // CHECK-NEXT:         * _d_j += this->x * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -121,13 +105,9 @@ struct ExperimentNNS {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * j;
-  // CHECK-NEXT:         double _r1 = _r0 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r1;
-  // CHECK-NEXT:         double _r2 = this->x * _r0;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = this->x * i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * j * i;
+  // CHECK-NEXT:         * _d_i += this->x * 1 * j;
+  // CHECK-NEXT:         * _d_j += this->x * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -189,13 +169,9 @@ int main() {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * j;
-  // CHECK-NEXT:         double _r1 = _r0 * i;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = i * _r0;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         * _d_i += 1 * j * i;
+  // CHECK-NEXT:         * _d_i += i * 1 * j;
+  // CHECK-NEXT:         * _d_j += i * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -205,12 +181,8 @@ int main() {
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * j;
-  // CHECK-NEXT:         double _r1 = _r0 * ii;
-  // CHECK-NEXT:         double _r2 = x * _r0;
-  // CHECK-NEXT:         * _d_ii += _r2;
-  // CHECK-NEXT:         double _r3 = x * ii * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         * _d_ii += x * 1 * j;
+  // CHECK-NEXT:         * _d_j += x * ii * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -57,12 +57,14 @@ struct ExperimentVolatile {
   };
 
   // CHECK: void operator_call_grad(double i, double j, clad::array_ref<volatile ExperimentVolatile> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = this->x * i;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * j * i;
   // CHECK-NEXT:         * _d_i += this->x * 1 * j;
-  // CHECK-NEXT:         * _d_j += this->x * i * 1;
+  // CHECK-NEXT:         * _d_j += _t0 * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -81,12 +83,14 @@ struct ExperimentConstVolatile {
   };
 
   // CHECK: void operator_call_grad(double i, double j, clad::array_ref<volatile ExperimentConstVolatile> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = this->x * i;
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * j * i;
   // CHECK-NEXT:         * _d_i += this->x * 1 * j;
-  // CHECK-NEXT:         * _d_j += this->x * i * 1;
+  // CHECK-NEXT:         * _d_j += _t0 * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -35,12 +35,8 @@ double f_add2(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * x;
-//CHECK-NEXT:           double _r1 = 3 * 1;
-//CHECK-NEXT:           * _d_x += _r1;
-//CHECK-NEXT:           double _r2 = 1 * y;
-//CHECK-NEXT:           double _r3 = 4 * 1;
-//CHECK-NEXT:           * _d_y += _r3;
+//CHECK-NEXT:           * _d_x += 3 * 1;
+//CHECK-NEXT:           * _d_y += 4 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -54,13 +50,8 @@ double f_add3(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * x;
-//CHECK-NEXT:           double _r1 = 3 * 1;
-//CHECK-NEXT:           * _d_x += _r1;
-//CHECK-NEXT:           double _r2 = 1 * 4;
-//CHECK-NEXT:           double _r3 = _r2 * y;
-//CHECK-NEXT:           double _r4 = 4 * _r2;
-//CHECK-NEXT:           * _d_y += _r4;
+//CHECK-NEXT:           * _d_x += 3 * 1;
+//CHECK-NEXT:           * _d_y += 4 * 1 * 4;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -88,12 +79,8 @@ double f_sub2(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * x;
-//CHECK-NEXT:           double _r1 = 3 * 1;
-//CHECK-NEXT:           * _d_x += _r1;
-//CHECK-NEXT:           double _r2 = -1 * y;
-//CHECK-NEXT:           double _r3 = 4 * -1;
-//CHECK-NEXT:           * _d_y += _r3;
+//CHECK-NEXT:           * _d_x += 3 * 1;
+//CHECK-NEXT:           * _d_y += 4 * -1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -107,10 +94,8 @@ double f_mult1(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * y;
-//CHECK-NEXT:           * _d_x += _r0;
-//CHECK-NEXT:           double _r1 = x * 1;
-//CHECK-NEXT:           * _d_y += _r1;
+//CHECK-NEXT:           * _d_x += 1 * y;
+//CHECK-NEXT:           * _d_y += x * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -124,13 +109,8 @@ double f_mult2(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * y;
-//CHECK-NEXT:           double _r1 = _r0 * 4;
-//CHECK-NEXT:           double _r2 = _r1 * x;
-//CHECK-NEXT:           double _r3 = 3 * _r1;
-//CHECK-NEXT:           * _d_x += _r3;
-//CHECK-NEXT:           double _r4 = 3 * x * 4 * 1;
-//CHECK-NEXT:           * _d_y += _r4;
+//CHECK-NEXT:           * _d_x += 3 * 1 * y * 4;
+//CHECK-NEXT:           * _d_y += 3 * x * 4 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -146,10 +126,9 @@ double f_div1(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 / _t0;
-//CHECK-NEXT:           * _d_x += _r0;
-//CHECK-NEXT:           double _r1 = 1 * -x / (_t0 * _t0);
-//CHECK-NEXT:           * _d_y += _r1;
+//CHECK-NEXT:           * _d_x += 1 / _t0;
+//CHECK-NEXT:           double _r0 = 1 * -x / (_t0 * _t0);
+//CHECK-NEXT:           * _d_y += _r0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -165,14 +144,9 @@ double f_div2(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 / _t0;
-//CHECK-NEXT:           double _r1 = _r0 * x;
-//CHECK-NEXT:           double _r2 = 3 * _r0;
-//CHECK-NEXT:           * _d_x += _r2;
-//CHECK-NEXT:           double _r3 = 1 * -3 * x / (_t0 * _t0);
-//CHECK-NEXT:           double _r4 = _r3 * y;
-//CHECK-NEXT:           double _r5 = 4 * _r3;
-//CHECK-NEXT:           * _d_y += _r5;
+//CHECK-NEXT:           * _d_x += 3 * 1 / _t0;
+//CHECK-NEXT:           double _r0 = 1 * -3 * x / (_t0 * _t0);
+//CHECK-NEXT:           * _d_y += 4 * _r0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -188,22 +162,15 @@ double f_c(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * y;
-//CHECK-NEXT:           * _d_x += -_r0;
-//CHECK-NEXT:           double _r1 = -x * 1;
-//CHECK-NEXT:           * _d_y += _r1;
-//CHECK-NEXT:           double _r2 = 1 * (x / y);
-//CHECK-NEXT:           * _d_x += _r2;
-//CHECK-NEXT:           * _d_y += _r2;
-//CHECK-NEXT:           double _r3 = (x + y) * 1;
-//CHECK-NEXT:           double _r4 = _r3 / _t0;
-//CHECK-NEXT:           * _d_x += _r4;
-//CHECK-NEXT:           double _r5 = _r3 * -x / (_t0 * _t0);
-//CHECK-NEXT:           * _d_y += _r5;
-//CHECK-NEXT:           double _r6 = -1 * x;
-//CHECK-NEXT:           * _d_x += _r6;
-//CHECK-NEXT:           double _r7 = x * -1;
-//CHECK-NEXT:           * _d_x += _r7;
+//CHECK-NEXT:           * _d_x += -1 * y;
+//CHECK-NEXT:           * _d_y += -x * 1;
+//CHECK-NEXT:           * _d_x += 1 * (x / y);
+//CHECK-NEXT:           * _d_y += 1 * (x / y);
+//CHECK-NEXT:           * _d_x += (x + y) * 1 / _t0;
+//CHECK-NEXT:           double _r0 = (x + y) * 1 * -x / (_t0 * _t0);
+//CHECK-NEXT:           * _d_y += _r0;
+//CHECK-NEXT:           * _d_x += -1 * x;
+//CHECK-NEXT:           * _d_x += x * -1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -217,24 +184,14 @@ double f_rosenbrock(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * (x - 1);
-//CHECK-NEXT:           * _d_x += _r0;
-//CHECK-NEXT:           double _r1 = (x - 1) * 1;
-//CHECK-NEXT:           * _d_x += _r1;
-//CHECK-NEXT:           double _r2 = 1 * (y - x * x);
-//CHECK-NEXT:           double _r3 = _r2 * (y - x * x);
-//CHECK-NEXT:           double _r4 = 100 * _r2;
-//CHECK-NEXT:           * _d_y += _r4;
-//CHECK-NEXT:           double _r5 = -_r4 * x;
-//CHECK-NEXT:           * _d_x += _r5;
-//CHECK-NEXT:           double _r6 = x * -_r4;
-//CHECK-NEXT:           * _d_x += _r6;
-//CHECK-NEXT:           double _r7 = 100 * (y - x * x) * 1;
-//CHECK-NEXT:           * _d_y += _r7;
-//CHECK-NEXT:           double _r8 = -_r7 * x;
-//CHECK-NEXT:           * _d_x += _r8;
-//CHECK-NEXT:           double _r9 = x * -_r7;
-//CHECK-NEXT:           * _d_x += _r9;
+//CHECK-NEXT:           * _d_x += 1 * (x - 1);
+//CHECK-NEXT:           * _d_x += (x - 1) * 1;
+//CHECK-NEXT:           * _d_y += 100 * 1 * (y - x * x);
+//CHECK-NEXT:           * _d_x += -100 * 1 * (y - x * x) * x;
+//CHECK-NEXT:           * _d_x += x * -100 * 1 * (y - x * x);
+//CHECK-NEXT:           * _d_y += 100 * (y - x * x) * 1;
+//CHECK-NEXT:           * _d_x += -100 * (y - x * x) * 1 * x;
+//CHECK-NEXT:           * _d_x += x * -100 * (y - x * x) * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -329,10 +286,8 @@ double f_cond4(double x, double y) {
 //CHECK-NEXT:           {
 //CHECK-NEXT:               y = _t0;
 //CHECK-NEXT:               double _r_d0 = * _d_y;
-//CHECK-NEXT:               double _r0 = _r_d0 * x;
-//CHECK-NEXT:               _d_arr[i] += _r0;
-//CHECK-NEXT:               double _r1 = arr[i] * _r_d0;
-//CHECK-NEXT:               * _d_x += _r1;
+//CHECK-NEXT:               _d_arr[i] += _r_d0 * x;
+//CHECK-NEXT:               * _d_x += arr[i] * _r_d0;
 //CHECK-NEXT:               * _d_y -= _r_d0;
 //CHECK-NEXT:               * _d_y;
 //CHECK-NEXT:           }
@@ -415,14 +370,10 @@ struct S {
   //CHECK-NEXT:       goto _label0;
   //CHECK-NEXT:     _label0:
   //CHECK-NEXT:       {
-  //CHECK-NEXT:           double _r0 = 1 * x;
-  //CHECK-NEXT:           (* _d_this).c1 += _r0;
-  //CHECK-NEXT:           double _r1 = this->c1 * 1;
-  //CHECK-NEXT:           * _d_x += _r1;
-  //CHECK-NEXT:           double _r2 = 1 * y;
-  //CHECK-NEXT:           (* _d_this).c2 += _r2;
-  //CHECK-NEXT:           double _r3 = this->c2 * 1;
-  //CHECK-NEXT:           * _d_y += _r3;
+  //CHECK-NEXT:           (* _d_this).c1 += 1 * x;
+  //CHECK-NEXT:           * _d_x += this->c1 * 1;
+  //CHECK-NEXT:           (* _d_this).c2 += 1 * y;
+  //CHECK-NEXT:           * _d_y += this->c2 * 1;
   //CHECK-NEXT:       }
   //CHECK-NEXT:   }
 
@@ -490,9 +441,8 @@ void f_norm_grad(double x,
 //CHECK-NEXT:           double _r4 = _grad3;
 //CHECK-NEXT:           * _d_d += _r4;
 //CHECK-NEXT:           double _r5 = _grad5;
-//CHECK-NEXT:           double _r6 = _r5 / _t0;
-//CHECK-NEXT:           double _r7 = _r5 * -1 / (_t0 * _t0);
-//CHECK-NEXT:           * _d_d += _r7;
+//CHECK-NEXT:           double _r6 = _r5 * -1 / (_t0 * _t0);
+//CHECK-NEXT:           * _d_d += _r6;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -505,14 +455,12 @@ void f_sin_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_re
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * (x + y);
-//CHECK-NEXT:           double _r1 = _r0 * clad::custom_derivatives::sin_pushforward(x, 1.).pushforward;
-//CHECK-NEXT:           * _d_x += _r1;
-//CHECK-NEXT:           double _r2 = _r0 * clad::custom_derivatives::sin_pushforward(y, 1.).pushforward;
-//CHECK-NEXT:           * _d_y += _r2;
-//CHECK-NEXT:           double _r3 = (std::sin(x) + std::sin(y)) * 1;
-//CHECK-NEXT:           * _d_x += _r3;
-//CHECK-NEXT:           * _d_y += _r3;
+//CHECK-NEXT:           double _r0 = 1 * (x + y) * clad::custom_derivatives::sin_pushforward(x, 1.).pushforward;
+//CHECK-NEXT:           * _d_x += _r0;
+//CHECK-NEXT:           double _r1 = 1 * (x + y) * clad::custom_derivatives::sin_pushforward(y, 1.).pushforward;
+//CHECK-NEXT:           * _d_y += _r1;
+//CHECK-NEXT:           * _d_x += (std::sin(x) + std::sin(y)) * 1;
+//CHECK-NEXT:           * _d_y += (std::sin(x) + std::sin(y)) * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -553,25 +501,13 @@ void f_decls1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array
 //CHECK-NEXT:       double c = a + b;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r4 = 1 * c;
-//CHECK-NEXT:           double _r5 = 2 * 1;
-//CHECK-NEXT:           _d_c += _r5;
-//CHECK-NEXT:       }
+//CHECK-NEXT:       _d_c += 2 * 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += _d_c;
 //CHECK-NEXT:           _d_b += _d_c;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r2 = _d_b * y;
-//CHECK-NEXT:           double _r3 = 5 * _d_b;
-//CHECK-NEXT:           * _d_y += _r3;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = _d_a * x;
-//CHECK-NEXT:           double _r1 = 3 * _d_a;
-//CHECK-NEXT:           * _d_x += _r1;
-//CHECK-NEXT:       }
+//CHECK-NEXT:       * _d_y += 5 * _d_b;
+//CHECK-NEXT:       * _d_x += 3 * _d_a;
 //CHECK-NEXT:   }
 
 double f_decls2(double x, double y) {
@@ -593,28 +529,20 @@ void f_decls2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += 1;
-//CHECK-NEXT:           double _r6 = 1 * b;
-//CHECK-NEXT:           double _r7 = 2 * 1;
-//CHECK-NEXT:           _d_b += _r7;
+//CHECK-NEXT:           _d_b += 2 * 1;
 //CHECK-NEXT:           _d_c += 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r4 = _d_c * y;
-//CHECK-NEXT:           * _d_y += _r4;
-//CHECK-NEXT:           double _r5 = y * _d_c;
-//CHECK-NEXT:           * _d_y += _r5;
+//CHECK-NEXT:           * _d_y += _d_c * y;
+//CHECK-NEXT:           * _d_y += y * _d_c;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r2 = _d_b * y;
-//CHECK-NEXT:           * _d_x += _r2;
-//CHECK-NEXT:           double _r3 = x * _d_b;
-//CHECK-NEXT:           * _d_y += _r3;
+//CHECK-NEXT:           * _d_x += _d_b * y;
+//CHECK-NEXT:           * _d_y += x * _d_b;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = _d_a * x;
-//CHECK-NEXT:           * _d_x += _r0;
-//CHECK-NEXT:           double _r1 = x * _d_a;
-//CHECK-NEXT:           * _d_x += _r1;
+//CHECK-NEXT:           * _d_x += _d_a * x;
+//CHECK-NEXT:           * _d_x += x * _d_a;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -651,35 +579,17 @@ void f_decls3_grad(double x, double y, clad::array_ref<double> _d_x, clad::array
 //CHECK-NEXT:     _label2:
 //CHECK-NEXT:       _d_b += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r8 = _d_b * a;
-//CHECK-NEXT:           _d_a += _r8;
-//CHECK-NEXT:           double _r9 = a * _d_b;
-//CHECK-NEXT:           _d_a += _r9;
+//CHECK-NEXT:           _d_a += _d_b * a;
+//CHECK-NEXT:           _d_a += a * _d_b;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:         _label0:
-//CHECK-NEXT:           {
-//CHECK-NEXT:               double _r4 = 1 * a;
-//CHECK-NEXT:               double _r5 = 2 * 1;
-//CHECK-NEXT:               _d_a += _r5;
-//CHECK-NEXT:           }
+//CHECK-NEXT:           _d_a += 2 * 1;
 //CHECK-NEXT:       else if (_cond1)
 //CHECK-NEXT:         _label1:
-//CHECK-NEXT:           {
-//CHECK-NEXT:               double _r6 = 1 * a;
-//CHECK-NEXT:               double _r7 = -2 * 1;
-//CHECK-NEXT:               _d_a += _r7;
-//CHECK-NEXT:           }
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r2 = _d_c * y;
-//CHECK-NEXT:           double _r3 = 333 * _d_c;
-//CHECK-NEXT:           * _d_y += _r3;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = _d_a * x;
-//CHECK-NEXT:           double _r1 = 3 * _d_a;
-//CHECK-NEXT:           * _d_x += _r1;
-//CHECK-NEXT:       }
+//CHECK-NEXT:           _d_a += -2 * 1;
+//CHECK-NEXT:       * _d_y += 333 * _d_c;
+//CHECK-NEXT:       * _d_x += 3 * _d_a;
 //CHECK-NEXT:   }
 
 double f_issue138(double x, double y) {
@@ -694,26 +604,14 @@ void f_issue138_grad(double x, double y, clad::array_ref<double> _d_x, clad::arr
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * x;
-//CHECK-NEXT:           double _r1 = _r0 * x;
-//CHECK-NEXT:           double _r2 = _r1 * x;
-//CHECK-NEXT:           * _d_x += _r2;
-//CHECK-NEXT:           double _r3 = x * _r1;
-//CHECK-NEXT:           * _d_x += _r3;
-//CHECK-NEXT:           double _r4 = x * x * _r0;
-//CHECK-NEXT:           * _d_x += _r4;
-//CHECK-NEXT:           double _r5 = x * x * x * 1;
-//CHECK-NEXT:           * _d_x += _r5;
-//CHECK-NEXT:           double _r6 = 1 * y;
-//CHECK-NEXT:           double _r7 = _r6 * y;
-//CHECK-NEXT:           double _r8 = _r7 * y;
-//CHECK-NEXT:           * _d_y += _r8;
-//CHECK-NEXT:           double _r9 = y * _r7;
-//CHECK-NEXT:           * _d_y += _r9;
-//CHECK-NEXT:           double _r10 = y * y * _r6;
-//CHECK-NEXT:           * _d_y += _r10;
-//CHECK-NEXT:           double _r11 = y * y * y * 1;
-//CHECK-NEXT:           * _d_y += _r11;
+//CHECK-NEXT:           * _d_x += 1 * x * x * x;
+//CHECK-NEXT:           * _d_x += x * 1 * x * x;
+//CHECK-NEXT:           * _d_x += x * x * 1 * x;
+//CHECK-NEXT:           * _d_x += x * x * x * 1;
+//CHECK-NEXT:           * _d_y += 1 * y * y * y;
+//CHECK-NEXT:           * _d_y += y * 1 * y * y;
+//CHECK-NEXT:           * _d_y += y * y * 1 * y;
+//CHECK-NEXT:           * _d_y += y * y * y * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -726,10 +624,8 @@ void f_const_grad(const double a, const double b, clad::array_ref<double> _d_a, 
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 1 * b;
-//CHECK-NEXT:           * _d_a += _r0;
-//CHECK-NEXT:           double _r1 = a * 1;
-//CHECK-NEXT:           * _d_b += _r1;
+//CHECK-NEXT:           * _d_a += 1 * b;
+//CHECK-NEXT:           * _d_b += a * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -751,11 +647,7 @@ void f_const_reference_grad(double i, double j, clad::array_ref<double> _d_i, cl
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
 //CHECK-NEXT:    _d_res += 1;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = _d_res * ar;
-//CHECK-NEXT:        double _r1 = 2 * _d_res;
-//CHECK-NEXT:        *_d_ar += _r1;
-//CHECK-NEXT:    }
+//CHECK-NEXT:    *_d_ar += 2 * _d_res;
 //CHECK-NEXT:    * _d_i += _d_a;
 //CHECK-NEXT:}
 double f_const02(double i, double j) {
@@ -801,9 +693,7 @@ float running_sum(float* p, int n) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             p[i] = clad::pop(_t1);
 // CHECK-NEXT:             float _r_d0 = _d_p[i];
-// CHECK-NEXT:             _d_p[i] += _r_d0;
 // CHECK-NEXT:             _d_p[i - 1] += _r_d0;
-// CHECK-NEXT:             _d_p[i] -= _r_d0;
 // CHECK-NEXT:             _d_p[i];
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
@@ -822,10 +712,8 @@ double fn_global_var_use(double i, double j) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * i;
-// CHECK-NEXT:         _d_ref += _r0;
-// CHECK-NEXT:         double _r1 = ref * 1;
-// CHECK-NEXT:         * _d_i += _r1;
+// CHECK-NEXT:         _d_ref += 1 * i;
+// CHECK-NEXT:         * _d_i += ref * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -121,13 +121,11 @@ double f_div1(double x, double y) {
 }
 
 //CHECK:   void f_div1_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       _t0 = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           * _d_x += 1 / _t0;
-//CHECK-NEXT:           double _r0 = 1 * -x / (_t0 * _t0);
+//CHECK-NEXT:           * _d_x += 1 / y;
+//CHECK-NEXT:           double _r0 = 1 * -x / (y * y);
 //CHECK-NEXT:           * _d_y += _r0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -152,13 +150,38 @@ double f_div2(double x, double y) {
 
 void f_div2_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 
+double f_div3(double x, double y) {
+    return (x = y) / (y * y);
+}
+
+//CHECK: void f_div3_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
+//CHECK-NEXT:     double _t0;
+//CHECK-NEXT:     double _t1;
+//CHECK-NEXT:     double _t2;
+//CHECK-NEXT:     _t1 = x;
+//CHECK-NEXT:     _t2 = (x = y);
+//CHECK-NEXT:     _t0 = (y * y);
+//CHECK-NEXT:     goto _label0;
+//CHECK-NEXT:   _label0:
+//CHECK-NEXT:     {
+//CHECK-NEXT:         * _d_x += 1 / _t0;
+//CHECK-NEXT:         x = _t1;
+//CHECK-NEXT:         double _r_d0 = * _d_x;
+//CHECK-NEXT:         * _d_y += _r_d0;
+//CHECK-NEXT:         * _d_x -= _r_d0;
+//CHECK-NEXT:         double _r0 = 1 * -_t2 / (_t0 * _t0);
+//CHECK-NEXT:         * _d_y += _r0 * y;
+//CHECK-NEXT:         * _d_y += y * _r0;
+//CHECK-NEXT:     }
+//CHECK-NEXT: }
+
+void f_div3_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
+
 double f_c(double x, double y) {
   return -x*y + (x + y)*(x/y) - x*x;
 }
 
 //CHECK:   void f_c_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       _t0 = y;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
@@ -166,8 +189,8 @@ double f_c(double x, double y) {
 //CHECK-NEXT:           * _d_y += -x * 1;
 //CHECK-NEXT:           * _d_x += 1 * (x / y);
 //CHECK-NEXT:           * _d_y += 1 * (x / y);
-//CHECK-NEXT:           * _d_x += (x + y) * 1 / _t0;
-//CHECK-NEXT:           double _r0 = (x + y) * 1 * -x / (_t0 * _t0);
+//CHECK-NEXT:           * _d_x += (x + y) * 1 / y;
+//CHECK-NEXT:           double _r0 = (x + y) * 1 * -x / (y * y);
 //CHECK-NEXT:           * _d_y += _r0;
 //CHECK-NEXT:           * _d_x += -1 * x;
 //CHECK-NEXT:           * _d_x += x * -1;
@@ -418,14 +441,12 @@ void f_norm_grad(double x,
                  double* _d_z,
                  double* _d_d);
 //CHECK:   void f_norm_grad(double x, double y, double z, double d, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y, clad::array_ref<double> _d_z, clad::array_ref<double> _d_d) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       _t0 = d;
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _grad4 = 0.;
 //CHECK-NEXT:           double _grad5 = 0.;
-//CHECK-NEXT:           clad::custom_derivatives::pow_pullback(sum_of_powers(x, y, z, d), 1 / _t0, 1, &_grad4, &_grad5);
+//CHECK-NEXT:           clad::custom_derivatives::pow_pullback(sum_of_powers(x, y, z, d), 1 / d, 1, &_grad4, &_grad5);
 //CHECK-NEXT:           double _r0 = _grad4;
 //CHECK-NEXT:           double _grad0 = 0.;
 //CHECK-NEXT:           double _grad1 = 0.;
@@ -441,7 +462,7 @@ void f_norm_grad(double x,
 //CHECK-NEXT:           double _r4 = _grad3;
 //CHECK-NEXT:           * _d_d += _r4;
 //CHECK-NEXT:           double _r5 = _grad5;
-//CHECK-NEXT:           double _r6 = _r5 * -1 / (_t0 * _t0);
+//CHECK-NEXT:           double _r6 = _r5 * -1 / (d * d);
 //CHECK-NEXT:           * _d_d += _r6;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -452,6 +473,8 @@ double f_sin(double x, double y) {
 
 void f_sin_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y);
 //CHECK:   void f_sin_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_ref<double> _d_y) {
+//CHECK-NEXT:       double _t0;
+//CHECK-NEXT:       _t0 = (std::sin(x) + std::sin(y));
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
@@ -459,8 +482,8 @@ void f_sin_grad(double x, double y, clad::array_ref<double> _d_x, clad::array_re
 //CHECK-NEXT:           * _d_x += _r0;
 //CHECK-NEXT:           double _r1 = 1 * (x + y) * clad::custom_derivatives::sin_pushforward(y, 1.).pushforward;
 //CHECK-NEXT:           * _d_y += _r1;
-//CHECK-NEXT:           * _d_x += (std::sin(x) + std::sin(y)) * 1;
-//CHECK-NEXT:           * _d_y += (std::sin(x) + std::sin(y)) * 1;
+//CHECK-NEXT:           * _d_x += _t0 * 1;
+//CHECK-NEXT:           * _d_y += _t0 * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -738,6 +761,7 @@ int main() {
   TEST(f_mult2, 1, 1); // CHECK-EXEC: Result is = {12.00, 12.00}
   TEST(f_div1, 1, 1); // CHECK-EXEC: Result is = {1.00, -1.00}
   TEST(f_div2, 1, 1); // CHECK-EXEC: Result is = {0.75, -0.75}
+  TEST(f_div3, 1, 1); // CHECK-EXEC: Result is = {0.00, -1.00}
   TEST(f_c, 1, 1); // CHECK-EXEC: Result is = {0.00, -2.00}
   TEST(f_rosenbrock, 1, 1); // CHECK-EXEC: Result is = {0.00, 0.00}
   TEST(f_cond1, 3, 2); // CHECK-EXEC: Result is = {1.00, 0.00}

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -323,7 +323,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
   double gaus = 1./std::sqrt(std::pow(2*M_PI, n) * sigma) * std::exp(power);
   return std::log(gaus);
 }
-//CHECK-NEXT: void f_log_gaus_grad_1(double *x, double *p, double n, double sigma, clad::array_ref<double> _d_p) {
+//CHECK: void f_log_gaus_grad_1(double *x, double *p, double n, double sigma, clad::array_ref<double> _d_p) {
 //CHECK-NEXT:     double _d_n = 0;
 //CHECK-NEXT:     double _d_sigma = 0;
 //CHECK-NEXT:     double _d_power = 0;
@@ -335,6 +335,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:     double _t4;
 //CHECK-NEXT:     double _t5;
 //CHECK-NEXT:     double _t6;
+//CHECK-NEXT:     double _t7;
 //CHECK-NEXT:     double _d_gaus = 0;
 //CHECK-NEXT:     double power = 0;
 //CHECK-NEXT:     _t0 = 0;
@@ -347,7 +348,8 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:     _t4 = sq(sigma);
 //CHECK-NEXT:     _t3 = (2 * _t4);
 //CHECK-NEXT:     power = -power / _t3;
-//CHECK-NEXT:     _t6 = std::sqrt(std::pow(2 * 3.1415926535897931, n) * sigma);
+//CHECK-NEXT:     _t7 = std::pow(2 * 3.1415926535897931, n);
+//CHECK-NEXT:     _t6 = std::sqrt(_t7 * sigma);
 //CHECK-NEXT:     _t5 = std::exp(power);
 //CHECK-NEXT:     double gaus = 1. / _t6 * _t5;
 //CHECK-NEXT:     goto _label0;
@@ -358,14 +360,14 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r3 = _d_gaus * _t5 * -1. / (_t6 * _t6);
-//CHECK-NEXT:         double _r4 = _r3 * clad::custom_derivatives::sqrt_pushforward(std::pow(2 * 3.1415926535897931, n) * sigma, 1.).pushforward;
+//CHECK-NEXT:         double _r4 = _r3 * clad::custom_derivatives::sqrt_pushforward(_t7 * sigma, 1.).pushforward;
 //CHECK-NEXT:         double _grad2 = 0.;
 //CHECK-NEXT:         double _grad3 = 0.;
 //CHECK-NEXT:         clad::custom_derivatives::pow_pullback(2 * 3.1415926535897931, n, _r4 * sigma, &_grad2, &_grad3);
 //CHECK-NEXT:         double _r5 = _grad2;
 //CHECK-NEXT:         double _r6 = _grad3;
 //CHECK-NEXT:         _d_n += _r6;
-//CHECK-NEXT:         _d_sigma += std::pow(2 * 3.1415926535897931, n) * _r4;
+//CHECK-NEXT:         _d_sigma += _t7 * _r4;
 //CHECK-NEXT:         double _r7 = 1. / _t6 * _d_gaus * clad::custom_derivatives::exp_pushforward(power, 1.).pushforward;
 //CHECK-NEXT:         _d_power += _r7;
 //CHECK-NEXT:     }
@@ -1563,34 +1565,32 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK: void f_loop_init_var_grad(double lower, double upper, clad::array_ref<double> _d_lower, clad::array_ref<double> _d_upper) {
 // CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double _d_num_points = 0;
-// CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _d_interval = 0;
-// CHECK-NEXT:     unsigned long _t1;
+// CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     double _d_x = 0;
+// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double sum = 0;
 // CHECK-NEXT:     double num_points = 10000;
-// CHECK-NEXT:     _t0 = num_points;
-// CHECK-NEXT:     double interval = (upper - lower) / _t0;
-// CHECK-NEXT:     _t1 = 0;
-// CHECK-NEXT:     for (double x = lower; x <= upper; clad::push(_t2, x) , (x += interval)) {
-// CHECK-NEXT:         _t1++;
-// CHECK-NEXT:         clad::push(_t3, sum);
+// CHECK-NEXT:     double interval = (upper - lower) / num_points;
+// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     for (double x = lower; x <= upper; clad::push(_t1, x) , (x += interval)) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         clad::push(_t2, sum);
 // CHECK-NEXT:         sum += x * x * interval;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         for (; _t1; _t1--) {
+// CHECK-NEXT:         for (; _t0; _t0--) {
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 x = clad::pop(_t2);
+// CHECK-NEXT:                 x = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_x;
 // CHECK-NEXT:                 _d_interval += _r_d0;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 sum = clad::pop(_t3);
+// CHECK-NEXT:                 sum = clad::pop(_t2);
 // CHECK-NEXT:                 double _r_d1 = _d_sum;
 // CHECK-NEXT:                 _d_x += _r_d1 * interval * x;
 // CHECK-NEXT:                 _d_x += x * _r_d1 * interval;
@@ -1600,9 +1600,9 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:         * _d_lower += _d_x;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         * _d_upper += _d_interval / _t0;
-// CHECK-NEXT:         * _d_lower += -_d_interval / _t0;
-// CHECK-NEXT:         double _r0 = _d_interval * -(upper - lower) / (_t0 * _t0);
+// CHECK-NEXT:         * _d_upper += _d_interval / num_points;
+// CHECK-NEXT:         * _d_lower += -_d_interval / num_points;
+// CHECK-NEXT:         double _r0 = _d_interval * -(upper - lower) / (num_points * num_points);
 // CHECK-NEXT:         _d_num_points += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -36,8 +36,7 @@ double f1(double x) {
 //CHECK-NEXT:           t = clad::pop(_t1);
 //CHECK-NEXT:           double _r_d0 = _d_t;
 //CHECK-NEXT:           _d_t += _r_d0 * x;
-//CHECK-NEXT:           double _r0 = t * _r_d0;
-//CHECK-NEXT:           * _d_x += _r0;
+//CHECK-NEXT:           * _d_x += t * _r_d0;
 //CHECK-NEXT:           _d_t -= _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -80,8 +79,7 @@ double f2(double x) {
 //CHECK-NEXT:               t = clad::pop(_t3);
 //CHECK-NEXT:               double _r_d0 = _d_t;
 //CHECK-NEXT:               _d_t += _r_d0 * x;
-//CHECK-NEXT:               double _r0 = t * _r_d0;
-//CHECK-NEXT:               * _d_x += _r0;
+//CHECK-NEXT:               * _d_x += t * _r_d0;
 //CHECK-NEXT:               _d_t -= _r_d0;
 //CHECK-NEXT:           }
 //CHECK-NEXT:           {
@@ -133,8 +131,7 @@ double f3(double x) {
 //CHECK-NEXT:               t = clad::pop(_t1);
 //CHECK-NEXT:               double _r_d0 = _d_t;
 //CHECK-NEXT:               _d_t += _r_d0 * x;
-//CHECK-NEXT:               double _r0 = t * _r_d0;
-//CHECK-NEXT:               * _d_x += _r0;
+//CHECK-NEXT:               * _d_x += t * _r_d0;
 //CHECK-NEXT:               _d_t -= _r_d0;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
@@ -166,8 +163,7 @@ double f4(double x) {
 //CHECK-NEXT:               t = clad::pop(_t1);
 //CHECK-NEXT:               double _r_d0 = _d_t;
 //CHECK-NEXT:               _d_t += _r_d0 * x;
-//CHECK-NEXT:               double _r0 = t * _r_d0;
-//CHECK-NEXT:               * _d_x += _r0;
+//CHECK-NEXT:               * _d_x += t * _r_d0;
 //CHECK-NEXT:               _d_t -= _r_d0;
 //CHECK-NEXT:           }
 //CHECK-NEXT:           i--;
@@ -231,12 +227,8 @@ double f_const_local(double x) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            res = clad::pop(_t2);
 //CHECK-NEXT:            double _r_d0 = _d_res;
-//CHECK-NEXT:            _d_res += _r_d0;
-//CHECK-NEXT:            double _r0 = _r_d0 * n;
-//CHECK-NEXT:            * _d_x += _r0;
-//CHECK-NEXT:            double _r1 = x * _r_d0;
-//CHECK-NEXT:            _d_n += _r1;
-//CHECK-NEXT:            _d_res -= _r_d0;
+//CHECK-NEXT:            * _d_x += _r_d0 * n;
+//CHECK-NEXT:            _d_n += x * _r_d0;
 //CHECK-NEXT:        }
 //CHECK-NEXT:        {
 //CHECK-NEXT:            * _d_x += _d_n;
@@ -274,9 +266,7 @@ double f_sum(double *p, int n) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         s = clad::pop(_t1);
 //CHECK-NEXT:         double _r_d0 = _d_s;
-//CHECK-NEXT:         _d_s += _r_d0;
 //CHECK-NEXT:         _d_p[i] += _r_d0;
-//CHECK-NEXT:         _d_s -= _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -285,10 +275,8 @@ double sq(double x) { return x * x; }
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = _d_y * x;
-//CHECK-NEXT:           * _d_x += _r0;
-//CHECK-NEXT:           double _r1 = x * _d_y;
-//CHECK-NEXT:           * _d_x += _r1;
+//CHECK-NEXT:           * _d_x += _d_y * x;
+//CHECK-NEXT:           * _d_x += x * _d_y;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -319,12 +307,10 @@ double f_sum_squares(double *p, int n) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         s = clad::pop(_t1);
 //CHECK-NEXT:         double _r_d0 = _d_s;
-//CHECK-NEXT:         _d_s += _r_d0;
 //CHECK-NEXT:         double _grad0 = 0.;
 //CHECK-NEXT:         sq_pullback(p[i], _r_d0, &_grad0);
 //CHECK-NEXT:         double _r0 = _grad0;
 //CHECK-NEXT:         _d_p[i] += _r0;
-//CHECK-NEXT:         _d_s -= _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -367,52 +353,41 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:     goto _label0;
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r17 = 1 * clad::custom_derivatives::log_pushforward(gaus, 1.).pushforward;
-//CHECK-NEXT:         _d_gaus += _r17;
+//CHECK-NEXT:         double _r8 = 1 * clad::custom_derivatives::log_pushforward(gaus, 1.).pushforward;
+//CHECK-NEXT:         _d_gaus += _r8;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r6 = _d_gaus * _t5;
-//CHECK-NEXT:         double _r7 = _r6 / _t6;
-//CHECK-NEXT:         double _r8 = _r6 * -1. / (_t6 * _t6);
-//CHECK-NEXT:         double _r9 = _r8 * clad::custom_derivatives::sqrt_pushforward(std::pow(2 * 3.1415926535897931, n) * sigma, 1.).pushforward;
-//CHECK-NEXT:         double _r10 = _r9 * sigma;
+//CHECK-NEXT:         double _r3 = _d_gaus * _t5 * -1. / (_t6 * _t6);
+//CHECK-NEXT:         double _r4 = _r3 * clad::custom_derivatives::sqrt_pushforward(std::pow(2 * 3.1415926535897931, n) * sigma, 1.).pushforward;
 //CHECK-NEXT:         double _grad2 = 0.;
 //CHECK-NEXT:         double _grad3 = 0.;
-//CHECK-NEXT:         clad::custom_derivatives::pow_pullback(2 * 3.1415926535897931, n, _r10, &_grad2, &_grad3);
-//CHECK-NEXT:         double _r11 = _grad2;
-//CHECK-NEXT:         double _r12 = _r11 * 3.1415926535897931;
-//CHECK-NEXT:         double _r13 = _grad3;
-//CHECK-NEXT:         _d_n += _r13;
-//CHECK-NEXT:         double _r14 = std::pow(2 * 3.1415926535897931, n) * _r9;
-//CHECK-NEXT:         _d_sigma += _r14;
-//CHECK-NEXT:         double _r15 = 1. / _t6 * _d_gaus;
-//CHECK-NEXT:         double _r16 = _r15 * clad::custom_derivatives::exp_pushforward(power, 1.).pushforward;
-//CHECK-NEXT:         _d_power += _r16;
+//CHECK-NEXT:         clad::custom_derivatives::pow_pullback(2 * 3.1415926535897931, n, _r4 * sigma, &_grad2, &_grad3);
+//CHECK-NEXT:         double _r5 = _grad2;
+//CHECK-NEXT:         double _r6 = _grad3;
+//CHECK-NEXT:         _d_n += _r6;
+//CHECK-NEXT:         _d_sigma += std::pow(2 * 3.1415926535897931, n) * _r4;
+//CHECK-NEXT:         double _r7 = 1. / _t6 * _d_gaus * clad::custom_derivatives::exp_pushforward(power, 1.).pushforward;
+//CHECK-NEXT:         _d_power += _r7;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         power = _t2;
 //CHECK-NEXT:         double _r_d1 = _d_power;
-//CHECK-NEXT:         double _r1 = _r_d1 / _t3;
-//CHECK-NEXT:         _d_power += -_r1;
-//CHECK-NEXT:         double _r2 = _r_d1 * --power / (_t3 * _t3);
-//CHECK-NEXT:         double _r3 = _r2 * _t4;
-//CHECK-NEXT:         double _r4 = 2 * _r2;
+//CHECK-NEXT:         _d_power += -_r_d1 / _t3;
+//CHECK-NEXT:         double _r1 = _r_d1 * --power / (_t3 * _t3);
 //CHECK-NEXT:         double _grad1 = 0.;
-//CHECK-NEXT:         sq_pullback(sigma, _r4, &_grad1);
-//CHECK-NEXT:         double _r5 = _grad1;
-//CHECK-NEXT:         _d_sigma += _r5;
+//CHECK-NEXT:         sq_pullback(sigma, 2 * _r1, &_grad1);
+//CHECK-NEXT:         double _r2 = _grad1;
+//CHECK-NEXT:         _d_sigma += _r2;
 //CHECK-NEXT:         _d_power -= _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         power = clad::pop(_t1);
 //CHECK-NEXT:         double _r_d0 = _d_power;
-//CHECK-NEXT:         _d_power += _r_d0;
 //CHECK-NEXT:         double _grad0 = 0.;
 //CHECK-NEXT:         sq_pullback(x[i] - p[i], _r_d0, &_grad0);
 //CHECK-NEXT:         double _r0 = _grad0;
 //CHECK-NEXT:         _d_p[i] += -_r0;
-//CHECK-NEXT:         _d_power -= _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -450,15 +425,11 @@ void f_const_grad(const double, const double, clad::array_ref<double>, clad::arr
 //CHECK-NEXT:           {
 //CHECK-NEXT:               r = clad::pop(_t2);
 //CHECK-NEXT:               int _r_d0 = _d_r;
-//CHECK-NEXT:               _d_r += _r_d0;
 //CHECK-NEXT:               _d_sq += _r_d0;
-//CHECK-NEXT:               _d_r -= _r_d0;
 //CHECK-NEXT:           }
 //CHECK-NEXT:           {
-//CHECK-NEXT:               double _r0 = _d_sq * b;
-//CHECK-NEXT:               * _d_b += _r0;
-//CHECK-NEXT:               double _r1 = b * _d_sq;
-//CHECK-NEXT:               * _d_b += _r1;
+//CHECK-NEXT:               * _d_b += _d_sq * b;
+//CHECK-NEXT:               * _d_b += b * _d_sq;
 //CHECK-NEXT:               _d_sq = 0;
 //CHECK-NEXT:               sq0 = clad::pop(_t1);
 //CHECK-NEXT:           }
@@ -507,32 +478,24 @@ double f6 (double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             a = clad::pop(_t4);
 // CHECK-NEXT:             double _r_d1 = _d_a;
-// CHECK-NEXT:             _d_a += _r_d1;
 // CHECK-NEXT:             _d_b += _r_d1;
 // CHECK-NEXT:             _d_c += _r_d1;
 // CHECK-NEXT:             * _d_i += _r_d1;
-// CHECK-NEXT:             _d_a -= _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             b = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_b;
-// CHECK-NEXT:             _d_b += _r_d0;
 // CHECK-NEXT:             * _d_j += _r_d0;
-// CHECK-NEXT:             _d_b -= _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r2 = _d_c * j;
-// CHECK-NEXT:             * _d_j += _r2;
-// CHECK-NEXT:             double _r3 = j * _d_c;
-// CHECK-NEXT:             * _d_j += _r3;
+// CHECK-NEXT:             * _d_j += _d_c * j;
+// CHECK-NEXT:             * _d_j += j * _d_c;
 // CHECK-NEXT:             _d_c = 0;
 // CHECK-NEXT:             c = clad::pop(_t2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r0 = _d_b * i;
-// CHECK-NEXT:             * _d_i += _r0;
-// CHECK-NEXT:             double _r1 = i * _d_b;
-// CHECK-NEXT:             * _d_i += _r1;
+// CHECK-NEXT:             * _d_i += _d_b * i;
+// CHECK-NEXT:             * _d_i += i * _d_b;
 // CHECK-NEXT:             _d_b = 0;
 // CHECK-NEXT:             b = clad::pop(_t1);
 // CHECK-NEXT:         }
@@ -569,13 +532,9 @@ double fn7(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 a = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_a;
-// CHECK-NEXT:                 _d_a += _r_d0;
-// CHECK-NEXT:                 double _r0 = _r_d0 * i;
-// CHECK-NEXT:                 * _d_i += _r0;
-// CHECK-NEXT:                 double _r1 = i * _r_d0;
-// CHECK-NEXT:                 * _d_i += _r1;
+// CHECK-NEXT:                 * _d_i += _r_d0 * i;
+// CHECK-NEXT:                 * _d_i += i * _r_d0;
 // CHECK-NEXT:                 * _d_j += _r_d0;
-// CHECK-NEXT:                 _d_a -= _r_d0;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _t0--;
 // CHECK-NEXT:         }
@@ -621,13 +580,9 @@ double fn8(double i, double j) {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             a = clad::pop(_t2);
 // CHECK-NEXT:                             double _r_d0 = _d_a;
-// CHECK-NEXT:                             _d_a += _r_d0;
-// CHECK-NEXT:                             double _r0 = _r_d0 * i;
-// CHECK-NEXT:                             * _d_i += _r0;
-// CHECK-NEXT:                             double _r1 = i * _r_d0;
-// CHECK-NEXT:                             * _d_i += _r1;
+// CHECK-NEXT:                             * _d_i += _r_d0 * i;
+// CHECK-NEXT:                             * _d_i += i * _r_d0;
 // CHECK-NEXT:                             * _d_j += _r_d0;
-// CHECK-NEXT:                             _d_a -= _r_d0;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     clad::back(_t1)--;
@@ -692,13 +647,9 @@ double fn9(double i, double j) {
 // CHECK-NEXT:                                 {
 // CHECK-NEXT:                                     a = clad::pop(_t5);
 // CHECK-NEXT:                                     double _r_d3 = _d_a;
-// CHECK-NEXT:                                     _d_a += _r_d3;
-// CHECK-NEXT:                                     double _r0 = _r_d3 * i;
-// CHECK-NEXT:                                     * _d_i += _r0;
-// CHECK-NEXT:                                     double _r1 = i * _r_d3;
-// CHECK-NEXT:                                     * _d_i += _r1;
+// CHECK-NEXT:                                     * _d_i += _r_d3 * i;
+// CHECK-NEXT:                                     * _d_i += i * _r_d3;
 // CHECK-NEXT:                                     * _d_j += _r_d3;
-// CHECK-NEXT:                                     _d_a -= _r_d3;
 // CHECK-NEXT:                                 }
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                             clad::back(_t4)--;
@@ -767,26 +718,18 @@ double fn10(double i, double j) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     counter = clad::pop(_t4);
 // CHECK-NEXT:                     int _r_d2 = _d_counter;
-// CHECK-NEXT:                     _d_counter += _r_d2;
-// CHECK-NEXT:                     _d_counter -= _r_d2;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     a = clad::pop(_t3);
 // CHECK-NEXT:                     double _r_d1 = _d_a;
-// CHECK-NEXT:                     _d_a += _r_d1;
 // CHECK-NEXT:                     _d_b += _r_d1;
-// CHECK-NEXT:                     _d_a -= _r_d1;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     b = clad::pop(_t2);
 // CHECK-NEXT:                     int _r_d0 = _d_b;
-// CHECK-NEXT:                     _d_b += _r_d0;
-// CHECK-NEXT:                     double _r0 = _r_d0 * i;
-// CHECK-NEXT:                     * _d_i += _r0;
-// CHECK-NEXT:                     double _r1 = i * _r_d0;
-// CHECK-NEXT:                     * _d_i += _r1;
+// CHECK-NEXT:                     * _d_i += _r_d0 * i;
+// CHECK-NEXT:                     * _d_i += i * _r_d0;
 // CHECK-NEXT:                     * _d_j += _r_d0;
-// CHECK-NEXT:                     _d_b -= _r_d0;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
@@ -832,19 +775,13 @@ double fn11(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 counter = clad::pop(_t2);
 // CHECK-NEXT:                 int _r_d1 = _d_counter;
-// CHECK-NEXT:                 _d_counter += _r_d1;
-// CHECK-NEXT:                 _d_counter -= _r_d1;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 a = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_a;
-// CHECK-NEXT:                 _d_a += _r_d0;
-// CHECK-NEXT:                 double _r0 = _r_d0 * i;
-// CHECK-NEXT:                 * _d_i += _r0;
-// CHECK-NEXT:                 double _r1 = i * _r_d0;
-// CHECK-NEXT:                 * _d_i += _r1;
+// CHECK-NEXT:                 * _d_i += _r_d0 * i;
+// CHECK-NEXT:                 * _d_i += i * _r_d0;
 // CHECK-NEXT:                 * _d_j += _r_d0;
-// CHECK-NEXT:                 _d_a -= _r_d0;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0--;
@@ -912,8 +849,6 @@ double fn12(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 counter = clad::pop(_t7);
 // CHECK-NEXT:                 int _r_d3 = _d_counter;
-// CHECK-NEXT:                 _d_counter += _r_d3;
-// CHECK-NEXT:                 _d_counter -= _r_d3;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 do {
@@ -923,9 +858,7 @@ double fn12(double i, double j) {
 // CHECK-NEXT:                                 {
 // CHECK-NEXT:                                     a = clad::pop(_t6);
 // CHECK-NEXT:                                     double _r_d2 = _d_a;
-// CHECK-NEXT:                                     _d_a += _r_d2;
 // CHECK-NEXT:                                     * _d_j += _r_d2;
-// CHECK-NEXT:                                     _d_a -= _r_d2;
 // CHECK-NEXT:                                 }
 // CHECK-NEXT:                                 clad::back(_t5)--;
 // CHECK-NEXT:                             } while (clad::back(_t5));
@@ -934,19 +867,13 @@ double fn12(double i, double j) {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             counter_again = clad::pop(_t4);
 // CHECK-NEXT:                             int _r_d1 = _d_counter_again;
-// CHECK-NEXT:                             _d_counter_again += _r_d1;
-// CHECK-NEXT:                             _d_counter_again -= _r_d1;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             a = clad::pop(_t3);
 // CHECK-NEXT:                             double _r_d0 = _d_a;
-// CHECK-NEXT:                             _d_a += _r_d0;
-// CHECK-NEXT:                             double _r0 = _r_d0 * i;
-// CHECK-NEXT:                             * _d_i += _r0;
-// CHECK-NEXT:                             double _r1 = i * _r_d0;
-// CHECK-NEXT:                             * _d_i += _r1;
+// CHECK-NEXT:                             * _d_i += _r_d0 * i;
+// CHECK-NEXT:                             * _d_i += i * _r_d0;
 // CHECK-NEXT:                             * _d_j += _r_d0;
-// CHECK-NEXT:                             _d_a -= _r_d0;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     clad::back(_t2)--;
@@ -1005,15 +932,11 @@ double fn13(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 counter = clad::pop(_t2);
 // CHECK-NEXT:                 int _r_d0 = _d_counter;
-// CHECK-NEXT:                 _d_counter += _r_d0;
-// CHECK-NEXT:                 _d_counter -= _r_d0;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 res = clad::pop(_t5);
 // CHECK-NEXT:                 double _r_d2 = _d_res;
-// CHECK-NEXT:                 _d_res += _r_d2;
 // CHECK-NEXT:                 _d_temp += _r_d2;
-// CHECK-NEXT:                 _d_res -= _r_d2;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 _d_k += _d_temp;
@@ -1023,12 +946,8 @@ double fn13(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 k = clad::pop(_t3);
 // CHECK-NEXT:                 int _r_d1 = _d_k;
-// CHECK-NEXT:                 _d_k += _r_d1;
 // CHECK-NEXT:                 * _d_i += _r_d1;
-// CHECK-NEXT:                 double _r0 = _r_d1 * j;
-// CHECK-NEXT:                 int _r1 = 2 * _r_d1;
-// CHECK-NEXT:                 * _d_j += _r1;
-// CHECK-NEXT:                 _d_k -= _r_d1;
+// CHECK-NEXT:                 * _d_j += 2 * _r_d1;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
@@ -1129,12 +1048,8 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         res = clad::pop(_t10);
 // CHECK-NEXT:                         double _r_d2 = _d_res;
-// CHECK-NEXT:                         _d_res += _r_d2;
-// CHECK-NEXT:                         double _r0 = _r_d2 * j;
-// CHECK-NEXT:                         * _d_i += _r0;
-// CHECK-NEXT:                         double _r1 = i * _r_d2;
-// CHECK-NEXT:                         * _d_j += _r1;
-// CHECK-NEXT:                         _d_res -= _r_d2;
+// CHECK-NEXT:                         * _d_i += _r_d2 * j;
+// CHECK-NEXT:                         * _d_j += i * _r_d2;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (clad::pop(_t6)) {
@@ -1143,9 +1058,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         res = clad::pop(_t7);
 // CHECK-NEXT:                         double _r_d1 = _d_res;
-// CHECK-NEXT:                         _d_res += _r_d1;
 // CHECK-NEXT:                         * _d_j += _r_d1;
-// CHECK-NEXT:                         _d_res -= _r_d1;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (clad::pop(_t2)) {
@@ -1154,9 +1067,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         res = clad::pop(_t3);
 // CHECK-NEXT:                         double _r_d0 = _d_res;
-// CHECK-NEXT:                         _d_res += _r_d0;
 // CHECK-NEXT:                         * _d_i += _r_d0;
-// CHECK-NEXT:                         _d_res -= _r_d0;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
@@ -1260,9 +1171,7 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                                     {
 // CHECK-NEXT:                                         res = clad::pop(_t12);
 // CHECK-NEXT:                                         double _r_d1 = _d_res;
-// CHECK-NEXT:                                         _d_res += _r_d1;
 // CHECK-NEXT:                                         * _d_j += _r_d1;
-// CHECK-NEXT:                                         _d_res -= _r_d1;
 // CHECK-NEXT:                                     }
 // CHECK-NEXT:                                 }
 // CHECK-NEXT:                                 if (clad::pop(_t7)) {
@@ -1271,9 +1180,7 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                                     {
 // CHECK-NEXT:                                         res = clad::pop(_t8);
 // CHECK-NEXT:                                         double _r_d0 = _d_res;
-// CHECK-NEXT:                                         _d_res += _r_d0;
 // CHECK-NEXT:                                         * _d_i += _r_d0;
-// CHECK-NEXT:                                         _d_res -= _r_d0;
 // CHECK-NEXT:                                     }
 // CHECK-NEXT:                                 }
 // CHECK-NEXT:                             }
@@ -1365,10 +1272,8 @@ double fn16(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 res = clad::pop(_t8);
 // CHECK-NEXT:                 double _r_d2 = _d_res;
-// CHECK-NEXT:                 _d_res += _r_d2;
 // CHECK-NEXT:                 * _d_i += _r_d2;
 // CHECK-NEXT:                 * _d_j += _r_d2;
-// CHECK-NEXT:                 _d_res -= _r_d2;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             if (clad::pop(_t6)) {
 // CHECK-NEXT:               case 2UL:
@@ -1376,11 +1281,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = clad::pop(_t7);
 // CHECK-NEXT:                     double _r_d1 = _d_res;
-// CHECK-NEXT:                     _d_res += _r_d1;
-// CHECK-NEXT:                     double _r2 = _r_d1 * i;
-// CHECK-NEXT:                     double _r3 = 2 * _r_d1;
-// CHECK-NEXT:                     * _d_i += _r3;
-// CHECK-NEXT:                     _d_res -= _r_d1;
+// CHECK-NEXT:                     * _d_i += 2 * _r_d1;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             if (clad::pop(_t2)) {
@@ -1389,12 +1290,8 @@ double fn16(double i, double j) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = clad::pop(_t3);
 // CHECK-NEXT:                     double _r_d0 = _d_res;
-// CHECK-NEXT:                     _d_res += _r_d0;
-// CHECK-NEXT:                     double _r0 = _r_d0 * j;
-// CHECK-NEXT:                     * _d_i += _r0;
-// CHECK-NEXT:                     double _r1 = i * _r_d0;
-// CHECK-NEXT:                     * _d_j += _r1;
-// CHECK-NEXT:                     _d_res -= _r_d0;
+// CHECK-NEXT:                     * _d_i += _r_d0 * j;
+// CHECK-NEXT:                     * _d_j += i * _r_d0;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
@@ -1493,18 +1390,10 @@ double fn17(double i, double j) {
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                                 res = clad::pop(_t10);
 // CHECK-NEXT:                                 double _r_d1 = _d_res;
-// CHECK-NEXT:                                 _d_res += _r_d1;
-// CHECK-NEXT:                                 double _r2 = _r_d1 * j;
-// CHECK-NEXT:                                 double _r3 = _r2 * j;
-// CHECK-NEXT:                                 double _r4 = _r3 * i;
-// CHECK-NEXT:                                 * _d_i += _r4;
-// CHECK-NEXT:                                 double _r5 = i * _r3;
-// CHECK-NEXT:                                 * _d_i += _r5;
-// CHECK-NEXT:                                 double _r6 = i * i * _r2;
-// CHECK-NEXT:                                 * _d_j += _r6;
-// CHECK-NEXT:                                 double _r7 = i * i * j * _r_d1;
-// CHECK-NEXT:                                 * _d_j += _r7;
-// CHECK-NEXT:                                 _d_res -= _r_d1;
+// CHECK-NEXT:                                 * _d_i += _r_d1 * j * j * i;
+// CHECK-NEXT:                                 * _d_i += i * _r_d1 * j * j;
+// CHECK-NEXT:                                 * _d_j += i * i * _r_d1 * j;
+// CHECK-NEXT:                                 * _d_j += i * i * j * _r_d1;
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                             if (clad::pop(_t7)) {
 // CHECK-NEXT:                               case 1UL:
@@ -1512,12 +1401,8 @@ double fn17(double i, double j) {
 // CHECK-NEXT:                                 {
 // CHECK-NEXT:                                     res = clad::pop(_t8);
 // CHECK-NEXT:                                     double _r_d0 = _d_res;
-// CHECK-NEXT:                                     _d_res += _r_d0;
-// CHECK-NEXT:                                     double _r0 = _r_d0 * j;
-// CHECK-NEXT:                                     * _d_i += _r0;
-// CHECK-NEXT:                                     double _r1 = i * _r_d0;
-// CHECK-NEXT:                                     * _d_j += _r1;
-// CHECK-NEXT:                                     _d_res -= _r_d0;
+// CHECK-NEXT:                                     * _d_i += _r_d0 * j;
+// CHECK-NEXT:                                     * _d_j += i * _r_d0;
 // CHECK-NEXT:                                 }
 // CHECK-NEXT:                             } else {
 // CHECK-NEXT:                               case 2UL:
@@ -1606,10 +1491,8 @@ double fn18(double i, double j) {
 // CHECK-NEXT:             if (clad::pop(_t2)) {
 // CHECK-NEXT:                 res = clad::pop(_t3);
 // CHECK-NEXT:                 double _r_d0 = _d_res;
-// CHECK-NEXT:                 _d_res += _r_d0;
 // CHECK-NEXT:                 * _d_i += _r_d0;
 // CHECK-NEXT:                 * _d_j += _r_d0;
-// CHECK-NEXT:                 _d_res -= _r_d0;
 // CHECK-NEXT:             } else if (clad::pop(_t5))
 // CHECK-NEXT:               case 1UL:
 // CHECK-NEXT:                 ;
@@ -1619,14 +1502,8 @@ double fn18(double i, double j) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = clad::pop(_t7);
 // CHECK-NEXT:                     double _r_d1 = _d_res;
-// CHECK-NEXT:                     _d_res += _r_d1;
-// CHECK-NEXT:                     double _r0 = _r_d1 * i;
-// CHECK-NEXT:                     double _r1 = 2 * _r_d1;
-// CHECK-NEXT:                     * _d_i += _r1;
-// CHECK-NEXT:                     double _r2 = _r_d1 * j;
-// CHECK-NEXT:                     double _r3 = 2 * _r_d1;
-// CHECK-NEXT:                     * _d_j += _r3;
-// CHECK-NEXT:                     _d_res -= _r_d1;
+// CHECK-NEXT:                     * _d_i += 2 * _r_d1;
+// CHECK-NEXT:                     * _d_j += 2 * _r_d1;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
@@ -1668,9 +1545,7 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_res;
-// CHECK-NEXT:             _d_res += _r_d0;
 // CHECK-NEXT:             *_t2 += _r_d0;
-// CHECK-NEXT:             _d_res -= _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -1712,32 +1587,23 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 x = clad::pop(_t2);
 // CHECK-NEXT:                 double _r_d0 = _d_x;
-// CHECK-NEXT:                 _d_x += _r_d0;
 // CHECK-NEXT:                 _d_interval += _r_d0;
-// CHECK-NEXT:                 _d_x -= _r_d0;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 sum = clad::pop(_t3);
 // CHECK-NEXT:                 double _r_d1 = _d_sum;
-// CHECK-NEXT:                 _d_sum += _r_d1;
-// CHECK-NEXT:                 double _r2 = _r_d1 * interval;
-// CHECK-NEXT:                 double _r3 = _r2 * x;
-// CHECK-NEXT:                 _d_x += _r3;
-// CHECK-NEXT:                 double _r4 = x * _r2;
-// CHECK-NEXT:                 _d_x += _r4;
-// CHECK-NEXT:                 double _r5 = x * x * _r_d1;
-// CHECK-NEXT:                 _d_interval += _r5;
-// CHECK-NEXT:                 _d_sum -= _r_d1;
+// CHECK-NEXT:                 _d_x += _r_d1 * interval * x;
+// CHECK-NEXT:                 _d_x += x * _r_d1 * interval;
+// CHECK-NEXT:                 _d_interval += x * x * _r_d1;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:         * _d_lower += _d_x;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = _d_interval / _t0;
-// CHECK-NEXT:         * _d_upper += _r0;
-// CHECK-NEXT:         * _d_lower += -_r0;
-// CHECK-NEXT:         double _r1 = _d_interval * -(upper - lower) / (_t0 * _t0);
-// CHECK-NEXT:         _d_num_points += _r1;
+// CHECK-NEXT:         * _d_upper += _d_interval / _t0;
+// CHECK-NEXT:         * _d_lower += -_d_interval / _t0;
+// CHECK-NEXT:         double _r0 = _d_interval * -(upper - lower) / (_t0 * _t0);
+// CHECK-NEXT:         _d_num_points += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -28,15 +28,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -46,15 +42,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -66,15 +58,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -86,15 +74,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -104,15 +88,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -124,15 +104,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -144,15 +120,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -164,15 +136,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -182,15 +150,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -202,15 +166,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -222,15 +182,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -242,15 +198,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -262,15 +214,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -282,15 +230,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -302,15 +246,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -322,15 +262,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -342,15 +278,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -362,15 +294,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -382,15 +310,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -402,15 +326,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -422,15 +342,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -442,15 +358,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -462,15 +374,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -482,15 +390,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         * _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -501,15 +405,11 @@ public:
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:         (* _d_this).x += _r0;
-  // CHECK-NEXT:         (* _d_this).y += _r0;
-  // CHECK-NEXT:         double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:         * _d_i += _r1;
-  // CHECK-NEXT:         double _r2 = 1 * j;
-  // CHECK-NEXT:         * _d_i += _r2;
-  // CHECK-NEXT:         double _r3 = i * 1;
-  // CHECK-NEXT:         _d_j += _r3;
+  // CHECK-NEXT:         (* _d_this).x += 1 * i;
+  // CHECK-NEXT:         (* _d_this).y += 1 * i;
+  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += 1 * j;
+  // CHECK-NEXT:         _d_j += i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -562,13 +462,9 @@ double fn(double i,double j) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * j;
-// CHECK-NEXT:         double _r1 = _r0 * i;
-// CHECK-NEXT:         * _d_i += _r1;
-// CHECK-NEXT:         double _r2 = i * _r0;
-// CHECK-NEXT:         * _d_i += _r2;
-// CHECK-NEXT:         double _r3 = i * i * 1;
-// CHECK-NEXT:         * _d_j += _r3;
+// CHECK-NEXT:         * _d_i += 1 * j * i;
+// CHECK-NEXT:         * _d_i += i * 1 * j;
+// CHECK-NEXT:         * _d_j += i * i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -644,9 +540,7 @@ double fn5(SimpleFunctions& v, double value) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t0;
 // CHECK-NEXT:         double _r_d0 = (* _d_this).x;
-// CHECK-NEXT:         (* _d_this).x += _r_d0;
 // CHECK-NEXT:         * _d_value += _r_d0;
-// CHECK-NEXT:         (* _d_this).x -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -687,8 +581,6 @@ double fn4(SimpleFunctions& v) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t0;
 // CHECK-NEXT:         double _r_d0 = (* _d_this).x;
-// CHECK-NEXT:         (* _d_this).x += _r_d0;
-// CHECK-NEXT:         (* _d_this).x -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -765,15 +657,11 @@ int main() {
   // CHECK-NEXT:       goto _label0;
   // CHECK-NEXT:       _label0:
   // CHECK-NEXT:       {
-  // CHECK-NEXT:           double _r0 = 1 * i;
-  // CHECK-NEXT:           (* _d_this).x += _r0;
-  // CHECK-NEXT:           (* _d_this).y += _r0;
-  // CHECK-NEXT:           double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:           * _d_i += _r1;
-  // CHECK-NEXT:           double _r2 = 1 * j;
-  // CHECK-NEXT:           * _d_i += _r2;
-  // CHECK-NEXT:           double _r3 = i * 1;
-  // CHECK-NEXT:           _d_j += _r3;
+  // CHECK-NEXT:           (* _d_this).x += 1 * i;
+  // CHECK-NEXT:           (* _d_this).y += 1 * i;
+  // CHECK-NEXT:           * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:           * _d_i += 1 * j;
+  // CHECK-NEXT:           _d_j += i * 1;
   // CHECK-NEXT:       }
   // CHECK-NEXT:   }
 
@@ -784,15 +672,11 @@ int main() {
   // CHECK-NEXT:       goto _label0;
   // CHECK-NEXT:       _label0:
   // CHECK-NEXT:       {
-  // CHECK-NEXT:         double _r0 = 1 * i;
-  // CHECK-NEXT:           (* _d_this).x += _r0;
-  // CHECK-NEXT:           (* _d_this).y += _r0;
-  // CHECK-NEXT:           double _r1 = (this->x + this->y) * 1;
-  // CHECK-NEXT:           _d_i += _r1;
-  // CHECK-NEXT:           double _r2 = 1 * j;
-  // CHECK-NEXT:           _d_i += _r2;
-  // CHECK-NEXT:           double _r3 = i * 1;
-  // CHECK-NEXT:           * _d_j += _r3;
+  // CHECK-NEXT:           (* _d_this).x += 1 * i;
+  // CHECK-NEXT:           (* _d_this).y += 1 * i;
+  // CHECK-NEXT:           _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:           _d_i += 1 * j;
+  // CHECK-NEXT:           * _d_j += i * 1;
   // CHECK-NEXT:       }
   // CHECK-NEXT:   }
 

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -55,12 +55,14 @@ public:
   }
 
   // CHECK: void volatile_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
-  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += _t0 * 1;
   // CHECK-NEXT:         * _d_i += 1 * j;
   // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
@@ -71,12 +73,14 @@ public:
   }
 
   // CHECK: void const_volatile_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
-  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += _t0 * 1;
   // CHECK-NEXT:         * _d_i += 1 * j;
   // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
@@ -117,12 +121,14 @@ public:
   }
 
   // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile & {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
-  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += _t0 * 1;
   // CHECK-NEXT:         * _d_i += 1 * j;
   // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
@@ -133,12 +139,14 @@ public:
   }
 
   // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile & {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
-  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += _t0 * 1;
   // CHECK-NEXT:         * _d_i += 1 * j;
   // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
@@ -179,12 +187,14 @@ public:
   }
 
   // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile && {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
-  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += _t0 * 1;
   // CHECK-NEXT:         * _d_i += 1 * j;
   // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
@@ -195,12 +205,14 @@ public:
   }
 
   // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile && {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
-  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += _t0 * 1;
   // CHECK-NEXT:         * _d_i += 1 * j;
   // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
@@ -243,12 +255,14 @@ public:
   }
 
   // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
-  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += _t0 * 1;
   // CHECK-NEXT:         * _d_i += 1 * j;
   // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
@@ -259,12 +273,14 @@ public:
   }
 
   // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
-  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += _t0 * 1;
   // CHECK-NEXT:         * _d_i += 1 * j;
   // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
@@ -307,12 +323,14 @@ public:
   }
 
   // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile & noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
-  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += _t0 * 1;
   // CHECK-NEXT:         * _d_i += 1 * j;
   // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
@@ -323,12 +341,14 @@ public:
   }
 
   // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile & noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
-  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += _t0 * 1;
   // CHECK-NEXT:         * _d_i += 1 * j;
   // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
@@ -371,12 +391,14 @@ public:
   }
 
   // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) volatile && noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
-  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += _t0 * 1;
   // CHECK-NEXT:         * _d_i += 1 * j;
   // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
@@ -387,12 +409,14 @@ public:
   }
 
   // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile && noexcept {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     goto _label0;
   // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (* _d_this).x += 1 * i;
   // CHECK-NEXT:         (* _d_this).y += 1 * i;
-  // CHECK-NEXT:         * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:         * _d_i += _t0 * 1;
   // CHECK-NEXT:         * _d_i += 1 * j;
   // CHECK-NEXT:         * _d_j += i * 1;
   // CHECK-NEXT:     }
@@ -654,12 +678,14 @@ int main() {
 
   // CHECK:   void const_volatile_lval_ref_mem_fn_grad_0(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_i) const volatile & {
   // CHECK-NEXT:       double _d_j = 0;
+  // CHECK-NEXT:       double _t0;
+  // CHECK-NEXT:       _t0 = (this->x + this->y);
   // CHECK-NEXT:       goto _label0;
   // CHECK-NEXT:       _label0:
   // CHECK-NEXT:       {
   // CHECK-NEXT:           (* _d_this).x += 1 * i;
   // CHECK-NEXT:           (* _d_this).y += 1 * i;
-  // CHECK-NEXT:           * _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:           * _d_i += _t0 * 1;
   // CHECK-NEXT:           * _d_i += 1 * j;
   // CHECK-NEXT:           _d_j += i * 1;
   // CHECK-NEXT:       }
@@ -669,12 +695,14 @@ int main() {
 
   // CHECK:   void const_volatile_rval_ref_mem_fn_grad_1(double i, double j, clad::array_ref<volatile SimpleFunctions> _d_this, clad::array_ref<double> _d_j) const volatile && {
   // CHECK-NEXT:       double _d_i = 0;
+  // CHECK-NEXT:       double _t0;
+  // CHECK-NEXT:       _t0 = (this->x + this->y);
   // CHECK-NEXT:       goto _label0;
   // CHECK-NEXT:       _label0:
   // CHECK-NEXT:       {
   // CHECK-NEXT:           (* _d_this).x += 1 * i;
   // CHECK-NEXT:           (* _d_this).y += 1 * i;
-  // CHECK-NEXT:           _d_i += (this->x + this->y) * 1;
+  // CHECK-NEXT:           _d_i += _t0 * 1;
   // CHECK-NEXT:           _d_i += 1 * j;
   // CHECK-NEXT:           * _d_j += i * 1;
   // CHECK-NEXT:       }

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -13,10 +13,8 @@ double nonMemFn(double i) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * i;
-// CHECK-NEXT:         * _d_i += _r0;
-// CHECK-NEXT:         double _r1 = i * 1;
-// CHECK-NEXT:         * _d_i += _r1;
+// CHECK-NEXT:         * _d_i += 1 * i;
+// CHECK-NEXT:         * _d_i += i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/TemplateFunctors.C
+++ b/test/Gradient/TemplateFunctors.C
@@ -59,12 +59,14 @@ template <typename T> struct ExperimentConstVolatile {
 };
 
 // CHECK: void operator_call_grad(double i, double j, clad::array_ref<volatile ExperimentConstVolatile<double> > _d_this, clad::array_ref<double> _d_i, clad::array_ref<double> _d_j) const volatile {
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     _t0 = this->x * i;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (* _d_this).x += 1 * i * i;
 // CHECK-NEXT:         * _d_i += this->x * 1 * i;
-// CHECK-NEXT:         * _d_i += this->x * i * 1;
+// CHECK-NEXT:         * _d_i += _t0 * 1;
 // CHECK-NEXT:         (* _d_this).y += 1 * j;
 // CHECK-NEXT:         * _d_j += this->y * 1;
 // CHECK-NEXT:     }
@@ -81,16 +83,20 @@ template <> struct ExperimentConstVolatile<long double> {
 };
 
 // CHECK: void operator_call_grad(long double i, long double j, clad::array_ref<volatile ExperimentConstVolatile<long double> > _d_this, clad::array_ref<long double> _d_i, clad::array_ref<long double> _d_j) const volatile {
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     _t0 = this->x * i;
+// CHECK-NEXT:     _t1 = this->y * j;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (* _d_this).x += 1 * j * i * i;
 // CHECK-NEXT:         * _d_i += this->x * 1 * j * i;
-// CHECK-NEXT:         * _d_i += this->x * i * 1 * j;
-// CHECK-NEXT:         * _d_j += this->x * i * i * 1;
+// CHECK-NEXT:         * _d_i += _t0 * 1 * j;
+// CHECK-NEXT:         * _d_j += _t0 * i * 1;
 // CHECK-NEXT:         (* _d_this).y += 1 * i * j;
 // CHECK-NEXT:         * _d_j += this->y * 1 * i;
-// CHECK-NEXT:         * _d_i += this->y * j * 1;
+// CHECK-NEXT:         * _d_i += _t1 * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/TemplateFunctors.C
+++ b/test/Gradient/TemplateFunctors.C
@@ -18,17 +18,11 @@ template <typename T> struct Experiment {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * i;
-// CHECK-NEXT:         double _r1 = _r0 * i;
-// CHECK-NEXT:         (* _d_this).x += _r1;
-// CHECK-NEXT:         double _r2 = this->x * _r0;
-// CHECK-NEXT:         * _d_i += _r2;
-// CHECK-NEXT:         double _r3 = this->x * i * 1;
-// CHECK-NEXT:         * _d_i += _r3;
-// CHECK-NEXT:         double _r4 = 1 * j;
-// CHECK-NEXT:         (* _d_this).y += _r4;
-// CHECK-NEXT:         double _r5 = this->y * 1;
-// CHECK-NEXT:         * _d_j += _r5;
+// CHECK-NEXT:         (* _d_this).x += 1 * i * i;
+// CHECK-NEXT:         * _d_i += this->x * 1 * i;
+// CHECK-NEXT:         * _d_i += this->x * i * 1;
+// CHECK-NEXT:         (* _d_this).y += 1 * j;
+// CHECK-NEXT:         * _d_j += this->y * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -46,23 +40,13 @@ template <> struct Experiment<long double> {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         long double _r0 = 1 * j;
-// CHECK-NEXT:         long double _r1 = _r0 * i;
-// CHECK-NEXT:         long double _r2 = _r1 * i;
-// CHECK-NEXT:         (* _d_this).x += _r2;
-// CHECK-NEXT:         long double _r3 = this->x * _r1;
-// CHECK-NEXT:         * _d_i += _r3;
-// CHECK-NEXT:         long double _r4 = this->x * i * _r0;
-// CHECK-NEXT:         * _d_i += _r4;
-// CHECK-NEXT:         long double _r5 = this->x * i * i * 1;
-// CHECK-NEXT:         * _d_j += _r5;
-// CHECK-NEXT:         long double _r6 = 1 * i;
-// CHECK-NEXT:         long double _r7 = _r6 * j;
-// CHECK-NEXT:         (* _d_this).y += _r7;
-// CHECK-NEXT:         long double _r8 = this->y * _r6;
-// CHECK-NEXT:         * _d_j += _r8;
-// CHECK-NEXT:         long double _r9 = this->y * j * 1;
-// CHECK-NEXT:         * _d_i += _r9;
+// CHECK-NEXT:         (* _d_this).x += 1 * j * i * i;
+// CHECK-NEXT:         * _d_i += this->x * 1 * j * i;
+// CHECK-NEXT:         * _d_i += this->x * i * 1 * j;
+// CHECK-NEXT:         * _d_j += this->x * i * i * 1;
+// CHECK-NEXT:         (* _d_this).y += 1 * i * j;
+// CHECK-NEXT:         * _d_j += this->y * 1 * i;
+// CHECK-NEXT:         * _d_i += this->y * j * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -78,17 +62,11 @@ template <typename T> struct ExperimentConstVolatile {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * i;
-// CHECK-NEXT:         double _r1 = _r0 * i;
-// CHECK-NEXT:         (* _d_this).x += _r1;
-// CHECK-NEXT:         double _r2 = this->x * _r0;
-// CHECK-NEXT:         * _d_i += _r2;
-// CHECK-NEXT:         double _r3 = this->x * i * 1;
-// CHECK-NEXT:         * _d_i += _r3;
-// CHECK-NEXT:         double _r4 = 1 * j;
-// CHECK-NEXT:         (* _d_this).y += _r4;
-// CHECK-NEXT:         double _r5 = this->y * 1;
-// CHECK-NEXT:         * _d_j += _r5;
+// CHECK-NEXT:         (* _d_this).x += 1 * i * i;
+// CHECK-NEXT:         * _d_i += this->x * 1 * i;
+// CHECK-NEXT:         * _d_i += this->x * i * 1;
+// CHECK-NEXT:         (* _d_this).y += 1 * j;
+// CHECK-NEXT:         * _d_j += this->y * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -106,23 +84,13 @@ template <> struct ExperimentConstVolatile<long double> {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         long double _r0 = 1 * j;
-// CHECK-NEXT:         long double _r1 = _r0 * i;
-// CHECK-NEXT:         long double _r2 = _r1 * i;
-// CHECK-NEXT:         (* _d_this).x += _r2;
-// CHECK-NEXT:         long double _r3 = this->x * _r1;
-// CHECK-NEXT:         * _d_i += _r3;
-// CHECK-NEXT:         long double _r4 = this->x * i * _r0;
-// CHECK-NEXT:         * _d_i += _r4;
-// CHECK-NEXT:         long double _r5 = this->x * i * i * 1;
-// CHECK-NEXT:         * _d_j += _r5;
-// CHECK-NEXT:         long double _r6 = 1 * i;
-// CHECK-NEXT:         long double _r7 = _r6 * j;
-// CHECK-NEXT:         (* _d_this).y += _r7;
-// CHECK-NEXT:         long double _r8 = this->y * _r6;
-// CHECK-NEXT:         * _d_j += _r8;
-// CHECK-NEXT:         long double _r9 = this->y * j * 1;
-// CHECK-NEXT:         * _d_i += _r9;
+// CHECK-NEXT:         (* _d_this).x += 1 * j * i * i;
+// CHECK-NEXT:         * _d_i += this->x * 1 * j * i;
+// CHECK-NEXT:         * _d_i += this->x * i * 1 * j;
+// CHECK-NEXT:         * _d_j += this->x * i * i * 1;
+// CHECK-NEXT:         (* _d_this).y += 1 * i * j;
+// CHECK-NEXT:         * _d_j += this->y * 1 * i;
+// CHECK-NEXT:         * _d_i += this->y * j * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -36,10 +36,8 @@ void fn_type_conversion_grad(float z, int a, clad::array_ref<float> _d_z, clad::
 // CHECK-NEXT:         {
 // CHECK-NEXT:             z = clad::pop(_t1);
 // CHECK-NEXT:             float _r_d0 = * _d_z;
-// CHECK-NEXT:             float _r0 = _r_d0 * a;
-// CHECK-NEXT:             * _d_z += _r0;
-// CHECK-NEXT:             float _r1 = z * _r_d0;
-// CHECK-NEXT:             * _d_a += _r1;
+// CHECK-NEXT:             * _d_z += _r_d0 * a;
+// CHECK-NEXT:             * _d_a += z * _r_d0;
 // CHECK-NEXT:             * _d_z -= _r_d0;
 // CHECK-NEXT:             * _d_z;
 // CHECK-NEXT:         }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -28,12 +28,8 @@ double fn1(pairdd p, double i) {
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (* _d_p).first += _d_res;
-// CHECK-NEXT:         double _r0 = _d_res * p.second;
-// CHECK-NEXT:         double _r1 = 2 * _d_res;
-// CHECK-NEXT:         (* _d_p).second += _r1;
-// CHECK-NEXT:         double _r2 = _d_res * i;
-// CHECK-NEXT:         double _r3 = 3 * _d_res;
-// CHECK-NEXT:         * _d_i += _r3;
+// CHECK-NEXT:         (* _d_p).second += 2 * _d_res;
+// CHECK-NEXT:         * _d_i += 3 * _d_res;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -79,9 +75,7 @@ double sum(Tangent& t) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         res = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         _d_res += _r_d0;
 // CHECK-NEXT:         (* _d_t).data[i] += _r_d0;
-// CHECK-NEXT:         _d_res -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -111,9 +105,7 @@ double sum(double *data) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         res = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         _d_res += _r_d0;
 // CHECK-NEXT:         _d_data[i] += _r_d0;
-// CHECK-NEXT:         _d_res -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -137,15 +129,11 @@ double fn2(Tangent t, double i) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t1;
 // CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         _d_res += _r_d0;
 // CHECK-NEXT:         clad::array_ref<double> _t2 = {(* _d_t).data, 5UL};
 // CHECK-NEXT:         sum_pullback(t.data, _r_d0, _t2);
 // CHECK-NEXT:         clad::array<double> _r1({(* _d_t).data, 5UL});
 // CHECK-NEXT:         * _d_i += _r_d0;
-// CHECK-NEXT:         double _r2 = _r_d0 * t.data[0];
-// CHECK-NEXT:         double _r3 = 2 * _r_d0;
-// CHECK-NEXT:         (* _d_t).data[0] += _r3;
-// CHECK-NEXT:         _d_res -= _r_d0;
+// CHECK-NEXT:         (* _d_t).data[0] += 2 * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t = _t0;
@@ -177,25 +165,19 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t = _t2;
 // CHECK-NEXT:         sum_pullback(_t2, 1, &_d_t);
-// CHECK-NEXT:         Tangent _r6 = _d_t;
+// CHECK-NEXT:         Tangent _r0 = _d_t;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t.data[1] = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_t.data[1];
-// CHECK-NEXT:         double _r2 = _r_d1 * i;
-// CHECK-NEXT:         double _r3 = 5 * _r_d1;
-// CHECK-NEXT:         * _d_i += _r3;
-// CHECK-NEXT:         double _r4 = _r_d1 * j;
-// CHECK-NEXT:         double _r5 = 3 * _r_d1;
-// CHECK-NEXT:         * _d_j += _r5;
+// CHECK-NEXT:         * _d_i += 5 * _r_d1;
+// CHECK-NEXT:         * _d_j += 3 * _r_d1;
 // CHECK-NEXT:         _d_t.data[1] -= _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t.data[0] = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_t.data[0];
-// CHECK-NEXT:         double _r0 = _r_d0 * i;
-// CHECK-NEXT:         double _r1 = 2 * _r_d0;
-// CHECK-NEXT:         * _d_i += _r1;
+// CHECK-NEXT:         * _d_i += 2 * _r_d0;
 // CHECK-NEXT:         _d_t.data[0] -= _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -214,22 +196,14 @@ double fn4(double i, double j) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * i;
-// CHECK-NEXT:         _d_p.first += _r0;
-// CHECK-NEXT:         double _r1 = p.first * 1;
-// CHECK-NEXT:         * _d_i += _r1;
-// CHECK-NEXT:         double _r2 = 1 * j;
-// CHECK-NEXT:         _d_p.second += _r2;
-// CHECK-NEXT:         double _r3 = p.second * 1;
-// CHECK-NEXT:         * _d_j += _r3;
-// CHECK-NEXT:         double _r4 = 1 * i;
-// CHECK-NEXT:         _d_q.first += _r4;
-// CHECK-NEXT:         double _r5 = q.first * 1;
-// CHECK-NEXT:         * _d_i += _r5;
-// CHECK-NEXT:         double _r6 = 1 * j;
-// CHECK-NEXT:         _d_q.second += _r6;
-// CHECK-NEXT:         double _r7 = q.second * 1;
-// CHECK-NEXT:         * _d_j += _r7;
+// CHECK-NEXT:         _d_p.first += 1 * i;
+// CHECK-NEXT:         * _d_i += p.first * 1;
+// CHECK-NEXT:         _d_p.second += 1 * j;
+// CHECK-NEXT:         * _d_j += p.second * 1;
+// CHECK-NEXT:         _d_q.first += 1 * i;
+// CHECK-NEXT:         * _d_i += q.first * 1;
+// CHECK-NEXT:         _d_q.second += 1 * j;
+// CHECK-NEXT:         * _d_j += q.second * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -237,21 +211,13 @@ double fn4(double i, double j) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * i;
-// CHECK-NEXT:         (* _d_this).data[0] += _r0;
-// CHECK-NEXT:         double _r1 = this->data[0] * 1;
-// CHECK-NEXT:         * _d_i += _r1;
-// CHECK-NEXT:         double _r2 = 1 * j;
-// CHECK-NEXT:         (* _d_this).data[1] += _r2;
-// CHECK-NEXT:         double _r3 = this->data[1] * 1;
-// CHECK-NEXT:         * _d_j += _r3;
-// CHECK-NEXT:         double _r4 = 1 * this->data[2];
-// CHECK-NEXT:         double _r5 = 3 * 1;
-// CHECK-NEXT:         (* _d_this).data[2] += _r5;
-// CHECK-NEXT:         double _r6 = 1 * this->data[4];
-// CHECK-NEXT:         (* _d_this).data[3] += _r6;
-// CHECK-NEXT:         double _r7 = this->data[3] * 1;
-// CHECK-NEXT:         (* _d_this).data[4] += _r7;
+// CHECK-NEXT:         (* _d_this).data[0] += 1 * i;
+// CHECK-NEXT:         * _d_i += this->data[0] * 1;
+// CHECK-NEXT:         (* _d_this).data[1] += 1 * j;
+// CHECK-NEXT:         * _d_j += this->data[1] * 1;
+// CHECK-NEXT:         (* _d_this).data[2] += 3 * 1;
+// CHECK-NEXT:         (* _d_this).data[3] += 1 * this->data[4];
+// CHECK-NEXT:         (* _d_this).data[4] += this->data[3] * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -263,17 +229,11 @@ double fn5(const Tangent& t, double i) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = _d_y * i;
-// CHECK-NEXT:         (* _d_this).data[0] += _r0;
-// CHECK-NEXT:         double _r1 = this->data[0] * _d_y;
-// CHECK-NEXT:         * _d_i += _r1;
-// CHECK-NEXT:         double _r2 = _d_y * j;
-// CHECK-NEXT:         double _r3 = _r2 * i;
-// CHECK-NEXT:         (* _d_this).data[1] += _r3;
-// CHECK-NEXT:         double _r4 = this->data[1] * _r2;
-// CHECK-NEXT:         * _d_i += _r4;
-// CHECK-NEXT:         double _r5 = this->data[1] * i * _d_y;
-// CHECK-NEXT:         * _d_j += _r5;
+// CHECK-NEXT:         (* _d_this).data[0] += _d_y * i;
+// CHECK-NEXT:         * _d_i += this->data[0] * _d_y;
+// CHECK-NEXT:         (* _d_this).data[1] += _d_y * j * i;
+// CHECK-NEXT:         * _d_i += this->data[1] * _d_y * j;
+// CHECK-NEXT:         * _d_j += this->data[1] * i * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -350,28 +310,18 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t4;
 // CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         _d_res += _r_d0;
-// CHECK-NEXT:         double _r7 = _r_d0 * _t5;
-// CHECK-NEXT:         double _r8 = 4 * _r_d0;
-// CHECK-NEXT:         _t6.real_pullback(_r8, &(* _d_c));
-// CHECK-NEXT:         _d_res -= _r_d0;
+// CHECK-NEXT:         _t6.real_pullback(4 * _r_d0, &(* _d_c));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t1.real_pullback(_d_res, &(* _d_c));
-// CHECK-NEXT:         double _r3 = _d_res * _t2;
-// CHECK-NEXT:         double _r4 = 3 * _d_res;
-// CHECK-NEXT:         _t3.imag_pullback(_r4, &(* _d_c));
-// CHECK-NEXT:         double _r5 = _d_res * i;
-// CHECK-NEXT:         double _r6 = 6 * _d_res;
-// CHECK-NEXT:         * _d_i += _r6;
+// CHECK-NEXT:         _t3.imag_pullback(3 * _d_res, &(* _d_c));
+// CHECK-NEXT:         * _d_i += 6 * _d_res;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _grad0 = 0.;
 // CHECK-NEXT:         _t0.real_pullback(5 * i, &(* _d_c), &_grad0);
 // CHECK-NEXT:         double _r0 = _grad0;
-// CHECK-NEXT:         double _r1 = _r0 * i;
-// CHECK-NEXT:         double _r2 = 5 * _r0;
-// CHECK-NEXT:         * _d_i += _r2;
+// CHECK-NEXT:         * _d_i += 5 * _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -400,18 +350,14 @@ double fn7(dcomplex c1, dcomplex c2) {
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t4.real_pullback(1, &(* _d_c1));
-// CHECK-NEXT:         double _r3 = 1 * _t5;
-// CHECK-NEXT:         double _r4 = 3 * 1;
-// CHECK-NEXT:         _t6.imag_pullback(_r4, &(* _d_c1));
+// CHECK-NEXT:         _t6.imag_pullback(3 * 1, &(* _d_c1));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _grad0 = 0.;
 // CHECK-NEXT:         _t3.real_pullback(c2.imag() + 5 * _t1, &(* _d_c1), &_grad0);
 // CHECK-NEXT:         double _r0 = _grad0;
 // CHECK-NEXT:         _t0.imag_pullback(_r0, &(* _d_c2));
-// CHECK-NEXT:         double _r1 = _r0 * _t1;
-// CHECK-NEXT:         double _r2 = 5 * _r0;
-// CHECK-NEXT:         _t2.real_pullback(_r2, &(* _d_c2));
+// CHECK-NEXT:         _t2.real_pullback(5 * _r0, &(* _d_c2));
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -499,25 +445,19 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t5;
 // CHECK-NEXT:         double _r_d1 = _d_res;
-// CHECK-NEXT:         _d_res += _r_d1;
 // CHECK-NEXT:         t = _t6;
 // CHECK-NEXT:         sum_pullback(_t6, _r_d1, &(* _d_t));
-// CHECK-NEXT:         Tangent _r4 = (* _d_t);
-// CHECK-NEXT:         _d_res -= _r_d1;
+// CHECK-NEXT:         Tangent _r2 = (* _d_t);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t1);
 // CHECK-NEXT:             double _r_d0 = _d_res;
-// CHECK-NEXT:             _d_res += _r_d0;
 // CHECK-NEXT:             std{{(::__1)?}}::complex<double> _r0 = clad::pop(_t2);
 // CHECK-NEXT:             _r0.real_pullback(_r_d0, &(* _d_c));
-// CHECK-NEXT:             double _r1 = _r_d0 * clad::pop(_t3);
-// CHECK-NEXT:             double _r2 = 2 * _r_d0;
-// CHECK-NEXT:             std{{(::__1)?}}::complex<double> _r3 = clad::pop(_t4);
-// CHECK-NEXT:             _r3.imag_pullback(_r2, &(* _d_c));
-// CHECK-NEXT:             _d_res -= _r_d0;
+// CHECK-NEXT:             std{{(::__1)?}}::complex<double> _r1 = clad::pop(_t4);
+// CHECK-NEXT:             _r1.imag_pullback(2 * _r_d0, &(* _d_c));
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Gradient/constexprTest.C
+++ b/test/Gradient/constexprTest.C
@@ -33,21 +33,19 @@ constexpr double fn( double a, double b, double c) {
 
 //CHECK: constexpr void fn_grad(double a, double b, double c, clad::array_ref<double> _d_a, clad::array_ref<double> _d_b, clad::array_ref<double> _d_c) {
 //CHECK-NEXT:    double _d_val = 0;
-//CHECK-NEXT:    double _t0;
 //CHECK-NEXT:    double _d_result = 0;
 //CHECK-NEXT:    double val = 98.;
-//CHECK-NEXT:    _t0 = c;
-//CHECK-NEXT:    double result = a * b / _t0 * (a + b) * 100 + c;
+//CHECK-NEXT:    double result = a * b / c * (a + b) * 100 + c;
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
 //CHECK-NEXT:    _d_result += 1;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        * _d_a += _d_result * 100 * (a + b) / _t0 * b;
-//CHECK-NEXT:        * _d_b += a * _d_result * 100 * (a + b) / _t0;
-//CHECK-NEXT:        double _r0 = _d_result * 100 * (a + b) * -a * b / (_t0 * _t0);
+//CHECK-NEXT:        * _d_a += _d_result * 100 * (a + b) / c * b;
+//CHECK-NEXT:        * _d_b += a * _d_result * 100 * (a + b) / c;
+//CHECK-NEXT:        double _r0 = _d_result * 100 * (a + b) * -a * b / (c * c);
 //CHECK-NEXT:        * _d_c += _r0;
-//CHECK-NEXT:        * _d_a += a * b / _t0 * _d_result * 100;
-//CHECK-NEXT:        * _d_b += a * b / _t0 * _d_result * 100;
+//CHECK-NEXT:        * _d_a += a * b / c * _d_result * 100;
+//CHECK-NEXT:        * _d_b += a * b / c * _d_result * 100;
 //CHECK-NEXT:        * _d_c += _d_result;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}

--- a/test/Gradient/constexprTest.C
+++ b/test/Gradient/constexprTest.C
@@ -19,13 +19,9 @@ constexpr double mul (double a, double b, double c) {
 //CHECK-NEXT:  _label0:
 //CHECK-NEXT:    _d_result += 1;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = _d_result * c;
-//CHECK-NEXT:        double _r1 = _r0 * b;
-//CHECK-NEXT:        * _d_a += _r1;
-//CHECK-NEXT:        double _r2 = a * _r0;
-//CHECK-NEXT:        * _d_b += _r2;
-//CHECK-NEXT:        double _r3 = a * b * _d_result;
-//CHECK-NEXT:        * _d_c += _r3;
+//CHECK-NEXT:        * _d_a += _d_result * c * b;
+//CHECK-NEXT:        * _d_b += a * _d_result * c;
+//CHECK-NEXT:        * _d_c += a * b * _d_result;
 //CHECK-NEXT:    }
 //CHECK-NEXT: }
 
@@ -46,18 +42,12 @@ constexpr double fn( double a, double b, double c) {
 //CHECK-NEXT:  _label0:
 //CHECK-NEXT:    _d_result += 1;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = _d_result * 100;
-//CHECK-NEXT:        double _r1 = _r0 * (a + b);
-//CHECK-NEXT:        double _r2 = _r1 / _t0;
-//CHECK-NEXT:        double _r3 = _r2 * b;
-//CHECK-NEXT:        * _d_a += _r3;
-//CHECK-NEXT:        double _r4 = a * _r2;
-//CHECK-NEXT:        * _d_b += _r4;
-//CHECK-NEXT:        double _r5 = _r1 * -a * b / (_t0 * _t0);
-//CHECK-NEXT:        * _d_c += _r5;
-//CHECK-NEXT:        double _r6 = a * b / _t0 * _r0;
-//CHECK-NEXT:        * _d_a += _r6;
-//CHECK-NEXT:        * _d_b += _r6;
+//CHECK-NEXT:        * _d_a += _d_result * 100 * (a + b) / _t0 * b;
+//CHECK-NEXT:        * _d_b += a * _d_result * 100 * (a + b) / _t0;
+//CHECK-NEXT:        double _r0 = _d_result * 100 * (a + b) * -a * b / (_t0 * _t0);
+//CHECK-NEXT:        * _d_c += _r0;
+//CHECK-NEXT:        * _d_a += a * b / _t0 * _d_result * 100;
+//CHECK-NEXT:        * _d_b += a * b / _t0 * _d_result * 100;
 //CHECK-NEXT:        * _d_c += _d_result;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -21,6 +21,8 @@ float f1(float x) {
 // CHECK-NEXT: }
 
 // CHECK: void sin_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_d_x) {
+// CHECK-NEXT:     float _t0;
+// CHECK-NEXT:     _t0 = ::std::cos(x);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
@@ -28,7 +30,7 @@ float f1(float x) {
 // CHECK-NEXT:         * _d_x += _r0;
 // CHECK-NEXT:         float _r1 = _d_y.pushforward * d_x * clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         * _d_x += _r1;
-// CHECK-NEXT:         * _d_d_x += ::std::cos(x) * _d_y.pushforward;
+// CHECK-NEXT:         * _d_d_x += _t0 * _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -94,6 +96,8 @@ float f2(float x) {
 // CHECK-NEXT: }
 
 // CHECK: void exp_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_d_x) {
+// CHECK-NEXT:     float _t0;
+// CHECK-NEXT:     _t0 = ::std::exp(x);
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
@@ -101,7 +105,7 @@ float f2(float x) {
 // CHECK-NEXT:         * _d_x += _r0;
 // CHECK-NEXT:         float _r1 = _d_y.pushforward * d_x * clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         * _d_x += _r1;
-// CHECK-NEXT:         * _d_d_x += ::std::exp(x) * _d_y.pushforward;
+// CHECK-NEXT:         * _d_d_x += _t0 * _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -140,16 +144,14 @@ float f3(float x) {
 // CHECK-NEXT: }
 
 // CHECK: void log_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, clad::array_ref<float> _d_x, clad::array_ref<float> _d_d_x) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _t0 = x;
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = _d_y.value * clad::custom_derivatives{{(::std)?}}::log_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         double _r1 = _d_y.pushforward * d_x * -1. / (_t0 * _t0);
+// CHECK-NEXT:         double _r1 = _d_y.pushforward * d_x * -1. / (x * x);
 // CHECK-NEXT:         * _d_x += _r1;
-// CHECK-NEXT:         * _d_d_x += (1. / _t0) * _d_y.pushforward;
+// CHECK-NEXT:         * _d_d_x += (1. / x) * _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -194,14 +196,16 @@ float f4(float x) {
 // CHECK-NEXT:     float _cond0;
 // CHECK-NEXT:     float _t1;
 // CHECK-NEXT:     float _t2;
+// CHECK-NEXT:     float _t3;
 // CHECK-NEXT:     float val = ::std::pow(x, exponent);
 // CHECK-NEXT:     _t0 = ::std::pow(x, exponent - 1);
 // CHECK-NEXT:     float derivative = (exponent * _t0) * d_x;
 // CHECK-NEXT:     _cond0 = d_exponent;
 // CHECK-NEXT:     if (_cond0) {
 // CHECK-NEXT:         _t1 = derivative;
+// CHECK-NEXT:         _t3 = ::std::pow(x, exponent);
 // CHECK-NEXT:         _t2 = ::std::log(x);
-// CHECK-NEXT:         derivative += (::std::pow(x, exponent) * _t2) * d_exponent;
+// CHECK-NEXT:         derivative += (_t3 * _t2) * d_exponent;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
@@ -219,9 +223,9 @@ float f4(float x) {
 // CHECK-NEXT:         * _d_x += _r4;
 // CHECK-NEXT:         float _r5 = _grad5;
 // CHECK-NEXT:         * _d_exponent += _r5;
-// CHECK-NEXT:         float _r6 = ::std::pow(x, exponent) * _r_d0 * d_exponent * clad::custom_derivatives{{(::std)?}}::log_pushforward(x, 1.F).pushforward;
+// CHECK-NEXT:         float _r6 = _t3 * _r_d0 * d_exponent * clad::custom_derivatives{{(::std)?}}::log_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         * _d_x += _r6;
-// CHECK-NEXT:         * _d_d_exponent += (::std::pow(x, exponent) * _t2) * _r_d0;
+// CHECK-NEXT:         * _d_d_exponent += (_t3 * _t2) * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         * _d_exponent += _d_derivative * d_x * _t0;

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -26,11 +26,9 @@ float f1(float x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = _d_y.value * clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         float _r1 = _d_y.pushforward * d_x;
-// CHECK-NEXT:         float _r2 = _r1 * clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, 1.F).pushforward;
-// CHECK-NEXT:         * _d_x += _r2;
-// CHECK-NEXT:         float _r3 = ::std::cos(x) * _d_y.pushforward;
-// CHECK-NEXT:         * _d_d_x += _r3;
+// CHECK-NEXT:         float _r1 = _d_y.pushforward * d_x * clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, 1.F).pushforward;
+// CHECK-NEXT:         * _d_x += _r1;
+// CHECK-NEXT:         * _d_d_x += ::std::cos(x) * _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -42,13 +40,9 @@ float f1(float x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = _d_y.value * clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         float _r1 = _d_y.pushforward * d_x;
-// CHECK-NEXT:         float _r2 = _r1 * _t0;
-// CHECK-NEXT:         float _r3 = -1 * _r1;
-// CHECK-NEXT:         float _r4 = _r3 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, 1.F).pushforward;
-// CHECK-NEXT:         * _d_x += _r4;
-// CHECK-NEXT:         float _r5 = -1 * _t0 * _d_y.pushforward;
-// CHECK-NEXT:         * _d_d_x += _r5;
+// CHECK-NEXT:         float _r1 = -1 * _d_y.pushforward * d_x * clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, 1.F).pushforward;
+// CHECK-NEXT:         * _d_x += _r1;
+// CHECK-NEXT:         * _d_d_x += -1 * _t0 * _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -105,11 +99,9 @@ float f2(float x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = _d_y.value * clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         float _r1 = _d_y.pushforward * d_x;
-// CHECK-NEXT:         float _r2 = _r1 * clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, 1.F).pushforward;
-// CHECK-NEXT:         * _d_x += _r2;
-// CHECK-NEXT:         float _r3 = ::std::exp(x) * _d_y.pushforward;
-// CHECK-NEXT:         * _d_d_x += _r3;
+// CHECK-NEXT:         float _r1 = _d_y.pushforward * d_x * clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, 1.F).pushforward;
+// CHECK-NEXT:         * _d_x += _r1;
+// CHECK-NEXT:         * _d_d_x += ::std::exp(x) * _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -155,12 +147,9 @@ float f3(float x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = _d_y.value * clad::custom_derivatives{{(::std)?}}::log_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         double _r1 = _d_y.pushforward * d_x;
-// CHECK-NEXT:         double _r2 = _r1 / _t0;
-// CHECK-NEXT:         double _r3 = _r1 * -1. / (_t0 * _t0);
-// CHECK-NEXT:         * _d_x += _r3;
-// CHECK-NEXT:         double _r4 = (1. / _t0) * _d_y.pushforward;
-// CHECK-NEXT:         * _d_d_x += _r4;
+// CHECK-NEXT:         double _r1 = _d_y.pushforward * d_x * -1. / (_t0 * _t0);
+// CHECK-NEXT:         * _d_x += _r1;
+// CHECK-NEXT:         * _d_d_x += (1. / _t0) * _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -223,37 +212,27 @@ float f4(float x) {
 // CHECK-NEXT:     if (_cond0) {
 // CHECK-NEXT:         derivative = _t1;
 // CHECK-NEXT:         float _r_d0 = _d_derivative;
-// CHECK-NEXT:         _d_derivative += _r_d0;
-// CHECK-NEXT:         float _r8 = _r_d0 * d_exponent;
-// CHECK-NEXT:         float _r9 = _r8 * _t2;
 // CHECK-NEXT:         float _grad4 = 0.F;
 // CHECK-NEXT:         float _grad5 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(x, exponent, _r9, &_grad4, &_grad5);
-// CHECK-NEXT:         float _r10 = _grad4;
-// CHECK-NEXT:         * _d_x += _r10;
-// CHECK-NEXT:         float _r11 = _grad5;
-// CHECK-NEXT:         * _d_exponent += _r11;
-// CHECK-NEXT:         float _r12 = ::std::pow(x, exponent) * _r8;
-// CHECK-NEXT:         float _r13 = _r12 * clad::custom_derivatives{{(::std)?}}::log_pushforward(x, 1.F).pushforward;
-// CHECK-NEXT:         * _d_x += _r13;
-// CHECK-NEXT:         float _r14 = (::std::pow(x, exponent) * _t2) * _r_d0;
-// CHECK-NEXT:         * _d_d_exponent += _r14;
-// CHECK-NEXT:         _d_derivative -= _r_d0;
+// CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(x, exponent, _r_d0 * d_exponent * _t2, &_grad4, &_grad5);
+// CHECK-NEXT:         float _r4 = _grad4;
+// CHECK-NEXT:         * _d_x += _r4;
+// CHECK-NEXT:         float _r5 = _grad5;
+// CHECK-NEXT:         * _d_exponent += _r5;
+// CHECK-NEXT:         float _r6 = ::std::pow(x, exponent) * _r_d0 * d_exponent * clad::custom_derivatives{{(::std)?}}::log_pushforward(x, 1.F).pushforward;
+// CHECK-NEXT:         * _d_x += _r6;
+// CHECK-NEXT:         * _d_d_exponent += (::std::pow(x, exponent) * _t2) * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         float _r2 = _d_derivative * d_x;
-// CHECK-NEXT:         float _r3 = _r2 * _t0;
-// CHECK-NEXT:         * _d_exponent += _r3;
-// CHECK-NEXT:         float _r4 = exponent * _r2;
+// CHECK-NEXT:         * _d_exponent += _d_derivative * d_x * _t0;
 // CHECK-NEXT:         float _grad2 = 0.F;
 // CHECK-NEXT:         float _grad3 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(x, exponent - 1, _r4, &_grad2, &_grad3);
-// CHECK-NEXT:         float _r5 = _grad2;
-// CHECK-NEXT:         * _d_x += _r5;
-// CHECK-NEXT:         float _r6 = _grad3;
-// CHECK-NEXT:         * _d_exponent += _r6;
-// CHECK-NEXT:         float _r7 = (exponent * _t0) * _d_derivative;
-// CHECK-NEXT:         * _d_d_x += _r7;
+// CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(x, exponent - 1, exponent * _d_derivative * d_x, &_grad2, &_grad3);
+// CHECK-NEXT:         float _r2 = _grad2;
+// CHECK-NEXT:         * _d_x += _r2;
+// CHECK-NEXT:         float _r3 = _grad3;
+// CHECK-NEXT:         * _d_exponent += _r3;
+// CHECK-NEXT:         * _d_d_x += (exponent * _t0) * _d_derivative;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _grad0 = 0.F;

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -24,48 +24,28 @@ void f_cubed_add1_darg0_grad(double a, double b, clad::array_ref<double> _d_a, c
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r4 = 1 * a;
-//CHECK-NEXT:        double _r5 = _r4 * a;
-//CHECK-NEXT:        _d__d_a += _r5;
-//CHECK-NEXT:        double _r6 = _d_a0 * _r4;
-//CHECK-NEXT:        * _d_a += _r6;
-//CHECK-NEXT:        double _r7 = _r4 * _d_a0;
-//CHECK-NEXT:        * _d_a += _r7;
-//CHECK-NEXT:        double _r8 = a * _r4;
-//CHECK-NEXT:        _d__d_a += _r8;
-//CHECK-NEXT:        double _r9 = (_d_a0 * a + a * _d_a0) * 1;
-//CHECK-NEXT:        * _d_a += _r9;
-//CHECK-NEXT:        double _r10 = 1 * _d_a0;
-//CHECK-NEXT:        _d__t0 += _r10;
-//CHECK-NEXT:        double _r11 = _t00 * 1;
-//CHECK-NEXT:        _d__d_a += _r11;
-//CHECK-NEXT:        double _r12 = 1 * b;
-//CHECK-NEXT:        double _r13 = _r12 * b;
-//CHECK-NEXT:        _d__d_b += _r13;
-//CHECK-NEXT:        double _r14 = _d_b0 * _r12;
-//CHECK-NEXT:        * _d_b += _r14;
-//CHECK-NEXT:        double _r15 = _r12 * _d_b0;
-//CHECK-NEXT:        * _d_b += _r15;
-//CHECK-NEXT:        double _r16 = b * _r12;
-//CHECK-NEXT:        _d__d_b += _r16;
-//CHECK-NEXT:        double _r17 = (_d_b0 * b + b * _d_b0) * 1;
-//CHECK-NEXT:        * _d_b += _r17;
-//CHECK-NEXT:        double _r18 = 1 * _d_b0;
-//CHECK-NEXT:        _d__t1 += _r18;
-//CHECK-NEXT:        double _r19 = _t10 * 1;
-//CHECK-NEXT:        _d__d_b += _r19;
+//CHECK-NEXT:        _d__d_a += 1 * a * a;
+//CHECK-NEXT:        * _d_a += _d_a0 * 1 * a;
+//CHECK-NEXT:        * _d_a += 1 * a * _d_a0;
+//CHECK-NEXT:        _d__d_a += a * 1 * a;
+//CHECK-NEXT:        * _d_a += (_d_a0 * a + a * _d_a0) * 1;
+//CHECK-NEXT:        _d__t0 += 1 * _d_a0;
+//CHECK-NEXT:        _d__d_a += _t00 * 1;
+//CHECK-NEXT:        _d__d_b += 1 * b * b;
+//CHECK-NEXT:        * _d_b += _d_b0 * 1 * b;
+//CHECK-NEXT:        * _d_b += 1 * b * _d_b0;
+//CHECK-NEXT:        _d__d_b += b * 1 * b;
+//CHECK-NEXT:        * _d_b += (_d_b0 * b + b * _d_b0) * 1;
+//CHECK-NEXT:        _d__t1 += 1 * _d_b0;
+//CHECK-NEXT:        _d__d_b += _t10 * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r2 = _d__t1 * b;
-//CHECK-NEXT:        * _d_b += _r2;
-//CHECK-NEXT:        double _r3 = b * _d__t1;
-//CHECK-NEXT:        * _d_b += _r3;
+//CHECK-NEXT:        * _d_b += _d__t1 * b;
+//CHECK-NEXT:        * _d_b += b * _d__t1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = _d__t0 * a;
-//CHECK-NEXT:        * _d_a += _r0;
-//CHECK-NEXT:        double _r1 = a * _d__t0;
-//CHECK-NEXT:        * _d_a += _r1;
+//CHECK-NEXT:        * _d_a += _d__t0 * a;
+//CHECK-NEXT:        * _d_a += a * _d__t0;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
@@ -82,48 +62,28 @@ void f_cubed_add1_darg1_grad(double a, double b, clad::array_ref<double> _d_a, c
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r4 = 1 * a;
-//CHECK-NEXT:        double _r5 = _r4 * a;
-//CHECK-NEXT:        _d__d_a += _r5;
-//CHECK-NEXT:        double _r6 = _d_a0 * _r4;
-//CHECK-NEXT:        * _d_a += _r6;
-//CHECK-NEXT:        double _r7 = _r4 * _d_a0;
-//CHECK-NEXT:        * _d_a += _r7;
-//CHECK-NEXT:        double _r8 = a * _r4;
-//CHECK-NEXT:        _d__d_a += _r8;
-//CHECK-NEXT:        double _r9 = (_d_a0 * a + a * _d_a0) * 1;
-//CHECK-NEXT:        * _d_a += _r9;
-//CHECK-NEXT:        double _r10 = 1 * _d_a0;
-//CHECK-NEXT:        _d__t0 += _r10;
-//CHECK-NEXT:        double _r11 = _t00 * 1;
-//CHECK-NEXT:        _d__d_a += _r11;
-//CHECK-NEXT:        double _r12 = 1 * b;
-//CHECK-NEXT:        double _r13 = _r12 * b;
-//CHECK-NEXT:        _d__d_b += _r13;
-//CHECK-NEXT:        double _r14 = _d_b0 * _r12;
-//CHECK-NEXT:        * _d_b += _r14;
-//CHECK-NEXT:        double _r15 = _r12 * _d_b0;
-//CHECK-NEXT:        * _d_b += _r15;
-//CHECK-NEXT:        double _r16 = b * _r12;
-//CHECK-NEXT:        _d__d_b += _r16;
-//CHECK-NEXT:        double _r17 = (_d_b0 * b + b * _d_b0) * 1;
-//CHECK-NEXT:        * _d_b += _r17;
-//CHECK-NEXT:        double _r18 = 1 * _d_b0;
-//CHECK-NEXT:        _d__t1 += _r18;
-//CHECK-NEXT:        double _r19 = _t10 * 1;
-//CHECK-NEXT:        _d__d_b += _r19;
+//CHECK-NEXT:        _d__d_a += 1 * a * a;
+//CHECK-NEXT:        * _d_a += _d_a0 * 1 * a;
+//CHECK-NEXT:        * _d_a += 1 * a * _d_a0;
+//CHECK-NEXT:        _d__d_a += a * 1 * a;
+//CHECK-NEXT:        * _d_a += (_d_a0 * a + a * _d_a0) * 1;
+//CHECK-NEXT:        _d__t0 += 1 * _d_a0;
+//CHECK-NEXT:        _d__d_a += _t00 * 1;
+//CHECK-NEXT:        _d__d_b += 1 * b * b;
+//CHECK-NEXT:        * _d_b += _d_b0 * 1 * b;
+//CHECK-NEXT:        * _d_b += 1 * b * _d_b0;
+//CHECK-NEXT:        _d__d_b += b * 1 * b;
+//CHECK-NEXT:        * _d_b += (_d_b0 * b + b * _d_b0) * 1;
+//CHECK-NEXT:        _d__t1 += 1 * _d_b0;
+//CHECK-NEXT:        _d__d_b += _t10 * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r2 = _d__t1 * b;
-//CHECK-NEXT:        * _d_b += _r2;
-//CHECK-NEXT:        double _r3 = b * _d__t1;
-//CHECK-NEXT:        * _d_b += _r3;
+//CHECK-NEXT:        * _d_b += _d__t1 * b;
+//CHECK-NEXT:        * _d_b += b * _d__t1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = _d__t0 * a;
-//CHECK-NEXT:        * _d_a += _r0;
-//CHECK-NEXT:        double _r1 = a * _d__t0;
-//CHECK-NEXT:        * _d_a += _r1;
+//CHECK-NEXT:        * _d_a += _d__t0 * a;
+//CHECK-NEXT:        * _d_a += a * _d__t0;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -34,30 +34,18 @@ double f2(double x, double y){
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = _d_y0.value * x;
-// CHECK-NEXT:         * _d_x += _r0;
-// CHECK-NEXT:         double _r1 = x * _d_y0.value;
-// CHECK-NEXT:         * _d_x += _r1;
-// CHECK-NEXT:         double _r2 = _d_y0.value * y;
-// CHECK-NEXT:         * _d_y += _r2;
-// CHECK-NEXT:         double _r3 = y * _d_y0.value;
-// CHECK-NEXT:         * _d_y += _r3;
-// CHECK-NEXT:         double _r4 = _d_y0.pushforward * x;
-// CHECK-NEXT:         * _d__d_x += _r4;
-// CHECK-NEXT:         double _r5 = _d_x * _d_y0.pushforward;
-// CHECK-NEXT:         * _d_x += _r5;
-// CHECK-NEXT:         double _r6 = _d_y0.pushforward * _d_x;
-// CHECK-NEXT:         * _d_x += _r6;
-// CHECK-NEXT:         double _r7 = x * _d_y0.pushforward;
-// CHECK-NEXT:         * _d__d_x += _r7;
-// CHECK-NEXT:         double _r8 = _d_y0.pushforward * y;
-// CHECK-NEXT:         * _d__d_y += _r8;
-// CHECK-NEXT:         double _r9 = _d_y * _d_y0.pushforward;
-// CHECK-NEXT:         * _d_y += _r9;
-// CHECK-NEXT:         double _r10 = _d_y0.pushforward * _d_y;
-// CHECK-NEXT:         * _d_y += _r10;
-// CHECK-NEXT:         double _r11 = y * _d_y0.pushforward;
-// CHECK-NEXT:         * _d__d_y += _r11;
+// CHECK-NEXT:         * _d_x += _d_y0.value * x;
+// CHECK-NEXT:         * _d_x += x * _d_y0.value;
+// CHECK-NEXT:         * _d_y += _d_y0.value * y;
+// CHECK-NEXT:         * _d_y += y * _d_y0.value;
+// CHECK-NEXT:         * _d__d_x += _d_y0.pushforward * x;
+// CHECK-NEXT:         * _d_x += _d_x * _d_y0.pushforward;
+// CHECK-NEXT:         * _d_x += _d_y0.pushforward * _d_x;
+// CHECK-NEXT:         * _d__d_x += x * _d_y0.pushforward;
+// CHECK-NEXT:         * _d__d_y += _d_y0.pushforward * y;
+// CHECK-NEXT:         * _d_y += _d_y * _d_y0.pushforward;
+// CHECK-NEXT:         * _d_y += _d_y0.pushforward * _d_y;
+// CHECK-NEXT:         * _d__d_y += y * _d_y0.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -24,14 +24,10 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * j;
-// CHECK-NEXT:         _d__d_i += _r0;
-// CHECK-NEXT:         double _r1 = _d_i0 * 1;
-// CHECK-NEXT:         * _d_j += _r1;
-// CHECK-NEXT:         double _r2 = 1 * _d_j0;
-// CHECK-NEXT:         * _d_i += _r2;
-// CHECK-NEXT:         double _r3 = i * 1;
-// CHECK-NEXT:         _d__d_j += _r3;
+// CHECK-NEXT:         _d__d_i += 1 * j;
+// CHECK-NEXT:         * _d_j += _d_i0 * 1;
+// CHECK-NEXT:         * _d_i += 1 * _d_j0;
+// CHECK-NEXT:         _d__d_j += i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -49,14 +45,10 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * j;
-// CHECK-NEXT:         _d__d_i += _r0;
-// CHECK-NEXT:         double _r1 = _d_i0 * 1;
-// CHECK-NEXT:         * _d_j += _r1;
-// CHECK-NEXT:         double _r2 = 1 * _d_j0;
-// CHECK-NEXT:         * _d_i += _r2;
-// CHECK-NEXT:         double _r3 = i * 1;
-// CHECK-NEXT:         _d__d_j += _r3;
+// CHECK-NEXT:         _d__d_i += 1 * j;
+// CHECK-NEXT:         * _d_j += _d_i0 * 1;
+// CHECK-NEXT:         * _d_i += 1 * _d_j0;
+// CHECK-NEXT:         _d__d_j += i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Jacobian/Functors.C
+++ b/test/Jacobian/Functors.C
@@ -72,17 +72,21 @@ struct ExperimentVolatile {
   }
 
   // CHECK: void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) volatile {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     _t0 = this->x * i;
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
+  // CHECK-NEXT:     _t1 = this->y * i;
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         jacobianMatrix[2UL] += this->y * 1 * j * j;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * j * 1;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += _t1 * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += _t1 * j * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
   // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * 1 * j * i;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[1UL] += this->x * i * i * 1;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += _t0 * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[1UL] += _t0 * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -99,17 +103,21 @@ struct ExperimentConstVolatile {
   }
 
   // CHECK: void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) const volatile {
+  // CHECK-NEXT:     double _t0;
+  // CHECK-NEXT:     double _t1;
+  // CHECK-NEXT:     _t0 = this->x * i;
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
+  // CHECK-NEXT:     _t1 = this->y * i;
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         jacobianMatrix[2UL] += this->y * 1 * j * j;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * j * 1;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += _t1 * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += _t1 * j * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
   // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * 1 * j * i;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[1UL] += this->x * i * i * 1;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += _t0 * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[1UL] += _t0 * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };

--- a/test/Jacobian/Functors.C
+++ b/test/Jacobian/Functors.C
@@ -21,26 +21,14 @@ struct Experiment {
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r6 = 1 * j;
-  // CHECK-NEXT:         double _r7 = _r6 * j;
-  // CHECK-NEXT:         double _r8 = _r7 * i;
-  // CHECK-NEXT:         double _r9 = this->y * _r7;
-  // CHECK-NEXT:         jacobianMatrix[2UL] += _r9;
-  // CHECK-NEXT:         double _r10 = this->y * i * _r6;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += _r10;
-  // CHECK-NEXT:         double _r11 = this->y * i * j * 1;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += _r11;
+  // CHECK-NEXT:         jacobianMatrix[2UL] += this->y * 1 * j * j;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * j * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * j;
-  // CHECK-NEXT:         double _r1 = _r0 * i;
-  // CHECK-NEXT:         double _r2 = _r1 * i;
-  // CHECK-NEXT:         double _r3 = this->x * _r1;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += _r3;
-  // CHECK-NEXT:         double _r4 = this->x * i * _r0;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += _r4;
-  // CHECK-NEXT:         double _r5 = this->x * i * i * 1;
-  // CHECK-NEXT:         jacobianMatrix[1UL] += _r5;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * 1 * j * i;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[1UL] += this->x * i * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -60,26 +48,14 @@ struct ExperimentConst {
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r6 = 1 * j;
-  // CHECK-NEXT:         double _r7 = _r6 * j;
-  // CHECK-NEXT:         double _r8 = _r7 * i;
-  // CHECK-NEXT:         double _r9 = this->y * _r7;
-  // CHECK-NEXT:         jacobianMatrix[2UL] += _r9;
-  // CHECK-NEXT:         double _r10 = this->y * i * _r6;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += _r10;
-  // CHECK-NEXT:         double _r11 = this->y * i * j * 1;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += _r11;
+  // CHECK-NEXT:         jacobianMatrix[2UL] += this->y * 1 * j * j;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * j * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * j;
-  // CHECK-NEXT:         double _r1 = _r0 * i;
-  // CHECK-NEXT:         double _r2 = _r1 * i;
-  // CHECK-NEXT:         double _r3 = this->x * _r1;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += _r3;
-  // CHECK-NEXT:         double _r4 = this->x * i * _r0;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += _r4;
-  // CHECK-NEXT:         double _r5 = this->x * i * i * 1;
-  // CHECK-NEXT:         jacobianMatrix[1UL] += _r5;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * 1 * j * i;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[1UL] += this->x * i * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -99,26 +75,14 @@ struct ExperimentVolatile {
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r6 = 1 * j;
-  // CHECK-NEXT:         double _r7 = _r6 * j;
-  // CHECK-NEXT:         double _r8 = _r7 * i;
-  // CHECK-NEXT:         double _r9 = this->y * _r7;
-  // CHECK-NEXT:         jacobianMatrix[2UL] += _r9;
-  // CHECK-NEXT:         double _r10 = this->y * i * _r6;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += _r10;
-  // CHECK-NEXT:         double _r11 = this->y * i * j * 1;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += _r11;
+  // CHECK-NEXT:         jacobianMatrix[2UL] += this->y * 1 * j * j;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * j * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * j;
-  // CHECK-NEXT:         double _r1 = _r0 * i;
-  // CHECK-NEXT:         double _r2 = _r1 * i;
-  // CHECK-NEXT:         double _r3 = this->x * _r1;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += _r3;
-  // CHECK-NEXT:         double _r4 = this->x * i * _r0;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += _r4;
-  // CHECK-NEXT:         double _r5 = this->x * i * i * 1;
-  // CHECK-NEXT:         jacobianMatrix[1UL] += _r5;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * 1 * j * i;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[1UL] += this->x * i * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -138,26 +102,14 @@ struct ExperimentConstVolatile {
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r6 = 1 * j;
-  // CHECK-NEXT:         double _r7 = _r6 * j;
-  // CHECK-NEXT:         double _r8 = _r7 * i;
-  // CHECK-NEXT:         double _r9 = this->y * _r7;
-  // CHECK-NEXT:         jacobianMatrix[2UL] += _r9;
-  // CHECK-NEXT:         double _r10 = this->y * i * _r6;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += _r10;
-  // CHECK-NEXT:         double _r11 = this->y * i * j * 1;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += _r11;
+  // CHECK-NEXT:         jacobianMatrix[2UL] += this->y * 1 * j * j;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * j * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * j;
-  // CHECK-NEXT:         double _r1 = _r0 * i;
-  // CHECK-NEXT:         double _r2 = _r1 * i;
-  // CHECK-NEXT:         double _r3 = this->x * _r1;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += _r3;
-  // CHECK-NEXT:         double _r4 = this->x * i * _r0;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += _r4;
-  // CHECK-NEXT:         double _r5 = this->x * i * i * 1;
-  // CHECK-NEXT:         jacobianMatrix[1UL] += _r5;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * 1 * j * i;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[1UL] += this->x * i * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -179,26 +131,14 @@ namespace outer {
       // CHECK-NEXT:     output[0] = this->x * i * i * j;
       // CHECK-NEXT:     output[1] = this->y * i * j * j;
       // CHECK-NEXT:     {
-      // CHECK-NEXT:         double _r6 = 1 * j;
-      // CHECK-NEXT:         double _r7 = _r6 * j;
-      // CHECK-NEXT:         double _r8 = _r7 * i;
-      // CHECK-NEXT:         double _r9 = this->y * _r7;
-      // CHECK-NEXT:         jacobianMatrix[2UL] += _r9;
-      // CHECK-NEXT:         double _r10 = this->y * i * _r6;
-      // CHECK-NEXT:         jacobianMatrix[3UL] += _r10;
-      // CHECK-NEXT:         double _r11 = this->y * i * j * 1;
-      // CHECK-NEXT:         jacobianMatrix[3UL] += _r11;
+      // CHECK-NEXT:         jacobianMatrix[2UL] += this->y * 1 * j * j;
+      // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * 1 * j;
+      // CHECK-NEXT:         jacobianMatrix[3UL] += this->y * i * j * 1;
       // CHECK-NEXT:     }
       // CHECK-NEXT:     {
-      // CHECK-NEXT:         double _r0 = 1 * j;
-      // CHECK-NEXT:         double _r1 = _r0 * i;
-      // CHECK-NEXT:         double _r2 = _r1 * i;
-      // CHECK-NEXT:         double _r3 = this->x * _r1;
-      // CHECK-NEXT:         jacobianMatrix[0UL] += _r3;
-      // CHECK-NEXT:         double _r4 = this->x * i * _r0;
-      // CHECK-NEXT:         jacobianMatrix[0UL] += _r4;
-      // CHECK-NEXT:         double _r5 = this->x * i * i * 1;
-      // CHECK-NEXT:         jacobianMatrix[1UL] += _r5;
+      // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * 1 * j * i;
+      // CHECK-NEXT:         jacobianMatrix[0UL] += this->x * i * 1 * j;
+      // CHECK-NEXT:         jacobianMatrix[1UL] += this->x * i * i * 1;
       // CHECK-NEXT:     }
       // CHECK-NEXT: }
     };
@@ -212,22 +152,14 @@ namespace outer {
     // CHECK-NEXT:     output[0] = i * i * j;
     // CHECK-NEXT:     output[1] = i * j * j;
     // CHECK-NEXT:     {
-    // CHECK-NEXT:         double _r4 = 1 * j;
-    // CHECK-NEXT:         double _r5 = _r4 * j;
-    // CHECK-NEXT:         jacobianMatrix[2UL] += _r5;
-    // CHECK-NEXT:         double _r6 = i * _r4;
-    // CHECK-NEXT:         jacobianMatrix[3UL] += _r6;
-    // CHECK-NEXT:         double _r7 = i * j * 1;
-    // CHECK-NEXT:         jacobianMatrix[3UL] += _r7;
+    // CHECK-NEXT:         jacobianMatrix[2UL] += 1 * j * j;
+    // CHECK-NEXT:         jacobianMatrix[3UL] += i * 1 * j;
+    // CHECK-NEXT:         jacobianMatrix[3UL] += i * j * 1;
     // CHECK-NEXT:     }
     // CHECK-NEXT:     {
-    // CHECK-NEXT:         double _r0 = 1 * j;
-    // CHECK-NEXT:         double _r1 = _r0 * i;
-    // CHECK-NEXT:         jacobianMatrix[0UL] += _r1;
-    // CHECK-NEXT:         double _r2 = i * _r0;
-    // CHECK-NEXT:         jacobianMatrix[0UL] += _r2;
-    // CHECK-NEXT:         double _r3 = i * i * 1;
-    // CHECK-NEXT:         jacobianMatrix[1UL] += _r3;
+    // CHECK-NEXT:         jacobianMatrix[0UL] += 1 * j * i;
+    // CHECK-NEXT:         jacobianMatrix[0UL] += i * 1 * j;
+    // CHECK-NEXT:         jacobianMatrix[1UL] += i * i * 1;
     // CHECK-NEXT:     }
     // CHECK-NEXT: }
   }
@@ -269,22 +201,14 @@ int main() {
   // CHECK-NEXT:     output[0] = i * i * j;
   // CHECK-NEXT:     output[1] = i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r4 = 1 * j;
-  // CHECK-NEXT:         double _r5 = _r4 * j;
-  // CHECK-NEXT:         jacobianMatrix[2UL] += _r5;
-  // CHECK-NEXT:         double _r6 = i * _r4;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += _r6;
-  // CHECK-NEXT:         double _r7 = i * j * 1;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += _r7;
+  // CHECK-NEXT:         jacobianMatrix[2UL] += 1 * j * j;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += i * j * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * j;
-  // CHECK-NEXT:         double _r1 = _r0 * i;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += _r1;
-  // CHECK-NEXT:         double _r2 = i * _r0;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += _r2;
-  // CHECK-NEXT:         double _r3 = i * i * 1;
-  // CHECK-NEXT:         jacobianMatrix[1UL] += _r3;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += 1 * j * i;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[1UL] += i * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -297,26 +221,14 @@ int main() {
   // CHECK-NEXT:     output[0] = x * i * i * jj;
   // CHECK-NEXT:     output[1] = y * i * jj * jj;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r6 = 1 * jj;
-  // CHECK-NEXT:         double _r7 = _r6 * jj;
-  // CHECK-NEXT:         double _r8 = _r7 * i;
-  // CHECK-NEXT:         double _r9 = y * _r7;
-  // CHECK-NEXT:         jacobianMatrix[2UL] += _r9;
-  // CHECK-NEXT:         double _r10 = y * i * _r6;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += _r10;
-  // CHECK-NEXT:         double _r11 = y * i * jj * 1;
-  // CHECK-NEXT:         jacobianMatrix[3UL] += _r11;
+  // CHECK-NEXT:         jacobianMatrix[2UL] += y * 1 * jj * jj;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += y * i * 1 * jj;
+  // CHECK-NEXT:         jacobianMatrix[3UL] += y * i * jj * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r0 = 1 * jj;
-  // CHECK-NEXT:         double _r1 = _r0 * i;
-  // CHECK-NEXT:         double _r2 = _r1 * i;
-  // CHECK-NEXT:         double _r3 = x * _r1;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += _r3;
-  // CHECK-NEXT:         double _r4 = x * i * _r0;
-  // CHECK-NEXT:         jacobianMatrix[0UL] += _r4;
-  // CHECK-NEXT:         double _r5 = x * i * i * 1;
-  // CHECK-NEXT:         jacobianMatrix[1UL] += _r5;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += x * 1 * jj * i;
+  // CHECK-NEXT:         jacobianMatrix[0UL] += x * i * 1 * jj;
+  // CHECK-NEXT:         jacobianMatrix[1UL] += x * i * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -20,40 +20,23 @@ void f_1_jac(double a, double b, double c, double output[], double *_result);
 //CHECK-NEXT:  output[1] = a * a * a + b * b * b;
 //CHECK-NEXT:  output[2] = c * c * 10 - a * a;
 //CHECK-NEXT:  {
-//CHECK-NEXT:    double _r12 = 1 * 10;
-//CHECK-NEXT:    double _r13 = _r12 * c;
-//CHECK-NEXT:    jacobianMatrix[8UL] += _r13;
-//CHECK-NEXT:    double _r14 = c * _r12;
-//CHECK-NEXT:    jacobianMatrix[8UL] += _r14;
-//CHECK-NEXT:    double _r15 = -1 * a;
-//CHECK-NEXT:    jacobianMatrix[6UL] += _r15;
-//CHECK-NEXT:    double _r16 = a * -1;
-//CHECK-NEXT:    jacobianMatrix[6UL] += _r16;
+//CHECK-NEXT:    jacobianMatrix[8UL] += 1 * 10 * c;
+//CHECK-NEXT:    jacobianMatrix[8UL] += c * 1 * 10;
+//CHECK-NEXT:    jacobianMatrix[6UL] += -1 * a;
+//CHECK-NEXT:    jacobianMatrix[6UL] += a * -1;
 //CHECK-NEXT:  }
 //CHECK-NEXT:  {
-//CHECK-NEXT:    double _r4 = 1 * a;
-//CHECK-NEXT:    double _r5 = _r4 * a;
-//CHECK-NEXT:    jacobianMatrix[3UL] += _r5;
-//CHECK-NEXT:    double _r6 = a * _r4;
-//CHECK-NEXT:    jacobianMatrix[3UL] += _r6;
-//CHECK-NEXT:    double _r7 = a * a * 1;
-//CHECK-NEXT:    jacobianMatrix[3UL] += _r7;
-//CHECK-NEXT:    double _r8 = 1 * b;
-//CHECK-NEXT:    double _r9 = _r8 * b;
-//CHECK-NEXT:    jacobianMatrix[4UL] += _r9;
-//CHECK-NEXT:    double _r10 = b * _r8;
-//CHECK-NEXT:    jacobianMatrix[4UL] += _r10;
-//CHECK-NEXT:    double _r11 = b * b * 1;
-//CHECK-NEXT:    jacobianMatrix[4UL] += _r11;
+//CHECK-NEXT:    jacobianMatrix[3UL] += 1 * a * a;
+//CHECK-NEXT:    jacobianMatrix[3UL] += a * 1 * a;
+//CHECK-NEXT:    jacobianMatrix[3UL] += a * a * 1;
+//CHECK-NEXT:    jacobianMatrix[4UL] += 1 * b * b;
+//CHECK-NEXT:    jacobianMatrix[4UL] += b * 1 * b;
+//CHECK-NEXT:    jacobianMatrix[4UL] += b * b * 1;
 //CHECK-NEXT:  }
 //CHECK-NEXT:  {
-//CHECK-NEXT:    double _r0 = 1 * a;
-//CHECK-NEXT:    double _r1 = _r0 * a;
-//CHECK-NEXT:    jacobianMatrix[0UL] += _r1;
-//CHECK-NEXT:    double _r2 = a * _r0;
-//CHECK-NEXT:    jacobianMatrix[0UL] += _r2;
-//CHECK-NEXT:    double _r3 = a * a * 1;
-//CHECK-NEXT:    jacobianMatrix[0UL] += _r3;
+//CHECK-NEXT:    jacobianMatrix[0UL] += 1 * a * a;
+//CHECK-NEXT:    jacobianMatrix[0UL] += a * 1 * a;
+//CHECK-NEXT:    jacobianMatrix[0UL] += a * a * 1;
 //CHECK-NEXT:  }
 //CHECK-NEXT:}
 
@@ -74,22 +57,16 @@ void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatr
 //CHECK-NEXT:  _result[1] = sin(y) * constant;
 //CHECK-NEXT:  _result[2] = sin(z) * constant;
 //CHECK-NEXT:  {
-//CHECK-NEXT:    double _r6 = 1 * constant;
-//CHECK-NEXT:    double _r7 = _r6 * clad::custom_derivatives::sin_pushforward(z, 1.).pushforward;
-//CHECK-NEXT:    jacobianMatrix[8UL] += _r7;
-//CHECK-NEXT:    double _r8 = sin(z) * 1;
+//CHECK-NEXT:    double _r2 = 1 * constant * clad::custom_derivatives::sin_pushforward(z, 1.).pushforward;
+//CHECK-NEXT:    jacobianMatrix[8UL] += _r2;
 //CHECK-NEXT:  }
 //CHECK-NEXT:  {
-//CHECK-NEXT:    double _r3 = 1 * constant;
-//CHECK-NEXT:    double _r4 = _r3 * clad::custom_derivatives::sin_pushforward(y, 1.).pushforward;
-//CHECK-NEXT:    jacobianMatrix[4UL] += _r4;
-//CHECK-NEXT:    double _r5 = sin(y) * 1;
+//CHECK-NEXT:    double _r1 = 1 * constant * clad::custom_derivatives::sin_pushforward(y, 1.).pushforward;
+//CHECK-NEXT:    jacobianMatrix[4UL] += _r1;
 //CHECK-NEXT:  }
 //CHECK-NEXT:  {
-//CHECK-NEXT:    double _r0 = 1 * constant;
-//CHECK-NEXT:    double _r1 = _r0 * clad::custom_derivatives::sin_pushforward(x, 1.).pushforward;
-//CHECK-NEXT:    jacobianMatrix[0UL] += _r1;
-//CHECK-NEXT:    double _r2 = sin(x) * 1;
+//CHECK-NEXT:    double _r0 = 1 * constant * clad::custom_derivatives::sin_pushforward(x, 1.).pushforward;
+//CHECK-NEXT:    jacobianMatrix[0UL] += _r0;
 //CHECK-NEXT:  }
 //CHECK-NEXT:}
 
@@ -98,10 +75,8 @@ double multiply(double x, double y) { return x * y; }
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:  _label0:
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = _d_y0 * y;
-//CHECK-NEXT:        * _d_x += _r0;
-//CHECK-NEXT:        double _r1 = x * _d_y0;
-//CHECK-NEXT:        * _d_y += _r1;
+//CHECK-NEXT:        * _d_x += _d_y0 * y;
+//CHECK-NEXT:        * _d_y += x * _d_y0;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
@@ -121,37 +96,31 @@ void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatr
 //CHECK-NEXT:    _result[1] = multiply(y, z) * constant;
 //CHECK-NEXT:    _result[2] = multiply(z, x) * constant;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r8 = 1 * constant;
 //CHECK-NEXT:        double _jac4 = 0.;
 //CHECK-NEXT:        double _jac5 = 0.;
-//CHECK-NEXT:        multiply_pullback(z, x, _r8, &_jac4, &_jac5);
-//CHECK-NEXT:        double _r9 = _jac4;
-//CHECK-NEXT:        jacobianMatrix[8UL] += _r9;
-//CHECK-NEXT:        double _r10 = _jac5;
-//CHECK-NEXT:        jacobianMatrix[6UL] += _r10;
-//CHECK-NEXT:        double _r11 = multiply(z, x) * 1;
+//CHECK-NEXT:        multiply_pullback(z, x, 1 * constant, &_jac4, &_jac5);
+//CHECK-NEXT:        double _r4 = _jac4;
+//CHECK-NEXT:        jacobianMatrix[8UL] += _r4;
+//CHECK-NEXT:        double _r5 = _jac5;
+//CHECK-NEXT:        jacobianMatrix[6UL] += _r5;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r4 = 1 * constant;
 //CHECK-NEXT:        double _jac2 = 0.;
 //CHECK-NEXT:        double _jac3 = 0.;
-//CHECK-NEXT:        multiply_pullback(y, z, _r4, &_jac2, &_jac3);
-//CHECK-NEXT:        double _r5 = _jac2;
-//CHECK-NEXT:        jacobianMatrix[4UL] += _r5;
-//CHECK-NEXT:        double _r6 = _jac3;
-//CHECK-NEXT:        jacobianMatrix[5UL] += _r6;
-//CHECK-NEXT:        double _r7 = multiply(y, z) * 1;
+//CHECK-NEXT:        multiply_pullback(y, z, 1 * constant, &_jac2, &_jac3);
+//CHECK-NEXT:        double _r2 = _jac2;
+//CHECK-NEXT:        jacobianMatrix[4UL] += _r2;
+//CHECK-NEXT:        double _r3 = _jac3;
+//CHECK-NEXT:        jacobianMatrix[5UL] += _r3;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = 1 * constant;
 //CHECK-NEXT:        double _jac0 = 0.;
 //CHECK-NEXT:        double _jac1 = 0.;
-//CHECK-NEXT:        multiply_pullback(x, y, _r0, &_jac0, &_jac1);
-//CHECK-NEXT:        double _r1 = _jac0;
-//CHECK-NEXT:        jacobianMatrix[0UL] += _r1;
-//CHECK-NEXT:        double _r2 = _jac1;
-//CHECK-NEXT:        jacobianMatrix[1UL] += _r2;
-//CHECK-NEXT:        double _r3 = multiply(x, y) * 1;
+//CHECK-NEXT:        multiply_pullback(x, y, 1 * constant, &_jac0, &_jac1);
+//CHECK-NEXT:        double _r0 = _jac0;
+//CHECK-NEXT:        jacobianMatrix[0UL] += _r0;
+//CHECK-NEXT:        double _r1 = _jac1;
+//CHECK-NEXT:        jacobianMatrix[1UL] += _r1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
@@ -163,35 +132,19 @@ void f_1_jac_0(double a, double b, double c, double output[], double *jacobianMa
 // CHECK-NEXT:  output[1] = a * a * a + b * b * b;
 // CHECK-NEXT:  output[2] = c * c * 10 - a * a;
 // CHECK-NEXT:  {
-// CHECK-NEXT:    double _r12 = 1 * 10;
-// CHECK-NEXT:    double _r13 = _r12 * c;
-// CHECK-NEXT:    double _r14 = c * _r12;
-// CHECK-NEXT:    double _r15 = -1 * a;
-// CHECK-NEXT:    jacobianMatrix[2UL] += _r15;
-// CHECK-NEXT:    double _r16 = a * -1;
-// CHECK-NEXT:    jacobianMatrix[2UL] += _r16;
+// CHECK-NEXT:    jacobianMatrix[2UL] += -1 * a;
+// CHECK-NEXT:    jacobianMatrix[2UL] += a * -1;
 // CHECK-NEXT:  }
 // CHECK-NEXT:  {
-// CHECK-NEXT:    double _r4 = 1 * a;
-// CHECK-NEXT:    double _r5 = _r4 * a;
-// CHECK-NEXT:    jacobianMatrix[1UL] += _r5;
-// CHECK-NEXT:    double _r6 = a * _r4;
-// CHECK-NEXT:    jacobianMatrix[1UL] += _r6;
-// CHECK-NEXT:    double _r7 = a * a * 1;
-// CHECK-NEXT:    jacobianMatrix[1UL] += _r7;
-// CHECK-NEXT:    double _r8 = 1 * b;
-// CHECK-NEXT:    double _r9 = _r8 * b;
-// CHECK-NEXT:    double _r10 = b * _r8;
-// CHECK-NEXT:    double _r11 = b * b * 1;
+// CHECK-NEXT:    jacobianMatrix[1UL] += 1 * a * a;
+// CHECK-NEXT:    jacobianMatrix[1UL] += a * 1 * a;
+// CHECK-NEXT:    jacobianMatrix[1UL] += a * a * 1;
 // CHECK-NEXT:  }
 // CHECK-NEXT:  {
-// CHECK-NEXT:    double _r0 = 1 * a;
-// CHECK-NEXT:    double _r1 = _r0 * a;
-// CHECK-NEXT:    jacobianMatrix[0UL] += _r1;
-// CHECK-NEXT:    double _r2 = a * _r0;
-// CHECK-NEXT:    jacobianMatrix[0UL] += _r2;
-// CHECK-NEXT:    double _r3 = a * a * 1;
-// CHECK-NEXT:    jacobianMatrix[0UL] += _r3;
+// CHECK-NEXT:    jacobianMatrix[0UL] += 1 * a * a;
+// CHECK-NEXT:    jacobianMatrix[0UL] += a * 1 * a;
+
+// CHECK-NEXT:    jacobianMatrix[0UL] += a * a * 1;
 // CHECK-NEXT:  }
 // CHECK-NEXT:}
 

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -52,9 +52,15 @@ void f_3(double x, double y, double z, double *_result) {
 void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatrix);
 //CHECK: void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatrix) {
 //CHECK-NEXT:  double _d_constant = 0;
+//CHECK-NEXT:  double _t0;
+//CHECK-NEXT:  double _t1;
+//CHECK-NEXT:  double _t2;
 //CHECK-NEXT:  double constant = 42;
+//CHECK-NEXT:  _t0 = sin(x);
 //CHECK-NEXT:  _result[0] = sin(x) * constant;
+//CHECK-NEXT:  _t1 = sin(y);
 //CHECK-NEXT:  _result[1] = sin(y) * constant;
+//CHECK-NEXT:  _t2 = sin(z);
 //CHECK-NEXT:  _result[2] = sin(z) * constant;
 //CHECK-NEXT:  {
 //CHECK-NEXT:    double _r2 = 1 * constant * clad::custom_derivatives::sin_pushforward(z, 1.).pushforward;
@@ -91,9 +97,15 @@ void f_4(double x, double y, double z, double *_result) {
 void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatrix);
 //CHECK: void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatrix) {
 //CHECK-NEXT:    double _d_constant = 0;
+//CHECK-NEXT:    double _t0;
+//CHECK-NEXT:    double _t1;
+//CHECK-NEXT:    double _t2;
 //CHECK-NEXT:    double constant = 42;
+//CHECK-NEXT:    _t0 = multiply(x, y);
 //CHECK-NEXT:    _result[0] = multiply(x, y) * constant;
+//CHECK-NEXT:    _t1 = multiply(y, z);
 //CHECK-NEXT:    _result[1] = multiply(y, z) * constant;
+//CHECK-NEXT:    _t2 = multiply(z, x);
 //CHECK-NEXT:    _result[2] = multiply(z, x) * constant;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _jac4 = 0.;

--- a/test/Jacobian/TemplateFunctors.C
+++ b/test/Jacobian/TemplateFunctors.C
@@ -20,26 +20,12 @@ template <typename T> struct Experiment {
 // CHECK-NEXT:     output[0] = this->x * this->y * i * j;
 // CHECK-NEXT:     output[1] = 2 * this->x * this->y * i * j;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r6 = 1 * j;
-// CHECK-NEXT:         double _r7 = _r6 * i;
-// CHECK-NEXT:         double _r8 = _r7 * this->y;
-// CHECK-NEXT:         double _r9 = _r8 * this->x;
-// CHECK-NEXT:         double _r10 = 2 * _r8;
-// CHECK-NEXT:         double _r11 = 2 * this->x * _r7;
-// CHECK-NEXT:         double _r12 = 2 * this->x * this->y * _r6;
-// CHECK-NEXT:         jacobianMatrix[2UL] += _r12;
-// CHECK-NEXT:         double _r13 = 2 * this->x * this->y * i * 1;
-// CHECK-NEXT:         jacobianMatrix[3UL] += _r13;
+// CHECK-NEXT:         jacobianMatrix[2UL] += 2 * this->x * this->y * 1 * j;
+// CHECK-NEXT:         jacobianMatrix[3UL] += 2 * this->x * this->y * i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 1 * j;
-// CHECK-NEXT:         double _r1 = _r0 * i;
-// CHECK-NEXT:         double _r2 = _r1 * this->y;
-// CHECK-NEXT:         double _r3 = this->x * _r1;
-// CHECK-NEXT:         double _r4 = this->x * this->y * _r0;
-// CHECK-NEXT:         jacobianMatrix[0UL] += _r4;
-// CHECK-NEXT:         double _r5 = this->x * this->y * i * 1;
-// CHECK-NEXT:         jacobianMatrix[1UL] += _r5;
+// CHECK-NEXT:         jacobianMatrix[0UL] += this->x * this->y * 1 * j;
+// CHECK-NEXT:         jacobianMatrix[1UL] += this->x * this->y * i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -57,32 +43,14 @@ template <> struct Experiment<long double> {
 // CHECK-NEXT:     output[0] = this->x * this->y * i * i * j;
 // CHECK-NEXT:     output[1] = 2 * this->x * this->y * i * i * j;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         long double _r8 = 1 * j;
-// CHECK-NEXT:         long double _r9 = _r8 * i;
-// CHECK-NEXT:         long double _r10 = _r9 * i;
-// CHECK-NEXT:         long double _r11 = _r10 * this->y;
-// CHECK-NEXT:         long double _r12 = _r11 * this->x;
-// CHECK-NEXT:         long double _r13 = 2 * _r11;
-// CHECK-NEXT:         long double _r14 = 2 * this->x * _r10;
-// CHECK-NEXT:         long double _r15 = 2 * this->x * this->y * _r9;
-// CHECK-NEXT:         jacobianMatrix[2UL] += _r15;
-// CHECK-NEXT:         long double _r16 = 2 * this->x * this->y * i * _r8;
-// CHECK-NEXT:         jacobianMatrix[2UL] += _r16;
-// CHECK-NEXT:         long double _r17 = 2 * this->x * this->y * i * i * 1;
-// CHECK-NEXT:         jacobianMatrix[3UL] += _r17;
+// CHECK-NEXT:         jacobianMatrix[2UL] += 2 * this->x * this->y * 1 * j * i;
+// CHECK-NEXT:         jacobianMatrix[2UL] += 2 * this->x * this->y * i * 1 * j;
+// CHECK-NEXT:         jacobianMatrix[3UL] += 2 * this->x * this->y * i * i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         long double _r0 = 1 * j;
-// CHECK-NEXT:         long double _r1 = _r0 * i;
-// CHECK-NEXT:         long double _r2 = _r1 * i;
-// CHECK-NEXT:         long double _r3 = _r2 * this->y;
-// CHECK-NEXT:         long double _r4 = this->x * _r2;
-// CHECK-NEXT:         long double _r5 = this->x * this->y * _r1;
-// CHECK-NEXT:         jacobianMatrix[0UL] += _r5;
-// CHECK-NEXT:         long double _r6 = this->x * this->y * i * _r0;
-// CHECK-NEXT:         jacobianMatrix[0UL] += _r6;
-// CHECK-NEXT:         long double _r7 = this->x * this->y * i * i * 1;
-// CHECK-NEXT:         jacobianMatrix[1UL] += _r7;
+// CHECK-NEXT:         jacobianMatrix[0UL] += this->x * this->y * 1 * j * i;
+// CHECK-NEXT:         jacobianMatrix[0UL] += this->x * this->y * i * 1 * j;
+// CHECK-NEXT:         jacobianMatrix[1UL] += this->x * this->y * i * i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Jacobian/constexprTest.C
+++ b/test/Jacobian/constexprTest.C
@@ -24,22 +24,16 @@ constexpr void fn_mul(double i, double j, double *res) {
 //CHECK-NEXT:    res[1] = j * j;
 //CHECK-NEXT:    res[2] = i * j;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r4 = 1 * j;
-//CHECK-NEXT:        jacobianMatrix[4UL] += _r4;
-//CHECK-NEXT:        double _r5 = i * 1;
-//CHECK-NEXT:        jacobianMatrix[5UL] += _r5;
+//CHECK-NEXT:        jacobianMatrix[4UL] += 1 * j;
+//CHECK-NEXT:        jacobianMatrix[5UL] += i * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r2 = 1 * j;
-//CHECK-NEXT:        jacobianMatrix[3UL] += _r2;
-//CHECK-NEXT:        double _r3 = j * 1;
-//CHECK-NEXT:        jacobianMatrix[3UL] += _r3;
+//CHECK-NEXT:        jacobianMatrix[3UL] += 1 * j;
+//CHECK-NEXT:        jacobianMatrix[3UL] += j * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = 1 * i;
-//CHECK-NEXT:        jacobianMatrix[0UL] += _r0;
-//CHECK-NEXT:        double _r1 = i * 1;
-//CHECK-NEXT:        jacobianMatrix[0UL] += _r1;
+//CHECK-NEXT:        jacobianMatrix[0UL] += 1 * i;
+//CHECK-NEXT:        jacobianMatrix[0UL] += i * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
@@ -54,40 +48,23 @@ constexpr void f_1(double x, double y, double z, double output[]) {
 //CHECK-NEXT:    output[1] = x * y * x + y * x * x;
 //CHECK-NEXT:    output[2] = z * x * 10 - y * z;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r12 = 1 * 10;
-//CHECK-NEXT:        double _r13 = _r12 * x;
-//CHECK-NEXT:        jacobianMatrix[8UL] += _r13;
-//CHECK-NEXT:        double _r14 = z * _r12;
-//CHECK-NEXT:        jacobianMatrix[6UL] += _r14;
-//CHECK-NEXT:        double _r15 = -1 * z;
-//CHECK-NEXT:        jacobianMatrix[7UL] += _r15;
-//CHECK-NEXT:        double _r16 = y * -1;
-//CHECK-NEXT:        jacobianMatrix[8UL] += _r16;
+//CHECK-NEXT:        jacobianMatrix[8UL] += 1 * 10 * x;
+//CHECK-NEXT:        jacobianMatrix[6UL] += z * 1 * 10;
+//CHECK-NEXT:        jacobianMatrix[7UL] += -1 * z;
+//CHECK-NEXT:        jacobianMatrix[8UL] += y * -1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r4 = 1 * x;
-//CHECK-NEXT:        double _r5 = _r4 * y;
-//CHECK-NEXT:        jacobianMatrix[3UL] += _r5;
-//CHECK-NEXT:        double _r6 = x * _r4;
-//CHECK-NEXT:        jacobianMatrix[4UL] += _r6;
-//CHECK-NEXT:        double _r7 = x * y * 1;
-//CHECK-NEXT:        jacobianMatrix[3UL] += _r7;
-//CHECK-NEXT:        double _r8 = 1 * x;
-//CHECK-NEXT:        double _r9 = _r8 * x;
-//CHECK-NEXT:        jacobianMatrix[4UL] += _r9;
-//CHECK-NEXT:        double _r10 = y * _r8;
-//CHECK-NEXT:        jacobianMatrix[3UL] += _r10;
-//CHECK-NEXT:        double _r11 = y * x * 1;
-//CHECK-NEXT:        jacobianMatrix[3UL] += _r11;
+//CHECK-NEXT:        jacobianMatrix[3UL] += 1 * x * y;
+//CHECK-NEXT:        jacobianMatrix[4UL] += x * 1 * x;
+//CHECK-NEXT:        jacobianMatrix[3UL] += x * y * 1;
+//CHECK-NEXT:        jacobianMatrix[4UL] += 1 * x * x;
+//CHECK-NEXT:        jacobianMatrix[3UL] += y * 1 * x;
+//CHECK-NEXT:        jacobianMatrix[3UL] += y * x * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = 1 * x;
-//CHECK-NEXT:        double _r1 = _r0 * x;
-//CHECK-NEXT:        jacobianMatrix[0UL] += _r1;
-//CHECK-NEXT:        double _r2 = x * _r0;
-//CHECK-NEXT:        jacobianMatrix[0UL] += _r2;
-//CHECK-NEXT:        double _r3 = x * x * 1;
-//CHECK-NEXT:        jacobianMatrix[0UL] += _r3;
+//CHECK-NEXT:        jacobianMatrix[0UL] += 1 * x * x;
+//CHECK-NEXT:        jacobianMatrix[0UL] += x * 1 * x;
+//CHECK-NEXT:        jacobianMatrix[0UL] += x * x * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 

--- a/test/Jacobian/testUtility.C
+++ b/test/Jacobian/testUtility.C
@@ -24,22 +24,16 @@ void fn_mul(double i, double j, double *res) {
 //CHECK-NEXT:    res[1] = j * j;
 //CHECK-NEXT:    res[2] = i * j;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r4 = 1 * j;
-//CHECK-NEXT:        jacobianMatrix[4UL] += _r4;
-//CHECK-NEXT:        double _r5 = i * 1;
-//CHECK-NEXT:        jacobianMatrix[5UL] += _r5;
+//CHECK-NEXT:        jacobianMatrix[4UL] += 1 * j;
+//CHECK-NEXT:        jacobianMatrix[5UL] += i * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r2 = 1 * j;
-//CHECK-NEXT:        jacobianMatrix[3UL] += _r2;
-//CHECK-NEXT:        double _r3 = j * 1;
-//CHECK-NEXT:        jacobianMatrix[3UL] += _r3;
+//CHECK-NEXT:        jacobianMatrix[3UL] += 1 * j;
+//CHECK-NEXT:        jacobianMatrix[3UL] += j * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = 1 * i;
-//CHECK-NEXT:        jacobianMatrix[0UL] += _r0;
-//CHECK-NEXT:        double _r1 = i * 1;
-//CHECK-NEXT:        jacobianMatrix[0UL] += _r1;
+//CHECK-NEXT:        jacobianMatrix[0UL] += 1 * i;
+//CHECK-NEXT:        jacobianMatrix[0UL] += i * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
@@ -55,40 +49,23 @@ void f_1(double x, double y, double z, double output[]) {
 //CHECK-NEXT:    output[1] = x * y * x + y * x * x;
 //CHECK-NEXT:    output[2] = z * x * 10 - y * z;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r12 = 1 * 10;
-//CHECK-NEXT:        double _r13 = _r12 * x;
-//CHECK-NEXT:        jacobianMatrix[8UL] += _r13;
-//CHECK-NEXT:        double _r14 = z * _r12;
-//CHECK-NEXT:        jacobianMatrix[6UL] += _r14;
-//CHECK-NEXT:        double _r15 = -1 * z;
-//CHECK-NEXT:        jacobianMatrix[7UL] += _r15;
-//CHECK-NEXT:        double _r16 = y * -1;
-//CHECK-NEXT:        jacobianMatrix[8UL] += _r16;
+//CHECK-NEXT:        jacobianMatrix[8UL] += 1 * 10 * x;
+//CHECK-NEXT:        jacobianMatrix[6UL] += z * 1 * 10;
+//CHECK-NEXT:        jacobianMatrix[7UL] += -1 * z;
+//CHECK-NEXT:        jacobianMatrix[8UL] += y * -1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r4 = 1 * x;
-//CHECK-NEXT:        double _r5 = _r4 * y;
-//CHECK-NEXT:        jacobianMatrix[3UL] += _r5;
-//CHECK-NEXT:        double _r6 = x * _r4;
-//CHECK-NEXT:        jacobianMatrix[4UL] += _r6;
-//CHECK-NEXT:        double _r7 = x * y * 1;
-//CHECK-NEXT:        jacobianMatrix[3UL] += _r7;
-//CHECK-NEXT:        double _r8 = 1 * x;
-//CHECK-NEXT:        double _r9 = _r8 * x;
-//CHECK-NEXT:        jacobianMatrix[4UL] += _r9;
-//CHECK-NEXT:        double _r10 = y * _r8;
-//CHECK-NEXT:        jacobianMatrix[3UL] += _r10;
-//CHECK-NEXT:        double _r11 = y * x * 1;
-//CHECK-NEXT:        jacobianMatrix[3UL] += _r11;
+//CHECK-NEXT:        jacobianMatrix[3UL] += 1 * x * y;
+//CHECK-NEXT:        jacobianMatrix[4UL] += x * 1 * x;
+//CHECK-NEXT:        jacobianMatrix[3UL] += x * y * 1;
+//CHECK-NEXT:        jacobianMatrix[4UL] += 1 * x * x;
+//CHECK-NEXT:        jacobianMatrix[3UL] += y * 1 * x;
+//CHECK-NEXT:        jacobianMatrix[3UL] += y * x * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = 1 * x;
-//CHECK-NEXT:        double _r1 = _r0 * x;
-//CHECK-NEXT:        jacobianMatrix[0UL] += _r1;
-//CHECK-NEXT:        double _r2 = x * _r0;
-//CHECK-NEXT:        jacobianMatrix[0UL] += _r2;
-//CHECK-NEXT:        double _r3 = x * x * 1;
-//CHECK-NEXT:        jacobianMatrix[0UL] += _r3;
+//CHECK-NEXT:        jacobianMatrix[0UL] += 1 * x * x;
+//CHECK-NEXT:        jacobianMatrix[0UL] += x * 1 * x;
+//CHECK-NEXT:        jacobianMatrix[0UL] += x * x * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -241,10 +241,8 @@
 //CHECK_GRADIENT_DESCENT-NEXT:   _label0:
 //CHECK_GRADIENT_DESCENT-NEXT:     {
 //CHECK_GRADIENT_DESCENT-NEXT:         * _d_theta_0 += _d_y;
-//CHECK_GRADIENT_DESCENT-NEXT:         double _r0 = _d_y * x;
-//CHECK_GRADIENT_DESCENT-NEXT:         * _d_theta_1 += _r0;
-//CHECK_GRADIENT_DESCENT-NEXT:         double _r1 = theta_1 * _d_y;
-//CHECK_GRADIENT_DESCENT-NEXT:         * _d_x += _r1;
+//CHECK_GRADIENT_DESCENT-NEXT:         * _d_theta_1 += _d_y * x;
+//CHECK_GRADIENT_DESCENT-NEXT:         * _d_x += theta_1 * _d_y;
 //CHECK_GRADIENT_DESCENT-NEXT:     }
 //CHECK_GRADIENT_DESCENT-NEXT: }
 
@@ -254,12 +252,10 @@
 //CHECK_GRADIENT_DESCENT-NEXT:     goto _label0;
 //CHECK_GRADIENT_DESCENT-NEXT:   _label0:
 //CHECK_GRADIENT_DESCENT-NEXT:     {
-//CHECK_GRADIENT_DESCENT-NEXT:         double _r3 = 1 * (f_x - y);
-//CHECK_GRADIENT_DESCENT-NEXT:         _d_f_x += _r3;
-//CHECK_GRADIENT_DESCENT-NEXT:         * _d_y += -_r3;
-//CHECK_GRADIENT_DESCENT-NEXT:         double _r4 = (f_x - y) * 1;
-//CHECK_GRADIENT_DESCENT-NEXT:         _d_f_x += _r4;
-//CHECK_GRADIENT_DESCENT-NEXT:         * _d_y += -_r4;
+//CHECK_GRADIENT_DESCENT-NEXT:         _d_f_x += 1 * (f_x - y);
+//CHECK_GRADIENT_DESCENT-NEXT:         * _d_y += -1 * (f_x - y);
+//CHECK_GRADIENT_DESCENT-NEXT:         _d_f_x += (f_x - y) * 1;
+//CHECK_GRADIENT_DESCENT-NEXT:         * _d_y += -(f_x - y) * 1;
 //CHECK_GRADIENT_DESCENT-NEXT:     }
 //CHECK_GRADIENT_DESCENT-NEXT:     {
 //CHECK_GRADIENT_DESCENT-NEXT:         double _grad0 = 0.;

--- a/test/NestedCalls/NestedCalls.C
+++ b/test/NestedCalls/NestedCalls.C
@@ -43,10 +43,8 @@ double f(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = _d_y * x;
-//CHECK-NEXT:           * _d_x += _r0;
-//CHECK-NEXT:           double _r1 = x * _d_y;
-//CHECK-NEXT:           * _d_x += _r1;
+//CHECK-NEXT:           * _d_x += _d_y * x;
+//CHECK-NEXT:           * _d_x += x * _d_y;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -73,10 +71,8 @@ double f(double x, double y) {
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r1 = 1 * y;
-//CHECK-NEXT:           _d_t += _r1;
-//CHECK-NEXT:           double _r2 = t * 1;
-//CHECK-NEXT:           * _d_y += _r2;
+//CHECK-NEXT:           _d_t += 1 * y;
+//CHECK-NEXT:           * _d_y += t * 1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _grad0 = 0.;

--- a/test/ROOT/Interface.C
+++ b/test/ROOT/Interface.C
@@ -27,9 +27,7 @@ void f_grad_1(Double_t* x, Double_t* p, clad::array_ref<Double_t> _d_p);
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_p[0] += 1;
-// CHECK-NEXT:         {{double|Double_t}} _r0 = 1 * p[1];
-// CHECK-NEXT:         {{double|Double_t}} _r1 = x[0] * 1;
-// CHECK-NEXT:         _d_p[1] += _r1;
+// CHECK-NEXT:         _d_p[1] += x[0] * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -44,15 +44,13 @@ void TFormula_example_grad_1(Double_t* x, Double_t* p, Double_t* _d_p);
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
-//CHECK-NEXT:           {{double|Double_t}} _r0 = 1 * (p[0] + p[1] + p[2]);
-//CHECK-NEXT:           {{double|Double_t}} _r1 = x[0] * 1;
-//CHECK-NEXT:           _d_p[0] += _r1;
+//CHECK-NEXT:           _d_p[0] += x[0] * 1;
+//CHECK-NEXT:           _d_p[1] += x[0] * 1;
+//CHECK-NEXT:           _d_p[2] += x[0] * 1;
+//CHECK-NEXT:           Double_t _r0 = 1 * clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(-p[0], 1.).pushforward;
+//CHECK-NEXT:           _d_p[0] += -_r0;
+//CHECK-NEXT:           Double_t _r1 = 1 * clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(p[1], 1.).pushforward;
 //CHECK-NEXT:           _d_p[1] += _r1;
-//CHECK-NEXT:           _d_p[2] += _r1;
-//CHECK-NEXT:           Double_t _r2 = 1 * clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(-p[0], 1.).pushforward;
-//CHECK-NEXT:           _d_p[0] += -_r2;
-//CHECK-NEXT:           Double_t _r3 = 1 * clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(p[1], 1.).pushforward;
-//CHECK-NEXT:           _d_p[1] += _r3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 


### PR DESCRIPTION
Every time we visit multiplication or division in the reverse mode, we store expressions for the derivatives of the LHS and the RHS.
```
dr = StoreAndRef(dr, direction::reverse); 
dl = StoreAndRef(dl, direction::reverse); 
```
This makes the derivative code less readable and often produces unused variables. For instance, this code
```
x = 5 * y;
```
will be differentiated as
```
x = 5 * y;
...
double _r_d0 = _d_x;
double _r0 = _r_d0 * y;
double _r1 = 5 * _r_d0;
_d_y += _r1;
_d_x -= _r_d0;
```
while could be just
```
x = 5 * y;
...
double _r_d0 = _d_x;
_d_y += 5 * _r_d0;
_d_x -= _r_d0;
```