### PR TITLE
[cmake] Work around a bug in the llvm config.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.7.0)
 
+include(GNUInstallDirs)
+
 if(POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)
 endif()


### PR DESCRIPTION
In short we use variables which require including `GNUInstallDirs` but we are expecting somebody else to include it for us.

See llvm/llvm-project#83802