### PR TITLE
[ci] Schedule the builds with debug clang earlier.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,12 @@ jobs:
             compiler: msvc
             clang-runtime: '16'
 
+          - name: ubu22-clang15-runtime16-debug
+            os: ubuntu-22.04
+            compiler: clang-15
+            clang-runtime: '16'
+            debug_build: true
+
           - name: ubu20-gcc7-runtime11-analyzers
             os: ubuntu-20.04
             compiler: gcc-7
@@ -386,12 +392,6 @@ jobs:
             os: ubuntu-22.04
             compiler: clang-15
             clang-runtime: '16'
-
-          - name: ubu22-clang15-runtime16-debug
-            os: ubuntu-22.04
-            compiler: clang-15
-            clang-runtime: '16'
-            debug_build: true
 
           - name: ubuntu-clang15-runtime16-doc
             os: ubuntu-latest


### PR DESCRIPTION
This way we can utilize the github actions parallelism as this build takes longer.