### PR TITLE
Don't synthesize 0 of the ArraySubscriptExpr type in forward mode

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -894,9 +894,9 @@ BaseForwardModeVisitor::VisitArraySubscriptExpr(const ArraySubscriptExpr* ASE) {
   std::transform(std::begin(Indices), std::end(Indices),
                  std::begin(clonedIndices),
                  [this](const Expr* E) { return Clone(E); });
-  auto cloned = BuildArraySubscript(clonedBase, clonedIndices);
+  Expr* cloned = BuildArraySubscript(clonedBase, clonedIndices);
 
-  auto zero = ConstantFolder::synthesizeLiteral(ExprTy, m_Context, 0);
+  Expr* zero = getZeroInit(ExprTy);
   ValueDecl* VD = nullptr;
   // Derived variables for member variables are also created when we are
   // differentiating a call operator.

--- a/test/Arrays/ArrayInputsForwardMode.C
+++ b/test/Arrays/ArrayInputsForwardMode.C
@@ -10,7 +10,7 @@ double multiply(const double *arr) {
 }
 
 //CHECK:   double multiply_darg0_1(const double *arr) {
-//CHECK-NEXT:       return 0. * arr[1] + arr[0] * 1.;
+//CHECK-NEXT:       return 0 * arr[1] + arr[0] * 1.;
 //CHECK-NEXT:   }
 
 double divide(const double *arr) {
@@ -18,7 +18,7 @@ double divide(const double *arr) {
 }
 
 //CHECK:   double divide_darg0_1(const double *arr) {
-//CHECK-NEXT:       return (0. * arr[1] - arr[0] * 1.) / (arr[1] * arr[1]);
+//CHECK-NEXT:       return (0 * arr[1] - arr[0] * 1.) / (arr[1] * arr[1]);
 //CHECK-NEXT:   }
 
 double addArr(const double *arr, int n) {

--- a/test/FirstDerivative/StructGlobalObjects.C
+++ b/test/FirstDerivative/StructGlobalObjects.C
@@ -37,7 +37,7 @@ double fn_array(double i, double j) {
 // CHECK-NEXT: double _d_j = 0;
 // CHECK-NEXT: double &_t0 = array.data[0];
 // CHECK-NEXT: double &_t1 = array.data[1];
-// CHECK-NEXT: return 0. * i + _t0 * _d_i + 0. * j + _t1 * _d_j;
+// CHECK-NEXT: return 0 * i + _t0 * _d_i + 0 * j + _t1 * _d_j;
 // CHECK-NEXT: }
 
 int main () {

--- a/test/ForwardMode/Functors.C
+++ b/test/ForwardMode/Functors.C
@@ -338,7 +338,7 @@ struct WidgetPointer {
   // CHECK-NEXT:       double &_t5 = this->arr[5];
   // CHECK-NEXT:       double &_t6 = this->arr[5];
   // CHECK-NEXT:       double &_t7 = this->j;
-  // CHECK-NEXT:       double _t8 = 0. * _t6 + _t5 * 0.;
+  // CHECK-NEXT:       double _t8 = 0 * _t6 + _t5 * 0;
   // CHECK-NEXT:       double _t9 = _t5 * _t6;
   // CHECK-NEXT:       _d_j = _d_j * _t9 + _t7 * _t8;
   // CHECK-NEXT:       _t7 *= _t9;
@@ -363,7 +363,7 @@ struct WidgetPointer {
   // CHECK-NEXT:       double &_t0 = this->arr[3];
   // CHECK-NEXT:       double &_t1 = this->arr[3];
   // CHECK-NEXT:       double &_t2 = this->i;
-  // CHECK-NEXT:       double _t3 = 0. * _t1 + _t0 * 0.;
+  // CHECK-NEXT:       double _t3 = 0 * _t1 + _t0 * 0;
   // CHECK-NEXT:       double _t4 = _t0 * _t1;
   // CHECK-NEXT:       _d_i = _d_i * _t4 + _t2 * _t3;
   // CHECK-NEXT:       _t2 *= _t4;

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -950,6 +950,21 @@ double fn17(A a, B b) {
 // CHECK-NEXT:     return _d_a.mem * _t1 + _t0 * _d_b.mem;
 // CHECK-NEXT: }
 
+double fn18(double i, double j) {
+  A v[2] = {2, 3};
+  v[0] = 9 * i;
+  return v[0].mem;
+}
+
+// CHECK: double fn18_darg0(double i, double j) {
+// CHECK-NEXT:     double _d_i = 1;
+// CHECK-NEXT:     double _d_j = 0;
+// CHECK-NEXT:     A _d_v[2] = {0, 0};
+// CHECK-NEXT:     A v[2] = {2, 3};
+// CHECK-NEXT:     clad::ValueAndPushforward<A &, A &> _t0 = v[0].operator_equal_pushforward(9 * i, &_d_v[0], 0 * i + 9 * _d_i);
+// CHECK-NEXT:     return _d_v[0].mem;
+// CHECK-NEXT: }
+
 template<unsigned N>
 void print(const Tensor<double, N>& t) {
   for (int i=0; i<N; ++i) {
@@ -977,6 +992,7 @@ int main() {
   INIT_DIFFERENTIATE(fn15, "u.first");
   INIT_DIFFERENTIATE(fn16, "v.second.second");
   INIT_DIFFERENTIATE(fn17, "b.mem");
+  INIT_DIFFERENTIATE(fn18, "i");
 
   TensorD5 t;
   t.updateTo(5);
@@ -999,6 +1015,7 @@ int main() {
   TEST_DIFFERENTIATE(fn15, pairdd(), pairdd());                   // CHECK-EXEC: {1.00}
   TEST_DIFFERENTIATE(fn16, pair_of_pairdd(), pair_of_pairdd());   // CHECK-EXEC: {2.00}
   TEST_DIFFERENTIATE(fn17, A(3.00), B(5.00));   // CHECK-EXEC: {3.00}
+  TEST_DIFFERENTIATE(fn18, 7, 3);   // CHECK-EXEC: {9.00}
 
 // CHECK: clad::ValueAndPushforward<double, double> sum_pushforward(Tensor<double, 5> *_d_this) {
 // CHECK-NEXT:     double _d_res = 0;

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -57,22 +57,22 @@ void TFormula_example_grad_1(Double_t* x, Double_t* p, Double_t* _d_p);
 //CHECK:   Double_t TFormula_example_darg1_0(Double_t *x, Double_t *p) {
 //CHECK-NEXT:       {{double|Double_t}} _t0 = (p[0] + p[1] + p[2]);
 //CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(-p[0], -1.);
-//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t2 = clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(p[1], 0.);
-//CHECK-NEXT:       return 0. * _t0 + x[0] * (1. + 0. + 0.) + _t1.pushforward + _t2.pushforward;
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t2 = clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(p[1], 0);
+//CHECK-NEXT:       return 0 * _t0 + x[0] * (1. + 0 + 0) + _t1.pushforward + _t2.pushforward;
 //CHECK-NEXT:   }
 
 //CHECK:   Double_t TFormula_example_darg1_1(Double_t *x, Double_t *p) {
 //CHECK-NEXT:       {{double|Double_t}} _t0 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(-p[0], -0.);
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(-p[0], -0);
 //CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t2 = clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(p[1], 1.);
-//CHECK-NEXT:       return 0. * _t0 + x[0] * (0. + 1. + 0.) + _t1.pushforward + _t2.pushforward;
+//CHECK-NEXT:       return 0 * _t0 + x[0] * (0 + 1. + 0) + _t1.pushforward + _t2.pushforward;
 //CHECK-NEXT:   }
 
 //CHECK:   Double_t TFormula_example_darg1_2(Double_t *x, Double_t *p) {
 //CHECK-NEXT:       {{double|Double_t}} _t0 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(-p[0], -0.);
-//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t2 = clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(p[1], 0.);
-//CHECK-NEXT:       return 0. * _t0 + x[0] * (0. + 0. + 1.) + _t1.pushforward + _t2.pushforward;
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(-p[0], -0);
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t2 = clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(p[1], 0);
+//CHECK-NEXT:       return 0 * _t0 + x[0] * (0 + 0 + 1.) + _t1.pushforward + _t2.pushforward;
 //CHECK-NEXT:   }
 
 Double_t TFormula_hess1(Double_t *x, Double_t *p) {


### PR DESCRIPTION
Currently, Clad can't differentiate ArraySubscriptExpr of non-numerical types. This happens because it attempts to synthesize a 0 of the same type, which is not always numerical. To avoid this error, we can use ``getZeroInit`` instead.
Here's a reproducer (it's added to the tests in this PR):
```
struct A {
  double mem;
  A(double p_mem = 0) : mem(p_mem) {}
};

double fn18(double i, double j) {
  A v[2] = {2, 3};
  v[0] = 9 * i;
  return v[0].mem;
}
```
Differentiating this in forward mode produces an error.

This bug arises when differentiating HepEmShow.