### PR TITLE
Revert removing clad::array_ref from InterfaceCompatibility.C

### DIFF
--- a/test/Gradient/InterfaceCompatibility.c
+++ b/test/Gradient/InterfaceCompatibility.c
@@ -17,14 +17,17 @@ double f2(double x[2], int* y) {
 
 int main() {
     double x[2] = {2, 5}, dx[2] = {0}, dy = 0;
+    clad::array_ref<double> dx_ref(dx, 2);
+    clad::array_ref<double> dy_ref(&dy, 1);
 
     auto df1 = clad::gradient(f1);
-    df1.execute(x, 5, dx, &dy);
-    printf("{%.2f, %.2f, %.2f}\n", dx[0], dx[1], dy);  // CHECK-EXEC: {0.00, 1.00, 0.00}
+    df1.execute(x, 5, dx_ref, dy_ref);
+    printf("{%.2f, %.2f, %.2f}\n", dx_ref[0], dx_ref[1], *dy_ref);  // CHECK-EXEC: {0.00, 1.00, 0.00}
 
-    dx[0] = dx[1] = 0;
+    dx_ref[0] = dx_ref[1] = 0;
     int y[] = {9}, dy2[] = {0};
+    clad::array_ref<int> dy2_ref(dy2, 1);
     auto df2 = clad::gradient(f2);
-    df2.execute(x, y, dx, dy2);
-    printf("{%.2f, %.2f, %.2f}\n", dx[0], dx[1], (double)*dy2);  // CHECK-EXEC: {9.00, 0.00, 2.00}
+    df2.execute(x, y, dx_ref, dy2_ref);
+    printf("{%.2f, %.2f, %.2f}\n", dx_ref[0], dx_ref[1], (double)*dy2_ref);  // CHECK-EXEC: {9.00, 0.00, 2.00}
 }


### PR DESCRIPTION
``clad::array_ref`` should not have been removed from InterfaceCompatibility.C in #925. The whole point of InterfaceCompatibility.C is to check the compatibility of Clad's interfaces with ``clad::array_ref``.