### PR TITLE
[cmake] Set the language and that we do not need C++ extensions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.7.0)
 
+enable_language(CXX)
+set(CMAKE_CXX_EXTENSIONS NO)
+
 include(GNUInstallDirs)
 
 if(POLICY CMP0075)


### PR DESCRIPTION
That fixes two cmake dev warnings:
  * The installed Kokkos configuration does not support CXX extensions.
  * Unable to determine default CMAKE_INSTALL_LIBDIR directory because no target architecture is known.  Please enable at least one language before including GNUInstallDirs.