### PR TITLE
Add primitive support for constructor custom pushforward functions

### DIFF
--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -3,6 +3,7 @@
 
 #include "Compatibility.h"
 #include "VisitorBase.h"
+#include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Sema/Sema.h"
@@ -140,6 +141,16 @@ protected:
   /// \return active switch case label after processing `stmt`
   clang::SwitchCase* DeriveSwitchStmtBodyHelper(const clang::Stmt* stmt,
                                                 clang::SwitchCase* activeSC);
+
+  /// Tries to build custom derivative constructor pushforward call for the
+  /// given CXXConstructExpr.
+  ///
+  /// \return A call expression if a suitable custom derivative is found;
+  /// Otherwise returns nullptr.
+  clang::Expr* BuildCustomDerivativeConstructorPFCall(
+      const clang::CXXConstructExpr* CE,
+      llvm::SmallVectorImpl<clang::Expr*>& clonedArgs,
+      llvm::SmallVectorImpl<clang::Expr*>& derivedArgs);
 };
 } // end namespace clad
 

--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -21,6 +21,26 @@ template <typename T, typename U> struct ValueAndPushforward {
   T value;
   U pushforward;
 };
+
+/// It is used to identify constructor custom pushforwards. For
+/// constructor custom pushforward functions, we cannot use the same
+/// strategy which we use for custom pushforward for member
+/// functions. Member functions custom pushforward have the following
+/// signature:
+///
+/// mem_fn_pushforward(ClassName *c, ..., ClassName *d_c, ...)
+///
+/// We use the first argument 'ClassName *c' to determine the class of member
+/// function for which the pushforward is defined.
+///
+/// In the case of constructor pushforward, there are no objects of the class
+/// type passed to the constructor. Therefore, we cannot simply use arguments
+/// to determine the class. To solve this, 'ConstructorPushforwardTag<T>' is
+/// used. A custom_derivative pushforward for constructor is required to have
+/// 'ConstructorPushforwardTag<T>' as the first argument, where 'T' is the
+/// class for which constructor pushforward is defined.
+template <class T> class ConstructorPushforwardTag {};
+
 namespace custom_derivatives {
 #ifdef __CUDACC__
 template <typename T>

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -1,8 +1,9 @@
 #ifndef CLAD_STL_BUILTINS_H
 #define CLAD_STL_BUILTINS_H
 
+#include <clad/Differentiator/BuiltinDerivatives.h>
+#include <initializer_list>
 #include <vector>
-#include "clad/Differentiator/BuiltinDerivatives.h"
 
 namespace clad {
 namespace custom_derivatives {
@@ -43,6 +44,90 @@ end_pushforward(const ::std::initializer_list<T>* il,
                 const ::std::initializer_list<T>* d_il) {
   return {il->end(), d_il->end()};
 }
+
+template <typename T>
+clad::ValueAndPushforward<::std::vector<T>, ::std::vector<T>>
+constructor_pushforward(
+    ConstructorPushforwardTag<::std::vector<T>>,
+    typename ::std::vector<T>::size_type n,
+    const typename ::std::vector<T>::allocator_type& alloc,
+    typename ::std::vector<T>::size_type d_n,
+    const typename ::std::vector<T>::allocator_type& d_alloc) {
+  ::std::vector<T> v(n, alloc);
+  ::std::vector<T> d_v(n, 0, alloc);
+  return {v, d_v};
+}
+
+template <typename T>
+clad::ValueAndPushforward<::std::vector<T>, ::std::vector<T>>
+constructor_pushforward(
+    ConstructorPushforwardTag<::std::vector<T>>,
+    typename ::std::vector<T>::size_type n, T val,
+    const typename ::std::vector<T>::allocator_type& alloc,
+    typename ::std::vector<T>::size_type d_n, T d_val,
+    const typename ::std::vector<T>::allocator_type& d_alloc) {
+  ::std::vector<T> v(n, val, alloc);
+  ::std::vector<T> d_v(n, d_val, alloc);
+  return {v, d_v};
+}
+
+template <typename T>
+clad::ValueAndPushforward<::std::vector<T>, ::std::vector<T>>
+constructor_pushforward(
+    ConstructorPushforwardTag<::std::vector<T>>,
+    ::std::initializer_list<T> list,
+    const typename ::std::vector<T>::allocator_type& alloc,
+    ::std::initializer_list<T> dlist,
+    const typename ::std::vector<T>::allocator_type& dalloc) {
+  ::std::vector<T> v(list, alloc);
+  ::std::vector<T> d_v(dlist, dalloc);
+  return {v, d_v};
+}
+
+template <typename T>
+clad::ValueAndPushforward<::std::vector<T>, ::std::vector<T>>
+constructor_pushforward(ConstructorPushforwardTag<::std::vector<T>>,
+                        typename ::std::vector<T>::size_type n,
+                        typename ::std::vector<T>::size_type d_n) {
+  ::std::vector<T> v(n);
+  ::std::vector<T> d_v(n, 0);
+  return {v, d_v};
+}
+
+template <typename T>
+clad::ValueAndPushforward<::std::vector<T>, ::std::vector<T>>
+constructor_pushforward(ConstructorPushforwardTag<::std::vector<T>>,
+                        typename ::std::vector<T>::size_type n, T val,
+                        typename ::std::vector<T>::size_type d_n, T d_val) {
+  ::std::vector<T> v(n, val);
+  ::std::vector<T> d_v(n, d_val);
+  return {v, d_v};
+}
+
+template <typename T>
+clad::ValueAndPushforward<::std::vector<T>, ::std::vector<T>>
+constructor_pushforward(ConstructorPushforwardTag<::std::vector<T>>,
+                        ::std::initializer_list<T> list,
+                        ::std::initializer_list<T> dlist) {
+  ::std::vector<T> v(list);
+  ::std::vector<T> d_v(dlist);
+  return {v, d_v};
+}
+
+template <typename T>
+ValueAndPushforward<T&, T&>
+operator_subscript_pushforward(::std::vector<T>* v, unsigned idx,
+                               ::std::vector<T>* d_v, unsigned d_idx) {
+  return {(*v)[idx], (*d_v)[idx]};
+}
+
+template <typename T>
+ValueAndPushforward<const T&, const T&>
+operator_subscript_pushforward(const ::std::vector<T>* v, unsigned idx,
+                               const ::std::vector<T>* d_v, unsigned d_idx) {
+  return {(*v)[idx], (*d_v)[idx]};
+}
+
 } // namespace class_functions
 } // namespace custom_derivatives
 } // namespace clad

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -18,7 +18,6 @@ namespace clad {
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/Sema.h"
-
 #include <array>
 #include <stack>
 #include <unordered_map>
@@ -600,6 +599,13 @@ namespace clad {
                                  bool isDerived);
 
     clang::QualType DetermineCladArrayValueType(clang::QualType T);
+
+    /// Returns clad::Identify template declaration.
+    clang::TemplateDecl* GetCladConstructorPushforwardTag();
+
+    /// Returns type clad::Identify<T>
+    clang::QualType GetCladConstructorPushforwardTagOfType(clang::QualType T);
+
   public:
     /// Rebuild a sequence of nested namespaces ending with DC.
     clang::NamespaceDecl* RebuildEnclosingNamespaces(clang::DeclContext* DC);
@@ -644,6 +650,9 @@ namespace clad {
     void ComputeEffectiveDOperands(StmtDiff& LDiff, StmtDiff& RDiff,
                                    clang::Expr*& derivedL,
                                    clang::Expr*& derivedR);
+
+  private:
+    clang::TemplateDecl* m_CladConstructorPushforwardTag = nullptr;
   };
 } // end namespace clad
 

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -10,6 +10,7 @@
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Sema/Lookup.h"
 #include "llvm/ADT/SmallVector.h"
