### PR TITLE
Pass the DiffRequest down to the visitors. NFC.

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -23,14 +23,12 @@ jobs:
           arch:  ${{ matrix.target }}
           branch: edge
           packages: >
-            llvm-dev
-            clang-dev
-            clang-static
+            llvm17-dev
+            clang17-dev
+            clang17-static
             llvm17-static
             llvm17-gtest
             cmake
-            llvm
-            clang
             make
             git
       - name: "Setup"

--- a/demos/ErrorEstimation/CustomModel/CustomModel.h
+++ b/demos/ErrorEstimation/CustomModel/CustomModel.h
@@ -15,8 +15,9 @@
 // FPErrorEstimationModel class.
 class CustomModel : public clad::FPErrorEstimationModel {
 public:
-  CustomModel(clad::DerivativeBuilder& builder)
-      : FPErrorEstimationModel(builder) {}
+  CustomModel(clad::DerivativeBuilder& builder,
+              const clad::DiffRequest& request)
+      : FPErrorEstimationModel(builder, request) {}
   /// Return an expression of the following kind:
   ///  dfdx * delta_x
   clang::Expr* AssignError(clad::StmtDiff refExpr,

--- a/demos/ErrorEstimation/PrintModel/PrintModel.h
+++ b/demos/ErrorEstimation/PrintModel/PrintModel.h
@@ -15,8 +15,8 @@
 // FPErrorEstimationModel class.
 class PrintModel : public clad::FPErrorEstimationModel {
 public:
-  PrintModel(clad::DerivativeBuilder& builder)
-      : FPErrorEstimationModel(builder) {}
+  PrintModel(clad::DerivativeBuilder& builder, const clad::DiffRequest& request)
+      : FPErrorEstimationModel(builder, request) {}
   // Return an expression of the following kind:
   //  dfdx * delta_x
   clang::Expr* AssignError(clad::StmtDiff refExpr, const std::string& name) override;

--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -24,7 +24,8 @@ protected:
   unsigned m_ArgIndex = ~0;
 
 public:
-  BaseForwardModeVisitor(DerivativeBuilder& builder);
+  BaseForwardModeVisitor(DerivativeBuilder& builder,
+                         const DiffRequest& request);
   virtual ~BaseForwardModeVisitor();
 
   ///\brief Produces the first derivative of a given function.
@@ -41,8 +42,7 @@ public:
                                           const DiffRequest& request);
 
   /// Returns the return type for the pushforward function of the function
-  /// `m_Function`.
-  /// \note `m_Function` field should be set before using this function.
+  /// `m_DiffReq->Function`.
   clang::QualType ComputePushforwardFnReturnType();
 
   virtual void ExecuteInsidePushforwardFunctionBlock();

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -105,6 +105,8 @@ struct DiffRequest {
            DeclarationOnly == other.DeclarationOnly;
   }
 
+  const clang::FunctionDecl* operator->() const { return Function; }
+
   // String operator for printing the node.
   operator std::string() const {
     std::string res = BaseFunctionName + "__order_" +

--- a/include/clad/Differentiator/HessianModeVisitor.h
+++ b/include/clad/Differentiator/HessianModeVisitor.h
@@ -33,7 +33,7 @@ namespace clad {
           size_t TotalIndependentArgsSize, std::string hessianFuncName);
 
   public:
-    HessianModeVisitor(DerivativeBuilder& builder);
+    HessianModeVisitor(DerivativeBuilder& builder, const DiffRequest& request);
     ~HessianModeVisitor();
 
     ///\brief Produces the hessian second derivative columns of a given

--- a/include/clad/Differentiator/HessianModeVisitor.h
+++ b/include/clad/Differentiator/HessianModeVisitor.h
@@ -34,7 +34,7 @@ namespace clad {
 
   public:
     HessianModeVisitor(DerivativeBuilder& builder, const DiffRequest& request);
-    ~HessianModeVisitor();
+    ~HessianModeVisitor() = default;
 
     ///\brief Produces the hessian second derivative columns of a given
     /// function.

--- a/include/clad/Differentiator/PushForwardModeVisitor.h
+++ b/include/clad/Differentiator/PushForwardModeVisitor.h
@@ -10,12 +10,14 @@
 #include "BaseForwardModeVisitor.h"
 
 namespace clad {
+
 /// A visitor for processing the function code in forward mode.
 /// Used to compute derivatives by clad::differentiate.
 class PushForwardModeVisitor : public BaseForwardModeVisitor {
 
 public:
-  PushForwardModeVisitor(DerivativeBuilder& builder);
+  PushForwardModeVisitor(DerivativeBuilder& builder,
+                         const DiffRequest& request);
   ~PushForwardModeVisitor() override;
 
   StmtDiff VisitReturnStmt(const clang::ReturnStmt* RS) override;

--- a/include/clad/Differentiator/ReverseModeForwPassVisitor.h
+++ b/include/clad/Differentiator/ReverseModeForwPassVisitor.h
@@ -22,7 +22,8 @@ private:
                                              clang::QualType xType);
 
 public:
-  ReverseModeForwPassVisitor(DerivativeBuilder& builder);
+  ReverseModeForwPassVisitor(DerivativeBuilder& builder,
+                             const DiffRequest& request);
   DerivativeAndOverload Derive(const clang::FunctionDecl* FD,
                                const DiffRequest& request);
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -336,7 +336,7 @@ namespace clad {
         llvm::SmallVectorImpl<clang::Expr*>& outputArgs);
 
   public:
-    ReverseModeVisitor(DerivativeBuilder& builder);
+    ReverseModeVisitor(DerivativeBuilder& builder, const DiffRequest& request);
     virtual ~ReverseModeVisitor();
 
     ///\brief Produces the gradient of a given function.
@@ -629,18 +629,14 @@ namespace clad {
     /// Computes and returns the sequence of derived function parameter types.
     ///
     /// Information about the original function and the differentiation mode
-    /// are taken from the data member variables. In particular, `m_Function`,
-    /// `m_Mode` data members should be correctly set before using this
-    /// function.
+    /// are taken from the data member variables.
     llvm::SmallVector<clang::QualType, 8> ComputeParamTypes(const DiffParams& diffParams);
 
     /// Builds and returns the sequence of derived function parameters.
     ///
     /// Information about the original function, derived function, derived
     /// function parameter types and the differentiation mode are implicitly
-    /// taken from the data member variables. In particular, `m_Function`,
-    /// `m_Mode` and `m_Derivative` should be correctly set before using this
-    /// function.
+    /// taken from the data member variables.
     llvm::SmallVector<clang::ParmVarDecl*, 8>
     BuildParams(DiffParams& diffParams);
 

--- a/include/clad/Differentiator/VectorForwardModeVisitor.h
+++ b/include/clad/Differentiator/VectorForwardModeVisitor.h
@@ -23,7 +23,8 @@ private:
   clang::Expr* m_IndVarCountExpr;
 
 public:
-  VectorForwardModeVisitor(DerivativeBuilder& builder);
+  VectorForwardModeVisitor(DerivativeBuilder& builder,
+                           const DiffRequest& request);
   ~VectorForwardModeVisitor();
 
   ///\brief Produces the first derivative of a given function with
@@ -53,9 +54,7 @@ public:
   ///
   /// Information about the original function, derived function, derived
   /// function parameter types and the differentiation mode are implicitly
-  /// taken from the data member variables. In particular, `m_Function`,
-  /// `m_Mode` and `m_Derivative` should be correctly set before using this
-  /// function.
+  /// taken from the data member variables.
   llvm::SmallVector<clang::ParmVarDecl*, 8>
   BuildVectorModeParams(DiffParams& diffParams);
 

--- a/include/clad/Differentiator/VectorPushForwardModeVisitor.h
+++ b/include/clad/Differentiator/VectorPushForwardModeVisitor.h
@@ -8,7 +8,8 @@ namespace clad {
 class VectorPushForwardModeVisitor : public VectorForwardModeVisitor {
 
 public:
-  VectorPushForwardModeVisitor(DerivativeBuilder& builder);
+  VectorPushForwardModeVisitor(DerivativeBuilder& builder,
+                               const DiffRequest& request);
   ~VectorPushForwardModeVisitor() override;
 
   void ExecuteInsidePushforwardFunctionBlock() override;

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -99,11 +99,11 @@ namespace clad {
   /// A base class for all common functionality for visitors
   class VisitorBase {
   protected:
-    VisitorBase(DerivativeBuilder& builder)
+    VisitorBase(DerivativeBuilder& builder, const DiffRequest& request)
         : m_Builder(builder), m_Sema(builder.m_Sema),
           m_CladPlugin(builder.m_CladPlugin), m_Context(builder.m_Context),
           m_DerivativeFnScope(nullptr), m_DerivativeInFlight(false),
-          m_Derivative(nullptr), m_Function(nullptr) {}
+          m_Derivative(nullptr), m_DiffReq(request) {}
 
     using Stmts = llvm::SmallVector<clang::Stmt*, 16>;
 
@@ -117,8 +117,8 @@ namespace clad {
     bool m_DerivativeInFlight;
     /// The Derivative function that is being generated.
     clang::FunctionDecl* m_Derivative;
-    /// The function that is currently differentiated.
-    const clang::FunctionDecl* m_Function;
+    /// The differentiation request that is being currently processed.
+    const DiffRequest& m_DiffReq;
     DiffMode m_Mode;
     /// Map used to keep track of variable declarations and match them
     /// with their derivatives.

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -166,7 +166,10 @@ BaseForwardModeVisitor::Derive(const FunctionDecl* FD,
   DeclarationNameInfo name(II, validLoc);
   llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
   llvm::SaveAndRestore<Scope*> SaveScope(getCurrentScope());
-  DeclContext* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
+
+  // FIXME: We should not use const_cast to get the decl context here.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  auto* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
   m_Sema.CurContext = DC;
   DeclWithContext result =
       m_Builder.cloneFunction(FD, *this, DC, validLoc, name, FD->getType());
@@ -392,6 +395,8 @@ void BaseForwardModeVisitor::ExecuteInsidePushforwardFunctionBlock() {
 DerivativeAndOverload
 BaseForwardModeVisitor::DerivePushforward(const FunctionDecl* FD,
                                           const DiffRequest& request) {
+  // FIXME: We must not reset the diff request here.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<DiffRequest&>(m_DiffReq) = request;
   m_Functor = request.Functor;
   m_DerivativeOrder = request.CurrentDerivativeOrder;
@@ -437,6 +442,8 @@ BaseForwardModeVisitor::DerivePushforward(const FunctionDecl* FD,
   llvm::SaveAndRestore<DeclContext*> saveContext(m_Sema.CurContext);
   llvm::SaveAndRestore<Scope*> saveScope(getCurrentScope(),
                                          getEnclosingNamespaceOrTUScope());
+  // FIXME: We should not use const_cast to get the decl context here.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   auto* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
   m_Sema.CurContext = DC;
 

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -313,7 +313,7 @@ void ErrorEstimationHandler::ActBeforeCreatingDerivedFnBodyScope() {
 void ErrorEstimationHandler::ActOnEndOfDerivedFnBody() {
   // Since 'return' is not an assignment, add its error to _final_error
   // given it is not a DeclRefExpr.
-  EmitFinalErrorStmts(*m_Params, m_RMV->m_Function->getNumParams());
+  EmitFinalErrorStmts(*m_Params, m_RMV->m_DiffReq->getNumParams());
 }
 
 void ErrorEstimationHandler::ActBeforeDifferentiatingStmtInVisitCompoundStmt() {

--- a/lib/Differentiator/PushForwardModeVisitor.cpp
+++ b/lib/Differentiator/PushForwardModeVisitor.cpp
@@ -14,8 +14,9 @@
 using namespace clang;
 
 namespace clad {
-PushForwardModeVisitor::PushForwardModeVisitor(DerivativeBuilder& builder)
-    : BaseForwardModeVisitor(builder) {}
+PushForwardModeVisitor::PushForwardModeVisitor(DerivativeBuilder& builder,
+                                               const DiffRequest& request)
+    : BaseForwardModeVisitor(builder, request) {}
 
 PushForwardModeVisitor::~PushForwardModeVisitor() = default;
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -155,6 +155,8 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
                                   // Cast to function pointer.
                                   gradFuncOverloadEPI);
 
+    // FIXME: We should not use const_cast to get the decl context here.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     auto* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
     m_Sema.CurContext = DC;
     DeclWithContext gradientOverloadFDWC =
@@ -363,6 +365,8 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
     llvm::SaveAndRestore<Scope*> SaveScope(getCurrentScope(),
                                            getEnclosingNamespaceOrTUScope());
+    // FIXME: We should not use const_cast to get the decl context here.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     auto* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
     m_Sema.CurContext = DC;
     DeclWithContext result = m_Builder.cloneFunction(
@@ -477,6 +481,8 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     if (m_ExternalSource)
       m_ExternalSource->ActOnStartOfDerive();
     silenceDiags = !request.VerboseDiags;
+    // FIXME: We should not use const_cast to get the decl request here.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     const_cast<DiffRequest&>(m_DiffReq) = request;
     m_Mode = DiffMode::experimental_pullback;
     assert(m_DiffReq.Function && "Must not be null.");
@@ -514,6 +520,8 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     llvm::SaveAndRestore<DeclContext*> saveContext(m_Sema.CurContext);
     llvm::SaveAndRestore<Scope*> saveScope(getCurrentScope(),
                                            getEnclosingNamespaceOrTUScope());
+    // FIXME: We should not use const_cast to get the decl context here.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     m_Sema.CurContext = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
 
     SourceLocation validLoc{m_DiffReq->getLocation()};
@@ -663,8 +671,12 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     llvm::SmallVector<ParmVarDecl*, 16> enzymeRealParamsDerived;
 
     // First add the function itself as a parameter/argument
+    // FIXME: We should not use const_cast to get the decl context here.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     enzymeArgs.push_back(
         BuildDeclRef(const_cast<FunctionDecl*>(m_DiffReq.Function)));
+    // FIXME: We should not use const_cast to get the decl context here.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     auto* fdDeclContext = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
     enzymeParams.push_back(m_Sema.BuildParmVarDeclForTypedef(
         fdDeclContext, noLoc, m_DiffReq->getType()));

--- a/lib/Differentiator/VectorForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorForwardModeVisitor.cpp
@@ -10,8 +10,9 @@
 using namespace clang;
 
 namespace clad {
-VectorForwardModeVisitor::VectorForwardModeVisitor(DerivativeBuilder& builder)
-    : BaseForwardModeVisitor(builder), m_IndVarCountExpr(nullptr) {}
+VectorForwardModeVisitor::VectorForwardModeVisitor(DerivativeBuilder& builder,
+                                                   const DiffRequest& request)
+    : BaseForwardModeVisitor(builder, request), m_IndVarCountExpr(nullptr) {}
 
 VectorForwardModeVisitor::~VectorForwardModeVisitor() {}
 
@@ -55,7 +56,7 @@ void VectorForwardModeVisitor::SetIndependentVarsExpr(Expr* IndVarCountExpr) {
 DerivativeAndOverload
 VectorForwardModeVisitor::DeriveVectorMode(const FunctionDecl* FD,
                                            const DiffRequest& request) {
-  m_Function = FD;
+  assert(m_DiffReq == request);
   m_Mode = DiffMode::vector_forward_mode;
 
   DiffParams args{};
@@ -74,16 +75,15 @@ VectorForwardModeVisitor::DeriveVectorMode(const FunctionDecl* FD,
     }
   }
   IdentifierInfo* II = &m_Context.Idents.get(derivedFnName);
-  SourceLocation loc{m_Function->getLocation()};
+  SourceLocation loc{m_DiffReq->getLocation()};
   DeclarationNameInfo name(II, loc);
 
   // Generate the function type for the derivative.
   llvm::SmallVector<clang::QualType, 8> paramTypes;
-  paramTypes.reserve(m_Function->getNumParams() + args.size());
-  for (auto PVD : m_Function->parameters()) {
+  paramTypes.reserve(m_DiffReq->getNumParams() + args.size());
+  for (auto PVD : m_DiffReq->parameters())
     paramTypes.push_back(PVD->getType());
-  }
-  for (auto PVD : m_Function->parameters()) {
+  for (auto PVD : m_DiffReq->parameters()) {
     auto it = std::find(std::begin(args), std::end(args), PVD);
     if (it == std::end(args))
       continue; // This parameter is not in the diff list.
@@ -105,13 +105,13 @@ VectorForwardModeVisitor::DeriveVectorMode(const FunctionDecl* FD,
       m_Context.VoidTy,
       llvm::ArrayRef<QualType>(paramTypes.data(), paramTypes.size()),
       // Cast to function pointer.
-      dyn_cast<FunctionProtoType>(m_Function->getType())->getExtProtoInfo());
+      dyn_cast<FunctionProtoType>(m_DiffReq->getType())->getExtProtoInfo());
 
   // Create the function declaration for the derivative.
-  DeclContext* DC = const_cast<DeclContext*>(m_Function->getDeclContext());
+  DeclContext* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
   m_Sema.CurContext = DC;
   DeclWithContext result = m_Builder.cloneFunction(
-      m_Function, *this, DC, loc, name, vectorDiffFunctionType);
+      m_DiffReq.Function, *this, DC, loc, name, vectorDiffFunctionType);
   FunctionDecl* vectorDiffFD = result.first;
   m_Derivative = vectorDiffFD;
 
@@ -153,15 +153,15 @@ VectorForwardModeVisitor::DeriveVectorMode(const FunctionDecl* FD,
   // Current Index of independent variable in the param list of the function.
   size_t independentVarIndex = 0;
 
-  for (size_t i = 0; i < m_Function->getNumParams(); ++i) {
+  for (size_t i = 0; i < m_DiffReq->getNumParams(); ++i) {
     bool is_array =
-        utils::isArrayOrPointerType(m_Function->getParamDecl(i)->getType());
+        utils::isArrayOrPointerType(m_DiffReq->getParamDecl(i)->getType());
     auto param = params[i];
     QualType dParamType = clad::utils::GetValueType(param->getType());
 
     Expr* dVectorParam = nullptr;
     if (m_IndependentVars.size() > independentVarIndex &&
-        m_IndependentVars[independentVarIndex] == m_Function->getParamDecl(i)) {
+        m_IndependentVars[independentVarIndex] == m_DiffReq->getParamDecl(i)) {
 
       // Current offset for independent variable.
       Expr* offsetExpr = arrayIndVarCountExpr;
@@ -175,8 +175,8 @@ VectorForwardModeVisitor::DeriveVectorMode(const FunctionDecl* FD,
 
       if (is_array) {
         // Get size of the array.
-        Expr* getSize = BuildArrayRefSizeExpr(
-            m_ParamVariables[m_Function->getParamDecl(i)]);
+        Expr* getSize =
+            BuildArrayRefSizeExpr(m_ParamVariables[m_DiffReq->getParamDecl(i)]);
 
         // Create an identity matrix for the parameter,
         // with number of rows equal to the size of the array,
@@ -259,36 +259,35 @@ clang::FunctionDecl* VectorForwardModeVisitor::CreateVectorModeOverload() {
   // Calculate the total number of parameters that would be required for
   // automatic differentiation in the derived function if all args are
   // requested.
-  std::size_t totalDerivedParamsSize = m_Function->getNumParams() * 2;
-  std::size_t numDerivativeParams = m_Function->getNumParams();
+  std::size_t totalDerivedParamsSize = m_DiffReq->getNumParams() * 2;
+  std::size_t numDerivativeParams = m_DiffReq->getNumParams();
 
   // Generate the function type for the derivative.
   llvm::SmallVector<clang::QualType, 8> paramTypes;
   paramTypes.reserve(totalDerivedParamsSize);
-  for (auto* PVD : m_Function->parameters()) {
+  for (auto* PVD : m_DiffReq->parameters())
     paramTypes.push_back(PVD->getType());
-  }
 
   // instantiate output parameter type as void*
   QualType outputParamType = GetCladArrayRefOfType(m_Context.VoidTy);
 
   // Push param types for derived params.
-  for (std::size_t i = 0; i < m_Function->getNumParams(); ++i)
+  for (std::size_t i = 0; i < m_DiffReq->getNumParams(); ++i)
     paramTypes.push_back(outputParamType);
 
   auto vectorModeFuncOverloadEPI =
-      dyn_cast<FunctionProtoType>(m_Function->getType())->getExtProtoInfo();
+      dyn_cast<FunctionProtoType>(m_DiffReq->getType())->getExtProtoInfo();
   QualType vectorModeFuncOverloadType = m_Context.getFunctionType(
       m_Context.VoidTy,
       llvm::ArrayRef<QualType>(paramTypes.data(), paramTypes.size()),
       vectorModeFuncOverloadEPI);
 
   // Create the function declaration for the derivative.
-  auto* DC = const_cast<DeclContext*>(m_Function->getDeclContext());
+  auto* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
   m_Sema.CurContext = DC;
   DeclWithContext result =
-      m_Builder.cloneFunction(m_Function, *this, DC, noLoc, vectorModeNameInfo,
-                              vectorModeFuncOverloadType);
+      m_Builder.cloneFunction(m_DiffReq.Function, *this, DC, noLoc,
+                              vectorModeNameInfo, vectorModeFuncOverloadType);
   FunctionDecl* vectorModeOverloadFD = result.first;
 
   // Function declaration scope
@@ -304,7 +303,7 @@ clang::FunctionDecl* VectorForwardModeVisitor::CreateVectorModeOverload() {
                                         // vectormode function.
   callArgs.reserve(vectorModeParams.size());
 
-  for (auto* PVD : m_Function->parameters()) {
+  for (auto* PVD : m_DiffReq->parameters()) {
     auto* VD = utils::BuildParmVarDecl(
         m_Sema, vectorModeOverloadFD, PVD->getIdentifier(), PVD->getType(),
         PVD->getStorageClass(), /*defArg=*/nullptr, PVD->getTypeSourceInfo());
@@ -314,7 +313,7 @@ clang::FunctionDecl* VectorForwardModeVisitor::CreateVectorModeOverload() {
 
   for (std::size_t i = 0; i < numDerivativeParams; ++i) {
     ParmVarDecl* PVD = nullptr;
-    std::size_t effectiveIndex = m_Function->getNumParams() + i;
+    std::size_t effectiveIndex = m_DiffReq->getNumParams() + i;
 
     if (effectiveIndex < vectorModeParams.size()) {
       // This parameter represents an actual derivative parameter.
@@ -349,7 +348,7 @@ clang::FunctionDecl* VectorForwardModeVisitor::CreateVectorModeOverload() {
   // Build derivatives to be used in the call to the actual derived function.
   // These are initialised by effectively casting the derivative parameters of
   // overloaded derived function to the correct type.
-  for (std::size_t i = m_Function->getNumParams(); i < vectorModeParams.size();
+  for (std::size_t i = m_DiffReq->getNumParams(); i < vectorModeParams.size();
        ++i) {
     auto* overloadParam = overloadParams[i];
     auto* vectorModeParam = vectorModeParams[i];
@@ -393,15 +392,15 @@ clang::FunctionDecl* VectorForwardModeVisitor::CreateVectorModeOverload() {
 llvm::SmallVector<clang::ParmVarDecl*, 8>
 VectorForwardModeVisitor::BuildVectorModeParams(DiffParams& diffParams) {
   llvm::SmallVector<clang::ParmVarDecl*, 8> params, paramDerivatives;
-  params.reserve(m_Function->getNumParams() + diffParams.size());
+  params.reserve(m_DiffReq->getNumParams() + diffParams.size());
   auto derivativeFnType = cast<FunctionProtoType>(m_Derivative->getType());
-  std::size_t dParamTypesIdx = m_Function->getNumParams();
+  std::size_t dParamTypesIdx = m_DiffReq->getNumParams();
 
   // Count the number of non-array independent variables requested for
   // differentiation.
   size_t nonArrayIndVarCount = 0;
 
-  for (auto PVD : m_Function->parameters()) {
+  for (auto PVD : m_DiffReq->parameters()) {
     auto newPVD = utils::BuildParmVarDecl(
         m_Sema, m_Derivative, PVD->getIdentifier(), PVD->getType(),
         PVD->getStorageClass(), /*DefArg=*/nullptr, PVD->getTypeSourceInfo());
@@ -499,7 +498,7 @@ StmtDiff VectorForwardModeVisitor::VisitReturnStmt(const ReturnStmt* RS) {
   Expr* derivedRetValE = retValDiff.getExpr_dx();
   // If we are in vector mode, we need to wrap the return value in a
   // vector.
-  SourceLocation loc{m_Function->getLocation()};
+  SourceLocation loc{m_DiffReq->getLocation()};
   llvm::SmallVector<Expr*, 2> args = {m_IndVarCountExpr, derivedRetValE};
   QualType cladArrayType = GetCladArrayOfType(utils::GetValueType(retType));
   TypeSourceInfo* TSI = m_Context.getTrivialTypeSourceInfo(cladArrayType, loc);
@@ -597,7 +596,7 @@ VectorForwardModeVisitor::DifferentiateVarDecl(const VarDecl* VD) {
   // clad::array<double> _d_vector_y(2, 1);
   // this means that we have to initialize the derivative vector of
   // size 2 with all elements equal to 1.
-  SourceLocation loc{m_Function->getLocation()};
+  SourceLocation loc{m_DiffReq->getLocation()};
   llvm::SmallVector<Expr*, 2> args = {m_IndVarCountExpr, initDiff.getExpr_dx()};
   QualType cladArrayType =
       GetCladArrayOfType(utils::GetValueType(VD->getType()));

--- a/lib/Differentiator/VectorForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorForwardModeVisitor.cpp
@@ -81,9 +81,9 @@ VectorForwardModeVisitor::DeriveVectorMode(const FunctionDecl* FD,
   // Generate the function type for the derivative.
   llvm::SmallVector<clang::QualType, 8> paramTypes;
   paramTypes.reserve(m_DiffReq->getNumParams() + args.size());
-  for (auto PVD : m_DiffReq->parameters())
+  for (auto* PVD : m_DiffReq->parameters())
     paramTypes.push_back(PVD->getType());
-  for (auto PVD : m_DiffReq->parameters()) {
+  for (auto* PVD : m_DiffReq->parameters()) {
     auto it = std::find(std::begin(args), std::end(args), PVD);
     if (it == std::end(args))
       continue; // This parameter is not in the diff list.
@@ -108,7 +108,9 @@ VectorForwardModeVisitor::DeriveVectorMode(const FunctionDecl* FD,
       dyn_cast<FunctionProtoType>(m_DiffReq->getType())->getExtProtoInfo());
 
   // Create the function declaration for the derivative.
-  DeclContext* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
+  // FIXME: We should not use const_cast to get the decl context here.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  auto* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
   m_Sema.CurContext = DC;
   DeclWithContext result = m_Builder.cloneFunction(
       m_DiffReq.Function, *this, DC, loc, name, vectorDiffFunctionType);
@@ -283,6 +285,8 @@ clang::FunctionDecl* VectorForwardModeVisitor::CreateVectorModeOverload() {
       vectorModeFuncOverloadEPI);
 
   // Create the function declaration for the derivative.
+  // FIXME: We should not use const_cast to get the decl context here.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   auto* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
   m_Sema.CurContext = DC;
   DeclWithContext result =
@@ -400,7 +404,7 @@ VectorForwardModeVisitor::BuildVectorModeParams(DiffParams& diffParams) {
   // differentiation.
   size_t nonArrayIndVarCount = 0;
 
-  for (auto PVD : m_DiffReq->parameters()) {
+  for (auto* PVD : m_DiffReq->parameters()) {
     auto newPVD = utils::BuildParmVarDecl(
         m_Sema, m_Derivative, PVD->getIdentifier(), PVD->getType(),
         PVD->getStorageClass(), /*DefArg=*/nullptr, PVD->getTypeSourceInfo());

--- a/lib/Differentiator/VectorPushForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorPushForwardModeVisitor.cpp
@@ -9,8 +9,8 @@ using namespace clang;
 
 namespace clad {
 VectorPushForwardModeVisitor::VectorPushForwardModeVisitor(
-    DerivativeBuilder& builder)
-    : VectorForwardModeVisitor(builder) {}
+    DerivativeBuilder& builder, const DiffRequest& request)
+    : VectorForwardModeVisitor(builder, request) {}
 
 VectorPushForwardModeVisitor::~VectorPushForwardModeVisitor() = default;
 

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -115,7 +115,7 @@ namespace clad {
                                      VarDecl::InitializationStyle IS) {
     // add namespace specifier in variable declaration if needed.
     Type = utils::AddNamespaceSpecifier(m_Sema, m_Context, Type);
-    auto VD = VarDecl::Create(
+    auto* VD = VarDecl::Create(
         m_Context, m_Sema.CurContext, m_DiffReq->getLocation(),
         m_DiffReq->getLocation(), Identifier, Type, TSI, SC_None);
 

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -179,7 +179,8 @@ namespace clad {
              it != ie; ++it) {
           auto estimationPlugin = it->instantiate();
           m_DerivativeBuilder->AddErrorEstimationModel(
-              estimationPlugin->InstantiateCustomModel(*m_DerivativeBuilder));
+              estimationPlugin->InstantiateCustomModel(*m_DerivativeBuilder,
+                                                       request));
         }
       }
 


### PR DESCRIPTION
The intent of this patch is to centralize the information about the diff request in one place. This will help upcoming patches to reduce the state of the visitors and refactor some of the implementation in a common place.

That will unblock work on #721.
