### PR TITLE
Fix condition declarations and assignments in for loops

### DIFF
--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -75,6 +75,8 @@ public:
   // Decl is not Stmt, so it cannot be visited directly.
   virtual DeclDiff<clang::VarDecl>
   DifferentiateVarDecl(const clang::VarDecl* VD);
+  virtual DeclDiff<clang::VarDecl>
+  DifferentiateVarDecl(const clang::VarDecl* VD, bool ignoreInit);
   /// Shorthand for warning on differentiation of unsupported operators
   void unsupportedOpWarn(clang::SourceLocation loc,
                          llvm::ArrayRef<llvm::StringRef> args = {}) {

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -27,6 +27,10 @@ namespace clad {
     /// function `FD`.
     std::string ComputeEffectiveFnName(const clang::FunctionDecl* FD);
 
+    // Unwraps S to a single statement if it's a compound statement only
+    // containing 1 statement.
+    clang::Stmt* unwrapIfSingleStmt(clang::Stmt* S);
+
     /// Creates and returns a compound statement having statements as follows:
     /// {`S`, all the statement of `initial` in sequence}
     clang::CompoundStmt* PrependAndCreateCompoundStmt(clang::ASTContext& C,

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -764,11 +764,7 @@ StmtDiff BaseForwardModeVisitor::VisitForStmt(const ForStmt* FS) {
   StmtDiff bodyVisited = Visit(body);
   for (Stmt* S : bodyVisited.getBothStmts())
     addToCurrentBlock(S);
-  CompoundStmt* bodyResultCmpd = endBlock();
-  if (bodyResultCmpd->size() == 1)
-    bodyResult = bodyResultCmpd->body_front();
-  else
-    bodyResult = bodyResultCmpd;
+  bodyResult = utils::unwrapIfSingleStmt(endBlock());
   endScope();
 
   Stmt* forStmtDiff = new (m_Context)

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -102,6 +102,19 @@ namespace clad {
       }
     }
 
+    Stmt* unwrapIfSingleStmt(Stmt* S) {
+      if (!S)
+        return nullptr;
+      if (!isa<CompoundStmt>(S))
+        return S;
+      auto* CS = cast<CompoundStmt>(S);
+      if (CS->size() == 0)
+        return nullptr;
+      if (CS->size() == 1)
+        return CS->body_front();
+      return CS;
+    }
+
     CompoundStmt* PrependAndCreateCompoundStmt(ASTContext& C, Stmt* initial,
                                                Stmt* S) {
       llvm::SmallVector<Stmt*, 16> block;


### PR DESCRIPTION
These changes fix the differentiation of variable declarations in for loop conditions that used to result into wrong derivatives. The commit also tackles the problem of having an assignment operator that affects the derivative in the for-loop condition, as well as adds support for logical operators in for-loops and allows to combine assignments with them.

Fixes: #273