+#include <clang/AST/DeclCXX.h>
 #include "clad/Differentiator/Compatibility.h"
 
 using namespace clang;
@@ -98,6 +99,8 @@ namespace clad {
       case OverloadedOperatorKind::OO_Subscript:
         return "operator_subscript";
       default:
+        if (isa<CXXConstructorDecl>(FD))
+          return "constructor";
         return FD->getNameAsString();
       }
     }

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -811,4 +811,16 @@ namespace clad {
     return m_Sema.ActOnCallExpr(getCurrentScope(), pushDRE, noLoc, args, noLoc)
         .get();
   }
+
+  clang::TemplateDecl* VisitorBase::GetCladConstructorPushforwardTag() {
+    if (!m_CladConstructorPushforwardTag)
+      m_CladConstructorPushforwardTag =
+          LookupTemplateDeclInCladNamespace("ConstructorPushforwardTag");
+    return m_CladConstructorPushforwardTag;
+  }
+
+  clang::QualType
+  VisitorBase::GetCladConstructorPushforwardTagOfType(clang::QualType T) {
+    return InstantiateTemplate(GetCladConstructorPushforwardTag(), {T});
+  }
 } // end namespace clad

--- a/test/ForwardMode/STLCustomDerivatives.C
+++ b/test/ForwardMode/STLCustomDerivatives.C
@@ -1,0 +1,129 @@
+// RUN: %cladclang %s -I%S/../../include -oUserDefinedTypes.out | %filecheck %s
+// RUN: ./UserDefinedTypes.out | %filecheck_exec %s
+
+// CHECK-NOT: {{.*error|warning|note:.*}}
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+
+#include <vector>
+#include <map>
+
+#include "../TestUtils.h"
+#include "../PrintOverloads.h"
+
+double fnVec1(double u, double v) {
+    std::vector<double> V1(2);
+    std::vector<long double> V2(4);
+    V1[0] = u;
+    V1[1] = v;
+    V2[0] = v;
+    V2[1] = u;
+    double res = V1[0] * V1[1] + V2[0] * V2[1];
+    return res;
+}
+
+// CHECK: double fnVec1_darg0(double u, double v) {
+// CHECK-NEXT:     double _d_u = 1;
+// CHECK-NEXT:     double _d_v = 0;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward< ::std::vector<double>, ::std::vector<double> > _t0 = clad::custom_derivatives::class_functions::constructor_pushforward(clad::ConstructorPushforwardTag<std::vector<double> >(), 2, {{.*}}0{{.*}});
+// CHECK-NEXT:     std::vector<double> _d_V1(_t0.pushforward);
+// CHECK-NEXT:     std::vector<double> V1(_t0.value);
+// CHECK-NEXT:     {{.*}}ValueAndPushforward< ::std::vector<long double>, ::std::vector<long double> > _t1 = clad::custom_derivatives::class_functions::constructor_pushforward(clad::ConstructorPushforwardTag<std::vector<long double> >(), 4, {{.*}}0{{.*}});
+// CHECK-NEXT:     std::vector<long double> _d_V2(_t1.pushforward);
+// CHECK-NEXT:     std::vector<long double> V2(_t1.value);
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V1, 0, &_d_V1, 0);
+// CHECK-NEXT:     _t2.pushforward = _d_u;
+// CHECK-NEXT:     _t2.value = u;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<double &, double &> _t3 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V1, 1, &_d_V1, 0);
+// CHECK-NEXT:     _t3.pushforward = _d_v;
+// CHECK-NEXT:     _t3.value = v;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<long double &, long double &> _t4 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V2, 0, &_d_V2, 0);
+// CHECK-NEXT:     _t4.pushforward = _d_v;
+// CHECK-NEXT:     _t4.value = v;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<long double &, long double &> _t5 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V2, 1, &_d_V2, 0);
+// CHECK-NEXT:     _t5.pushforward = _d_u;
+// CHECK-NEXT:     _t5.value = u;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<double &, double &> _t6 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V1, 0, &_d_V1, 0);
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<double &, double &> _t7 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V1, 1, &_d_V1, 0);
+// CHECK-NEXT:     double &_t8 = _t6.value;
+// CHECK-NEXT:     double &_t9 = _t7.value;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<long double &, long double &> _t10 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V2, 0, &_d_V2, 0);
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<long double &, long double &> _t11 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V2, 1, &_d_V2, 0);
+// CHECK-NEXT:     long double &_t12 = _t10.value;
+// CHECK-NEXT:     long double &_t13 = _t11.value;
+// CHECK-NEXT:     double _d_res = _t6.pushforward * _t9 + _t8 * _t7.pushforward + _t10.pushforward * _t13 + _t12 * _t11.pushforward;
+// CHECK-NEXT:     double res = _t8 * _t9 + _t12 * _t13;
+// CHECK-NEXT:     return _d_res;
+// CHECK-NEXT: }
+
+double fnVec2(double u, double v) {
+    const std::vector<double> V1(2, u);
+    const std::vector<double> V2(2, v);
+    return V1[0] * V2[1];
+}
+
+// CHECK: double fnVec2_darg0(double u, double v) {
+// CHECK-NEXT:     double _d_u = 1;
+// CHECK-NEXT:     double _d_v = 0;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward< ::std::vector<double>, ::std::vector<double> > _t0 = clad::custom_derivatives::class_functions::constructor_pushforward(clad::ConstructorPushforwardTag<std::vector<double> >(), 2, u, {{.*}}0, _d_u{{.*}});
+// CHECK-NEXT:     const std::vector<double> _d_V1(_t0.pushforward);
+// CHECK-NEXT:     const std::vector<double> V1(_t0.value);
+// CHECK-NEXT:     {{.*}}ValueAndPushforward< ::std::vector<double>, ::std::vector<double> > _t1 = clad::custom_derivatives::class_functions::constructor_pushforward(clad::ConstructorPushforwardTag<std::vector<double> >(), 2, v, {{.*}}0, _d_v{{.*}});
+// CHECK-NEXT:     const std::vector<double> _d_V2(_t1.pushforward);
+// CHECK-NEXT:     const std::vector<double> V2(_t1.value);
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<const double &, const double &> _t2 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V1, 0, &_d_V1, 0);
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<const double &, const double &> _t3 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V2, 1, &_d_V2, 0);
+// CHECK-NEXT:     const double _t4 = _t2.value;
+// CHECK-NEXT:     const double _t5 = _t3.value;
+// CHECK-NEXT:     return _t2.pushforward * _t5 + _t4 * _t3.pushforward;
+// CHECK-NEXT: }
+
+double fnVec3(double u, double v) {
+    std::vector<double> V1(2, u);
+    std::vector<double> &V2 = V1;
+    return V1[0] + V2[1];
+}
+
+// CHECK: double fnVec3_darg0(double u, double v) {
+// CHECK-NEXT:     double _d_u = 1;
+// CHECK-NEXT:     double _d_v = 0;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward< ::std::vector<double>, ::std::vector<double> > _t0 = clad::custom_derivatives::class_functions::constructor_pushforward(clad::ConstructorPushforwardTag<std::vector<double> >(), 2, u, {{.*}}0, _d_u{{.*}});
+// CHECK-NEXT:     std::vector<double> _d_V1(_t0.pushforward);
+// CHECK-NEXT:     std::vector<double> V1(_t0.value);
+// CHECK-NEXT:     std::vector<double> &_d_V2 = _d_V1;
+// CHECK-NEXT:     std::vector<double> &V2 = V1;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<double &, double &> _t1 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V1, 0, &_d_V1, 0);
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V2, 1, &_d_V2, 0);
+// CHECK-NEXT:     return _t1.pushforward + _t2.pushforward;
+// CHECK-NEXT: }
+
+double fnVec4(double u, double v) {
+    std::vector<double> V{u, v, u * v};
+    return V[0] * V[2];
+}
+
+// CHECK: double fnVec4_darg0(double u, double v) {
+// CHECK-NEXT:     double _d_u = 1;
+// CHECK-NEXT:     double _d_v = 0;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward< ::std::vector<double>, ::std::vector<double> > _t0 = clad::custom_derivatives::class_functions::constructor_pushforward(clad::ConstructorPushforwardTag<std::vector<double> >(), {u, v, u * v}, {{.*}}{_d_u, _d_v, _d_u * v + u * _d_v}{{.*}});
+// CHECK-NEXT:     std::vector<double> _d_V_t0.pushforward;
+// CHECK-NEXT:     std::vector<double> V_t0.value;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<double &, double &> _t1 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V, 0, &_d_V, 0);
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V, 2, &_d_V, 0);
+// CHECK-NEXT:     double &_t3 = _t1.value;
+// CHECK-NEXT:     double &_t4 = _t2.value;
+// CHECK-NEXT:     return _t1.pushforward * _t4 + _t3 * _t2.pushforward;
+// CHECK-NEXT: }
+
+int main() {
+    INIT_DIFFERENTIATE(fnVec1, "u");
+    INIT_DIFFERENTIATE(fnVec2, "u");
+    INIT_DIFFERENTIATE(fnVec3, "u");
+    INIT_DIFFERENTIATE(fnVec4, "u");
+
+    TEST_DIFFERENTIATE(fnVec1, 3, 5); // CHECK-EXEC: {10.00}
+    TEST_DIFFERENTIATE(fnVec2, 3, 5); // CHECK-EXEC: {5.00}
+    TEST_DIFFERENTIATE(fnVec3, 3, 5); // CHECK-EXEC: {2.00}
+    TEST_DIFFERENTIATE(fnVec4, 3, 5); // CHECK-EXEC: {30.00}
+}

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -881,10 +881,10 @@ double fn14(double i, double j) {
 // CHECK-NEXT:     vectorD _d_v;
 // CHECK-NEXT:     vectorD v;
 // CHECK-NEXT:     clad::custom_derivatives::class_functions::resize_pushforward(&v, 5, 0, &_d_v, 0, 0);
-// CHECK-NEXT:     clad::ValueAndPushforward<{{.*}}, {{.*}}> _t0 = v.operator_subscript_pushforward(0, &_d_v, 0);
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<{{.*}}, {{.*}}> _t0 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&v, 0, &_d_v, 0);
 // CHECK-NEXT:     _t0.pushforward = 0 * i + 9 * _d_i;
 // CHECK-NEXT:     _t0.value = 9 * i;
