### PR TITLE
Fix clang tidy ci

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -26,6 +26,7 @@ jobs:
         run: pip install lit
 
       - name: run git config command
+        run: |
           git config --global --add safe.directory /github/workspace
 
       - name: Run clang-tidy

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -22,18 +22,21 @@ jobs:
         with:
           version: "16.0.0"
 
+      - name: install lit
+        run: pip install lit
+
+      - name: run git config command
+          git config --global --add safe.directory /github/workspace
+
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.18.0
         id: review
         with:
           build_dir: build
-          apt_packages: libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev
+          apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev
           exclude: "test/*,unittests/*,benchmark/*,demos/*"
           split_workflow: true
           cmake_command: >
-            pip install cmake lit &&
-            cmake --version &&
-            git config --global --add safe.directory /github/workspace &&
             cmake . -B build -DLLVM_DIR="$GITHUB_WORKSPACE/llvm"
             -DClang_DIR="$GITHUB_WORKSPACE/llvm"
             -DCMAKE_BUILD_TYPE="Release"

--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -389,7 +389,6 @@ getConstantArrayType(const ASTContext& Ctx, QualType EltTy,
    #define CLAD_COMPAT_CLANG11_UnaryOperator_ExtraParams ,Node->getFPOptionsOverride()
 #endif
 
-
 // Clang 12 rename DeclaratorContext::LambdaExprContext to DeclaratorContext::LambdaExpr.
 // Clang 15 add one extra param to clang::Declarator() - const ParsedAttributesView & DeclarationAttrs
 


### PR DESCRIPTION
@vgvassilev based on the PR in CppInterOp this should fix the clang tidy issue. Its at least running in CppInterOp again after these changes. It seems the one action now has issues taking multiple commands.