### PR TITLE
[cmake] Properly compute the path to gtest.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,8 @@ jobs:
             os: ubuntu-22.04
             compiler: clang-16
             clang-runtime: '17'
-            extra_packages: 'libtrilinos-kokkos-dev'
+            extra_packages: 'libtrilinos-kokkos-dev ninja-build'
+            extra_cmake_options: '-G Ninja'
 
           # Оld, still supported versions
 

--- a/cmake/modules/CladGoogleTest.cmake
+++ b/cmake/modules/CladGoogleTest.cmake
@@ -1,5 +1,5 @@
 set(_gtest_byproduct_binary_dir
-  ${CMAKE_BINARY_DIR}/downloads/googletest-prefix/src/googletest-build)
+  ${CMAKE_BINARY_DIR}/unittests/googletest-prefix/src/googletest-build)
 set(_gtest_byproducts
   ${_gtest_byproduct_binary_dir}/lib/libgtest.a
   ${_gtest_byproduct_binary_dir}/lib/libgtest_main.a


### PR DESCRIPTION
Fixes #753.