### PR TITLE
Take StorageClass from the canonical decl when cloning functions

### DIFF
--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -101,32 +101,25 @@ static void registerDerivative(FunctionDecl* derivedFD, Sema& semaRef) {
     NamespaceDecl* enclosingNS = nullptr;
     if (isa<CXXMethodDecl>(FD)) {
       CXXRecordDecl* CXXRD = cast<CXXRecordDecl>(DC);
-      returnedFD = CXXMethodDecl::Create(m_Context, 
-                                         CXXRD, 
-                                         noLoc, 
-                                         name,
-                                         functionType, 
-                                         FD->getTypeSourceInfo(),
-                                         FD->getStorageClass()
-                                         CLAD_COMPAT_FunctionDecl_UsesFPIntrin_Param(FD),
-                                         FD->isInlineSpecified(),
-                                         clad_compat::Function_GetConstexprKind
-                                         (FD), noLoc);
+      returnedFD = CXXMethodDecl::Create(
+          m_Context, CXXRD, noLoc, name, functionType, FD->getTypeSourceInfo(),
+          FD->getCanonicalDecl()->getStorageClass()
+              CLAD_COMPAT_FunctionDecl_UsesFPIntrin_Param(FD),
+          FD->isInlineSpecified(), clad_compat::Function_GetConstexprKind(FD),
+          noLoc);
       returnedFD->setAccess(FD->getAccess());
     } else {
       assert (isa<FunctionDecl>(FD) && "Unexpected!");
       enclosingNS = VB.RebuildEnclosingNamespaces(DC);
-      returnedFD = FunctionDecl::Create(m_Context, 
-                                        m_Sema.CurContext, 
-                                        noLoc,
-                                        name, 
-                                        functionType,
-                                        FD->getTypeSourceInfo(),
-                                        FD->getStorageClass()
-                                        CLAD_COMPAT_FunctionDecl_UsesFPIntrin_Param(FD),
-                                        FD->isInlineSpecified(),
-                                        FD->hasWrittenPrototype(),
-                                        clad_compat::Function_GetConstexprKind(FD)CLAD_COMPAT_CLANG10_FunctionDecl_Create_ExtraParams(FD->getTrailingRequiresClause()));
+      returnedFD = FunctionDecl::Create(
+          m_Context, m_Sema.CurContext, noLoc, name, functionType,
+          FD->getTypeSourceInfo(),
+          FD->getCanonicalDecl()->getStorageClass()
+              CLAD_COMPAT_FunctionDecl_UsesFPIntrin_Param(FD),
+          FD->isInlineSpecified(), FD->hasWrittenPrototype(),
+          clad_compat::Function_GetConstexprKind(FD)
+              CLAD_COMPAT_CLANG10_FunctionDecl_Create_ExtraParams(
+                  FD->getTrailingRequiresClause()));
     } 
 
     for (const FunctionDecl* NFD : FD->redecls())

--- a/test/FirstDerivative/FunctionCalls.C
+++ b/test/FirstDerivative/FunctionCalls.C
@@ -162,6 +162,27 @@ double test_8(double x) {
 // CHECK-NEXT: return _t0.pushforward;
 // CHECK-NEXT: }
 
+class A {
+  public:
+  static double static_method(double x);
+};
+
+double A::static_method(double x) {
+  return x;
+}
+
+double test_9(double x) {
+  return A::static_method(x);
+}
+
+// CHECK: static clad::ValueAndPushforward<double, double> static_method_pushforward(double x, double _d_x);
+
+// CHECK: double test_9_darg0(double x) {
+// CHECK-NEXT: double _d_x = 1;
+// CHECK-NEXT: clad::ValueAndPushforward<double, double> _t0 = static_method_pushforward(x, _d_x);
+// CHECK-NEXT: return _t0.pushforward;
+// CHECK-NEXT: }
+
 int main () {
   clad::differentiate(test_1, 0);
   clad::differentiate(test_2, 0);
@@ -173,6 +194,7 @@ int main () {
   clad::differentiate(test_8, "x");
   clad::differentiate<clad::opts::enable_tbr>(test_8); // expected-error {{TBR analysis is not meant for forward mode AD.}}
   clad::differentiate<clad::opts::enable_tbr, clad::opts::disable_tbr>(test_8); // expected-error {{Both enable and disable TBR options are specified.}}
+  clad::differentiate(test_9);
   return 0;
 
 // CHECK: void increment_pushforward(int &i, int &_d_i) {
@@ -181,5 +203,9 @@ int main () {
 
 // CHECK: clad::ValueAndPushforward<double, double> func_with_enum_pushforward(double x, E e, double _d_x) {
 // CHECK-NEXT: return {x * x, _d_x * x + x * _d_x};
+// CHECK-NEXT: }
+
+// CHECK: static clad::ValueAndPushforward<double, double> static_method_pushforward(double x, double _d_x) {
+// CHECK-NEXT: return {x, _d_x};
 // CHECK-NEXT: }
 }


### PR DESCRIPTION
When cloning functions, we have to take the StorageClass from the canonical declaration of the function. This matters when dealing with out-of-line defined functions. For example, only the first definition might have some qualifiers. To see an example, look at #951.

Fixes #951