-// CHECK-NEXT:     clad::ValueAndPushforward<{{.*}}, {{.*}}> _t1 = v.operator_subscript_pushforward(1, &_d_v, 0);
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<{{.*}}, {{.*}}> _t1 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&v, 1, &_d_v, 0);
 // CHECK-NEXT:     _t1.pushforward = 0 * i + 11 * _d_i;
 // CHECK-NEXT:     _t1.value = 11 * i;
 // CHECK-NEXT:     clad::ValueAndPushforward<decltype({{.*}}.begin()), decltype({{.*}}.begin())> _t2 = begin_pushforward(v, _d_v);


### PR DESCRIPTION
This commit adds primitive support for custom pushforward functions for
constructors. Custom constructor pushforward function support will enable the
below features:
- Class differentiation support for classes whose constructor Clad
  cannot automatically differentiate. Now, We can enable differentiation of
  entire C++ standard library by providing custom derivatives.
- Remove the restriction of default-constructible for class types. This
  was a troublesome restriction. Now, the only restriction for class
  types is to have a sensible copy-constructor. That is, copy
  constructor should copy the class members and after copy-construction,
  both the objects should be equivalent, mathematically speaking.

Constructor pushforward functions differ from ordinary pushforward
functions in two important ways:
- Constructor pushforward functions initialize the primal class object
  and the corresponding derivative object. Ordinary member function
  pushforwards takes an already-existing primal class object and the
  corresponding derivative object as inputs.
