### PR TITLE
[cmake] Do not build the error estimation codes with differentiable clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,9 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
     include(GoogleBenchmark)
   endif(CLAD_ENABLE_BENCHMARKS)
 
+  add_subdirectory(demos/ErrorEstimation/CustomModel)
+  add_subdirectory(demos/ErrorEstimation/PrintModel)
+
   # Change the default compiler to the clang which we run clad upon. Our unittests
   # need to use a supported by clad compiler. Note that's a huge hack and it is
   # not guaranteed to work with cmake.
@@ -330,8 +333,6 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
 
   add_subdirectory(unittests)
   add_subdirectory(test)
-  add_subdirectory(demos/ErrorEstimation/CustomModel)
-  add_subdirectory(demos/ErrorEstimation/PrintModel)
 
   # Add benchmarking infrastructure.
   if (CLAD_ENABLE_BENCHMARKS)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,7 +41,7 @@ if(CLANG_TEST_USE_VG)
   set(CLANG_TEST_EXTRA_ARGS ${CLANG_TEST_EXTRA_ARGS} "--vg")
 endif ()
 
-list(APPEND CLAD_TEST_DEPS clad)
+list(APPEND CLAD_TEST_DEPS clad cladCustomModelPlugin cladPrintModelPlugin)
 # Try to append dependencies only if we are building in-tree.
 if(NOT CLAD_BUILT_STANDALONE)
   list(APPEND CLAD_TEST_DEPS llvm-config FileCheck clang opt count not)


### PR DESCRIPTION
We do not need to use a clad-compatible clang to build the error estimation demos.

This issue is related to #715.