### PR TITLE
Compute and process Differentiation Request graph

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -38,9 +38,6 @@ namespace clad {
     class CladPlugin;
     clang::FunctionDecl* ProcessDiffRequest(CladPlugin& P,
                                             DiffRequest& request);
-    // FIXME: This function should be removed and the entire plans array
-    // should be somehow made accessible to all the visitors.
-    void AddRequestToSchedule(CladPlugin& P, const DiffRequest& request);
   } // namespace plugin
 
 } // namespace clad
@@ -87,6 +84,7 @@ namespace clad {
     plugin::CladPlugin& m_CladPlugin;
     clang::ASTContext& m_Context;
     const DerivedFnCollector& m_DFC;
+    clad::DynamicGraph<DiffRequest>& m_DiffRequestGraph;
     std::unique_ptr<utils::StmtClone> m_NodeCloner;
     clang::NamespaceDecl* m_BuiltinDerivativesNSD;
     /// A reference to the model to use for error estimation (if any).
@@ -137,7 +135,8 @@ namespace clad {
 
   public:
     DerivativeBuilder(clang::Sema& S, plugin::CladPlugin& P,
-                      const DerivedFnCollector& DFC);
+                      const DerivedFnCollector& DFC,
+                      clad::DynamicGraph<DiffRequest>& DRG);
     ~DerivativeBuilder();
     /// Reset the model use for error estimation (if any).
     /// \param[in] estModel The error estimation model, can be either
@@ -172,6 +171,16 @@ namespace clad {
     ///
     /// \returns The derived function if found, nullptr otherwise.
     clang::FunctionDecl* FindDerivedFunction(const DiffRequest& request);
+    /// Add edge from current request to the given request in the DiffRequest
+    /// graph.
+    ///
+    /// \param[in] request The request to add the edge to.
+    void AddEdgeToGraph(const DiffRequest& request);
+    /// Add edge between two requests in the DiffRequest graph.
+    ///
+    /// \param[in] from The source request.
+    /// \param[in] to The destination request.
+    void AddEdgeToGraph(const DiffRequest& from, const DiffRequest& to);
   };
 
 } // end namespace clad

--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -176,11 +176,6 @@ namespace clad {
     ///
     /// \param[in] request The request to add the edge to.
     void AddEdgeToGraph(const DiffRequest& request);
-    /// Add edge between two requests in the DiffRequest graph.
-    ///
-    /// \param[in] from The source request.
-    /// \param[in] to The destination request.
-    void AddEdgeToGraph(const DiffRequest& from, const DiffRequest& to);
   };
 
 } // end namespace clad

--- a/include/clad/Differentiator/DerivedFnCollector.h
+++ b/include/clad/Differentiator/DerivedFnCollector.h
@@ -6,6 +6,7 @@
 #include "clang/AST/Decl.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace clad {
@@ -14,10 +15,13 @@ namespace clad {
 /// making it possible to reuse previously computed derivatives.
 class DerivedFnCollector {
   using DerivedFns = llvm::SmallVector<DerivedFnInfo, 16>;
+  using DerivativeSet = llvm::SmallSet<const clang::FunctionDecl*, 16>;
   /// Mapping to efficiently find out information about all the derivatives of
   /// a function.
   llvm::DenseMap<const clang::FunctionDecl*, DerivedFns>
       m_DerivedFnInfoCollection;
+  /// Set to keep track of all the functions that are derivatives.
+  DerivativeSet m_DerivativeSet;
 
 public:
   /// Adds a derived function to the collection.

--- a/include/clad/Differentiator/DiffMode.h
+++ b/include/clad/Differentiator/DiffMode.h
@@ -43,14 +43,6 @@ inline const char* DiffModeToString(DiffMode mode) {
     return "unknown";
   }
 }
-
-/// Returns true if the given mode is a pullback/pushforward mode.
-inline bool IsPullbackOrPushforwardMode(DiffMode mode) {
-  return mode == DiffMode::experimental_pushforward ||
-         mode == DiffMode::experimental_pullback ||
-         mode == DiffMode::experimental_vector_pushforward ||
-         mode == DiffMode::reverse_mode_forward_pass;
-}
 }
 
 #endif

--- a/include/clad/Differentiator/DiffMode.h
+++ b/include/clad/Differentiator/DiffMode.h
@@ -15,6 +15,42 @@ enum class DiffMode {
   reverse_mode_forward_pass,
   error_estimation
 };