- Constructor pushforward functions return a value even though
  constructor do not return anything. Constructor pushforward functions
  return initialized primal object and the derivative object. These are
  then used to initialize primal object and the derivative in the
  derivative function code.

How to write custom constructor pushforward functions
----------------------------------------

Let's see how to write custom pushforward function for a
constructor:

- Custom constructor pushforwards must have the name `constructor_pushforward`
- Custom constructor pushforwards must be defined in
  `::clad::custom_derivatives::class_functions` namespace.
- The parameters of the custom constructor pushforward must be:
  {`::clad::Identify<Class>`, original params..., derivative params...}.

'original parameters...' and 'derivative parameters...' is same as what
we have for other pushforward functions. We will soon see why do we need
`::clad::Identify<T>` for constructor custom pushforwards.

Let's see a basic example of how to write custom constructor
pushforward.

```cpp
class Coordinates {
  Coordinates(double px, double py, double pz) :
    x(px), y(py), z(pz) {}

  public:
  double x, y, z;
}

namespace clad {
namespace custom_derivatives {
namespace class_functions {
// custom constructor pushforward function
clad::ValueAndPushforward<Coordinates, Coordinates>
constructor_pushforward(clad::Identify<Coordinates>, double x, double y,
                        double z, double d_x, double d_y, double d_z) {
  return {Coordinates(x, y, z), Coordinates(d_x, d_y, d_z) };
}
} // namespace class_functions
} // namespace custom_derivatives
} // namespace clad

// custom constructor pushforward is used as follows:
// primal code
Constructor c(u, v, w);

// derivative code
clad::ValueAndPushforward<Coordinates, Coordinates> _t0 =
  constructor_pushforward(clad::Identify<Coordinates>, u, v, w, _d_u,
    _d_v, _d_w);
Coordinates _d_c = _t0.pushforward;
Coordinates c = _t0.value;
```

