### PR TITLE
Handle variable declarations in conditions of if-statements (#865)

### DIFF
--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -25,6 +25,7 @@ float func(float x, float y) {
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _t2;
 //CHECK-NEXT:     double _ret_value0 = 0;
+//CHECK-NEXT:     {
 //CHECK-NEXT:     _cond0 = x > y;
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         _t0 = y;
@@ -35,6 +36,7 @@ float func(float x, float y) {
 //CHECK-NEXT:         temp = y * y;
 //CHECK-NEXT:         _t2 = x;
 //CHECK-NEXT:         x = y;
+//CHECK-NEXT:     }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _ret_value0 = x + y;
 //CHECK-NEXT:     goto _label0;
@@ -91,6 +93,7 @@ float func2(float x) {
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     float z = x * x;
+//CHECK-NEXT:     {
 //CHECK-NEXT:     _cond0 = z > 9;
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         _ret_value0 = x + x;
@@ -98,6 +101,7 @@ float func2(float x) {
 //CHECK-NEXT:     } else {
 //CHECK-NEXT:         _ret_value0 = x * x;
 //CHECK-NEXT:         goto _label1;
+//CHECK-NEXT:     }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     if (_cond0)
 //CHECK-NEXT:       _label0:

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -38,10 +38,12 @@ double f2(double x, double y) {
 //CHECK:   void f2_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       _cond0 = x < y;
-//CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:           _t0 = x;
-//CHECK-NEXT:           x = y;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           _cond0 = x < y;
+//CHECK-NEXT:           if (_cond0) {
+//CHECK-NEXT:               _t0 = x;
+//CHECK-NEXT:               x = y;
+//CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label0;
 //CHECK-NEXT:     _label0:
@@ -160,17 +162,21 @@ double f5(double x, double y) {
 //CHECK-NEXT:       double z = 0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double t = x * x;
+//CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x < 0;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           _t0 = t;
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:           goto _label0;
 //CHECK-NEXT:       }
+//CHECK-NEXT:       }
+//CHECK-NEXT:       {
 //CHECK-NEXT:       _cond1 = y < 0;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           z = t;
 //CHECK-NEXT:           _t1 = t;
 //CHECK-NEXT:           t = -t;
+//CHECK-NEXT:       }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label1;
 //CHECK-NEXT:     _label1:
@@ -223,17 +229,21 @@ double f6(double x, double y) {
 //CHECK-NEXT:       double z = 0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double t = x * x;
+//CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x < 0;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           _t0 = t;
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:           goto _label0;
 //CHECK-NEXT:       }
+//CHECK-NEXT:       }
+//CHECK-NEXT:       {
 //CHECK-NEXT:       _cond1 = y < 0;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           z = t;
 //CHECK-NEXT:           _t1 = t;
 //CHECK-NEXT:           t = -t;
+//CHECK-NEXT:       }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label1;
 //CHECK-NEXT:     _label1:

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -915,9 +915,11 @@ double sq_defined_later(double x) {
 
 // CHECK: void check_and_return_pullback(double x, char c, const char *s, double _d_y, double *_d_x, char *_d_c, char *_d_s) {
 // CHECK-NEXT:     bool _cond0;
+// CHECK-NEXT:     {
 // CHECK-NEXT:     _cond0 = c == 'a' && s[0] == 'a';
 // CHECK-NEXT:     if (_cond0)
 // CHECK-NEXT:         goto _label0;
+// CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label1;
 // CHECK-NEXT:   _label1:
 // CHECK-NEXT:     ;
@@ -957,9 +959,11 @@ double sq_defined_later(double x) {
 
 //CHECK: void recFun_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     bool _cond0;
+//CHECK-NEXT:    {
 //CHECK-NEXT:     _cond0 = x > y;
 //CHECK-NEXT:     if (_cond0)
 //CHECK-NEXT:         goto _label0;
+//CHECK-NEXT:    }
 //CHECK-NEXT:     goto _label1;
 //CHECK-NEXT:   _label1:
 //CHECK-NEXT:     {

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -115,8 +115,8 @@ double f3(double x) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           clad::push(_t1, t);
 //CHECK-NEXT:           t *= x;
-//CHECK-NEXT:           bool _t2 = i == 1;
 //CHECK-NEXT:           {
+//CHECK-NEXT:               bool _t2 = i == 1;
 //CHECK-NEXT:               if (_t2)
 //CHECK-NEXT:                   goto _label0;
 //CHECK-NEXT:               clad::push(_t3, _t2);
@@ -999,8 +999,8 @@ double fn14(double i, double j) {
 // CHECK-NEXT:     while (choice--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
-// CHECK-NEXT:             bool _t1 = choice > 3;
 // CHECK-NEXT:             {
+// CHECK-NEXT:                 bool _t1 = choice > 3;
 // CHECK-NEXT:                 if (_t1) {
 // CHECK-NEXT:                     clad::push(_t3, res);
 // CHECK-NEXT:                     res += i;
@@ -1011,8 +1011,8 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 clad::push(_t2, _t1);
 // CHECK-NEXT:             }
-// CHECK-NEXT:             bool _t5 = choice > 1;
 // CHECK-NEXT:             {
+// CHECK-NEXT:                 bool _t5 = choice > 1;
 // CHECK-NEXT:                 if (_t5) {
 // CHECK-NEXT:                     clad::push(_t7, res);
 // CHECK-NEXT:                     res += j;
@@ -1023,8 +1023,8 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 clad::push(_t6, _t5);
 // CHECK-NEXT:             }
-// CHECK-NEXT:             bool _t8 = choice > 0;
 // CHECK-NEXT:             {
+// CHECK-NEXT:                 bool _t8 = choice > 0;
 // CHECK-NEXT:                 if (_t8) {
 // CHECK-NEXT:                     clad::push(_t10, res);
 // CHECK-NEXT:                     res += i * j;
@@ -1119,8 +1119,8 @@ double fn15(double i, double j) {
 // CHECK-NEXT:     while (choice--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
-// CHECK-NEXT:             bool _t1 = choice > 2;
 // CHECK-NEXT:             {
+// CHECK-NEXT:                 bool _t1 = choice > 2;
 // CHECK-NEXT:                 if (_t1) {
 // CHECK-NEXT:                     clad::push(_t3, {{1U|1UL}});
 // CHECK-NEXT:                     continue;
@@ -1132,8 +1132,8 @@ double fn15(double i, double j) {
 // CHECK-NEXT:             while (another_choice--)
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     clad::back(_t5)++;
-// CHECK-NEXT:                     bool _t6 = another_choice > 1;
 // CHECK-NEXT:                     {
+// CHECK-NEXT:                     bool _t6 = another_choice > 1;
 // CHECK-NEXT:                         if (_t6) {
 // CHECK-NEXT:                             clad::push(_t8, res);
 // CHECK-NEXT:                             res += i;
@@ -1144,8 +1144,8 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                         clad::push(_t7, _t6);
 // CHECK-NEXT:                     }
-// CHECK-NEXT:                     bool _t10 = another_choice > 0;
 // CHECK-NEXT:                     {
+// CHECK-NEXT:                     bool _t10 = another_choice > 0;
 // CHECK-NEXT:                         if (_t10) {
 // CHECK-NEXT:                             clad::push(_t12, res);
 // CHECK-NEXT:                             res += j;
@@ -1237,8 +1237,8 @@ double fn16(double i, double j) {
 // CHECK-NEXT:     _t0 = 0;
 // CHECK-NEXT:     for (ii = 0; ii < counter; ++ii) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         bool _t1 = ii == 4;
 // CHECK-NEXT:         {
+// CHECK-NEXT:             bool _t1 = ii == 4;
 // CHECK-NEXT:             if (_t1) {
 // CHECK-NEXT:                 clad::push(_t3, res);
 // CHECK-NEXT:                 res += i * j;
@@ -1249,8 +1249,8 @@ double fn16(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:             clad::push(_t2, _t1);
 // CHECK-NEXT:         }
-// CHECK-NEXT:         bool _t5 = ii > 2;
 // CHECK-NEXT:         {
+// CHECK-NEXT:         bool _t5 = ii > 2;
 // CHECK-NEXT:             if (_t5) {
 // CHECK-NEXT:                 clad::push(_t7, res);
 // CHECK-NEXT:                 res += 2 * i;
@@ -1343,8 +1343,8 @@ double fn17(double i, double j) {
 // CHECK-NEXT:     for (ii = 0; ii < counter; ++ii) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, jj) , jj = ii;
-// CHECK-NEXT:         bool _t2 = ii < 2;
 // CHECK-NEXT:         {
+// CHECK-NEXT:             bool _t2 = ii < 2;
 // CHECK-NEXT:             if (_t2) {
 // CHECK-NEXT:                 clad::push(_t4, {{1U|1UL}});
 // CHECK-NEXT:                 continue;
@@ -1355,8 +1355,8 @@ double fn17(double i, double j) {
 // CHECK-NEXT:         while (jj--)
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 clad::back(_t5)++;
-// CHECK-NEXT:                 bool _t6 = jj < 3;
 // CHECK-NEXT:                 {
+// CHECK-NEXT:                     bool _t6 = jj < 3;
 // CHECK-NEXT:                     if (_t6) {
 // CHECK-NEXT:                         clad::push(_t8, res);
 // CHECK-NEXT:                         res += i * j;
@@ -1460,14 +1460,13 @@ double fn18(double i, double j) {
 // CHECK-NEXT:     _t0 = 0;
 // CHECK-NEXT:     for (counter = 0; counter < choice; ++counter) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         bool _t1 = counter < 2;
 // CHECK-NEXT:         {
+// CHECK-NEXT:         bool _t1 = counter < 2;
 // CHECK-NEXT:             if (_t1) {
 // CHECK-NEXT:                 clad::push(_t3, res);
 // CHECK-NEXT:                 res += i + j;
 // CHECK-NEXT:             } else {
 // CHECK-NEXT:                 bool _t4 = counter < 4;
-// CHECK-NEXT:                 {
 // CHECK-NEXT:                     if (_t4) {
 // CHECK-NEXT:                         clad::push(_t6, {{1U|1UL}});
 // CHECK-NEXT:                         continue;
@@ -1480,7 +1479,6 @@ double fn18(double i, double j) {
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     clad::push(_t5, _t4);
-// CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             clad::push(_t2, _t1);
 // CHECK-NEXT:         }

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -383,19 +383,21 @@ int main() {
 // CHECK-NEXT:     float _d_val = 0;
 // CHECK-NEXT:     float _t0;
 // CHECK-NEXT:     float _d_derivative = 0;
-// CHECK-NEXT:     float _cond0;
+// CHECK-NEXT:     bool _cond0;
 // CHECK-NEXT:     float _t1;
 // CHECK-NEXT:     float _t2;
 // CHECK-NEXT:     float _t3;
 // CHECK-NEXT:     float val = ::std::pow(x, exponent);
 // CHECK-NEXT:     _t0 = ::std::pow(x, exponent - 1);
 // CHECK-NEXT:     float derivative = (exponent * _t0) * d_x;
+// CHECK-NEXT:     {
 // CHECK-NEXT:     _cond0 = d_exponent;
 // CHECK-NEXT:     if (_cond0) {
 // CHECK-NEXT:         _t1 = derivative;
 // CHECK-NEXT:         _t3 = ::std::pow(x, exponent);
 // CHECK-NEXT:         _t2 = ::std::log(x);
 // CHECK-NEXT:         derivative += (_t3 * _t2) * d_exponent;
+// CHECK-NEXT:     }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:

--- a/test/NumericalDiff/NumDiff.C
+++ b/test/NumericalDiff/NumDiff.C
@@ -43,10 +43,12 @@ double test_3(double x) {
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     double _d_constant = 0;
 //CHECK-NEXT:     double constant = 0;
+//CHECK-NEXT:     {
 //CHECK-NEXT:     _cond0 = x > 0;
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         constant = 11.;
 //CHECK-NEXT:         goto _label0;
+//CHECK-NEXT:     }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     goto _label1;
 //CHECK-NEXT:   _label1:


### PR DESCRIPTION
This patch handles variable declarations in conditions of if-statements in reverse mode differentiation. This is done by actually visiting the conditions instead of just cloning them inside the VisitIfStmt and by choosing the condition variable DeclStmt over cond when possible. This also helps to handle conditions that may affect derivatives as a side-effect. Also a couple of blocks have been added to wrap some statements and preserve the correct logic in the constructed derivatives and some unused code has been removed from the method.

Fixes: #865