### PR TITLE
Add inst folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /.vscode
+/inst


### PR DESCRIPTION
The instructions in README propose that the developer stores the compiled clad lib into a folder named `inst`. In order for the developers to easily keep track of the changes they make, they need to add this line in `.gitignore` in every branch they're working on. So this PR does that for them.