### PR TITLE
[cmake] Generate CMakeArgs.txt file to store CMake src, build dir and invocation arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,20 @@ set(CMAKE_CXX_EXTENSIONS NO)
 
 include(GNUInstallDirs)
 
+# MUST be done before call to clad project
+get_cmake_property(_cache_vars CACHE_VARIABLES)
+foreach(_cache_var ${_cache_vars})
+  get_property(_helpstring CACHE ${_cache_var} PROPERTY HELPSTRING)
+  if(_helpstring STREQUAL 
+    "No help, variable specified on the command line.")
+    set(CMAKE_ARGS "${CMAKE_ARGS} -D${_cache_var}=\"${${_cache_var}}\"")
+  endif()
+endforeach()
+
+# Generate CMakeArgs.txt file with source, build dir and command line args
+write_file("${CMAKE_CURRENT_BINARY_DIR}/CMakeArgs.txt"
+  "-S${CMAKE_SOURCE_DIR} -B${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_ARGS}")
+
 if(POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)
 endif()


### PR DESCRIPTION
Fixes #811 

This PR updates the `CMakeLists.txt` file with steps to store cmake command line arguments into a new file `CMakeArgs.txt` in the build directory.

#### Testing
Command
```
cmake -S ../clad -DClang_DIR=/home/saurav/Desktop/llvm-dev/build/ -DLLVM_DIR=/home/saurav/Desktop/llvm-dev/build/ -DCMAKE_INSTALL_PREFIX=../inst -DLLVM_EXTERNAL_LIT="$(which lit)" -B ../build
```

`CMakeArgs.txt` file content:
```
-S/home/saurav/Desktop/clad-dev/clad -B/home/saurav/Desktop/clad-dev/build  -DClang_DIR="/home/saurav/Desktop/llvm-dev/build/" -DLLVM_DIR="/home/saurav/Desktop/llvm-dev/build/" -DLLVM_EXTERNAL_LIT="/home/saurav/.local/bin/lit"
```