### PR TITLE
Fix install-llvm-action version number so 18.1.3 available

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.2
         with:
           version: "18.1.3"
 


### PR DESCRIPTION
@vgvassilev This should fix the issue found in https://github.com/vgvassilev/clad/pull/883 about the clang tidy workflow. Once its been shown to work I will update CppInterOps and xeus-cpps workflows too.