### PR TITLE
Return type adjusted to depend on called function's return type

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1175,8 +1175,8 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
                                validLoc, llvm::MutableArrayRef<Expr*>(CallArgs),
                                validLoc)
                 .get();
-        auto* zero =
-            ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, 0);
+        auto* zero = ConstantFolder::synthesizeLiteral(CE->getType(), m_Context,
+                                                       /*val=*/0);
         return StmtDiff(call, zero);
       }
     }

--- a/test/FirstDerivative/FunctionCallsWithResults.C
+++ b/test/FirstDerivative/FunctionCallsWithResults.C
@@ -165,7 +165,7 @@ double fn4(double i, double j) {
 // CHECK: double fn4_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = nonRealParamFn(0, 0);
 // CHECK-NEXT:     _d_res += _d_i;
 // CHECK-NEXT:     res += i;
@@ -266,7 +266,7 @@ double fn8(double i, double j) {
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = check_and_return_pushforward(_t0.value, 'a', _t0.pushforward, 0);
 // CHECK-NEXT:     double &_t2 = _t1.value;
 // CHECK-NEXT:     double _t3 = std::tanh(1.);
-// CHECK-NEXT:     return _t1.pushforward * _t3 + _t2 * 0;
+// CHECK-NEXT:     return _t1.pushforward * _t3 + _t2 * 0.;
 // CHECK-NEXT: }
 
 double g (double x) { return x; }


### PR DESCRIPTION
This commit changes the return type of 0 that is returned in case all arguments are constant literals. In particular it used to give warnings when differentiating NaN(or __builtin_nanf (const char * str )) which is crucial for the future fmax custom derivative implementation.

Fixes: https://github.com/vgvassilev/clad/issues/908.