### PR TITLE
Fix loop body and its AST Indexing when there's a continue stmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /.vscode
+/inst

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -522,12 +522,6 @@ namespace clad {
     /// PopBreakContStmtHandler();
     /// ```
     class BreakContStmtHandler {
-      /// Keeps track of all the created switch cases. It is required
-      /// because we need to register all the switch cases later with the
-      /// switch statement that will be used to manage the control flow in
-      /// the reverse block.
-      llvm::SmallVector<clang::SwitchCase*, 4> m_SwitchCases;
-
       /// `m_ControlFlowTape` tape keeps track of which `break`/`continue`
       /// statement was hit in which iteration.
       /// \note `m_ControlFlowTape` is only initialized if the body contains
@@ -539,8 +533,6 @@ namespace clad {
       /// statement. `m_CaseCounter` stores the value that was used for last
       /// `break`/`continue` statement.
       std::size_t m_CaseCounter = 0;
-
-      ReverseModeVisitor& m_RMV;
 
       const bool m_IsInvokedBySwitchStmt = false;
       /// Builds and returns a literal expression of type `std::size_t` with
@@ -557,6 +549,14 @@ namespace clad {
       clang::Expr* CreateCFTapePushExpr(std::size_t value);
 
     public:
+      /// Keeps track of all the created switch cases. It is required
+      /// because we need to register all the switch cases later with the
+      /// switch statement that will be used to manage the control flow in
+      /// the reverse block.
+      llvm::SmallVector<clang::SwitchCase*, 4> m_SwitchCases;
+
+      ReverseModeVisitor& m_RMV;
+
       BreakContStmtHandler(ReverseModeVisitor& RMV, bool forSwitchStmt = false)
           : m_RMV(RMV), m_IsInvokedBySwitchStmt(forSwitchStmt) {}
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -58,6 +58,8 @@ namespace clad {
     std::set<clang::SourceLocation> m_ToBeRecorded;
     /// A flag indicating if the Stmt we are currently visiting is inside loop.
     bool isInsideLoop = false;
+    /// A flag indicating if the Stmt we are currently visiting is inside loop.
+    bool hasContStmt = false;
     /// Output variable of vector-valued function
     std::string outputArrayStr;
     std::vector<Stmts> m_LoopBlock;

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -439,12 +439,12 @@ namespace clad {
 
     void AppendIndividualStmts(llvm::SmallVectorImpl<clang::Stmt*>& block,
                                clang::Stmt* S) {
-      if (auto CS = dyn_cast_or_null<CompoundStmt>(S))
+      if (auto CS = dyn_cast_or_null<CompoundStmt>(S)) {
         for (auto stmt : CS->body())
-          block.push_back(stmt);
-      else if (S)
+          AppendIndividualStmts(block, stmt);
+      } else if (S)
         block.push_back(S);
-    }
+      }
 
     MemberExpr*
     BuildMemberExpr(clang::Sema& semaRef, clang::Scope* S, clang::Expr* base,

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -444,7 +444,7 @@ namespace clad {
           AppendIndividualStmts(block, stmt);
       } else if (S)
         block.push_back(S);
-      }
+    }
 
     MemberExpr*
     BuildMemberExpr(clang::Sema& semaRef, clang::Scope* S, clang::Expr* base,

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -944,6 +944,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     } 
     // if only then block contains a continue statement, we need to add
     // the then block to the current block and create an if stmt for the else block
+    // afterwards to ensure that in the reverse pass it will be included in the prior case
     else if (SaveHasContStmtThen.get()) {
       addToCurrentBlock(thenDiff.getStmt_dx(), direction::reverse);
       if (elseDiff.getStmt_dx()){
@@ -956,6 +957,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     } 
     // if only else block contains a continue statement, we need to add
     // the else block to the current block and create an if stmt for the then block
+    // afterwards to ensure that in the reverse pass it will be included in the prior case
     else if (hasContStmt) {
       addToCurrentBlock(elseDiff.getStmt_dx(), direction::reverse);
       Stmt* Reverse = clad_compat::IfStmt_Create(
@@ -3710,7 +3712,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
               betweenCase = true;
             } else {
               curBlockStmts.push_back(new (m_Context)
-                                          BreakStmt(Stmt::EmptyShell()));
+                                          BreakStmt(Stmt::EmptyShell())); // compatible with all clang versions
               curCaseStmt->setSubStmt(MakeCompoundStmt(curBlockStmts));
               curBlockStmts.clear();
             }


### PR DESCRIPTION
This PR fixes #710 and expands to propose a different way of loop's body derivation in reverse mode. As a result, `tests` need to be updated accordingly if the PR is approved.

For more details please see [this comment](https://github.com/vgvassilev/clad/issues/710#issuecomment-2007143504).