### PR TITLE
[cmake] Only require git when running benchmarks.

### DIFF
--- a/cmake/modules/AddClad.cmake
+++ b/cmake/modules/AddClad.cmake
@@ -1,14 +1,17 @@
-# Find the current branch.
-execute_process(WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                COMMAND git rev-parse HEAD
-                OUTPUT_VARIABLE CURRENT_REPO_COMMIT
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-string(REPLACE "/" "" CURRENT_REPO_COMMIT ${CURRENT_REPO_COMMIT})
+if (CLAD_ENABLE_BENCHMARKS)
+  # Find the current branch.
+  execute_process(WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                  COMMAND git rev-parse HEAD
+                  OUTPUT_VARIABLE CURRENT_REPO_COMMIT
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REPLACE "/" "" CURRENT_REPO_COMMIT ${CURRENT_REPO_COMMIT})
 
 # Ask cmake to reconfigure each time we change the branch so that it can change
 # the value of CURRENT_REPO_COMMIT.
 set_property(DIRECTORY APPEND PROPERTY
              CMAKE_CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/.git/HEAD")
+
+endif(CLAD_ENABLE_BENCHMARKS)
 
 #-------------------------------------------------------------------------------
 # function ENABLE_CLAD_FOR_EXECUTABLE(<executable>


### PR DESCRIPTION
This should improve the current infrastructure for releasing clad on conda. The conda recipe downloads the tarball and it currently fails because we rely on being inside a git setup when building.