### PR TITLE
Remove implicit bool conversion check from clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,7 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-function-cognitive-complexity,
+  -readability-implicit-bool-conversion,
   -cppcoreguidelines-avoid-magic-numbers,
 
 CheckOptions:


### PR DESCRIPTION
more about this check: https://clang.llvm.org/extra/clang-tidy/checks/readability/implicit-bool-conversion.html