### PR TITLE
Fix an assertion when building the clad benchmarks with clang18 on osx.

### DIFF
--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -280,10 +280,10 @@ namespace clad {
         (isa<CXXOperatorCallExpr>(ENoCasts) &&
          cast<CXXOperatorCallExpr>(ENoCasts)->getNumArgs() == 2) ||
         isa<ConditionalOperator>(ENoCasts) ||
-        isa<CXXBindTemporaryExpr>(ENoCasts))
-      return m_Sema.ActOnParenExpr(noLoc, noLoc, E).get();
-    else
-      return E;
+        isa<CXXBindTemporaryExpr>(ENoCasts)) {
+      return m_Sema.ActOnParenExpr(E->getBeginLoc(), E->getEndLoc(), E).get();
+    }
+    return E;
   }
 
   Expr* VisitorBase::StoreAndRef(Expr* E, llvm::StringRef prefix,


### PR DESCRIPTION
Unfortunately, it'd be difficult to come up with a test...