### PR TITLE
Add support for initializer_list in forward mode AD

### DIFF
--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -112,6 +112,8 @@ public:
   StmtDiff VisitImplicitValueInitExpr(const clang::ImplicitValueInitExpr* IVIE);
   StmtDiff VisitCStyleCastExpr(const clang::CStyleCastExpr* CSCE);
   StmtDiff VisitNullStmt(const clang::NullStmt* NS) { return StmtDiff{}; };
+  StmtDiff
+  VisitCXXStdInitializerListExpr(const clang::CXXStdInitializerListExpr* ILE);
   static DeclDiff<clang::StaticAssertDecl>
   DifferentiateStaticAssertDecl(const clang::StaticAssertDecl* SAD);
 

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -2,6 +2,7 @@
 #define CLAD_STL_BUILTINS_H
 
 #include <vector>
+#include "clad/Differentiator/BuiltinDerivatives.h"
 
 namespace clad {
 namespace custom_derivatives {
@@ -25,6 +26,22 @@ void resize_pushforward(::std::vector<T>* v, unsigned sz, U val,
                         ::std::vector<T>* d_v, unsigned d_sz, U d_val) {
   d_v->resize(sz, d_val);
   v->resize(sz, val);
+}
+
+template <typename T>
+ValueAndPushforward<typename ::std::initializer_list<T>::iterator,
+                    typename ::std::initializer_list<T>::iterator>
+begin_pushforward(::std::initializer_list<T>* il,
+                  ::std::initializer_list<T>* d_il) {
+  return {il->begin(), d_il->begin()};
+}
+
+template <typename T>
+ValueAndPushforward<typename ::std::initializer_list<T>::iterator,
+                    typename ::std::initializer_list<T>::iterator>
+end_pushforward(const ::std::initializer_list<T>* il,
+                const ::std::initializer_list<T>* d_il) {
+  return {il->end(), d_il->end()};
 }
 } // namespace class_functions
 } // namespace custom_derivatives

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -2159,4 +2159,9 @@ BaseForwardModeVisitor::DifferentiateStaticAssertDecl(
     const clang::StaticAssertDecl* SAD) {
   return DeclDiff<StaticAssertDecl>();
 }
+
+StmtDiff BaseForwardModeVisitor::VisitCXXStdInitializerListExpr(
+    const clang::CXXStdInitializerListExpr* ILE) {
+  return Visit(ILE->getSubExpr());
+}
 } // end namespace clad


### PR DESCRIPTION
This commit adds primitive support for initializer_list in the forward mode AD.