### PR TITLE
Initial support for memory operations in reverse mode

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -28,6 +28,7 @@ Checks: >
   -readability-function-cognitive-complexity,
   -readability-implicit-bool-conversion,
   -cppcoreguidelines-avoid-magic-numbers,
+  -clang-analyzer-cplusplus.NewDeleteLeaks,
 
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase

--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -106,6 +106,7 @@ public:
   StmtDiff VisitPseudoObjectExpr(const clang::PseudoObjectExpr* POE);
   StmtDiff VisitSubstNonTypeTemplateParmExpr(
       const clang::SubstNonTypeTemplateParmExpr* NTTP);
+  StmtDiff VisitImplicitValueInitExpr(const clang::ImplicitValueInitExpr* IVIE);
 
   virtual clang::QualType
   GetPushForwardDerivativeType(clang::QualType ParamType);

--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -107,6 +107,7 @@ public:
   StmtDiff VisitSubstNonTypeTemplateParmExpr(
       const clang::SubstNonTypeTemplateParmExpr* NTTP);
   StmtDiff VisitImplicitValueInitExpr(const clang::ImplicitValueInitExpr* IVIE);
+  StmtDiff VisitCStyleCastExpr(const clang::CStyleCastExpr* CSCE);
 
   virtual clang::QualType
   GetPushForwardDerivativeType(clang::QualType ParamType);

--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -196,6 +196,31 @@ CUDA_HOST_DEVICE void clamp_pullback(const T& v, const T& lo, const T& hi,
 #endif
 
 } // namespace std
+
+// NOLINTBEGIN(cppcoreguidelines-no-malloc)
+// NOLINTBEGIN(cppcoreguidelines-owning-memory)
+inline ValueAndPushforward<void*, void*> malloc_pushforward(size_t sz,
+                                                            size_t d_sz) {
+  return {malloc(sz), malloc(sz)};
+}
+
+inline ValueAndPushforward<void*, void*>
+calloc_pushforward(size_t n, size_t sz, size_t d_n, size_t d_sz) {
+  return {calloc(n, sz), calloc(n, sz)};
+}
+
+inline ValueAndPushforward<void*, void*>
+realloc_pushforward(void* ptr, size_t sz, void* d_ptr, size_t d_sz) {
+  return {realloc(ptr, sz), realloc(d_ptr, sz)};
+}
+
+inline void free_pushforward(void* ptr, void* d_ptr) {
+  free(ptr);
+  free(d_ptr);
+}
+// NOLINTEND(cppcoreguidelines-owning-memory)
+// NOLINTEND(cppcoreguidelines-no-malloc)
+
 // These are required because C variants of mathematical functions are
 // defined in global namespace.
 using std::abs_pushforward;

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -328,6 +328,9 @@ namespace clad {
     void SetSwitchCaseSubStmt(clang::SwitchCase* SC, clang::Stmt* subStmt);
 
     bool IsLiteral(const clang::Expr* E);
+
+    bool IsMemoryAllocationFunction(const clang::FunctionDecl* FD);
+    bool IsMemoryDeallocationFunction(const clang::FunctionDecl* FD);
     } // namespace utils
     } // namespace clad
 

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -329,7 +329,7 @@ namespace clad {
 
     bool IsLiteral(const clang::Expr* E);
 
-    bool IsMemoryAllocationFunction(const clang::FunctionDecl* FD);
+    bool IsMemoryFunction(const clang::FunctionDecl* FD);
     bool IsMemoryDeallocationFunction(const clang::FunctionDecl* FD);
     } // namespace utils
     } // namespace clad

