### PR TITLE
Add timings report if -ftime-report is enabled

### DIFF
--- a/test/Misc/TimingsReport.C
+++ b/test/Misc/TimingsReport.C
@@ -1,0 +1,31 @@
+// RUN: %cladclang %s -I%S/../../include -oTimingsReport.out -ftime-report 2>&1 | FileCheck %s
+
+#include "clad/Differentiator/Differentiator.h"
+// CHECK-NOT: {{.*error|warning|note:.*}}
+// CHECK: Timers for Clad Funcs
+
+double nested1(double c){
+  return c*3*c;
+}
+
+double nested2(double z){
+  return 4*z*z;
+}
+
+double test1(double x, double y) {
+  return 2*y*nested1(y) * 3 * x * nested1(x);
+}
+
+double test2(double a, double b) {
+  return 3*a*a + b * nested2(a) + a * b;
+}
+
+int main() {
+  auto d_fn_1 = clad::differentiate(test1, "x");
+  double dp = -1, dq = -1;
+  auto f_grad = clad::gradient(test2);
+  f_grad.execute(3, 4, &dp, &dq);
+  printf("Result is = %f\n", d_fn_1.execute(3,4));
+  printf("Result is = %f %f\n", dp, dq);
+  return 0;
+}

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -19,8 +19,9 @@
 #include "clang/Basic/Version.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
 
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Timer.h"
 
 namespace clang {
   class ASTContext;
@@ -61,6 +62,15 @@ namespace clad {
     /// argument `DFI`.
     bool AlreadyExists(const DerivedFnInfo& DFI) const;
   };
+  class CladTimerGroup {
+    llvm::TimerGroup m_Tg;
+    std::vector<std::unique_ptr<llvm::Timer>> m_Timers;
+
+  public:
+    CladTimerGroup();
+    void StartNewTimer(llvm::StringRef TimerName, llvm::StringRef TimerDesc);
+    void StopTimer();
+  };
 
   namespace plugin {
     struct DifferentiationOptions {
@@ -89,6 +99,7 @@ namespace clad {
       bool m_HasRuntime = false;
       bool m_PendingInstantiationsInFlight = false;
       bool m_HandleTopLevelDeclInternal = false;
+      CladTimerGroup m_CTG;
       DerivedFnCollector m_DFC;
     public:
       CladPlugin(clang::CompilerInstance& CI, DifferentiationOptions& DO);


### PR DESCRIPTION
Fixes #769 
Makes use of `llvm::TimerGroup` and `llvm::Timer` classes to record timings for function differentiations
SourceFile.cpp
```cpp
#include "clad/Differentiator/Differentiator.h"
#include <iostream>
double fnr(double c){
  return c*3*c;
}

double fns(double z){
  return 4*z;
}

double fn(double x, double y) {
  return x*x*x*x + 2*y*fnr(y) * 3 * x * fns(x);
}

double fn2(double a, double b) {
  return 3*a*a + b * fns(b);
}

double grad_func(double p, double q){
  return p*q;
}

int main() {
  // differentiate 'fn' w.r.t 'x'.
  auto d_fn_1 = clad::differentiate(fn, "x");
  auto d_fn_2 = clad::differentiate(fn2, "a");
  double dp = -1, dq = -1;
  auto f_grad = clad::gradient(grad_func);
  f_grad.execute(3, 4, &dp, &dq);
  // computes derivative of 'fn' w.r.t 'x' when (x, y) = (3, 4).
  std::cout<<d_fn_1.execute(3, 4)<<"\n";
  std::cout<<d_fn_2.execute(2, 4)<<"\n";
  std::cout<<"dp="<<dp<<" dq="<<dq<<"\n";
  return 0;
}
```
***
Output with -ftime-report
```
❯ clang++ -std=c++11 -I /home/warrenjacinto/Projects/clad/include/ -fplugin=/home/warrenjacinto/Projects/inst/lib/clad.so SourceFile.cpp -lstdc++ -lm -ftime-report
===-------------------------------------------------------------------------===
                             Timers for clad funcs
===-------------------------------------------------------------------------===
  Total Execution Time: 0.0730 seconds (0.0754 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   0.0311 ( 44.6%)   0.0000 (  0.0%)   0.0311 ( 42.7%)   0.0329 ( 43.7%)  fn
   0.0274 ( 39.3%)   0.0000 (  0.0%)   0.0274 ( 37.6%)   0.0280 ( 37.2%)  grad_func
   0.0044 (  6.4%)   0.0032 (100.0%)   0.0077 ( 10.5%)   0.0077 ( 10.1%)  fn2
   0.0045 (  6.5%)   0.0000 (  0.0%)   0.0045 (  6.2%)   0.0045 (  6.0%)  fnr
   0.0023 (  3.2%)   0.0000 (  0.0%)   0.0023 (  3.1%)   0.0023 (  3.0%)  fns
   0.0698 (100.0%)   0.0032 (100.0%)   0.0730 (100.0%)   0.0754 (100.0%)  Total

===-------------------------------------------------------------------------===
                          Pass execution timing report
===-------------------------------------------------------------------------===
  Total Execution Time: 0.0012 seconds (0.0012 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   0.0007 ( 61.7%)   0.0000 ( 66.7%)   0.0007 ( 61.7%)   0.0007 ( 61.6%)  AnnotationRemarksPass
   0.0004 ( 31.6%)   0.0000 ( 33.3%)   0.0004 ( 31.6%)   0.0004 ( 31.7%)  AlwaysInlinerPass
   0.0001 (  6.7%)   0.0000 (  0.0%)   0.0001 (  6.7%)   0.0001 (  6.7%)  CoroConditionalWrapper
   0.0012 (100.0%)   0.0000 (100.0%)   0.0012 (100.0%)   0.0012 (100.0%)  Total

===-------------------------------------------------------------------------===
                        Analysis execution timing report
===-------------------------------------------------------------------------===
  Total Execution Time: 0.0003 seconds (0.0003 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   0.0002 ( 82.0%)   0.0000 (100.0%)   0.0002 ( 82.1%)   0.0002 ( 82.1%)  TargetLibraryAnalysis
   0.0000 ( 13.1%)   0.0000 (  0.0%)   0.0000 ( 13.1%)   0.0000 ( 13.1%)  ProfileSummaryAnalysis
   0.0000 (  4.8%)   0.0000 (  0.0%)   0.0000 (  4.8%)   0.0000 (  4.8%)  InnerAnalysisManagerProxy<llvm::AnalysisManager<llvm::Function>, llvm::Module>
   0.0003 (100.0%)   0.0000 (100.0%)   0.0003 (100.0%)   0.0003 (100.0%)  Total

===-------------------------------------------------------------------------===
                         Miscellaneous Ungrouped Timers
===-------------------------------------------------------------------------===

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   0.4330 ( 69.6%)   0.0021 ( 14.9%)   0.4351 ( 68.3%)   0.4520 ( 66.9%)  LLVM IR Generation Time
   0.1896 ( 30.4%)   0.0121 ( 85.1%)   0.2016 ( 31.7%)   0.2238 ( 33.1%)  Code Generation Time
   0.6226 (100.0%)   0.0142 (100.0%)   0.6368 (100.0%)   0.6758 (100.0%)  Total

===-------------------------------------------------------------------------===
                      Instruction Selection and Scheduling
===-------------------------------------------------------------------------===
  Total Execution Time: 0.0124 seconds (0.0174 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   0.0028 ( 22.5%)   0.0000 ( 16.7%)   0.0028 ( 22.5%)   0.0051 ( 29.3%)  DAG Combining 1
   0.0026 ( 21.4%)   0.0000 ( 41.7%)   0.0027 ( 21.4%)   0.0038 ( 22.1%)  Instruction Selection
   0.0010 (  8.1%)   0.0000 ( 16.7%)   0.0010 (  8.1%)   0.0022 ( 12.7%)  DAG Legalization
   0.0018 ( 14.7%)   0.0000 (  0.0%)   0.0018 ( 14.7%)   0.0018 ( 10.4%)  DAG Combining 2
   0.0018 ( 14.4%)   0.0000 (  8.3%)   0.0018 ( 14.4%)   0.0018 ( 10.2%)  Instruction Scheduling
   0.0016 ( 12.6%)   0.0000 (  8.3%)   0.0016 ( 12.6%)   0.0016 (  8.9%)  Instruction Creation
   0.0005 (  4.3%)   0.0000 (  0.0%)   0.0005 (  4.3%)   0.0008 (  4.8%)  Type Legalization
   0.0001 (  1.2%)   0.0000 (  0.0%)   0.0001 (  1.2%)   0.0002 (  0.9%)  Vector Legalization
   0.0001 (  0.9%)   0.0000 (  8.3%)   0.0001 (  0.9%)   0.0001 (  0.6%)  Instruction Scheduling Cleanup
   0.0124 (100.0%)   0.0000 (100.0%)   0.0124 (100.0%)   0.0174 (100.0%)  Total

===-------------------------------------------------------------------------===
                          Pass execution timing report
===-------------------------------------------------------------------------===
  Total Execution Time: 0.1363 seconds (0.1487 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   0.0504 ( 38.5%)   0.0000 (  0.6%)   0.0504 ( 37.0%)   0.0605 ( 40.7%)  X86 DAG->DAG Instruction Selection
   0.0203 ( 15.5%)   0.0018 ( 33.1%)   0.0221 ( 16.2%)   0.0224 ( 15.1%)  X86 Assembly Printer
   0.0100 (  7.6%)   0.0009 ( 16.5%)   0.0109 (  8.0%)   0.0109 (  7.3%)  Fast Register Allocator
   0.0078 (  5.9%)   0.0006 ( 10.9%)   0.0084 (  6.1%)   0.0088 (  5.9%)  Module Verifier
   0.0074 (  5.6%)   0.0000 (  0.8%)   0.0074 (  5.4%)   0.0074 (  5.0%)  Module Verifier #2
   0.0063 (  4.8%)   0.0005 (  9.6%)   0.0068 (  5.0%)   0.0071 (  4.8%)  Prologue/Epilogue Insertion & Frame Finalization
   0.0046 (  3.5%)   0.0000 (  0.0%)   0.0046 (  3.4%)   0.0055 (  3.7%)  Pre-ISel Intrinsic Lowering
   0.0034 (  2.6%)   0.0002 (  4.2%)   0.0036 (  2.6%)   0.0036 (  2.4%)  Two-Address instruction pass
   0.0014 (  1.1%)   0.0001 (  2.1%)   0.0015 (  1.1%)   0.0015 (  1.0%)  Lower AMX type for load/store
   0.0013 (  1.0%)   0.0000 (  0.9%)   0.0013 (  1.0%)   0.0013 (  0.9%)  Finalize ISel and expand pseudo-instructions
   0.0012 (  0.9%)   0.0001 (  1.4%)   0.0013 (  0.9%)   0.0013 (  0.9%)  Machine Module Information
   0.0011 (  0.8%)   0.0001 (  1.6%)   0.0012 (  0.9%)   0.0012 (  0.8%)  Lower constant intrinsics
   0.0010 (  0.8%)   0.0001 (  1.3%)   0.0011 (  0.8%)   0.0011 (  0.7%)  Expand vector predication intrinsics
   0.0009 (  0.7%)   0.0000 (  0.7%)   0.0010 (  0.7%)   0.0010 (  0.7%)  MachineDominator Tree Construction
   0.0008 (  0.6%)   0.0001 (  1.2%)   0.0009 (  0.7%)   0.0009 (  0.6%)  Free MachineFunction
   0.0008 (  0.6%)   0.0000 (  0.7%)   0.0008 (  0.6%)   0.0008 (  0.6%)  X86 EFLAGS copy lowering
   0.0005 (  0.4%)   0.0000 (  0.8%)   0.0006 (  0.4%)   0.0008 (  0.5%)  Post-RA pseudo instruction expansion pass
   0.0007 (  0.5%)   0.0001 (  1.4%)   0.0007 (  0.5%)   0.0007 (  0.5%)  Check CFA info and insert CFI instructions if needed
   0.0005 (  0.4%)   0.0000 (  0.3%)   0.0005 (  0.4%)   0.0007 (  0.5%)  Exception handling preparation
   0.0007 (  0.5%)   0.0000 (  0.4%)   0.0007 (  0.5%)   0.0007 (  0.5%)  Expand reduction intrinsics
   0.0006 (  0.5%)   0.0000 (  0.4%)   0.0007 (  0.5%)   0.0007 (  0.4%)  Scalarize Masked Memory Intrinsics
   0.0005 (  0.4%)   0.0001 (  1.2%)   0.0006 (  0.4%)   0.0006 (  0.4%)  Remove unreachable blocks from the CFG
   0.0005 (  0.4%)   0.0000 (  0.7%)   0.0005 (  0.4%)   0.0005 (  0.4%)  Expand large div/rem
   0.0005 (  0.3%)   0.0000 (  0.2%)   0.0005 (  0.3%)   0.0005 (  0.3%)  Eliminate PHI nodes for register allocation
   0.0004 (  0.3%)   0.0000 (  0.6%)   0.0004 (  0.3%)   0.0004 (  0.3%)  Expand Atomic instructions
   0.0004 (  0.3%)   0.0000 (  0.0%)   0.0004 (  0.3%)   0.0004 (  0.3%)  Assignment Tracking Analysis
   0.0004 (  0.3%)   0.0000 (  0.2%)   0.0004 (  0.3%)   0.0004 (  0.3%)  Insert stack protectors
   0.0004 (  0.3%)   0.0000 (  0.7%)   0.0004 (  0.3%)   0.0004 (  0.3%)  Fast Tile Register Configure
   0.0004 (  0.3%)   0.0000 (  0.5%)   0.0004 (  0.3%)   0.0004 (  0.3%)  X86 pseudo instruction expansion pass
   0.0003 (  0.3%)   0.0000 (  0.5%)   0.0004 (  0.3%)   0.0004 (  0.2%)  Insert KCFI indirect call checks
   0.0003 (  0.3%)   0.0000 (  0.5%)   0.0004 (  0.3%)   0.0004 (  0.2%)  Expand large fp convert
   0.0003 (  0.2%)   0.0000 (  0.4%)   0.0003 (  0.2%)   0.0003 (  0.2%)  Unpack machine instruction bundles
   0.0003 (  0.2%)   0.0000 (  0.2%)   0.0003 (  0.2%)   0.0003 (  0.2%)  Fast Tile Register Preconfigure
   0.0003 (  0.2%)   0.0000 (  0.4%)   0.0003 (  0.2%)   0.0003 (  0.2%)  X86 Lower Tile Copy
   0.0002 (  0.2%)   0.0000 (  0.3%)   0.0003 (  0.2%)   0.0003 (  0.2%)  X86 Indirect Branch Tracking
   0.0003 (  0.2%)   0.0000 (  0.2%)   0.0003 (  0.2%)   0.0003 (  0.2%)  Expand indirectbr instructions
   0.0002 (  0.1%)   0.0000 (  0.4%)   0.0002 (  0.2%)   0.0002 (  0.1%)  Bundle Machine CFG Edges
   0.0002 (  0.1%)   0.0000 (  0.1%)   0.0002 (  0.1%)   0.0002 (  0.1%)  Argument Stack Rebase
   0.0002 (  0.1%)   0.0000 (  0.2%)   0.0002 (  0.1%)   0.0002 (  0.1%)  Insert fentry calls
   0.0001 (  0.1%)   0.0000 (  0.2%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Insert XRay ops
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Machine Optimization Remark Emitter
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Live DEBUG_VALUE analysis
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Stack Frame Layout Analysis
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  X86 PIC Global Base Reg Initialization
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  X86 Indirect Thunks
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  X86 FP Stackifier
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Implement the 'patchable-function' attribute
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Lazy Machine Block Frequency Analysis
   0.0001 (  0.1%)   0.0000 (  0.2%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Machine Optimization Remark Emitter #2
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Fixup Statepoint Caller Saved
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Contiguously Lay Out Funclets
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Machine Optimization Remark Emitter #3
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Prepare callbr
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Local Stack Slot Allocation
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Remove Redundant DEBUG_VALUE analysis
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  StackMap Liveness Analysis
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Lazy Machine Block Frequency Analysis #3
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  X86 DynAlloca Expander
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  X86 Insert Cache Prefetches
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  X86 Speculative Execution Side Effect Suppression
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  X86 vzeroupper inserter
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  X86 Return Thunks
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Lazy Machine Block Frequency Analysis #2
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  X86 insert wait instruction
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  X86 Load Value Injection (LVI) Ret-Hardening
   0.0001 (  0.1%)   0.0000 (  0.0%)   0.0001 (  0.1%)   0.0001 (  0.1%)  X86 speculative load hardening
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Analyze Machine Code For Garbage Collection
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Machine Sanitizer Binary Metadata
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.1%)  Compressing EVEX instrs to VEX encoding when possible
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.0%)  Pseudo Probe Inserter
   0.0001 (  0.1%)   0.0000 (  0.1%)   0.0001 (  0.1%)   0.0001 (  0.0%)  X86 Discriminate Memory Operands
   0.0001 (  0.0%)   0.0000 (  0.0%)   0.0001 (  0.0%)   0.0001 (  0.0%)  Safe Stack instrumentation pass
   0.0001 (  0.0%)   0.0000 (  0.1%)   0.0001 (  0.0%)   0.0001 (  0.0%)  Lower Garbage Collection Instructions
   0.0001 (  0.0%)   0.0000 (  0.1%)   0.0001 (  0.0%)   0.0001 (  0.0%)  Shadow Stack GC Lowering
   0.0001 (  0.0%)   0.0000 (  0.1%)   0.0001 (  0.0%)   0.0001 (  0.0%)  Lower AMX intrinsics
   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)  Assumption Cache Tracker
   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)  Create Garbage Collector Module Metadata
   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)  Target Pass Configuration
   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)  Machine Branch Probability Analysis
   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)  Target Library Information
   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)  Target Transform Information
   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)   0.0000 (  0.0%)  Profile summary info
   0.1309 (100.0%)   0.0054 (100.0%)   0.1363 (100.0%)   0.1487 (100.0%)  Total

===-------------------------------------------------------------------------===
                                 DWARF Emission
===-------------------------------------------------------------------------===
  Total Execution Time: 0.0027 seconds (0.0028 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   0.0025 (100.0%)   0.0002 (100.0%)   0.0027 (100.0%)   0.0028 (100.0%)  DWARF Exception Writer
   0.0025 (100.0%)   0.0002 (100.0%)   0.0027 (100.0%)   0.0028 (100.0%)  Total

===-------------------------------------------------------------------------===
                          Clang front-end time report
===-------------------------------------------------------------------------===
  Total Execution Time: 19.4630 seconds (19.6675 wall clock)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
  19.3916 (100.0%)   0.0715 (100.0%)  19.4630 (100.0%)  19.6675 (100.0%)  Clang front-end timer
  19.3916 (100.0%)   0.0715 (100.0%)  19.4630 (100.0%)  19.6675 (100.0%)  Total


~/Projects took 20s 

```
The dummy timer here

https://github.com/DeadSpheroid/clad/blob/ec56e48eab5bbd167628c8e12f2515e898f4d099/tools/ClangPlugin.cpp#L169

is because the documentation of [llvm::TimerGroup](https://llvm.org/doxygen/classllvm_1_1TimerGroup.html) fails to specify that the TimerGroup prints when all Timers in it are destroyed, the dummy timer prevents this printing from happening ensuring a single report
