### PR TITLE
[cmake] Move away from flat namespaces.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
 endif ()
 
 if (APPLE)
-  set(CMAKE_MODULE_LINKER_FLAGS "-Wl,-flat_namespace -Wl,-undefined -Wl,suppress")
+  set(CMAKE_MODULE_LINKER_FLAGS "-Wl,-undefined -Wl,dynamic_lookup")
 endif ()
 
 # FIXME: Use merge this with the content from the LLVMConfig and ClangConfig.


### PR DESCRIPTION
This patch removes the flat_namespace option that we pass to the linker on osx. Instead we will make a dynamic lookup when a symbol is missing which is more consistent with the default behavior for osx.

Fixes #300.