--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -766,5 +766,16 @@ static inline const DeclSpec& Sema_ActOnStartOfLambdaDefinition_ScopeOrDeclSpec(
   ,Node->isTransparent()
 #endif
 
+// Clang 9 above added isa_and_nonnull.
+#if CLANG_VERSION_MAJOR < 9
+template <typename X, typename Y> bool isa_and_nonnull(const Y* Val) {
+  return Val && isa<X>(Val);
+}
+#else
+template <typename X, typename Y> bool isa_and_nonnull(const Y* Val) {
+  return llvm::isa_and_nonnull<X>(Val);
+}
+#endif
+
 } // namespace clad_compat
 #endif //CLAD_COMPATIBILITY

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -360,6 +360,7 @@ namespace clad {
     StmtDiff VisitImplicitCastExpr(const clang::ImplicitCastExpr* ICE);
     StmtDiff
     VisitImplicitValueInitExpr(const clang::ImplicitValueInitExpr* IVIE);
+    StmtDiff VisitCStyleCastExpr(const clang::CStyleCastExpr* CSCE);
     StmtDiff VisitInitListExpr(const clang::InitListExpr* ILE);
     StmtDiff VisitIntegerLiteral(const clang::IntegerLiteral* IL);
     StmtDiff VisitMemberExpr(const clang::MemberExpr* ME);

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -358,6 +358,8 @@ namespace clad {
     StmtDiff VisitForStmt(const clang::ForStmt* FS);
     StmtDiff VisitIfStmt(const clang::IfStmt* If);
     StmtDiff VisitImplicitCastExpr(const clang::ImplicitCastExpr* ICE);
+    StmtDiff
+    VisitImplicitValueInitExpr(const clang::ImplicitValueInitExpr* IVIE);
     StmtDiff VisitInitListExpr(const clang::InitListExpr* ILE);
     StmtDiff VisitIntegerLiteral(const clang::IntegerLiteral* IL);
     StmtDiff VisitMemberExpr(const clang::MemberExpr* ME);

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -41,6 +41,8 @@ namespace clad {
     /// the reverse mode we also accumulate Stmts for the reverse pass which
     /// will be executed on return.
     std::vector<Stmts> m_Reverse;
+    /// Storing expressions to delete/free memory in the reverse pass.
+    Stmts m_DeallocExprs;
     /// Stack is used to pass the arguments (dfdx) to further nodes
     /// in the Visit method.
     std::stack<clang::Expr*> m_Stack;
@@ -370,6 +372,8 @@ namespace clad {
     StmtDiff VisitContinueStmt(const clang::ContinueStmt* CS);
     StmtDiff VisitBreakStmt(const clang::BreakStmt* BS);
     StmtDiff VisitCXXThisExpr(const clang::CXXThisExpr* CTE);
+    StmtDiff VisitCXXNewExpr(const clang::CXXNewExpr* CNE);
+    StmtDiff VisitCXXDeleteExpr(const clang::CXXDeleteExpr* CDE);
     StmtDiff VisitCXXConstructExpr(const clang::CXXConstructExpr* CE);
     StmtDiff
     VisitMaterializeTemporaryExpr(const clang::MaterializeTemporaryExpr* MTE);

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1451,6 +1451,25 @@ StmtDiff BaseForwardModeVisitor::VisitImplicitValueInitExpr(
 }
 
 StmtDiff
+BaseForwardModeVisitor::VisitCStyleCastExpr(const CStyleCastExpr* CSCE) {
+  StmtDiff subExprDiff = Visit(CSCE->getSubExpr());
+  // Create a new CStyleCastExpr with the same type and the same subexpression
+  // as the original one.
+  Expr* castExpr = m_Sema
+                       .BuildCStyleCastExpr(
+                           CSCE->getLParenLoc(), CSCE->getTypeInfoAsWritten(),
+                           CSCE->getRParenLoc(), subExprDiff.getExpr())
+                       .get();
+  Expr* castExprDiff =
+      m_Sema
+          .BuildCStyleCastExpr(CSCE->getLParenLoc(),
+                               CSCE->getTypeInfoAsWritten(),
+                               CSCE->getRParenLoc(), subExprDiff.getExpr_dx())
+          .get();
+  return StmtDiff(castExpr, castExprDiff);
+}
+
+StmtDiff
 BaseForwardModeVisitor::VisitCXXDefaultArgExpr(const CXXDefaultArgExpr* DE) {
   // FIXME: Shouldn't we simply clone the CXXDefaultArgExpr?
   // return {Clone(DE), Clone(DE)};

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1445,6 +1445,11 @@ BaseForwardModeVisitor::VisitImplicitCastExpr(const ImplicitCastExpr* ICE) {
   return StmtDiff(subExprDiff.getExpr(), subExprDiff.getExpr_dx());
 }
 
+StmtDiff BaseForwardModeVisitor::VisitImplicitValueInitExpr(
+    const ImplicitValueInitExpr* E) {
+  return StmtDiff(Clone(E), Clone(E));
+}
+
 StmtDiff
 BaseForwardModeVisitor::VisitCXXDefaultArgExpr(const CXXDefaultArgExpr* DE) {
   // FIXME: Shouldn't we simply clone the CXXDefaultArgExpr?

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -641,5 +641,19 @@ namespace clad {
              isa<ObjCBoolLiteralExpr>(E) || isa<CXXBoolLiteralExpr>(E) ||
              isa<GNUNullExpr>(E);
     }
+
+    bool IsMemoryAllocationFunction(const clang::FunctionDecl* FD) {
+      if (FD->getBuiltinID() == Builtin::BImalloc)
+        return true;
+      if (FD->getBuiltinID() == Builtin::BIcalloc)
+        return true;
+      if (FD->getBuiltinID() == Builtin::BIrealloc)
+        return true;
+      return false;
+    }
+
+    bool IsMemoryDeallocationFunction(const clang::FunctionDecl* FD) {
+      return FD->getBuiltinID() == Builtin::BIfree;
+    }
   } // namespace utils
 } // namespace clad

--- a/test/ForwardMode/Pointer.C
+++ b/test/ForwardMode/Pointer.C
@@ -161,7 +161,7 @@ double fn7(double i) {
 // CHECK-NEXT:     t->i = i;
 // CHECK-NEXT:     double _d_res = *_d_p + _d_t->i;
 // CHECK-NEXT:     double res = *p + t->i;
-// CHECK-NEXT:     unsigned long _t2 = sizeof(double);
+// CHECK-NEXT:     unsigned {{(int|long)}} _t2 = sizeof(double);
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<void *, void *> _t3 = clad::custom_derivatives::realloc_pushforward(p, 2 * _t2, _d_p, 0 * _t2 + 2 * sizeof(double));
 // CHECK-NEXT:     _d_p = (double *)_t3.pushforward;
 // CHECK-NEXT:     p = (double *)_t3.value;

--- a/test/ForwardMode/Pointer.C
+++ b/test/ForwardMode/Pointer.C
@@ -110,16 +110,41 @@ double fn5(double i, double j) {
 // CHECK-NEXT:     return *(_d_arr + idx1) + *(_d_arr + idx2);
 // CHECK-NEXT: }
 
+struct T {
+  double i;
+  int j;
+};
+
+double fn6 (double i) {
+  T* t = new T{i};
+  double res = t->i;
+  delete t;
+  return res;
+}
+
+// CHECK: double fn6_darg0(double i) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     T *_d_t = new T({_d_i, /*implicit*/(int)0});
+// CHECK-NEXT:     T *t = new T({i, /*implicit*/(int)0});
+// CHECK-NEXT:     double _d_res = _d_t->i;
+// CHECK-NEXT:     double res = t->i;
+// CHECK-NEXT:     delete _d_t;
+// CHECK-NEXT:     delete t;
+// CHECK-NEXT:     return _d_res;
+// CHECK-NEXT: }
+
 int main() {
   INIT_DIFFERENTIATE(fn1, "i");
   INIT_DIFFERENTIATE(fn2, "i");
   INIT_DIFFERENTIATE(fn3, "i");
   INIT_DIFFERENTIATE(fn4, "i");
   INIT_DIFFERENTIATE(fn5, "i");
+  INIT_DIFFERENTIATE(fn6, "i");
 
   TEST_DIFFERENTIATE(fn1, 3, 5);  // CHECK-EXEC: {5.00}
   TEST_DIFFERENTIATE(fn2, 3, 5);  // CHECK-EXEC: {5.00}
   TEST_DIFFERENTIATE(fn3, 3, 5);  // CHECK-EXEC: {6.00}
   TEST_DIFFERENTIATE(fn4, 3, 5);  // CHECK-EXEC: {16.00}
   TEST_DIFFERENTIATE(fn5, 3, 5);  // CHECK-EXEC: {57.00}
+  TEST_DIFFERENTIATE(fn6, 3);     // CHECK-EXEC: {1.00}
 }

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -433,7 +433,13 @@ double structPointer (double x) {
 double cStyleMemoryAlloc(double x, size_t n) {
   T* t = (T*)malloc(n * sizeof(T));
   t->x = x;
-  double res = t->x;
+  double* p = (double*)calloc(1, sizeof(double));
+  *p = x;
+  double res = t->x + *p;
+  p = (double*)realloc(p, 2*sizeof(double));
+  p[1] = 2*x;
+  res += p[1];
+  free(p);
   free(t);
   return res;
 }
@@ -442,22 +448,66 @@ double cStyleMemoryAlloc(double x, size_t n) {
 // CHECK-NEXT:     size_t _d_n = 0;
 // CHECK-NEXT:     T *_d_t = 0;
 // CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double *_d_p = 0;
+// CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     double *_t2;
+// CHECK-NEXT:     double *_t3;
+// CHECK-NEXT:     double _t4;
+// CHECK-NEXT:     double _t5;
 // CHECK-NEXT:     _d_t = (T *)malloc(n * sizeof(T));
 // CHECK-NEXT:     T *t = (T *)malloc(n * sizeof(T));
 // CHECK-NEXT:     _t0 = t->x;
 // CHECK-NEXT:     t->x = x;
-// CHECK-NEXT:     double res = t->x;
+// CHECK-NEXT:     _d_p = (double *)calloc(1, sizeof(double));
+// CHECK-NEXT:     double *p = (double *)calloc(1, sizeof(double));
+// CHECK-NEXT:     _t1 = *p;
+// CHECK-NEXT:     *p = x;
+// CHECK-NEXT:     double res = t->x + *p;
+// CHECK-NEXT:     _t2 = p;
+// CHECK-NEXT:     _t3 = _d_p;
+// CHECK-NEXT:     _d_p = (double *)realloc(_d_p, 2 * sizeof(double));
+// CHECK-NEXT:     p = (double *)realloc(p, 2 * sizeof(double));
+// CHECK-NEXT:     _t4 = p[1];
+// CHECK-NEXT:     p[1] = 2 * x;
+// CHECK-NEXT:     _t5 = res;
+// CHECK-NEXT:     res += p[1];
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     _d_t->x += _d_res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         res = _t5;
+// CHECK-NEXT:         double _r_d3 = _d_res;
+// CHECK-NEXT:         _d_p[1] += _r_d3;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         p[1] = _t4;
+// CHECK-NEXT:         double _r_d2 = _d_p[1];
+// CHECK-NEXT:         _d_p[1] -= _r_d2;
+// CHECK-NEXT:         * _d_x += 2 * _r_d2;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         p = _t2;
+// CHECK-NEXT:         _d_p = _t3;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_t->x += _d_res;
+// CHECK-NEXT:         *_d_p += _d_res;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *p = _t1;
+// CHECK-NEXT:         double _r_d1 = *_d_p;
+// CHECK-NEXT:         *_d_p -= _r_d1;
+// CHECK-NEXT:         * _d_x += _r_d1;
+// CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t->x = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_t->x;
 // CHECK-NEXT:         _d_t->x -= _r_d0;
 // CHECK-NEXT:         * _d_x += _r_d0;
 // CHECK-NEXT:     }
+// CHECK-NEXT:     free(p);
+// CHECK-NEXT:     free(_d_p);
 // CHECK-NEXT:     free(t);
 // CHECK-NEXT:     free(_d_t);
 // CHECK-NEXT: }
@@ -570,5 +620,5 @@ int main() {
   auto d_cStyleMemoryAlloc = clad::gradient(cStyleMemoryAlloc, "x");
   d_x = 0;
   d_cStyleMemoryAlloc.execute(5, 7, &d_x);
-  printf("%.2f\n", d_x); // CHECK-EXEC: 1.00
+  printf("%.2f\n", d_x); // CHECK-EXEC: 4.00
 }

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -395,14 +395,40 @@ double newAndDeletePointer(double i, double j) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     * _d_j += *_d_q;
 // CHECK-NEXT:     * _d_i += *_d_p;
-// CHECK-NEXT:     delete [] r;
-// CHECK-NEXT:     delete [] _d_r;
-// CHECK-NEXT:     delete q;
-// CHECK-NEXT:     delete _d_q;
 // CHECK-NEXT:     delete p;
 // CHECK-NEXT:     delete _d_p;
+// CHECK-NEXT:     delete q;
+// CHECK-NEXT:     delete _d_q;
+// CHECK-NEXT:     delete [] r;
+// CHECK-NEXT:     delete [] _d_r;
 // CHECK-NEXT: }
-  
+
+struct T {
+  double x;
+  int y;
+};
+
+double structPointer (double x) {
+  T* t = new T{x};
+  double res = t->x;
+  delete t;
+  return res;
+}
+
+// CHECK: void structPointer_grad(double x, clad::array_ref<double> _d_x) {
+// CHECK-NEXT:     T *_d_t = 0;
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     _d_t = new T;
+// CHECK-NEXT:     T *t = new T({x, /*implicit*/(int)0});
+// CHECK-NEXT:     double res = t->x;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_t->x += _d_res;
+// CHECK-NEXT:     * _d_x += *_d_t.x;
+// CHECK-NEXT:     delete t;
+// CHECK-NEXT:     delete _d_t;
+// CHECK-NEXT: }
 
 #define NON_MEM_FN_TEST(var)\
 res[0]=0;\
@@ -503,4 +529,8 @@ int main() {
   double d_i = 0, d_j = 0;
   d_newAndDeletePointer.execute(5, 7, &d_i, &d_j);
   printf("%.2f %.2f\n", d_i, d_j); // CHECK-EXEC: 9.00 7.00
+
+  auto d_structPointer = clad::gradient(structPointer);
+  double d_x = 0;
+  d_structPointer.execute(5, &d_x);
 }

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -363,7 +363,7 @@ double newAndDeletePointer(double i, double j) {
 // CHECK-NEXT:     double *p = new double(i);
 // CHECK-NEXT:     _d_q = new double(* _d_j);
 // CHECK-NEXT:     double *q = new double(j);
-// CHECK-NEXT:     _d_r = new double [2];
+// CHECK-NEXT:     _d_r = new double [2](/*implicit*/(double{{[ ]?}}[2])0);
 // CHECK-NEXT:     double *r = new double [2];
 // CHECK-NEXT:     _t0 = r[0];
 // CHECK-NEXT:     r[0] = i + j;
@@ -418,7 +418,7 @@ double structPointer (double x) {
 // CHECK: void structPointer_grad(double x, clad::array_ref<double> _d_x) {
 // CHECK-NEXT:     T *_d_t = 0;
 // CHECK-NEXT:     double _d_res = 0;
-// CHECK-NEXT:     _d_t = new T;
+// CHECK-NEXT:     _d_t = new T();
 // CHECK-NEXT:     T *t = new T({x, /*implicit*/(int)0});
 // CHECK-NEXT:     double res = t->x;
 // CHECK-NEXT:     goto _label0;
@@ -432,6 +432,7 @@ double structPointer (double x) {
 
 double cStyleMemoryAlloc(double x, size_t n) {
   T* t = (T*)malloc(n * sizeof(T));
+  memset(t, 0, n * sizeof(T));
   t->x = x;
   double* p = (double*)calloc(1, sizeof(double));
   *p = x;
@@ -457,6 +458,8 @@ double cStyleMemoryAlloc(double x, size_t n) {
 // CHECK-NEXT:     double _t5;
 // CHECK-NEXT:     _d_t = (T *)malloc(n * sizeof(T));
 // CHECK-NEXT:     T *t = (T *)malloc(n * sizeof(T));
+// CHECK-NEXT:     memset(_d_t, 0, n * sizeof(T));
+// CHECK-NEXT:     memset(t, 0, n * sizeof(T));
 // CHECK-NEXT:     _t0 = t->x;
 // CHECK-NEXT:     t->x = x;
 // CHECK-NEXT:     _d_p = (double *)calloc(1, sizeof(double));

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -430,6 +430,38 @@ double structPointer (double x) {
 // CHECK-NEXT:     delete _d_t;
 // CHECK-NEXT: }
 
+double cStyleMemoryAlloc(double x, size_t n) {
+  T* t = (T*)malloc(n * sizeof(T));
+  t->x = x;
+  double res = t->x;
+  free(t);
+  return res;
+}
+
+// CHECK: void cStyleMemoryAlloc_grad_0(double x, size_t n, clad::array_ref<double> _d_x) {
+// CHECK-NEXT:     size_t _d_n = 0;
+// CHECK-NEXT:     T *_d_t = 0;
+// CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     _d_t = (T *)malloc(n * sizeof(T));
+// CHECK-NEXT:     T *t = (T *)malloc(n * sizeof(T));
+// CHECK-NEXT:     _t0 = t->x;
+// CHECK-NEXT:     t->x = x;
+// CHECK-NEXT:     double res = t->x;
+// CHECK-NEXT:     goto _label0;
+// CHECK-NEXT:   _label0:
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_t->x += _d_res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         t->x = _t0;
+// CHECK-NEXT:         double _r_d0 = _d_t->x;
+// CHECK-NEXT:         _d_t->x -= _r_d0;
+// CHECK-NEXT:         * _d_x += _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     free(t);
+// CHECK-NEXT:     free(_d_t);
+// CHECK-NEXT: }
+
 #define NON_MEM_FN_TEST(var)\
 res[0]=0;\
 var.execute(5,res);\
@@ -533,4 +565,10 @@ int main() {
   auto d_structPointer = clad::gradient(structPointer);
   double d_x = 0;
   d_structPointer.execute(5, &d_x);
+  printf("%.2f\n", d_x); // CHECK-EXEC: 1.00
+
+  auto d_cStyleMemoryAlloc = clad::gradient(cStyleMemoryAlloc, "x");
+  d_x = 0;
+  d_cStyleMemoryAlloc.execute(5, 7, &d_x);
+  printf("%.2f\n", d_x); // CHECK-EXEC: 1.00
 }


### PR DESCRIPTION
This does not add complete support for `new` and `delete` operators, there are many examples that can be constructed which will fail or crash. However, it covers the mostly-used case of allocating memory in the beginning and deallocating in the end.

Edit: Also, added C-style memory alloc and `free` operations.

fixes #654 