+
+/// Convert enum value to string.
+inline const char* DiffModeToString(DiffMode mode) {
+  switch (mode) {
+  case DiffMode::forward:
+    return "forward";
+  case DiffMode::vector_forward_mode:
+    return "vector_forward_mode";
+  case DiffMode::experimental_pushforward:
+    return "pushforward";
+  case DiffMode::experimental_pullback:
+    return "pullback";
+  case DiffMode::experimental_vector_pushforward:
+    return "vector_pushforward";
+  case DiffMode::reverse:
+    return "reverse";
+  case DiffMode::hessian:
+    return "hessian";
+  case DiffMode::jacobian:
+    return "jacobian";
+  case DiffMode::reverse_mode_forward_pass:
+    return "reverse_mode_forward_pass";
+  case DiffMode::error_estimation:
+    return "error_estimation";
+  default:
+    return "unknown";
+  }
+}
+
+/// Returns true if the given mode is a pullback/pushforward mode.
+inline bool IsPullbackOrPushforwardMode(DiffMode mode) {
+  return mode == DiffMode::experimental_pushforward ||
+         mode == DiffMode::experimental_pullback ||
+         mode == DiffMode::experimental_vector_pushforward ||
+         mode == DiffMode::reverse_mode_forward_pass;
+}
 }
 
 #endif

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -95,9 +95,7 @@ struct DiffRequest {
   /// Define the == operator for DiffRequest.
   bool operator==(const DiffRequest& other) const {
     // either function match or previous declaration match
-    return (Function == other.Function ||
-            Function->getPreviousDecl() == other.Function ||
-            Function == other.Function->getPreviousDecl()) &&
+    return Function == other.Function &&
            BaseFunctionName == other.BaseFunctionName &&
            CurrentDerivativeOrder == other.CurrentDerivativeOrder &&
            RequestedDerivativeOrder == other.RequestedDerivativeOrder &&

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -11,6 +11,7 @@
 #include "ArrayRef.h"
 #include "BuiltinDerivatives.h"
 #include "CladConfig.h"
+#include "DynamicGraph.h"
 #include "FunctionTraits.h"
 #include "Matrix.h"
 #include "NumericalDiff.h"

--- a/include/clad/Differentiator/DynamicGraph.h
+++ b/include/clad/Differentiator/DynamicGraph.h
@@ -1,0 +1,137 @@
+#ifndef CLAD_DIFFERENTIATOR_DYNAMICGRAPH_H
+#define CLAD_DIFFERENTIATOR_DYNAMICGRAPH_H
+
+#include <algorithm>
+#include <functional>
+#include <iostream>
+#include <queue>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace clad {
+template <typename T> class DynamicGraph {
+private:
+  /// Storing nodes in the graph. The index of the node in the vector is used as
+  /// a unique identifier for the node in the adjacency list.
+  std::vector<T> m_nodes;
+
+  /// Store the nodes in the graph as an unordered map from the node to a
+  /// boolean indicating whether the node is processed or not. The second
+  /// element in the pair is the id of the node in the nodes vector.
+  std::unordered_map<T, std::pair<bool, size_t>> m_nodeMap;
+
+  /// Store the adjacency list for the graph. The adjacency list is a map from
+  /// a node to the set of nodes that it has an edge to. We use integers inside
+  /// the set to avoid copying the nodes.
+  std::unordered_map<size_t, std::set<size_t>> m_adjList;
+
+  /// Set of source nodes in the graph.
+  std::set<size_t> m_sources;
+
+  /// Store the id of the node being processed right now.
+  int m_currentId = -1; // -1 means no node is being processed.
+
+  /// Maintain a queue of nodes to be processed next.
+  std::queue<size_t> m_toProcessQueue;
+
+public:
+  DynamicGraph() = default;
+
+  /// Add an edge from the source node to the destination node.
+  /// \param src
+  /// \param dest
+  void addEdge(const T& src, const T& dest) {
+    std::pair<bool, size_t> srcInfo = addNode(src);
+    std::pair<bool, size_t> destInfo = addNode(dest);
+    size_t srcId = srcInfo.second;
+    size_t destId = destInfo.second;
+    m_adjList[srcId].insert(destId);
+  }
+
+  /// Add a node to the graph. If the node is already present, return the
+  /// id of the node in the graph. If the node is a source node, add it to the
+  /// queue of nodes to be processed.
+  /// \param node
+  /// \param isSource
+  /// \returns A pair of a boolean indicating whether the node is already
+  /// processed and the id of the node in the graph.
+  std::pair<bool, size_t> addNode(const T& node, bool isSource = false) {
+    if (m_nodeMap.find(node) == m_nodeMap.end()) {
+      size_t id = m_nodes.size();
+      m_nodes.push_back(node);
+      m_nodeMap[node] = {false, id}; // node is not processed yet.
+      m_adjList[id] = {};
+      if (isSource) {
+        m_sources.insert(id);
+        m_toProcessQueue.push(id);
+      }
+    }
+    return m_nodeMap[node];
+  }
+
+  /// Add an edge from the current node being processed to the
+  /// destination node.
+  /// \param dest
+  void addEdgeToCurrentNode(const T& dest) {
+    if (m_currentId == -1)
+      return;
+    addEdge(m_nodes[m_currentId], dest);
+  }
+
+  /// Set the current node being processed.
+  /// \param node
+  void setCurrentProcessingNode(const T& node) {
+    if (m_nodeMap.find(node) != m_nodeMap.end())
+      m_currentId = m_nodeMap[node].second;
+  }
+
+  /// Mark the current node being processed as processed and add the
+  /// destination nodes to the queue of nodes to be processed.
+  void markCurrentNodeProcessed() {
+    if (m_currentId != -1) {
+      m_nodeMap[m_nodes[m_currentId]].first = true;
+      for (size_t destId : m_adjList[m_currentId])
+        if (!m_nodeMap[m_nodes[destId]].first)
+          m_toProcessQueue.push(destId);
+    }
+    m_currentId = -1;
+  }
+
+  /// Get the nodes in the graph.
+  std::vector<T> getNodes() { return m_nodes; }
+
+  /// Print the nodes and edges in the graph.
+  void print() {
+    // First print the nodes with their insertion order.
+    for (const T& node : m_nodes) {
+      std::pair<bool, int> nodeInfo = m_nodeMap[node];
+      std::cout << (std::string)node << ": #" << nodeInfo.second;
+      if (m_sources.find(nodeInfo.second) != m_sources.end())
+        std::cout << " (source)";
+      if (nodeInfo.first)
+        std::cout << ", (done)\n";
+      else
+        std::cout << ", (unprocessed)\n";
+    }
+    // Then print the edges.
+    for (int i = 0; i < m_nodes.size(); i++)
+      for (size_t dest : m_adjList[i])
+        std::cout << i << " -> " << dest << "\n";
+  }
+
+  /// Get the next node to be processed from the queue of nodes to be
+  /// processed.
+  /// \returns The next node to be processed.
+  T getNextToProcessNode() {
+    if (m_toProcessQueue.empty())
+      return T();
+    size_t nextId = m_toProcessQueue.front();
+    m_toProcessQueue.pop();
+    return m_nodes[nextId];
+  }
+};
+} // end namespace clad
+
+#endif // CLAD_DIFFERENTIATOR_DYNAMICGRAPH_H

--- a/include/clad/Differentiator/DynamicGraph.h
+++ b/include/clad/Differentiator/DynamicGraph.h
@@ -75,9 +75,8 @@ public:
   /// destination node.
   /// \param dest
   void addEdgeToCurrentNode(const T& dest) {
-    if (m_currentId == -1)
-      return;
-    addEdge(m_nodes[m_currentId], dest);
+    if (m_currentId != -1)
+      addEdge(m_nodes[m_currentId], dest);
   }
 
   /// Set the current node being processed.

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1168,8 +1168,8 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
       // into the queue.
       pushforwardFnRequest.DeclarationOnly = false;
       pushforwardFnRequest.DerivedFDPrototype = pushforwardFD;
-      plugin::AddRequestToSchedule(m_CladPlugin, pushforwardFnRequest);
     }
