### PR TITLE
Update InstallationAndUsage.rst

### DIFF
--- a/docs/userDocs/source/user/InstallationAndUsage.rst
+++ b/docs/userDocs/source/user/InstallationAndUsage.rst
@@ -60,7 +60,7 @@ Building from source LLVM, Clang and Clad (development environment)
 
    sudo -H pip install lit
    git clone https://github.com/llvm/llvm-project.git src
-   cd src; git chekout llvmorg-13.0.0
+   cd src; git checkout llvmorg-13.0.0
    cd /tools
    git clone https://github.com/vgvassilev/clad.git clad
    cd ../../../


### PR DESCRIPTION
Fixed a minor typo in the installation commands for Building from source LLVM, Clang and Clad (development environment). I made a pull request directly as I thought it was a trivial issue (changed "chekout" to "checkout")