### PR TITLE
Make built-in type variable declarations global

### DIFF
--- a/include/clad/Differentiator/Array.h
+++ b/include/clad/Differentiator/Array.h
@@ -23,8 +23,8 @@ private:
   std::size_t m_size = 0;
 
 public:
-  /// Delete default constructor
-  array() = delete;
+  /// Default constructor
+  array() = default;
   /// Constructor to create an array of the specified size
   CUDA_HOST_DEVICE array(std::size_t size)
       : m_arr(new T[size]{static_cast<T>(0)}), m_size(size) {}
@@ -81,6 +81,12 @@ public:
   }
 
   CUDA_HOST_DEVICE array<T>& operator=(const array<T>& arr) {
+    if (m_size < arr.m_size) {
+      delete[] m_arr;
+      // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+      m_arr = new T[arr.m_size];
+      m_size = arr.m_size;
+    }
     (*this) = arr.m_arr;
     return *this;
   }

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -277,7 +277,23 @@ namespace clad {
                          clang::Expr* R, clang::SourceLocation OpLoc = noLoc);
 
     clang::Expr* BuildParens(clang::Expr* E);
-
+    /// Builds variable declaration to be used inside the derivative
+    /// body.
+    /// \param[in] Type The type of variable declaration to build.
+    /// \param[in] Identifier The identifier information for the variable
+    /// declaration.
+    /// \param[in] Init The initalization expression to assign to the variable
+    ///  declaration.
+    /// \param[in] DirectInit A check for if the initialization expression is a
+    /// C style initalization.
+    /// \param[in] TSI The type source information of the variable declaration.
+    /// \returns The newly built variable declaration.
+    clang::VarDecl*
+    BuildVarDecl(clang::QualType Type, clang::IdentifierInfo* Identifier,
+                 clang::Scope* scope, clang::Expr* Init = nullptr,
+                 bool DirectInit = false, clang::TypeSourceInfo* TSI = nullptr,
+                 clang::VarDecl::InitializationStyle IS =
+                     clang::VarDecl::InitializationStyle::CInit);
     /// Builds variable declaration to be used inside the derivative
     /// body.
     /// \param[in] Type The type of variable declaration to build.
@@ -311,6 +327,14 @@ namespace clad {
                  clang::TypeSourceInfo* TSI = nullptr,
                  clang::VarDecl::InitializationStyle IS =
                      clang::VarDecl::InitializationStyle::CInit);