+    m_Builder.AddEdgeToGraph(pushforwardFnRequest);
 
     if (pushforwardFD) {
       if (baseDiff.getExpr()) {

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -294,12 +294,9 @@ static void registerDerivative(FunctionDecl* derivedFD, Sema& semaRef) {
     assert(FD && "Must not be null.");
     // If FD is only a declaration, try to find its definition.
     if (!FD->getDefinition()) {
-      // If only declaration is requested, allow this for non
-      // pullback/pushforward modes. For ex, this is required for Hessian -
-      // where we have forward mode followed by reverse mode, but we only need
-      // the declaration of the forward mode initially.
-      if (!request.DeclarationOnly ||
-          IsPullbackOrPushforwardMode(request.Mode)) {
+      // If only declaration is requested, allow this for clad-generated
+      // functions.
+      if (!request.DeclarationOnly || !m_DFC.IsDerivative(FD)) {
         if (request.VerboseDiags)
           diag(DiagnosticsEngine::Error,
                request.CallContext ? request.CallContext->getBeginLoc() : noLoc,
@@ -403,10 +400,5 @@ static void registerDerivative(FunctionDecl* derivedFD, Sema& semaRef) {
 
   void DerivativeBuilder::AddEdgeToGraph(const DiffRequest& request) {
     m_DiffRequestGraph.addEdgeToCurrentNode(request);
-  }
-
-  void DerivativeBuilder::AddEdgeToGraph(const DiffRequest& from,
-                                         const DiffRequest& to) {
-    m_DiffRequestGraph.addEdge(from, to);
   }
 }// end namespace clad

--- a/lib/Differentiator/DerivedFnCollector.cpp
+++ b/lib/Differentiator/DerivedFnCollector.cpp
@@ -8,6 +8,7 @@ void DerivedFnCollector::Add(const DerivedFnInfo& DFI) {
          "`DerivedFnCollector::Add` more than once for the same derivative "
          ". Ideally, we shouldn't do either.");
   m_DerivedFnInfoCollection[DFI.OriginalFn()].push_back(DFI);
+  m_DerivativeSet.insert(DFI.DerivedFn());
 }
 
 bool DerivedFnCollector::AlreadyExists(const DerivedFnInfo& DFI) const {
@@ -35,5 +36,9 @@ DerivedFnInfo DerivedFnCollector::Find(const DiffRequest& request) const {
   if (it == subCollection.end())
     return DerivedFnInfo();
   return *it;
+}
+
+bool DerivedFnCollector::IsDerivative(const clang::FunctionDecl* FD) const {
+  return m_DerivativeSet.count(FD);
 }
 } // namespace clad

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1784,6 +1784,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
         if (m_ExternalSource)
           m_ExternalSource->ActBeforeDifferentiatingCallExpr(
               pullbackCallArgs, PreCallStmts, dfdx());
+
         // Overloaded derivative was not found, request the CladPlugin to
         // derive the called function.
         DiffRequest pullbackRequest{};
@@ -1812,7 +1813,6 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
             // function.
             pullbackRequest.DeclarationOnly = false;
             pullbackRequest.DerivedFDPrototype = pullbackFD;
-            plugin::AddRequestToSchedule(m_CladPlugin, pullbackRequest);
           } else {
             // FIXME: Error estimation currently uses singleton objects -
             // m_ErrorEstHandler and m_EstModel, which is cleared after each
@@ -1822,6 +1822,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
                 plugin::ProcessDiffRequest(m_CladPlugin, pullbackRequest);
           }
         }
+        m_Builder.AddEdgeToGraph(pullbackRequest);
 
         // Clad failed to derive it.
         // FIXME: Add support for reference arguments to the numerical diff. If
@@ -1923,8 +1924,8 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
         // function.
         calleeFnForwPassReq.DeclarationOnly = false;
         calleeFnForwPassReq.DerivedFDPrototype = calleeFnForwPassFD;
-        plugin::AddRequestToSchedule(m_CladPlugin, calleeFnForwPassReq);
       }
+      m_Builder.AddEdgeToGraph(calleeFnForwPassReq);
 
       assert(calleeFnForwPassFD &&
              "Clad failed to generate callee function forward pass function");

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -13,12 +13,7 @@ float f1(float x) {
   return sin(x) + cos(x);
 }
 
-// CHECK: float f1_darg0(float x) {
-// CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, _d_x);
-// CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
-// CHECK-NEXT: }
+// CHECK: float f1_darg0(float x);
 
 // CHECK: void f1_darg0_grad(float x, float *_d_x);
 
@@ -30,11 +25,7 @@ float f2(float x) {
   return exp(x);
 }
 
-// CHECK: float f2_darg0(float x) {
-// CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, _d_x);
-// CHECK-NEXT:     return _t0.pushforward;
-// CHECK-NEXT: }
+// CHECK: float f2_darg0(float x);
 
 // CHECK: void f2_darg0_grad(float x, float *_d_x);
 
@@ -47,11 +38,7 @@ float f3(float x) {
   return log(x);
 }
 
-// CHECK: float f3_darg0(float x) {
-// CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::log_pushforward(x, _d_x);
-// CHECK-NEXT:     return _t0.pushforward;
-// CHECK-NEXT: }
+// CHECK: float f3_darg0(float x);
 
 // CHECK: void f3_darg0_grad(float x, float *_d_x);
 
@@ -64,11 +51,7 @@ float f4(float x) {
   return pow(x, 4.0F);
 }
 
-// CHECK: float f4_darg0(float x) {
-// CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 4.F, _d_x, 0.F);
-// CHECK-NEXT:     return _t0.pushforward;
-// CHECK-NEXT: }
+// CHECK: float f4_darg0(float x);
 
 // CHECK: void f4_darg0_grad(float x, float *_d_x);
 
@@ -81,11 +64,7 @@ float f5(float x) {
   return pow(2.0F, x);
 }
 
-// CHECK: float f5_darg0(float x) {
-// CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(2.F, x, 0.F, _d_x);
-// CHECK-NEXT:     return _t0.pushforward;
-// CHECK-NEXT: }
+// CHECK: float f5_darg0(float x);
 
 // CHECK: void f5_darg0_grad(float x, float *_d_x);
 
@@ -98,21 +77,11 @@ float f6(float x, float y) {
   return pow(x, y);
 }
 
-// CHECK: float f6_darg0(float x, float y) {
-// CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     float _d_y = 0;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x, _d_y);
-// CHECK-NEXT:     return _t0.pushforward;
-// CHECK-NEXT: }
+// CHECK: float f6_darg0(float x, float y);
 
 // CHECK: void f6_darg0_grad(float x, float y, float *_d_x, float *_d_y);
 
-// CHECK: float f6_darg1(float x, float y) {
-// CHECK-NEXT:     float _d_x = 0;
-// CHECK-NEXT:     float _d_y = 1;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x, _d_y);
-// CHECK-NEXT:     return _t0.pushforward;
-// CHECK-NEXT: }
+// CHECK: float f6_darg1(float x, float y);
 
 // CHECK: void f6_darg1_grad(float x, float y, float *_d_x, float *_d_y);
 
@@ -147,6 +116,13 @@ int main() {
   TEST1(f5, 3); // CHECK-EXEC: Result is = {3.84}
   TEST2(f6, 3, 4); // CHECK-EXEC: Result is = {108.00, 145.65, 145.65, 97.76}
 
+// CHECK: float f1_darg0(float x) {
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x);
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t1 = clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, _d_x);
+// CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
+// CHECK-NEXT: }
+
 // CHECK: void sin_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
 // CHECK: void cos_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
@@ -180,6 +156,12 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
+// CHECK: float f2_darg0(float x) {
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, _d_x);
+// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT: }
+
 // CHECK: void exp_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
 // CHECK: void f2_darg0_grad(float x, float *_d_x) {
@@ -199,6 +181,12 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
+// CHECK: float f3_darg0(float x) {
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives{{(::std)?}}::log_pushforward(x, _d_x);
+// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT: }
+
 // CHECK: void log_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
 // CHECK: void f3_darg0_grad(float x, float *_d_x) {
@@ -216,6 +204,12 @@ int main() {
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         _d__d_x += _r1;
 // CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: float f4_darg0(float x) {
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 4.F, _d_x, 0.F);
+// CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
 // CHECK: void pow_pushforward_pullback(float x, float exponent, float d_x, float d_exponent, ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d_y, float *_d_x, float *_d_exponent, float *_d_d_x, float *_d_d_exponent);
@@ -239,6 +233,12 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
+// CHECK: float f5_darg0(float x) {
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(2.F, x, 0.F, _d_x);
+// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT: }
+
 // CHECK: void f5_darg0_grad(float x, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
@@ -256,6 +256,13 @@ int main() {
 // CHECK-NEXT:         *_d_x += _r1;
 // CHECK-NEXT:         _d__d_x += _r3;
 // CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: float f6_darg0(float x, float y) {
+// CHECK-NEXT:     float _d_x = 1;
+// CHECK-NEXT:     float _d_y = 0;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
 // CHECK: void f6_darg0_grad(float x, float y, float *_d_x, float *_d_y) {
@@ -279,6 +286,13 @@ int main() {
 // CHECK-NEXT:         _d__d_x += _r2;
 // CHECK-NEXT:         _d__d_y += _r3;
 // CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: float f6_darg1(float x, float y) {
+// CHECK-NEXT:     float _d_x = 0;
+// CHECK-NEXT:     float _d_y = 1;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t0 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
 // CHECK: void f6_darg1_grad(float x, float y, float *_d_x, float *_d_y) {

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -10,13 +10,7 @@
 __attribute__((always_inline)) double f_cubed_add1(double a, double b) {
   return a * a * a + b * b * b;
 }
-//CHECK:{{[__attribute__((always_inline)) ]*}}double f_cubed_add1_darg0(double a, double b){{[ __attribute__((always_inline))]*}} {
-//CHECK-NEXT:    double _d_a = 1;
-//CHECK-NEXT:    double _d_b = 0;
-//CHECK-NEXT:    double _t0 = a * a;
-//CHECK-NEXT:    double _t1 = b * b;
-//CHECK-NEXT:    return (_d_a * a + a * _d_a) * a + _t0 * _d_a + (_d_b * b + b * _d_b) * b + _t1 * _d_b;
-//CHECK-NEXT:}
+//CHECK:{{[__attribute__((always_inline)) ]*}}double f_cubed_add1_darg0(double a, double b){{[ __attribute__((always_inline))]*}};
 
 void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b);
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}};
@@ -211,6 +205,14 @@ int main() {
   TEST3(&Widget::memFn_1, W, 7, 9); // CHECK-EXEC: Result is = {0.00, 15.00, 15.00, 0.00}
   TEST3(&Widget::memFn_2, W, 7, 9); // CHECK-EXEC: Result is = {5400.00, 4200.00, 4200.00, 0.00}
   TEST2(fn_def_arg, 3, 5);  // CHECK-EXEC: Result is = {0.00, 2.00, 2.00, 0.00}
+
+//CHECK:{{[__attribute__((always_inline)) ]*}}double f_cubed_add1_darg0(double a, double b){{[ __attribute__((always_inline))]*}} {
+//CHECK-NEXT:    double _d_a = 1;
+//CHECK-NEXT:    double _d_b = 0;
+//CHECK-NEXT:    double _t0 = a * a;
+//CHECK-NEXT:    double _t1 = b * b;
+//CHECK-NEXT:    return (_d_a * a + a * _d_a) * a + _t0 * _d_a + (_d_b * b + b * _d_b) * b + _t1 * _d_b;
+//CHECK-NEXT:}
 
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
 //CHECK-NEXT:    double _d__d_a = 0;

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -17,6 +17,16 @@ double f2(double x, double y){
     return ans;
 }
 
+// CHECK: double f2_darg0(double x, double y);
+// CHECK: void f2_darg0_grad(double x, double y, double *_d_x, double *_d_y);
+// CHECK: double f2_darg1(double x, double y);
+// CHECK: void f2_darg1_grad(double x, double y, double *_d_x, double *_d_y);
+
+// CHECK: void f2_hessian(double x, double y, double *hessianMatrix) {
+// CHECK-NEXT:     f2_darg0_grad(x, y, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+// CHECK-NEXT:     f2_darg1_grad(x, y, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT: }
+
 // CHECK: clad::ValueAndPushforward<double, double> f_pushforward(double x, double y, double _d_x, double _d_y);
 
 // CHECK: double f2_darg0(double x, double y) {
@@ -27,32 +37,6 @@ double f2(double x, double y){
 // CHECK-NEXT:     double ans = _t0.value;
 // CHECK-NEXT:     return _d_ans;
 // CHECK-NEXT: }
-
-
-// CHECK: void f2_darg0_grad(double x, double y, double *_d_x, double *_d_y);
-
-
-// CHECK: double f2_darg1(double x, double y) {
-// CHECK-NEXT:     double _d_x = 0;
-// CHECK-NEXT:     double _d_y = 1;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = f_pushforward(x, y, _d_x, _d_y);
-// CHECK-NEXT:     double _d_ans = _t0.pushforward;
-// CHECK-NEXT:     double ans = _t0.value;
-// CHECK-NEXT:     return _d_ans;
-// CHECK-NEXT: }
-
-// CHECK: void f2_darg1_grad(double x, double y, double *_d_x, double *_d_y);
-
-// CHECK: void f2_hessian(double x, double y, double *hessianMatrix) {
-// CHECK-NEXT:     f2_darg0_grad(x, y, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:     f2_darg1_grad(x, y, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
-// CHECK-NEXT: }
-
-
-// CHECK: clad::ValueAndPushforward<double, double> f_pushforward(double x, double y, double _d_x, double _d_y) {
-// CHECK-NEXT:     return {x * x + y * y, _d_x * x + x * _d_x + _d_y * y + y * _d_y};
-// CHECK-NEXT: }
-
 
 // CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x, double *_d_y, double *_d__d_x, double *_d__d_y);
 
@@ -85,6 +69,14 @@ double f2(double x, double y){
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
+// CHECK: double f2_darg1(double x, double y) {
+// CHECK-NEXT:     double _d_x = 0;
+// CHECK-NEXT:     double _d_y = 1;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = f_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     double _d_ans = _t0.pushforward;
+// CHECK-NEXT:     double ans = _t0.value;
+// CHECK-NEXT:     return _d_ans;
+// CHECK-NEXT: }
 
 // CHECK: void f2_darg1_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     double _d__d_x = 0;
@@ -113,6 +105,10 @@ double f2(double x, double y){
 // CHECK-NEXT:         _d__d_x += _r2;
 // CHECK-NEXT:         _d__d_y += _r3;
 // CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<double, double> f_pushforward(double x, double y, double _d_x, double _d_y) {
+// CHECK-NEXT:     return {x * x + y * y, _d_x * x + x * _d_x + _d_y * y + y * _d_y};
 // CHECK-NEXT: }
 
 // CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x, double *_d_y, double *_d__d_x, double *_d__d_y) {

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -10,25 +10,20 @@ double nonMemFn(double i, double j) {
   return i*j;
 }
 
-// CHECK: double nonMemFn_darg0(double i, double j) {
-// CHECK-NEXT:     double _d_i = 1;
-// CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     return _d_i * j + i * _d_j;
-// CHECK-NEXT: }
-
+// CHECK: double nonMemFn_darg0(double i, double j);
 // CHECK: void nonMemFn_darg0_grad(double i, double j, double *_d_i, double *_d_j);
-
-// CHECK: double nonMemFn_darg1(double i, double j) {
-// CHECK-NEXT:     double _d_i = 0;
-// CHECK-NEXT:     double _d_j = 1;
-// CHECK-NEXT:     return _d_i * j + i * _d_j;
-// CHECK-NEXT: }
-
+// CHECK: double nonMemFn_darg1(double i, double j);
 // CHECK: void nonMemFn_darg1_grad(double i, double j, double *_d_i, double *_d_j);
 
 // CHECK: void nonMemFn_hessian(double i, double j, double *hessianMatrix) {
 // CHECK-NEXT:     nonMemFn_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
 // CHECK-NEXT:     nonMemFn_darg1_grad(i, j, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT: }
+
+// CHECK: double nonMemFn_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     return _d_i * j + i * _d_j;
 // CHECK-NEXT: }
 
 // CHECK: void nonMemFn_darg0_grad(double i, double j, double *_d_i, double *_d_j) {
@@ -44,6 +39,12 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:         *_d_i += 1 * _d_j0;
 // CHECK-NEXT:         _d__d_j += i * 1;
 // CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: double nonMemFn_darg1(double i, double j) {
+// CHECK-NEXT:     double _d_i = 0;
+// CHECK-NEXT:     double _d_j = 1;
+// CHECK-NEXT:     return _d_i * j + i * _d_j;
 // CHECK-NEXT: }
 
 // CHECK: void nonMemFn_darg1_grad(double i, double j, double *_d_i, double *_d_j) {

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -122,8 +122,8 @@ namespace clad {
       Sema& S = m_CI.getSema();
 
       if (!m_DerivativeBuilder)
-        m_DerivativeBuilder = std::make_unique<DerivativeBuilder>(
-            S, *this, m_DFC, m_DiffRequestGraph);
+        m_DerivativeBuilder.reset(
+            new DerivativeBuilder(S, *this, m_DFC, m_DiffRequestGraph));
 
       RequestOptions opts{};
       SetRequestOptions(opts);

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -102,7 +102,7 @@ public:
     bool m_HasRuntime = false;
     CladTimerGroup m_CTG;
     DerivedFnCollector m_DFC;
-    DiffSchedule m_DiffSchedule;
+    DynamicGraph<DiffRequest> m_DiffRequestGraph;
     enum class CallKind {
       HandleCXXStaticMemberVarInstantiation,
       HandleTopLevelDecl,
@@ -237,10 +237,6 @@ public:
       m_Multiplexer->ForgetSema();
     }
 
-    void AddRequestToSchedule(const DiffRequest& request) {
-      m_DiffSchedule.push_back(request);
-    }
-
     // FIXME: We should hide ProcessDiffRequest when we implement proper
     // handling of the differentiation plans.
     clang::FunctionDecl* ProcessDiffRequest(DiffRequest& request);
@@ -269,10 +265,6 @@ public:
     clang::FunctionDecl* ProcessDiffRequest(CladPlugin& P,
                                             DiffRequest& request) {
       return P.ProcessDiffRequest(request);
-    }
-
-    void AddRequestToSchedule(CladPlugin& P, const DiffRequest& request) {
-      P.AddRequestToSchedule(request);
     }
 
     template <typename ConsumerType>

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -40,3 +40,5 @@ if (Kokkos_FOUND)
   set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
   add_subdirectory(Kokkos)
 endif(Kokkos_FOUND)
+
+add_subdirectory(Misc)

--- a/unittests/Misc/CMakeLists.txt
+++ b/unittests/Misc/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_clad_unittest(MiscTests
+  main.cpp
+  DynamicGraph.cpp
+)

--- a/unittests/Misc/DynamicGraph.cpp
+++ b/unittests/Misc/DynamicGraph.cpp
@@ -1,0 +1,67 @@
+#include "clad/Differentiator/Differentiator.h"
+
+#include <iostream>
+#include <string>
+
+#include "gtest/gtest.h"
+
+struct Node {
+  std::string name;
+  int id;
+
+  Node(std::string name, int id) : name(name), id(id) {}
+
+  bool operator==(const Node& other) const {
+    return name == other.name && id == other.id;
+  }
+
+  // String operator for printing the node.
+  operator std::string() const { return name + std::to_string(id); }
+};
+
+// Specialize std::hash for the Node type.
+template <> struct std::hash<Node> {
+  std::size_t operator()(const Node& n) const {
+    return std::hash<std::string>()(n.name) ^ std::hash<int>()(n.id);
+  }
+};
+
+TEST(DynamicGraphTest, Printing) {
+  clad::DynamicGraph<Node> G;
+  for (int i = 0; i < 6; i++) {
+    Node n("node", i);
+    if (i == 0)
+      G.addNode(n, /*isSource=*/true);
+    Node m("node", i + 1);
+    G.addEdge(n, m);
+  }
+  std::vector<Node> nodes = G.getNodes();
+  EXPECT_EQ(nodes.size(), 7);
+
+  // Edge from node 0 to node 3 and node 4 to node 0.
+  G.addEdge(nodes[0], nodes[3]);
+  G.addEdge(nodes[4], nodes[0]);
+
+  // Check the printed output.
+  std::stringstream ss;
+  std::streambuf* coutbuf = std::cout.rdbuf();
+  std::cout.rdbuf(ss.rdbuf());
+  G.print();
+  std::cout.rdbuf(coutbuf);
+  std::string expectedOutput = "node0: #0 (source), (unprocessed)\n"
+                               "node1: #1, (unprocessed)\n"
+                               "node2: #2, (unprocessed)\n"
+                               "node3: #3, (unprocessed)\n"
+                               "node4: #4, (unprocessed)\n"
+                               "node5: #5, (unprocessed)\n"
+                               "node6: #6, (unprocessed)\n"
+                               "0 -> 1\n"
+                               "0 -> 3\n"
+                               "1 -> 2\n"
+                               "2 -> 3\n"
+                               "3 -> 4\n"
+                               "4 -> 0\n"
+                               "4 -> 5\n"
+                               "5 -> 6\n";
+  EXPECT_EQ(ss.str(), expectedOutput);
+}

--- a/unittests/Misc/main.cpp
+++ b/unittests/Misc/main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Plan for dynamic graph
- The relations between different differentiation requests can be modelled as a graph.
For example, if `f_a` calls `f_b`, there will be two differentiation requests `df_a` and `df_b`, the edge between them can be understood as `created_because_of`. 
This also means that the functions called by the users to be explicitly differentiated (or `DiffRequests` created because of these) are the source nodes, i.e. no incoming edges. In most cases, this graph aligns with the call graph, but in some cases, the graph depends on the internal implementation, like the Hessian computation, which requires creating multiple `fwd_mode` requests followed by a `rev_mode` request.

- We can use this graph to order the computation of differentiation requests. This was already being done implicitly in the initial recursive implementation. Whenever we encountered a call expression, we started differentiation of the
called function; this was sort of like a depth-first search strategy.
  - This had problems, as `Clang` reported errors when it encountered a new function scope (of the derivative of the called function) in the middle of the old function scope (of the derivative of the callee function). It treated the nested one like a lambda expression. The issue regarding this: https://github.com/vgvassilev/clad/issues/745.

- To fix this, an initial strategy was to eliminate the recursive approach. Hence, a queue-based breadth-first approach was implemented in this PR: https://github.com/vgvassilev/clad/pull/848.
  - Although it fixed the problem, the graph traversal was still implicit. We needed some way to compute/store the complete graph and possibly optimize it, such as converting edges to model the `requires_derivative_of` relation. Using this, we could proceed with differentiation in a topologically sorted ordering.
  - It also required one caveat: although we don't differentiate the called function completely in a recursive way, we still need to declare it so that we can have the call expression completed (i.e. `auto t0 = f_pushforward(...)`).

- To move towards the final stage of having the complete graph computed before starting the differentiation, we need the complete information on how the `DiffRequest` will be formed inside the visitors (including arguments or `DVI` info).
This whole approach will require activity analysis in the first pass.
  - As an incremental improvement, the first requirement was to implement infrastructure to support explicit modelling of the graph and use that to have a breadth-first traversal (and eventually topological ordering).

This is the initial PR for capturing the differentiation plan in a graphical format.

However, the traversal order is still breadth-first, as we don't have the complete graph in the first pass - mainly because of a lack of information about the args required for `pushforward` and `pullbacks`.

This can be improved with the help of activity analysis to capture the complete graph in the first pass, processing the plan in a topologically sorted manner and pruning the graph for user-defined functions. I started this with this approach, and the initial experimental commit is available here for future reference: https://github.com/vaithak/clad/commit/82c0b4250c1f0399b21ebbc71e50b52a218eae27.