### PR TITLE
Use struct Slab in grow() so that tape elements do not relocate

### DIFF
--- a/include/clad/Differentiator/Tape.h
+++ b/include/clad/Differentiator/Tape.h
@@ -114,34 +114,33 @@ namespace clad {
           T(std::move(*first));
       }
     }
-    /// Initial capacity (allocated whenever a value is pushed into empty tape).
+    
+    // Slab struct to store the elements. Contains the pointer to the next slab
+    template <typename T>
+    struct Slab {
+      T elements[32]; // can store 32 elements
+      Slab *nextSlab;
+    }
     constexpr static std::size_t _init_capacity = 32;
     CUDA_HOST_DEVICE void grow() {
-      // If empty, use initial capacity.
-      if (!_capacity)
-        _capacity = _init_capacity;
-      else
-        // Double the capacity on each reallocation.
-        _capacity *= 2;
-      T* new_data = AllocateRawStorage(_capacity);
+      Slab<T>* newSlab = new Slab<T>;
+      newSlab->nextSlab = nullptr;
 
-      if (!new_data) {
-        // clean up the memory mess just in case!
-        destroy(begin(), end());
-        printf("Allocation failure during tape resize! Aborting.\n");
-        trap(EXIT_FAILURE);
+      if (!_capacity) {
+        // the Tape is empty and we can update
+        // the _data pointer to the newly allocated slab.
+        _data = newSlab;
+      } else {
+        // find the last slab by iterating the chain of slabs
+        Slab<T>* currentSlab = static_cast<Slab<T>*>(_data);
+        while(currentSlab->nextSlab != nullptr) {
+          currentSlab = currentSlab->nextSlab;
+        }
+        // update pointer to the newly allocated slab
+        currentSlab->nextSlab = newSlab;
       }
-
-      // Move values from old storage to the new storage. Should call move
-      // constructors on non-trivial types, otherwise is expected to use
-      // memcpy/memmove.
-      MoveData(begin(), end(), new_data);
-      // Destroy all values in the old storage.
-      destroy(begin(), end());
-      // delete the old data here to make sure we do not leak anything.
-      ::operator delete(const_cast<void*>(
-            static_cast<const volatile void*>(_data)));
-      _data = new_data;
+        // Double the capacity on each slab addition
+        _capacity *= 2;
     }
 
     template <typename It>

--- a/include/clad/Differentiator/Tape.h
+++ b/include/clad/Differentiator/Tape.h
@@ -118,12 +118,12 @@ namespace clad {
     // Slab struct to store the elements. Contains the pointer to the next slab
     template <typename T>
     struct Slab {
-      T elements[32]; // can store 32 elements
-      Slab *nextSlab;
-    }
+	  std::array<T, 32> elements; // can store 32 elements
+	  std::unique_ptr<Slab<T>> nextSlab;
+    };
     constexpr static std::size_t _init_capacity = 32;
     CUDA_HOST_DEVICE void grow() {
-      Slab<T>* newSlab = new Slab<T>;
+	  std::unique_ptr<Slab<T>> newSlab = std::make_unique<Slab<T>>();
       newSlab->nextSlab = nullptr;
 
       if (!_capacity) {
@@ -132,7 +132,7 @@ namespace clad {
         _data = newSlab;
       } else {
         // find the last slab by iterating the chain of slabs
-        Slab<T>* currentSlab = static_cast<Slab<T>*>(_data);
+        auto* currentSlab = static_cast<Slab<T>*>(_data);
         while(currentSlab->nextSlab != nullptr) {
           currentSlab = currentSlab->nextSlab;
         }

--- a/include/clad/Differentiator/Tape.h
+++ b/include/clad/Differentiator/Tape.h
@@ -116,14 +116,14 @@ namespace clad {
     }
     
     // Slab struct to store the elements. Contains the pointer to the next slab
-    template <typename T>
+    template <typename SlabT>
     struct Slab {
-	  std::array<T, 32> elements; // can store 32 elements
-	  std::unique_ptr<Slab<T>> nextSlab;
+	  std::array<SlabT, 32> elements; // can store 32 elements
+	  std::unique_ptr<Slab<SlabT>> nextSlab;
     };
     constexpr static std::size_t _init_capacity = 32;
     CUDA_HOST_DEVICE void grow() {
-	  std::unique_ptr<Slab<T>> newSlab = std::make_unique<Slab<T>>();
+	  std::unique_ptr<Slab<SlabT>> newSlab = std::make_unique<Slab<SlabT>>();
       newSlab->nextSlab = nullptr;
 
       if (!_capacity) {
@@ -132,7 +132,7 @@ namespace clad {
         _data = newSlab;
       } else {
         // find the last slab by iterating the chain of slabs
-        auto* currentSlab = static_cast<Slab<T>*>(_data);
+        auto* currentSlab = static_cast<Slab<SlabT>*>(_data);
         while(currentSlab->nextSlab != nullptr) {
           currentSlab = currentSlab->nextSlab;
         }


### PR DESCRIPTION
### Release Notes:

- N/A

### Change explanation

The current implementation of the `grow()` function for Tape uses a `destroy()` function whenever there is a memory allocation failure with `AllocateRawStorage` and relocates the old data to new a Tape. 

My change uses a struct which contains array of size 32('elements`) and a pointer to the next Slab struct. 

**Workflow:**
- Dynamically allocate a slab with the `new` keyword and set the pointer to a `nullptr`.
- If the Tape capacity is 0, meaning it is empty, then our newly allocated slab is the first and the `_data` pointer is updated to point to the newly allocated slab
- If the Tape is not empty, then the chain of Slabs are iterated using the pointer variable until it reaches the last Slab and is appended to it.
- After the addition of a new slab, the overall capacity of the Tape gets doubled.

Fixes #793 

```mermaid
graph TD;
  Slab0;
  Slab1;
  Slab2;
  Slab0-->Slab1;
  Slab1-->Slab2;
```