+    /// Builds variable declaration to be used inside the derivative
+    /// body in the derivative function global scope.
+    clang::VarDecl*
+    BuildGlobalVarDecl(clang::QualType Type, llvm::StringRef prefix = "_t",
+                       clang::Expr* Init = nullptr, bool DirectInit = false,
+                       clang::TypeSourceInfo* TSI = nullptr,
+                       clang::VarDecl::InitializationStyle IS =
+                           clang::VarDecl::InitializationStyle::CInit);
     /// Creates a namespace declaration and enters its context. All subsequent
     /// Stmts are built inside that namespace, until
     /// m_Sema.PopDeclContextIsUsed.

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -520,8 +520,12 @@ bool ReferencesUpdater::VisitDeclRefExpr(DeclRefExpr* DRE) {
   // Replace the declaration if it is present in `m_DeclReplacements`.
   if (VarDecl* VD = dyn_cast<VarDecl>(DRE->getDecl())) {
     auto it = m_DeclReplacements.find(VD);
-    if (it != std::end(m_DeclReplacements))
+    if (it != std::end(m_DeclReplacements)) {
       DRE->setDecl(it->second);
+      QualType NonRefQT = it->second->getType().getNonReferenceType();
+      if (NonRefQT != DRE->getType())
+        DRE->setType(NonRefQT);
+    }
   }
 
   DeclarationNameInfo DNI = DRE->getNameInfo();

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -19,10 +19,11 @@ double addArr(const double *arr, int n) {
 //CHECK-NEXT:     double _d_ret = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double ret = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, ret);
 //CHECK-NEXT:         ret += arr[i];
@@ -71,11 +72,12 @@ float func(float* a, float* b) {
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 3; i++) {
+//CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, a[i]);
 //CHECK-NEXT:         a[i] *= b[i];
@@ -123,10 +125,11 @@ float func2(float* a) {
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 3; i++) {
+//CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += helper(a[i]);
@@ -156,11 +159,12 @@ float func3(float* a, float* b) {
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 3; i++) {
+//CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         clad::push(_t2, a[i]);
@@ -194,11 +198,12 @@ double func4(double x) {
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double arr[3] = {x, 2 * x, x * x};
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 3; i++) {
+//CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += addArr(arr, 3);
@@ -242,23 +247,25 @@ double func5(int k) {
 //CHECK-NEXT:     int _d_n = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned long _t2;
-//CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int _d_i0 = 0;
+//CHECK-NEXT:     int i0 = 0;
 //CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     int n = k;
 //CHECK-NEXT:     clad::array<double> _d_arr(n);
 //CHECK-NEXT:     double arr[n];
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, arr[i]);
 //CHECK-NEXT:         arr[i] = k;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _t2 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 3; i++) {
+//CHECK-NEXT:     for (i0 = 0; i0 < 3; i0++) {
 //CHECK-NEXT:         _t2++;
 //CHECK-NEXT:         clad::push(_t3, sum);
 //CHECK-NEXT:         sum += addArr(arr, n);
@@ -267,7 +274,7 @@ double func5(int k) {
 //CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t2; _t2--) {
-//CHECK-NEXT:         i--;
+//CHECK-NEXT:         i0--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t3);
 //CHECK-NEXT:             double _r_d1 = _d_sum;
@@ -304,14 +311,19 @@ double func6(double seed) {
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
+//CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
 //CHECK-NEXT:     clad::array<double> _d_arr(3UL);
-//CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     clad::array<double> arr(3UL);
+//CHECK-NEXT:     clad::tape<double> _t2 = {};
+//CHECK-NEXT:     clad::tape<clad::array<double> > _t3 = {};
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 3; i++) {
+//CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         double arr[3] = {seed, seed * i, seed + i};
-//CHECK-NEXT:         clad::push(_t1, sum);
+//CHECK-NEXT:         clad::push(_t1, arr) , arr = {seed, seed * i, seed + i};
+//CHECK-NEXT:         clad::push(_t2, sum);
+//CHECK-NEXT:         clad::push(_t3, arr);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
@@ -320,12 +332,14 @@ double func6(double seed) {
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t1);
+//CHECK-NEXT:             sum = clad::pop(_t2);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
+//CHECK-NEXT:             clad::array<double> _r1 = clad::pop(_t3);
+//CHECK-NEXT:             arr = _r1;
 //CHECK-NEXT:             int _grad1 = 0;
-//CHECK-NEXT:             addArr_pullback(arr, 3, _r_d0, _d_arr, &_grad1);
-//CHECK-NEXT:             clad::array<double> _r0(_d_arr);
-//CHECK-NEXT:             int _r1 = _grad1;
+//CHECK-NEXT:             addArr_pullback(_r1, 3, _r_d0, _d_arr, &_grad1);
+//CHECK-NEXT:             clad::array<double> _r0 = _d_arr;
+//CHECK-NEXT:             int _r2 = _grad1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             * _d_seed += _d_arr[0];
@@ -334,6 +348,7 @@ double func6(double seed) {
 //CHECK-NEXT:             * _d_seed += _d_arr[2];
 //CHECK-NEXT:             _d_i += _d_arr[2];
 //CHECK-NEXT:             _d_arr = {};
+//CHECK-NEXT:             arr = clad::pop(_t1);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -367,14 +382,19 @@ double func7(double *params) {
 //CHECK-NEXT:     double _d_out = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     std::size_t _d_i = 0;
+//CHECK-NEXT:     std::size_t i = 0;
+//CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
 //CHECK-NEXT:     clad::array<double> _d_paramsPrime(1UL);
-//CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     clad::array<double> paramsPrime(1UL);
+//CHECK-NEXT:     clad::tape<double> _t2 = {};
+//CHECK-NEXT:     clad::tape<clad::array<double> > _t3 = {};
 //CHECK-NEXT:     double out = 0.;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (std::size_t i = 0; i < 1; ++i) {
+//CHECK-NEXT:     for (i = 0; i < 1; ++i) {
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         double paramsPrime[1] = {params[0]};
-//CHECK-NEXT:         clad::push(_t1, out);
+//CHECK-NEXT:         clad::push(_t1, paramsPrime) , paramsPrime = {params[0]};
+//CHECK-NEXT:         clad::push(_t2, out);
+//CHECK-NEXT:         clad::push(_t3, paramsPrime);
 //CHECK-NEXT:         out = out + inv_square(paramsPrime);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label0;
@@ -383,16 +403,19 @@ double func7(double *params) {
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         --i;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             out = clad::pop(_t1);
+//CHECK-NEXT:             out = clad::pop(_t2);
 //CHECK-NEXT:             double _r_d0 = _d_out;
 //CHECK-NEXT:             _d_out -= _r_d0;
 //CHECK-NEXT:             _d_out += _r_d0;
-//CHECK-NEXT:             inv_square_pullback(paramsPrime, _r_d0, _d_paramsPrime);
-//CHECK-NEXT:             clad::array<double> _r0(_d_paramsPrime);
+//CHECK-NEXT:             clad::array<double> _r1 = clad::pop(_t3);
+//CHECK-NEXT:             paramsPrime = _r1;
+//CHECK-NEXT:             inv_square_pullback(_r1, _r_d0, _d_paramsPrime);
+//CHECK-NEXT:             clad::array<double> _r0 = _d_paramsPrime;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _d_params[0] += _d_paramsPrime[0];
 //CHECK-NEXT:             _d_paramsPrime = {};
+//CHECK-NEXT:             paramsPrime = clad::pop(_t1);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -491,10 +514,11 @@ double func9(double i, double j) {
 //CHECK-NEXT:     clad::array<double> _d_arr(5UL);
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_idx = 0;
+//CHECK-NEXT:     int idx = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double arr[5] = {};
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int idx = 0; idx < 5; ++idx) {
+//CHECK-NEXT:     for (idx = 0; idx < 5; ++idx) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, arr[idx]);
 //CHECK-NEXT:         modify(arr[idx], i);
@@ -557,11 +581,12 @@ double func10(double *arr, int n) {
 //CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; ++i) {
+//CHECK-NEXT:     for (i = 0; i < n; ++i) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, res);
 //CHECK-NEXT:         clad::push(_t2, arr[i]);

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -34,6 +34,7 @@ auto gauss_g = clad::gradient(gauss, "p");
 //CHECK-NEXT:     double _d_t = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _t2;
 //CHECK-NEXT:     double _t3;
@@ -42,7 +43,7 @@ auto gauss_g = clad::gradient(gauss, "p");
 //CHECK-NEXT:     double _t6;
 //CHECK-NEXT:     double t = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < dim; i++) {
+//CHECK-NEXT:     for (i = 0; i < dim; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, t);
 //CHECK-NEXT:         t += (x[i] - p[i]) * (x[i] - p[i]);

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -26,6 +26,7 @@ float func(float x, float y) {
 //CHECK-NEXT:     float _d_temp = 0;
 //CHECK-NEXT:     double _delta_temp = 0;
 //CHECK-NEXT:     float _EERepl_temp0;
+//CHECK-NEXT:     float temp = 0;
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _EERepl_temp1;
 //CHECK-NEXT:     float _t2;
@@ -36,7 +37,7 @@ float func(float x, float y) {
 //CHECK-NEXT:         y = y * x;
 //CHECK-NEXT:         _EERepl_y1 = y;
 //CHECK-NEXT:     } else {
-//CHECK-NEXT:         float temp = y;
+//CHECK-NEXT:         temp = y;
 //CHECK-NEXT:         _EERepl_temp0 = temp;
 //CHECK-NEXT:         _t1 = temp;
 //CHECK-NEXT:         temp = y * y;
@@ -77,7 +78,10 @@ float func(float x, float y) {
 //CHECK-NEXT:             * _d_y += y * _r_d1;
 //CHECK-NEXT:             _delta_temp += std::abs(_r_d1 * _EERepl_temp1 * {{.+}});
 //CHECK-NEXT:         }
-//CHECK-NEXT:         * _d_y += _d_temp;
+//CHECK-NEXT:         {
+//CHECK-NEXT:             * _d_y += _d_temp;
+//CHECK-NEXT:             _delta_temp += std::abs(_d_temp * _EERepl_temp0 * {{.+}});
+//CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _delta_x = 0;
 //CHECK-NEXT:     _delta_x += std::abs(* _d_x * x * {{.+}});

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -20,12 +20,13 @@ float func(float* p, int n) {
 //CHECK-NEXT:     float _EERepl_sum0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _EERepl_sum1 = {};
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _EERepl_sum0 = sum;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += p[i];
@@ -46,10 +47,10 @@ float func(float* p, int n) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_p(_d_p.size());
-//CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     for (; i < _d_p.size(); i++) {
-//CHECK-NEXT:         double _t2 = std::abs(_d_p[i] * p[i] * {{.+}});
-//CHECK-NEXT:         _delta_p[i] += _t2;
+//CHECK-NEXT:     int i0 = 0;
+//CHECK-NEXT:     for (; i0 < _d_p.size(); i0++) {
+//CHECK-NEXT:         double _t2 = std::abs(_d_p[i0] * p[i0] * {{.+}});
+//CHECK-NEXT:         _delta_p[i0] += _t2;
 //CHECK-NEXT:         _final_error += _t2;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += _delta_sum;
@@ -71,6 +72,7 @@ float func2(float x) {
 //CHECK-NEXT:     float _EERepl_z0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     float _d_m = 0;
 //CHECK-NEXT:     double _delta_m = 0;
@@ -81,7 +83,7 @@ float func2(float x) {
 //CHECK-NEXT:     float z;
 //CHECK-NEXT:     _EERepl_z0 = z;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 9; i++) {
+//CHECK-NEXT:     for (i = 0; i < 9; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, m) , m = x * x;
 //CHECK-NEXT:         clad::push(_EERepl_m0, m);
@@ -199,6 +201,7 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:     float _EERepl_sum0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::array<float> _delta_x(_d_x.size());
 //CHECK-NEXT:     clad::array<float> _EERepl_x0(_d_x.size());
@@ -211,7 +214,7 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _EERepl_sum0 = sum;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < 10; i++) {
+//CHECK-NEXT:     for (i = 0; i < 10; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, x[i]);
 //CHECK-NEXT:         x[i] += y[i];
@@ -242,17 +245,17 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
-//CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     for (; i < _d_x.size(); i++) {
-//CHECK-NEXT:         double _t3 = std::abs(_d_x[i] * _EERepl_x0[i] * {{.+}});
-//CHECK-NEXT:         _delta_x[i] += _t3;
+//CHECK-NEXT:     int i0 = 0;
+//CHECK-NEXT:     for (; i0 < _d_x.size(); i0++) {
+//CHECK-NEXT:         double _t3 = std::abs(_d_x[i0] * _EERepl_x0[i0] * {{.+}});
+//CHECK-NEXT:         _delta_x[i0] += _t3;
 //CHECK-NEXT:         _final_error += _t3;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     clad::array<float> _delta_y(_d_y.size());
-//CHECK-NEXT:     i = 0;
-//CHECK-NEXT:     for (; i < _d_y.size(); i++) {
-//CHECK-NEXT:         double _t4 = std::abs(_d_y[i] * y[i] * {{.+}});
-//CHECK-NEXT:         _delta_y[i] += _t4;
+//CHECK-NEXT:     i0 = 0;
+//CHECK-NEXT:     for (; i0 < _d_y.size(); i0++) {
+//CHECK-NEXT:         double _t4 = std::abs(_d_y[i0] * y[i0] * {{.+}});
+//CHECK-NEXT:         _delta_y[i0] += _t4;
 //CHECK-NEXT:         _final_error += _t4;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += _delta_sum;

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -21,12 +21,13 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:     double _EERepl_sum0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _EERepl_sum1 = {};
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _EERepl_sum0 = sum;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 1; i < n; i++) {
+//CHECK-NEXT:     for (i = 1; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += f[i] + f[i - 1];
@@ -48,10 +49,10 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_f(_d_f.size());
-//CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     for (; i < _d_f.size(); i++) {
-//CHECK-NEXT:         double _t2 = std::abs(_d_f[i] * f[i] * {{.+}});
-//CHECK-NEXT:         _delta_f[i] += _t2;
+//CHECK-NEXT:     int i0 = 0;
+//CHECK-NEXT:     for (; i0 < _d_f.size(); i0++) {
+//CHECK-NEXT:         double _t2 = std::abs(_d_f[i0] * f[i0] * {{.+}});
+//CHECK-NEXT:         _delta_f[i0] += _t2;
 //CHECK-NEXT:         _final_error += _t2;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += _delta_sum;
@@ -72,6 +73,7 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:     double _EERepl_sum0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<unsigned long> _t1 = {};
 //CHECK-NEXT:     clad::tape<int> _t2 = {};
 //CHECK-NEXT:     int _d_j = 0;
@@ -81,7 +83,7 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _EERepl_sum0 = sum;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, 0UL);
 //CHECK-NEXT:         for (clad::push(_t2, j) , j = 0; j < n; j++) {
@@ -115,17 +117,17 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_a(_d_a.size());
-//CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     for (; i < _d_a.size(); i++) {
-//CHECK-NEXT:         double _t4 = std::abs(_d_a[i] * a[i] * {{.+}});
-//CHECK-NEXT:         _delta_a[i] += _t4;
+//CHECK-NEXT:     int i0 = 0;
+//CHECK-NEXT:     for (; i0 < _d_a.size(); i0++) {
+//CHECK-NEXT:         double _t4 = std::abs(_d_a[i0] * a[i0] * {{.+}});
+//CHECK-NEXT:         _delta_a[i0] += _t4;
 //CHECK-NEXT:         _final_error += _t4;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     clad::array<float> _delta_b(_d_b.size());
-//CHECK-NEXT:     i = 0;
-//CHECK-NEXT:     for (; i < _d_b.size(); i++) {
-//CHECK-NEXT:         double _t5 = std::abs(_d_b[i] * b[i] * {{.+}});
-//CHECK-NEXT:         _delta_b[i] += _t5;
+//CHECK-NEXT:     i0 = 0;
+//CHECK-NEXT:     for (; i0 < _d_b.size(); i0++) {
+//CHECK-NEXT:         double _t5 = std::abs(_d_b[i0] * b[i0] * {{.+}});
+//CHECK-NEXT:         _delta_b[i0] += _t5;
 //CHECK-NEXT:         _final_error += _t5;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += _delta_sum;
@@ -145,12 +147,13 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:     double _EERepl_sum0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _EERepl_sum1 = {};
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _EERepl_sum0 = sum;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += a[i] / b[i];
@@ -173,17 +176,17 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _delta_sum += std::abs(_d_sum * _EERepl_sum0 * {{.+}});
 //CHECK-NEXT:     clad::array<float> _delta_a(_d_a.size());
-//CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     for (; i < _d_a.size(); i++) {
-//CHECK-NEXT:         double _t2 = std::abs(_d_a[i] * a[i] * {{.+}});
-//CHECK-NEXT:         _delta_a[i] += _t2;
+//CHECK-NEXT:     int i0 = 0;
+//CHECK-NEXT:     for (; i0 < _d_a.size(); i0++) {
+//CHECK-NEXT:         double _t2 = std::abs(_d_a[i0] * a[i0] * {{.+}});
+//CHECK-NEXT:         _delta_a[i0] += _t2;
 //CHECK-NEXT:         _final_error += _t2;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     clad::array<float> _delta_b(_d_b.size());
-//CHECK-NEXT:     i = 0;
-//CHECK-NEXT:     for (; i < _d_b.size(); i++) {
-//CHECK-NEXT:         double _t3 = std::abs(_d_b[i] * b[i] * {{.+}});
-//CHECK-NEXT:         _delta_b[i] += _t3;
+//CHECK-NEXT:     i0 = 0;
+//CHECK-NEXT:     for (; i0 < _d_b.size(); i0++) {
+//CHECK-NEXT:         double _t3 = std::abs(_d_b[i0] * b[i0] * {{.+}});
+//CHECK-NEXT:         _delta_b[i0] += _t3;
 //CHECK-NEXT:         _final_error += _t3;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += _delta_sum;

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -165,6 +165,7 @@ double f5(double x, double y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       double _d_z = 0;
+//CHECK-NEXT:       double z = 0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double t = x * x;
 //CHECK-NEXT:       _cond0 = x < 0;
@@ -175,7 +176,7 @@ double f5(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       _cond1 = y < 0;
 //CHECK-NEXT:       if (_cond1) {
-//CHECK-NEXT:           double z = t;
+//CHECK-NEXT:           z = t;
 //CHECK-NEXT:           _t1 = t;
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:       }
@@ -227,6 +228,7 @@ double f6(double x, double y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       double _d_z = 0;
+//CHECK-NEXT:       double z = 0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double t = x * x;
 //CHECK-NEXT:       _cond0 = x < 0;
@@ -237,7 +239,7 @@ double f6(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       _cond1 = y < 0;
 //CHECK-NEXT:       if (_cond1) {
-//CHECK-NEXT:           double z = t;
+//CHECK-NEXT:           z = t;
 //CHECK-NEXT:           _t1 = t;
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:       }

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -206,11 +206,12 @@ float sum(double* arr, int n) {
 // CHECK-NEXT:     float _d_res = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     float res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 0; i < n; ++i) {
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += arr[i];
@@ -266,6 +267,7 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:     double *_t1;
 // CHECK-NEXT:     unsigned long _t2;
 // CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     double res = 0;
@@ -273,7 +275,7 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:     _t1 = arr;
 // CHECK-NEXT:     res += sum(arr, n);
 // CHECK-NEXT:     _t2 = 0;
-// CHECK-NEXT:     for (int i = 0; i < n; ++i) {
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t2++;
 // CHECK-NEXT:         clad::push(_t3, arr[i]);
 // CHECK-NEXT:         twice(arr[i]);

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -701,9 +701,10 @@ float running_sum(float* p, int n) {
 // CHECK: void running_sum_grad(float *p, int n, clad::array_ref<float> _d_p, clad::array_ref<int> _d_n) {
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 1; i < n; i++) {
+// CHECK-NEXT:     for (i = 1; i < n; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, p[i]);
 // CHECK-NEXT:         p[i] += p[i - 1];

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -20,10 +20,11 @@ double f1(double x) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
+//CHECK-NEXT:       int i = 0;
 //CHECK-NEXT:       clad::tape<double> _t1 = {};
 //CHECK-NEXT:       double t = 1;
 //CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < 3; i++) {
+//CHECK-NEXT:       for (i = 0; i < 3; i++) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           clad::push(_t1, t);
 //CHECK-NEXT:           t *= x;
@@ -53,6 +54,7 @@ double f2(double x) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
+//CHECK-NEXT:       int i = 0;
 //CHECK-NEXT:       clad::tape<unsigned long> _t1 = {};
 //CHECK-NEXT:       clad::tape<int> _t2 = {};
 //CHECK-NEXT:       int _d_j = 0;
@@ -60,7 +62,7 @@ double f2(double x) {
 //CHECK-NEXT:       clad::tape<double> _t3 = {};
 //CHECK-NEXT:       double t = 1;
 //CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < 3; i++) {
+//CHECK-NEXT:       for (i = 0; i < 3; i++) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           clad::push(_t1, 0UL);
 //CHECK-NEXT:           for (clad::push(_t2, j) , j = 0; j < 3; j++) {
@@ -104,11 +106,12 @@ double f3(double x) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
+//CHECK-NEXT:       int i = 0;
 //CHECK-NEXT:       clad::tape<double> _t1 = {};
 //CHECK-NEXT:       clad::tape<bool> _t3 = {};
 //CHECK-NEXT:       double t = 1;
 //CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < 3; i++) {
+//CHECK-NEXT:       for (i = 0; i < 3; i++) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           clad::push(_t1, t);
 //CHECK-NEXT:           t *= x;
@@ -148,10 +151,11 @@ double f4(double x) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
+//CHECK-NEXT:       int i = 0;
 //CHECK-NEXT:       clad::tape<double> _t1 = {};
 //CHECK-NEXT:       double t = 1;
 //CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < 3; clad::push(_t1, t) , (t *= x)) {
+//CHECK-NEXT:       for (i = 0; i < 3; clad::push(_t1, t) , (t *= x)) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           i++;
 //CHECK-NEXT:       }
@@ -179,8 +183,9 @@ double f5(double x){
 //CHECK:   void f5_grad(double x, clad::array_ref<double> _d_x) {
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
+//CHECK-NEXT:       int i = 0;
 //CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < 10; i++) {
+//CHECK-NEXT:       for (i = 0; i < 10; i++) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           x++;
 //CHECK-NEXT:       }
@@ -207,13 +212,14 @@ double f_const_local(double x) {
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    unsigned long _t0;
 //CHECK-NEXT:    int _d_i = 0;
+//CHECK-NEXT:    int i = 0;
 //CHECK-NEXT:    clad::tape<double> _t1 = {};
 //CHECK-NEXT:    double _d_n = 0;
 //CHECK-NEXT:    double n = 0;
 //CHECK-NEXT:    clad::tape<double> _t2 = {};
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    _t0 = 0;
-//CHECK-NEXT:    for (int i = 0; i < 3; ++i) {
+//CHECK-NEXT:    for (i = 0; i < 3; ++i) {
 //CHECK-NEXT:        _t0++;
 //CHECK-NEXT:        clad::push(_t1, n) , n = x + i;
 //CHECK-NEXT:        clad::push(_t2, res);
@@ -251,10 +257,11 @@ double f_sum(double *p, int n) {
 //CHECK-NEXT:     double _d_s = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double s = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, s);
 //CHECK-NEXT:         s += p[i];
@@ -292,10 +299,11 @@ double f_sum_squares(double *p, int n) {
 //CHECK-NEXT:     double _d_s = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double s = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, s);
 //CHECK-NEXT:         s += sq(p[i]);
@@ -329,6 +337,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:     double _d_power = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _t2;
 //CHECK-NEXT:     double _t3;
@@ -339,7 +348,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:     double _d_gaus = 0;
 //CHECK-NEXT:     double power = 0;
 //CHECK-NEXT:     _t0 = 0;
-//CHECK-NEXT:     for (int i = 0; i < n; i++) {
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, power);
 //CHECK-NEXT:         power += sq(x[i] - p[i]);
@@ -407,13 +416,14 @@ void f_const_grad(const double, const double, clad::array_ref<double>, clad::arr
 //CHECK-NEXT:       int _d_r = 0;
 //CHECK-NEXT:       unsigned long _t0;
 //CHECK-NEXT:       int _d_i = 0;
+//CHECK-NEXT:       int i = 0;
 //CHECK-NEXT:       clad::tape<int> _t1 = {};
 //CHECK-NEXT:       int _d_sq = 0;
 //CHECK-NEXT:       int sq0 = 0;
 //CHECK-NEXT:       clad::tape<int> _t2 = {};
 //CHECK-NEXT:       int r = 0;
 //CHECK-NEXT:       _t0 = 0;
-//CHECK-NEXT:       for (int i = 0; i < a; i++) {
+//CHECK-NEXT:       for (i = 0; i < a; i++) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           clad::push(_t1, sq0) , sq0 = b * b;
 //CHECK-NEXT:           clad::push(_t2, r);
@@ -453,6 +463,7 @@ double f6 (double i, double j) {
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_counter = 0;
+// CHECK-NEXT:     int counter = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_b = 0;
 // CHECK-NEXT:     double b = 0;
@@ -463,7 +474,7 @@ double f6 (double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int counter = 0; counter < 3; ++counter) {
+// CHECK-NEXT:     for (counter = 0; counter < 3; ++counter) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, b) , b = i * i;
 // CHECK-NEXT:         clad::push(_t2, c) , c = j * j;
@@ -1224,6 +1235,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_ii = 0;
+// CHECK-NEXT:     int ii = 0;
 // CHECK-NEXT:     clad::tape<bool> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<unsigned long> _t4 = {};
@@ -1233,7 +1245,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:     int counter = 5;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int ii = 0; ii < counter; ++ii) {
+// CHECK-NEXT:     for (ii = 0; ii < counter; ++ii) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         bool _t1 = ii == 4;
 // CHECK-NEXT:         {
@@ -1324,6 +1336,7 @@ double fn17(double i, double j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_ii = 0;
+// CHECK-NEXT:     int ii = 0;
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_jj = 0;
 // CHECK-NEXT:     int jj = 0;
@@ -1337,7 +1350,7 @@ double fn17(double i, double j) {
 // CHECK-NEXT:     int counter = 5;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int ii = 0; ii < counter; ++ii) {
+// CHECK-NEXT:     for (ii = 0; ii < counter; ++ii) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, jj) , jj = ii;
 // CHECK-NEXT:         bool _t2 = ii < 2;
@@ -1446,6 +1459,7 @@ double fn18(double i, double j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_counter = 0;
+// CHECK-NEXT:     int counter = 0;
 // CHECK-NEXT:     clad::tape<bool> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<bool> _t5 = {};
@@ -1454,7 +1468,7 @@ double fn18(double i, double j) {
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int counter = 0; counter < choice; ++counter) {
+// CHECK-NEXT:     for (counter = 0; counter < choice; ++counter) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         bool _t1 = counter < 2;
 // CHECK-NEXT:         {
@@ -1525,30 +1539,34 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double *> _t1 = {};
+// CHECK-NEXT:     clad::tape<double *> _t2 = {};
 // CHECK-NEXT:     double *_d_ref = 0;
+// CHECK-NEXT:     double *ref = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 0; i < n; ++i) {
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         _d_ref = &_d_arr[i];
 // CHECK-NEXT:         clad::push(_t1, _d_ref);
-// CHECK-NEXT:         double &ref = arr[i];
+// CHECK-NEXT:         clad::push(_t2, ref) , ref = &arr[i];
 // CHECK-NEXT:         clad::push(_t3, res);
-// CHECK-NEXT:         res += ref;
+// CHECK-NEXT:         res += *ref;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
-// CHECK-NEXT:         double *_t2 = clad::pop(_t1);
+// CHECK-NEXT:         _d_ref = clad::pop(_t1);
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_res;
-// CHECK-NEXT:             *_t2 += _r_d0;
+// CHECK-NEXT:             *_d_ref += _r_d0;
 // CHECK-NEXT:         }
+// CHECK-NEXT:         ref = clad::pop(_t2);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -1568,13 +1586,14 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:     double _d_interval = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     double _d_x = 0;
+// CHECK-NEXT:     double x = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double sum = 0;
 // CHECK-NEXT:     double num_points = 10000;
 // CHECK-NEXT:     double interval = (upper - lower) / num_points;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (double x = lower; x <= upper; clad::push(_t1, x) , (x += interval)) {
+// CHECK-NEXT:     for (x = lower; x <= upper; clad::push(_t1, x) , (x += interval)) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t2, sum);
 // CHECK-NEXT:         sum += x * x * interval;

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -171,22 +171,25 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     size_t _d_i = 0;
+// CHECK-NEXT:     size_t i = 0;
 // CHECK-NEXT:     clad::tape<size_t *> _t1 = {};
+// CHECK-NEXT:     clad::tape<size_t *> _t3 = {};
 // CHECK-NEXT:     size_t *_d_j = 0;
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<const double *> _t4 = {};
-// CHECK-NEXT:     clad::tape<clad::array_ref<double> > _t5 = {};
+// CHECK-NEXT:     size_t *j = 0;
+// CHECK-NEXT:     clad::tape<double> _t4 = {};
+// CHECK-NEXT:     clad::tape<const double *> _t5 = {};
+// CHECK-NEXT:     clad::tape<clad::array_ref<double> > _t6 = {};
 // CHECK-NEXT:     double sum = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (size_t i = 0; i < n; ++i) {
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         _d_j = &_d_i;
 // CHECK-NEXT:         clad::push(_t1, _d_j);
-// CHECK-NEXT:         size_t *j = &i;
-// CHECK-NEXT:         clad::push(_t3, sum);
+// CHECK-NEXT:         clad::push(_t3, j) , j = &i;
+// CHECK-NEXT:         clad::push(_t4, sum);
 // CHECK-NEXT:         sum += arr[0] * (*j);
-// CHECK-NEXT:         clad::push(_t4, arr);
-// CHECK-NEXT:         clad::push(_t5, _d_arr);
+// CHECK-NEXT:         clad::push(_t5, arr);
+// CHECK-NEXT:         clad::push(_t6, _d_arr);
 // CHECK-NEXT:         _d_arr.ptr_ref() = _d_arr.ptr_ref() + 1;
 // CHECK-NEXT:         arr = arr + 1;
 // CHECK-NEXT:     }
@@ -197,15 +200,16 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         size_t *_t2 = clad::pop(_t1);
 // CHECK-NEXT:         {
-// CHECK-NEXT:             arr = clad::pop(_t4);
-// CHECK-NEXT:             _d_arr = clad::pop(_t5);
+// CHECK-NEXT:             arr = clad::pop(_t5);
+// CHECK-NEXT:             _d_arr = clad::pop(_t6);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             sum = clad::pop(_t3);
+// CHECK-NEXT:             sum = clad::pop(_t4);
 // CHECK-NEXT:             double _r_d0 = _d_sum;
 // CHECK-NEXT:             _d_arr[0] += _r_d0 * (*j);
 // CHECK-NEXT:             *_t2 += arr[0] * _r_d0;
 // CHECK-NEXT:         }
+// CHECK-NEXT:         j = clad::pop(_t3);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -21,9 +21,10 @@ void fn_type_conversion_grad(float z, int a, clad::array_ref<float> _d_z, clad::
 // CHECK: void fn_type_conversion_grad(float z, int a, clad::array_ref<float> _d_z, clad::array_ref<int> _d_a) {
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 1; i < a; i++) {
+// CHECK-NEXT:     for (i = 1; i < a; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, z);
 // CHECK-NEXT:         z = z * a;

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -60,10 +60,11 @@ double sum(Tangent& t) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 0; i < 5; ++i) {
+// CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += t.data[i];
@@ -90,10 +91,11 @@ double sum(double *data) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 0; i < 5; ++i) {
+// CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += data[i];
@@ -369,9 +371,10 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK: void updateTo_pullback(double d, clad::array_ref<Tangent> _d_this, clad::array_ref<double> _d_d) {
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 0; i < 5; ++i) {
+// CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, this->data[i]);
 // CHECK-NEXT:         this->data[i] = d;
@@ -421,6 +424,7 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned long _t0;
 // CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<dcomplex> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
@@ -429,7 +433,7 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     Tangent _t6;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = 0;
-// CHECK-NEXT:     for (int i = 0; i < 5; ++i) {
+// CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         clad::push(_t2, c);

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -112,12 +112,13 @@
 //CHECK_FLOAT_SUM:     float _EERepl_sum0;
 //CHECK_FLOAT_SUM:     unsigned long _t0;
 //CHECK_FLOAT_SUM:     unsigned int _d_i = 0;
+//CHECK_FLOAT_SUM:     unsigned int i = 0;
 //CHECK_FLOAT_SUM:     clad::tape<float> _t1 = {};
 //CHECK_FLOAT_SUM:     clad::tape<float> _EERepl_sum1 = {};
 //CHECK_FLOAT_SUM:     float sum = 0.;
 //CHECK_FLOAT_SUM:     _EERepl_sum0 = sum;
 //CHECK_FLOAT_SUM:     _t0 = 0;
-//CHECK_FLOAT_SUM:     for (unsigned int i = 0; i < n; i++) {
+//CHECK_FLOAT_SUM:     for (i = 0; i < n; i++) {
 //CHECK_FLOAT_SUM:         _t0++;
 //CHECK_FLOAT_SUM:         clad::push(_t1, sum);
 //CHECK_FLOAT_SUM:         sum = sum + x;


### PR DESCRIPTION
When we produce a gradient function we generally have a forward and reverse
sweep. In the forward sweep we accumulate the state and in the reverse sweep
we use that state to invert the program execution. The forward sweep generally
follows the sematics of the primal function and when neccessary stores the state
which would be needed but lost for the reverse sweep.

However, to minimize the stores onto the tape we need to reuse some of the
variables between the forward and the reverse sweeps which requires some
variables to be promoted to the enclosing lexical scope of both sweeps.

Fixes https://github.com/vgvassilev/clad/issues/659, fixes https://github.com/vgvassilev/clad/issues/681.