### PR TITLE
Fix erroneous TBR option setting

### DIFF
--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -393,12 +393,8 @@ namespace clad {
       Sema::GlobalEagerInstantiationScope GlobalInstantiations(S, Enabled);
       Sema::LocalEagerInstantiationScope LocalInstantiations(S);
 
-      for (DiffRequest& request : m_DiffSchedule) {
-        // FIXME: flags have to be set manually since DiffCollector's
-        // constructor does not have access to m_DO.
-        request.EnableTBRAnalysis = m_DO.EnableTBRAnalysis;
+      for (DiffRequest& request : m_DiffSchedule)
         ProcessDiffRequest(request);
-      }
       // Put the TUScope in a consistent state after clad is done.
       S.TUScope = nullptr;
       // Force emission of the produced pending template instantiations.


### PR DESCRIPTION
This was removed and moved to `SetRequestOptions` here: [808](https://github.com/vgvassilev/clad/pull/808/files#diff-959ddda1c4fe3a3b7c6560ce25882ad6ef819af216c1f8c0db57d2bced814ee5L116), but somehow got reverted back in [766](https://github.com/vgvassilev/clad/pull/766/files#diff-959ddda1c4fe3a3b7c6560ce25882ad6ef819af216c1f8c0db57d2bced814ee5R397), and I missed it during the review also :(.

This doesn't do any harm for now, but if we want to enable-tbr by default in future, this will nullify that.