### PR TITLE
Change clang tidy ci to version 16

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2.0.2
         with:
-          version: "18.1.3"
+          version: "16.0.0"
 
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.18.0


### PR DESCRIPTION
@vgvassilev This will try a version 16 for the clang tidy. Before all these changes it was version 12.