### PR TITLE
Make GlobalStoreAndRef consistent in usage inside and outside of loops

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -253,8 +253,6 @@ namespace clad {
     clang::Expr* GlobalStoreAndRef(clang::Expr* E,
                                    llvm::StringRef prefix = "_t",
                                    bool force = false);
-    StmtDiff BuildPushPop(clang::Expr* E, clang::QualType Type,
-                          llvm::StringRef prefix = "_t", bool force = false);
     StmtDiff StoreAndRestore(clang::Expr* E, llvm::StringRef prefix = "_t",
                              bool force = false);
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -242,17 +242,17 @@ namespace clad {
     /// it into m_Globals block (to be inserted into the beginning of fn's
     /// body). Returns reference R to the created declaration. If E is not null,
     /// puts an additional assignment statement (R = E) in the forward block.
-    /// Alternatively, if isInsideLoop is true, stores E in a stack. Returns
-    /// StmtDiff, where .getExpr() is intended to be used in forward pass and
-    /// .getExpr_dx() in the reverse pass. Two expressions can be different in
-    /// some cases, e.g. clad::push/pop inside loops.
-    StmtDiff GlobalStoreAndRef(clang::Expr* E,
-                               clang::QualType Type,
-                               llvm::StringRef prefix = "_t",
-                               bool force = false);
-    StmtDiff GlobalStoreAndRef(clang::Expr* E,
-                               llvm::StringRef prefix = "_t",
-                               bool force = false);
+    /// Alternatively, if isInsideLoop is true, stores E in a stack S. Puts a
+    /// push statement (clad::push(S, E)) in the forward block and a pop
+    /// statement
+    /// ((clad::pop(S))) in the reverse block. Returns a reference to the top
+    /// of the stack (clad::back(S)).
+    clang::Expr* GlobalStoreAndRef(clang::Expr* E, clang::QualType Type,
+                                   llvm::StringRef prefix = "_t",
+                                   bool force = false);
+    clang::Expr* GlobalStoreAndRef(clang::Expr* E,
+                                   llvm::StringRef prefix = "_t",
+                                   bool force = false);
     StmtDiff BuildPushPop(clang::Expr* E, clang::QualType Type,
                           llvm::StringRef prefix = "_t", bool force = false);
     StmtDiff StoreAndRestore(clang::Expr* E, llvm::StringRef prefix = "_t",

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2125,11 +2125,8 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
         // FIXME: We should support boolean differentiation or ignore it
         // completely
         unsupportedOpWarn(UnOp->getEndLoc());
-
-      if (isa<DeclRefExpr>(E))
-        diff = Visit(E);
-      else
-        diff = StmtDiff(E);
+      diff = Visit(E);
+      ResultRef = diff.getExpr_dx();
     }
     Expr* op = BuildOp(opCode, diff.getExpr());
     return StmtDiff(op, ResultRef, nullptr, valueForRevPass);

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -47,7 +47,7 @@ float func(float* a, float* b) {
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, a[i]);
@@ -95,7 +95,7 @@ float func2(float* a) {
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
@@ -129,7 +129,7 @@ float func3(float* a, float* b) {
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
@@ -168,7 +168,7 @@ double func4(double x) {
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double arr[3] = {x, 2 * x, x * x};
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
@@ -226,14 +226,14 @@ double func5(int k) {
 //CHECK-NEXT:     double _d_arr[n];
 //CHECK-NEXT:     clad::zero_init(_d_arr, n);
 //CHECK-NEXT:     double arr[n];
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, arr[i]);
 //CHECK-NEXT:         arr[i] = k;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t2 = 0;
+//CHECK-NEXT:     _t2 = {{0U|0UL}};
 //CHECK-NEXT:     for (i0 = 0; i0 < 3; i0++) {
 //CHECK-NEXT:         _t2++;
 //CHECK-NEXT:         clad::push(_t3, sum);
@@ -283,7 +283,7 @@ double func6(double seed) {
 //CHECK-NEXT:     clad::array<double> arr({{3U|3UL}});
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, arr) , arr = {seed, seed * i, seed + i};
@@ -338,7 +338,7 @@ double func7(double *params) {
 //CHECK-NEXT:     clad::array<double> paramsPrime({{1U|1UL}});
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     double out = 0.;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < 1; ++i) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, paramsPrime) , paramsPrime = {params[0]};
@@ -438,7 +438,7 @@ double func9(double i, double j) {
 //CHECK-NEXT:     int idx = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double arr[5] = {};
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (idx = 0; idx < 5; ++idx) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, arr[idx]);
@@ -456,11 +456,11 @@ double func9(double i, double j) {
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         --idx;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             double _r0 = clad::pop(_t1);
-//CHECK-NEXT:             arr[idx] = _r0;
-//CHECK-NEXT:             double _r1 = 0;
-//CHECK-NEXT:             modify_pullback(_r0, i, &_d_arr[idx], &_r1);
-//CHECK-NEXT:             *_d_i += _r1;
+//CHECK-NEXT:             arr[idx] = clad::back(_t1);
+//CHECK-NEXT:             double _r0 = 0;
+//CHECK-NEXT:             modify_pullback(clad::back(_t1), i, &_d_arr[idx], &_r0);
+//CHECK-NEXT:             clad::pop(_t1);
+//CHECK-NEXT:             *_d_i += _r0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -489,7 +489,7 @@ double func10(double *arr, int n) {
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     double res = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < n; ++i) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, res);
@@ -504,9 +504,9 @@ double func10(double *arr, int n) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             res = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_res;
-//CHECK-NEXT:             double _r0 = clad::pop(_t2);
-//CHECK-NEXT:             arr[i] = _r0;
-//CHECK-NEXT:             sq_pullback(_r0, _r_d0, &_d_arr[i]);
+//CHECK-NEXT:             arr[i] = clad::back(_t2);
+//CHECK-NEXT:             sq_pullback(clad::back(_t2), _r_d0, &_d_arr[i]);
+//CHECK-NEXT:             clad::pop(_t2);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -584,7 +584,7 @@ int main() {
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double ret = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, ret);

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -42,7 +42,7 @@ __device__ __host__ double gauss(double* x, double* p, double sigma, int dim) {
 //CHECK-NEXT:     double _t5;
 //CHECK-NEXT:     double _t6;
 //CHECK-NEXT:     double t = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < dim; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, t);

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -22,7 +22,7 @@ float func(float* p, int n) {
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     unsigned {{int|long}} p_size = 0;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
@@ -67,7 +67,7 @@ float func2(float x) {
 //CHECK-NEXT:     float m = 0;
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float z;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < 9; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, m) , m = x * x;
@@ -168,7 +168,7 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:     unsigned {{int|long}} y_size = 0;
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < 10; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, x[i]);

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -23,7 +23,7 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     unsigned {{int|long}} f_size = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 1; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
@@ -72,7 +72,7 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:     unsigned {{int|long}} a_size = 0;
 //CHECK-NEXT:     unsigned {{int|long}} b_size = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, {{0U|0UL}});
@@ -131,7 +131,7 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:     unsigned {{int|long}} b_size = 0;
 //CHECK-NEXT:     unsigned {{int|long}} a_size = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -171,7 +171,7 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = res;
 // CHECK-NEXT:     res += sum(arr, n);
-// CHECK-NEXT:     _t1 = 0;
+// CHECK-NEXT:     _t1 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t1++;
 // CHECK-NEXT:         clad::push(_t2, arr[i]);
@@ -190,9 +190,9 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:             _d_arr[i] += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r1 = clad::pop(_t2);
-// CHECK-NEXT:             arr[i] = _r1;
-// CHECK-NEXT:             twice_pullback(_r1, &_d_arr[i]);
+// CHECK-NEXT:             arr[i] = clad::back(_t2);
+// CHECK-NEXT:             twice_pullback(clad::back(_t2), &_d_arr[i]);
+// CHECK-NEXT:             clad::pop(_t2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -494,7 +494,7 @@ double fn13(double* x, const double* w) {
 // CHECK-NEXT:     std::size_t i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double wCopy[2];
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; i < 2; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, wCopy[i]);
@@ -834,7 +834,7 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     float res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -706,7 +706,7 @@ float running_sum(float* p, int n) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 1; i < n; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, p[i]);

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -23,7 +23,7 @@ double f1(double x) {
 //CHECK-NEXT:       int i = 0;
 //CHECK-NEXT:       clad::tape<double> _t1 = {};
 //CHECK-NEXT:       double t = 1;
-//CHECK-NEXT:       _t0 = 0;
+//CHECK-NEXT:       _t0 = {{0U|0UL}};
 //CHECK-NEXT:       for (i = 0; i < 3; i++) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           clad::push(_t1, t);
@@ -61,7 +61,7 @@ double f2(double x) {
 //CHECK-NEXT:       int j = 0;
 //CHECK-NEXT:       clad::tape<double> _t3 = {};
 //CHECK-NEXT:       double t = 1;
-//CHECK-NEXT:       _t0 = 0;
+//CHECK-NEXT:       _t0 = {{0U|0UL}};
 //CHECK-NEXT:       for (i = 0; i < 3; i++) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           clad::push(_t1, {{0U|0UL}});
@@ -108,18 +108,17 @@ double f3(double x) {
 //CHECK-NEXT:       int _d_i = 0;
 //CHECK-NEXT:       int i = 0;
 //CHECK-NEXT:       clad::tape<double> _t1 = {};
-//CHECK-NEXT:       clad::tape<bool> _t3 = {};
+//CHECK-NEXT:       clad::tape<bool> _cond0 = {};
 //CHECK-NEXT:       double t = 1;
-//CHECK-NEXT:       _t0 = 0;
+//CHECK-NEXT:       _t0 = {{0U|0UL}};
 //CHECK-NEXT:       for (i = 0; i < 3; i++) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           clad::push(_t1, t);
 //CHECK-NEXT:           t *= x;
 //CHECK-NEXT:           {
-//CHECK-NEXT:               bool _t2 = i == 1;
-//CHECK-NEXT:               if (_t2)
+//CHECK-NEXT:               clad::push(_cond0, i == 1);
+//CHECK-NEXT:               if (clad::back(_cond0))
 //CHECK-NEXT:                   goto _label0;
-//CHECK-NEXT:               clad::push(_t3, _t2);
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       goto _label1;
@@ -127,9 +126,12 @@ double f3(double x) {
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           i--;
-//CHECK-NEXT:           if (clad::pop(_t3))
-//CHECK-NEXT:             _label0:
-//CHECK-NEXT:               _d_t += 1;
+//CHECK-NEXT:           {
+//CHECK-NEXT:               if (clad::back(_cond0))
+//CHECK-NEXT:                 _label0:
+//CHECK-NEXT:                   _d_t += 1;
+//CHECK-NEXT:               clad::pop(_cond0);
+//CHECK-NEXT:           }
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = clad::pop(_t1);
 //CHECK-NEXT:               double _r_d0 = _d_t;
@@ -154,7 +156,7 @@ double f4(double x) {
 //CHECK-NEXT:       int i = 0;
 //CHECK-NEXT:       clad::tape<double> _t1 = {};
 //CHECK-NEXT:       double t = 1;
-//CHECK-NEXT:       _t0 = 0;
+//CHECK-NEXT:       _t0 = {{0U|0UL}};
 //CHECK-NEXT:       for (i = 0; i < 3; clad::push(_t1, t) , (t *= x)) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           i++;
@@ -184,7 +186,7 @@ double f5(double x){
 //CHECK-NEXT:       unsigned {{int|long}} _t0;
 //CHECK-NEXT:       int _d_i = 0;
 //CHECK-NEXT:       int i = 0;
-//CHECK-NEXT:       _t0 = 0;
+//CHECK-NEXT:       _t0 = {{0U|0UL}};
 //CHECK-NEXT:       for (i = 0; i < 10; i++) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           x++;
@@ -217,7 +219,7 @@ double f_const_local(double x) {
 //CHECK-NEXT:    double n = 0;
 //CHECK-NEXT:    clad::tape<double> _t2 = {};
 //CHECK-NEXT:    double res = 0;
-//CHECK-NEXT:    _t0 = 0;
+//CHECK-NEXT:    _t0 = {{0U|0UL}};
 //CHECK-NEXT:    for (i = 0; i < 3; ++i) {
 //CHECK-NEXT:        _t0++;
 //CHECK-NEXT:        clad::push(_t1, n) , n = x + i;
@@ -259,7 +261,7 @@ double f_sum(double *p, int n) {
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double s = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, s);
@@ -294,7 +296,7 @@ double f_sum_squares(double *p, int n) {
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double s = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, s);
@@ -338,7 +340,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:     double _t7;
 //CHECK-NEXT:     double _d_gaus = 0;
 //CHECK-NEXT:     double power = 0;
-//CHECK-NEXT:     _t0 = 0;
+//CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, power);
@@ -412,7 +414,7 @@ void f_const_grad(const double, const double, double*, double*);
 //CHECK-NEXT:       int sq0 = 0;
 //CHECK-NEXT:       clad::tape<int> _t2 = {};
 //CHECK-NEXT:       int r = 0;
-//CHECK-NEXT:       _t0 = 0;
+//CHECK-NEXT:       _t0 = {{0U|0UL}};
 //CHECK-NEXT:       for (i = 0; i < a; i++) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           clad::push(_t1, sq0) , sq0 = b * b;
@@ -463,7 +465,7 @@ double f6 (double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (counter = 0; counter < 3; ++counter) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, b) , b = i * i;
@@ -520,7 +522,7 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (counter--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -561,7 +563,7 @@ double fn8(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (counter > 0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -623,7 +625,7 @@ double fn9(double i, double j) {
 // CHECK-NEXT:     _t1 = counter_again;
 // CHECK-NEXT:     counter = counter_again = 3;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     _t2 = 0;
+// CHECK-NEXT:     _t2 = {{0U|0UL}};
 // CHECK-NEXT:     while (counter--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t2++;
@@ -701,7 +703,7 @@ double fn10(double i, double j) {
 // CHECK-NEXT:     clad::tape<int> _t4 = {};
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (clad::push(_t1, b) , b = counter)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -762,7 +764,7 @@ double fn11(double i, double j) {
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, a);
@@ -823,7 +825,7 @@ double fn12(double i, double j) {
 // CHECK-NEXT:     clad::tape<int> _t7 = {};
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, counter_again) , counter_again = 3;
@@ -918,7 +920,7 @@ double fn13(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t5 = {};
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (; clad::push(_t1, k) , k = counter; clad::push(_t2, counter) , (counter -= 1)) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t3, k);
@@ -986,92 +988,98 @@ double fn14(double i, double j) {
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
-// CHECK-NEXT:     clad::tape<bool> _t2 = {};
+// CHECK-NEXT:     clad::tape<bool> _cond0 = {};
+// CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<bool> _cond1 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t4 = {};
-// CHECK-NEXT:     clad::tape<bool> _t6 = {};
-// CHECK-NEXT:     clad::tape<double> _t7 = {};
-// CHECK-NEXT:     clad::tape<bool> _t9 = {};
-// CHECK-NEXT:     clad::tape<double> _t10 = {};
+// CHECK-NEXT:     clad::tape<bool> _cond2 = {};
+// CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (choice--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 bool _t1 = choice > 3;
-// CHECK-NEXT:                 if (_t1) {
-// CHECK-NEXT:                     clad::push(_t3, res);
+// CHECK-NEXT:                 clad::push(_cond0, choice > 3);
+// CHECK-NEXT:                 if (clad::back(_cond0)) {
+// CHECK-NEXT:                     clad::push(_t1, res);
 // CHECK-NEXT:                     res += i;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         clad::push(_t4, {{1U|1UL}});
+// CHECK-NEXT:                         clad::push(_t2, {{1U|1UL}});
 // CHECK-NEXT:                         continue;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 clad::push(_t2, _t1);
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 bool _t5 = choice > 1;
-// CHECK-NEXT:                 if (_t5) {
-// CHECK-NEXT:                     clad::push(_t7, res);
+// CHECK-NEXT:                 clad::push(_cond1, choice > 1);
+// CHECK-NEXT:                 if (clad::back(_cond1)) {
+// CHECK-NEXT:                     clad::push(_t3, res);
 // CHECK-NEXT:                     res += j;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         clad::push(_t4, {{2U|2UL}});
+// CHECK-NEXT:                         clad::push(_t2, {{2U|2UL}});
 // CHECK-NEXT:                         continue;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 clad::push(_t6, _t5);
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 bool _t8 = choice > 0;
-// CHECK-NEXT:                 if (_t8) {
-// CHECK-NEXT:                     clad::push(_t10, res);
+// CHECK-NEXT:                 clad::push(_cond2, choice > 0);
+// CHECK-NEXT:                 if (clad::back(_cond2)) {
+// CHECK-NEXT:                     clad::push(_t4, res);
 // CHECK-NEXT:                     res += i * j;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         clad::push(_t4, {{3U|3UL}});
+// CHECK-NEXT:                         clad::push(_t2, {{3U|3UL}});
 // CHECK-NEXT:                         continue;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 clad::push(_t9, _t8);
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t4, {{4U|4UL}});
+// CHECK-NEXT:             clad::push(_t2, {{4U|4UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
-// CHECK-NEXT:             switch (clad::pop(_t4)) {
+// CHECK-NEXT:             switch (clad::pop(_t2)) {
 // CHECK-NEXT:               case {{4U|4UL}}:
 // CHECK-NEXT:                 ;
-// CHECK-NEXT:                 if (clad::pop(_t9)) {
-// CHECK-NEXT:                   case {{3U|3UL}}:
-// CHECK-NEXT:                     ;
-// CHECK-NEXT:                     {
-// CHECK-NEXT:                         res = clad::pop(_t10);
-// CHECK-NEXT:                         double _r_d2 = _d_res;
-// CHECK-NEXT:                         *_d_i += _r_d2 * j;
-// CHECK-NEXT:                         *_d_j += i * _r_d2;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     if (clad::back(_cond2)) {
+// CHECK-NEXT:                       case {{3U|3UL}}:
+// CHECK-NEXT:                         ;
+// CHECK-NEXT:                         {
+// CHECK-NEXT:                             res = clad::pop(_t4);
+// CHECK-NEXT:                             double _r_d2 = _d_res;
+// CHECK-NEXT:                             *_d_i += _r_d2 * j;
+// CHECK-NEXT:                             *_d_j += i * _r_d2;
+// CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
+// CHECK-NEXT:                     clad::pop(_cond2);
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 if (clad::pop(_t6)) {
-// CHECK-NEXT:                   case {{2U|2UL}}:
-// CHECK-NEXT:                     ;
-// CHECK-NEXT:                     {
-// CHECK-NEXT:                         res = clad::pop(_t7);
-// CHECK-NEXT:                         double _r_d1 = _d_res;
-// CHECK-NEXT:                         *_d_j += _r_d1;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     if (clad::back(_cond1)) {
+// CHECK-NEXT:                       case {{2U|2UL}}:
+// CHECK-NEXT:                        ;
+// CHECK-NEXT:                         {
+// CHECK-NEXT:                             res = clad::pop(_t3);
+// CHECK-NEXT:                             double _r_d1 = _d_res;
+// CHECK-NEXT:                             *_d_j += _r_d1;
+// CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
+// CHECK-NEXT:                     clad::pop(_cond1);
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 if (clad::pop(_t2)) {
-// CHECK-NEXT:                   case {{1U|1UL}}:
-// CHECK-NEXT:                     ;
-// CHECK-NEXT:                     {
-// CHECK-NEXT:                         res = clad::pop(_t3);
-// CHECK-NEXT:                         double _r_d0 = _d_res;
-// CHECK-NEXT:                         *_d_i += _r_d0;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     if (clad::back(_cond0)) {
+// CHECK-NEXT:                       case {{1U|1UL}}:
+// CHECK-NEXT:                         ;
+// CHECK-NEXT:                         {
+// CHECK-NEXT:                             res = clad::pop(_t1);
+// CHECK-NEXT:                             double _r_d0 = _d_res;
+// CHECK-NEXT:                             *_d_i += _r_d0;
+// CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
+// CHECK-NEXT:                     clad::pop(_cond0);
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _t0--;
@@ -1102,102 +1110,108 @@ double fn15(double i, double j) {
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
-// CHECK-NEXT:     clad::tape<bool> _t2 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
-// CHECK-NEXT:     clad::tape<int> _t4 = {};
+// CHECK-NEXT:     clad::tape<bool> _cond0 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+// CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     int _d_another_choice = 0;
 // CHECK-NEXT:     int another_choice = 0;
+// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+// CHECK-NEXT:     clad::tape<bool> _cond1 = {};
+// CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t5 = {};
-// CHECK-NEXT:     clad::tape<bool> _t7 = {};
-// CHECK-NEXT:     clad::tape<double> _t8 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t9 = {};
-// CHECK-NEXT:     clad::tape<bool> _t11 = {};
-// CHECK-NEXT:     clad::tape<double> _t12 = {};
+// CHECK-NEXT:     clad::tape<bool> _cond2 = {};
+// CHECK-NEXT:     clad::tape<double> _t6 = {};
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (choice--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 bool _t1 = choice > 2;
-// CHECK-NEXT:                 if (_t1) {
-// CHECK-NEXT:                     clad::push(_t3, {{1U|1UL}});
+// CHECK-NEXT:                 clad::push(_cond0, choice > 2);
+// CHECK-NEXT:                 if (clad::back(_cond0)) {
+// CHECK-NEXT:                     clad::push(_t1, {{1U|1UL}});
 // CHECK-NEXT:                     continue;
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 clad::push(_t2, _t1);
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t4, another_choice) , another_choice = 3;
-// CHECK-NEXT:             clad::push(_t5, {{0U|0UL}});
+// CHECK-NEXT:             clad::push(_t2, another_choice) , another_choice = 3;
+// CHECK-NEXT:             clad::push(_t3, {{0U|0UL}});
 // CHECK-NEXT:             while (another_choice--)
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::back(_t5)++;
+// CHECK-NEXT:                     clad::back(_t3)++;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                     bool _t6 = another_choice > 1;
-// CHECK-NEXT:                         if (_t6) {
-// CHECK-NEXT:                             clad::push(_t8, res);
+// CHECK-NEXT:                         clad::push(_cond1, another_choice > 1);
+// CHECK-NEXT:                         if (clad::back(_cond1)) {
+// CHECK-NEXT:                             clad::push(_t4, res);
 // CHECK-NEXT:                             res += i;
 // CHECK-NEXT:                             {
-// CHECK-NEXT:                                 clad::push(_t9, {{1U|1UL}});
+// CHECK-NEXT:                                 clad::push(_t5, {{1U|1UL}});
 // CHECK-NEXT:                                 continue;
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                         }
-// CHECK-NEXT:                         clad::push(_t7, _t6);
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                     bool _t10 = another_choice > 0;
-// CHECK-NEXT:                         if (_t10) {
-// CHECK-NEXT:                             clad::push(_t12, res);
+// CHECK-NEXT:                         clad::push(_cond2, another_choice > 0);
+// CHECK-NEXT:                         if (clad::back(_cond2)) {
+// CHECK-NEXT:                             clad::push(_t6, res);
 // CHECK-NEXT:                             res += j;
 // CHECK-NEXT:                         }
-// CHECK-NEXT:                         clad::push(_t11, _t10);
 // CHECK-NEXT:                     }
-// CHECK-NEXT:                     clad::push(_t9, {{2U|2UL}});
+// CHECK-NEXT:                     clad::push(_t5, {{2U|2UL}});
 // CHECK-NEXT:                 }
-// CHECK-NEXT:             clad::push(_t3, {{2U|2UL}});
+// CHECK-NEXT:             clad::push(_t1, {{2U|2UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
-// CHECK-NEXT:             switch (clad::pop(_t3)) {
+// CHECK-NEXT:             switch (clad::pop(_t1)) {
 // CHECK-NEXT:               case {{2U|2UL}}:
 // CHECK-NEXT:                 ;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     while (clad::back(_t5))
+// CHECK-NEXT:                     while (clad::back(_t3))
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             switch (clad::pop(_t9)) {
+// CHECK-NEXT:                             switch (clad::pop(_t5)) {
 // CHECK-NEXT:                               case {{2U|2UL}}:
 // CHECK-NEXT:                                 ;
-// CHECK-NEXT:                                 if (clad::pop(_t11)) {
-// CHECK-NEXT:                                     {
-// CHECK-NEXT:                                         res = clad::pop(_t12);
-// CHECK-NEXT:                                         double _r_d1 = _d_res;
-// CHECK-NEXT:                                         *_d_j += _r_d1;
+// CHECK-NEXT:                                 {
+// CHECK-NEXT:                                     if (clad::back(_cond2)) {
+// CHECK-NEXT:                                         {
+// CHECK-NEXT:                                             res = clad::pop(_t6);
+// CHECK-NEXT:                                             double _r_d1 = _d_res;
+// CHECK-NEXT:                                             *_d_j += _r_d1;
+// CHECK-NEXT:                                         }
 // CHECK-NEXT:                                     }
+// CHECK-NEXT:                                     clad::pop(_cond2);
 // CHECK-NEXT:                                 }
-// CHECK-NEXT:                                 if (clad::pop(_t7)) {
-// CHECK-NEXT:                                   case {{1U|1UL}}:
-// CHECK-NEXT:                                     ;
-// CHECK-NEXT:                                     {
-// CHECK-NEXT:                                         res = clad::pop(_t8);
-// CHECK-NEXT:                                         double _r_d0 = _d_res;
-// CHECK-NEXT:                                         *_d_i += _r_d0;
+// CHECK-NEXT:                                 {
+// CHECK-NEXT:                                     if (clad::back(_cond1)) {
+// CHECK-NEXT:                                       case {{1U|1UL}}:
+// CHECK-NEXT:                                         ;
+// CHECK-NEXT:                                         {
+// CHECK-NEXT:                                             res = clad::pop(_t4);
+// CHECK-NEXT:                                             double _r_d0 = _d_res;
+// CHECK-NEXT:                                             *_d_i += _r_d0;
+// CHECK-NEXT:                                         }
 // CHECK-NEXT:                                     }
+// CHECK-NEXT:                                     clad::pop(_cond1);
 // CHECK-NEXT:                                 }
 // CHECK-NEXT:                             }
-// CHECK-NEXT:                             clad::back(_t5)--;
+// CHECK-NEXT:                             clad::back(_t3)--;
 // CHECK-NEXT:                         }
-// CHECK-NEXT:                     clad::pop(_t5);
+// CHECK-NEXT:                     clad::pop(_t3);
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     _d_another_choice = 0;
-// CHECK-NEXT:                     another_choice = clad::pop(_t4);
+// CHECK-NEXT:                     another_choice = clad::pop(_t2);
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 if (clad::pop(_t2))
-// CHECK-NEXT:                   case {{1U|1UL}}:
-// CHECK-NEXT:                     ;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     if (clad::back(_cond0))
+// CHECK-NEXT:                       case {{1U|1UL}}:
+// CHECK-NEXT:                         ;
+// CHECK-NEXT:                     clad::pop(_cond0);
+// CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _t0--;
 // CHECK-NEXT:         }
@@ -1226,77 +1240,81 @@ double fn16(double i, double j) {
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_ii = 0;
 // CHECK-NEXT:     int ii = 0;
-// CHECK-NEXT:     clad::tape<bool> _t2 = {};
+// CHECK-NEXT:     clad::tape<bool> _cond0 = {};
+// CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<bool> _cond1 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t4 = {};
-// CHECK-NEXT:     clad::tape<bool> _t6 = {};
-// CHECK-NEXT:     clad::tape<double> _t7 = {};
-// CHECK-NEXT:     clad::tape<double> _t8 = {};
+// CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     int counter = 5;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (ii = 0; ii < counter; ++ii) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             bool _t1 = ii == 4;
-// CHECK-NEXT:             if (_t1) {
-// CHECK-NEXT:                 clad::push(_t3, res);
+// CHECK-NEXT:             clad::push(_cond0, ii == 4);
+// CHECK-NEXT:             if (clad::back(_cond0)) {
+// CHECK-NEXT:                 clad::push(_t1, res);
 // CHECK-NEXT:                 res += i * j;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_t4, {{1U|1UL}});
+// CHECK-NEXT:                     clad::push(_t2, {{1U|1UL}});
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t2, _t1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:         bool _t5 = ii > 2;
-// CHECK-NEXT:             if (_t5) {
-// CHECK-NEXT:                 clad::push(_t7, res);
+// CHECK-NEXT:             clad::push(_cond1, ii > 2);
+// CHECK-NEXT:             if (clad::back(_cond1)) {
+// CHECK-NEXT:                 clad::push(_t3, res);
 // CHECK-NEXT:                 res += 2 * i;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_t4, {{2U|2UL}});
+// CHECK-NEXT:                     clad::push(_t2, {{2U|2UL}});
 // CHECK-NEXT:                     continue;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t6, _t5);
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t8, res);
+// CHECK-NEXT:         clad::push(_t4, res);
 // CHECK-NEXT:         res += i + j;
-// CHECK-NEXT:         clad::push(_t4, {{3U|3UL}});
+// CHECK-NEXT:         clad::push(_t2, {{3U|3UL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--)
-// CHECK-NEXT:         switch (clad::pop(_t4)) {
+// CHECK-NEXT:         switch (clad::pop(_t2)) {
 // CHECK-NEXT:           case {{3U|3UL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             --ii;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 res = clad::pop(_t8);
+// CHECK-NEXT:                 res = clad::pop(_t4);
 // CHECK-NEXT:                 double _r_d2 = _d_res;
 // CHECK-NEXT:                 *_d_i += _r_d2;
 // CHECK-NEXT:                 *_d_j += _r_d2;
 // CHECK-NEXT:             }
-// CHECK-NEXT:             if (clad::pop(_t6)) {
-// CHECK-NEXT:               case {{2U|2UL}}:
-// CHECK-NEXT:                 ;
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     res = clad::pop(_t7);
-// CHECK-NEXT:                     double _r_d1 = _d_res;
-// CHECK-NEXT:                     *_d_i += 2 * _r_d1;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (clad::back(_cond1)) {
+// CHECK-NEXT:                   case {{2U|2UL}}:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         res = clad::pop(_t3);
+// CHECK-NEXT:                         double _r_d1 = _d_res;
+// CHECK-NEXT:                         *_d_i += 2 * _r_d1;
+// CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
+// CHECK-NEXT:                 clad::pop(_cond1);
 // CHECK-NEXT:             }
-// CHECK-NEXT:             if (clad::pop(_t2)) {
-// CHECK-NEXT:               case {{1U|1UL}}:
-// CHECK-NEXT:                 ;
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     res = clad::pop(_t3);
-// CHECK-NEXT:                     double _r_d0 = _d_res;
-// CHECK-NEXT:                     *_d_i += _r_d0 * j;
-// CHECK-NEXT:                     *_d_j += i * _r_d0;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (clad::back(_cond0)) {
+// CHECK-NEXT:                   case {{1U|1UL}}:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         res = clad::pop(_t1);
+// CHECK-NEXT:                         double _r_d0 = _d_res;
+// CHECK-NEXT:                         *_d_i += _r_d0 * j;
+// CHECK-NEXT:                         *_d_j += i * _r_d0;
+// CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
+// CHECK-NEXT:                 clad::pop(_cond0);
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT: }
@@ -1330,97 +1348,101 @@ double fn17(double i, double j) {
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_jj = 0;
 // CHECK-NEXT:     int jj = 0;
-// CHECK-NEXT:     clad::tape<bool> _t3 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t4 = {};
+// CHECK-NEXT:     clad::tape<bool> _cond0 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+// CHECK-NEXT:     clad::tape<bool> _cond1 = {};
+// CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t5 = {};
-// CHECK-NEXT:     clad::tape<bool> _t7 = {};
-// CHECK-NEXT:     clad::tape<double> _t8 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t9 = {};
-// CHECK-NEXT:     clad::tape<double> _t10 = {};
+// CHECK-NEXT:     clad::tape<double> _t6 = {};
 // CHECK-NEXT:     int counter = 5;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (ii = 0; ii < counter; ++ii) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, jj) , jj = ii;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             bool _t2 = ii < 2;
-// CHECK-NEXT:             if (_t2) {
-// CHECK-NEXT:                 clad::push(_t4, {{1U|1UL}});
+// CHECK-NEXT:             clad::push(_cond0, ii < 2);
+// CHECK-NEXT:             if (clad::back(_cond0)) {
+// CHECK-NEXT:                 clad::push(_t2, {{1U|1UL}});
 // CHECK-NEXT:                 continue;
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t3, _t2);
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t5, {{0U|0UL}});
+// CHECK-NEXT:         clad::push(_t3, {{0U|0UL}});
 // CHECK-NEXT:         while (jj--)
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::back(_t5)++;
+// CHECK-NEXT:                 clad::back(_t3)++;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     bool _t6 = jj < 3;
-// CHECK-NEXT:                     if (_t6) {
-// CHECK-NEXT:                         clad::push(_t8, res);
+// CHECK-NEXT:                     clad::push(_cond1, jj < 3);
+// CHECK-NEXT:                     if (clad::back(_cond1)) {
+// CHECK-NEXT:                         clad::push(_t4, res);
 // CHECK-NEXT:                         res += i * j;
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             clad::push(_t9, {{1U|1UL}});
+// CHECK-NEXT:                             clad::push(_t5, {{1U|1UL}});
 // CHECK-NEXT:                             break;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     } else {
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             clad::push(_t9, {{2U|2UL}});
+// CHECK-NEXT:                             clad::push(_t5, {{2U|2UL}});
 // CHECK-NEXT:                             continue;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
-// CHECK-NEXT:                     clad::push(_t7, _t6);
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 clad::push(_t10, res);
+// CHECK-NEXT:                 clad::push(_t6, res);
 // CHECK-NEXT:                 res += i * i * j * j;
-// CHECK-NEXT:                 clad::push(_t9, {{3U|3UL}});
+// CHECK-NEXT:                 clad::push(_t5, {{3U|3UL}});
 // CHECK-NEXT:             }
-// CHECK-NEXT:         clad::push(_t4, {{2U|2UL}});
+// CHECK-NEXT:         clad::push(_t2, {{2U|2UL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--)
-// CHECK-NEXT:         switch (clad::pop(_t4)) {
+// CHECK-NEXT:         switch (clad::pop(_t2)) {
 // CHECK-NEXT:           case {{2U|2UL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             --ii;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 while (clad::back(_t5))
+// CHECK-NEXT:                 while (clad::back(_t3))
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         switch (clad::pop(_t9)) {
+// CHECK-NEXT:                         switch (clad::pop(_t5)) {
 // CHECK-NEXT:                           case {{3U|3UL}}:
 // CHECK-NEXT:                             ;
 // CHECK-NEXT:                             {
-// CHECK-NEXT:                                 res = clad::pop(_t10);
+// CHECK-NEXT:                                 res = clad::pop(_t6);
 // CHECK-NEXT:                                 double _r_d1 = _d_res;
 // CHECK-NEXT:                                 *_d_i += _r_d1 * j * j * i;
 // CHECK-NEXT:                                 *_d_i += i * _r_d1 * j * j;
 // CHECK-NEXT:                                 *_d_j += i * i * _r_d1 * j;
 // CHECK-NEXT:                                 *_d_j += i * i * j * _r_d1;
 // CHECK-NEXT:                             }
-// CHECK-NEXT:                             if (clad::pop(_t7)) {
-// CHECK-NEXT:                               case {{1U|1UL}}:
-// CHECK-NEXT:                                 ;
-// CHECK-NEXT:                                 {
-// CHECK-NEXT:                                     res = clad::pop(_t8);
-// CHECK-NEXT:                                     double _r_d0 = _d_res;
-// CHECK-NEXT:                                     *_d_i += _r_d0 * j;
-// CHECK-NEXT:                                     *_d_j += i * _r_d0;
+// CHECK-NEXT:                             {
+// CHECK-NEXT:                                 if (clad::back(_cond1)) {
+// CHECK-NEXT:                                   case {{1U|1UL}}:
+// CHECK-NEXT:                                     ;
+// CHECK-NEXT:                                     {
+// CHECK-NEXT:                                        res = clad::pop(_t4);
+// CHECK-NEXT:                                         double _r_d0 = _d_res;
+// CHECK-NEXT:                                         *_d_i += _r_d0 * j;
+// CHECK-NEXT:                                         *_d_j += i * _r_d0;
+// CHECK-NEXT:                                     }
+// CHECK-NEXT:                                 } else {
+// CHECK-NEXT:                                   case {{2U|2UL}}:
+// CHECK-NEXT:                                     ;
 // CHECK-NEXT:                                 }
-// CHECK-NEXT:                             } else {
-// CHECK-NEXT:                               case {{2U|2UL}}:
-// CHECK-NEXT:                                 ;
+// CHECK-NEXT:                                 clad::pop(_cond1);
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                         }
-// CHECK-NEXT:                         clad::back(_t5)--;
+// CHECK-NEXT:                         clad::back(_t3)--;
 // CHECK-NEXT:                     }
-// CHECK-NEXT:                 clad::pop(_t5);
+// CHECK-NEXT:                 clad::pop(_t3);
 // CHECK-NEXT:             }
-// CHECK-NEXT:             if (clad::pop(_t3))
-// CHECK-NEXT:               case {{1U|1UL}}:
-// CHECK-NEXT:                 ;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (clad::back(_cond0))
+// CHECK-NEXT:                   case {{1U|1UL}}:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                 clad::pop(_cond0);
+// CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 _d_ii += _d_jj;
 // CHECK-NEXT:                 _d_jj = 0;
@@ -1450,66 +1472,68 @@ double fn18(double i, double j) {
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 0;
-// CHECK-NEXT:     clad::tape<bool> _t2 = {};
+// CHECK-NEXT:     clad::tape<bool> _cond0 = {};
+// CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     clad::tape<bool> _cond1 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<bool> _t5 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t6 = {};
-// CHECK-NEXT:     clad::tape<double> _t7 = {};
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (counter = 0; counter < choice; ++counter) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         {
-// CHECK-NEXT:         bool _t1 = counter < 2;
-// CHECK-NEXT:             if (_t1) {
-// CHECK-NEXT:                 clad::push(_t3, res);
+// CHECK-NEXT:             clad::push(_cond0, counter < 2);
+// CHECK-NEXT:             if (clad::back(_cond0)) {
+// CHECK-NEXT:                 clad::push(_t1, res);
 // CHECK-NEXT:                 res += i + j;
 // CHECK-NEXT:             } else {
-// CHECK-NEXT:                 bool _t4 = counter < 4;
-// CHECK-NEXT:                     if (_t4) {
-// CHECK-NEXT:                         clad::push(_t6, {{1U|1UL}});
+// CHECK-NEXT:                     clad::push(_cond1, counter < 4);
+// CHECK-NEXT:                     if (clad::back(_cond1)) {
+// CHECK-NEXT:                         clad::push(_t2, {{1U|1UL}});
 // CHECK-NEXT:                         continue;
 // CHECK-NEXT:                     } else {
-// CHECK-NEXT:                         clad::push(_t7, res);
+// CHECK-NEXT:                         clad::push(_t3, res);
 // CHECK-NEXT:                         res += 2 * i + 2 * j;
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             clad::push(_t6, {{2U|2UL}});
+// CHECK-NEXT:                             clad::push(_t2, {{2U|2UL}});
 // CHECK-NEXT:                             break;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
-// CHECK-NEXT:                     clad::push(_t5, _t4);
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t2, _t1);
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t6, {{3U|3UL}});
+// CHECK-NEXT:         clad::push(_t2, {{3U|3UL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     goto _label0;
 // CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--)
-// CHECK-NEXT:         switch (clad::pop(_t6)) {
+// CHECK-NEXT:         switch (clad::pop(_t2)) {
 // CHECK-NEXT:           case {{3U|3UL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             --counter;
-// CHECK-NEXT:             if (clad::pop(_t2)) {
-// CHECK-NEXT:                 res = clad::pop(_t3);
+// CHECK-NEXT:             if (clad::back(_cond0)) {
+// CHECK-NEXT:                 res = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_res;
 // CHECK-NEXT:                 *_d_i += _r_d0;
 // CHECK-NEXT:                 *_d_j += _r_d0;
-// CHECK-NEXT:             } else if (clad::pop(_t5))
-// CHECK-NEXT:               case {{1U|1UL}}:
-// CHECK-NEXT:                 ;
-// CHECK-NEXT:             else {
-// CHECK-NEXT:               case {{2U|2UL}}:
-// CHECK-NEXT:                 ;
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     res = clad::pop(_t7);
-// CHECK-NEXT:                     double _r_d1 = _d_res;
-// CHECK-NEXT:                     *_d_i += 2 * _r_d1;
-// CHECK-NEXT:                     *_d_j += 2 * _r_d1;
+// CHECK-NEXT:             } else {
+// CHECK-NEXT:                 if (clad::back(_cond1))
+// CHECK-NEXT:                   case {{1U|1UL}}:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                 else {
+// CHECK-NEXT:                   case {{2U|2UL}}:
+// CHECK-NEXT:                     ;
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                         res = clad::pop(_t3);
+// CHECK-NEXT:                         double _r_d1 = _d_res;
+// CHECK-NEXT:                         *_d_i += 2 * _r_d1;
+// CHECK-NEXT:                         *_d_j += 2 * _r_d1;
+// CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
+// CHECK-NEXT:                 clad::pop(_cond1);
 // CHECK-NEXT:             }
+// CHECK-NEXT:             clad::pop(_cond0);
 // CHECK-NEXT:         }
 // CHECK-NEXT: }
 
@@ -1534,7 +1558,7 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:     double *ref = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         _d_ref = &_d_arr[i];
@@ -1580,7 +1604,7 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:     double sum = 0;
 // CHECK-NEXT:     double num_points = 10000;
 // CHECK-NEXT:     double interval = (upper - lower) / num_points;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (x = lower; x <= upper; clad::push(_t1, x) , (x += interval)) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t2, sum);
@@ -1631,7 +1655,7 @@ double fn20(double *arr, int n) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
@@ -1675,7 +1699,7 @@ double fn21(double x) {
 // CHECK-NEXT:     clad::array<double> arr({{3U|3UL}});
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, arr) , arr = {1, x, 2};

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -181,7 +181,7 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:     clad::tape<const double *> _t5 = {};
 // CHECK-NEXT:     clad::tape<double *> _t6 = {};
 // CHECK-NEXT:     double sum = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         _d_j = &_d_i;

--- a/test/Gradient/Switch.C
+++ b/test/Gradient/Switch.C
@@ -277,12 +277,13 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t5 = {};
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     int counter = 2;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (counter--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 switch (clad::push(_cond0, counter)) {
+// CHECK-NEXT:                 clad::push(_cond0, counter);
+// CHECK-NEXT:                 switch (clad::back(_cond0)) {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                       case 0:
 // CHECK-NEXT:                         res += i * i * j * j;
@@ -415,7 +416,7 @@ double fn4(double i, double j) {
 // CHECK-NEXT:               case 1:
 // CHECK-NEXT:                 counter = 2;
 // CHECK-NEXT:             }
-// CHECK-NEXT:             _t2 = 0;
+// CHECK-NEXT:             _t2 = {{0U|0UL}};
 // CHECK-NEXT:             while (counter--)
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     _t2++;
@@ -604,11 +605,12 @@ double fn7(double u, double v) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             switch (clad::push(_cond0, i)) {
+// CHECK-NEXT:             clad::push(_cond0, i)
+// CHECK-NEXT:             switch (clad::back(_cond0)) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                   case 0:
 // CHECK-NEXT:                     {

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -23,7 +23,7 @@ void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a);
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 1; i < a; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, z);

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -331,7 +331,7 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     double _t5;
 // CHECK-NEXT:     Tangent _t6;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
@@ -356,10 +356,10 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t1);
 // CHECK-NEXT:             double _r_d0 = _d_res;
-// CHECK-NEXT:             std{{(::__1)?}}::complex<double> _r0 = clad::pop(_t2);
-// CHECK-NEXT:             _r0.real_pullback(_r_d0, &(*_d_c));
-// CHECK-NEXT:             std{{(::__1)?}}::complex<double> _r1 = clad::pop(_t4);
-// CHECK-NEXT:             _r1.imag_pullback(2 * _r_d0, &(*_d_c));
+// CHECK-NEXT:             clad::back(_t2).real_pullback(_r_d0, &(*_d_c));
+// CHECK-NEXT:             clad::pop(_t2);
+// CHECK-NEXT:             clad::back(_t4).imag_pullback(2 * _r_d0, &(*_d_c));
+// CHECK-NEXT:             clad::pop(_t4);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -411,7 +411,7 @@ int main() {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
@@ -435,7 +435,7 @@ int main() {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
@@ -493,7 +493,7 @@ int main() {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     _t0 = 0;
+// CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, this->data[i]);

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -113,7 +113,7 @@
 //CHECK_FLOAT_SUM:     unsigned int i = 0;
 //CHECK_FLOAT_SUM:     clad::tape<float> _t1 = {};
 //CHECK_FLOAT_SUM:     float sum = 0.;
-//CHECK_FLOAT_SUM:     _t0 = 0;
+//CHECK_FLOAT_SUM:     _t0 = {{0U|0UL}};
 //CHECK_FLOAT_SUM:     for (i = 0; i < n; i++) {
 //CHECK_FLOAT_SUM:         _t0++;
 //CHECK_FLOAT_SUM:         clad::push(_t1, sum);


### PR DESCRIPTION
The purpose of this PR is to make ``GlobalStoreAndRef`` work more consistently inside and outside of loops. The issue is well described in #431. The solution proposed in this PR is as follows:
When ``GlobalStoreAndRef`` is called inside a loop, it adds a push statement (``clad::push(_t0, x)``) to the forward block and a pop statement (``clad::pop(_t0)``) to the reverse block. The return type of ``GlobalStoreAndRef`` is changed from ``StmtDiff`` to ``clang::Expr*``. The return value is the top element on the tape (``clad::back(_t0)``). When ``GlobalStoreAndRef`` is called outside a loop, the behavior is essentially the same as before except now it returns a single reference to the created variable ``ref`` instead of ``StmtDiff(ref, ref)``.
For example (when used to store the condition of an if-stmt inside a loop):
```
 // forward sweep:
clad::push(_cond1, another_choice > 1);
if (clad::back(_cond1)) {
    ...
}
```
```
 // reverse sweep:
if (clad::back(_cond1)) {
    ...
}
clad::pop(_cond1);
```
With this approach, we automatically ensure safe tape pushes/pops when working with return/break/continue statements, which wasn't the case previously. Because of this a lot of the code used to handle those statements got simplified.
Also, the change of the return type makes ``GlobalStoreAndRef`` consistent in usage with ``StoreAndRef``.

Note: I made ``GlobalStoreAndRef`` return ``clad::back(_t0)`` instead of stored values of ``clad::push(_t0)`` and ``clad::pop(_t0)`` (as proposed by @parth-07 in #431) because in all use cases ``_r0 = clad::pop(_t0)`` was added to the reverse block after ``_r0`` was used (because reverse blocks are reversed). Getting the statement order right would make ``GlobalStoreAndRef`` a lot harder to use.

Fixes #431.