Now, let's see a bit advanced example based on `std::vector` constructor.

```cpp
namespace clad {
namespace custom_derivatives {
namespace class_functions {
// Custom pushforward for: vector(size_t n, const typename
::std::vector<T>::allocator_type alloc)
template <typename T>
clad::ValueAndPushforward<::std::vector<T>, ::std::vector<T>>
constructor_pushforward(
    Identify<::std::vector<T>>, size_t n,
    const typename ::std::vector<T>::allocator_type alloc, size_t d_n,
    const typename ::std::vector<T>::allocator_type d_alloc) {
  ::std::vector<T> v(n, alloc);
  ::std::vector<T> d_v(n, 0, alloc);
  return {v, d_v};
}

// Custom pushfoward for: vector(size_t n, T val, const typename
::std::vector<T>::allocator_type alloc)
template <typename T>
clad::ValueAndPushforward<::std::vector<T>, ::std::vector<T>>
constructor_pushforward(
    Identify<::std::vector<T>>, size_t n, T val,
    const typename ::std::vector<T>::allocator_type alloc, size_t d_n, T d_val,
    const typename ::std::vector<T>::allocator_type d_alloc) {
  ::std::vector<T> v(n, val, alloc);
  ::std::vector<T> d_v(n, d_val, alloc);
  return {v, d_v};
}
} // namespace class_functions
} // namespace custom_derivatives
} // namespace clad

// The custom constructor pushforwards is used as follows:

// Primal code:
std::vector<double> v(10, u);

// Derivative code:
clad::ValueAndPushforward<std::vector<double>, std::vector<double>> _t0 =
  clad::custom_derivatives::class_functions::constructor_pushforward(
    clad::Identify<std::vector<double> >(), 10, u, allocator_type(),
    0, _d_u, allocator_type());
std::vector<double> d_v = _t0.pushforward;
std::vector<double> v = _t0.value;
```

Why `clad::Identify<T>`?
------------------------

So, why do we need clad::Identify<T>?

For a constructor that takes two parameters of types `size_t` and `double`,
the custom pushforward will have the following signature if we do not
include `::clad::Identify<T>`:

```cpp
clad::ValueAndPushforward<Class, Class> constructor_pushforward(size_t n,
  double val, size_t d_n, double d_val);
```

Now, the question is: How to distinguish custom constructor pushforwards
for different classes?

```cpp
MyClassA a(3, 5.0);
MyClassB b(7, 9.0);
```

There is no way for overload resolution selector to distinguish
constructor_pushforward for classes `MyClassA` and `MyClassB`.

`clad::Identify<T>` is used to identify the class for which
custom constructor pushforward is defined.

Please note that we cannot use the same strategy which we use for custom
member function pushforwards because member function pushforwards
always have parameters of the class type which are used for identifying
the class.

We also cannot simply ask users to define the pushforwards inside the
declaration context of the class because it may not always be feasible
to modify the source code of external libraries.

--------------------------------------------

If anyone has better ideas for interface for defining custom constructor
pushforward function, then definitely share them!