### PR TITLE
Write numerical diff results to c-style arrays in the generated code.

### DIFF
--- a/test/NumericalDiff/GradientMultiArg.C
+++ b/test/NumericalDiff/GradientMultiArg.C
@@ -4,7 +4,6 @@
 // RUN: ./GradientMultiArg.out | FileCheck -check-prefix=CHECK-EXEC %s
 
 //CHECK-NOT: {{.*error|warning|note:.*}}
-//XFAIL: asserts
 
 #include "clad/Differentiator/Differentiator.h"
 

--- a/test/NumericalDiff/GradientMultiArg.C
+++ b/test/NumericalDiff/GradientMultiArg.C
@@ -21,14 +21,10 @@ double test_1(double x, double y){
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;
-// CHECK-NEXT:         clad::tape<clad::array_ref<double> > _t0 = {};
-// CHECK-NEXT:         double _grad0 = 0;
-// CHECK-NEXT:         clad::push(_t0, &_grad0);
-// CHECK-NEXT:         double _grad1 = 0;
-// CHECK-NEXT:         clad::push(_t0, &_grad1);
-// CHECK-NEXT:         numerical_diff::central_difference(std::hypot, _t0, 0, x, y);
-// CHECK-NEXT:         _r0 += 1 * _grad0;
-// CHECK-NEXT:         _r1 += 1 * _grad1;
+// CHECK-NEXT:         double _grad0[2] = {0};
+// CHECK-NEXT:         numerical_diff::central_difference(std::hypot, _grad0, 0, x, y);
+// CHECK-NEXT:         _r0 += 1 * _grad0[0];
+// CHECK-NEXT:         _r1 += 1 * _grad0[1];
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         *_d_y += _r1;
 // CHECK-NEXT:     }

--- a/test/NumericalDiff/NumDiff.C
+++ b/test/NumericalDiff/NumDiff.C
@@ -3,7 +3,6 @@
 // RUN: %cladnumdiffclang -Xclang -plugin-arg-clad -Xclang -enable-tbr %s -I%S/../../include -oNumDiff.out
 // RUN: ./NumDiff.out | FileCheck -check-prefix=CHECK-EXEC %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
-//XFAIL: asserts
 #include "clad/Differentiator/Differentiator.h"
 
 double test_1(double x){

--- a/test/NumericalDiff/NumDiff.C
+++ b/test/NumericalDiff/NumDiff.C
@@ -58,14 +58,10 @@ double test_3(double x) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r0 = 0;
 //CHECK-NEXT:             double _r1 = 0;
-//CHECK-NEXT:             clad::tape<clad::array_ref<double> > _t0 = {};
-//CHECK-NEXT:             double _grad0 = 0;
-//CHECK-NEXT:             clad::push(_t0, &_grad0);
-//CHECK-NEXT:             double _grad1 = 0;
-//CHECK-NEXT:             clad::push(_t0, &_grad1);
-//CHECK-NEXT:             numerical_diff::central_difference(std::hypot, _t0, 0, x, constant);
-//CHECK-NEXT:             _r0 += 1 * _grad0;
-//CHECK-NEXT:             _r1 += 1 * _grad1;
+//CHECK-NEXT:             double _grad0[2] = {0};
+//CHECK-NEXT:             numerical_diff::central_difference(std::hypot, _grad0, 0, x, constant);
+//CHECK-NEXT:             _r0 += 1 * _grad0[0];
+//CHECK-NEXT:             _r1 += 1 * _grad0[1];
 //CHECK-NEXT:             *_d_x += _r0;
 //CHECK-NEXT:             _d_constant += _r1;
 //CHECK-NEXT:         }


### PR DESCRIPTION
Currently, the numerical diff generated inside gradients is unable to handle different type arguments. As an example, let's differentiate a call to  "double ff(double, unsigned int);":
```
x = ff(a, n);
```
-->
```
...
clad::tape<clad::array_ref<double> > _t1 = {};
double _grad0 = 0;
clad::push(_t1, &_grad0);
unsigned int _grad1 = 0;
clad::push(_t1, &_grad1);
numerical_diff::central_difference(ff, _t1, 0, a, n);
...
```
So ``&_grad1``(``unsigned int*``) is pushed to ``_t1`` (``clad::tape<clad::array_ref<double>>``). The obvious solution here would be to only use the type of the tape element. In this case, there's no point in creating separate ``_grad``, it would make more sense to create an array. This is the solution suggested in this PR:
```
x = ff(a, n);
```
-->
```
 double _grad0[2] = {0};
 numerical_diff::central_difference(ff, _grad0, 0, a, n);
```
One could argue this will only work for numerical type arguments but other types are not supported in reverse mode numerical diff anyway.