### PR TITLE
Redesign of loop's body in reverse pass 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /.vscode
+/inst

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -522,12 +522,6 @@ namespace clad {
     /// PopBreakContStmtHandler();
     /// ```
     class BreakContStmtHandler {
-      /// Keeps track of all the created switch cases. It is required
-      /// because we need to register all the switch cases later with the
-      /// switch statement that will be used to manage the control flow in
-      /// the reverse block.
-      llvm::SmallVector<clang::SwitchCase*, 4> m_SwitchCases;
-
       /// `m_ControlFlowTape` tape keeps track of which `break`/`continue`
       /// statement was hit in which iteration.
       /// \note `m_ControlFlowTape` is only initialized if the body contains
@@ -539,8 +533,6 @@ namespace clad {
       /// statement. `m_CaseCounter` stores the value that was used for last
       /// `break`/`continue` statement.
       std::size_t m_CaseCounter = 0;
-
-      ReverseModeVisitor& m_RMV;
 
       const bool m_IsInvokedBySwitchStmt = false;
       /// Builds and returns a literal expression of type `std::size_t` with
@@ -557,6 +549,14 @@ namespace clad {
       clang::Expr* CreateCFTapePushExpr(std::size_t value);
 
     public:
+      /// Keeps track of all the created switch cases. It is required
+      /// because we need to register all the switch cases later with the
+      /// switch statement that will be used to manage the control flow in
+      /// the reverse block.
+      llvm::SmallVector<clang::SwitchCase*, 4> m_SwitchCases;
+
+      ReverseModeVisitor& m_RMV;
+
       BreakContStmtHandler(ReverseModeVisitor& RMV, bool forSwitchStmt = false)
           : m_RMV(RMV), m_IsInvokedBySwitchStmt(forSwitchStmt) {}
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -503,6 +503,15 @@ namespace clad {
       }
     };
 
+    /// Helper function to bring the cases created by a continue or break stmt
+    /// foward to the loop's body and append them correctly.
+    /// The statements that belong to the main body of the loop are added directly
+    /// to the current block, while the cases followed by with their corresponding stmts
+    /// are stored in a separate vector.
+    void AppendCaseStmts(llvm::SmallVectorImpl<clang::Stmt*>& curBlock,
+                          llvm::SmallVectorImpl<clang::Stmt*>& cases, clang::Stmt* S,
+                          bool& afterCase);
+
     /// Helper function to differentiate a loop body.
     ///
     ///\param[in] body body of the loop

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -58,6 +58,8 @@ namespace clad {
     std::set<clang::SourceLocation> m_ToBeRecorded;
     /// A flag indicating if the Stmt we are currently visiting is inside loop.
     bool isInsideLoop = false;
+    /// A flag indicating if the Stmt we are currently visiting is inside loop.
+    bool hasContStmt = false;
     /// Output variable of vector-valued function
     std::string outputArrayStr;
     std::vector<Stmts> m_LoopBlock;

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -443,10 +443,10 @@ namespace clad {
 
     void AppendIndividualStmts(llvm::SmallVectorImpl<clang::Stmt*>& block,
                                clang::Stmt* S) {
-      if (auto CS = dyn_cast_or_null<CompoundStmt>(S)) {
+      if (auto CS = dyn_cast_or_null<CompoundStmt>(S))
         for (auto stmt : CS->body())
           block.push_back(stmt);
-      } else if (S)
+      else if (S)
         block.push_back(S);
     }
 

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -439,12 +439,12 @@ namespace clad {
 
     void AppendIndividualStmts(llvm::SmallVectorImpl<clang::Stmt*>& block,
                                clang::Stmt* S) {
-      if (auto CS = dyn_cast_or_null<CompoundStmt>(S))
+      if (auto CS = dyn_cast_or_null<CompoundStmt>(S)) {
         for (auto stmt : CS->body())
-          block.push_back(stmt);
-      else if (S)
+          AppendIndividualStmts(block, stmt);
+      } else if (S)
         block.push_back(S);
-    }
+      }
 
     MemberExpr*
     BuildMemberExpr(clang::Sema& semaRef, clang::Scope* S, clang::Expr* base,

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -445,7 +445,7 @@ namespace clad {
                                clang::Stmt* S) {
       if (auto CS = dyn_cast_or_null<CompoundStmt>(S)) {
         for (auto stmt : CS->body())
-          AppendIndividualStmts(block, stmt);
+          block.push_back(stmt);
       } else if (S)
         block.push_back(S);
     }

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -444,7 +444,7 @@ namespace clad {
           AppendIndividualStmts(block, stmt);
       } else if (S)
         block.push_back(S);
-      }
+    }
 
     MemberExpr*
     BuildMemberExpr(clang::Sema& semaRef, clang::Scope* S, clang::Expr* base,

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -944,6 +944,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     } 
     // if only then block contains a continue statement, we need to add
     // the then block to the current block and create an if stmt for the else block
+    // afterwards to ensure that in the reverse pass it will be included in the prior case
     else if (SaveHasContStmtThen.get()) {
       addToCurrentBlock(thenDiff.getStmt_dx(), direction::reverse);
       if (elseDiff.getStmt_dx()){
@@ -956,6 +957,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     } 
     // if only else block contains a continue statement, we need to add
     // the else block to the current block and create an if stmt for the then block
+    // afterwards to ensure that in the reverse pass it will be included in the prior case
     else if (hasContStmt) {
       addToCurrentBlock(elseDiff.getStmt_dx(), direction::reverse);
       Stmt* Reverse = clad_compat::IfStmt_Create(
@@ -3710,7 +3712,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
               betweenCase = true;
             } else {
               curBlockStmts.push_back(new (m_Context)
-                                          BreakStmt(Stmt::EmptyShell()));
+                                          BreakStmt(Stmt::EmptyShell())); // compatible with all clang versions
               curCaseStmt->setSubStmt(MakeCompoundStmt(curBlockStmts));
               curBlockStmts.clear();
             }


### PR DESCRIPTION
This PR closes #832. What these changes establish is a cleaner switch body, where the cases are independent and indexed correctly, AST speaking.

[This comment](https://github.com/vgvassilev/clad/issues/710#issuecomment-2007143504) contains a comparison of the current version and the proposed one. Cases of nested continue statements have also been tested and the derived body and the results were correct. 

The workflow in a nutshell is the following:
* Replace the `then` or `else` stmt of `if` with the `case` one when there's a `continue` stmt in its body
* The branch of `if` that doesn't include a `continue` stmt is added firstly as it belongs to the previous switch case (outer one)
* After visiting the nodes of the loop's body in the reverse pass, the `case` stmts are brought forward, on the first level of the loop's body, by performing a Depth-First search on its compounds
* The compounds/stmts that are on the same level as the `case` stmt and that follow it (belong to this case) are also brought foward, while the rest of the stmts remain to their level and later appended in the beginning of the loop's body (as the main loop's body compound)
* At that point we add the switch case of the main body in the beginning and set the stmts present between two cases as a substmt to the first of them  



Keep in mind that since the compilation ends up in a completely different result compared to the current implementation in cases were there's a continue stmt, the `tests` have to be updated (so they're expected to currently fail).

If the changes are well received, support for the `break` stmt in a similar manner only requires an additional variable.