### PR TITLE
Add support for null (empty) statements

### DIFF
--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -109,6 +109,7 @@ public:
       const clang::SubstNonTypeTemplateParmExpr* NTTP);
   StmtDiff VisitImplicitValueInitExpr(const clang::ImplicitValueInitExpr* IVIE);
   StmtDiff VisitCStyleCastExpr(const clang::CStyleCastExpr* CSCE);
+  StmtDiff VisitNullStmt(const clang::NullStmt* NS) { return StmtDiff{}; };
   static DeclDiff<clang::StaticAssertDecl>
   DifferentiateStaticAssertDecl(const clang::StaticAssertDecl* SAD);
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -411,6 +411,7 @@ namespace clad {
         const clang::SubstNonTypeTemplateParmExpr* NTTP);
     StmtDiff
     VisitCXXNullPtrLiteralExpr(const clang::CXXNullPtrLiteralExpr* NPE);
+    StmtDiff VisitNullStmt(const clang::NullStmt* NS) { return StmtDiff{}; };
     static DeclDiff<clang::StaticAssertDecl>
     DifferentiateStaticAssertDecl(const clang::StaticAssertDecl* SAD);
 

--- a/test/FirstDerivative/Simple.C
+++ b/test/FirstDerivative/Simple.C
@@ -7,7 +7,7 @@ extern "C" int printf(const char* fmt, ...);
 
 int f(int x) {
   printf("This is f(x).\n");
-  return x*x + x - x*x*x*x;
+  return x*x + x - x*x*x*x;;
 }
 
 int main () {

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -901,6 +901,18 @@ double fn_cond_init(double x) {
 //CHECK-NEXT:              }
 //CHECK-NEXT:          }
 
+double fn_null_stmts(double x) {
+    ;;;;;;;;;;;;;;;;;
+    ;;;;;return x;;;;
+    ;;;;;;;;;;;;;;;;;
+} // = x
+
+//CHECK:               void fn_null_stmts_grad(double x, double *_d_x) {
+//CHECK-NEXT:              goto _label0;
+//CHECK-NEXT:            _label0:
+//CHECK-NEXT:              *_d_x += 1;
+//CHECK-NEXT:          }
+
 #define TEST(F, x, y)                                                          \
   {                                                                            \
     result[0] = 0;                                                             \
@@ -971,4 +983,6 @@ int main() {
   INIT_GRADIENT(fn_cond_init);
   TEST_GRADIENT(fn_cond_init, /*numOfDerivativeArgs=*/1, 0, &dx); // CHECK-EXEC: 1.00
   TEST_GRADIENT(fn_cond_init, /*numOfDerivativeArgs=*/1, -1, &dx); // CHECK-EXEC: 1.00
+
+  INIT_GRADIENT(fn_null_stmts);
 }


### PR DESCRIPTION
This commit removes the "unsupported" warning when differentiating code with ";" in both forward and reverse modes. It also prevents additional semicolons from getting pulled into the derivative code.

Fixes: #899