### PR TITLE
[cmake] Use the compiler clad is built for if compiling benchmarks and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,8 +295,20 @@ if (CLAD_INCLUDE_DOCS)
   add_subdirectory(docs)
 endif()
 
+
 if (NOT CLAD_BUILD_STATIC_ONLY)
   include(AddClad)
+
+  if (CLAD_ENABLE_BENCHMARKS)
+    include(GoogleBenchmark)
+  endif(CLAD_ENABLE_BENCHMARKS)
+
+  # Change the default compiler to the clang which we run clad upon. Our unittests
+  # need to use a supported by clad compiler. Note that's a huge hack and it is
+  # not guaranteed to work with cmake.
+  set(stored_cxx_compiler ${CMAKE_CXX_COMPILER})
+  set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
+
   add_subdirectory(unittests)
   add_subdirectory(test)
   add_subdirectory(demos/ErrorEstimation/CustomModel)
@@ -307,6 +319,8 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
     add_subdirectory(benchmark)
   endif(CLAD_ENABLE_BENCHMARKS)
 
+  # Restore the default compiler.
+  set(CMAKE_CXX_COMPILER ${stored_cxx_compiler})
 endif()
 
 # Workaround for MSVS10 to avoid the Dialog Hell

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,8 +1,6 @@
 set(CTEST_BUILD_NAME ${ROOT_ARCHITECTURE}-${CMAKE_BUILD_TYPE})
 enable_testing()
 
-include(GoogleBenchmark)
-
 CB_ADD_GBENCHMARK(Simple Simple.cpp)
 CB_ADD_GBENCHMARK(AlgorithmicComplexity AlgorithmicComplexity.cpp)
 CB_ADD_GBENCHMARK(ArrayExpressionTemplates ArrayExpressionTemplates.cpp)

--- a/cmake/modules/AddClad.cmake
+++ b/cmake/modules/AddClad.cmake
@@ -10,9 +10,6 @@ string(REPLACE "/" "" CURRENT_REPO_COMMIT ${CURRENT_REPO_COMMIT})
 set_property(DIRECTORY APPEND PROPERTY
              CMAKE_CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/.git/HEAD")
 
-# Change the default compiler to the clang which we run clad upon.
-set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
-
 #-------------------------------------------------------------------------------
 # function ENABLE_CLAD_FOR_EXECUTABLE(<executable>
 #   DEPENDS dependencies...

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 # Will compile the list of files together and link against clad.
 # Produces a binary named 'basename(test_dirname)'.
 function(add_clad_unittest test_dirname)
+
   add_unittest(CladUnitTests ${test_dirname} ${ARGN})
 
   # Remove the llvm_gtest_* coming from add_unittest.
@@ -32,4 +33,3 @@ function(add_clad_unittest test_dirname)
 endfunction()
 
 add_subdirectory(Basic)
-


### PR DESCRIPTION
We need to attach the clad plugin to the compiler invocations in order to either benchmark or test clad's infrastructure. The best way I could find is by setting/resetting the CMAKE_CXX_COMPILER variable which is a hack that works. Note that we do not have a cmake guarantee that will work but since that's in the core of our testing infrastructure we will find out quickly if, when and where it breaks.