### PR TITLE
Remove useless goto/label statements

### DIFF
--- a/demos/ErrorEstimation/CustomModel/README.md
+++ b/demos/ErrorEstimation/CustomModel/README.md
@@ -48,8 +48,6 @@ The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double &
     float z;
     _t0 = z;
     z = x + y;
-    goto _label0;
-  _label0:
     _d_z += 1;
     {
         _final_error += _d_z * z;

--- a/demos/ErrorEstimation/PrintModel/README.md
+++ b/demos/ErrorEstimation/PrintModel/README.md
@@ -47,8 +47,6 @@ The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double &
     float z;
     _t0 = z;
     z = x + y;
-    goto _label0;
-  _label0:
     _d_z += 1;
     {
         _final_error += _d_z * z;

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -22,8 +22,6 @@ double f(double *arr) {
 }
 
 //CHECK:   void f_grad(double *arr, double *_d_arr) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         int _r0 = 0;
 //CHECK-NEXT:         addArr_pullback(arr, 3, 1, _d_arr, &_r0);
@@ -55,8 +53,6 @@ float func(float* a, float* b) {
 //CHECK-NEXT:         clad::push(_t2, sum);
 //CHECK-NEXT:         sum += a[i];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -101,8 +97,6 @@ float func2(float* a) {
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += helper(a[i]);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -136,8 +130,6 @@ float func3(float* a, float* b) {
 //CHECK-NEXT:         clad::push(_t2, a[i]);
 //CHECK-NEXT:         sum += (a[i] += b[i]);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -174,8 +166,6 @@ double func4(double x) {
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -239,8 +229,6 @@ double func5(int k) {
 //CHECK-NEXT:         clad::push(_t3, sum);
 //CHECK-NEXT:         sum += addArr(arr, n);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t2; _t2--) {
 //CHECK-NEXT:         i0--;
@@ -290,8 +278,6 @@ double func6(double seed) {
 //CHECK-NEXT:         clad::push(_t2, sum);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -345,8 +331,6 @@ double func7(double *params) {
 //CHECK-NEXT:         clad::push(_t2, out);
 //CHECK-NEXT:         out = out + inv_square(paramsPrime);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_out += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         --i;
@@ -391,8 +375,6 @@ double func8(double i, double *arr, int n) {
 //CHECK-NEXT:     res = helper2(i, arr, n);
 //CHECK-NEXT:     _t2 = arr[0];
 //CHECK-NEXT:     arr[0] = 5;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_res += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         arr[0] = _t2;
@@ -444,8 +426,6 @@ double func9(double i, double j) {
 //CHECK-NEXT:         clad::push(_t1, arr[idx]);
 //CHECK-NEXT:         modify(arr[idx], i);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_arr[0] += 1;
 //CHECK-NEXT:         _d_arr[1] += 1;
@@ -496,8 +476,6 @@ double func10(double *arr, int n) {
 //CHECK-NEXT:         clad::push(_t2, arr[i]);
 //CHECK-NEXT:         res += sq(arr[i]);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_res += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         --i;
@@ -590,8 +568,6 @@ int main() {
 //CHECK-NEXT:         clad::push(_t1, ret);
 //CHECK-NEXT:         ret += arr[i];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_ret += _d_y;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -604,16 +580,12 @@ int main() {
 //CHECK-NEXT: }
 
 // CHECK: void helper_pullback(float x, float _d_y, float *_d_x) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     *_d_x += 2 * _d_y;
 // CHECK-NEXT: }
 
 //CHECK: void inv_square_pullback(double *params, double _d_y, double *_d_params) {
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     _t0 = (params[0] * params[0]);
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = _d_y * -(1 / (_t0 * _t0));
 //CHECK-NEXT:         _d_params[0] += _r0 * params[0];
@@ -622,8 +594,6 @@ int main() {
 //CHECK-NEXT: }
 
 //CHECK: void helper2_pullback(double i, double *arr, int n, double _d_y, double *_d_i, double *_d_arr, int *_d_n) {
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_arr[0] += _d_y * i;
 //CHECK-NEXT:         *_d_i += arr[0] * _d_y;
@@ -646,8 +616,6 @@ int main() {
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     _t0 = elem;
 //CHECK-NEXT:     elem = elem * elem;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_elem += _d_y;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         elem = _t0;

--- a/test/Arrays/Arrays.C
+++ b/test/Arrays/Arrays.C
@@ -96,8 +96,6 @@ double const_dot_product(double x, double y, double z) {
 //CHECK-NEXT:       double _d_consts[3] = {0};
 //CHECK-NEXT:       double vars[3] = {x, y, z};
 //CHECK-NEXT:       double consts[3] = {1, 2, 3};
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_vars[0] += 1 * consts[0];
 //CHECK-NEXT:           _d_consts[0] += vars[0] * 1;
@@ -177,8 +175,6 @@ double const_matmul_sum(double a, double b, double c, double d) {
 //:       _t15 = A[1][1];
 //:       _t14 = B[1][1];
 //:       double C[2][2] = {{[{][{]}}_t1 * _t0 + _t3 * _t2, _t5 * _t4 + _t7 * _t6}, {_t9 * _t8 + _t11 * _t10, _t13 * _t12 + _t15 * _t14}};
-//:       goto _label0;
-//:     _label0:
 //:       {
 //:           _d_C[0][0] += 1;
 //:           _d_C[0][1] += 1;

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -54,8 +54,6 @@ __device__ __host__ double gauss(double* x, double* p, double sigma, int dim) {
 //CHECK-NEXT:     _t6 = std::pow(2 * 3.1415926535897931, -dim / 2.);
 //CHECK-NEXT:     _t5 = std::pow(sigma, -0.5);
 //CHECK-NEXT:     _t4 = std::exp(t);
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r1 = 0;
 //CHECK-NEXT:         double _r2 = 0;

--- a/test/Enzyme/DifferentCladEnzymeDerivatives.C
+++ b/test/Enzyme/DifferentCladEnzymeDerivatives.C
@@ -11,8 +11,6 @@ double foo(double x, double y){
 }
 
 // CHECK: void foo_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_x += 1 * y;
 // CHECK-NEXT:         *_d_y += x * 1;

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -19,8 +19,6 @@ float func(float x, float y) {
 //CHECK-NEXT:     x = x + y;
 //CHECK-NEXT:     _t1 = y;
 //CHECK-NEXT:     y = x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_y += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t1;
@@ -49,8 +47,6 @@ float func2(float x, int y) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = y * x + x * x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
@@ -74,8 +70,6 @@ float func3(int x, int y) {
 //CHECK-NEXT:     int _t0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_y += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
@@ -97,8 +91,6 @@ float func4(float x, float y) {
 //CHECK-NEXT:     double z = y;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = z + y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
@@ -125,8 +117,6 @@ float func5(float x, float y) {
 //CHECK-NEXT:     int z = 56;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = z + y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
@@ -143,8 +133,6 @@ float func5(float x, float y) {
 float func6(float x) { return x; }
 
 //CHECK: void func6_grad(float x, float *_d_x, double &_final_error) {
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT: }
@@ -154,8 +142,6 @@ float func7(float x, float y) { return (x * y); }
 //CHECK: void func7_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _ret_value0 = (x * y);
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += 1 * y;
 //CHECK-NEXT:         *_d_y += x * 1;
@@ -174,8 +160,6 @@ float func8(int x, int y) {
 //CHECK-NEXT:     int _t0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = y * y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -22,8 +22,6 @@ float func(float x, float y) {
 //CHECK-NEXT:     _t1 = y;
 //CHECK-NEXT:     y = y + y++ + y;
 //CHECK-NEXT:     float z = y * x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _final_error += std::abs(_d_z * z * {{.+}});
@@ -67,8 +65,6 @@ float func2(float x, float y) {
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = x - y - y * y;
 //CHECK-NEXT:     float z = y / x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _final_error += std::abs(_d_z * z * {{.+}});
@@ -111,8 +107,6 @@ float func3(float x, float y) {
 //CHECK-NEXT:     _t2 = y;
 //CHECK-NEXT:     _t1 = (y = x + x);
 //CHECK-NEXT:     float t = x * z * _t1;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_t += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _final_error += std::abs(_d_t * t * {{.+}});
@@ -147,8 +141,6 @@ float func4(float x, float y) { return std::pow(x, y); }
 //CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _ret_value0 = std::pow(x, y);
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r0 = 0;
 //CHECK-NEXT:         float _r1 = 0;
@@ -173,8 +165,6 @@ float func5(float x, float y) {
 //CHECK-NEXT:     _t0 = y;
 //CHECK-NEXT:     y = std::sin(x);
 //CHECK-NEXT:     _ret_value0 = y * y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_y += 1 * y;
 //CHECK-NEXT:         *_d_y += y * 1;
@@ -199,8 +189,6 @@ double helper(double x, double y) { return x * y; }
 //CHECK: void helper_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y, double &_final_error) {
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _ret_value0 = x * y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += _d_y0 * y;
 //CHECK-NEXT:         *_d_y += x * _d_y0;
@@ -220,8 +208,6 @@ float func6(float x, float y) {
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     float z = helper(x, y);
 //CHECK-NEXT:     _ret_value0 = z * z;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_z += 1 * z;
 //CHECK-NEXT:         _d_z += z * 1;
@@ -248,8 +234,6 @@ float func7(float x) {
 //CHECK: void func7_grad(float x, float *_d_x, double &_final_error) {
 //CHECK-NEXT:     int _d_z = 0;
 //CHECK-NEXT:     int z = x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_z += 1;
 //CHECK-NEXT:         _d_z += 1;
@@ -264,8 +248,6 @@ double helper2(float& x) { return x * x; }
 //CHECK: void helper2_pullback(float &x, double _d_y, float *_d_x, double &_final_error) {
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _ret_value0 = x * x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += _d_y * x;
 //CHECK-NEXT:         *_d_x += x * _d_y;
@@ -287,8 +269,6 @@ float func8(float x, float y) {
 //CHECK-NEXT:     _t0 = z;
 //CHECK-NEXT:     _t1 = x;
 //CHECK-NEXT:     z = y + helper2(x);
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         z = _t0;
@@ -327,8 +307,6 @@ float func9(float x, float y) {
 //CHECK-NEXT:     _t8 = y;
 //CHECK-NEXT:     _t4 = helper2(y);
 //CHECK-NEXT:     z += _t7 * _t4;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         z = _t3;

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -39,8 +39,6 @@ float func(float x, float y) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _ret_value0 = x + y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += 1;
 //CHECK-NEXT:         *_d_y += 1;
@@ -131,8 +129,6 @@ float func3(float x, float y) { return x > 30 ? x * y : x + y; }
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _cond0 = x > 30;
 //CHECK-NEXT:     _ret_value0 = _cond0 ? x * y : x + y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         *_d_x += 1 * y;
 //CHECK-NEXT:         *_d_y += x * 1;
@@ -162,8 +158,6 @@ float func4(float x, float y) {
 //CHECK-NEXT:         _t1 = x;
 //CHECK-NEXT:     _cond0 ? (x += 1) : (x *= x);
 //CHECK-NEXT:     _ret_value0 = y / x;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_y += 1 / x;
 //CHECK-NEXT:         float _r0 = 1 * -(y / (x * x));

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -28,8 +28,6 @@ float func(float* p, int n) {
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += p[i];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -74,8 +72,6 @@ float func2(float x) {
 //CHECK-NEXT:         clad::push(_t2, z);
 //CHECK-NEXT:         z = m + m;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -118,8 +114,6 @@ float func3(float x, float y) {
 //CHECK-NEXT:     arr[1] = x * x;
 //CHECK-NEXT:     _t2 = arr[2];
 //CHECK-NEXT:     arr[2] = arr[0] + arr[1];
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_arr[2] += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _final_error += std::abs(_d_arr[2] * arr[2] * {{.+}});
@@ -176,8 +170,6 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:         clad::push(_t2, sum);
 //CHECK-NEXT:         sum += x[i];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -229,8 +221,6 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:     _t2 = output[2];
 //CHECK-NEXT:     output[2] = x[0] * y[1] - y[0] * x[1];
 //CHECK-NEXT:     _ret_value0 = output[0] + output[1] + output[2];
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_output[0] += 1;
 //CHECK-NEXT:         output_size = std::max(output_size, 0);

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -29,8 +29,6 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += f[i] + f[i - 1];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -82,8 +80,6 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:             sum += a[i] * b[j];
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -137,8 +133,6 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += a[i] / b[i];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -102,8 +102,6 @@ float f7(float x) {
 void f7_grad(float x, float *_d_x);
 
 // CHECK: void f7_grad(float x, float *_d_x) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;
@@ -125,8 +123,6 @@ double f8(float x) {
 void f8_grad(float x, float *_d_x);
 
 // CHECK: void f8_grad(float x, float *_d_x) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         int _r1 = 0;
@@ -149,8 +145,6 @@ float f9(float x, float y) {
 void f9_grad(float x, float y, float *_d_x, float *_d_y);
 
 // CHECK: void f9_grad(float x, float y, float *_d_x, float *_d_y) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         float _r1 = 0;
@@ -174,8 +168,6 @@ double f10(float x, int y) {
 void f10_grad(float x, int y, float *_d_x, int *_d_y);
 
 // CHECK: void f10_grad(float x, int y, float *_d_x, int *_d_y) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         int _r1 = 0;
@@ -192,8 +184,6 @@ double f11(double x, double y) {
 // CHECK: void f11_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     typename {{.*}} _t0;
 // CHECK-NEXT:     _t0 = std::pow(y - std::pow(x, 2), 2);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         int _r1 = 0;

--- a/test/FirstDerivative/UnsupportedOpsWarn.C
+++ b/test/FirstDerivative/UnsupportedOpsWarn.C
@@ -20,9 +20,6 @@ int binOpWarn_1(int x){
 }
 
 // CHECK: void binOpWarn_1_grad(int x, int *_d_x) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
-// CHECK-NEXT:     ;
 // CHECK-NEXT: }
 
 int unOpWarn_0(int x){

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -17,8 +17,6 @@ double f1(double x, double y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       x = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t0;
@@ -45,8 +43,6 @@ double f2(double x, double y) {
 //CHECK-NEXT:               x = y;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       *_d_x += 1;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           x = _t0;
@@ -78,8 +74,6 @@ double f3(double x, double y) {
 //CHECK-NEXT:       y = x * x;
 //CHECK-NEXT:       _t3 = x;
 //CHECK-NEXT:       x = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t3;
@@ -123,8 +117,6 @@ double f4(double x, double y) {
 //CHECK-NEXT:       y = x;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       x = 0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t1;
@@ -178,8 +170,6 @@ double f5(double x, double y) {
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label1;
-//CHECK-NEXT:     _label1:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           {
@@ -245,8 +235,6 @@ double f6(double x, double y) {
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label1;
-//CHECK-NEXT:     _label1:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           {
@@ -317,8 +305,6 @@ double f7(double x, double y) {
 //CHECK-NEXT:       t[0] -= t[1];
 //CHECK-NEXT:       _t6 = x;
 //CHECK-NEXT:       x = ++t[0];
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t[0] += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t6;
@@ -393,8 +379,6 @@ double f8(double x, double y) {
 //CHECK-NEXT:       _t2 = t[0];
 //CHECK-NEXT:       _t3 = t[1];
 //CHECK-NEXT:       t[3] = (y *= (t[0] = t[1] = t[2]));
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:       _label0:
 //CHECK-NEXT:       _d_t[3] += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[3] = _t0;
@@ -436,8 +420,6 @@ double f9(double x, double y) {
 //CHECK-NEXT:       double &_t1 = (t *= x);
 //CHECK-NEXT:       _t2 = t;
 //CHECK-NEXT:       _t1 *= y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:       _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t2;
@@ -468,8 +450,6 @@ double f10(double x, double y) {
 //CHECK-NEXT:       _t0 = t;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       t = x = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:       _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t0;
@@ -499,8 +479,6 @@ double f11(double x, double y) {
 //CHECK-NEXT:       double &_t1 = (t = x);
 //CHECK-NEXT:       _t2 = t;
 //CHECK-NEXT:       _t1 = y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:       _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t2;
@@ -538,8 +516,6 @@ double f12(double x, double y) {
 //CHECK-NEXT:       _t3 = t;
 //CHECK-NEXT:       _t4 = t;
 //CHECK-NEXT:       _t2 *= y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:       _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t3;
@@ -574,8 +550,6 @@ double f13(double x, double y) {
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       _t0 = (y = x);
 //CHECK-NEXT:       double t = x * _t0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:       _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_t += 1 * y;
 //CHECK-NEXT:           *_d_y += t * 1;
@@ -611,8 +585,6 @@ double f14(double i, double j) {
 // CHECK-NEXT:     a += i;
 // CHECK-NEXT:     _t2 = a;
 // CHECK-NEXT:     a *= i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:     _label0:
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t2;
@@ -670,8 +642,6 @@ double f15(double i, double j) {
 // CHECK-NEXT:     c += 3 * i;
 // CHECK-NEXT:     _t3 = d;
 // CHECK-NEXT:     d *= 3 * j;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_a += 1;
 // CHECK-NEXT:         *_d_c += 1;
@@ -728,8 +698,6 @@ double f16(double i, double j) {
 // CHECK-NEXT:     double &c = b;
 // CHECK-NEXT:     _t0 = c;
 // CHECK-NEXT:     c *= 4 * j;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:     _label0:
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         c = _t0;
@@ -751,8 +719,6 @@ double f17(double i, double j, double k) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     _t0 = j;
 // CHECK-NEXT:     j = 2 * i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:     _label0:
 // CHECK-NEXT:     _d_j += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         j = _t0;
@@ -776,8 +742,6 @@ double f18(double i, double j, double k) {
 // CHECK-NEXT:     k = 2 * i + 2 * j;
 // CHECK-NEXT:     _t1 = k;
 // CHECK-NEXT:     k += i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:     _label0:
 // CHECK-NEXT:     _d_k += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         k = _t1;
@@ -798,8 +762,6 @@ double f19(double a, double b) {
 }
 
 //CHECK: void f19_grad(double a, double b, double *_d_a, double *_d_b) {
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0;
 //CHECK-NEXT:         double _r1 = 0;
@@ -828,8 +790,6 @@ double f20(double x, double y) {
 //CHECK-NEXT:     r = 3;
 //CHECK-NEXT:     _t1 = x;
 //CHECK-NEXT:     x = r * y;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t1;
@@ -854,8 +814,6 @@ double f21 (double x, double y) {
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     _t0 = y;
 //CHECK-NEXT:     y = (y++ , x);
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_y += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t0;

--- a/test/Gradient/DiffInterface.C
+++ b/test/Gradient/DiffInterface.C
@@ -15,8 +15,6 @@ double f_1(double x, double y, double z) {
 
 // all
 //CHECK:   void f_1_grad(double x, double y, double z, double *_d_x, double *_d_y, double *_d_z) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 0 * 1;
 //CHECK-NEXT:           *_d_y += 1 * 1;
@@ -28,8 +26,6 @@ double f_1(double x, double y, double z) {
 //CHECK:   void f_1_grad_0(double x, double y, double z, double *_d_x) {
 //CHECK-NEXT:       double _d_y = 0;
 //CHECK-NEXT:       double _d_z = 0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 0 * 1;
 //CHECK-NEXT:           _d_y += 1 * 1;
@@ -41,8 +37,6 @@ double f_1(double x, double y, double z) {
 //CHECK:   void f_1_grad_1(double x, double y, double z, double *_d_y) {
 //CHECK-NEXT:       double _d_x = 0;
 //CHECK-NEXT:       double _d_z = 0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_x += 0 * 1;
 //CHECK-NEXT:           *_d_y += 1 * 1;
@@ -54,8 +48,6 @@ double f_1(double x, double y, double z) {
 //CHECK:   void f_1_grad_2(double x, double y, double z, double *_d_z) {
 //CHECK-NEXT:       double _d_x = 0;
 //CHECK-NEXT:       double _d_y = 0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_x += 0 * 1;
 //CHECK-NEXT:           _d_y += 1 * 1;
@@ -66,8 +58,6 @@ double f_1(double x, double y, double z) {
 // x, y
 //CHECK:   void f_1_grad_0_1(double x, double y, double z, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_z = 0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 0 * 1;
 //CHECK-NEXT:           *_d_y += 1 * 1;
@@ -78,8 +68,6 @@ double f_1(double x, double y, double z) {
 // y, z
 //CHECK:   void f_1_grad_1_2(double x, double y, double z, double *_d_y, double *_d_z) {
 //CHECK-NEXT:       double _d_x = 0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_x += 0 * 1;
 //CHECK-NEXT:           *_d_y += 1 * 1;

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -27,8 +27,6 @@ double fn1(float i) {
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     float res = A::constantFn(i);
 // CHECK-NEXT:     double a = res * i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_res += _d_a * i;
@@ -74,8 +72,6 @@ double fn2(double i, double j) {
 // CHECK-NEXT:     _t4 = i;
 // CHECK-NEXT:     _t5 = j;
 // CHECK-NEXT:     temp = modify1(i, j);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         temp = _t3;
@@ -119,8 +115,6 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     _t2 = i;
 // CHECK-NEXT:     _t3 = j;
 // CHECK-NEXT:     update1(i, j);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         i = _t2;
@@ -179,8 +173,6 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:         clad::push(_t3, res);
 // CHECK-NEXT:         res += arr[i];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t1; _t1--) {
 // CHECK-NEXT:         --i;
@@ -219,8 +211,6 @@ double fn5(double* arr, int n) {
 // CHECK: void fn5_grad(double *arr, int n, double *_d_arr, int *_d_n) {
 // CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double temp = modify2(arr);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_arr[0] += 1;
 // CHECK-NEXT:     modify2_pullback(arr, _d_temp, _d_arr);
 // CHECK-NEXT: }
@@ -249,8 +239,6 @@ double fn7(double i, double j) {
 }
 
 // CHECK: void fn6_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += 1 * j;
 // CHECK-NEXT:         *_d_j += i * 1;
@@ -280,8 +268,6 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     k += 7 * j;
 // CHECK-NEXT:     _t5 = l;
 // CHECK-NEXT:     l += 9 * i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += 1;
 // CHECK-NEXT:         *_d_j += 1;
@@ -325,8 +311,6 @@ double fn8(double x, double y) {
 // CHECK-NEXT:     _t2 = check_and_return(x, 'a', "aa");
 // CHECK-NEXT:     _t1 = std::tanh(1.);
 // CHECK-NEXT:     _t0 = std::max(1., 2.);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         char _r1 = 0;
@@ -349,8 +333,6 @@ double fn9(double x, double y) {
 // CHECK:void fn9_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:    double _t0;
 // CHECK-NEXT:    _t0 = y;
-// CHECK-NEXT:    goto _label0;
-// CHECK-NEXT:  _label0:
 // CHECK-NEXT:    {
 // CHECK-NEXT:        y = _t0;
 // CHECK-NEXT:        double _r0 = 0;
@@ -386,8 +368,6 @@ double fn10(double x, double y) {
 // CHECK-NEXT:    _t4 = out;
 // CHECK-NEXT:    _t5 = out;
 // CHECK-NEXT:    out = std::clamp(out, 3., 7.);
-// CHECK-NEXT:    goto _label0;
-// CHECK-NEXT:  _label0:
 // CHECK-NEXT:    {
 // CHECK-NEXT:        _d_out += 1 * y;
 // CHECK-NEXT:        *_d_y += out * 1;
@@ -450,8 +430,6 @@ double fn11(double x, double y) {
 // CHECK-NEXT:    double _t1;
 // CHECK-NEXT:    _t0 = x;
 // CHECK-NEXT:    _t1 = y;
-// CHECK-NEXT:    goto _label0;
-// CHECK-NEXT:  _label0:
 // CHECK-NEXT:    {
 // CHECK-NEXT:        x = _t0;
 // CHECK-NEXT:        y = _t1;
@@ -470,8 +448,6 @@ double fn12(double x, double y) {
 }
 
 // CHECK: void fn12_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     do_nothing_pullback(&x, nullptr, 0, 1, &*_d_x, nullptr, 0);
 // CHECK-NEXT: }
 
@@ -500,8 +476,6 @@ double fn13(double* x, const double* w) {
 // CHECK-NEXT:         clad::push(_t1, wCopy[i]);
 // CHECK-NEXT:         wCopy[i] = w[i];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     multiply_pullback(x, wCopy + 1, 1, _d_x, _d_wCopy + 1);
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
@@ -526,8 +500,6 @@ double fn14(double x, double y) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     _t0 = x;
 // CHECK-NEXT:     emptyFn(x, y);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_x += 1;
 // CHECK-NEXT:         *_d_y += 1;
@@ -549,8 +521,6 @@ double fn15(double x, double y) {
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     _t0 = y;
 //CHECK-NEXT:     A::constantFn(y += x);
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_y += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t0;
@@ -572,8 +542,6 @@ double fn16(double x, double y) {
 }
 
 //CHECK: void fn16_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0;
 //CHECK-NEXT:         double _r1 = 0;
@@ -605,8 +573,6 @@ double fn17 (double x, double* y) {
 //CHECK-NEXT:     x = add(x, y);
 //CHECK-NEXT:     _t1 = x;
 //CHECK-NEXT:     x = add(x, &x);
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t1;
@@ -635,8 +601,6 @@ double fn18(double x, double y) {
 }
 
 // CHECK: void fn18_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         sq_defined_later_pullback(x, 1, &_r0);
@@ -661,8 +625,6 @@ double fn19(double x) {
 }
 
 // CHECK: void fn19_grad(double x, double *_d_x) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         templated_fn_pullback(x, 1, &_r0);
@@ -683,8 +645,6 @@ double fn20(double* x, const double* w) {
 
 // CHECK: void fn20_grad_0(double *x, const double *w, double *_d_x) {
 // CHECK-NEXT:     const double *auxW = w + 1;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     weighted_sum_pullback(x, auxW, 1, _d_x);
 // CHECK-NEXT: }
 
@@ -705,8 +665,6 @@ double fn21(double x) {
 // CHECK-NEXT:     _d_ptr = &*_d_x;
 // CHECK-NEXT:     double *ptr = &x;
 // CHECK-NEXT:     _t0 = ptr;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         ptr = _t0;
 // CHECK-NEXT:         ptrRef_pullback(_t0, 1, &_d_ptr);
@@ -826,9 +784,6 @@ double sq_defined_later(double x) {
 }
 
 // CHECK: void constantFn_pullback(float i, float _d_y, float *_d_i) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
-// CHECK-NEXT:     ;
 // CHECK-NEXT: }
 
 // CHECK: void modify1_pullback(double &i, double &j, double _d_y, double *_d_i, double *_d_j) {
@@ -840,8 +795,6 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:     _t1 = j;
 // CHECK-NEXT:     j += j;
 // CHECK-NEXT:     double res = i + j;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += _d_res;
@@ -894,8 +847,6 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _t2 = arr[0];
 // CHECK-NEXT:     arr[0] += 10 * arr[0];
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         arr[0] = _t2;
@@ -926,9 +877,6 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     _t0 = arr[0];
 // CHECK-NEXT:     arr[0] = 5 * arr[0] + arr[1];
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
-// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         arr[0] = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_arr[0];
@@ -945,8 +893,6 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:     double _d_i0 = i;
 // CHECK-NEXT:     _t0 = _d_i0;
 // CHECK-NEXT:     _d_i0 += 1;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     *_d_i += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_i0 = _t0;
@@ -972,9 +918,6 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:     if (_cond0)
 // CHECK-NEXT:         goto _label0;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label1;
-// CHECK-NEXT:   _label1:
-// CHECK-NEXT:     ;
 // CHECK-NEXT:     if (_cond0)
 // CHECK-NEXT:       _label0:
 // CHECK-NEXT:         *_d_x += _d_y;
@@ -983,8 +926,6 @@ double sq_defined_later(double x) {
 // CHECK: void custom_max_pullback(const double &a, const double &b, double _d_y, double *_d_a, double *_d_b) {
 // CHECK-NEXT:     bool _cond0;
 // CHECK-NEXT:     _cond0 = a > b;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     if (_cond0)
 // CHECK-NEXT:         *_d_a += _d_y;
 // CHECK-NEXT:     else
@@ -992,14 +933,10 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: void do_nothing_pullback(double *u, double *v, double *w, double _d_y, double *_d_u, double *_d_v, double *_d_w) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_u[0] += _d_y;
 // CHECK-NEXT: }
 
 // CHECK: void multiply_pullback(double *a, double *b, double _d_y, double *_d_a, double *_d_b) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_a[0] += _d_y * b[0];
 // CHECK-NEXT:         _d_b[0] += a[0] * _d_y;
@@ -1011,13 +948,11 @@ double sq_defined_later(double x) {
 
 //CHECK: void recFun_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     bool _cond0;
-//CHECK-NEXT:    {
+//CHECK-NEXT:     {
 //CHECK-NEXT:     _cond0 = x > y;
 //CHECK-NEXT:     if (_cond0)
 //CHECK-NEXT:         goto _label0;
-//CHECK-NEXT:    }
-//CHECK-NEXT:     goto _label1;
-//CHECK-NEXT:   _label1:
+//CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += _d_y0 * y;
 //CHECK-NEXT:         *_d_y += x * _d_y0;
@@ -1034,14 +969,10 @@ double sq_defined_later(double x) {
 //CHECK-NEXT: }
 
 //CHECK: void add_pullback(double a, double *b, double _d_y, double *_d_a) {
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     *_d_a += _d_y;
 //CHECK-NEXT: }
 
 //CHECK: void add_pullback(double a, double *b, double _d_y, double *_d_a, double *_d_b) {
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_a += _d_y;
 //CHECK-NEXT:         _d_b[0] += _d_y;
@@ -1049,8 +980,6 @@ double sq_defined_later(double x) {
 //CHECK-NEXT: }
 
 // CHECK: void sq_defined_later_pullback(double x, double _d_y, double *_d_x) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:       *_d_x += _d_y * x;
 // CHECK-NEXT:       *_d_x += x * _d_y;
@@ -1058,14 +987,10 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: void templated_fn_pullback(double x, double _d_y, double *_d_x) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     *_d_x += _d_y;
 // CHECK-NEXT: }
 
 // CHECK: void weighted_sum_pullback(double *x, const double *w, double _d_y, double *_d_x) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_x[0] += w[0] * _d_y;
 // CHECK-NEXT:         _d_x[1] += w[1] * _d_y;
@@ -1073,7 +998,5 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: void ptrRef_pullback(double *&ptr_ref, double _d_y, double **_d_ptr_ref) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     **_d_ptr_ref += _d_y;
 // CHECK-NEXT: }

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -15,8 +15,6 @@ struct Experiment {
   Experiment& operator=(const Experiment& E) = default;
 
   // CHECK: void operator_call_grad(double i, double j, Experiment *_d_this, double *_d_i, double *_d_j) {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
   // CHECK-NEXT:         *_d_i += this->x * 1 * j;
@@ -33,8 +31,6 @@ struct ExperimentConst {
 
   ExperimentConst& operator=(const ExperimentConst& E) = default;
   // CHECK: void operator_call_grad(double i, double j, ExperimentConst *_d_this, double *_d_i, double *_d_j) const {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
   // CHECK-NEXT:         *_d_i += this->x * 1 * j;
@@ -59,8 +55,6 @@ struct ExperimentVolatile {
   // CHECK: void operator_call_grad(double i, double j, volatile ExperimentVolatile *_d_this, double *_d_i, double *_d_j) volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = this->x * i;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
   // CHECK-NEXT:         *_d_i += this->x * 1 * j;
@@ -85,8 +79,6 @@ struct ExperimentConstVolatile {
   // CHECK: void operator_call_grad(double i, double j, volatile ExperimentConstVolatile *_d_this, double *_d_i, double *_d_j) const volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = this->x * i;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
   // CHECK-NEXT:         *_d_i += this->x * 1 * j;
@@ -106,8 +98,6 @@ struct ExperimentNNS {
   ExperimentNNS& operator=(const ExperimentNNS& E) = default;
 
   // CHECK: void operator_call_grad(double i, double j, outer::inner::ExperimentNNS *_d_this, double *_d_i, double *_d_j) {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
   // CHECK-NEXT:         *_d_i += this->x * 1 * j;
@@ -170,8 +160,6 @@ int main() {
   auto lambda = [](double i, double j) { return i * i * j; };
 
   // CHECK: inline void operator_call_grad(double i, double j, double *_d_i, double *_d_j) const {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         *_d_i += 1 * j * i;
   // CHECK-NEXT:         *_d_i += i * 1 * j;
@@ -182,8 +170,6 @@ int main() {
   auto lambdaWithCapture = [&](double ii, double j) { return x * ii * j; };
 
   // CHECK: inline void operator_call_grad(double ii, double j, double *_d_ii, double *_d_j) const {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         *_d_ii += x * 1 * j;
   // CHECK-NEXT:         *_d_j += x * ii * 1;
@@ -243,8 +229,6 @@ int main() {
   // CHECK-NEXT:     Experiment _t0;
   // CHECK-NEXT:     Experiment E(3, 5);
   // CHECK-NEXT:     _t0 = E;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0;
   // CHECK-NEXT:         double _r1 = 0;
@@ -263,8 +247,6 @@ int main() {
   // CHECK: void FunctorAsArg_grad(Experiment fn, double i, double j, Experiment *_d_fn, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     Experiment _t0;
   // CHECK-NEXT:     _t0 = fn;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0;
   // CHECK-NEXT:         double _r1 = 0;
@@ -286,8 +268,6 @@ int main() {
   // CHECK: void FunctorAsArgWrapper_grad(double i, double j, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     Experiment _d_E({});
   // CHECK-NEXT:     Experiment E(3, 5);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:     _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         Experiment _r0 = {};
   // CHECK-NEXT:         double _r1 = 0;
@@ -308,8 +288,6 @@ int main() {
 // CHECK: void FunctorAsArg_pullback(Experiment fn, double i, double j, double _d_y, Experiment *_d_fn, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     Experiment _t0;
 // CHECK-NEXT:     _t0 = fn;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:     _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -17,8 +17,6 @@ __attribute__((always_inline)) double f_add1(double x, double y) {
 }
 
 //CHECK: {{[__attribute__((always_inline))]*}}void f_add1_grad(double x, double y, double *_d_x, double *_d_y){{[ __attribute__((always_inline))]*}} {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 1;
 //CHECK-NEXT:           *_d_y += 1;
@@ -32,8 +30,6 @@ double f_add2(double x, double y) {
 }
 
 //CHECK:   void f_add2_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 3 * 1;
 //CHECK-NEXT:           *_d_y += 4 * 1;
@@ -47,8 +43,6 @@ double f_add3(double x, double y) {
 }
 
 //CHECK:   void f_add3_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 3 * 1;
 //CHECK-NEXT:           *_d_y += 4 * 1 * 4;
@@ -62,8 +56,6 @@ double f_sub1(double x, double y) {
 }
 
 //CHECK:   void f_sub1_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 1;
 //CHECK-NEXT:           *_d_y += -1;
@@ -76,8 +68,6 @@ double f_sub2(double x, double y) {
 }
 
 //CHECK:   void f_sub2_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 3 * 1;
 //CHECK-NEXT:           *_d_y += 4 * -1;
@@ -91,8 +81,6 @@ double f_mult1(double x, double y) {
 }
 
 //CHECK:   void f_mult1_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 1 * y;
 //CHECK-NEXT:           *_d_y += x * 1;
@@ -106,8 +94,6 @@ double f_mult2(double x, double y) {
 }
 
 //CHECK:   void f_mult2_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 3 * 1 * y * 4;
 //CHECK-NEXT:           *_d_y += 3 * x * 4 * 1;
@@ -121,8 +107,6 @@ double f_div1(double x, double y) {
 }
 
 //CHECK:   void f_div1_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 1 / y;
 //CHECK-NEXT:           double _r0 = 1 * -(x / (y * y));
@@ -139,8 +123,6 @@ double f_div2(double x, double y) {
 //CHECK:   void f_div2_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       _t0 = (4 * y);
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 3 * 1 / _t0;
 //CHECK-NEXT:           double _r0 = 1 * -(3 * x / (_t0 * _t0));
@@ -161,8 +143,6 @@ double f_div3(double x, double y) {
 //CHECK-NEXT:     _t1 = x;
 //CHECK-NEXT:     _t2 = (x = y);
 //CHECK-NEXT:     _t0 = (y * y);
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += 1 / _t0;
 //CHECK-NEXT:         x = _t1;
@@ -182,8 +162,6 @@ double f_c(double x, double y) {
 }
 
 //CHECK:   void f_c_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += -1 * y;
 //CHECK-NEXT:           *_d_y += -x * 1;
@@ -204,8 +182,6 @@ double f_rosenbrock(double x, double y) {
 }
 
 //CHECK:   void f_rosenbrock_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 1 * (x - 1);
 //CHECK-NEXT:           *_d_x += (x - 1) * 1;
@@ -227,8 +203,6 @@ double f_cond1(double x, double y) {
 //CHECK:   void f_cond1_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       _cond0 = x > y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:           *_d_x += 1;
 //CHECK-NEXT:       else
@@ -249,8 +223,6 @@ double f_cond2(double x, double y) {
 //CHECK-NEXT:           ;
 //CHECK-NEXT:       else
 //CHECK-NEXT:           _cond1 = y > 0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:           *_d_x += 1;
 //CHECK-NEXT:       else if (_cond1)
@@ -268,8 +240,6 @@ double f_cond3(double x, double c) {
 //CHECK:   void f_cond3_grad(double x, double c, double *_d_x, double *_d_c) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       _cond0 = c > 0;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           *_d_x += 1;
 //CHECK-NEXT:           *_d_c += 1;
@@ -304,8 +274,6 @@ double f_cond4(double x, double y) {
 //CHECK-NEXT:           y = arr[i] * x;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           {
@@ -395,8 +363,6 @@ struct S {
   }
 
   //CHECK:   void f_grad(double x, double y, S *_d_this, double *_d_x, double *_d_y) {
-  //CHECK-NEXT:       goto _label0;
-  //CHECK-NEXT:     _label0:
   //CHECK-NEXT:       {
   //CHECK-NEXT:           (*_d_this).c1 += 1 * x;
   //CHECK-NEXT:           *_d_x += this->c1 * 1;
@@ -446,8 +412,6 @@ void f_norm_grad(double x,
                  double* _d_z,
                  double* _d_d);
 //CHECK:   void f_norm_grad(double x, double y, double z, double d, double *_d_x, double *_d_y, double *_d_z, double *_d_d) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 0;
 //CHECK-NEXT:           double _r5 = 0;
@@ -474,8 +438,6 @@ void f_sin_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK:   void f_sin_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       _t0 = (std::sin(x) + std::sin(y));
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 0;
 //CHECK-NEXT:           _r0 += 1 * (x + y) * clad::custom_derivatives::sin_pushforward(x, 1.).pushforward;
@@ -499,8 +461,6 @@ void f_types_grad(int x,
                   float *_d_y,
                   double *_d_z);
 //CHECK:   void f_types_grad(int x, float y, double z, int *_d_x, float *_d_y, double *_d_z) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 1;
 //CHECK-NEXT:           *_d_y += 1;
@@ -523,8 +483,6 @@ void f_decls1_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK-NEXT:       double a = 3 * x;
 //CHECK-NEXT:       double b = 5 * y;
 //CHECK-NEXT:       double c = a + b;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_c += 2 * 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += _d_c;
@@ -549,8 +507,6 @@ void f_decls2_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK-NEXT:       double a = x * x;
 //CHECK-NEXT:       double b = x * y;
 //CHECK-NEXT:       double c = y * y;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += 1;
 //CHECK-NEXT:           _d_b += 2 * 1;
@@ -601,8 +557,6 @@ void f_decls3_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       double b = a * a;
-//CHECK-NEXT:       goto _label2;
-//CHECK-NEXT:     _label2:
 //CHECK-NEXT:       _d_b += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += _d_b * a;
@@ -627,8 +581,6 @@ void f_issue138_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK:   void f_issue138_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d__t1 = 0;
 //CHECK-NEXT:       double _t10 = 1;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 1 * x * x * x;
 //CHECK-NEXT:           *_d_x += x * 1 * x * x;
@@ -647,8 +599,6 @@ double f_const(const double a, const double b) {
 
 void f_const_grad(const double a, const double b, double *_d_a, double *_d_b);
 //CHECK:   void f_const_grad(const double a, const double b, double *_d_a, double *_d_b) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_a += 1 * b;
 //CHECK-NEXT:           *_d_b += a * 1;
@@ -670,8 +620,6 @@ void f_const_reference_grad(double i, double j, double *_d_i, double *_d_j);
 //CHECK-NEXT:    _d_ar = &_d_a;
 //CHECK-NEXT:    const double &ar = a;
 //CHECK-NEXT:    double res = 2 * ar;
-//CHECK-NEXT:    goto _label0;
-//CHECK-NEXT:  _label0:
 //CHECK-NEXT:    _d_res += 1;
 //CHECK-NEXT:    *_d_ar += 2 * _d_res;
 //CHECK-NEXT:    *_d_i += _d_a;
@@ -687,8 +635,6 @@ void f_const02_grad(double i, double j, double *_d_i, double *_d_j);
 //CHECK-NEXT:       double _d_res = 0;
 //CHECK-NEXT:       const double a = i;
 //CHECK-NEXT:       double res = a;
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_res += 1;
 //CHECK-NEXT:       _d_a += _d_res;
 //CHECK-NEXT:       *_d_i += _d_a;
@@ -712,8 +658,6 @@ float running_sum(float* p, int n) {
 // CHECK-NEXT:         clad::push(_t1, p[i]);
 // CHECK-NEXT:         p[i] += p[i - 1];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_p[n - 1] += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
@@ -735,8 +679,6 @@ double fn_global_var_use(double i, double j) {
 // CHECK: void fn_global_var_use_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_ref = 0;
 // CHECK-NEXT:     double &ref = global;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_ref += 1 * i;
 // CHECK-NEXT:         *_d_i += ref * 1;
@@ -754,8 +696,6 @@ void fn_increment_in_return_grad(double i, double j, double *_d_i, double *_d_j)
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double temp = i;
 // CHECK-NEXT:     _t0 = ++i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += 1 * temp;
 // CHECK-NEXT:         --i;
@@ -778,8 +718,6 @@ double fn_template_non_type(double x) {
 // CHECK-NEXT:     const size_t maxN = 53;
 // CHECK-NEXT:     _cond0 = maxN < {{15U|15UL}};
 // CHECK-NEXT:     const size_t m = _cond0 ? maxN : {{15U|15UL}};
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     *_d_x += 1 * m;
 // CHECK-NEXT:     if (_cond0)
 // CHECK-NEXT:         _d_maxN += _d_m;
@@ -790,8 +728,6 @@ double fn_div(double x) {
 }
 
 // CHECK: void fn_div_grad(double x, double *_d_x) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:   {
 // CHECK-NEXT:       double _r0 = 1 * -(-0.5 / (x * x));
 // CHECK-NEXT:       *_d_x += _r0;
@@ -816,8 +752,6 @@ double fn_cond_decl(double x, double y) {
 //CHECK-NEXT:                if (_cond0)
 //CHECK-NEXT:                    goto _label0;
 //CHECK-NEXT:            }
-//CHECK-NEXT:            goto _label1;
-//CHECK-NEXT:          _label1:
 //CHECK-NEXT:            {
 //CHECK-NEXT:                *_d_x += 1 * x;
 //CHECK-NEXT:                *_d_x += x * 1;
@@ -854,8 +788,6 @@ double fn_cond_side_eff(double x) {
 //CHECK-NEXT:                     goto _label0;
 //CHECK-NEXT:                 }
 //CHECK-NEXT:             }
-//CHECK-NEXT:             goto _label1;
-//CHECK-NEXT:           _label1:
 //CHECK-NEXT:             *_d_x += 1;
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 if (_cond0) {
@@ -888,8 +820,6 @@ double fn_cond_init(double x) {
 //CHECK-NEXT:                      goto _label0;
 //CHECK-NEXT:                  }
 //CHECK-NEXT:              }
-//CHECK-NEXT:              goto _label1;
-//CHECK-NEXT:            _label1:
 //CHECK-NEXT:              *_d_x += 1;
 //CHECK-NEXT:              if (_cond0) {
 //CHECK-NEXT:                _label0:
@@ -920,8 +850,6 @@ double fn_const_cond_op(double x) {
 //CHECK:               void fn_const_cond_op_grad(double x, double *_d_x) {
 //CHECK-NEXT:              bool _cond0;
 //CHECK-NEXT:              _cond0 = x > 0;
-//CHECK-NEXT:              goto _label0;
-//CHECK-NEXT:            _label0:
 //CHECK-NEXT:              *_d_x += 1;
 //CHECK-NEXT:          }
 

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -29,8 +29,6 @@ double f1(double x) {
 //CHECK-NEXT:           clad::push(_t1, t);
 //CHECK-NEXT:           t *= x;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           i--;
@@ -71,8 +69,6 @@ double f2(double x) {
 //CHECK-NEXT:               t *= x;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           i--;
@@ -121,8 +117,6 @@ double f3(double x) {
 //CHECK-NEXT:                   goto _label0;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label1;
-//CHECK-NEXT:     _label1:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           i--;
@@ -161,8 +155,6 @@ double f4(double x) {
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           i++;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           {
@@ -191,8 +183,6 @@ double f5(double x){
 //CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           x++;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       *_d_x += 1;
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           i--;
@@ -226,8 +216,6 @@ double f_const_local(double x) {
 //CHECK-NEXT:        clad::push(_t2, res);
 //CHECK-NEXT:        res += x * n;
 //CHECK-NEXT:    }
-//CHECK-NEXT:    goto _label0;
-//CHECK-NEXT:  _label0:
 //CHECK-NEXT:    _d_res += 1;
 //CHECK-NEXT:    for (; _t0; _t0--) {
 //CHECK-NEXT:        --i;
@@ -267,8 +255,6 @@ double f_sum(double *p, int n) {
 //CHECK-NEXT:         clad::push(_t1, s);
 //CHECK-NEXT:         s += p[i];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_s += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -302,8 +288,6 @@ double f_sum_squares(double *p, int n) {
 //CHECK-NEXT:         clad::push(_t1, s);
 //CHECK-NEXT:         s += sq(p[i]);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     _d_s += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
@@ -354,8 +338,6 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 //CHECK-NEXT:     _t6 = std::sqrt(_t7 * sigma);
 //CHECK-NEXT:     _t5 = std::exp(power);
 //CHECK-NEXT:     double gaus = 1. / _t6 * _t5;
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r8 = 0;
 //CHECK-NEXT:         _r8 += 1 * clad::custom_derivatives::log_pushforward(gaus, 1.).pushforward;
@@ -421,8 +403,6 @@ void f_const_grad(const double, const double, double*, double*);
 //CHECK-NEXT:           clad::push(_t2, r);
 //CHECK-NEXT:           r += sq0;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       _d_r += 1;
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           i--;
@@ -475,8 +455,6 @@ double f6 (double i, double j) {
 // CHECK-NEXT:         clad::push(_t4, a);
 // CHECK-NEXT:         a += b + c + i;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --counter;
@@ -529,8 +507,6 @@ double fn7(double i, double j) {
 // CHECK-NEXT:             clad::push(_t1, a);
 // CHECK-NEXT:             a += i * i + j;
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -574,8 +550,6 @@ double fn8(double i, double j) {
 // CHECK-NEXT:                 a += i * i + j;
 // CHECK-NEXT:             } while (--counter);
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -639,8 +613,6 @@ double fn9(double i, double j) {
 // CHECK-NEXT:                     a += i * i + j;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t2)
 // CHECK-NEXT:         {
@@ -714,8 +686,6 @@ double fn10(double i, double j) {
 // CHECK-NEXT:             clad::push(_t4, counter);
 // CHECK-NEXT:             counter -= 1;
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -772,8 +742,6 @@ double fn11(double i, double j) {
 // CHECK-NEXT:         clad::push(_t2, counter);
 // CHECK-NEXT:         counter -= 1;
 // CHECK-NEXT:     } while (counter);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         {
@@ -846,8 +814,6 @@ double fn12(double i, double j) {
 // CHECK-NEXT:         clad::push(_t7, counter);
 // CHECK-NEXT:         counter -= 1;
 // CHECK-NEXT:     } while (counter);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         {
@@ -929,8 +895,6 @@ double fn13(double i, double j) {
 // CHECK-NEXT:         clad::push(_t5, res);
 // CHECK-NEXT:         res += temp;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
@@ -1036,8 +1000,6 @@ double fn14(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:             clad::push(_t2, {{4U|4UL}});
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -1161,8 +1123,6 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             clad::push(_t1, {{2U|2UL}});
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -1277,8 +1237,6 @@ double fn16(double i, double j) {
 // CHECK-NEXT:         res += i + j;
 // CHECK-NEXT:         clad::push(_t2, {{3U|3UL}});
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--)
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
@@ -1394,8 +1352,6 @@ double fn17(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:         clad::push(_t2, {{2U|2UL}});
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--)
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
@@ -1504,8 +1460,6 @@ double fn18(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         clad::push(_t2, {{3U|3UL}});
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--)
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
@@ -1567,8 +1521,6 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:         clad::push(_t3, res);
 // CHECK-NEXT:         res += *ref;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
@@ -1610,8 +1562,6 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:         clad::push(_t2, sum);
 // CHECK-NEXT:         sum += x * x * interval;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         for (; _t0; _t0--) {
@@ -1662,8 +1612,6 @@ double fn20(double *arr, int n) {
 // CHECK-NEXT:         clad::push(_t2, arr[i]);
 // CHECK-NEXT:         res += (arr[i] *= 5);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
@@ -1706,8 +1654,6 @@ double fn21(double x) {
 // CHECK-NEXT:         clad::push(_t2, res);
 // CHECK-NEXT:         res += arr[0] + arr[1];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
@@ -1754,8 +1700,6 @@ double fn22(double param) {
 // CHECK-NEXT:        clad::push(_t3, arr[0]);
 // CHECK-NEXT:        out += clad::back(_t3) * param;
 // CHECK-NEXT:    }
-// CHECK-NEXT:    goto _label0;
-// CHECK-NEXT:  _label0:
 // CHECK-NEXT:    _d_out += 1;
 // CHECK-NEXT:    for (; _t0; _t0--) {
 // CHECK-NEXT:        i--;
@@ -1848,8 +1792,6 @@ int main() {
 }
 
 //CHECK:   void sq_pullback(double x, double _d_y, double *_d_x) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += _d_y * x;
 //CHECK-NEXT:           *_d_x += x * _d_y;

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -23,8 +23,6 @@ public:
   double mem_fn(double i, double j) { return (x + y) * i + i * j; }
 
   // CHECK: void mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -37,8 +35,6 @@ public:
   double const_mem_fn(double i, double j) const { return (x + y) * i + i * j; }
 
   // CHECK: void const_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -55,8 +51,6 @@ public:
   // CHECK: void volatile_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -73,8 +67,6 @@ public:
   // CHECK: void const_volatile_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -87,8 +79,6 @@ public:
   double lval_ref_mem_fn(double i, double j) & { return (x + y) * i + i * j; }
 
   // CHECK: void lval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) & {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -103,8 +93,6 @@ public:
   }
 
   // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const & {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -121,8 +109,6 @@ public:
   // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -139,8 +125,6 @@ public:
   // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -153,8 +137,6 @@ public:
   double rval_ref_mem_fn(double i, double j) && { return (x + y) * i + i * j; }
 
   // CHECK: void rval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) && {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -169,8 +151,6 @@ public:
   }
 
   // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const && {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -187,8 +167,6 @@ public:
   // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -205,8 +183,6 @@ public:
   // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -221,8 +197,6 @@ public:
   }
 
   // CHECK: void noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) noexcept {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -237,8 +211,6 @@ public:
   }
 
   // CHECK: void const_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const noexcept {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -255,8 +227,6 @@ public:
   // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -273,8 +243,6 @@ public:
   // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -289,8 +257,6 @@ public:
   }
 
   // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) & noexcept {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -305,8 +271,6 @@ public:
   }
 
   // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const & noexcept {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -323,8 +287,6 @@ public:
   // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -341,8 +303,6 @@ public:
   // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -357,8 +317,6 @@ public:
   }
 
   // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) && noexcept {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -373,8 +331,6 @@ public:
   }
 
   // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const && noexcept {
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -391,8 +347,6 @@ public:
   // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -409,8 +363,6 @@ public:
   // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -424,8 +376,6 @@ public:
 
   // CHECK: void partial_mem_fn_grad_0(double i, double j, SimpleFunctions *_d_this, double *_d_i) {
   // CHECK-NEXT:     double _d_j = 0;
-  // CHECK-NEXT:     goto _label0;
-  // CHECK-NEXT:   _label0:
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -481,8 +431,6 @@ double fn(double i,double j) {
 }
 
 // CHECK: void fn_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += 1 * j * i;
 // CHECK-NEXT:         *_d_i += i * 1 * j;
@@ -502,8 +450,6 @@ double fn2(SimpleFunctions& sf, double i) {
 // CHECK-NEXT:     SimpleFunctions _t0;
 // CHECK-NEXT:     _t0 = sf;
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = _t0.ref_mem_fn_forw(i, &(*_d_sf), nullptr);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         _t0.ref_mem_fn_pullback(i, 1, &(*_d_sf), &_r0);
@@ -529,8 +475,6 @@ double fn5(SimpleFunctions& v, double value) {
 // CHECK-NEXT:     SimpleFunctions _t0;
 // CHECK-NEXT:     _t0 = v;
 // CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = _t0.operator_plus_equal_forw(value, &(*_d_v), nullptr);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
@@ -552,8 +496,6 @@ double fn4(SimpleFunctions& v) {
 // CHECK-NEXT:     SimpleFunctions _t0;
 // CHECK-NEXT:     _t0 = v;
 // CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = _t0.operator_plus_plus_forw(&(*_d_v));
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     _t0.operator_plus_plus_pullback({}, &(*_d_v));
 // CHECK-NEXT: }
@@ -613,8 +555,6 @@ int main() {
   // CHECK-NEXT:       double _d_j = 0;
   // CHECK-NEXT:       double _t0;
   // CHECK-NEXT:       _t0 = (this->x + this->y);
-  // CHECK-NEXT:       goto _label0;
-  // CHECK-NEXT:       _label0:
   // CHECK-NEXT:       {
   // CHECK-NEXT:           (*_d_this).x += 1 * i;
   // CHECK-NEXT:           (*_d_this).y += 1 * i;
@@ -630,8 +570,6 @@ int main() {
   // CHECK-NEXT:       double _d_i = 0;
   // CHECK-NEXT:       double _t0;
   // CHECK-NEXT:       _t0 = (this->x + this->y);
-  // CHECK-NEXT:       goto _label0;
-  // CHECK-NEXT:       _label0:
   // CHECK-NEXT:       {
   // CHECK-NEXT:           (*_d_this).x += 1 * i;
   // CHECK-NEXT:           (*_d_this).y += 1 * i;
@@ -653,8 +591,6 @@ int main() {
 // CHECK-NEXT:     SimpleFunctions _t0;
 // CHECK-NEXT:     SimpleFunctions sf(x, y);
 // CHECK-NEXT:     _t0 = sf;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;
@@ -671,8 +607,6 @@ int main() {
 // CHECK-NEXT:     this->x = +i;
 // CHECK-NEXT:     _t1 = this->x;
 // CHECK-NEXT:     this->x = -i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     (*_d_this).x += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t1;
@@ -702,9 +636,6 @@ int main() {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     _t0 = this->x;
 // CHECK-NEXT:     this->x += value;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
-// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t0;
 // CHECK-NEXT:         double _r_d0 = (*_d_this).x;
@@ -723,9 +654,6 @@ int main() {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     _t0 = this->x;
 // CHECK-NEXT:     this->x += 1.;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
-// CHECK-NEXT:     ;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t0;
 // CHECK-NEXT:         double _r_d0 = (*_d_this).x;

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -12,8 +12,6 @@ double nonMemFn(double i) {
   return i*i;
 }
 // CHECK: void nonMemFn_grad(double i, double *_d_i) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += 1 * i;
 // CHECK-NEXT:         *_d_i += i * 1;
@@ -33,8 +31,6 @@ double minimalPointer(double x) {
 // CHECK-NEXT:     double *const p = &x;
 // CHECK-NEXT:     _t0 = *p;
 // CHECK-NEXT:     *p = *p * (*p);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     *_d_p += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *p = _t0;
@@ -107,8 +103,6 @@ double arrayPointer(const double* arr) {
 // CHECK-NEXT:     p = p - 2;
 // CHECK-NEXT:     _t11 = sum;
 // CHECK-NEXT:     sum += 5 * (*p);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         sum = _t11;
@@ -194,8 +188,6 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:         _d_arr = _d_arr + 1;
 // CHECK-NEXT:         arr = arr + 1;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
@@ -270,8 +262,6 @@ double pointerMultipleParams(const double* a, const double* b) {
 // CHECK-NEXT:     --a;
 // CHECK-NEXT:     _t7 = sum;
 // CHECK-NEXT:     sum += a[0] + b[0];
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         sum = _t7;
@@ -367,8 +357,6 @@ double newAndDeletePointer(double i, double j) {
 // CHECK-NEXT:     _t1 = r[1];
 // CHECK-NEXT:     r[1] = i * j;
 // CHECK-NEXT:     double sum = *p + *q + r[0] + r[1];
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_p += _d_sum;
@@ -418,8 +406,6 @@ double structPointer (double x) {
 // CHECK-NEXT:     _d_t = new T();
 // CHECK-NEXT:     T *t = new T({x, /*implicit*/(int)0});
 // CHECK-NEXT:     double res = t->x;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     _d_t->x += _d_res;
 // CHECK-NEXT:     *_d_x += *_d_t.x;
@@ -472,8 +458,6 @@ double cStyleMemoryAlloc(double x, size_t n) {
 // CHECK-NEXT:     p[1] = 2 * x;
 // CHECK-NEXT:     _t5 = res;
 // CHECK-NEXT:     res += p[1];
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t5;

--- a/test/Gradient/Switch.C
+++ b/test/Gradient/Switch.C
@@ -61,8 +61,6 @@ double fn1(double i, double j) {
 // CHECK-NEXT:             clad::push(_t1, {{2U|2UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t1)) {
@@ -183,8 +181,6 @@ double fn2(double i, double j) {
 // CHECK-NEXT:             clad::push(_t3, {{3U|3UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t3)) {
@@ -314,8 +310,6 @@ double fn3(double i, double j) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
@@ -430,8 +424,6 @@ double fn4(double i, double j) {
 // CHECK-NEXT:             clad::push(_t1, {{3U|3UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t1)) {
@@ -499,8 +491,6 @@ double fn5(double i, double j) {
 // CHECK-NEXT:             clad::push(_t1, {{1U|1UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t1)) {
@@ -550,8 +540,6 @@ double fn6(double u, double v) {
 // CHECK-NEXT:             clad::push(_t2, {{1U|1UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
@@ -642,8 +630,6 @@ double fn7(double u, double v) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;

--- a/test/Gradient/SwitchInit.C
+++ b/test/Gradient/SwitchInit.C
@@ -60,8 +60,6 @@ double fn1(double i, double j) {
 // CHECK-NEXT:             clad::push(_t1, {{2U|2UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t1)) {

--- a/test/Gradient/TemplateFunctors.C
+++ b/test/Gradient/TemplateFunctors.C
@@ -15,8 +15,6 @@ template <typename T> struct Experiment {
 };
 
 // CHECK: void operator_call_grad(double i, double j, Experiment<double> *_d_this, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (*_d_this).x += 1 * i * i;
 // CHECK-NEXT:         *_d_i += this->x * 1 * i;
@@ -37,8 +35,6 @@ template <> struct Experiment<long double> {
 };
 
 // CHECK: void operator_call_grad(long double i, long double j, Experiment<long double>  *_d_this, long double  *_d_i, long double  *_d_j) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (*_d_this).x += 1 * j * i * i;
 // CHECK-NEXT:         *_d_i += this->x * 1 * j * i;
@@ -61,8 +57,6 @@ template <typename T> struct ExperimentConstVolatile {
 // CHECK: void operator_call_grad(double i, double j, volatile ExperimentConstVolatile<double> *_d_this, double *_d_i, double *_d_j) const volatile {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     _t0 = this->x * i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (*_d_this).x += 1 * i * i;
 // CHECK-NEXT:         *_d_i += this->x * 1 * i;
@@ -87,8 +81,6 @@ template <> struct ExperimentConstVolatile<long double> {
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     _t0 = this->x * i;
 // CHECK-NEXT:     _t1 = this->y * j;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (*_d_this).x += 1 * j * i * i;
 // CHECK-NEXT:         *_d_i += this->x * 1 * j * i;

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -29,8 +29,6 @@ void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a);
 // CHECK-NEXT:         clad::push(_t1, z);
 // CHECK-NEXT:         z = z * a;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     *_d_z += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -22,8 +22,6 @@ double fn1(pairdd p, double i) {
 // CHECK: void fn1_grad(pairdd p, double i, pairdd *_d_p, double *_d_i) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = p.first + 2 * p.second + 3 * i;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (*_d_p).first += _d_res;
@@ -80,8 +78,6 @@ double fn2(Tangent t, double i) {
 // CHECK-NEXT:     double res = sum(t);
 // CHECK-NEXT:     _t1 = res;
 // CHECK-NEXT:     res += sum(t.data) + i + 2 * t.data[0];
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t1;
@@ -114,8 +110,6 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     _t1 = t.data[1];
 // CHECK-NEXT:     t.data[1] = 5 * i + 3 * j;
 // CHECK-NEXT:     _t2 = t;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t = _t2;
 // CHECK-NEXT:         sum_pullback(_t2, 1, &_d_t);
@@ -146,8 +140,6 @@ double fn4(double i, double j) {
 // CHECK-NEXT:     pairdd _d_q({});
 // CHECK-NEXT:     pairdd p(1, 3);
 // CHECK-NEXT:     pairdd q({7, 5});
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_p.first += 1 * i;
 // CHECK-NEXT:         *_d_i += p.first * 1;
@@ -161,8 +153,6 @@ double fn4(double i, double j) {
 // CHECK-NEXT: }
 
 // CHECK: void someMemFn_grad(double i, double j, Tangent *_d_this, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (*_d_this).data[0] += 1 * i;
 // CHECK-NEXT:         *_d_i += this->data[0] * 1;
@@ -183,8 +173,6 @@ double fn5(const Tangent& t, double i) {
 // CHECK: void fn5_grad(const Tangent &t, double i, Tangent *_d_t, double *_d_i) {
 // CHECK-NEXT:     Tangent _t0;
 // CHECK-NEXT:     _t0 = t;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;
@@ -227,8 +215,6 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT:     _t6 = c;
 // CHECK-NEXT:     _t5 = c.real();
 // CHECK-NEXT:     res += 4 * _t5;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t4;
@@ -268,8 +254,6 @@ double fn7(dcomplex c1, dcomplex c2) {
 // CHECK-NEXT:     _t4 = c1;
 // CHECK-NEXT:     _t6 = c1;
 // CHECK-NEXT:     _t5 = c1.imag();
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t4.real_pullback(1, &(*_d_c1));
 // CHECK-NEXT:         _t6.imag_pullback(3 * 1, &(*_d_c1));
@@ -297,8 +281,6 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK-NEXT:     _t1 = t;
 // CHECK-NEXT:     t.updateTo(c.real());
 // CHECK-NEXT:     _t2 = t;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t = _t2;
 // CHECK-NEXT:         sum_pullback(_t2, 1, &(*_d_t));
@@ -342,8 +324,6 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     _t5 = res;
 // CHECK-NEXT:     _t6 = t;
 // CHECK-NEXT:     res += sum(t);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t5;
@@ -417,8 +397,6 @@ int main() {
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += t.data[i];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
@@ -441,8 +419,6 @@ int main() {
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += data[i];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
@@ -453,8 +429,6 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void someMemFn2_pullback(double i, double j, double _d_y, Tangent *_d_this, double *_d_i, double *_d_j) const {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (*_d_this).data[0] += _d_y * i;
 // CHECK-NEXT:         *_d_i += this->data[0] * _d_y;
@@ -477,14 +451,10 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: constexpr void real_pullback(double _d_y, std{{(::__1)?}}::complex<double> *_d_this){{.*}} {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {{(__real)?}} (*_d_this).{{.*}} += _d_y;
 // CHECK-NEXT: }
 
 // CHECK: constexpr void imag_pullback(double _d_y, std{{(::__1)?}}::complex<double> *_d_this){{.*}} {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {{(__imag)?}} (*_d_this).{{.*}} += _d_y;
 // CHECK-NEXT: }
 

--- a/test/Gradient/constexprTest.C
+++ b/test/Gradient/constexprTest.C
@@ -15,8 +15,6 @@ constexpr double mul (double a, double b, double c) {
 //CHECK: constexpr void mul_grad(double a, double b, double c, double *_d_a, double *_d_b, double *_d_c) {
 //CHECK-NEXT:    double _d_result = 0;
 //CHECK-NEXT:    double result = a * b * c;
-//CHECK-NEXT:    goto _label0;
-//CHECK-NEXT:  _label0:
 //CHECK-NEXT:    _d_result += 1;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        *_d_a += _d_result * c * b;
@@ -36,8 +34,6 @@ constexpr double fn( double a, double b, double c) {
 //CHECK-NEXT:    double _d_result = 0;
 //CHECK-NEXT:    double val = 98.;
 //CHECK-NEXT:    double result = a * b / c * (a + b) * 100 + c;
-//CHECK-NEXT:    goto _label0;
-//CHECK-NEXT:  _label0:
 //CHECK-NEXT:    _d_result += 1;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        *_d_a += _d_result * 100 * (a + b) / c * b;

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -134,8 +134,6 @@ int main() {
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x0);
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t10 = clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, _d_x0);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d__t0.pushforward += 1;
 // CHECK-NEXT:         _d__t1.pushforward += 1;
@@ -169,8 +167,6 @@ int main() {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, _d_x0);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
@@ -194,8 +190,6 @@ int main() {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::log_pushforward(x, _d_x0);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
@@ -219,8 +213,6 @@ int main() {
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 4.F, _d_x0, 0.F);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
@@ -244,8 +236,6 @@ int main() {
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(2.F, x, 0.F, _d_x0);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
@@ -272,8 +262,6 @@ int main() {
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     float _d_y0 = 0;
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y0);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
@@ -302,8 +290,6 @@ int main() {
 // CHECK-NEXT:     float _d_x0 = 0;
 // CHECK-NEXT:     float _d_y0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y0);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
@@ -321,8 +307,6 @@ int main() {
 // CHECK: void sin_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
 // CHECK-NEXT:     float _t0;
 // CHECK-NEXT:     _t0 = ::std::cos(x);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         _r0 += _d_y.value * clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, 1.F).pushforward;
@@ -337,8 +321,6 @@ int main() {
 // CHECK: void cos_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
 // CHECK-NEXT:     float _t0;
 // CHECK-NEXT:     _t0 = ::std::sin(x);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         _r0 += _d_y.value * clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, 1.F).pushforward;
@@ -353,8 +335,6 @@ int main() {
 // CHECK: void exp_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
 // CHECK-NEXT:     float _t0;
 // CHECK-NEXT:     _t0 = ::std::exp(x);
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         _r0 += _d_y.value * clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, 1.F).pushforward;
@@ -367,8 +347,6 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void log_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         _r0 += _d_y.value * clad::custom_derivatives{{(::std)?}}::log_pushforward(x, 1.F).pushforward;
@@ -399,8 +377,6 @@ int main() {
 // CHECK-NEXT:         derivative += (_t3 * _t2) * d_exponent;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_val += _d_y.value;
 // CHECK-NEXT:         _d_derivative += _d_y.pushforward;

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -223,8 +223,6 @@ int main() {
 //CHECK-NEXT:    double _d_b0 = 0;
 //CHECK-NEXT:    double _t00 = a * a;
 //CHECK-NEXT:    double _t10 = b * b;
-//CHECK-NEXT:    goto _label0;
-//CHECK-NEXT:  _label0:
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _d__d_a += 1 * a * a;
 //CHECK-NEXT:        *_d_a += _d_a0 * 1 * a;
@@ -260,8 +258,6 @@ int main() {
 //CHECK-NEXT:    double _d_b0 = 1;
 //CHECK-NEXT:    double _t00 = a * a;
 //CHECK-NEXT:    double _t10 = b * b;
-//CHECK-NEXT:    goto _label0;
-//CHECK-NEXT:  _label0:
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _d__d_a += 1 * a * a;
 //CHECK-NEXT:        *_d_a += _d_a0 * 1 * a;

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -51,8 +51,6 @@ double f2(double x, double y){
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
 // CHECK-NEXT:     double _d_ans = _t00.pushforward;
 // CHECK-NEXT:     double ans = _t00.value;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d__d_ans += 1;
 // CHECK-NEXT:     _d__t0.value += _d_ans0;
 // CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
@@ -89,8 +87,6 @@ double f2(double x, double y){
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
 // CHECK-NEXT:     double _d_ans = _t00.pushforward;
 // CHECK-NEXT:     double ans = _t00.value;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     _d__d_ans += 1;
 // CHECK-NEXT:     _d__t0.value += _d_ans0;
 // CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
@@ -112,8 +108,6 @@ double f2(double x, double y){
 // CHECK-NEXT: }
 
 // CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x, double *_d_y, double *_d__d_x, double *_d__d_y) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_x += _d_y0.value * x;
 // CHECK-NEXT:         *_d_x += x * _d_y0.value;

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -31,8 +31,6 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:     double _d__d_j = 0;
 // CHECK-NEXT:     double _d_i0 = 1;
 // CHECK-NEXT:     double _d_j0 = 0;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d__d_i += 1 * j;
 // CHECK-NEXT:         *_d_j += _d_i0 * 1;
@@ -52,8 +50,6 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:     double _d__d_j = 0;
 // CHECK-NEXT:     double _d_i0 = 0;
 // CHECK-NEXT:     double _d_j0 = 1;
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d__d_i += 1 * j;
 // CHECK-NEXT:         *_d_j += _d_i0 * 1;

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -184,8 +184,6 @@ int main() {
 }
 
 //CHECK: void multiply_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
-//CHECK-NEXT:    goto _label0;
-//CHECK-NEXT:  _label0:
 //CHECK-NEXT:    {
 //CHECK-NEXT:        *_d_x += _d_y0 * y;
 //CHECK-NEXT:        *_d_y += x * _d_y0;

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -119,8 +119,6 @@
 //CHECK_FLOAT_SUM:         clad::push(_t1, sum);
 //CHECK_FLOAT_SUM:         sum = sum + x;
 //CHECK_FLOAT_SUM:     }
-//CHECK_FLOAT_SUM:     goto _label0;
-//CHECK_FLOAT_SUM:   _label0:
 //CHECK_FLOAT_SUM:     _d_sum += 1;
 //CHECK_FLOAT_SUM:     for (; _t0; _t0--) {
 //CHECK_FLOAT_SUM:         i--;
@@ -156,8 +154,6 @@
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    _t0 = z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    z = x + y;
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:    goto _label0;
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:  _label0:
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    _d_z += 1;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    {
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        _final_error += _d_z * z;
@@ -190,8 +186,6 @@
 // CHECK_PRINT_MODEL_EXEC-NEXT:    float z;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    _t0 = z;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    z = x + y;
-// CHECK_PRINT_MODEL_EXEC-NEXT:    goto _label0;
-// CHECK_PRINT_MODEL_EXEC-NEXT:  _label0:
 // CHECK_PRINT_MODEL_EXEC-NEXT:    _d_z += 1;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    {
 // CHECK_PRINT_MODEL_EXEC-NEXT:        _final_error += clad::getErrorVal(_d_z, z, "z");
@@ -218,8 +212,6 @@
 //CHECK_GRADIENT_DESCENT-NEXT: void cost_grad(double theta_0, double theta_1, double x, double y, double *_d_theta_0, double *_d_theta_1, double *_d_x, double *_d_y) {
 //CHECK_GRADIENT_DESCENT-NEXT:     double _d_f_x = 0;
 //CHECK_GRADIENT_DESCENT-NEXT:     double f_x = f(theta_0, theta_1, x);
-//CHECK_GRADIENT_DESCENT-NEXT:     goto _label0;
-//CHECK_GRADIENT_DESCENT-NEXT:   _label0:
 //CHECK_GRADIENT_DESCENT-NEXT:     {
 //CHECK_GRADIENT_DESCENT-NEXT:         _d_f_x += 1 * (f_x - y);
 //CHECK_GRADIENT_DESCENT-NEXT:         *_d_y += -1 * (f_x - y);
@@ -238,8 +230,6 @@
 //CHECK_GRADIENT_DESCENT-NEXT: }
 
 //CHECK_GRADIENT_DESCENT: void f_pullback(double theta_0, double theta_1, double x, double _d_y, double *_d_theta_0, double *_d_theta_1, double *_d_x) {
-//CHECK_GRADIENT_DESCENT-NEXT:     goto _label0;
-//CHECK_GRADIENT_DESCENT-NEXT:   _label0:
 //CHECK_GRADIENT_DESCENT-NEXT:     {
 //CHECK_GRADIENT_DESCENT-NEXT:         *_d_theta_0 += _d_y;
 //CHECK_GRADIENT_DESCENT-NEXT:         *_d_theta_1 += _d_y * x;

--- a/test/NestedCalls/NestedCalls.C
+++ b/test/NestedCalls/NestedCalls.C
@@ -34,8 +34,6 @@ double f(double x, double y) {
 //CHECK:   void f_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = one(x);
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_t += 1 * y;
 //CHECK-NEXT:           *_d_y += t * 1;
@@ -71,8 +69,6 @@ int main () { // expected-no-diagnostics
 //CHECK:   void sq_pullback(double x, double _d_y, double *_d_x);
 
 //CHECK:   void one_pullback(double x, double _d_y, double *_d_x) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 0;
 //CHECK-NEXT:           sq_pullback(std::sin(x), _d_y, &_r0);
@@ -92,8 +88,6 @@ int main () { // expected-no-diagnostics
 // CHECK-NEXT: }
 
 //CHECK:   void sq_pullback(double x, double _d_y, double *_d_x) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += _d_y * x;
 //CHECK-NEXT:           *_d_x += x * _d_y;

--- a/test/NumericalDiff/GradientMultiArg.C
+++ b/test/NumericalDiff/GradientMultiArg.C
@@ -15,8 +15,6 @@ double test_1(double x, double y){
 }
 // CHECK: warning: Falling back to numerical differentiation for 'hypot' since no suitable overload was found and clad could not derive it. To disable this feature, compile your programs with -DCLAD_NO_NUM_DIFF.
 // CHECK: void test_1_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;

--- a/test/NumericalDiff/NoNumDiff.C
+++ b/test/NumericalDiff/NoNumDiff.C
@@ -16,8 +16,6 @@ double func(double x) { return std::tanh(x); }
 //CHECK-NEXT: }
 
 //CHECK: void func_grad(double x, double *_d_x) {
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0;
 //CHECK-NEXT:         *_d_x += _r0;

--- a/test/NumericalDiff/NumDiff.C
+++ b/test/NumericalDiff/NumDiff.C
@@ -12,8 +12,6 @@ double test_1(double x){
 //CHECK: warning: Falling back to numerical differentiation for 'log10' since no suitable overload was found and clad could not derive it. To disable this feature, compile your programs with -DCLAD_NO_NUM_DIFF.
 
 //CHECK: void test_1_grad(double x, double *_d_x) {
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0;
 //CHECK-NEXT:         _r0 += 1 * numerical_diff::forward_central_difference(tanh, x, 0, 0, x);
@@ -49,9 +47,6 @@ double test_3(double x) {
 //CHECK-NEXT:         goto _label0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     goto _label1;
-//CHECK-NEXT:   _label1:
-//CHECK-NEXT:     ;
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:       _label0:
 //CHECK-NEXT:         {

--- a/test/NumericalDiff/PrintErrorNumDiff.C
+++ b/test/NumericalDiff/PrintErrorNumDiff.C
@@ -17,8 +17,6 @@ double test_1(double x){
 
 //CHECK: warning: Falling back to numerical differentiation for 'tanh' since no suitable overload was found and clad could not derive it. To disable this feature, compile your programs with -DCLAD_NO_NUM_DIFF.
 //CHECK: void test_1_grad(double x, double *_d_x) {
-//CHECK-NEXT:     goto _label0;
-//CHECK-NEXT:   _label0:
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0;
 //CHECK-NEXT:         _r0 += 1 * numerical_diff::forward_central_difference(tanh, x, 0, 1, x);

--- a/test/ROOT/Interface.C
+++ b/test/ROOT/Interface.C
@@ -23,8 +23,6 @@ Double_t f(Double_t* x, Double_t* p) {
 void f_grad_1(Double_t* x, Double_t* p, Double_t *_d_p);
 
 // CHECK: void f_grad_1(Double_t *x, Double_t *p, Double_t *_d_p) {
-// CHECK-NEXT:     goto _label0;
-// CHECK-NEXT:   _label0:
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_p[0] += 1;
 // CHECK-NEXT:         _d_p[1] += x[0] * 1;

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -41,8 +41,6 @@ Double_t TFormula_example(Double_t* x, Double_t* p) {
 
 void TFormula_example_grad_1(Double_t* x, Double_t* p, Double_t* _d_p);
 //CHECK:   void TFormula_example_grad_1(Double_t *x, Double_t *p, Double_t *_d_p) {
-//CHECK-NEXT:       goto _label0;
-//CHECK-NEXT:     _label0:
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_p[0] += x[0] * 1;
 //CHECK-NEXT:           _d_p[1] += x[0] * 1;

--- a/unittests/Misc/CallDeclOnly.cpp
+++ b/unittests/Misc/CallDeclOnly.cpp
@@ -26,8 +26,6 @@ TEST(CallDeclOnly, CheckNumDiff) {
 void wrapper1_grad(double *params, double *_d_params) {
     double _d_ix = 0;
     const double ix = 1 + params[0];
-    goto _label0;
-  _label0:
     {
         double _r0 = 0;
         double _r1 = 0;

--- a/unittests/Misc/Defs.cpp
+++ b/unittests/Misc/Defs.cpp
@@ -14,12 +14,11 @@ clad::ValueAndPushforward<double, double> sq_pushforward(double x,
 void sq_pushforward_pullback(double x, double _dx,
                              clad::ValueAndPushforward<double, double> _d_y,
                              double* _d_x, double* _d__d_x) {
-  goto _label0;
-_label0: {
-  *_d_x += _d_y.value * x;
-  *_d_x += x * _d_y.value;
-  *_d_x += 2 * _d_y.pushforward;
-}
+  {
+    *_d_x += _d_y.value * x;
+    *_d_x += x * _d_y.value;
+    *_d_x += 2 * _d_y.pushforward;
+  }
 }
 } // namespace custom_derivatives
 } // namespace clad


### PR DESCRIPTION
This PR removes all pairs of goto/label statements with nothing in between:
```
goto _label0;
_label0:
```
Obviously, this bit of code doesn't do anything. Such cases make up the majority of goto uses in Clad. 
The idea in this PR is to check whether the corresponding return statement is the last statement in the function's body. If it is, there's no need to create a goto statement.
Before this PR, Clad tests contained 328 goto stmts, now they only contain 21.

Fixes #526.