### PR TITLE
Simplify the reverse mode by having just one DiffMode for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,12 +337,12 @@ namespace custom_derivatives {
   double my_pow_darg1(dobule x, double y) { return my_pow(x, y) * std::log(x); }
 }
 ```
-You can also specify a custom gradient:
+You can also specify a custom pullback:
 ```cpp
 namespace custom_derivatives {
-  void my_pow_grad(double x, double y, array_ref<double> _d_x, array_ref<double> _d_y) {
+  void my_pow_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
      double t = my_pow(x, y - 1);
-     *_d_x = y * t;
+     *_d_x = y * t * _d_y0;
      *_d_y = x * t * std::log(x);
    }
 }

--- a/demos/ErrorEstimation/CustomModel/README.md
+++ b/demos/ErrorEstimation/CustomModel/README.md
@@ -42,13 +42,13 @@ clang++ -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang CLAD_INST/lib/cla
 To verify your results, you can build the dummy `test.cpp` file with the commands shown above. Once you compile and run the test file correctly, you will notice the generated code is as follows:
 
 ```cpp
-The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+The code is: void func_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
     float _d_z = 0;
     float _t0;
     float z;
     _t0 = z;
     z = x + y;
-    _d_z += 1;
+    _d_z += _d_y0;
     {
         *_final_error += _d_z * z;
         z = _t0;

--- a/demos/ErrorEstimation/CustomModel/README.md
+++ b/demos/ErrorEstimation/CustomModel/README.md
@@ -42,7 +42,7 @@ clang++ -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang CLAD_INST/lib/cla
 To verify your results, you can build the dummy `test.cpp` file with the commands shown above. Once you compile and run the test file correctly, you will notice the generated code is as follows:
 
 ```cpp
-The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
     float _d_z = 0;
     float _t0;
     float z;
@@ -50,18 +50,18 @@ The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double &
     z = x + y;
     _d_z += 1;
     {
-        _final_error += _d_z * z;
+        *_final_error += _d_z * z;
         z = _t0;
         float _r_d0 = _d_z;
         _d_z = 0;
         *_d_x += _r_d0;
         *_d_y += _r_d0;
     }
-    _final_error += *_d_x * x;
-    _final_error += *_d_y * y;
+    *_final_error += *_d_x * x;
+    *_final_error += *_d_y * y;
  }
 ```
 
-Here, notice that the result in the `_final_error` variable  now reflects the error expression defined in the custom model we just compiled!
+Here, notice that the result in the `*_final_error` variable  now reflects the error expression defined in the custom model we just compiled!
 
 This demo is also a runnable test under `CLAD_BASE/test/Misc/RunDemos.C` and will run as a part of the lit test suite. Thus, the same can be verified by running `make check-clad`.

--- a/demos/ErrorEstimation/FloatSum.cpp
+++ b/demos/ErrorEstimation/FloatSum.cpp
@@ -106,7 +106,7 @@ int main() {
     finalError = 0;
     unsigned int dn = 0;
     // First execute the derived function.
-    df.execute(x, n, &ret[0], &dn, finalError);
+    df.execute(x, n, &ret[0], &dn, &finalError);
 
     double kahanResult = kahanSum(x, n);
     double vanillaResult = vanillaSum(x, n);

--- a/demos/ErrorEstimation/PrintModel/README.md
+++ b/demos/ErrorEstimation/PrintModel/README.md
@@ -41,7 +41,7 @@ clang++ -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang CLAD_INST/lib/cla
 To verify your results, you can build the dummy `test.cpp` file with the commands shown above. Once you compile and run the test file correctly, you will notice the generated code is as follows:
 
 ```cpp
-The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
     float _d_z = 0;
     float _t0;
     float z;
@@ -49,18 +49,18 @@ The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double &
     z = x + y;
     _d_z += 1;
     {
-        _final_error += _d_z * z;
+        *_final_error += _d_z * z;
         z = _t0;
         float _r_d0 = _d_z;
         _d_z = 0;
         *_d_x += _r_d0;
         *_d_y += _r_d0;
     }
-    _final_error += *_d_x * x;
-    _final_error += *_d_y * y;
+    *_final_error += *_d_x * x;
+    *_final_error += *_d_y * y;
  }
 ```
 
-Here, notice that the result in the `_final_error` variable  now reflects the error expression defined in the custom model we just compiled!
+Here, notice that the result in the `*_final_error` variable  now reflects the error expression defined in the custom model we just compiled!
 
 This demo is also a runnable test under `CLAD_BASE/test/Misc/RunDemos.C` and will run as a part of the lit test suite. Thus, the same can be verified by running `make check-clad`.

--- a/demos/ErrorEstimation/PrintModel/README.md
+++ b/demos/ErrorEstimation/PrintModel/README.md
@@ -41,13 +41,13 @@ clang++ -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang CLAD_INST/lib/cla
 To verify your results, you can build the dummy `test.cpp` file with the commands shown above. Once you compile and run the test file correctly, you will notice the generated code is as follows:
 
 ```cpp
-The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+The code is: void func_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
     float _d_z = 0;
     float _t0;
     float z;
     _t0 = z;
     z = x + y;
-    _d_z += 1;
+    _d_z += _d_y0;
     {
         *_final_error += _d_z * z;
         z = _t0;

--- a/demos/ErrorEstimation/PrintModel/test.cpp
+++ b/demos/ErrorEstimation/PrintModel/test.cpp
@@ -29,5 +29,5 @@ int main() {
   // Calculate the error
   float dx, dy; 
   double error;
-  df.execute(2, 3, &dx, &dy, error);
+  df.execute(2, 3, &dx, &dy, &error);
 }

--- a/demos/Jupyter/Intro.ipynb
+++ b/demos/Jupyter/Intro.ipynb
@@ -356,7 +356,7 @@
      "output_type": "stream",
      "text": [
       "The code is: \n",
-      "void fn_grad(double x, double y, double *_d_x, double *_d_y, double &_final_error) {\n",
+      "void fn_grad(double x, double y, double *_d_x, double *_d_y, double *_final_error) {\n",
       "    double _t2;\n",
       "    double _t3;\n",
       "    double _t4;\n",
@@ -390,7 +390,7 @@
       "    _delta_x += std::abs(*_d_x * x * 1.1920928955078125E-7);\n",
       "    double _delta_y = 0;\n",
       "    _delta_y += std::abs(*_d_y * y * 1.1920928955078125E-7);\n",
-      "    _final_error += _delta_y + _delta_x + std::abs(1. * _ret_value0 * 1.1920928955078125E-7);\n",
+      "    *_final_error += _delta_y + _delta_x + std::abs(1. * _ret_value0 * 1.1920928955078125E-7);\n",
       "}\n",
       "\n"
      ]

--- a/include/clad/Differentiator/DiffMode.h
+++ b/include/clad/Differentiator/DiffMode.h
@@ -7,7 +7,6 @@ enum class DiffMode {
   forward,
   vector_forward_mode,
   experimental_pushforward,
-  experimental_pullback,
   experimental_vector_pushforward,
   reverse,
   hessian,
@@ -26,8 +25,6 @@ inline const char* DiffModeToString(DiffMode mode) {
     return "vector_forward_mode";
   case DiffMode::experimental_pushforward:
     return "pushforward";
-  case DiffMode::experimental_pullback:
-    return "pullback";
   case DiffMode::experimental_vector_pushforward:
     return "vector_pushforward";
   case DiffMode::reverse:

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -482,8 +482,7 @@ namespace clad {
   // GradientDerivedEstFnTraits specializations for pure function pointer types
   template <class ReturnType, class... Args>
   struct GradientDerivedEstFnTraits<ReturnType (*)(Args...)> {
-    using type = void (*)(Args..., OutputParamType_t<Args, Args>...,
-                          double&);
+    using type = void (*)(Args..., OutputParamType_t<Args, void>..., void*);
   };
 
   /// These macro expansions are used to cover all possible cases of
@@ -495,12 +494,12 @@ namespace clad {
   /// qualifier and reference respectively. The AddNOEX adds cases for noexcept
   /// qualifier only if it is supported and finally AddSPECS declares the
   /// function with all the cases
-#define GradientDerivedEstFnTraits_AddSPECS(var, cv, vol, ref, noex)           \
-  template <typename R, typename C, typename... Args>                          \
-  struct GradientDerivedEstFnTraits<R (C::*)(Args...) cv vol ref noex> {       \
-    using type = void (C::*)(Args..., OutputParamType_t<Args, Args>...,           \
-                             double&) cv vol ref noex;                         \
-  };
+#define GradientDerivedEstFnTraits_AddSPECS(var, cv, vol, ref, noex)         \
+    template <typename R, typename C, typename... Args>                        \
+    struct GradientDerivedEstFnTraits<R (C::*)(Args...) cv vol ref noex> {     \
+      using type = void (C::*)(Args..., OutputParamType_t<Args, void>...,      \
+                               void*) cv vol ref noex;                         \
+    };
 
 #if __cpp_noexcept_function_type > 0
 #define GradientDerivedEstFnTraits_AddNOEX(var, con, vol, ref)                 \

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -385,8 +385,6 @@ namespace clad {
     /// y" will give 'f_grad_0_1' and "x, z" will give 'f_grad_0_2'.
     DerivativeAndOverload Derive(const clang::FunctionDecl* FD,
                                  const DiffRequest& request);
-    DerivativeAndOverload DerivePullback(const clang::FunctionDecl* FD,
-                                         const DiffRequest& request);
     StmtDiff VisitArraySubscriptExpr(const clang::ArraySubscriptExpr* ASE);
     StmtDiff VisitBinaryOperator(const clang::BinaryOperator* BinOp);
     StmtDiff VisitCallExpr(const clang::CallExpr* CE);

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -444,7 +444,7 @@ namespace clad {
     /// Builds an overload for the gradient function that has derived params for
     /// all the arguments of the requested function and it calls the original
     /// gradient function internally
-    clang::FunctionDecl* CreateGradientOverload();
+    clang::FunctionDecl* CreateGradientOverload(unsigned numExtraParams);
 
     /// Returns the type that should be used to represent the derivative of a
     /// variable of type `yType` with respect to a parameter variable of type

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -419,17 +419,13 @@ static void registerDerivative(FunctionDecl* derivedFD, Sema& semaRef) {
       result = V.DerivePushforward(FD, request);
     } else if (request.Mode == DiffMode::reverse) {
       ReverseModeVisitor V(*this, request);
-      if (request.CallUpdateRequired) {
-        result = V.Derive(FD, request);
-      } else {
-        if (!m_ErrorEstHandler.empty()) {
-          InitErrorEstimation(m_ErrorEstHandler, m_EstModel, *this, request);
-          V.AddExternalSource(*m_ErrorEstHandler.back());
-        }
-        result = V.DerivePullback(FD, request);
-        if (!m_ErrorEstHandler.empty())
-          CleanupErrorEstimation(m_ErrorEstHandler, m_EstModel);
+      if (!request.CallUpdateRequired && !m_ErrorEstHandler.empty()) {
+        InitErrorEstimation(m_ErrorEstHandler, m_EstModel, *this, request);
+        V.AddExternalSource(*m_ErrorEstHandler.back());
       }
+      result = V.Derive(FD, request);
+      if (!request.CallUpdateRequired && !m_ErrorEstHandler.empty())
+        CleanupErrorEstimation(m_ErrorEstHandler, m_EstModel);
     } else if (request.Mode == DiffMode::reverse_mode_forward_pass) {
       ReverseModeForwPassVisitor V(*this, request);
       result = V.Derive(FD, request);

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -275,9 +275,10 @@ namespace clad {
   }
 
   void DiffRequest::UpdateDiffParamsInfo(Sema& semaRef) {
-    // Diff info for pullbacks is generated automatically,
+    // Some Diff info is generated automatically,
     // its parameters are not provided by the user.
-    if (Mode == DiffMode::experimental_pullback) {
+    // Update parameters only if no DVI info is present.
+    if (Mode == DiffMode::reverse && !DVI.empty()) {
       // Might need to update DVI args, as they may be pointing to the
       // declaration parameters, not the definition parameters.
       if (!Function->getPreviousDecl())

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -285,7 +285,7 @@ void ErrorEstimationHandler::ActAfterCreatingDerivedFnParamTypes(
   // If we are performing error estimation, our gradient function
   // will have an extra argument which will hold the final error value
   paramTypes.push_back(
-      m_RMV->m_Context.getLValueReferenceType(m_RMV->m_Context.DoubleTy));
+      m_RMV->m_Context.getPointerType(m_RMV->m_Context.DoubleTy));
 }
 
 void ErrorEstimationHandler::ActAfterCreatingDerivedFnParams(
@@ -307,7 +307,8 @@ void ErrorEstimationHandler::ActAfterCreatingDerivedFnParams(
 
 void ErrorEstimationHandler::ActBeforeCreatingDerivedFnBodyScope() {
   // Reference to the final error statement
-  SetFinalErrorExpr(m_RMV->BuildDeclRef(m_Params->back()));
+  Expr* finalErrorPointer = m_RMV->BuildDeclRef(m_Params->back());
+  SetFinalErrorExpr(m_RMV->BuildOp(UO_Deref, finalErrorPointer));
 }
 
 void ErrorEstimationHandler::ActOnEndOfDerivedFnBody() {
@@ -473,7 +474,7 @@ void ErrorEstimationHandler::ActBeforeDifferentiatingCallExpr(
                           m_RMV->getZeroInit(m_RMV->m_Context.DoubleTy));
   ArgDecls.push_back(m_RMV->BuildDeclStmt(errorRef));
   auto finErr = m_RMV->BuildDeclRef(errorRef);
-  pullbackArgs.push_back(finErr);
+  pullbackArgs.push_back(m_RMV->BuildOp(UO_AddrOf, finErr));
   if (hasAssignee) {
     if (m_NestedFuncError)
       m_NestedFuncError = m_RMV->BuildOp(BO_Add, m_NestedFuncError, finErr);

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -346,6 +346,16 @@ static FunctionDecl* DeriveUsingForwardModeTwice(
                      });
       DeclRefToParams.pop_back();
 
+      if (m_DiffReq.Mode == DiffMode::hessian) {
+        // Pass 1 as the middle parameter to the pullback to effectively get the
+        // gradient.
+        QualType intTy = m_Context.IntTy;
+        llvm::APInt APVal(m_Context.getIntWidth(intTy), 1);
+        Expr* one =
+            IntegerLiteral::Create(m_Context, APVal, m_Context.IntTy, noLoc);
+        DeclRefToParams.push_back(one);
+      }
+
       /// If we are differentiating a member function then create a parameter
       /// that can represent the derivative for the implicit `this` pointer. It
       /// is required because reverse mode derived function expects an explicit

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -21,10 +21,10 @@ double f(double *arr) {
   return addArr(arr, 3);
 }
 
-//CHECK:   void f_grad(double *arr, double *_d_arr) {
+//CHECK:   void f_pullback(double *arr, double _d_y, double *_d_arr) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         int _r0 = 0;
-//CHECK-NEXT:         addArr_pullback(arr, 3, 1, _d_arr, &_r0);
+//CHECK-NEXT:         addArr_pullback(arr, 3, _d_y, _d_arr, &_r0);
 //CHECK-NEXT:     }
 //CHECK-NEXT:   }
 
@@ -37,7 +37,7 @@ float func(float* a, float* b) {
   return sum;
 }
 
-//CHECK: void func_grad(float *a, float *b, float *_d_a, float *_d_b) {
+//CHECK: void func_pullback(float *a, float *b, float _d_y, float *_d_a, float *_d_b) {
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -57,7 +57,7 @@ float func(float* a, float* b) {
 //CHECK-NEXT:         clad::push(_t2, sum);
 //CHECK-NEXT:         sum += a[i];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _d_sum += 1;
+//CHECK-NEXT:     _d_sum += _d_y;
 //CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -92,7 +92,7 @@ float func2(float* a) {
   return sum;
 }
 
-//CHECK: void func2_grad(float *a, float *_d_a) {
+//CHECK: void func2_pullback(float *a, float _d_y, float *_d_a) {
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -109,7 +109,7 @@ float func2(float* a) {
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += helper(a[i]);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _d_sum += 1;
+//CHECK-NEXT:     _d_sum += _d_y;
 //CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -131,7 +131,7 @@ float func3(float* a, float* b) {
   return sum;
 }
 
-//CHECK: void func3_grad(float *a, float *b, float *_d_a, float *_d_b) {
+//CHECK: void func3_pullback(float *a, float *b, float _d_y, float *_d_a, float *_d_b) {
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -150,7 +150,7 @@ float func3(float* a, float* b) {
 //CHECK-NEXT:         clad::push(_t2, a[i]);
 //CHECK-NEXT:         sum += (a[i] += b[i]);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _d_sum += 1;
+//CHECK-NEXT:     _d_sum += _d_y;
 //CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -175,7 +175,7 @@ double func4(double x) {
   return sum;
 }
 
-//CHECK: void func4_grad(double x, double *_d_x) {
+//CHECK: void func4_pullback(double x, double _d_y, double *_d_x) {
 //CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -194,7 +194,7 @@ double func4(double x) {
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _d_sum += 1;
+//CHECK-NEXT:     _d_sum += _d_y;
 //CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -233,7 +233,7 @@ double func5(int k) {
   return sum;
 }
 
-//CHECK: void func5_grad(int k, int *_d_k) {
+//CHECK: void func5_pullback(int k, double _d_y, int *_d_k) {
 //CHECK-NEXT:     int _d_n = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -269,7 +269,7 @@ double func5(int k) {
 //CHECK-NEXT:         clad::push(_t3, sum);
 //CHECK-NEXT:         sum += addArr(arr, n);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _d_sum += 1;
+//CHECK-NEXT:     _d_sum += _d_y;
 //CHECK-NEXT:     for (;; _t2--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t2)
@@ -309,7 +309,7 @@ double func6(double seed) {
   return sum;
 }
 
-//CHECK: void func6_grad(double seed, double *_d_seed) {
+//CHECK: void func6_pullback(double seed, double _d_y, double *_d_seed) {
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -330,7 +330,7 @@ double func6(double seed) {
 //CHECK-NEXT:         clad::push(_t2, sum);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _d_sum += 1;
+//CHECK-NEXT:     _d_sum += _d_y;
 //CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -370,7 +370,7 @@ double func7(double *params) {
   return out;
 }
 
-//CHECK: void func7_grad(double *params, double *_d_params) {
+//CHECK: void func7_pullback(double *params, double _d_y, double *_d_params) {
 //CHECK-NEXT:     double _d_out = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     std::size_t _d_i = 0;
@@ -391,7 +391,7 @@ double func7(double *params) {
 // CHECK-NEXT:         clad::push(_t2, out);
 // CHECK-NEXT:         out = out + inv_square(paramsPrime);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_out += 1;
+// CHECK-NEXT:     _d_out += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -427,7 +427,7 @@ double func8(double i, double *arr, int n) {
   return res;
 }
 
-//CHECK: void func8_grad(double i, double *arr, int n, double *_d_i, double *_d_arr, int *_d_n) {
+//CHECK: void func8_pullback(double i, double *arr, int n, double _d_y, double *_d_i, double *_d_arr, int *_d_n) {
 //CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     double _t1;
@@ -439,7 +439,7 @@ double func8(double i, double *arr, int n) {
 //CHECK-NEXT:     res = helper2(i, arr, n);
 //CHECK-NEXT:     _t2 = arr[0];
 //CHECK-NEXT:     arr[0] = 5;
-//CHECK-NEXT:     _d_res += 1;
+//CHECK-NEXT:     _d_res += _d_y;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         arr[0] = _t2;
 //CHECK-NEXT:         double _r_d2 = _d_arr[0];
@@ -477,7 +477,7 @@ double func9(double i, double j) {
 }
 
 
-//CHECK: void func9_grad(double i, double j, double *_d_i, double *_d_j) {
+//CHECK: void func9_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 //CHECK-NEXT:     double _d_arr[5] = {0};
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_idx = 0;
@@ -495,11 +495,11 @@ double func9(double i, double j) {
 // CHECK-NEXT:         modify(arr[idx], i);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_arr[0] += 1;
-// CHECK-NEXT:         _d_arr[1] += 1;
-// CHECK-NEXT:         _d_arr[2] += 1;
-// CHECK-NEXT:         _d_arr[3] += 1;
-// CHECK-NEXT:         _d_arr[4] += 1;
+// CHECK-NEXT:         _d_arr[0] += _d_y;
+// CHECK-NEXT:         _d_arr[1] += _d_y;
+// CHECK-NEXT:         _d_arr[2] += _d_y;
+// CHECK-NEXT:         _d_arr[3] += _d_y;
+// CHECK-NEXT:         _d_arr[4] += _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
@@ -532,7 +532,7 @@ double func10(double *arr, int n) {
   return res;
 }
 
-//CHECK: void func10_grad_0(double *arr, int n, double *_d_arr) {
+//CHECK: void func10_pullback_0(double *arr, int n, double _d_y, double *_d_arr) {
 //CHECK-NEXT:     int _d_n = 0;
 //CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -552,7 +552,7 @@ double func10(double *arr, int n) {
 // CHECK-NEXT:         clad::push(_t2, arr[i]);
 // CHECK-NEXT:         res += sq(arr[i]);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)

--- a/test/Arrays/Arrays.C
+++ b/test/Arrays/Arrays.C
@@ -91,18 +91,18 @@ double const_dot_product(double x, double y, double z) {
 //CHECK-NEXT:       return _d_vars[0] * consts[0] + vars[0] * _d_consts[0] + _d_vars[1] * consts[1] + vars[1] * _d_consts[1] + _d_vars[2] * consts[2] + vars[2] * _d_consts[2];
 //CHECK-NEXT:   }
 
-//CHECK:   void const_dot_product_grad(double x, double y, double z, double *_d_x, double *_d_y, double *_d_z) {
+//CHECK:   void const_dot_product_pullback(double x, double y, double z, double _d_y0, double *_d_x, double *_d_y, double *_d_z) {
 //CHECK-NEXT:       double _d_vars[3] = {0};
 //CHECK-NEXT:       double _d_consts[3] = {0};
 //CHECK-NEXT:       double vars[3] = {x, y, z};
 //CHECK-NEXT:       double consts[3] = {1, 2, 3};
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _d_vars[0] += 1 * consts[0];
-//CHECK-NEXT:           _d_consts[0] += vars[0] * 1;
-//CHECK-NEXT:           _d_vars[1] += 1 * consts[1];
-//CHECK-NEXT:           _d_consts[1] += vars[1] * 1;
-//CHECK-NEXT:           _d_vars[2] += 1 * consts[2];
-//CHECK-NEXT:           _d_consts[2] += vars[2] * 1;
+//CHECK-NEXT:           _d_vars[0] += _d_y0 * consts[0];
+//CHECK-NEXT:           _d_consts[0] += vars[0] * _d_y0;
+//CHECK-NEXT:           _d_vars[1] += _d_y0 * consts[1];
+//CHECK-NEXT:           _d_consts[1] += vars[1] * _d_y0;
+//CHECK-NEXT:           _d_vars[2] += _d_y0 * consts[2];
+//CHECK-NEXT:           _d_consts[2] += vars[2] * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += _d_vars[0];
@@ -136,7 +136,7 @@ double const_matmul_sum(double a, double b, double c, double d) {
 //:       return _d_C[0][0] + _d_C[0][1] + _d_C[1][0] + _d_C[1][1];
 //:   }
 
-//:   void const_matmul_sum_grad(double a, double b, double c, double d, double *_d_a, double *_d_b, double *_d_c, double *_d_d) {
+//:   void const_matmul_sum_pullback(double a, double b, double c, double d, double _d_y0, double *_d_a, double *_d_b, double *_d_c, double *_d_d) {
 //:       double _d_A[2][2] = {};
 //:       double _d_B[2][2] = {};
 //:       double _t0;
@@ -176,10 +176,10 @@ double const_matmul_sum(double a, double b, double c, double d) {
 //:       _t14 = B[1][1];
 //:       double C[2][2] = {{[{][{]}}_t1 * _t0 + _t3 * _t2, _t5 * _t4 + _t7 * _t6}, {_t9 * _t8 + _t11 * _t10, _t13 * _t12 + _t15 * _t14}};
 //:       {
-//:           _d_C[0][0] += 1;
-//:           _d_C[0][1] += 1;
-//:           _d_C[1][0] += 1;
-//:           _d_C[1][1] += 1;
+//:           _d_C[0][0] += _d_y0;
+//:           _d_C[0][1] += _d_y0;
+//:           _d_C[1][0] += _d_y0;
+//:           _d_C[1][1] += _d_y0;
 //:       }
 //:       {
 //:           double _r0 = _d_C[0][0] * _t0;

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -28,7 +28,7 @@ __device__ __host__ double gauss(double* x, double* p, double sigma, int dim) {
 }
 
 
-// CHECK:    void gauss_grad_1(double *x, double *p, double sigma, int dim, double *_d_p) __attribute__((device)) __attribute__((host)) {
+// CHECK:    void gauss_pullback_1(double *x, double *p, double sigma, int dim, double _d_y, double *_d_p) __attribute__((device)) __attribute__((host)) {
 //CHECK-NEXT:     double _d_sigma = 0;
 //CHECK-NEXT:     int _d_dim = 0;
 //CHECK-NEXT:     double _d_t = 0;
@@ -61,14 +61,14 @@ __device__ __host__ double gauss(double* x, double* p, double sigma, int dim) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r1 = 0;
 //CHECK-NEXT:         double _r2 = 0;
-//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(2 * 3.1415926535897931, -dim / 2., 1 * _t4 * _t5, &_r1, &_r2);
+//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(2 * 3.1415926535897931, -dim / 2., _d_y * _t4 * _t5, &_r1, &_r2);
 //CHECK-NEXT:         _d_dim += -_r2 / 2.;
 //CHECK-NEXT:         double _r3 = 0;
 //CHECK-NEXT:         double _r4 = 0;
-//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(sigma, -0.5, _t6 * 1 * _t4, &_r3, &_r4);
+//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(sigma, -0.5, _t6 * _d_y * _t4, &_r3, &_r4);
 //CHECK-NEXT:         _d_sigma += _r3;
 //CHECK-NEXT:         double _r5 = 0;
-//CHECK-NEXT:         _r5 += _t6 * _t5 * 1 * clad::custom_derivatives::exp_pushforward(t, 1.).pushforward;
+//CHECK-NEXT:         _r5 += _t6 * _t5 * _d_y * clad::custom_derivatives::exp_pushforward(t, 1.).pushforward;
 //CHECK-NEXT:         _d_t += _r5;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {

--- a/test/Enzyme/DifferentCladEnzymeDerivatives.C
+++ b/test/Enzyme/DifferentCladEnzymeDerivatives.C
@@ -10,10 +10,10 @@ double foo(double x, double y){
     return x*y;
 }
 
-// CHECK: void foo_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: void foo_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_x += 1 * y;
-// CHECK-NEXT:         *_d_y += x * 1;
+// CHECK-NEXT:         *_d_x += _d_y0 * y;
+// CHECK-NEXT:         *_d_y += x * _d_y0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -12,7 +12,7 @@ float func(float x, float y) {
   return y;
 }
 
-//CHECK: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     _t0 = x;
@@ -27,15 +27,15 @@ float func(float x, float y) {
 //CHECK-NEXT:         *_d_x += _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_x += _r_d0;
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT: }
 
 float func2(float x, int y) {
@@ -43,13 +43,13 @@ float func2(float x, int y) {
   return x;
 }
 
-//CHECK: void func2_grad(float x, int y, float *_d_x, int *_d_y, double &_final_error) {
+//CHECK: void func2_grad(float x, int y, float *_d_x, int *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = y * x + x * x;
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
@@ -58,7 +58,7 @@ float func2(float x, int y) {
 //CHECK-NEXT:         *_d_x += _r_d0 * x;
 //CHECK-NEXT:         *_d_x += x * _r_d0;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT: }
 
 float func3(int x, int y) {
@@ -66,7 +66,7 @@ float func3(int x, int y) {
   return y;
 }
 
-//CHECK: void func3_grad(int x, int y, int *_d_x, int *_d_y, double &_final_error) {
+//CHECK: void func3_grad(int x, int y, int *_d_x, int *_d_y, double *_final_error) {
 //CHECK-NEXT:     int _t0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = y;
@@ -85,7 +85,7 @@ float func4(float x, float y) {
   return x;
 }
 
-//CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     double _d_z = 0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     double z = y;
@@ -93,7 +93,7 @@ float func4(float x, float y) {
 //CHECK-NEXT:     x = z + y;
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
@@ -101,8 +101,8 @@ float func4(float x, float y) {
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     *_d_y += _d_z;
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT: }
 
 float func5(float x, float y) {
@@ -111,7 +111,7 @@ float func5(float x, float y) {
   return x;
 }
 
-//CHECK: void func5_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func5_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     int _d_z = 0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     int z = 56;
@@ -119,36 +119,36 @@ float func5(float x, float y) {
 //CHECK-NEXT:     x = z + y;
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         _d_z += _r_d0;
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT: }
 
 float func6(float x) { return x; }
 
-//CHECK: void func6_grad(float x, float *_d_x, double &_final_error) {
+//CHECK: void func6_grad(float x, float *_d_x, double *_final_error) {
 //CHECK-NEXT:     *_d_x += 1;
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT: }
 
 float func7(float x, float y) { return (x * y); }
 
-//CHECK: void func7_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func7_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _ret_value0 = (x * y);
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += 1 * y;
 //CHECK-NEXT:         *_d_y += x * 1;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 float func8(int x, int y) {
@@ -156,7 +156,7 @@ float func8(int x, int y) {
     return x;
 }
 
-//CHECK: void func8_grad(int x, int y, int *_d_x, int *_d_y, double &_final_error) {
+//CHECK: void func8_grad(int x, int y, int *_d_x, int *_d_y, double *_final_error) {
 //CHECK-NEXT:     int _t0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = y * y;

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -12,14 +12,14 @@ float func(float x, float y) {
   return y;
 }
 
-//CHECK: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = x + y;
 //CHECK-NEXT:     _t1 = y;
 //CHECK-NEXT:     y = x;
-//CHECK-NEXT:     *_d_y += 1;
+//CHECK-NEXT:     *_d_y += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t1;
 //CHECK-NEXT:         float _r_d1 = *_d_y;
@@ -43,11 +43,11 @@ float func2(float x, int y) {
   return x;
 }
 
-//CHECK: void func2_grad(float x, int y, float *_d_x, int *_d_y, double *_final_error) {
+//CHECK: void func2_pullback(float x, int y, float _d_y0, float *_d_x, int *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = y * x + x * x;
-//CHECK-NEXT:     *_d_x += 1;
+//CHECK-NEXT:     *_d_x += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
@@ -66,11 +66,11 @@ float func3(int x, int y) {
   return y;
 }
 
-//CHECK: void func3_grad(int x, int y, int *_d_x, int *_d_y, double *_final_error) {
+//CHECK: void func3_pullback(int x, int y, float _d_y0, int *_d_x, int *_d_y, double *_final_error) {
 //CHECK-NEXT:     int _t0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = y;
-//CHECK-NEXT:     *_d_y += 1;
+//CHECK-NEXT:     *_d_y += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         int _r_d0 = *_d_x;
@@ -85,13 +85,13 @@ float func4(float x, float y) {
   return x;
 }
 
-//CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func4_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     double _d_z = 0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     double z = y;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = z + y;
-//CHECK-NEXT:     *_d_x += 1;
+//CHECK-NEXT:     *_d_x += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
@@ -111,13 +111,13 @@ float func5(float x, float y) {
   return x;
 }
 
-//CHECK: void func5_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func5_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     int _d_z = 0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     int z = 56;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = z + y;
-//CHECK-NEXT:     *_d_x += 1;
+//CHECK-NEXT:     *_d_x += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
@@ -132,19 +132,19 @@ float func5(float x, float y) {
 
 float func6(float x) { return x; }
 
-//CHECK: void func6_grad(float x, float *_d_x, double *_final_error) {
-//CHECK-NEXT:     *_d_x += 1;
+//CHECK: void func6_pullback(float x, float _d_y, float *_d_x, double *_final_error) {
+//CHECK-NEXT:     *_d_x += _d_y;
 //CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT: }
 
 float func7(float x, float y) { return (x * y); }
 
-//CHECK: void func7_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func7_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _ret_value0 = (x * y);
 //CHECK-NEXT:     {
-//CHECK-NEXT:         *_d_x += 1 * y;
-//CHECK-NEXT:         *_d_y += x * 1;
+//CHECK-NEXT:         *_d_x += _d_y0 * y;
+//CHECK-NEXT:         *_d_y += x * _d_y0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
@@ -156,11 +156,11 @@ float func8(int x, int y) {
     return x;
 }
 
-//CHECK: void func8_grad(int x, int y, int *_d_x, int *_d_y, double *_final_error) {
+//CHECK: void func8_pullback(int x, int y, float _d_y0, int *_d_x, int *_d_y, double *_final_error) {
 //CHECK-NEXT:     int _t0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = y * y;
-//CHECK-NEXT:     *_d_x += 1;
+//CHECK-NEXT:     *_d_x += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         int _r_d0 = *_d_x;

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -13,7 +13,7 @@ float func(float x, float y) {
   return z;
 }
 
-//CHECK: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _d_z = 0;
@@ -24,13 +24,13 @@ float func(float x, float y) {
 //CHECK-NEXT:     float z = y * x;
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(_d_z * z * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_z * z * {{.+}});
 //CHECK-NEXT:         *_d_y += _d_z * x;
 //CHECK-NEXT:         *_d_x += y * _d_z;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(*_d_y * y * {{.+}});
-//CHECK-NEXT:         _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT:         y = _t1;
 //CHECK-NEXT:         float _r_d1 = *_d_y;
 //CHECK-NEXT:         *_d_y = 0;
@@ -40,15 +40,15 @@ float func(float x, float y) {
 //CHECK-NEXT:         *_d_y += _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_x += _r_d0;
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT: }
 
 // This function may evaluate incorrectly due to absence of usage of
@@ -59,7 +59,7 @@ float func2(float x, float y) {
   return z;
 }
 
-//CHECK: void func2_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func2_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     _t0 = x;
@@ -67,13 +67,13 @@ float func2(float x, float y) {
 //CHECK-NEXT:     float z = y / x;
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(_d_z * z * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_z * z * {{.+}});
 //CHECK-NEXT:         *_d_y += _d_z / x;
 //CHECK-NEXT:         float _r0 = _d_z * -(y / (x * x));
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
@@ -82,8 +82,8 @@ float func2(float x, float y) {
 //CHECK-NEXT:         *_d_y += -_r_d0 * y;
 //CHECK-NEXT:         *_d_y += y * -_r_d0;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT: }
 
 
@@ -95,7 +95,7 @@ float func3(float x, float y) {
   return t;
 }
 
-//CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float _t1;
@@ -109,8 +109,8 @@ float func3(float x, float y) {
 //CHECK-NEXT:     float t = x * z * _t1;
 //CHECK-NEXT:     _d_t += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(_d_t * t * {{.+}});
-//CHECK-NEXT:         _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_t * t * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT:         *_d_x += _d_t * _t1 * z;
 //CHECK-NEXT:         _d_z += x * _d_t * _t1;
 //CHECK-NEXT:         *_d_y += x * z * _d_t;
@@ -122,7 +122,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     *_d_y += _d_z;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
@@ -131,14 +131,14 @@ float func3(float x, float y) {
 //CHECK-NEXT:         *_d_y += -_r_d0 * y;
 //CHECK-NEXT:         *_d_y += y * -_r_d0;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT: }
 
 // Function call custom derivative exists but no assign expr
 float func4(float x, float y) { return std::pow(x, y); }
 
-//CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _ret_value0 = std::pow(x, y);
 //CHECK-NEXT:     {
@@ -148,9 +148,9 @@ float func4(float x, float y) { return std::pow(x, y); }
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:         *_d_y += _r1;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 // Function call custom derivative exists and is assigned
@@ -159,7 +159,7 @@ float func5(float x, float y) {
   return y * y;
 }
 
-//CHECK: void func5_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func5_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _t0 = y;
@@ -170,7 +170,7 @@ float func5(float x, float y) {
 //CHECK-NEXT:         *_d_y += y * 1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT:         y = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_y;
 //CHECK-NEXT:         *_d_y = 0;
@@ -178,24 +178,24 @@ float func5(float x, float y) {
 //CHECK-NEXT:         _r0 += _r_d0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, 1.F).pushforward;
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 // Function call non custom derivative
 double helper(double x, double y) { return x * y; }
 
-//CHECK: void helper_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y, double &_final_error) {
+//CHECK: void helper_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y, double *_final_error) {
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _ret_value0 = x * y;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += _d_y0 * y;
 //CHECK-NEXT:         *_d_y += x * _d_y0;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 float func6(float x, float y) {
@@ -203,7 +203,7 @@ float func6(float x, float y) {
   return z * z;
 }
 
-//CHECK: void func6_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func6_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     float z = helper(x, y);
@@ -216,14 +216,14 @@ float func6(float x, float y) {
 //CHECK-NEXT:         double _r0 = 0;
 //CHECK-NEXT:         double _r1 = 0;
 //CHECK-NEXT:         double _t0 = 0;
-//CHECK-NEXT:         helper_pullback(x, y, _d_z, &_r0, &_r1, _t0);
+//CHECK-NEXT:         helper_pullback(x, y, _d_z, &_r0, &_r1, &_t0);
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:         *_d_y += _r1;
-//CHECK-NEXT:         _final_error += _t0;
+//CHECK-NEXT:         *_final_error += _t0;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 float func7(float x) {
@@ -231,7 +231,7 @@ float func7(float x) {
   return z + z;
 }
 
-//CHECK: void func7_grad(float x, float *_d_x, double &_final_error) {
+//CHECK: void func7_grad(float x, float *_d_x, double *_final_error) {
 //CHECK-NEXT:     int _d_z = 0;
 //CHECK-NEXT:     int z = x;
 //CHECK-NEXT:     {
@@ -239,20 +239,20 @@ float func7(float x) {
 //CHECK-NEXT:         _d_z += 1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     *_d_x += _d_z;
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT: }
 
 
 double helper2(float& x) { return x * x; }
 
-//CHECK: void helper2_pullback(float &x, double _d_y, float *_d_x, double &_final_error) {
+//CHECK: void helper2_pullback(float &x, double _d_y, float *_d_x, double *_final_error) {
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _ret_value0 = x * x;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += _d_y * x;
 //CHECK-NEXT:         *_d_x += x * _d_y;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 float func8(float x, float y) {
@@ -261,7 +261,7 @@ float func8(float x, float y) {
   return z;
 }
 
-//CHECK: void func8_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func8_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
@@ -277,12 +277,12 @@ float func8(float x, float y) {
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _t2 = 0;
-//CHECK-NEXT:         helper2_pullback(_t1, _r_d0, &*_d_x, _t2);
-//CHECK-NEXT:         _final_error += _t2;
-//CHECK-NEXT:         _final_error += std::abs(*_d_x * _t1 * {{.+}});
+//CHECK-NEXT:         helper2_pullback(_t1, _r_d0, &*_d_x, &_t2);
+//CHECK-NEXT:         *_final_error += _t2;
+//CHECK-NEXT:         *_final_error += std::abs(*_d_x * _t1 * {{.+}});
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT: }
 
 float func9(float x, float y) {
@@ -291,7 +291,7 @@ float func9(float x, float y) {
   return z;
 }
 
-//CHECK: void func9_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func9_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float _t3;
@@ -313,29 +313,29 @@ float func9(float x, float y) {
 //CHECK-NEXT:         float _r_d0 = _d_z;
 //CHECK-NEXT:         x = _t5;
 //CHECK-NEXT:         double _t6 = 0;
-//CHECK-NEXT:         helper2_pullback(_t5, _r_d0 * _t4, &*_d_x, _t6);
+//CHECK-NEXT:         helper2_pullback(_t5, _r_d0 * _t4, &*_d_x, &_t6);
 //CHECK-NEXT:         y = _t8;
 //CHECK-NEXT:         double _t9 = 0;
-//CHECK-NEXT:         helper2_pullback(_t8, _t7 * _r_d0, &*_d_y, _t9);
-//CHECK-NEXT:         _final_error += _t6 + _t9;
-//CHECK-NEXT:         _final_error += std::abs(*_d_y * _t8 * {{.+}});
-//CHECK-NEXT:         _final_error += std::abs(*_d_x * _t5 * {{.+}});
+//CHECK-NEXT:         helper2_pullback(_t8, _t7 * _r_d0, &*_d_y, &_t9);
+//CHECK-NEXT:         *_final_error += _t6 + _t9;
+//CHECK-NEXT:         *_final_error += std::abs(*_d_y * _t8 * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_x * _t5 * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0;
 //CHECK-NEXT:         double _r1 = 0;
 //CHECK-NEXT:         double _t0 = 0;
-//CHECK-NEXT:         helper_pullback(x, y, _d_z, &_r0, &_r1, _t0);
+//CHECK-NEXT:         helper_pullback(x, y, _d_z, &_r0, &_r1, &_t0);
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:         *_d_y += _r1;
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _t2 = 0;
-//CHECK-NEXT:         helper2_pullback(_t1, _d_z, &*_d_x, _t2);
-//CHECK-NEXT:         _final_error += _t0 + _t2;
-//CHECK-NEXT:         _final_error += std::abs(*_d_x * _t1 * {{.+}});
+//CHECK-NEXT:         helper2_pullback(_t1, _d_z, &*_d_x, &_t2);
+//CHECK-NEXT:         *_final_error += _t0 + _t2;
+//CHECK-NEXT:         *_final_error += std::abs(*_d_x * _t1 * {{.+}});
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT: }
 
 int main() {

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -13,7 +13,7 @@ float func(float x, float y) {
   return z;
 }
 
-//CHECK: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _d_z = 0;
@@ -22,7 +22,7 @@ float func(float x, float y) {
 //CHECK-NEXT:     _t1 = y;
 //CHECK-NEXT:     y = y + y++ + y;
 //CHECK-NEXT:     float z = y * x;
-//CHECK-NEXT:     _d_z += 1;
+//CHECK-NEXT:     _d_z += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_final_error += std::abs(_d_z * z * {{.+}});
 //CHECK-NEXT:         *_d_y += _d_z * x;
@@ -59,13 +59,13 @@ float func2(float x, float y) {
   return z;
 }
 
-//CHECK: void func2_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func2_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = x - y - y * y;
 //CHECK-NEXT:     float z = y / x;
-//CHECK-NEXT:     _d_z += 1;
+//CHECK-NEXT:     _d_z += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_final_error += std::abs(_d_z * z * {{.+}});
 //CHECK-NEXT:         *_d_y += _d_z / x;
@@ -95,7 +95,7 @@ float func3(float x, float y) {
   return t;
 }
 
-//CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func3_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float _t1;
@@ -107,7 +107,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:     _t2 = y;
 //CHECK-NEXT:     _t1 = (y = x + x);
 //CHECK-NEXT:     float t = x * z * _t1;
-//CHECK-NEXT:     _d_t += 1;
+//CHECK-NEXT:     _d_t += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_final_error += std::abs(_d_t * t * {{.+}});
 //CHECK-NEXT:         *_final_error += std::abs(*_d_y * y * {{.+}});
@@ -138,13 +138,13 @@ float func3(float x, float y) {
 // Function call custom derivative exists but no assign expr
 float func4(float x, float y) { return std::pow(x, y); }
 
-//CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func4_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _ret_value0 = std::pow(x, y);
 //CHECK-NEXT:     {
 //CHECK-NEXT:         float _r0 = 0;
 //CHECK-NEXT:         float _r1 = 0;
-//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(x, y, 1, &_r0, &_r1);
+//CHECK-NEXT:         clad::custom_derivatives{{(::std)?}}::pow_pullback(x, y, _d_y0, &_r0, &_r1);
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:         *_d_y += _r1;
 //CHECK-NEXT:     }
@@ -159,15 +159,15 @@ float func5(float x, float y) {
   return y * y;
 }
 
-//CHECK: void func5_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func5_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _t0 = y;
 //CHECK-NEXT:     y = std::sin(x);
 //CHECK-NEXT:     _ret_value0 = y * y;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         *_d_y += 1 * y;
-//CHECK-NEXT:         *_d_y += y * 1;
+//CHECK-NEXT:         *_d_y += _d_y0 * y;
+//CHECK-NEXT:         *_d_y += y * _d_y0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_final_error += std::abs(*_d_y * y * {{.+}});
@@ -203,14 +203,14 @@ float func6(float x, float y) {
   return z * z;
 }
 
-//CHECK: void func6_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func6_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     float z = helper(x, y);
 //CHECK-NEXT:     _ret_value0 = z * z;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _d_z += 1 * z;
-//CHECK-NEXT:         _d_z += z * 1;
+//CHECK-NEXT:         _d_z += _d_y0 * z;
+//CHECK-NEXT:         _d_z += z * _d_y0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0;
@@ -231,12 +231,12 @@ float func7(float x) {
   return z + z;
 }
 
-//CHECK: void func7_grad(float x, float *_d_x, double *_final_error) {
+//CHECK: void func7_pullback(float x, float _d_y, float *_d_x, double *_final_error) {
 //CHECK-NEXT:     int _d_z = 0;
 //CHECK-NEXT:     int z = x;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _d_z += 1;
-//CHECK-NEXT:         _d_z += 1;
+//CHECK-NEXT:         _d_z += _d_y;
+//CHECK-NEXT:         _d_z += _d_y;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     *_d_x += _d_z;
 //CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
@@ -261,7 +261,7 @@ float func8(float x, float y) {
   return z;
 }
 
-//CHECK: void func8_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func8_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
@@ -269,7 +269,7 @@ float func8(float x, float y) {
 //CHECK-NEXT:     _t0 = z;
 //CHECK-NEXT:     _t1 = x;
 //CHECK-NEXT:     z = y + helper2(x);
-//CHECK-NEXT:     _d_z += 1;
+//CHECK-NEXT:     _d_z += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         z = _t0;
 //CHECK-NEXT:         float _r_d0 = _d_z;
@@ -291,7 +291,7 @@ float func9(float x, float y) {
   return z;
 }
 
-//CHECK: void func9_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func9_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float _t3;
@@ -307,7 +307,7 @@ float func9(float x, float y) {
 //CHECK-NEXT:     _t8 = y;
 //CHECK-NEXT:     _t4 = helper2(y);
 //CHECK-NEXT:     z += _t7 * _t4;
-//CHECK-NEXT:     _d_z += 1;
+//CHECK-NEXT:     _d_z += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         z = _t3;
 //CHECK-NEXT:         float _r_d0 = _d_z;

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -17,7 +17,7 @@ float func(float x, float y) {
   return x + y;
 }
 
-//CHECK: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _d_temp = 0;
@@ -45,7 +45,7 @@ float func(float x, float y) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:             *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT:             y = _t0;
 //CHECK-NEXT:             float _r_d0 = *_d_y;
 //CHECK-NEXT:             *_d_y = 0;
@@ -60,7 +60,7 @@ float func(float x, float y) {
 //CHECK-NEXT:             *_d_y += _r_d2;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _final_error += std::abs(_d_temp * temp * {{.+}});
+//CHECK-NEXT:             *_final_error += std::abs(_d_temp * temp * {{.+}});
 //CHECK-NEXT:             temp = _t1;
 //CHECK-NEXT:             float _r_d1 = _d_temp;
 //CHECK-NEXT:             _d_temp = 0;
@@ -68,13 +68,13 @@ float func(float x, float y) {
 //CHECK-NEXT:             *_d_y += y * _r_d1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _final_error += std::abs(_d_temp * temp * {{.+}});
+//CHECK-NEXT:             *_final_error += std::abs(_d_temp * temp * {{.+}});
 //CHECK-NEXT:             *_d_y += _d_temp;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 // Single return statement if/else
@@ -86,7 +86,7 @@ float func2(float x) {
     return x * x;
 }
 
-//CHECK: void func2_grad(float x, float *_d_x, double &_final_error) {
+//CHECK: void func2_grad(float x, float *_d_x, double *_final_error) {
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     double _ret_value0 = 0;
@@ -114,17 +114,17 @@ float func2(float x) {
 //CHECK-NEXT:             *_d_x += x * 1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(_d_z * z * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_z * z * {{.+}});
 //CHECK-NEXT:         *_d_x += _d_z * x;
 //CHECK-NEXT:         *_d_x += x * _d_z;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 float func3(float x, float y) { return x > 30 ? x * y : x + y; }
 
-//CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _cond0 = x > 30;
@@ -136,9 +136,9 @@ float func3(float x, float y) { return x > 30 ? x * y : x + y; }
 //CHECK-NEXT:         *_d_x += 1;
 //CHECK-NEXT:         *_d_y += 1;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 float func4(float x, float y) {
@@ -146,7 +146,7 @@ float func4(float x, float y) {
   return y / x;
 }
 
-//CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
@@ -164,20 +164,20 @@ float func4(float x, float y) {
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     if (_cond0) {
-//CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
 //CHECK-NEXT:     } else {
-//CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         float _r_d1 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_x += _r_d1 * x;
 //CHECK-NEXT:         *_d_x += x * _r_d1;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 int main() {

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -17,7 +17,7 @@ float func(float x, float y) {
   return x + y;
 }
 
-//CHECK: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _d_temp = 0;
@@ -40,8 +40,8 @@ float func(float x, float y) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _ret_value0 = x + y;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         *_d_x += 1;
-//CHECK-NEXT:         *_d_y += 1;
+//CHECK-NEXT:         *_d_x += _d_y0;
+//CHECK-NEXT:         *_d_y += _d_y0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         {
@@ -86,7 +86,7 @@ float func2(float x) {
     return x * x;
 }
 
-//CHECK: void func2_grad(float x, float *_d_x, double *_final_error) {
+//CHECK: void func2_pullback(float x, float _d_y, float *_d_x, double *_final_error) {
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     double _ret_value0 = 0;
@@ -104,14 +104,14 @@ float func2(float x) {
 //CHECK-NEXT:     if (_cond0)
 //CHECK-NEXT:       _label0:
 //CHECK-NEXT:         {
-//CHECK-NEXT:             *_d_x += 1;
-//CHECK-NEXT:             *_d_x += 1;
+//CHECK-NEXT:             *_d_x += _d_y;
+//CHECK-NEXT:             *_d_x += _d_y;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     else
 //CHECK-NEXT:       _label1:
 //CHECK-NEXT:         {
-//CHECK-NEXT:             *_d_x += 1 * x;
-//CHECK-NEXT:             *_d_x += x * 1;
+//CHECK-NEXT:             *_d_x += _d_y * x;
+//CHECK-NEXT:             *_d_x += x * _d_y;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_final_error += std::abs(_d_z * z * {{.+}});
@@ -124,17 +124,17 @@ float func2(float x) {
 
 float func3(float x, float y) { return x > 30 ? x * y : x + y; }
 
-//CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func3_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     _cond0 = x > 30;
 //CHECK-NEXT:     _ret_value0 = _cond0 ? x * y : x + y;
 //CHECK-NEXT:     if (_cond0) {
-//CHECK-NEXT:         *_d_x += 1 * y;
-//CHECK-NEXT:         *_d_y += x * 1;
+//CHECK-NEXT:         *_d_x += _d_y0 * y;
+//CHECK-NEXT:         *_d_y += x * _d_y0;
 //CHECK-NEXT:     } else {
-//CHECK-NEXT:         *_d_x += 1;
-//CHECK-NEXT:         *_d_y += 1;
+//CHECK-NEXT:         *_d_x += _d_y0;
+//CHECK-NEXT:         *_d_y += _d_y0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
@@ -146,7 +146,7 @@ float func4(float x, float y) {
   return y / x;
 }
 
-//CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func4_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
@@ -159,8 +159,8 @@ float func4(float x, float y) {
 //CHECK-NEXT:     _cond0 ? (x += 1) : (x *= x);
 //CHECK-NEXT:     _ret_value0 = y / x;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         *_d_y += 1 / x;
-//CHECK-NEXT:         float _r0 = 1 * -(y / (x * x));
+//CHECK-NEXT:         *_d_y += _d_y0 / x;
+//CHECK-NEXT:         float _r0 = _d_y0 * -(y / (x * x));
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     if (_cond0) {

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -14,7 +14,7 @@ float func(float* p, int n) {
   return sum;
 }
 
-//CHECK: void func_grad(float *p, int n, float *_d_p, int *_d_n, double *_final_error) {
+//CHECK: void func_pullback(float *p, int n, float _d_y, float *_d_p, int *_d_n, double *_final_error) {
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -32,7 +32,7 @@ float func(float* p, int n) {
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += p[i];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _d_sum += 1;
+//CHECK-NEXT:     _d_sum += _d_y;
 //CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -63,7 +63,7 @@ float func2(float x) {
   return z;
 }
 
-//CHECK: void func2_grad(float x, float *_d_x, double *_final_error) {
+//CHECK: void func2_pullback(float x, float _d_y, float *_d_x, double *_final_error) {
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -84,7 +84,7 @@ float func2(float x) {
 //CHECK-NEXT:         clad::push(_t2, z);
 //CHECK-NEXT:         z = m + m;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _d_z += 1;
+//CHECK-NEXT:     _d_z += _d_y;
 //CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -118,7 +118,7 @@ float func3(float x, float y) {
   return arr[2];
 }
 
-//CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func3_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     double _t1;
@@ -130,7 +130,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:     arr[1] = x * x;
 //CHECK-NEXT:     _t2 = arr[2];
 //CHECK-NEXT:     arr[2] = arr[0] + arr[1];
-//CHECK-NEXT:     _d_arr[2] += 1;
+//CHECK-NEXT:     _d_arr[2] += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_final_error += std::abs(_d_arr[2] * arr[2] * {{.+}});
 //CHECK-NEXT:         arr[2] = _t2;
@@ -168,7 +168,7 @@ float func4(float x[10], float y[10]) {
   return sum;
 }
 
-//CHECK: void func4_grad(float x[10], float y[10], float *_d_x, float *_d_y, double *_final_error) {
+//CHECK: void func4_pullback(float x[10], float y[10], float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -190,7 +190,7 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:         clad::push(_t2, sum);
 //CHECK-NEXT:         sum += x[i];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _d_sum += 1;
+//CHECK-NEXT:     _d_sum += _d_y0;
 //CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -230,7 +230,7 @@ double func5(double* x, double* y, double* output) {
   return output[0] + output[1] + output[2];
 }
 
-//CHECK: void func5_grad(double *x, double *y, double *output, double *_d_x, double *_d_y, double *_d_output, double *_final_error) {
+//CHECK: void func5_pullback(double *x, double *y, double *output, double _d_y0, double *_d_x, double *_d_y, double *_d_output, double *_final_error) {
 //CHECK-NEXT:     unsigned {{int|long}} output_size = 0;
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     unsigned {{int|long}} x_size = 0;
@@ -246,11 +246,11 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:     output[2] = x[0] * y[1] - y[0] * x[1];
 //CHECK-NEXT:     _ret_value0 = output[0] + output[1] + output[2];
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _d_output[0] += 1;
+//CHECK-NEXT:         _d_output[0] += _d_y0;
 //CHECK-NEXT:         output_size = std::max(output_size, 0);
-//CHECK-NEXT:         _d_output[1] += 1;
+//CHECK-NEXT:         _d_output[1] += _d_y0;
 //CHECK-NEXT:         output_size = std::max(output_size, 1);
-//CHECK-NEXT:         _d_output[2] += 1;
+//CHECK-NEXT:         _d_output[2] += _d_y0;
 //CHECK-NEXT:         output_size = std::max(output_size, 2);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -14,7 +14,7 @@ float func(float* p, int n) {
   return sum;
 }
 
-//CHECK: void func_grad(float *p, int n, float *_d_p, int *_d_n, double &_final_error) {
+//CHECK: void func_grad(float *p, int n, float *_d_p, int *_d_n, double *_final_error) {
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -40,17 +40,17 @@ float func(float* p, int n) {
 // CHECK-NEXT:         }
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});
+//CHECK-NEXT:             *_final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             float _r_d0 = _d_sum;
 //CHECK-NEXT:             _d_p[i] += _r_d0;
 //CHECK-NEXT:             p_size = std::max(p_size, i);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(_d_sum * sum * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:     int i0 = 0;
 //CHECK-NEXT:     for (; i0 <= p_size; i0++)
-//CHECK-NEXT:         _final_error += std::abs(_d_p[i0] * p[i0] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_p[i0] * p[i0] * {{.+}});
 //CHECK-NEXT: }
 
 
@@ -63,7 +63,7 @@ float func2(float x) {
   return z;
 }
 
-//CHECK: void func2_grad(float x, float *_d_x, double &_final_error) {
+//CHECK: void func2_grad(float x, float *_d_x, double *_final_error) {
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -92,7 +92,7 @@ float func2(float x) {
 // CHECK-NEXT:         }
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _final_error += std::abs(_d_z * z * {{.+}});
+//CHECK-NEXT:             *_final_error += std::abs(_d_z * z * {{.+}});
 //CHECK-NEXT:             z = clad::pop(_t2);
 //CHECK-NEXT:             float _r_d0 = _d_z;
 //CHECK-NEXT:             _d_z = 0;
@@ -100,14 +100,14 @@ float func2(float x) {
 //CHECK-NEXT:             _d_m += _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _final_error += std::abs(_d_m * m * {{.+}});
+//CHECK-NEXT:             *_final_error += std::abs(_d_m * m * {{.+}});
 //CHECK-NEXT:             *_d_x += _d_m * x;
 //CHECK-NEXT:             *_d_x += x * _d_m;
 //CHECK-NEXT:             _d_m = 0;
 //CHECK-NEXT:             m = clad::pop(_t1);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT: }
 
 float func3(float x, float y) {
@@ -118,7 +118,7 @@ float func3(float x, float y) {
   return arr[2];
 }
 
-//CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     double _t1;
@@ -132,7 +132,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:     arr[2] = arr[0] + arr[1];
 //CHECK-NEXT:     _d_arr[2] += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(_d_arr[2] * arr[2] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_arr[2] * arr[2] * {{.+}});
 //CHECK-NEXT:         arr[2] = _t2;
 //CHECK-NEXT:         double _r_d2 = _d_arr[2];
 //CHECK-NEXT:         _d_arr[2] = 0;
@@ -140,7 +140,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:         _d_arr[1] += _r_d2;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(_d_arr[1] * arr[1] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_arr[1] * arr[1] * {{.+}});
 //CHECK-NEXT:         arr[1] = _t1;
 //CHECK-NEXT:         double _r_d1 = _d_arr[1];
 //CHECK-NEXT:         _d_arr[1] = 0;
@@ -148,15 +148,15 @@ float func3(float x, float y) {
 //CHECK-NEXT:         *_d_x += x * _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(_d_arr[0] * arr[0] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_arr[0] * arr[0] * {{.+}});
 //CHECK-NEXT:         arr[0] = _t0;
 //CHECK-NEXT:         double _r_d0 = _d_arr[0];
 //CHECK-NEXT:         _d_arr[0] = 0;
 //CHECK-NEXT:         *_d_x += _r_d0;
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT: }
 
 float func4(float x[10], float y[10]) {
@@ -168,7 +168,7 @@ float func4(float x[10], float y[10]) {
   return sum;
 }
 
-//CHECK: void func4_grad(float x[10], float y[10], float *_d_x, float *_d_y, double &_final_error) {
+//CHECK: void func4_grad(float x[10], float y[10], float *_d_x, float *_d_y, double *_final_error) {
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -198,14 +198,14 @@ float func4(float x[10], float y[10]) {
 // CHECK-NEXT:         }
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});
+//CHECK-NEXT:             *_final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:             sum = clad::pop(_t2);
 //CHECK-NEXT:             float _r_d1 = _d_sum;
 //CHECK-NEXT:             _d_x[i] += _r_d1;
 //CHECK-NEXT:             x_size = std::max(x_size, i);
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _final_error += std::abs(_d_x[i] * x[i] * {{.+}});
+//CHECK-NEXT:             *_final_error += std::abs(_d_x[i] * x[i] * {{.+}});
 //CHECK-NEXT:             x[i] = clad::pop(_t1);
 //CHECK-NEXT:             float _r_d0 = _d_x[i];
 //CHECK-NEXT:             _d_y[i] += _r_d0;
@@ -213,13 +213,13 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:             x_size = std::max(x_size, i);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(_d_sum * sum * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:     int i0 = 0;
 //CHECK-NEXT:     for (; i0 <= x_size; i0++)
-//CHECK-NEXT:         _final_error += std::abs(_d_x[i0] * x[i0] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_x[i0] * x[i0] * {{.+}});
 //CHECK-NEXT:     i0 = 0;
 //CHECK-NEXT:     for (; i0 <= y_size; i0++)
-//CHECK-NEXT:         _final_error += std::abs(_d_y[i0] * y[i0] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_y[i0] * y[i0] * {{.+}});
 //CHECK-NEXT: }
 
 
@@ -230,7 +230,7 @@ double func5(double* x, double* y, double* output) {
   return output[0] + output[1] + output[2];
 }
 
-//CHECK: void func5_grad(double *x, double *y, double *output, double *_d_x, double *_d_y, double *_d_output, double &_final_error) {
+//CHECK: void func5_grad(double *x, double *y, double *output, double *_d_x, double *_d_y, double *_d_output, double *_final_error) {
 //CHECK-NEXT:     unsigned {{int|long}} output_size = 0;
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     unsigned {{int|long}} x_size = 0;
@@ -254,7 +254,7 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         output_size = std::max(output_size, 2);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(_d_output[2] * output[2] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_output[2] * output[2] * {{.+}});
 //CHECK-NEXT:         output[2] = _t2;
 //CHECK-NEXT:         double _r_d2 = _d_output[2];
 //CHECK-NEXT:         _d_output[2] = 0;
@@ -269,7 +269,7 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         output_size = std::max(output_size, 2);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(_d_output[1] * output[1] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_output[1] * output[1] * {{.+}});
 //CHECK-NEXT:         output[1] = _t1;
 //CHECK-NEXT:         double _r_d1 = _d_output[1];
 //CHECK-NEXT:         _d_output[1] = 0;
@@ -284,7 +284,7 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         output_size = std::max(output_size, 1);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(_d_output[0] * output[0] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_output[0] * output[0] * {{.+}});
 //CHECK-NEXT:         output[0] = _t0;
 //CHECK-NEXT:         double _r_d0 = _d_output[0];
 //CHECK-NEXT:         _d_output[0] = 0;
@@ -300,14 +300,14 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     for (; i <= x_size; i++)
-//CHECK-NEXT:         _final_error += std::abs(_d_x[i] * x[i] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_x[i] * x[i] * {{.+}});
 //CHECK-NEXT:     i = 0;
 //CHECK-NEXT:     for (; i <= y_size; i++)
-//CHECK-NEXT:         _final_error += std::abs(_d_y[i] * y[i] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_y[i] * y[i] * {{.+}});
 //CHECK-NEXT:     i = 0;
 //CHECK-NEXT:     for (; i <= output_size; i++)
-//CHECK-NEXT:         _final_error += std::abs(_d_output[i] * output[i] * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_output[i] * output[i] * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
 int main() {

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -15,7 +15,7 @@ double runningSum(float* f, int n) {
   return sum;
 }
 
-//CHECK: void runningSum_grad(float *f, int n, float *_d_f, int *_d_n, double *_final_error) {
+//CHECK: void runningSum_pullback(float *f, int n, double _d_y, float *_d_f, int *_d_n, double *_final_error) {
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -33,7 +33,7 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += f[i] + f[i - 1];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _d_sum += 1;
+//CHECK-NEXT:     _d_sum += _d_y;
 //CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -65,7 +65,7 @@ double mulSum(float* a, float* b, int n) {
   return sum;
 }
 
-//CHECK: void mulSum_grad(float *a, float *b, int n, float *_d_a, float *_d_b, int *_d_n, double *_final_error) {
+//CHECK: void mulSum_pullback(float *a, float *b, int n, double _d_y, float *_d_a, float *_d_b, int *_d_n, double *_final_error) {
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -96,7 +96,7 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:             sum += a[i] * b[j];
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _d_sum += 1;
+//CHECK-NEXT:     _d_sum += _d_y;
 //CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -142,7 +142,7 @@ double divSum(float* a, float* b, int n) {
   return sum;
 }
 
-//CHECK: void divSum_grad(float *a, float *b, int n, float *_d_a, float *_d_b, int *_d_n, double *_final_error) {
+//CHECK: void divSum_pullback(float *a, float *b, int n, double _d_y, float *_d_a, float *_d_b, int *_d_n, double *_final_error) {
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -161,7 +161,7 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += a[i] / b[i];
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _d_sum += 1;
+//CHECK-NEXT:     _d_sum += _d_y;
 //CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -15,7 +15,7 @@ double runningSum(float* f, int n) {
   return sum;
 }
 
-//CHECK: void runningSum_grad(float *f, int n, float *_d_f, int *_d_n, double &_final_error) {
+//CHECK: void runningSum_grad(float *f, int n, float *_d_f, int *_d_n, double *_final_error) {
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -41,7 +41,7 @@ double runningSum(float* f, int n) {
 // CHECK-NEXT:         }
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});
+//CHECK-NEXT:             *_final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
 //CHECK-NEXT:             _d_f[i] += _r_d0;
@@ -50,10 +50,10 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:             f_size = std::max(f_size, i - 1);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(_d_sum * sum * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:     int i0 = 0;
 //CHECK-NEXT:     for (; i0 <= f_size; i0++)
-//CHECK-NEXT:         _final_error += std::abs(_d_f[i0] * f[i0] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_f[i0] * f[i0] * {{.+}});
 //CHECK-NEXT: }
 
 double mulSum(float* a, float* b, int n) {
@@ -65,7 +65,7 @@ double mulSum(float* a, float* b, int n) {
   return sum;
 }
 
-//CHECK: void mulSum_grad(float *a, float *b, int n, float *_d_a, float *_d_b, int *_d_n, double &_final_error) {
+//CHECK: void mulSum_grad(float *a, float *b, int n, float *_d_a, float *_d_b, int *_d_n, double *_final_error) {
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -110,7 +110,7 @@ double mulSum(float* a, float* b, int n) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:              }
 //CHECK-NEXT:                 j--;
-//CHECK-NEXT:                 _final_error += std::abs(_d_sum * sum * {{.+}});
+//CHECK-NEXT:                 *_final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:                 sum = clad::pop(_t3);
 //CHECK-NEXT:                 double _r_d0 = _d_sum;
 //CHECK-NEXT:                 _d_a[i] += _r_d0 * b[j];
@@ -125,13 +125,13 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:             clad::pop(_t1);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(_d_sum * sum * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:     int i0 = 0;
 //CHECK-NEXT:     for (; i0 <= a_size; i0++)
-//CHECK-NEXT:         _final_error += std::abs(_d_a[i0] * a[i0] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_a[i0] * a[i0] * {{.+}});
 //CHECK-NEXT:     i0 = 0;
 //CHECK-NEXT:     for (; i0 <= b_size; i0++)
-//CHECK-NEXT:         _final_error += std::abs(_d_b[i0] * b[i0] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_b[i0] * b[i0] * {{.+}});
 //CHECK-NEXT: }
 
 double divSum(float* a, float* b, int n) {
@@ -142,7 +142,7 @@ double divSum(float* a, float* b, int n) {
   return sum;
 }
 
-//CHECK: void divSum_grad(float *a, float *b, int n, float *_d_a, float *_d_b, int *_d_n, double &_final_error) {
+//CHECK: void divSum_grad(float *a, float *b, int n, float *_d_a, float *_d_b, int *_d_n, double *_final_error) {
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
@@ -169,7 +169,7 @@ double divSum(float* a, float* b, int n) {
 // CHECK-NEXT:         }
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});
+//CHECK-NEXT:             *_final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
 //CHECK-NEXT:             b_size = std::max(b_size, i);
@@ -180,13 +180,13 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:             b_size = std::max(b_size, i);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(_d_sum * sum * {{.+}});
+//CHECK-NEXT:     *_final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:     int i0 = 0;
 //CHECK-NEXT:     for (; i0 <= a_size; i0++)
-//CHECK-NEXT:         _final_error += std::abs(_d_a[i0] * a[i0] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_a[i0] * a[i0] * {{.+}});
 //CHECK-NEXT:     i0 = 0;
 //CHECK-NEXT:     for (; i0 <= b_size; i0++)
-//CHECK-NEXT:         _final_error += std::abs(_d_b[i0] * b[i0] * {{.+}});
+//CHECK-NEXT:         *_final_error += std::abs(_d_b[i0] * b[i0] * {{.+}});
 //CHECK-NEXT: }
 
 int main() {
@@ -195,7 +195,7 @@ int main() {
   double finalError = 0;
   float darr[3] = {0, 0, 0};
   int dn = 0;
-  df.execute(arrf, 3, darr, &dn, finalError);
+  df.execute(arrf, 3, darr, &dn, &finalError);
   printf("Result (RS) = {%.2f, %.2f, %.2f} error = %.5f\n", darr[0], darr[1],
          darr[2], finalError); // CHECK-EXEC: Result (RS) = {1.00, 2.00, 1.00} error = 0.00000
 
@@ -204,7 +204,7 @@ int main() {
   dn = 0;
   float darr2[3] = {0, 0, 0};
   auto df2 = clad::estimate_error(mulSum);
-  df2.execute(arrf, arrf, 3, darr, darr2, &dn, finalError);
+  df2.execute(arrf, arrf, 3, darr, darr2, &dn, &finalError);
   printf("Result (MS) = {%.2f, %.2f, %.2f}, {%.2f, %.2f, %.2f}  error = %.5f\n",
          darr[0], darr[1], darr[2], darr2[0], darr2[1], darr2[2],
          finalError); // CHECK-EXEC: Result (MS) = {2.18, 2.18, 2.18}, {2.18, 2.18, 2.18}  error = 0.00000
@@ -214,7 +214,7 @@ int main() {
   darr2[0] = darr2[1] = darr2[2] = 0;
   dn = 0;
   auto df3 = clad::estimate_error(divSum);
-  df3.execute(arrf, arrf, 3, darr, darr2, &dn, finalError);
+  df3.execute(arrf, arrf, 3, darr, darr2, &dn, &finalError);
   printf("Result (DS) = {%.2f, %.2f, %.2f}, {%.2f, %.2f, %.2f}  error = %.5f\n",
          darr[0], darr[1], darr[2], darr2[0], darr2[1], darr2[2],
          finalError); // CHECK-EXEC: Result (DS) = {2.19, 1.30, 1.05}, {-2.19, -1.30, -1.05}  error = 0.00000

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -105,13 +105,13 @@ float f7(float x) {
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
-void f7_grad(float x, float *_d_x);
+void f7_grad(float x, void *_d_x);
 
-// CHECK: void f7_grad(float x, float *_d_x) {
+// CHECK: void f7_pullback(float x, float _d_y, float *_d_x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;
-// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(x, 2., 1, &_r0, &_r1);
+// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(x, 2., _d_y, &_r0, &_r1);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -126,13 +126,13 @@ double f8(float x) {
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
-void f8_grad(float x, float *_d_x);
+void f8_grad(float x, void *_d_x);
 
-// CHECK: void f8_grad(float x, float *_d_x) {
+// CHECK: void f8_pullback(float x, double _d_y, float *_d_x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         int _r1 = 0;
-// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(x, 2, 1, &_r0, &_r1);
+// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(x, 2, _d_y, &_r0, &_r1);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -148,13 +148,13 @@ float f9(float x, float y) {
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
-void f9_grad(float x, float y, float *_d_x, float *_d_y);
+void f9_grad(float x, float y, void *_d_x, void *_d_y);
 
-// CHECK: void f9_grad(float x, float y, float *_d_x, float *_d_y) {
+// CHECK: void f9_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         float _r1 = 0;
-// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(x, y, 1, &_r0, &_r1);
+// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(x, y, _d_y0, &_r0, &_r1);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         *_d_y += _r1;
 // CHECK-NEXT:     }
@@ -171,13 +171,13 @@ double f10(float x, int y) {
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
-void f10_grad(float x, int y, float *_d_x, int *_d_y);
+void f10_grad(float x, int y, void *_d_x, void *_d_y);
 
-// CHECK: void f10_grad(float x, int y, float *_d_x, int *_d_y) {
+// CHECK: void f10_pullback(float x, int y, double _d_y0, float *_d_x, int *_d_y) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         int _r1 = 0;
-// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(x, y, 1, &_r0, &_r1);
+// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(x, y, _d_y0, &_r0, &_r1);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         *_d_y += _r1;
 // CHECK-NEXT:     }
@@ -187,17 +187,17 @@ double f11(double x, double y) {
   return std::pow((1.-x),2) + 100. * std::pow(y-std::pow(x,2),2);
 }
 
-// CHECK: void f11_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: void f11_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     typename {{.*}} _t0;
 // CHECK-NEXT:     _t0 = std::pow(y - std::pow(x, 2), 2);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         int _r1 = 0;
-// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback((1. - x), 2, 1, &_r0, &_r1);
+// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback((1. - x), 2, _d_y0, &_r0, &_r1);
 // CHECK-NEXT:         *_d_x += -_r0;
 // CHECK-NEXT:         double _r2 = 0;
 // CHECK-NEXT:         int _r5 = 0;
-// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(y - std::pow(x, 2), 2, 100. * 1, &_r2, &_r5);
+// CHECK-NEXT:         {{(clad::)?}}custom_derivatives{{(::std)?}}::pow_pullback(y - std::pow(x, 2), 2, 100. * _d_y0, &_r2, &_r5);
 // CHECK-NEXT:         *_d_y += _r2;
 // CHECK-NEXT:         double _r3 = 0;
 // CHECK-NEXT:         int _r4 = 0;

--- a/test/FirstDerivative/UnsupportedOpsWarn.C
+++ b/test/FirstDerivative/UnsupportedOpsWarn.C
@@ -19,7 +19,7 @@ int binOpWarn_1(int x){
     return x ^ 1;   // expected-warning {{attempt to differentiate unsupported operator, ignored.}}
 }
 
-// CHECK: void binOpWarn_1_grad(int x, int *_d_x) {
+// CHECK: void binOpWarn_1_pullback(int x, int _d_y, int *_d_x) {
 // CHECK-NEXT: }
 
 int unOpWarn_0(int x){

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -13,11 +13,11 @@ double f1(double x, double y) {
   return y;
 }
 
-//CHECK:   void f1_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       _t0 = x;
 //CHECK-NEXT:       x = y;
-//CHECK-NEXT:       *_d_y += 1;
+//CHECK-NEXT:       *_d_y += _d_y0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t0;
 //CHECK-NEXT:           double _r_d0 = *_d_x;
@@ -33,7 +33,7 @@ double f2(double x, double y) {
   return x;
 }
 
-//CHECK:   void f2_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       {
@@ -43,7 +43,7 @@ double f2(double x, double y) {
 //CHECK-NEXT:               x = y;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       *_d_x += 1;
+//CHECK-NEXT:       *_d_x += _d_y0;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           x = _t0;
 //CHECK-NEXT:           double _r_d0 = *_d_x;
@@ -61,7 +61,7 @@ double f3(double x, double y) {
   return y;
 }
 
-//CHECK:   void f3_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f3_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -74,7 +74,7 @@ double f3(double x, double y) {
 //CHECK-NEXT:       y = x * x;
 //CHECK-NEXT:       _t3 = x;
 //CHECK-NEXT:       x = y;
-//CHECK-NEXT:       *_d_y += 1;
+//CHECK-NEXT:       *_d_y += _d_y0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t3;
 //CHECK-NEXT:           double _r_d3 = *_d_x;
@@ -110,14 +110,14 @@ double f4(double x, double y) {
    return y;
 }
 
-//CHECK:   void f4_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f4_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       _t0 = y;
 //CHECK-NEXT:       y = x;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       x = 0;
-//CHECK-NEXT:       *_d_y += 1;
+//CHECK-NEXT:       *_d_y += _d_y0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t1;
 //CHECK-NEXT:           double _r_d1 = *_d_x;
@@ -145,7 +145,7 @@ double f5(double x, double y) {
   return t;
 }
 
-//CHECK:   void f5_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f5_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       double _t0;
@@ -170,7 +170,7 @@ double f5(double x, double y) {
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       _d_t += 1;
+//CHECK-NEXT:       _d_t += _d_y0;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = _t1;
@@ -182,7 +182,7 @@ double f5(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:         _label0:
-//CHECK-NEXT:           _d_t += 1;
+//CHECK-NEXT:           _d_t += _d_y0;
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = _t0;
 //CHECK-NEXT:               double _r_d0 = _d_t;
@@ -210,7 +210,7 @@ double f6(double x, double y) {
   return t;
 }
 
-//CHECK:   void f6_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f6_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       double _t0;
@@ -235,7 +235,7 @@ double f6(double x, double y) {
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       _d_t += 1;
+//CHECK-NEXT:       _d_t += _d_y0;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = _t1;
@@ -247,7 +247,7 @@ double f6(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:         _label0:
-//CHECK-NEXT:           _d_t += 1;
+//CHECK-NEXT:           _d_t += _d_y0;
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = _t0;
 //CHECK-NEXT:               double _r_d0 = _d_t;
@@ -277,7 +277,7 @@ double f7(double x, double y) {
   return t[0]; // == x
 }
 
-//CHECK:   void f7_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f7_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_t[3] = {0};
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
@@ -305,7 +305,7 @@ double f7(double x, double y) {
 //CHECK-NEXT:       t[0] -= t[1];
 //CHECK-NEXT:       _t6 = x;
 //CHECK-NEXT:       x = ++t[0];
-//CHECK-NEXT:       _d_t[0] += 1;
+//CHECK-NEXT:       _d_t[0] += _d_y0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t6;
 //CHECK-NEXT:           double _r_d6 = *_d_x;
@@ -367,7 +367,7 @@ double f8(double x, double y) {
   return t[3]; // == y * y
 }
 
-//CHECK: void f8_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK: void f8_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_t[4] = {0};
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
@@ -379,7 +379,7 @@ double f8(double x, double y) {
 //CHECK-NEXT:       _t2 = t[0];
 //CHECK-NEXT:       _t3 = t[1];
 //CHECK-NEXT:       t[3] = (y *= (t[0] = t[1] = t[2]));
-//CHECK-NEXT:       _d_t[3] += 1;
+//CHECK-NEXT:       _d_t[3] += _d_y0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[3] = _t0;
 //CHECK-NEXT:           double _r_d0 = _d_t[3];
@@ -411,7 +411,7 @@ double f9(double x, double y) {
   return t; // x * x * y
 }
 
-//CHECK:   void f9_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f9_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
@@ -420,7 +420,7 @@ double f9(double x, double y) {
 //CHECK-NEXT:       (t *= x);
 //CHECK-NEXT:       _t1 = t;
 //CHECK-NEXT:       t *= y;
-//CHECK-NEXT:       _d_t += 1;
+//CHECK-NEXT:       _d_t += _d_y0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t1;
 //CHECK-NEXT:           double _r_d1 = _d_t;
@@ -442,7 +442,7 @@ double f10(double x, double y) {
   return t; // = y
 }
 
-//CHECK:   void f10_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f10_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
@@ -450,7 +450,7 @@ double f10(double x, double y) {
 //CHECK-NEXT:       _t0 = t;
 //CHECK-NEXT:       _t1 = x;
 //CHECK-NEXT:       t = x = y;
-//CHECK-NEXT:       _d_t += 1;
+//CHECK-NEXT:       _d_t += _d_y0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t0;
 //CHECK-NEXT:           double _r_d0 = _d_t;
@@ -470,7 +470,7 @@ double f11(double x, double y) {
   return t; // = y
 }
 
-//CHECK:   void f11_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f11_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
@@ -479,7 +479,7 @@ double f11(double x, double y) {
 //CHECK-NEXT:       (t = x);
 //CHECK-NEXT:       _t1 = t;
 //CHECK-NEXT:       t = y;
-//CHECK-NEXT:       _d_t += 1;
+//CHECK-NEXT:       _d_t += _d_y0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t1;
 //CHECK-NEXT:           double _r_d1 = _d_t;
@@ -499,7 +499,7 @@ double f12(double x, double y) {
   return t; // == max(x, y) * y;
 }
 
-//CHECK:   void f12_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f12_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       double _t0;
@@ -515,7 +515,7 @@ double f12(double x, double y) {
 //CHECK-NEXT:       _t2 = &(_cond0 ? (t = x) : (t = y));
 //CHECK-NEXT:       _t3 = *_t2;
 //CHECK-NEXT:       *_t2 *= y;
-//CHECK-NEXT:       _d_t += 1;
+//CHECK-NEXT:       _d_t += _d_y0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_t2 = _t3;
 //CHECK-NEXT:           double _r_d2 = (_cond0 ? _d_t : _d_t);
@@ -541,7 +541,7 @@ double f13(double x, double y) {
   return t * y; // == x * x * x
 }
 
-//CHECK:   void f13_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f13_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_t = 0;
@@ -549,8 +549,8 @@ double f13(double x, double y) {
 //CHECK-NEXT:       _t0 = (y = x);
 //CHECK-NEXT:       double t = x * _t0;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _d_t += 1 * y;
-//CHECK-NEXT:           *_d_y += t * 1;
+//CHECK-NEXT:           _d_t += _d_y0 * y;
+//CHECK-NEXT:           *_d_y += t * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += _d_t * _t0;
@@ -570,7 +570,7 @@ double f14(double i, double j) {
   return i;
 }
 
-// CHECK: void f14_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void f14_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double *_d_a = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
@@ -583,7 +583,7 @@ double f14(double i, double j) {
 // CHECK-NEXT:     a += i;
 // CHECK-NEXT:     _t2 = a;
 // CHECK-NEXT:     a *= i;
-// CHECK-NEXT:     *_d_i += 1;
+// CHECK-NEXT:     *_d_i += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t2;
 // CHECK-NEXT:         double _r_d2 = *_d_a;
@@ -616,7 +616,7 @@ double f15(double i, double j) {
   return a+c+d;
 }
 
-// CHECK: void f15_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void f15_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_b = 0;
 // CHECK-NEXT:     double *_d_a = 0;
 // CHECK-NEXT:     double *_d_c = 0;
@@ -641,9 +641,9 @@ double f15(double i, double j) {
 // CHECK-NEXT:     _t3 = d;
 // CHECK-NEXT:     d *= 3 * j;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_a += 1;
-// CHECK-NEXT:         *_d_c += 1;
-// CHECK-NEXT:         *_d_d += 1;
+// CHECK-NEXT:         *_d_a += _d_y;
+// CHECK-NEXT:         *_d_c += _d_y;
+// CHECK-NEXT:         *_d_d += _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         d = _t3;
@@ -683,7 +683,7 @@ double f16(double i, double j) {
   return i;
 }
 
-// CHECK: void f16_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void f16_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double *_d_a = 0;
 // CHECK-NEXT:     double *_d_b = 0;
 // CHECK-NEXT:     double *_d_c = 0;
@@ -696,7 +696,7 @@ double f16(double i, double j) {
 // CHECK-NEXT:     double &c = b;
 // CHECK-NEXT:     _t0 = c;
 // CHECK-NEXT:     c *= 4 * j;
-// CHECK-NEXT:     *_d_i += 1;
+// CHECK-NEXT:     *_d_i += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         c = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_c;
@@ -711,13 +711,13 @@ double f17(double i, double j, double k) {
   return j;
 }
 
-// CHECK: void f17_grad_0(double i, double j, double k, double *_d_i) {
+// CHECK: void f17_pullback_0(double i, double j, double k, double _d_y, double *_d_i) {
 // CHECK-NEXT:     double _d_j = 0;
 // CHECK-NEXT:     double _d_k = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     _t0 = j;
 // CHECK-NEXT:     j = 2 * i;
-// CHECK-NEXT:     _d_j += 1;
+// CHECK-NEXT:     _d_j += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         j = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_j;
@@ -732,7 +732,7 @@ double f18(double i, double j, double k) {
   return k;
 }
 
-// CHECK: void f18_grad_0_1(double i, double j, double k, double *_d_i, double *_d_j) {
+// CHECK: void f18_pullback_0_1(double i, double j, double k, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_k = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
@@ -740,7 +740,7 @@ double f18(double i, double j, double k) {
 // CHECK-NEXT:     k = 2 * i + 2 * j;
 // CHECK-NEXT:     _t1 = k;
 // CHECK-NEXT:     k += i;
-// CHECK-NEXT:     _d_k += 1;
+// CHECK-NEXT:     _d_k += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         k = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_k;
@@ -759,12 +759,12 @@ double f19(double a, double b) {
   return std::fma(a, b, b);
 }
 
-//CHECK: void f19_grad(double a, double b, double *_d_a, double *_d_b) {
+//CHECK: void f19_pullback(double a, double b, double _d_y, double *_d_a, double *_d_b) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0;
 //CHECK-NEXT:         double _r1 = 0;
 //CHECK-NEXT:         double _r2 = 0;
-//CHECK-NEXT:         clad::custom_derivatives::fma_pullback(a, b, b, 1, &_r0, &_r1, &_r2);
+//CHECK-NEXT:         clad::custom_derivatives::fma_pullback(a, b, b, _d_y, &_r0, &_r1, &_r2);
 //CHECK-NEXT:         *_d_a += _r0;
 //CHECK-NEXT:         *_d_b += _r1;
 //CHECK-NEXT:         *_d_b += _r2;
@@ -778,7 +778,7 @@ double f20(double x, double y) {
   return x; // 3y
 }
 
-//CHECK: void f20_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK: void f20_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     double *_d_r = 0;
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     double _t1;
@@ -788,7 +788,7 @@ double f20(double x, double y) {
 //CHECK-NEXT:     r = 3;
 //CHECK-NEXT:     _t1 = x;
 //CHECK-NEXT:     x = r * y;
-//CHECK-NEXT:     *_d_x += 1;
+//CHECK-NEXT:     *_d_x += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _r_d1 = *_d_x;
@@ -808,11 +808,11 @@ double f21 (double x, double y) {
     return y;
 }
 
-//CHECK: void f21_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK: void f21_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     _t0 = y;
 //CHECK-NEXT:     y = (y++ , x);
-//CHECK-NEXT:     *_d_y += 1;
+//CHECK-NEXT:     *_d_y += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t0;
 //CHECK-NEXT:         double _r_d0 = *_d_y;

--- a/test/Gradient/DiffInterface.C
+++ b/test/Gradient/DiffInterface.C
@@ -14,64 +14,64 @@ double f_1(double x, double y, double z) {
 }
 
 // all
-//CHECK:   void f_1_grad(double x, double y, double z, double *_d_x, double *_d_y, double *_d_z) {
+//CHECK:   void f_1_pullback(double x, double y, double z, double _d_y0, double *_d_x, double *_d_y, double *_d_z) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 0 * 1;
-//CHECK-NEXT:           *_d_y += 1 * 1;
-//CHECK-NEXT:           *_d_z += 2 * 1;
+//CHECK-NEXT:           *_d_x += 0 * _d_y0;
+//CHECK-NEXT:           *_d_y += 1 * _d_y0;
+//CHECK-NEXT:           *_d_z += 2 * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // x
-//CHECK:   void f_1_grad_0(double x, double y, double z, double *_d_x) {
-//CHECK-NEXT:       double _d_y = 0;
+//CHECK:   void f_1_pullback_0(double x, double y, double z, double _d_y, double *_d_x) {
+//CHECK-NEXT:       double _d_y0 = 0;
 //CHECK-NEXT:       double _d_z = 0;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 0 * 1;
-//CHECK-NEXT:           _d_y += 1 * 1;
-//CHECK-NEXT:           _d_z += 2 * 1;
+//CHECK-NEXT:           *_d_x += 0 * _d_y;
+//CHECK-NEXT:           _d_y0 += 1 * _d_y;
+//CHECK-NEXT:           _d_z += 2 * _d_y;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // y
-//CHECK:   void f_1_grad_1(double x, double y, double z, double *_d_y) {
+//CHECK:   void f_1_pullback_1(double x, double y, double z, double _d_y0, double *_d_y) {
 //CHECK-NEXT:       double _d_x = 0;
 //CHECK-NEXT:       double _d_z = 0;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _d_x += 0 * 1;
-//CHECK-NEXT:           *_d_y += 1 * 1;
-//CHECK-NEXT:           _d_z += 2 * 1;
+//CHECK-NEXT:           _d_x += 0 * _d_y0;
+//CHECK-NEXT:           *_d_y += 1 * _d_y0;
+//CHECK-NEXT:           _d_z += 2 * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // z
-//CHECK:   void f_1_grad_2(double x, double y, double z, double *_d_z) {
+//CHECK:   void f_1_pullback_2(double x, double y, double z, double _d_y, double *_d_z) {
 //CHECK-NEXT:       double _d_x = 0;
-//CHECK-NEXT:       double _d_y = 0;
+//CHECK-NEXT:       double _d_y0 = 0;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _d_x += 0 * 1;
-//CHECK-NEXT:           _d_y += 1 * 1;
-//CHECK-NEXT:           *_d_z += 2 * 1;
+//CHECK-NEXT:           _d_x += 0 * _d_y;
+//CHECK-NEXT:           _d_y0 += 1 * _d_y;
+//CHECK-NEXT:           *_d_z += 2 * _d_y;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // x, y
-//CHECK:   void f_1_grad_0_1(double x, double y, double z, double *_d_x, double *_d_y) {
+//CHECK:   void f_1_pullback_0_1(double x, double y, double z, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_z = 0;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 0 * 1;
-//CHECK-NEXT:           *_d_y += 1 * 1;
-//CHECK-NEXT:           _d_z += 2 * 1;
+//CHECK-NEXT:           *_d_x += 0 * _d_y0;
+//CHECK-NEXT:           *_d_y += 1 * _d_y0;
+//CHECK-NEXT:           _d_z += 2 * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
 // y, z
-//CHECK:   void f_1_grad_1_2(double x, double y, double z, double *_d_y, double *_d_z) {
+//CHECK:   void f_1_pullback_1_2(double x, double y, double z, double _d_y0, double *_d_y, double *_d_z) {
 //CHECK-NEXT:       double _d_x = 0;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _d_x += 0 * 1;
-//CHECK-NEXT:           *_d_y += 1 * 1;
-//CHECK-NEXT:           *_d_z += 2 * 1;
+//CHECK-NEXT:           _d_x += 0 * _d_y0;
+//CHECK-NEXT:           *_d_y += 1 * _d_y0;
+//CHECK-NEXT:           *_d_z += 2 * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -87,37 +87,37 @@ double f_1(double x, double y, double z) {
 int main () {
   double result[3];
 
-  auto f1_grad_all = clad::gradient(f_1);
-  TEST(f1_grad_all,
+  auto f1_pullback_all = clad::gradient(f_1);
+  TEST(f1_pullback_all,
        &result[0],
        &result[1],
        &result[2]); // CHECK-EXEC: {0.00, 1.00, 2.00}
 
-  auto f1_grad_x = clad::gradient(f_1, "x");
-  TEST(f1_grad_x, &result[0]); // CHECK-EXEC: {0.00, 0.00, 0.00}
+  auto f1_pullback_x = clad::gradient(f_1, "x");
+  TEST(f1_pullback_x, &result[0]); // CHECK-EXEC: {0.00, 0.00, 0.00}
 
-  auto f1_grad_y = clad::gradient(f_1, "y");
-  TEST(f1_grad_y, &result[1]); // CHECK-EXEC: {0.00, 1.00, 0.00}
-  auto f1_grad_z = clad::gradient(f_1, "z");
-  TEST(f1_grad_z, &result[2]); // CHECK-EXEC: {0.00, 0.00, 2.00}
+  auto f1_pullback_y = clad::gradient(f_1, "y");
+  TEST(f1_pullback_y, &result[1]); // CHECK-EXEC: {0.00, 1.00, 0.00}
+  auto f1_pullback_z = clad::gradient(f_1, "z");
+  TEST(f1_pullback_z, &result[2]); // CHECK-EXEC: {0.00, 0.00, 2.00}
 
-  auto f1_grad_xy = clad::gradient(f_1, "x, y");
-  TEST(f1_grad_xy, &result[0], &result[1]); // CHECK-EXEC: {0.00, 1.00, 0.00}
+  auto f1_pullback_xy = clad::gradient(f_1, "x, y");
+  TEST(f1_pullback_xy, &result[0], &result[1]); // CHECK-EXEC: {0.00, 1.00, 0.00}
 
-  auto f1_grad_yx = clad::gradient(f_1, "y, x");
-  TEST(f1_grad_yx, &result[0], &result[1]); // CHECK-EXEC: {0.00, 1.00, 0.00}
+  auto f1_pullback_yx = clad::gradient(f_1, "y, x");
+  TEST(f1_pullback_yx, &result[0], &result[1]); // CHECK-EXEC: {0.00, 1.00, 0.00}
 
-  auto f1_grad_yz = clad::gradient(f_1, "y, z");
-  TEST(f1_grad_yz, &result[1], &result[2]); // CHECK-EXEC: {0.00, 1.00, 2.00}
+  auto f1_pullback_yz = clad::gradient(f_1, "y, z");
+  TEST(f1_pullback_yz, &result[1], &result[2]); // CHECK-EXEC: {0.00, 1.00, 2.00}
 
-  auto f1_grad_xyz = clad::gradient(f_1, "x, y, z");
-  TEST(f1_grad_xyz,
+  auto f1_pullback_xyz = clad::gradient(f_1, "x, y, z");
+  TEST(f1_pullback_xyz,
        &result[0],
        &result[1],
        &result[2]); // CHECK-EXEC: {0.00, 1.00, 2.00}
 
-  auto f1_grad_zyx = clad::gradient(f_1, "z,y,x");
-  TEST(f1_grad_zyx,
+  auto f1_pullback_zyx = clad::gradient(f_1, "z,y,x");
+  TEST(f1_pullback_zyx,
        &result[0],
        &result[1],
        &result[2]); // CHECK-EXEC: {0.00, 1.00, 2.00}

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -602,7 +602,7 @@ double add(double a, double* b) {
 }
 
 
-//CHECK: void add_pullback(double a, double *b, double _d_y, double *_d_a);
+//CHECK: void add_pullback_0(double a, double *b, double _d_y, double *_d_a);
 
 //CHECK: void add_pullback(double a, double *b, double _d_y, double *_d_a, double *_d_b);
 
@@ -633,7 +633,7 @@ double fn17 (double x, double* y) {
 //CHECK-NEXT:         double _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         double _r0 = 0;
-//CHECK-NEXT:         add_pullback(x, y, _r_d0, &_r0);
+//CHECK-NEXT:         add_pullback_0(x, y, _r_d0, &_r0);
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -682,7 +682,7 @@ double weighted_sum(double* x, const double* w) {
   return w[0] * x[0] + w[1] * x[1];
 }
 
-// CHECK: void weighted_sum_pullback(double *x, const double *w, double _d_y, double *_d_x);
+// CHECK: void weighted_sum_pullback_0(double *x, const double *w, double _d_y, double *_d_x);
 
 double fn20(double* x, const double* w) {
   const double* auxW = w + 1;
@@ -691,7 +691,7 @@ double fn20(double* x, const double* w) {
 
 // CHECK: void fn20_pullback_0(double *x, const double *w, double _d_y, double *_d_x) {
 // CHECK-NEXT:     const double *auxW = w + 1;
-// CHECK-NEXT:     weighted_sum_pullback(x, auxW, _d_y, _d_x);
+// CHECK-NEXT:     weighted_sum_pullback_0(x, auxW, _d_y, _d_x);
 // CHECK-NEXT: }
 
 double ptrRef(double*& ptr_ref) {
@@ -1067,7 +1067,7 @@ double sq_defined_later(double x) {
 //CHECK-NEXT:         }
 //CHECK-NEXT: }
 
-//CHECK: void add_pullback(double a, double *b, double _d_y, double *_d_a) {
+//CHECK: void add_pullback_0(double a, double *b, double _d_y, double *_d_a) {
 //CHECK-NEXT:     *_d_a += _d_y;
 //CHECK-NEXT: }
 
@@ -1089,7 +1089,7 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:     *_d_x += _d_y;
 // CHECK-NEXT: }
 
-// CHECK: void weighted_sum_pullback(double *x, const double *w, double _d_y, double *_d_x) {
+// CHECK: void weighted_sum_pullback_0(double *x, const double *w, double _d_y, double *_d_x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_x[0] += w[0] * _d_y;
 // CHECK-NEXT:         _d_x[1] += w[1] * _d_y;

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -22,12 +22,12 @@ double fn1(float i) {
   return a;
 }
 
-// CHECK: void fn1_grad(float i, float *_d_i) {
+// CHECK: void fn1_pullback(float i, double _d_y, float *_d_i) {
 // CHECK-NEXT:     float _d_res = 0;
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     float res = A::constantFn(i);
 // CHECK-NEXT:     double a = res * i;
-// CHECK-NEXT:     _d_a += 1;
+// CHECK-NEXT:     _d_a += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_res += _d_a * i;
 // CHECK-NEXT:         *_d_i += res * _d_a;
@@ -55,7 +55,7 @@ double fn2(double i, double j) {
   return i;
 }
 
-// CHECK: void fn2_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn2_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
@@ -72,7 +72,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:     _t4 = i;
 // CHECK-NEXT:     _t5 = j;
 // CHECK-NEXT:     temp = modify1(i, j);
-// CHECK-NEXT:     *_d_i += 1;
+// CHECK-NEXT:     *_d_i += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         temp = _t3;
 // CHECK-NEXT:         double _r_d1 = _d_temp;
@@ -104,7 +104,7 @@ double fn3(double i, double j) {
   return i;
 }
 
-// CHECK: void fn3_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn3_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _t2;
@@ -115,7 +115,7 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     _t2 = i;
 // CHECK-NEXT:     _t3 = j;
 // CHECK-NEXT:     update1(i, j);
-// CHECK-NEXT:     *_d_i += 1;
+// CHECK-NEXT:     *_d_i += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         i = _t2;
 // CHECK-NEXT:         j = _t3;
@@ -154,7 +154,7 @@ double fn4(double* arr, int n) {
   return res;
 }
 
-// CHECK: void fn4_grad(double *arr, int n, double *_d_arr, int *_d_n) {
+// CHECK: void fn4_pullback(double *arr, int n, double _d_y, double *_d_arr, int *_d_n) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     unsigned {{int|long}} _t1;
@@ -177,7 +177,7 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:         clad::push(_t3, res);
 // CHECK-NEXT:         res += arr[i];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t1--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t1)
@@ -216,10 +216,10 @@ double fn5(double* arr, int n) {
     return arr[0];
 }
 
-// CHECK: void fn5_grad(double *arr, int n, double *_d_arr, int *_d_n) {
+// CHECK: void fn5_pullback(double *arr, int n, double _d_y, double *_d_arr, int *_d_n) {
 // CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double temp = modify2(arr);
-// CHECK-NEXT:     _d_arr[0] += 1;
+// CHECK-NEXT:     _d_arr[0] += _d_y;
 // CHECK-NEXT:     modify2_pullback(arr, _d_temp, _d_arr);
 // CHECK-NEXT: }
 
@@ -259,10 +259,10 @@ double fn7(double i, double j) {
   return i + j + temp;
 }
 
-// CHECK: void fn6_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn6_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_i += 1 * j;
-// CHECK-NEXT:         *_d_j += i * 1;
+// CHECK-NEXT:         *_d_i += _d_y * j;
+// CHECK-NEXT:         *_d_j += i * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -276,7 +276,7 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     return {i, *d_i};
 // CHECK-NEXT: }
 
-// CHECK: void fn7_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn7_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double *_d_k = 0;
 // CHECK-NEXT:     double _t2;
@@ -302,9 +302,9 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     _t7 = l;
 // CHECK-NEXT:     l += 9 * i;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_i += 1;
-// CHECK-NEXT:         *_d_j += 1;
-// CHECK-NEXT:         _d_temp += 1;
+// CHECK-NEXT:         *_d_i += _d_y;
+// CHECK-NEXT:         *_d_j += _d_y;
+// CHECK-NEXT:         _d_temp += _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         l = _t7;
@@ -342,7 +342,7 @@ double fn8(double x, double y) {
   return check_and_return(x, 'a', "aa") * y * std::tanh(1.0) * std::max(1.0, 2.0); // expected-warning {{ISO C++11 does not allow conversion from string literal to 'char *' [-Wwritable-strings]}}
 }
 
-// CHECK: void fn8_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: void fn8_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _t2;
@@ -352,9 +352,9 @@ double fn8(double x, double y) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         char _r1 = 0;
-// CHECK-NEXT:         check_and_return_pullback(x, 'a', "aa", 1 * _t0 * _t1 * y, &_r0, &_r1, "");
+// CHECK-NEXT:         check_and_return_pullback(x, 'a', "aa", _d_y0 * _t0 * _t1 * y, &_r0, &_r1, "");
 // CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         *_d_y += _t2 * 1 * _t0 * _t1;
+// CHECK-NEXT:         *_d_y += _t2 * _d_y0 * _t0 * _t1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -368,13 +368,13 @@ double fn9(double x, double y) {
   return custom_max(x*y, y);
 }
 
-// CHECK:void fn9_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK:void fn9_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 // CHECK-NEXT:    double _t0;
 // CHECK-NEXT:    _t0 = y;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        y = _t0;
 // CHECK-NEXT:        double _r0 = 0;
-// CHECK-NEXT:        custom_max_pullback(x * y, _t0, 1, &_r0, &*_d_y);
+// CHECK-NEXT:        custom_max_pullback(x * y, _t0, _d_y0, &_r0, &*_d_y);
 // CHECK-NEXT:        *_d_x += _r0 * y;
 // CHECK-NEXT:        *_d_y += x * _r0;
 // CHECK-NEXT:    }
@@ -388,7 +388,7 @@ double fn10(double x, double y) {
   return out * y;
 }
 
-// CHECK: void fn10_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: void fn10_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 // CHECK-NEXT:    double _d_out = 0;
 // CHECK-NEXT:    double _t0;
 // CHECK-NEXT:    double _t1;
@@ -407,8 +407,8 @@ double fn10(double x, double y) {
 // CHECK-NEXT:    _t5 = out;
 // CHECK-NEXT:    out = std::clamp(out, 3., 7.);
 // CHECK-NEXT:    {
-// CHECK-NEXT:        _d_out += 1 * y;
-// CHECK-NEXT:        *_d_y += out * 1;
+// CHECK-NEXT:        _d_out += _d_y0 * y;
+// CHECK-NEXT:        *_d_y += out * _d_y0;
 // CHECK-NEXT:    }
 // CHECK-NEXT:    {
 // CHECK-NEXT:        out = _t4;
@@ -463,7 +463,7 @@ double fn11(double x, double y) {
   return n1::n2::sum(x, y);
 }
 
-// CHECK: void fn11_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: void fn11_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 // CHECK-NEXT:    double _t0;
 // CHECK-NEXT:    double _t1;
 // CHECK-NEXT:    _t0 = x;
@@ -471,7 +471,7 @@ double fn11(double x, double y) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        x = _t0;
 // CHECK-NEXT:        y = _t1;
-// CHECK-NEXT:        clad::custom_derivatives::n1::sum_pullback(_t0, _t1, 1, &*_d_x, &*_d_y);
+// CHECK-NEXT:        clad::custom_derivatives::n1::sum_pullback(_t0, _t1, _d_y0, &*_d_x, &*_d_y);
 // CHECK-NEXT:    }
 // CHECK-NEXT: }
 
@@ -485,8 +485,8 @@ double fn12(double x, double y) {
   return do_nothing(&x, nullptr, 0);
 }
 
-// CHECK: void fn12_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     do_nothing_pullback(&x, nullptr, 0, 1, &*_d_x, nullptr, 0);
+// CHECK: void fn12_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
+// CHECK-NEXT:     do_nothing_pullback(&x, nullptr, 0, _d_y0, &*_d_x, nullptr, 0);
 // CHECK-NEXT: }
 
 double multiply(double* a, double* b) {
@@ -501,7 +501,7 @@ double fn13(double* x, const double* w) {
   return multiply(x, wCopy + 1);
 }
 
-// CHECK: void fn13_grad_0(double *x, const double *w, double *_d_x) {
+// CHECK: void fn13_pullback_0(double *x, const double *w, double _d_y, double *_d_x) {
 // CHECK-NEXT:     double _d_wCopy[2] = {0};
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     std::size_t _d_i = 0;
@@ -518,7 +518,7 @@ double fn13(double* x, const double* w) {
 // CHECK-NEXT:         clad::push(_t1, wCopy[i]);
 // CHECK-NEXT:         wCopy[i] = w[i];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     multiply_pullback(x, wCopy + 1, 1, _d_x, _d_wCopy + 1);
+// CHECK-NEXT:     multiply_pullback(x, wCopy + 1, _d_y, _d_x, _d_wCopy + 1);
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -542,13 +542,13 @@ double fn14(double x, double y) {
     return x + y;
 }
 
-// CHECK: void fn14_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: void fn14_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     _t0 = x;
 // CHECK-NEXT:     emptyFn(x, y);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_x += 1;
-// CHECK-NEXT:         *_d_y += 1;
+// CHECK-NEXT:         *_d_x += _d_y0;
+// CHECK-NEXT:         *_d_y += _d_y0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         x = _t0;
@@ -563,11 +563,11 @@ double fn15(double x, double y) {
     return y;
 }
 
-//CHECK: void fn15_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK: void fn15_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     _t0 = y;
 //CHECK-NEXT:     A::constantFn(y += x);
-//CHECK-NEXT:     *_d_y += 1;
+//CHECK-NEXT:     *_d_y += _d_y0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t0;
 //CHECK-NEXT:         double _r_d0 = *_d_y;
@@ -587,11 +587,11 @@ double fn16(double x, double y) {
     return recFun(x, y);
 }
 
-//CHECK: void fn16_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK: void fn16_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0;
 //CHECK-NEXT:         double _r1 = 0;
-//CHECK-NEXT:         recFun_pullback(x, y, 1, &_r0, &_r1);
+//CHECK-NEXT:         recFun_pullback(x, y, _d_y0, &_r0, &_r1);
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:         *_d_y += _r1;
 //CHECK-NEXT:     }
@@ -612,14 +612,14 @@ double fn17 (double x, double* y) {
     return x;
 }
 
-//CHECK: void fn17_grad_0(double x, double *y, double *_d_x) {
+//CHECK: void fn17_pullback_0(double x, double *y, double _d_y, double *_d_x) {
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     double _t1;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = add(x, y);
 //CHECK-NEXT:     _t1 = x;
 //CHECK-NEXT:     x = add(x, &x);
-//CHECK-NEXT:     *_d_x += 1;
+//CHECK-NEXT:     *_d_x += _d_y;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _r_d1 = *_d_x;
@@ -646,13 +646,13 @@ double fn18(double x, double y) {
     return sq_defined_later(x) + sq_defined_later(y);
 }
 
-// CHECK: void fn18_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: void fn18_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
-// CHECK-NEXT:         sq_defined_later_pullback(x, 1, &_r0);
+// CHECK-NEXT:         sq_defined_later_pullback(x, _d_y0, &_r0);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         double _r1 = 0;
-// CHECK-NEXT:         sq_defined_later_pullback(y, 1, &_r1);
+// CHECK-NEXT:         sq_defined_later_pullback(y, _d_y0, &_r1);
 // CHECK-NEXT:         *_d_y += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -670,10 +670,10 @@ double fn19(double x) {
   return templated_fn<double>(x);
 }
 
-// CHECK: void fn19_grad(double x, double *_d_x) {
+// CHECK: void fn19_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
-// CHECK-NEXT:         templated_fn_pullback(x, 1, &_r0);
+// CHECK-NEXT:         templated_fn_pullback(x, _d_y, &_r0);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -689,9 +689,9 @@ double fn20(double* x, const double* w) {
   return weighted_sum(x, auxW);
 }
 
-// CHECK: void fn20_grad_0(double *x, const double *w, double *_d_x) {
+// CHECK: void fn20_pullback_0(double *x, const double *w, double _d_y, double *_d_x) {
 // CHECK-NEXT:     const double *auxW = w + 1;
-// CHECK-NEXT:     weighted_sum_pullback(x, auxW, 1, _d_x);
+// CHECK-NEXT:     weighted_sum_pullback(x, auxW, _d_y, _d_x);
 // CHECK-NEXT: }
 
 double ptrRef(double*& ptr_ref) {
@@ -705,7 +705,7 @@ double fn21(double x) {
   return ptrRef(ptr);
 }
 
-// CHECK: void fn21_grad(double x, double *_d_x) {
+// CHECK: void fn21_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:     double *_d_ptr = 0;
 // CHECK-NEXT:     double *_t0;
 // CHECK-NEXT:     _d_ptr = &*_d_x;
@@ -713,12 +713,12 @@ double fn21(double x) {
 // CHECK-NEXT:     _t0 = ptr;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         ptr = _t0;
-// CHECK-NEXT:         ptrRef_pullback(_t0, 1, &_d_ptr);
+// CHECK-NEXT:         ptrRef_pullback(_t0, _d_y, &_d_ptr);
 // CHECK-NEXT:     }
 
 namespace clad{
 namespace custom_derivatives{
-  void fn22_grad_1(double x, double y, double *d_y) {
+  void fn22_pullback_1(double x, double y, double _d_y0, double *d_y) {
     *d_y += x;
   }
 }
@@ -728,7 +728,7 @@ double fn22(double x, double y) {
   return x*y; // fn22 has a custom derivative defined.
 }
 
-// CHECK: void fn22_grad_1(double x, double y, double *d_y) {
+// CHECK: void fn22_pullback_1(double x, double y, double _d_y0, double *d_y) {
 // CHECK-NEXT:   *d_y += x;
 // CHECK-NEXT: }
 

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -14,11 +14,11 @@ struct Experiment {
 
   Experiment& operator=(const Experiment& E) = default;
 
-  // CHECK: void operator_call_grad(double i, double j, Experiment *_d_this, double *_d_i, double *_d_j) {
+  // CHECK: void operator_call_pullback(double i, double j, double _d_y, Experiment *_d_this, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
-  // CHECK-NEXT:         *_d_i += this->x * 1 * j;
-  // CHECK-NEXT:         *_d_j += this->x * i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * j * i;
+  // CHECK-NEXT:         *_d_i += this->x * _d_y * j;
+  // CHECK-NEXT:         *_d_j += this->x * i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -30,11 +30,11 @@ struct ExperimentConst {
   void setX(double val) const { x = val; }
 
   ExperimentConst& operator=(const ExperimentConst& E) = default;
-  // CHECK: void operator_call_grad(double i, double j, ExperimentConst *_d_this, double *_d_i, double *_d_j) const {
+  // CHECK: void operator_call_pullback(double i, double j, double _d_y, ExperimentConst *_d_this, double *_d_i, double *_d_j) const {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
-  // CHECK-NEXT:         *_d_i += this->x * 1 * j;
-  // CHECK-NEXT:         *_d_j += this->x * i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * j * i;
+  // CHECK-NEXT:         *_d_i += this->x * _d_y * j;
+  // CHECK-NEXT:         *_d_j += this->x * i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -52,13 +52,13 @@ struct ExperimentVolatile {
     return (*this);
   };
 
-  // CHECK: void operator_call_grad(double i, double j, volatile ExperimentVolatile *_d_this, double *_d_i, double *_d_j) volatile {
+  // CHECK: void operator_call_pullback(double i, double j, double _d_y, volatile ExperimentVolatile *_d_this, double *_d_i, double *_d_j) volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = this->x * i;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
-  // CHECK-NEXT:         *_d_i += this->x * 1 * j;
-  // CHECK-NEXT:         *_d_j += _t0 * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * j * i;
+  // CHECK-NEXT:         *_d_i += this->x * _d_y * j;
+  // CHECK-NEXT:         *_d_j += _t0 * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -76,13 +76,13 @@ struct ExperimentConstVolatile {
     return (*this);
   };
 
-  // CHECK: void operator_call_grad(double i, double j, volatile ExperimentConstVolatile *_d_this, double *_d_i, double *_d_j) const volatile {
+  // CHECK: void operator_call_pullback(double i, double j, double _d_y, volatile ExperimentConstVolatile *_d_this, double *_d_i, double *_d_j) const volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = this->x * i;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
-  // CHECK-NEXT:         *_d_i += this->x * 1 * j;
-  // CHECK-NEXT:         *_d_j += _t0 * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * j * i;
+  // CHECK-NEXT:         *_d_i += this->x * _d_y * j;
+  // CHECK-NEXT:         *_d_j += _t0 * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -97,11 +97,11 @@ struct ExperimentNNS {
 
   ExperimentNNS& operator=(const ExperimentNNS& E) = default;
 
-  // CHECK: void operator_call_grad(double i, double j, outer::inner::ExperimentNNS *_d_this, double *_d_i, double *_d_j) {
+  // CHECK: void operator_call_pullback(double i, double j, double _d_y, outer::inner::ExperimentNNS *_d_this, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
-  // CHECK-NEXT:         *_d_i += this->x * 1 * j;
-  // CHECK-NEXT:         *_d_j += this->x * i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * j * i;
+  // CHECK-NEXT:         *_d_i += this->x * _d_y * j;
+  // CHECK-NEXT:         *_d_j += this->x * i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -159,20 +159,20 @@ int main() {
 
   auto lambda = [](double i, double j) { return i * i * j; };
 
-  // CHECK: inline void operator_call_grad(double i, double j, double *_d_i, double *_d_j) const {
+  // CHECK: inline void operator_call_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) const {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         *_d_i += 1 * j * i;
-  // CHECK-NEXT:         *_d_i += i * 1 * j;
-  // CHECK-NEXT:         *_d_j += i * i * 1;
+  // CHECK-NEXT:         *_d_i += _d_y * j * i;
+  // CHECK-NEXT:         *_d_i += i * _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   auto lambdaWithCapture = [&](double ii, double j) { return x * ii * j; };
 
-  // CHECK: inline void operator_call_grad(double ii, double j, double *_d_ii, double *_d_j) const {
+  // CHECK: inline void operator_call_pullback(double ii, double j, double _d_y, double *_d_ii, double *_d_j) const {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         *_d_ii += x * 1 * j;
-  // CHECK-NEXT:         *_d_j += x * ii * 1;
+  // CHECK-NEXT:         *_d_ii += x * _d_y * j;
+  // CHECK-NEXT:         *_d_j += x * ii * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -224,7 +224,7 @@ int main() {
   TEST_LAMBDA(lambdaWithCapture);             // CHECK-EXEC: 54.00 42.00
                                               // CHECK-EXEC: 54.00 42.00
 
-  // CHECK: void CallFunctor_grad(double i, double j, double *_d_i, double *_d_j) {
+  // CHECK: void CallFunctor_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     Experiment _d_E({});
   // CHECK-NEXT:     Experiment _t0;
   // CHECK-NEXT:     Experiment E(3, 5);
@@ -232,7 +232,7 @@ int main() {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0;
   // CHECK-NEXT:         double _r1 = 0;
-  // CHECK-NEXT:         _t0.operator_call_pullback(i, j, 1, &_d_E, &_r0, &_r1);
+  // CHECK-NEXT:         _t0.operator_call_pullback(i, j, _d_y, &_d_E, &_r0, &_r1);
   // CHECK-NEXT:         *_d_i += _r0;
   // CHECK-NEXT:         *_d_j += _r1;
   // CHECK-NEXT:     }
@@ -244,13 +244,13 @@ int main() {
   CallFunctor_grad.execute(7, 9, &di, &dj);
   printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 27.00 21.00
 
-  // CHECK: void FunctorAsArg_grad(Experiment fn, double i, double j, Experiment *_d_fn, double *_d_i, double *_d_j) {
+  // CHECK: void FunctorAsArg_pullback(Experiment fn, double i, double j, double _d_y, Experiment *_d_fn, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     Experiment _t0;
   // CHECK-NEXT:     _t0 = fn;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0;
   // CHECK-NEXT:         double _r1 = 0;
-  // CHECK-NEXT:         _t0.operator_call_pullback(i, j, 1, &(*_d_fn), &_r0, &_r1);
+  // CHECK-NEXT:         _t0.operator_call_pullback(i, j, _d_y, &(*_d_fn), &_r0, &_r1);
   // CHECK-NEXT:         *_d_i += _r0;
   // CHECK-NEXT:         *_d_j += _r1;
   // CHECK-NEXT:     }
@@ -263,16 +263,14 @@ int main() {
   FunctorAsArg_grad.execute(E_temp, 7, 9, &dE_temp, &di, &dj);
   printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 27.00 21.00
 
-  // CHECK: void FunctorAsArg_pullback(Experiment fn, double i, double j, double _d_y, Experiment *_d_fn, double *_d_i, double *_d_j);
-
-  // CHECK: void FunctorAsArgWrapper_grad(double i, double j, double *_d_i, double *_d_j) {
+  // CHECK: void FunctorAsArgWrapper_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     Experiment _d_E({});
   // CHECK-NEXT:     Experiment E(3, 5);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         Experiment _r0 = {};
   // CHECK-NEXT:         double _r1 = 0;
   // CHECK-NEXT:         double _r2 = 0;
-  // CHECK-NEXT:         FunctorAsArg_pullback(E, i, j, 1, &_r0, &_r1, &_r2);
+  // CHECK-NEXT:         FunctorAsArg_pullback(E, i, j, _d_y, &_r0, &_r1, &_r2);
   // CHECK-NEXT:         *_d_i += _r1;
   // CHECK-NEXT:         *_d_j += _r2;
   // CHECK-NEXT:     }
@@ -284,15 +282,3 @@ int main() {
   FunctorAsArgWrapper_grad.execute(7, 9, &di, &dj);
   printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 27.00 21.00
 }
-
-// CHECK: void FunctorAsArg_pullback(Experiment fn, double i, double j, double _d_y, Experiment *_d_fn, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     Experiment _t0;
-// CHECK-NEXT:     _t0 = fn;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 0;
-// CHECK-NEXT:         double _r1 = 0;
-// CHECK-NEXT:         _t0.operator_call_pullback(i, j, _d_y, &(*_d_fn), &_r0, &_r1);
-// CHECK-NEXT:         *_d_i += _r0;
-// CHECK-NEXT:         *_d_j += _r1;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -16,127 +16,127 @@ __attribute__((always_inline)) double f_add1(double x, double y) {
   return x + y;
 }
 
-//CHECK: {{[__attribute__((always_inline))]*}}void f_add1_grad(double x, double y, double *_d_x, double *_d_y){{[ __attribute__((always_inline))]*}} {
+//CHECK: {{[__attribute__((always_inline))]*}}void f_add1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y){{[ __attribute__((always_inline))]*}} {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 1;
-//CHECK-NEXT:           *_d_y += 1;
+//CHECK-NEXT:           *_d_x += _d_y0;
+//CHECK-NEXT:           *_d_y += _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_add1_grad(double x, double y, double *_d_x, double *_d_y);
+void f_add1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_add2(double x, double y) {
   return 3*x + 4*y;
 }
 
-//CHECK:   void f_add2_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_add2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 3 * 1;
-//CHECK-NEXT:           *_d_y += 4 * 1;
+//CHECK-NEXT:           *_d_x += 3 * _d_y0;
+//CHECK-NEXT:           *_d_y += 4 * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_add2_grad(double x, double y, double *_d_x, double *_d_y);
+void f_add2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_add3(double x, double y) {
   return 3*x + 4*y*4;
 }
 
-//CHECK:   void f_add3_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_add3_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 3 * 1;
-//CHECK-NEXT:           *_d_y += 4 * 1 * 4;
+//CHECK-NEXT:           *_d_x += 3 * _d_y0;
+//CHECK-NEXT:           *_d_y += 4 * _d_y0 * 4;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_add3_grad(double x, double y, double *_d_x, double *_d_y);
+void f_add3_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_sub1(double x, double y) {
   return x - y;
 }
 
-//CHECK:   void f_sub1_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_sub1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 1;
-//CHECK-NEXT:           *_d_y += -1;
+//CHECK-NEXT:           *_d_x += _d_y0;
+//CHECK-NEXT:           *_d_y += -_d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
-void f_sub1_grad(double x, double y, double *_d_x, double *_d_y);
+void f_sub1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_sub2(double x, double y) {
   return 3*x - 4*y;
 }
 
-//CHECK:   void f_sub2_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_sub2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 3 * 1;
-//CHECK-NEXT:           *_d_y += 4 * -1;
+//CHECK-NEXT:           *_d_x += 3 * _d_y0;
+//CHECK-NEXT:           *_d_y += 4 * -_d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_sub2_grad(double x, double y, double *_d_x, double *_d_y);
+void f_sub2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_mult1(double x, double y) {
   return x*y;
 }
 
-//CHECK:   void f_mult1_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_mult1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 1 * y;
-//CHECK-NEXT:           *_d_y += x * 1;
+//CHECK-NEXT:           *_d_x += _d_y0 * y;
+//CHECK-NEXT:           *_d_y += x * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_mult1_grad(double x, double y, double *_d_x, double *_d_y);
+void f_mult1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_mult2(double x, double y) {
    return 3*x*4*y;
 }
 
-//CHECK:   void f_mult2_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_mult2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 3 * 1 * y * 4;
-//CHECK-NEXT:           *_d_y += 3 * x * 4 * 1;
+//CHECK-NEXT:           *_d_x += 3 * _d_y0 * y * 4;
+//CHECK-NEXT:           *_d_y += 3 * x * 4 * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_mult2_grad(double x, double y, double *_d_x, double *_d_y);
+void f_mult2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_div1(double x, double y) {
   return x/y;
 }
 
-//CHECK:   void f_div1_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_div1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 1 / y;
-//CHECK-NEXT:           double _r0 = 1 * -(x / (y * y));
+//CHECK-NEXT:           *_d_x += _d_y0 / y;
+//CHECK-NEXT:           double _r0 = _d_y0 * -(x / (y * y));
 //CHECK-NEXT:           *_d_y += _r0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_div1_grad(double x, double y, double *_d_x, double *_d_y);
+void f_div1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_div2(double x, double y) {
   return 3*x/(4*y);
 }
 
-//CHECK:   void f_div2_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_div2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       _t0 = (4 * y);
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 3 * 1 / _t0;
-//CHECK-NEXT:           double _r0 = 1 * -(3 * x / (_t0 * _t0));
+//CHECK-NEXT:           *_d_x += 3 * _d_y0 / _t0;
+//CHECK-NEXT:           double _r0 = _d_y0 * -(3 * x / (_t0 * _t0));
 //CHECK-NEXT:           *_d_y += 4 * _r0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_div2_grad(double x, double y, double *_d_x, double *_d_y);
+void f_div2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_div3(double x, double y) {
     return (x = y) / (y * y);
 }
 
-//CHECK: void f_div3_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK: void f_div3_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     double _t1;
 //CHECK-NEXT:     double _t2;
@@ -144,78 +144,78 @@ double f_div3(double x, double y) {
 //CHECK-NEXT:     _t2 = (x = y);
 //CHECK-NEXT:     _t0 = (y * y);
 //CHECK-NEXT:     {
-//CHECK-NEXT:         *_d_x += 1 / _t0;
+//CHECK-NEXT:         *_d_x += _d_y0 / _t0;
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_y += _r_d0;
-//CHECK-NEXT:         double _r0 = 1 * -(_t2 / (_t0 * _t0));
+//CHECK-NEXT:         double _r0 = _d_y0 * -(_t2 / (_t0 * _t0));
 //CHECK-NEXT:         *_d_y += _r0 * y;
 //CHECK-NEXT:         *_d_y += y * _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
-void f_div3_grad(double x, double y, double *_d_x, double *_d_y);
+void f_div3_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_c(double x, double y) {
   return -x*y + (x + y)*(x/y) - x*x;
 }
 
-//CHECK:   void f_c_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_c_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += -1 * y;
-//CHECK-NEXT:           *_d_y += -x * 1;
-//CHECK-NEXT:           *_d_x += 1 * (x / y);
-//CHECK-NEXT:           *_d_y += 1 * (x / y);
-//CHECK-NEXT:           *_d_x += (x + y) * 1 / y;
-//CHECK-NEXT:           double _r0 = (x + y) * 1 * -(x / (y * y));
+//CHECK-NEXT:           *_d_x += -_d_y0 * y;
+//CHECK-NEXT:           *_d_y += -x * _d_y0;
+//CHECK-NEXT:           *_d_x += _d_y0 * (x / y);
+//CHECK-NEXT:           *_d_y += _d_y0 * (x / y);
+//CHECK-NEXT:           *_d_x += (x + y) * _d_y0 / y;
+//CHECK-NEXT:           double _r0 = (x + y) * _d_y0 * -(x / (y * y));
 //CHECK-NEXT:           *_d_y += _r0;
-//CHECK-NEXT:           *_d_x += -1 * x;
-//CHECK-NEXT:           *_d_x += x * -1;
+//CHECK-NEXT:           *_d_x += -_d_y0 * x;
+//CHECK-NEXT:           *_d_x += x * -_d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_c_grad(double x, double y, double *_d_x, double *_d_y);
+void f_c_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_rosenbrock(double x, double y) {
   return (x - 1) * (x - 1) + 100 * (y - x * x) * (y - x * x);
 }
 
-//CHECK:   void f_rosenbrock_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_rosenbrock_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 1 * (x - 1);
-//CHECK-NEXT:           *_d_x += (x - 1) * 1;
-//CHECK-NEXT:           *_d_y += 100 * 1 * (y - x * x);
-//CHECK-NEXT:           *_d_x += -100 * 1 * (y - x * x) * x;
-//CHECK-NEXT:           *_d_x += x * -100 * 1 * (y - x * x);
-//CHECK-NEXT:           *_d_y += 100 * (y - x * x) * 1;
-//CHECK-NEXT:           *_d_x += -100 * (y - x * x) * 1 * x;
-//CHECK-NEXT:           *_d_x += x * -100 * (y - x * x) * 1;
+//CHECK-NEXT:           *_d_x += _d_y0 * (x - 1);
+//CHECK-NEXT:           *_d_x += (x - 1) * _d_y0;
+//CHECK-NEXT:           *_d_y += 100 * _d_y0 * (y - x * x);
+//CHECK-NEXT:           *_d_x += -100 * _d_y0 * (y - x * x) * x;
+//CHECK-NEXT:           *_d_x += x * -100 * _d_y0 * (y - x * x);
+//CHECK-NEXT:           *_d_y += 100 * (y - x * x) * _d_y0;
+//CHECK-NEXT:           *_d_x += -100 * (y - x * x) * _d_y0 * x;
+//CHECK-NEXT:           *_d_x += x * -100 * (y - x * x) * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_rosenbrock_grad(double x, double y, double *_d_x, double *_d_y);
+void f_rosenbrock_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_cond1(double x, double y) {
   return (x > y ? x : y);
 }
 
-//CHECK:   void f_cond1_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_cond1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       _cond0 = x > y;
 //CHECK-NEXT:       if (_cond0)
-//CHECK-NEXT:           *_d_x += 1;
+//CHECK-NEXT:           *_d_x += _d_y0;
 //CHECK-NEXT:       else
-//CHECK-NEXT:           *_d_y += 1;
+//CHECK-NEXT:           *_d_y += _d_y0;
 //CHECK-NEXT:   }
 
-void f_cond1_grad(double x, double y, double *_d_x, double *_d_y);
+void f_cond1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_cond2(double x, double y) {
   return (x > y ? x : (y > 0 ? y : -y));
 }
 
-//CHECK:   void f_cond2_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_cond2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       _cond0 = x > y;
@@ -224,32 +224,32 @@ double f_cond2(double x, double y) {
 //CHECK-NEXT:       else
 //CHECK-NEXT:           _cond1 = y > 0;
 //CHECK-NEXT:       if (_cond0)
-//CHECK-NEXT:           *_d_x += 1;
+//CHECK-NEXT:           *_d_x += _d_y0;
 //CHECK-NEXT:       else if (_cond1)
-//CHECK-NEXT:           *_d_y += 1;
+//CHECK-NEXT:           *_d_y += _d_y0;
 //CHECK-NEXT:       else
-//CHECK-NEXT:           *_d_y += -1;
+//CHECK-NEXT:           *_d_y += -_d_y0;
 //CHECK-NEXT:   }
 
-void f_cond2_grad(double x, double y, double *_d_x, double *_d_y);
+void f_cond2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_cond3(double x, double c) {
   return (c > 0 ? x + c : x - c);
 }
 
-//CHECK:   void f_cond3_grad(double x, double c, double *_d_x, double *_d_c) {
+//CHECK:   void f_cond3_pullback(double x, double c, double _d_y, double *_d_x, double *_d_c) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       _cond0 = c > 0;
 //CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:           *_d_x += 1;
-//CHECK-NEXT:           *_d_c += 1;
+//CHECK-NEXT:           *_d_x += _d_y;
+//CHECK-NEXT:           *_d_c += _d_y;
 //CHECK-NEXT:       } else {
-//CHECK-NEXT:           *_d_x += 1;
-//CHECK-NEXT:           *_d_c += -1;
+//CHECK-NEXT:           *_d_x += _d_y;
+//CHECK-NEXT:           *_d_c += -_d_y;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_cond3_grad(double x, double c, double *_d_x, double *_d_y);
+void f_cond3_pullback(double x, double c, double _d_y, double *_d_x, double *_d_c);
 
 double f_cond4(double x, double y) {
     int i = 0;
@@ -260,7 +260,7 @@ double f_cond4(double x, double y) {
     return y;
 }
 
-//CHECK:   void f_cond4_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_cond4_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       int _d_i = 0;
 //CHECK-NEXT:       double _d_arr[2] = {0};
 //CHECK-NEXT:       bool _cond0;
@@ -274,7 +274,7 @@ double f_cond4(double x, double y) {
 //CHECK-NEXT:           y = arr[i] * x;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       *_d_y += 1;
+//CHECK-NEXT:       *_d_y += _d_y0;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           {
 //CHECK-NEXT:               y = _t0;
@@ -290,7 +290,7 @@ double f_cond4(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-void f_cond4_grad(double x, double c, double *_d_x, double *_d_y);
+void f_cond4_pullback(double x, double c, double _d_y, double *_d_x, double *_d_c);
 
 double f_if1(double x, double y) {
   if (x > y)
@@ -299,7 +299,7 @@ double f_if1(double x, double y) {
     return y;
 }
 
-//CHECK:   void f_if1_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_if1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x > y;
@@ -310,13 +310,13 @@ double f_if1(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:         _label0:
-//CHECK-NEXT:           *_d_x += 1;
+//CHECK-NEXT:           *_d_x += _d_y0;
 //CHECK-NEXT:       else
 //CHECK-NEXT:         _label1:
-//CHECK-NEXT:           *_d_y += 1;
+//CHECK-NEXT:           *_d_y += _d_y0;
 //CHECK-NEXT:   }
 
-void f_if1_grad(double x, double y, double *_d_x, double *_d_y);
+void f_if1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 double f_if2(double x, double y) {
   if (x > y)
@@ -327,7 +327,7 @@ double f_if2(double x, double y) {
     return -y;
 }
 
-//CHECK:   void f_if2_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_if2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       {
@@ -344,16 +344,16 @@ double f_if2(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:         _label0:
-//CHECK-NEXT:           *_d_x += 1;
+//CHECK-NEXT:           *_d_x += _d_y0;
 //CHECK-NEXT:       else if (_cond1)
 //CHECK-NEXT:         _label1:
-//CHECK-NEXT:           *_d_y += 1;
+//CHECK-NEXT:           *_d_y += _d_y0;
 //CHECK-NEXT:       else
 //CHECK-NEXT:         _label2:
-//CHECK-NEXT:           *_d_y += -1;
+//CHECK-NEXT:           *_d_y += -_d_y0;
 //CHECK-NEXT:   }
 
-void f_if2_grad(double x, double y, double *_d_x, double *_d_y);
+void f_if2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 struct S {
   double c1;
@@ -362,16 +362,16 @@ struct S {
     return c1 * x + c2 * y;
   }
 
-  //CHECK:   void f_grad(double x, double y, S *_d_this, double *_d_x, double *_d_y) {
+  //CHECK:   void f_pullback(double x, double y, double _d_y0, S *_d_this, double *_d_x, double *_d_y) {
   //CHECK-NEXT:       {
-  //CHECK-NEXT:           (*_d_this).c1 += 1 * x;
-  //CHECK-NEXT:           *_d_x += this->c1 * 1;
-  //CHECK-NEXT:           (*_d_this).c2 += 1 * y;
-  //CHECK-NEXT:           *_d_y += this->c2 * 1;
+  //CHECK-NEXT:           (*_d_this).c1 += _d_y0 * x;
+  //CHECK-NEXT:           *_d_x += this->c1 * _d_y0;
+  //CHECK-NEXT:           (*_d_this).c2 += _d_y0 * y;
+  //CHECK-NEXT:           *_d_y += this->c2 * _d_y0;
   //CHECK-NEXT:       }
   //CHECK-NEXT:   }
 
-  void f_grad(double x, double y, double *_d_x, double *_d_y);
+  void f_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 };
 
 double sum_of_powers(double x, double y, double z, double p) {
@@ -403,7 +403,7 @@ double f_norm(double x, double y, double z, double d) {
   return std::pow(sum_of_powers(x, y, z, d), 1/d);
 }
 
-void f_norm_grad(double x,
+void f_norm_pullback(double x,
                  double y,
                  double z,
                  double d,
@@ -411,11 +411,11 @@ void f_norm_grad(double x,
                  double* _d_y,
                  double* _d_z,
                  double* _d_d);
-//CHECK:   void f_norm_grad(double x, double y, double z, double d, double *_d_x, double *_d_y, double *_d_z, double *_d_d) {
+//CHECK:   void f_norm_pullback(double x, double y, double z, double d, double _d_y0, double *_d_x, double *_d_y, double *_d_z, double *_d_d) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 0;
 //CHECK-NEXT:           double _r5 = 0;
-//CHECK-NEXT:           clad::custom_derivatives::pow_pullback(sum_of_powers(x, y, z, d), 1 / d, 1, &_r0, &_r5);
+//CHECK-NEXT:           clad::custom_derivatives::pow_pullback(sum_of_powers(x, y, z, d), 1 / d, _d_y0, &_r0, &_r5);
 //CHECK-NEXT:           double _r1 = 0;
 //CHECK-NEXT:           double _r2 = 0;
 //CHECK-NEXT:           double _r3 = 0;
@@ -434,19 +434,19 @@ double f_sin(double x, double y) {
   return (std::sin(x) + std::sin(y))*(x + y);
 }
 
-void f_sin_grad(double x, double y, double *_d_x, double *_d_y);
-//CHECK:   void f_sin_grad(double x, double y, double *_d_x, double *_d_y) {
+void f_sin_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
+//CHECK:   void f_sin_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       _t0 = (std::sin(x) + std::sin(y));
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 0;
-//CHECK-NEXT:           _r0 += 1 * (x + y) * clad::custom_derivatives::sin_pushforward(x, 1.).pushforward;
+//CHECK-NEXT:           _r0 += _d_y0 * (x + y) * clad::custom_derivatives::sin_pushforward(x, 1.).pushforward;
 //CHECK-NEXT:           *_d_x += _r0;
 //CHECK-NEXT:           double _r1 = 0;
-//CHECK-NEXT:           _r1 += 1 * (x + y) * clad::custom_derivatives::sin_pushforward(y, 1.).pushforward;
+//CHECK-NEXT:           _r1 += _d_y0 * (x + y) * clad::custom_derivatives::sin_pushforward(y, 1.).pushforward;
 //CHECK-NEXT:           *_d_y += _r1;
-//CHECK-NEXT:           *_d_x += _t0 * 1;
-//CHECK-NEXT:           *_d_y += _t0 * 1;
+//CHECK-NEXT:           *_d_x += _t0 * _d_y0;
+//CHECK-NEXT:           *_d_y += _t0 * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -454,17 +454,17 @@ unsigned f_types(int x, float y, double z) {
   return x + y + z;
 }
 
-void f_types_grad(int x,
+void f_types_pullback(int x,
                   float y,
                   double z,
                   int *_d_x,
                   float *_d_y,
                   double *_d_z);
-//CHECK:   void f_types_grad(int x, float y, double z, int *_d_x, float *_d_y, double *_d_z) {
+//CHECK:   void f_types_pullback(int x, float y, double z, unsigned int _d_y0, int *_d_x, float *_d_y, double *_d_z) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 1;
-//CHECK-NEXT:           *_d_y += 1;
-//CHECK-NEXT:           *_d_z += 1;
+//CHECK-NEXT:           *_d_x += _d_y0;
+//CHECK-NEXT:           *_d_y += _d_y0;
+//CHECK-NEXT:           *_d_z += _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -475,15 +475,15 @@ double f_decls1(double x, double y) {
   return 2 * c;
 }
 
-void f_decls1_grad(double x, double y, double *_d_x, double *_d_y);
-//CHECK:   void f_decls1_grad(double x, double y, double *_d_x, double *_d_y) {
+void f_decls1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
+//CHECK:   void f_decls1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_a = 0;
 //CHECK-NEXT:       double _d_b = 0;
 //CHECK-NEXT:       double _d_c = 0;
 //CHECK-NEXT:       double a = 3 * x;
 //CHECK-NEXT:       double b = 5 * y;
 //CHECK-NEXT:       double c = a + b;
-//CHECK-NEXT:       _d_c += 2 * 1;
+//CHECK-NEXT:       _d_c += 2 * _d_y0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += _d_c;
 //CHECK-NEXT:           _d_b += _d_c;
@@ -499,8 +499,8 @@ double f_decls2(double x, double y) {
   return a + 2 * b + c;
 }
 
-void f_decls2_grad(double x, double y, double *_d_x, double *_d_y);
-//CHECK:   void f_decls2_grad(double x, double y, double *_d_x, double *_d_y) {
+void f_decls2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
+//CHECK:   void f_decls2_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_a = 0;
 //CHECK-NEXT:       double _d_b = 0;
 //CHECK-NEXT:       double _d_c = 0;
@@ -508,9 +508,9 @@ void f_decls2_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK-NEXT:       double b = x * y;
 //CHECK-NEXT:       double c = y * y;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _d_a += 1;
-//CHECK-NEXT:           _d_b += 2 * 1;
-//CHECK-NEXT:           _d_c += 1;
+//CHECK-NEXT:           _d_a += _d_y0;
+//CHECK-NEXT:           _d_b += 2 * _d_y0;
+//CHECK-NEXT:           _d_c += _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_y += _d_c * y;
@@ -537,8 +537,8 @@ double f_decls3(double x, double y) {
   return b;
 }
 
-void f_decls3_grad(double x, double y, double *_d_x, double *_d_y);
-//CHECK:   void f_decls3_grad(double x, double y, double *_d_x, double *_d_y) {
+void f_decls3_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
+//CHECK:   void f_decls3_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_a = 0;
 //CHECK-NEXT:       double _d_c = 0;
 //CHECK-NEXT:       bool _cond0;
@@ -557,17 +557,17 @@ void f_decls3_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       double b = a * a;
-//CHECK-NEXT:       _d_b += 1;
+//CHECK-NEXT:       _d_b += _d_y0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += _d_b * a;
 //CHECK-NEXT:           _d_a += a * _d_b;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:         _label0:
-//CHECK-NEXT:           _d_a += 2 * 1;
+//CHECK-NEXT:           _d_a += 2 * _d_y0;
 //CHECK-NEXT:       else if (_cond1)
 //CHECK-NEXT:         _label1:
-//CHECK-NEXT:           _d_a += -2 * 1;
+//CHECK-NEXT:           _d_a += -2 * _d_y0;
 //CHECK-NEXT:       *_d_y += 333 * _d_c;
 //CHECK-NEXT:       *_d_x += 3 * _d_a;
 //CHECK-NEXT:   }
@@ -577,19 +577,19 @@ double f_issue138(double x, double y) {
     return x*x*x*x + y*y*y*y;
 }
 
-void f_issue138_grad(double x, double y, double *_d_x, double *_d_y);
-//CHECK:   void f_issue138_grad(double x, double y, double *_d_x, double *_d_y) {
+void f_issue138_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
+//CHECK:   void f_issue138_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d__t1 = 0;
 //CHECK-NEXT:       double _t10 = 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += 1 * x * x * x;
-//CHECK-NEXT:           *_d_x += x * 1 * x * x;
-//CHECK-NEXT:           *_d_x += x * x * 1 * x;
-//CHECK-NEXT:           *_d_x += x * x * x * 1;
-//CHECK-NEXT:           *_d_y += 1 * y * y * y;
-//CHECK-NEXT:           *_d_y += y * 1 * y * y;
-//CHECK-NEXT:           *_d_y += y * y * 1 * y;
-//CHECK-NEXT:           *_d_y += y * y * y * 1;
+//CHECK-NEXT:           *_d_x += _d_y0 * x * x * x;
+//CHECK-NEXT:           *_d_x += x * _d_y0 * x * x;
+//CHECK-NEXT:           *_d_x += x * x * _d_y0 * x;
+//CHECK-NEXT:           *_d_x += x * x * x * _d_y0;
+//CHECK-NEXT:           *_d_y += _d_y0 * y * y * y;
+//CHECK-NEXT:           *_d_y += y * _d_y0 * y * y;
+//CHECK-NEXT:           *_d_y += y * y * _d_y0 * y;
+//CHECK-NEXT:           *_d_y += y * y * y * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -597,11 +597,11 @@ double f_const(const double a, const double b) {
   return a * b;
 }
 
-void f_const_grad(const double a, const double b, double *_d_a, double *_d_b);
-//CHECK:   void f_const_grad(const double a, const double b, double *_d_a, double *_d_b) {
+void f_const_pullback(const double a, const double b, double _d_y, double *_d_a, double *_d_b);
+//CHECK:   void f_const_pullback(const double a, const double b, double _d_y, double *_d_a, double *_d_b) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_a += 1 * b;
-//CHECK-NEXT:           *_d_b += a * 1;
+//CHECK-NEXT:           *_d_a += _d_y * b;
+//CHECK-NEXT:           *_d_b += a * _d_y;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -611,8 +611,8 @@ double f_const_reference(double i, double j) {
   double res = 2*ar;
   return res;
 }
-void f_const_reference_grad(double i, double j, double *_d_i, double *_d_j);
-//CHECK: void f_const_reference_grad(double i, double j, double *_d_i, double *_d_j) {
+void f_const_reference_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j);
+//CHECK: void f_const_reference_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 //CHECK-NEXT:    double _d_a = 0;
 //CHECK-NEXT:    double *_d_ar = 0;
 //CHECK-NEXT:    double _d_res = 0;
@@ -620,7 +620,7 @@ void f_const_reference_grad(double i, double j, double *_d_i, double *_d_j);
 //CHECK-NEXT:    _d_ar = &_d_a;
 //CHECK-NEXT:    const double &ar = a;
 //CHECK-NEXT:    double res = 2 * ar;
-//CHECK-NEXT:    _d_res += 1;
+//CHECK-NEXT:    _d_res += _d_y;
 //CHECK-NEXT:    *_d_ar += 2 * _d_res;
 //CHECK-NEXT:    *_d_i += _d_a;
 //CHECK-NEXT:}
@@ -629,13 +629,13 @@ double f_const02(double i, double j) {
   double res = a;
   return res;
 }
-void f_const02_grad(double i, double j, double *_d_i, double *_d_j);
-//CHECK:  void f_const02_grad(double i, double j, double *_d_i, double *_d_j) {
+void f_const02_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j);
+//CHECK:  void f_const02_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 //CHECK-NEXT:       double _d_a = 0;
 //CHECK-NEXT:       double _d_res = 0;
 //CHECK-NEXT:       const double a = i;
 //CHECK-NEXT:       double res = a;
-//CHECK-NEXT:       _d_res += 1;
+//CHECK-NEXT:       _d_res += _d_y;
 //CHECK-NEXT:       _d_a += _d_res;
 //CHECK-NEXT:       *_d_i += _d_a;
 //CHECK-NEXT: }
@@ -647,7 +647,7 @@ float running_sum(float* p, int n) {
   return p[n - 1];
 }
 
-// CHECK: void running_sum_grad(float *p, int n, float *_d_p, int *_d_n) {
+// CHECK: void running_sum_pullback(float *p, int n, float _d_y, float *_d_p, int *_d_n) {
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
@@ -662,7 +662,7 @@ float running_sum(float* p, int n) {
 // CHECK-NEXT:         clad::push(_t1, p[i]);
 // CHECK-NEXT:         p[i] += p[i - 1];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_p[n - 1] += 1;
+// CHECK-NEXT:     _d_p[n - 1] += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -684,12 +684,12 @@ double fn_global_var_use(double i, double j) {
   return ref * i;
 }
 
-// CHECK: void fn_global_var_use_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn_global_var_use_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_ref = 0;
 // CHECK-NEXT:     double &ref = global;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_ref += 1 * i;
-// CHECK-NEXT:         *_d_i += ref * 1;
+// CHECK-NEXT:         _d_ref += _d_y * i;
+// CHECK-NEXT:         *_d_i += ref * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -697,17 +697,17 @@ double fn_increment_in_return(double i, double j) {
   double temp = i;
   return (++i) * temp; // (i+1)*i
 }
-void fn_increment_in_return_grad(double i, double j, double *_d_i, double *_d_j);
+void fn_increment_in_return_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j);
 
-// CHECK: void fn_increment_in_return_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn_increment_in_return_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double temp = i;
 // CHECK-NEXT:     _t0 = ++i;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_i += 1 * temp;
+// CHECK-NEXT:         *_d_i += _d_y * temp;
 // CHECK-NEXT:         --i;
-// CHECK-NEXT:         _d_temp += _t0 * 1;
+// CHECK-NEXT:         _d_temp += _t0 * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_i += _d_temp;
 // CHECK-NEXT: }
@@ -719,14 +719,14 @@ double fn_template_non_type(double x) {
   return x*m;
 }
 
-// CHECK: void fn_template_non_type_grad(double x, double *_d_x) {
+// CHECK: void fn_template_non_type_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:     size_t _d_maxN = 0;
 // CHECK-NEXT:     bool _cond0;
 // CHECK-NEXT:     size_t _d_m = 0;
 // CHECK-NEXT:     const size_t maxN = 53;
 // CHECK-NEXT:     _cond0 = maxN < {{15U|15UL}};
 // CHECK-NEXT:     const size_t m = _cond0 ? maxN : {{15U|15UL}};
-// CHECK-NEXT:     *_d_x += 1 * m;
+// CHECK-NEXT:     *_d_x += _d_y * m;
 // CHECK-NEXT:     if (_cond0)
 // CHECK-NEXT:         _d_maxN += _d_m;
 // CHECK-NEXT: }
@@ -735,9 +735,9 @@ double fn_div(double x) {
   return -0.5 / x;
 }
 
-// CHECK: void fn_div_grad(double x, double *_d_x) {
+// CHECK: void fn_div_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:   {
-// CHECK-NEXT:       double _r0 = 1 * -(-0.5 / (x * x));
+// CHECK-NEXT:       double _r0 = _d_y * -(-0.5 / (x * x));
 // CHECK-NEXT:       *_d_x += _r0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -749,7 +749,7 @@ double fn_cond_decl(double x, double y) {
     return x*x + y*y;
 } // = y^2
 
-//CHECK:        void fn_cond_decl_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:        void fn_cond_decl_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:            int _d_flag = 0;
 //CHECK-NEXT:            int _d_cond = 0;
 //CHECK-NEXT:            int cond = 0;
@@ -761,17 +761,17 @@ double fn_cond_decl(double x, double y) {
 //CHECK-NEXT:                    goto _label0;
 //CHECK-NEXT:            }
 //CHECK-NEXT:            {
-//CHECK-NEXT:                *_d_x += 1 * x;
-//CHECK-NEXT:                *_d_x += x * 1;
-//CHECK-NEXT:                *_d_y += 1 * y;
-//CHECK-NEXT:                *_d_y += y * 1;
+//CHECK-NEXT:                *_d_x += _d_y0 * x;
+//CHECK-NEXT:                *_d_x += x * _d_y0;
+//CHECK-NEXT:                *_d_y += _d_y0 * y;
+//CHECK-NEXT:                *_d_y += y * _d_y0;
 //CHECK-NEXT:            }
 //CHECK-NEXT:            {
 //CHECK-NEXT:                if (_cond0)
 //CHECK-NEXT:                  _label0:
 //CHECK-NEXT:                    {
-//CHECK-NEXT:                        *_d_y += 1 * y;
-//CHECK-NEXT:                        *_d_y += y * 1;
+//CHECK-NEXT:                        *_d_y += _d_y0 * y;
+//CHECK-NEXT:                        *_d_y += y * _d_y0;
 //CHECK-NEXT:                    }
 //CHECK-NEXT:                {
 //CHECK-NEXT:                    _d_flag += _d_cond;
@@ -786,7 +786,7 @@ double fn_cond_side_eff(double x) {
     return x;
 } // = 2x
 
-//CHECK:         void fn_cond_side_eff_grad(double x, double *_d_x) {
+//CHECK:         void fn_cond_side_eff_pullback(double x, double _d_y, double *_d_x) {
 //CHECK-NEXT:             double _t0;
 //CHECK-NEXT:             bool _cond0;
 //CHECK-NEXT:             {
@@ -796,11 +796,11 @@ double fn_cond_side_eff(double x) {
 //CHECK-NEXT:                     goto _label0;
 //CHECK-NEXT:                 }
 //CHECK-NEXT:             }
-//CHECK-NEXT:             *_d_x += 1;
+//CHECK-NEXT:             *_d_x += _d_y;
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 if (_cond0) {
 //CHECK-NEXT:                   _label0:
-//CHECK-NEXT:                     *_d_x += 1;
+//CHECK-NEXT:                     *_d_x += _d_y;
 //CHECK-NEXT:                 }
 //CHECK-NEXT:                 {
 //CHECK-NEXT:                     x = _t0;
@@ -817,7 +817,7 @@ double fn_cond_init(double x) {
     return x;
 } // = x
 
-//CHECK:          void fn_cond_init_grad(double x, double *_d_x) {
+//CHECK:          void fn_cond_init_pullback(double x, double _d_y, double *_d_x) {
 //CHECK-NEXT:              int _d_a = 0;
 //CHECK-NEXT:              int a = 0;
 //CHECK-NEXT:              bool _cond0;
@@ -828,13 +828,13 @@ double fn_cond_init(double x) {
 //CHECK-NEXT:                      goto _label0;
 //CHECK-NEXT:                  }
 //CHECK-NEXT:              }
-//CHECK-NEXT:              *_d_x += 1;
+//CHECK-NEXT:              *_d_x += _d_y;
 //CHECK-NEXT:              if (_cond0) {
 //CHECK-NEXT:                _label0:
 //CHECK-NEXT:                  {
-//CHECK-NEXT:                      *_d_x += 1;
-//CHECK-NEXT:                      *_d_x += 1 * x;
-//CHECK-NEXT:                      *_d_x += x * 1;
+//CHECK-NEXT:                      *_d_x += _d_y;
+//CHECK-NEXT:                      *_d_x += _d_y * x;
+//CHECK-NEXT:                      *_d_x += x * _d_y;
 //CHECK-NEXT:                  }
 //CHECK-NEXT:              }
 //CHECK-NEXT:          }
@@ -845,24 +845,24 @@ double fn_null_stmts(double x) {
   ;
 } // = x
 
-//CHECK: void fn_null_stmts_grad(double x, double *_d_x) {
+//CHECK: void fn_null_stmts_pullback(double x, double _d_y, double *_d_x) {
 //CHECK-NEXT:    goto _label0;
 //CHECK-NEXT:    ;
 //CHECK-NEXT:    ;
 //CHECK-NEXT:    ;
 //CHECK-NEXT:    ;
 //CHECK-NEXT:  _label0:
-//CHECK-NEXT:    *_d_x += 1;
+//CHECK-NEXT:    *_d_x += _d_y;
 //CHECK-NEXT:}
 
 double fn_const_cond_op(double x) {
   return x + (x > 0 ? 1.0 : 0.0);
 }
 
-//CHECK:               void fn_const_cond_op_grad(double x, double *_d_x) {
+//CHECK:               void fn_const_cond_op_pullback(double x, double _d_y, double *_d_x) {
 //CHECK-NEXT:              bool _cond0;
 //CHECK-NEXT:              _cond0 = x > 0;
-//CHECK-NEXT:              *_d_x += 1;
+//CHECK-NEXT:              *_d_x += _d_y;
 //CHECK-NEXT:          }
 
 
@@ -873,7 +873,7 @@ double fn_empty_if_block(double x) {
   return res;
 }
 
-//CHECK:void fn_empty_if_block_grad(double x, double *_d_x) {
+//CHECK:void fn_empty_if_block_pullback(double x, double _d_y, double *_d_x) {
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    bool _cond0;
 //CHECK-NEXT:    double res = 0;
@@ -882,7 +882,7 @@ double fn_empty_if_block(double x) {
 //CHECK-NEXT:        if (_cond0)
 //CHECK-NEXT:            ;
 //CHECK-NEXT:    }
-//CHECK-NEXT:    _d_res += 1;
+//CHECK-NEXT:    _d_res += _d_y;
 //CHECK-NEXT:    if (_cond0)
 //CHECK-NEXT:        ;
 //CHECK-NEXT:}
@@ -896,7 +896,7 @@ double fn_empty_if_else(double x) {
   return res;
 }
 
-//CHECK: void fn_empty_if_else_grad(double x, double *_d_x) {
+//CHECK: void fn_empty_if_else_pullback(double x, double _d_y, double *_d_x) {
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double _t0;
 //CHECK-NEXT:    bool _cond0;
@@ -912,7 +912,7 @@ double fn_empty_if_else(double x) {
 //CHECK-NEXT:            res = 5 * x;
 //CHECK-NEXT:        }
 //CHECK-NEXT:    }
-//CHECK-NEXT:    _d_res += 1;
+//CHECK-NEXT:    _d_res += _d_y;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        if (_cond0)
 //CHECK-NEXT:            ;
@@ -940,7 +940,7 @@ double fn_cond_false(double i, double j) {
   return res;
 }
 
-// CHECK: void fn_cond_false_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn_cond_false_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:    double _d_res = 0;
 // CHECK-NEXT:    bool _cond0;
 // CHECK-NEXT:    double _d_cond0;
@@ -964,7 +964,7 @@ double fn_cond_false(double i, double j) {
 // CHECK-NEXT:            res = 6 * i * j;
 // CHECK-NEXT:        }
 // CHECK-NEXT:    }
-// CHECK-NEXT:    _d_res += 1;
+// CHECK-NEXT:    _d_res += _d_y;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        if (_cond2) {
 // CHECK-NEXT:            {
@@ -993,7 +993,7 @@ double fn_cond_add_assign(double i, double j) {
   return res;
 }
 
-// CHECK: void fn_cond_add_assign_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn_cond_add_assign_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:    double _d_res = 0;
 // CHECK-NEXT:    bool _cond0;
 // CHECK-NEXT:    double _d_cond0;
@@ -1035,7 +1035,7 @@ double fn_cond_add_assign(double i, double j) {
 // CHECK-NEXT:            res += 6 * i * j;
 // CHECK-NEXT:        }
 // CHECK-NEXT:    }
-// CHECK-NEXT:    _d_res += 1;
+// CHECK-NEXT:    _d_res += _d_y;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        if (_cond4) {
 // CHECK-NEXT:            {
@@ -1088,7 +1088,7 @@ double fn_cond_add_assign(double i, double j) {
     result[0] = 0;                                                             \
     result[1] = 0;                                                             \
     clad::gradient(F);                                                         \
-    F##_grad(x, y, &result[0], &result[1]);                                    \
+    F##_pullback(x, y, 1, &result[0], &result[1]);                                    \
     printf("Result is = {%.2f, %.2f}\n", result[0], result[1]);                \
   }
 

--- a/test/Gradient/Lambdas.C
+++ b/test/Gradient/Lambdas.C
@@ -14,14 +14,14 @@ double f1(double i, double j) {
 }
 
 // CHECK:     inline void operator_call_pullback(double t, double _d_y, double *_d_t) const;
-// CHECK-NEXT:     void f1_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK-NEXT:     void f1_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:         auto _f = []{{ ?}}(double t) {
 // CHECK-NEXT:             return t * t + 1.;
 // CHECK-NEXT:         }{{;?}}
 // CHECK:         {
-// CHECK-NEXT:             *_d_i += 1;
+// CHECK-NEXT:             *_d_i += _d_y;
 // CHECK-NEXT:             double _r0 = 0;
-// CHECK-NEXT:             _f.operator_call_pullback(j, 1, &_r0);
+// CHECK-NEXT:             _f.operator_call_pullback(j, _d_y, &_r0);
 // CHECK-NEXT:             *_d_j += _r0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
@@ -35,13 +35,13 @@ double f2(double i, double j) {
 }
 
 // CHECK:     inline void operator_call_pullback(double t, double k, double _d_y, double *_d_t, double *_d_k) const;
-// CHECK-NEXT:     void f2_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK-NEXT:     void f2_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:         double _d_x = 0;
 // CHECK-NEXT:             auto _f = []{{ ?}}(double t, double k) {
 // CHECK-NEXT:                 return t + k;
 // CHECK-NEXT:             }{{;?}}
 // CHECK:             double x = operator()(i + j, i);
-// CHECK-NEXT:             _d_x += 1;
+// CHECK-NEXT:             _d_x += _d_y;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 double _r0 = 0;
 // CHECK-NEXT:                 double _r1 = 0;

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -16,7 +16,7 @@ double f1(double x) {
   return t;
 } // == x^3
 
-// CHECK: void f1_grad(double x, double *_d_x) {
+// CHECK: void f1_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
@@ -33,7 +33,7 @@ double f1(double x) {
 // CHECK-NEXT:         clad::push(_t1, t);
 // CHECK-NEXT:         t *= x;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_t += 1;
+// CHECK-NEXT:     _d_t += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -56,7 +56,7 @@ double f2(double x) {
   return t;
 } // == x^9
 
-// CHECK: void f2_grad(double x, double *_d_x) {
+// CHECK: void f2_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
@@ -85,7 +85,7 @@ double f2(double x) {
 // CHECK-NEXT:             t *= x;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_t += 1;
+// CHECK-NEXT:     _d_t += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -122,7 +122,7 @@ double f3(double x) {
   return t;
 } // == x^2
 
-// CHECK: void f3_grad(double x, double *_d_x) {
+// CHECK: void f3_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
@@ -145,7 +145,7 @@ double f3(double x) {
 // CHECK-NEXT:                 goto _label0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_t += 1;
+// CHECK-NEXT:     _d_t += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -155,7 +155,7 @@ double f3(double x) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (clad::back(_cond0))
 // CHECK-NEXT:               _label0:
-// CHECK-NEXT:                 _d_t += 1;
+// CHECK-NEXT:                 _d_t += _d_y;
 // CHECK-NEXT:             clad::pop(_cond0);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
@@ -175,7 +175,7 @@ double f4(double x) {
   return t;
 } // == x^3
 
-// CHECK: void f4_grad(double x, double *_d_x) {
+// CHECK: void f4_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
@@ -191,7 +191,7 @@ double f4(double x) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         i++;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_t += 1;
+// CHECK-NEXT:     _d_t += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -214,7 +214,7 @@ double f5(double x){
   return x;
 } // == x + 10
 
-// CHECK: void f5_grad(double x, double *_d_x) {
+// CHECK: void f5_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
@@ -227,7 +227,7 @@ double f5(double x){
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         x++;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     *_d_x += 1;
+// CHECK-NEXT:     *_d_x += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -247,7 +247,7 @@ double f_const_local(double x) {
   return res;
 } // == 3x^2 + 3x
 
-// CHECK: void f_const_local_grad(double x, double *_d_x) {
+// CHECK: void f_const_local_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
@@ -268,7 +268,7 @@ double f_const_local(double x) {
 // CHECK-NEXT:         clad::push(_t2, res);
 // CHECK-NEXT:         res += x * n;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -297,7 +297,7 @@ double f_sum(double *p, int n) {
   return s;
 }
 
-// CHECK: void f_sum_grad_0(double *p, int n, double *_d_p) {
+// CHECK: void f_sum_pullback_0(double *p, int n, double _d_y, double *_d_p) {
 // CHECK-NEXT:     int _d_n = 0;
 // CHECK-NEXT:     double _d_s = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -315,7 +315,7 @@ double f_sum(double *p, int n) {
 // CHECK-NEXT:         clad::push(_t1, s);
 // CHECK-NEXT:         s += p[i];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_s += 1;
+// CHECK-NEXT:     _d_s += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -338,7 +338,7 @@ double f_sum_squares(double *p, int n) {
   return s;
 }
 
-// CHECK: void f_sum_squares_grad_0(double *p, int n, double *_d_p) {
+// CHECK: void f_sum_squares_pullback_0(double *p, int n, double _d_y, double *_d_p) {
 // CHECK-NEXT:     int _d_n = 0;
 // CHECK-NEXT:     double _d_s = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -356,7 +356,7 @@ double f_sum_squares(double *p, int n) {
 // CHECK-NEXT:         clad::push(_t1, s);
 // CHECK-NEXT:         s += sq(p[i]);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_s += 1;
+// CHECK-NEXT:     _d_s += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -380,7 +380,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
   double gaus = 1./std::sqrt(std::pow(2*M_PI, n) * sigma) * std::exp(power);
   return std::log(gaus);
 }
-// CHECK: void f_log_gaus_grad_1(double *x, double *p, double n, double sigma, double *_d_p) {
+// CHECK: void f_log_gaus_pullback_1(double *x, double *p, double n, double sigma, double _d_y, double *_d_p) {
 // CHECK-NEXT:     double _d_n = 0;
 // CHECK-NEXT:     double _d_sigma = 0;
 // CHECK-NEXT:     double _d_power = 0;
@@ -416,7 +416,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 // CHECK-NEXT:     double gaus = 1. / _t6 * _t5;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r8 = 0;
-// CHECK-NEXT:         _r8 += 1 * clad::custom_derivatives::log_pushforward(gaus, 1.).pushforward;
+// CHECK-NEXT:         _r8 += _d_y * clad::custom_derivatives::log_pushforward(gaus, 1.).pushforward;
 // CHECK-NEXT:         _d_gaus += _r8;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -464,8 +464,8 @@ double f_const(const double a, const double b) {
   return r;
 }
 
-void f_const_grad(const double, const double, double*, double*);
-// CHECK: void f_const_grad(const double a, const double b, double *_d_a, double *_d_b) {
+void f_const_pullback(const double, const double, double*, double*);
+// CHECK: void f_const_pullback(const double a, const double b, double _d_y, double *_d_a, double *_d_b) {
 // CHECK-NEXT:     int _d_r = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
@@ -486,7 +486,7 @@ void f_const_grad(const double, const double, double*, double*);
 // CHECK-NEXT:         clad::push(_t2, r);
 // CHECK-NEXT:         r += sq0;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_r += 1;
+// CHECK-NEXT:     _d_r += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -518,7 +518,7 @@ double f6 (double i, double j) {
   return a;
 }
 
-// CHECK: void f6_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void f6_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_counter = 0;
@@ -546,7 +546,7 @@ double f6 (double i, double j) {
 // CHECK-NEXT:         clad::push(_t4, a);
 // CHECK-NEXT:         a += b + c + i;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_a += 1;
+// CHECK-NEXT:     _d_a += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -588,7 +588,7 @@ double fn7(double i, double j) {
   return a;
 }
 
-// CHECK: void fn7_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn7_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -602,7 +602,7 @@ double fn7(double i, double j) {
 // CHECK-NEXT:             clad::push(_t1, a);
 // CHECK-NEXT:             a += i * i + j;
 // CHECK-NEXT:         }
-// CHECK-NEXT:     _d_a += 1;
+// CHECK-NEXT:     _d_a += _d_y;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -626,7 +626,7 @@ double fn8(double i, double j) {
   return a;
 }
 
-// CHECK: void fn8_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn8_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -645,7 +645,7 @@ double fn8(double i, double j) {
 // CHECK-NEXT:                 a += i * i + j;
 // CHECK-NEXT:             } while (--counter);
 // CHECK-NEXT:         }
-// CHECK-NEXT:     _d_a += 1;
+// CHECK-NEXT:     _d_a += _d_y;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -680,7 +680,7 @@ double fn9(double i, double j) {
   return a;
 }
 
-// CHECK: void fn9_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn9_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_counter = 0, _d_counter_again = 0;
 // CHECK-NEXT:     int _t0;
 // CHECK-NEXT:     int _t1;
@@ -708,7 +708,7 @@ double fn9(double i, double j) {
 // CHECK-NEXT:                     a += i * i + j;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     _d_a += 1;
+// CHECK-NEXT:     _d_a += _d_y;
 // CHECK-NEXT:     while (_t2)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -758,7 +758,7 @@ double fn10(double i, double j) {
   return a;
 }
 
-// CHECK: void fn10_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn10_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -781,7 +781,7 @@ double fn10(double i, double j) {
 // CHECK-NEXT:             clad::push(_t4, counter);
 // CHECK-NEXT:             counter -= 1;
 // CHECK-NEXT:         }
-// CHECK-NEXT:     _d_a += 1;
+// CHECK-NEXT:     _d_a += _d_y;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -821,7 +821,7 @@ double fn11(double i, double j) {
   return a;
 }
 
-// CHECK: void fn11_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn11_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -837,7 +837,7 @@ double fn11(double i, double j) {
 // CHECK-NEXT:         clad::push(_t2, counter);
 // CHECK-NEXT:         counter -= 1;
 // CHECK-NEXT:     } while (counter);
-// CHECK-NEXT:     _d_a += 1;
+// CHECK-NEXT:     _d_a += _d_y;
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -873,7 +873,7 @@ double fn12(double i, double j) {
   return a;
 }
 
-// CHECK: void fn12_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn12_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -909,7 +909,7 @@ double fn12(double i, double j) {
 // CHECK-NEXT:         clad::push(_t7, counter);
 // CHECK-NEXT:         counter -= 1;
 // CHECK-NEXT:     } while (counter);
-// CHECK-NEXT:     _d_a += 1;
+// CHECK-NEXT:     _d_a += _d_y;
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -966,7 +966,7 @@ double fn13(double i, double j) {
   return res;
 }
 
-// CHECK: void fn13_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn13_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -994,7 +994,7 @@ double fn13(double i, double j) {
 // CHECK-NEXT:         clad::push(_t5, res);
 // CHECK-NEXT:         res += temp;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -1051,7 +1051,7 @@ double fn14(double i, double j) {
   return res;
 }
 
-// CHECK: void fn14_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn14_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -1103,7 +1103,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:             clad::push(_t2, {{4U|4UL}});
 // CHECK-NEXT:         }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             switch (clad::pop(_t2)) {
@@ -1171,7 +1171,7 @@ double fn15(double i, double j) {
   return res;
 }
 
-// CHECK: void fn15_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn15_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -1226,7 +1226,7 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             clad::push(_t1, {{2U|2UL}});
 // CHECK-NEXT:         }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             switch (clad::pop(_t1)) {
@@ -1297,7 +1297,7 @@ double fn16(double i, double j) {
   return res;
 }
 
-// CHECK: void fn16_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn16_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -1344,7 +1344,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:         res += i + j;
 // CHECK-NEXT:         clad::push(_t2, {{3U|3UL}});
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -1409,7 +1409,7 @@ double fn17(double i, double j) {
   return res;
 }
 
-// CHECK: void fn17_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn17_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -1468,7 +1468,7 @@ double fn17(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:         clad::push(_t2, {{2U|2UL}});
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -1543,7 +1543,7 @@ double fn18(double i, double j) {
   return res;
 }
 
-// CHECK: void fn18_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn18_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -1585,7 +1585,7 @@ double fn18(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         clad::push(_t2, {{3U|3UL}});
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -1630,7 +1630,7 @@ double fn19(double* arr, int n) {
   return res;
 }
 
-// CHECK: void fn19_grad_0(double *arr, int n, double *_d_arr) {
+// CHECK: void fn19_pullback_0(double *arr, int n, double _d_y, double *_d_arr) {
 // CHECK-NEXT:     int _d_n = 0;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -1655,7 +1655,7 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:         clad::push(_t3, res);
 // CHECK-NEXT:         res += *ref;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -1682,7 +1682,7 @@ double f_loop_init_var(double lower, double upper) {
   return sum;
 }
 
-// CHECK: void f_loop_init_var_grad(double lower, double upper, double *_d_lower, double *_d_upper) {
+// CHECK: void f_loop_init_var_pullback(double lower, double upper, double _d_y, double *_d_lower, double *_d_upper) {
 // CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double _d_num_points = 0;
 // CHECK-NEXT:     double _d_interval = 0;
@@ -1704,7 +1704,7 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:         clad::push(_t2, sum);
 // CHECK-NEXT:         sum += x * x * interval;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_sum += 1;
+// CHECK-NEXT:     _d_sum += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         for (;; _t0--) {
 // CHECK-NEXT:             {
@@ -1741,7 +1741,7 @@ double fn20(double *arr, int n) {
   return res;
 }
 
-// CHECK: void fn20_grad_0(double *arr, int n, double *_d_arr) {
+// CHECK: void fn20_pullback_0(double *arr, int n, double _d_y, double *_d_arr) {
 // CHECK-NEXT:     int _d_n = 0;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -1761,7 +1761,7 @@ double fn20(double *arr, int n) {
 // CHECK-NEXT:         clad::push(_t2, arr[i]);
 // CHECK-NEXT:         res += (arr[i] *= 5);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -1790,7 +1790,7 @@ double fn21(double x) {
 }
 
 
-// CHECK: void fn21_grad(double x, double *_d_x) {
+// CHECK: void fn21_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
@@ -1811,7 +1811,7 @@ double fn21(double x) {
 // CHECK-NEXT:         clad::push(_t2, res);
 // CHECK-NEXT:         res += arr[0] + arr[1];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -1842,7 +1842,7 @@ double fn22(double param) {
 }
 
 
-// CHECK: void fn22_grad(double param, double *_d_param) {
+// CHECK: void fn22_pullback(double param, double _d_y, double *_d_param) {
 // CHECK-NEXT:     double _d_out = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
@@ -1865,7 +1865,7 @@ double fn22(double param) {
 // CHECK-NEXT:         clad::push(_t3, arr[0]);
 // CHECK-NEXT:         out += clad::back(_t3) * param;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_out += 1;
+// CHECK-NEXT:     _d_out += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -1895,7 +1895,7 @@ double fn23(double i, double j) {
     return res;
 }
 
-// CHECK: void fn23_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn23_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
@@ -1923,7 +1923,7 @@ double fn23(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         clad::push(_t2, {{2U|2UL}});
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0 || (clad::back(_t2) != 1)) {
@@ -1957,7 +1957,7 @@ double fn24(double i, double j) {
   return res;
 }
 
-// CHECK: void fn24_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn24_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
@@ -1975,7 +1975,7 @@ double fn24(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2003,7 +2003,7 @@ double fn25(double i, double j) {
   return res;
 }
 
-// CHECK: void fn25_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn25_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
@@ -2036,7 +2036,7 @@ double fn25(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         clad::push(_t3, {{2U|2UL}});
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0 || (clad::back(_t3) != 1)) {
@@ -2080,7 +2080,7 @@ double fn26(double i, double j) {
   return res;
 }
 
-// CHECK: void fn26_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn26_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
@@ -2109,7 +2109,7 @@ double fn26(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         clad::push(_t3, {{2U|2UL}});
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0 || (clad::back(_t3) != 1)) {
@@ -2154,7 +2154,7 @@ double fn27(double i, double j) {
   return res;
 }
 
-// CHECK: void fn27_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn27_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
@@ -2185,7 +2185,7 @@ double fn27(double i, double j) {
 // CHECK-NEXT:         res = c * i * j;
 // CHECK-NEXT:         clad::push(_t2, {{2U|2UL}});
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0 || (clad::back(_t2) != 1)) {
@@ -2227,7 +2227,7 @@ double fn28(double i, double j) {
   return res;
 }
 
-// CHECK: void fn28_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn28_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
@@ -2248,7 +2248,7 @@ double fn28(double i, double j) {
 // CHECK-NEXT:         clad::push(_t2, res);
 // CHECK-NEXT:         res = 3 * i * j;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2279,7 +2279,7 @@ double fn29(double i, double j) {
   return res;
 }
 
-// CHECK: void fn29_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn29_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
@@ -2298,7 +2298,7 @@ double fn29(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2330,7 +2330,7 @@ double fn30(double i, double j) {
     return res;
 }
 
-// CHECK: void fn30_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn30_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
@@ -2360,7 +2360,7 @@ double fn30(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2390,7 +2390,7 @@ double fn31(double i, double j) {
   return res;
 }
 
-//CHECK:void fn31_grad(double i, double j, double *_d_i, double *_d_j) {
+//CHECK:void fn31_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    unsigned {{int|long}} _t0;
 //CHECK-NEXT:    int _d_c = 0;
@@ -2410,7 +2410,7 @@ double fn31(double i, double j) {
 //CHECK-NEXT:        }
 //CHECK-NEXT:        _t0++;
 //CHECK-NEXT:    }
-//CHECK-NEXT:    _d_res += 1;
+//CHECK-NEXT:    _d_res += _d_y;
 //CHECK-NEXT:    for (;; _t0--) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            {
@@ -2451,7 +2451,7 @@ double fn32(double i, double j) {
   return res;
 }
 
-//CHECK:void fn32_grad(double i, double j, double *_d_i, double *_d_j) {
+//CHECK:void fn32_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    unsigned {{int|long}} _t0;
 //CHECK-NEXT:    int _d_c = 0;
@@ -2515,7 +2515,7 @@ double fn32(double i, double j) {
 //CHECK-NEXT:        }
 //CHECK-NEXT:        clad::push(_t8, {{2U|2UL}});
 //CHECK-NEXT:    }
-//CHECK-NEXT:    _d_res += 1;
+//CHECK-NEXT:    _d_res += _d_y;
 //CHECK-NEXT:    for (;; _t0--) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            if (!_t0 || (clad::back(_t8) != 1)) {
@@ -2598,7 +2598,7 @@ double fn33(double i, double j) {
   return res;
 }
 
-//CHECK: void fn33_grad(double i, double j, double *_d_i, double *_d_j) {
+//CHECK: void fn33_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    unsigned {{int|long}} _t0;
 //CHECK-NEXT:    int _d_c = 0;
@@ -2666,7 +2666,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:        }
 //CHECK-NEXT:        clad::push(_t4, {{3U|3UL}});
 //CHECK-NEXT:    }
-//CHECK-NEXT:    _d_res += 1;
+//CHECK-NEXT:    _d_res += _d_y;
 //CHECK-NEXT:    for (;; _t0--) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            if (!_t0 || (clad::back(_t4) != 1 && clad::back(_t4) != 2)) {

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -398,32 +398,6 @@ public:
     x += 1.0;
     return *this;
   }
-
-  void mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void const_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void volatile_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void const_volatile_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void lval_ref_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void const_lval_ref_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void volatile_lval_ref_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void const_volatile_lval_ref_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void rval_ref_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void const_rval_ref_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void volatile_rval_ref_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void const_volatile_rval_ref_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void noexcept_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void const_noexcept_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void volatile_noexcept_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void const_volatile_noexcept_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void lval_ref_noexcept_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void const_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void rval_ref_noexcept_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void const_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, double *_d_i, double *_d_j);
-  void partial_mem_fn_grad(double i, double j, double *_d_i);
 };
 
 double fn(double i,double j) {

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -22,25 +22,25 @@ public:
   double x, y;
   double mem_fn(double i, double j) { return (x + y) * i + i * j; }
 
-  // CHECK: void mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) {
+  // CHECK: void mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double const_mem_fn(double i, double j) const { return (x + y) * i + i * j; }
 
-  // CHECK: void const_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const {
+  // CHECK: void const_mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -48,15 +48,15 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile {
+  // CHECK: void volatile_mem_fn_pullback(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += _t0 * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -64,27 +64,27 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile {
+  // CHECK: void const_volatile_mem_fn_pullback(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += _t0 * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double lval_ref_mem_fn(double i, double j) & { return (x + y) * i + i * j; }
 
-  // CHECK: void lval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) & {
+  // CHECK: void lval_ref_mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i, double *_d_j) & {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -92,13 +92,13 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const & {
+  // CHECK: void const_lval_ref_mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const & {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -106,15 +106,15 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & {
+  // CHECK: void volatile_lval_ref_mem_fn_pullback(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += _t0 * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -122,27 +122,27 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & {
+  // CHECK: void const_volatile_lval_ref_mem_fn_pullback(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += _t0 * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double rval_ref_mem_fn(double i, double j) && { return (x + y) * i + i * j; }
 
-  // CHECK: void rval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) && {
+  // CHECK: void rval_ref_mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i, double *_d_j) && {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -150,13 +150,13 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const && {
+  // CHECK: void const_rval_ref_mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const && {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -164,15 +164,15 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && {
+  // CHECK: void volatile_rval_ref_mem_fn_pullback(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += _t0 * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -180,15 +180,15 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && {
+  // CHECK: void const_volatile_rval_ref_mem_fn_pullback(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += _t0 * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -196,13 +196,13 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) noexcept {
+  // CHECK: void noexcept_mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i, double *_d_j) noexcept {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -210,13 +210,13 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const noexcept {
+  // CHECK: void const_noexcept_mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const noexcept {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -224,15 +224,15 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile noexcept {
+  // CHECK: void volatile_noexcept_mem_fn_pullback(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += _t0 * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -240,15 +240,15 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile noexcept {
+  // CHECK: void const_volatile_noexcept_mem_fn_pullback(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += _t0 * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -256,13 +256,13 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) & noexcept {
+  // CHECK: void lval_ref_noexcept_mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i, double *_d_j) & noexcept {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -270,13 +270,13 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const & noexcept {
+  // CHECK: void const_lval_ref_noexcept_mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const & noexcept {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -284,15 +284,15 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & noexcept {
+  // CHECK: void volatile_lval_ref_noexcept_mem_fn_pullback(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += _t0 * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -300,15 +300,15 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & noexcept {
+  // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_pullback(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += _t0 * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -316,13 +316,13 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) && noexcept {
+  // CHECK: void rval_ref_noexcept_mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i, double *_d_j) && noexcept {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -330,13 +330,13 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const && noexcept {
+  // CHECK: void const_rval_ref_noexcept_mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const && noexcept {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -344,15 +344,15 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && noexcept {
+  // CHECK: void volatile_rval_ref_noexcept_mem_fn_pullback(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += _t0 * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -360,28 +360,28 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && noexcept {
+  // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_pullback(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && noexcept {
   // CHECK-NEXT:     double _t0;
   // CHECK-NEXT:     _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += _t0 * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         *_d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         *_d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
   double partial_mem_fn(double i, double j) { return (x + y) * i + i * j; }
 
-  // CHECK: void partial_mem_fn_grad_0(double i, double j, SimpleFunctions *_d_this, double *_d_i) {
+  // CHECK: void partial_mem_fn_pullback_0(double i, double j, double _d_y, SimpleFunctions *_d_this, double *_d_i) {
   // CHECK-NEXT:     double _d_j = 0;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
-  // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
-  // CHECK-NEXT:         *_d_i += 1 * j;
-  // CHECK-NEXT:         _d_j += i * 1;
+  // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:         (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
+  // CHECK-NEXT:         *_d_i += _d_y * j;
+  // CHECK-NEXT:         _d_j += i * _d_y;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -404,11 +404,11 @@ double fn(double i,double j) {
   return i*i*j;
 }
 
-// CHECK: void fn_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_i += 1 * j * i;
-// CHECK-NEXT:         *_d_i += i * 1 * j;
-// CHECK-NEXT:         *_d_j += i * i * 1;
+// CHECK-NEXT:         *_d_i += _d_y * j * i;
+// CHECK-NEXT:         *_d_i += i * _d_y * j;
+// CHECK-NEXT:         *_d_j += i * i * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -420,13 +420,13 @@ double fn2(SimpleFunctions& sf, double i) {
 
 // CHECK: clad::ValueAndAdjoint<double &, double &> ref_mem_fn_forw(double i, SimpleFunctions *_d_this, double *_d_i);
 
-// CHECK: void fn2_grad(SimpleFunctions &sf, double i, SimpleFunctions *_d_sf, double *_d_i) {
+// CHECK: void fn2_pullback(SimpleFunctions &sf, double i, double _d_y, SimpleFunctions *_d_sf, double *_d_i) {
 // CHECK-NEXT:     SimpleFunctions _t0;
 // CHECK-NEXT:     _t0 = sf;
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = _t0.ref_mem_fn_forw(i, &(*_d_sf), nullptr);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
-// CHECK-NEXT:         _t0.ref_mem_fn_pullback(i, 1, &(*_d_sf), &_r0);
+// CHECK-NEXT:         _t0.ref_mem_fn_pullback(i, _d_y, &(*_d_sf), &_r0);
 // CHECK-NEXT:         *_d_i += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -445,11 +445,11 @@ double fn5(SimpleFunctions& v, double value) {
 
 // CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_equal_forw(double value, SimpleFunctions *_d_this, SimpleFunctions *_d_value);
 
-// CHECK: void fn5_grad(SimpleFunctions &v, double value, SimpleFunctions *_d_v, double *_d_value) {
+// CHECK: void fn5_pullback(SimpleFunctions &v, double value, double _d_y, SimpleFunctions *_d_v, double *_d_value) {
 // CHECK-NEXT:     SimpleFunctions _t0;
 // CHECK-NEXT:     _t0 = v;
 // CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = _t0.operator_plus_equal_forw(value, &(*_d_v), nullptr);
-// CHECK-NEXT:     (*_d_v).x += 1;
+// CHECK-NEXT:     (*_d_v).x += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         _t0.operator_plus_equal_pullback(value, {}, &(*_d_v), &_r0);
@@ -466,11 +466,11 @@ double fn4(SimpleFunctions& v) {
 
 // CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_plus_forw(SimpleFunctions *_d_this);
 
-// CHECK: void fn4_grad(SimpleFunctions &v, SimpleFunctions *_d_v) {
+// CHECK: void fn4_pullback(SimpleFunctions &v, double _d_y, SimpleFunctions *_d_v) {
 // CHECK-NEXT:     SimpleFunctions _t0;
 // CHECK-NEXT:     _t0 = v;
 // CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = _t0.operator_plus_plus_forw(&(*_d_v));
-// CHECK-NEXT:     (*_d_v).x += 1;
+// CHECK-NEXT:     (*_d_v).x += _d_y;
 // CHECK-NEXT:     _t0.operator_plus_plus_pullback({}, &(*_d_v));
 // CHECK-NEXT: }
 
@@ -525,31 +525,31 @@ int main() {
 
   auto d_const_volatile_lval_ref_mem_fn_i = clad::gradient(&SimpleFunctions::const_volatile_lval_ref_mem_fn, "i");
 
-  // CHECK:   void const_volatile_lval_ref_mem_fn_grad_0(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i) const volatile & {
+  // CHECK:   void const_volatile_lval_ref_mem_fn_pullback_0(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_i) const volatile & {
   // CHECK-NEXT:       double _d_j = 0;
   // CHECK-NEXT:       double _t0;
   // CHECK-NEXT:       _t0 = (this->x + this->y);
   // CHECK-NEXT:       {
-  // CHECK-NEXT:           (*_d_this).x += 1 * i;
-  // CHECK-NEXT:           (*_d_this).y += 1 * i;
-  // CHECK-NEXT:           *_d_i += _t0 * 1;
-  // CHECK-NEXT:           *_d_i += 1 * j;
-  // CHECK-NEXT:           _d_j += i * 1;
+  // CHECK-NEXT:           (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:           (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:           *_d_i += _t0 * _d_y;
+  // CHECK-NEXT:           *_d_i += _d_y * j;
+  // CHECK-NEXT:           _d_j += i * _d_y;
   // CHECK-NEXT:       }
   // CHECK-NEXT:   }
 
   auto d_const_volatile_rval_ref_mem_fn_j = clad::gradient(&SimpleFunctions::const_volatile_rval_ref_mem_fn, "j");
 
-  // CHECK:   void const_volatile_rval_ref_mem_fn_grad_1(double i, double j, volatile SimpleFunctions *_d_this, double *_d_j) const volatile && {
+  // CHECK:   void const_volatile_rval_ref_mem_fn_pullback_1(double i, double j, double _d_y, volatile SimpleFunctions *_d_this, double *_d_j) const volatile && {
   // CHECK-NEXT:       double _d_i = 0;
   // CHECK-NEXT:       double _t0;
   // CHECK-NEXT:       _t0 = (this->x + this->y);
   // CHECK-NEXT:       {
-  // CHECK-NEXT:           (*_d_this).x += 1 * i;
-  // CHECK-NEXT:           (*_d_this).y += 1 * i;
-  // CHECK-NEXT:           _d_i += _t0 * 1;
-  // CHECK-NEXT:           _d_i += 1 * j;
-  // CHECK-NEXT:           *_d_j += i * 1;
+  // CHECK-NEXT:           (*_d_this).x += _d_y * i;
+  // CHECK-NEXT:           (*_d_this).y += _d_y * i;
+  // CHECK-NEXT:           _d_i += _t0 * _d_y;
+  // CHECK-NEXT:           _d_i += _d_y * j;
+  // CHECK-NEXT:           *_d_j += i * _d_y;
   // CHECK-NEXT:       }
   // CHECK-NEXT:   }
 
@@ -558,9 +558,9 @@ int main() {
   d_fn3.execute(2, 3, 4, 5, &result[0], &result[1]);
   printf("%.2f %.2f", result[0], result[1]); // CHECK-EXEC: 10.00 4.00
 
-// CHECK: void fn3_grad_2_3(double x, double y, double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn3_pullback_2_3(double x, double y, double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_x = 0;
-// CHECK-NEXT:     double _d_y = 0;
+// CHECK-NEXT:     double _d_y0 = 0;
 // CHECK-NEXT:     SimpleFunctions _d_sf({});
 // CHECK-NEXT:     SimpleFunctions _t0;
 // CHECK-NEXT:     SimpleFunctions sf(x, y);
@@ -568,7 +568,7 @@ int main() {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;
-// CHECK-NEXT:         _t0.mem_fn_pullback(i, j, 1, &_d_sf, &_r0, &_r1);
+// CHECK-NEXT:         _t0.mem_fn_pullback(i, j, _d_y, &_d_sf, &_r0, &_r1);
 // CHECK-NEXT:         *_d_i += _r0;
 // CHECK-NEXT:         *_d_j += _r1;
 // CHECK-NEXT:     }

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -125,7 +125,7 @@ int main() {
 
     // CHECK: void mem_fn_1_pullback(double i, double j, double _d_y, SimpleFunctions1 *_d_this, double *_d_i, double *_d_j);
 
-    // CHECK: void fn_s1_mem_fn_grad(double i, double j, double *_d_i, double *_d_j) {
+    // CHECK: void fn_s1_mem_fn_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
     // CHECK-NEXT:     SimpleFunctions1 _d_obj({});
     // CHECK-NEXT:     SimpleFunctions1 _t0;
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
@@ -133,46 +133,46 @@ int main() {
     // CHECK-NEXT:     {
     // CHECK-NEXT:         double _r0 = 0;
     // CHECK-NEXT:         double _r1 = 0;
-    // CHECK-NEXT:         _t0.mem_fn_1_pullback(i, j, 1, &_d_obj, &_r0, &_r1);
+    // CHECK-NEXT:         _t0.mem_fn_1_pullback(i, j, _d_y, &_d_obj, &_r0, &_r1);
     // CHECK-NEXT:         *_d_i += _r0;
     // CHECK-NEXT:         *_d_j += _r1;
-    // CHECK-NEXT:         *_d_i += 1 * j;
-    // CHECK-NEXT:         *_d_j += i * 1;
+    // CHECK-NEXT:         *_d_i += _d_y * j;
+    // CHECK-NEXT:         *_d_j += i * _d_y;
     // CHECK-NEXT:     }
     // CHECK-NEXT: }
     
-    // CHECK: void fn_s1_field_grad(double i, double j, double *_d_i, double *_d_j) {
+    // CHECK: void fn_s1_field_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
     // CHECK-NEXT:     SimpleFunctions1 _d_obj({});
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
     // CHECK-NEXT:     {
-    // CHECK-NEXT:         _d_obj.x += 1 * obj.y;
-    // CHECK-NEXT:         *_d_i += 1 * j;
-    // CHECK-NEXT:         *_d_j += i * 1;
+    // CHECK-NEXT:         _d_obj.x += _d_y * obj.y;
+    // CHECK-NEXT:         *_d_i += _d_y * j;
+    // CHECK-NEXT:         *_d_j += i * _d_y;
     // CHECK-NEXT:     }
     // CHECK-NEXT: }
     
-    // CHECK: void fn_s1_field_pointer_grad(double i, double j, double *_d_i, double *_d_j) {
+    // CHECK: void fn_s1_field_pointer_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
     // CHECK-NEXT:     SimpleFunctions1 _d_obj({});
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
     // CHECK-NEXT:     {
-    // CHECK-NEXT:         *_d_obj.x_pointer += 1 * (*obj.y_pointer);
-    // CHECK-NEXT:         *_d_i += 1 * j;
-    // CHECK-NEXT:         *_d_j += i * 1;
+    // CHECK-NEXT:         *_d_obj.x_pointer += _d_y * (*obj.y_pointer);
+    // CHECK-NEXT:         *_d_i += _d_y * j;
+    // CHECK-NEXT:         *_d_j += i * _d_y;
     // CHECK-NEXT:     }
     // CHECK-NEXT: }
 
-    // CHECK: void fn_s2_mem_fn_grad(double i, double j, double *_d_i, double *_d_j) {
+    // CHECK: void fn_s2_mem_fn_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
     // CHECK-NEXT:     SimpleFunctions2 obj(2, 3);
     // CHECK-NEXT:     {
-    // CHECK-NEXT:         *_d_i += 1 * j;
-    // CHECK-NEXT:         *_d_j += i * 1;
+    // CHECK-NEXT:         *_d_i += _d_y * j;
+    // CHECK-NEXT:         *_d_j += i * _d_y;
     // CHECK-NEXT:     }
     // CHECK-NEXT: }
 
-    // CHECK: void fn_non_diff_var_grad(double i, double j, double *_d_i, double *_d_j) {
+    // CHECK: void fn_non_diff_var_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
     // CHECK-NEXT:     double _d_k = 0;
     // CHECK-NEXT:     double k = i * i * j;
-    // CHECK-NEXT:     _d_k += 1;
+    // CHECK-NEXT:     _d_k += _d_y;
     // CHECK-NEXT: }
     
     // CHECK: void mem_fn_1_pullback(double i, double j, double _d_y, SimpleFunctions1 *_d_this, double *_d_i, double *_d_j) {

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -11,10 +11,10 @@
 double nonMemFn(double i) {
   return i*i;
 }
-// CHECK: void nonMemFn_grad(double i, double *_d_i) {
+// CHECK: void nonMemFn_pullback(double i, double _d_y, double *_d_i) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_i += 1 * i;
-// CHECK-NEXT:         *_d_i += i * 1;
+// CHECK-NEXT:         *_d_i += _d_y * i;
+// CHECK-NEXT:         *_d_i += i * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -24,14 +24,14 @@ double minimalPointer(double x) {
   return *p; // x*x
 }
 
-// CHECK: void minimalPointer_grad(double x, double *_d_x) {
+// CHECK: void minimalPointer_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:     double *_d_p = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     _d_p = &*_d_x;
 // CHECK-NEXT:     double *const p = &x;
 // CHECK-NEXT:     _t0 = *p;
 // CHECK-NEXT:     *p = *p * (*p);
-// CHECK-NEXT:     *_d_p += 1;
+// CHECK-NEXT:     *_d_p += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *p = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_p;
@@ -57,7 +57,7 @@ double arrayPointer(const double* arr) {
   return sum; // 5*arr[0] + arr[1] + 2*arr[2] + 4*arr[3] + 3*arr[4]
 }
 
-// CHECK: void arrayPointer_grad(const double *arr, double *_d_arr) {
+// CHECK: void arrayPointer_pullback(const double *arr, double _d_y, double *_d_arr) {
 // CHECK-NEXT:     double *_d_p = 0;
 // CHECK-NEXT:     const double *_t0;
 // CHECK-NEXT:     double *_t1;
@@ -103,7 +103,7 @@ double arrayPointer(const double* arr) {
 // CHECK-NEXT:     p = p - 2;
 // CHECK-NEXT:     _t11 = sum;
 // CHECK-NEXT:     sum += 5 * (*p);
-// CHECK-NEXT:     _d_sum += 1;
+// CHECK-NEXT:     _d_sum += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         sum = _t11;
 // CHECK-NEXT:         double _r_d3 = _d_sum;
@@ -161,7 +161,7 @@ double pointerParam(const double* arr, size_t n) {
   return sum;
 }
 
-// CHECK: void pointerParam_grad_0(const double *arr, size_t n, double *_d_arr) {
+// CHECK: void pointerParam_pullback_0(const double *arr, size_t n, double _d_y, double *_d_arr) {
 // CHECK-NEXT:     size_t _d_n = 0;
 // CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -192,7 +192,7 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:         _d_arr = _d_arr + 1;
 // CHECK-NEXT:         arr = arr + 1;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_sum += 1;
+// CHECK-NEXT:     _d_sum += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)
@@ -229,7 +229,7 @@ double pointerMultipleParams(const double* a, const double* b) {
   return sum; // 2*a[0] + 4*a[1] + 2*a[2] + b[2]
 }
 
-// CHECK: void pointerMultipleParams_grad(const double *a, const double *b, double *_d_a, double *_d_b) {
+// CHECK: void pointerMultipleParams_pullback(const double *a, const double *b, double _d_y, double *_d_a, double *_d_b) {
 // CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     const double *_t0;
 // CHECK-NEXT:     double *_t1;
@@ -270,7 +270,7 @@ double pointerMultipleParams(const double* a, const double* b) {
 // CHECK-NEXT:     --a;
 // CHECK-NEXT:     _t7 = sum;
 // CHECK-NEXT:     sum += a[0] + b[0];
-// CHECK-NEXT:     _d_sum += 1;
+// CHECK-NEXT:     _d_sum += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         sum = _t7;
 // CHECK-NEXT:         double _r_d3 = _d_sum;
@@ -347,7 +347,7 @@ double newAndDeletePointer(double i, double j) {
   return sum;
 }
 
-// CHECK: void newAndDeletePointer_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void newAndDeletePointer_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double *_d_p = 0;
 // CHECK-NEXT:     double *_d_q = 0;
 // CHECK-NEXT:     double *_d_r = 0;
@@ -365,7 +365,7 @@ double newAndDeletePointer(double i, double j) {
 // CHECK-NEXT:     _t1 = r[1];
 // CHECK-NEXT:     r[1] = i * j;
 // CHECK-NEXT:     double sum = *p + *q + r[0] + r[1];
-// CHECK-NEXT:     _d_sum += 1;
+// CHECK-NEXT:     _d_sum += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_p += _d_sum;
 // CHECK-NEXT:         *_d_q += _d_sum;
@@ -408,13 +408,13 @@ double structPointer (double x) {
   return res;
 }
 
-// CHECK: void structPointer_grad(double x, double *_d_x) {
+// CHECK: void structPointer_pullback(double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:     T *_d_t = 0;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     _d_t = new T();
 // CHECK-NEXT:     T *t = new T({x, /*implicit*/(int)0});
 // CHECK-NEXT:     double res = t->x;
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     _d_t->x += _d_res;
 // CHECK-NEXT:     *_d_x += *_d_t.x;
 // CHECK-NEXT:     delete t;
@@ -436,7 +436,7 @@ double cStyleMemoryAlloc(double x, size_t n) {
   return res;
 }
 
-// CHECK: void cStyleMemoryAlloc_grad_0(double x, size_t n, double *_d_x) {
+// CHECK: void cStyleMemoryAlloc_pullback_0(double x, size_t n, double _d_y, double *_d_x) {
 // CHECK-NEXT:     size_t _d_n = 0;
 // CHECK-NEXT:     T *_d_t = 0;
 // CHECK-NEXT:     double _t0;
@@ -466,7 +466,7 @@ double cStyleMemoryAlloc(double x, size_t n) {
 // CHECK-NEXT:     p[1] = 2 * x;
 // CHECK-NEXT:     _t5 = res;
 // CHECK-NEXT:     res += p[1];
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t5;
 // CHECK-NEXT:         double _r_d3 = _d_res;

--- a/test/Gradient/Switch.C
+++ b/test/Gradient/Switch.C
@@ -18,7 +18,7 @@ double fn1(double i, double j) {
   return res;
 }
 
-// CHECK: void fn1_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn1_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     int _d_count = 0;
 // CHECK-NEXT:     int _cond0;
@@ -61,7 +61,7 @@ double fn1(double i, double j) {
 // CHECK-NEXT:             clad::push(_t1, {{2U|2UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t1)) {
 // CHECK-NEXT:           case {{2U|2UL}}:
@@ -129,7 +129,7 @@ double fn2(double i, double j) {
   return res;
 }
 
-// CHECK: void fn2_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn2_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     int _d_count = 0;
 // CHECK-NEXT:     int count = 0;
@@ -181,7 +181,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:             clad::push(_t3, {{3U|3UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t3)) {
 // CHECK-NEXT:           case {{3U|3UL}}:
@@ -261,7 +261,7 @@ double fn3(double i, double j) {
   return res;
 }
 
-// CHECK: void fn3_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn3_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
@@ -310,7 +310,7 @@ double fn3(double i, double j) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -386,7 +386,7 @@ double fn4(double i, double j) {
   return res;
 }
 
-// CHECK: void fn4_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn4_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
@@ -424,7 +424,7 @@ double fn4(double i, double j) {
 // CHECK-NEXT:             clad::push(_t1, {{3U|3UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t1)) {
 // CHECK-NEXT:           case {{3U|3UL}}:
@@ -473,7 +473,7 @@ double fn5(double i, double j) {
   return res;
 }
 
-// CHECK: void fn5_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn5_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     int _d_count = 0;
 // CHECK-NEXT:     int count = 0;
@@ -491,7 +491,7 @@ double fn5(double i, double j) {
 // CHECK-NEXT:             clad::push(_t1, {{1U|1UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t1)) {
 // CHECK-NEXT:           case {{1U|1UL}}:
@@ -518,7 +518,7 @@ double fn6(double u, double v) {
   return res;
 }
 
-// CHECK: void fn6_grad(double u, double v, double *_d_u, double *_d_v) {
+// CHECK: void fn6_pullback(double u, double v, double _d_y, double *_d_u, double *_d_v) {
 // CHECK-NEXT:     int _d_res = 0;
 // CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     int _t0;
@@ -540,7 +540,7 @@ double fn6(double u, double v) {
 // CHECK-NEXT:             clad::push(_t2, {{1U|1UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
 // CHECK-NEXT:           case {{1U|1UL}}:
@@ -583,7 +583,7 @@ double fn7(double u, double v) {
     return res;
 }
 
-// CHECK: void fn7_grad(double u, double v, double *_d_u, double *_d_v) {
+// CHECK: void fn7_pullback(double u, double v, double _d_y, double *_d_u, double *_d_v) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
@@ -634,7 +634,7 @@ double fn7(double u, double v) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)

--- a/test/Gradient/SwitchInit.C
+++ b/test/Gradient/SwitchInit.C
@@ -16,7 +16,7 @@ double fn1(double i, double j) {
   return res;
 }
 
-// CHECK: void fn1_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn1_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     int _d_count = 0;
 // CHECK-NEXT:     int count = 0;
@@ -60,7 +60,7 @@ double fn1(double i, double j) {
 // CHECK-NEXT:             clad::push(_t1, {{2U|2UL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t1)) {
 // CHECK-NEXT:           case {{2U|2UL}}:

--- a/test/Gradient/TemplateFunctors.C
+++ b/test/Gradient/TemplateFunctors.C
@@ -14,13 +14,13 @@ template <typename T> struct Experiment {
   Experiment& operator=(const Experiment& E) = default;
 };
 
-// CHECK: void operator_call_grad(double i, double j, Experiment<double> *_d_this, double *_d_i, double *_d_j) {
+// CHECK: void operator_call_pullback(double i, double j, double _d_y, Experiment<double> *_d_this, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_this).x += 1 * i * i;
-// CHECK-NEXT:         *_d_i += this->x * 1 * i;
-// CHECK-NEXT:         *_d_i += this->x * i * 1;
-// CHECK-NEXT:         (*_d_this).y += 1 * j;
-// CHECK-NEXT:         *_d_j += this->y * 1;
+// CHECK-NEXT:         (*_d_this).x += _d_y * i * i;
+// CHECK-NEXT:         *_d_i += this->x * _d_y * i;
+// CHECK-NEXT:         *_d_i += this->x * i * _d_y;
+// CHECK-NEXT:         (*_d_this).y += _d_y * j;
+// CHECK-NEXT:         *_d_j += this->y * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -34,15 +34,15 @@ template <> struct Experiment<long double> {
   Experiment& operator=(const Experiment& E) = default;
 };
 
-// CHECK: void operator_call_grad(long double i, long double j, Experiment<long double>  *_d_this, long double  *_d_i, long double  *_d_j) {
+// CHECK: void operator_call_pullback(long double i, long double j, long double _d_y, Experiment<long double>  *_d_this, long double  *_d_i, long double  *_d_j) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_this).x += 1 * j * i * i;
-// CHECK-NEXT:         *_d_i += this->x * 1 * j * i;
-// CHECK-NEXT:         *_d_i += this->x * i * 1 * j;
-// CHECK-NEXT:         *_d_j += this->x * i * i * 1;
-// CHECK-NEXT:         (*_d_this).y += 1 * i * j;
-// CHECK-NEXT:         *_d_j += this->y * 1 * i;
-// CHECK-NEXT:         *_d_i += this->y * j * 1;
+// CHECK-NEXT:         (*_d_this).x += _d_y * j * i * i;
+// CHECK-NEXT:         *_d_i += this->x * _d_y * j * i;
+// CHECK-NEXT:         *_d_i += this->x * i * _d_y * j;
+// CHECK-NEXT:         *_d_j += this->x * i * i * _d_y;
+// CHECK-NEXT:         (*_d_this).y += _d_y * i * j;
+// CHECK-NEXT:         *_d_j += this->y * _d_y * i;
+// CHECK-NEXT:         *_d_i += this->y * j * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -54,15 +54,15 @@ template <typename T> struct ExperimentConstVolatile {
   ExperimentConstVolatile& operator=(const ExperimentConstVolatile& E) = default;
 };
 
-// CHECK: void operator_call_grad(double i, double j, volatile ExperimentConstVolatile<double> *_d_this, double *_d_i, double *_d_j) const volatile {
+// CHECK: void operator_call_pullback(double i, double j, double _d_y, volatile ExperimentConstVolatile<double> *_d_this, double *_d_i, double *_d_j) const volatile {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     _t0 = this->x * i;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_this).x += 1 * i * i;
-// CHECK-NEXT:         *_d_i += this->x * 1 * i;
-// CHECK-NEXT:         *_d_i += _t0 * 1;
-// CHECK-NEXT:         (*_d_this).y += 1 * j;
-// CHECK-NEXT:         *_d_j += this->y * 1;
+// CHECK-NEXT:         (*_d_this).x += _d_y * i * i;
+// CHECK-NEXT:         *_d_i += this->x * _d_y * i;
+// CHECK-NEXT:         *_d_i += _t0 * _d_y;
+// CHECK-NEXT:         (*_d_this).y += _d_y * j;
+// CHECK-NEXT:         *_d_j += this->y * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -76,19 +76,19 @@ template <> struct ExperimentConstVolatile<long double> {
   ExperimentConstVolatile& operator=(const ExperimentConstVolatile& E) = default;
 };
 
-// CHECK: void operator_call_grad(long double i, long double j, volatile ExperimentConstVolatile<long double> *_d_this, long double  *_d_i, long double  *_d_j) const volatile {
+// CHECK: void operator_call_pullback(long double i, long double j, long double _d_y, volatile ExperimentConstVolatile<long double> *_d_this, long double  *_d_i, long double  *_d_j) const volatile {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     _t0 = this->x * i;
 // CHECK-NEXT:     _t1 = this->y * j;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_this).x += 1 * j * i * i;
-// CHECK-NEXT:         *_d_i += this->x * 1 * j * i;
-// CHECK-NEXT:         *_d_i += _t0 * 1 * j;
-// CHECK-NEXT:         *_d_j += _t0 * i * 1;
-// CHECK-NEXT:         (*_d_this).y += 1 * i * j;
-// CHECK-NEXT:         *_d_j += this->y * 1 * i;
-// CHECK-NEXT:         *_d_i += _t1 * 1;
+// CHECK-NEXT:         (*_d_this).x += _d_y * j * i * i;
+// CHECK-NEXT:         *_d_i += this->x * _d_y * j * i;
+// CHECK-NEXT:         *_d_i += _t0 * _d_y * j;
+// CHECK-NEXT:         *_d_j += _t0 * i * _d_y;
+// CHECK-NEXT:         (*_d_this).y += _d_y * i * j;
+// CHECK-NEXT:         *_d_j += this->y * _d_y * i;
+// CHECK-NEXT:         *_d_i += _t1 * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/TestAgainstDiff.C
+++ b/test/Gradient/TestAgainstDiff.C
@@ -10,7 +10,6 @@
 double f(double x, double y) {
   return (x - 1) * (x - 1) + 100 * (y - x * x) * (y - x * x);
 }
-void f_grad(double x, double y, double *_d_x, double *_d_y);
 
 void f_grad_old(double x, double y, double* _d_x, double* _d_y) {
   auto dx = clad::differentiate(f, 0);
@@ -21,14 +20,15 @@ void f_grad_old(double x, double y, double* _d_x, double* _d_y) {
 }
 
 int main() {
-  clad::gradient(f).dump();
+  auto df = clad::gradient(f);
+  df.dump();
   
   auto test = [&] (double x, double y) { // expected-no-diagnostics
     double result_old[2] = {};
     double result_new[2] = {};
 
     f_grad_old(x, y, &result_old[0], &result_old[1]);
-    f_grad(x, y, &result_new[0], &result_new[1]);
+    df.execute(x, y, &result_new[0], &result_new[1]);
 
     for (int i = 0; i < 2; i++)
       if (result_old[i] != result_new[i])

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -50,15 +50,6 @@ void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-#define TEST(F, x, y)                                                 \
-  {                                                                   \
-    result_0 = 0;                                                     \
-    result_1 = 0;                                                     \
-    clad::gradient(F);                                                \
-    F##_grad(x, y, &result_0, &result_1);                             \
-    printf("Result is = {%.2f, %.2f}\n", result_0, (float)result_1);  \
-  }
-
 int main() {
   float result_0;
   int result_1;

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -17,8 +17,8 @@ float fn_type_conversion(float z, int a) {
   return z;
 }
 
-void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a);
-// CHECK: void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a) {
+void fn_type_conversion_pullback(float z, int a, float *_d_z, int *_d_a);
+// CHECK: void fn_type_conversion_pullback(float z, int a, float _d_y, float *_d_z, int *_d_a) {
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
@@ -33,7 +33,7 @@ void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a);
 // CHECK-NEXT:         clad::push(_t1, z);
 // CHECK-NEXT:         z = z * a;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     *_d_z += 1;
+// CHECK-NEXT:     *_d_z += _d_y;
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0)

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -19,10 +19,10 @@ double fn1(pairdd p, double i) {
     return res;
 }
 
-// CHECK: void fn1_grad(pairdd p, double i, pairdd *_d_p, double *_d_i) {
+// CHECK: void fn1_pullback(pairdd p, double i, double _d_y, pairdd *_d_p, double *_d_i) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = p.first + 2 * p.second + 3 * i;
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (*_d_p).first += _d_res;
 // CHECK-NEXT:         (*_d_p).second += 2 * _d_res;
@@ -70,7 +70,7 @@ double fn2(Tangent t, double i) {
     return res;
 }
 
-// CHECK: void fn2_grad(Tangent t, double i, Tangent *_d_t, double *_d_i) {
+// CHECK: void fn2_pullback(Tangent t, double i, double _d_y, Tangent *_d_t, double *_d_i) {
 // CHECK-NEXT:     Tangent _t0;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double _t1;
@@ -78,7 +78,7 @@ double fn2(Tangent t, double i) {
 // CHECK-NEXT:     double res = sum(t);
 // CHECK-NEXT:     _t1 = res;
 // CHECK-NEXT:     res += sum(t.data) + i + 2 * t.data[0];
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t1;
 // CHECK-NEXT:         double _r_d0 = _d_res;
@@ -99,7 +99,7 @@ double fn3(double i, double j) {
     return sum(t);
 }
 
-// CHECK: void fn3_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn3_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     Tangent _d_t({});
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
@@ -112,7 +112,7 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     _t2 = t;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t = _t2;
-// CHECK-NEXT:         sum_pullback(_t2, 1, &_d_t);
+// CHECK-NEXT:         sum_pullback(_t2, _d_y, &_d_t);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t.data[1] = _t1;
@@ -135,32 +135,32 @@ double fn4(double i, double j) {
     return p.first*i + p.second*j + q.first*i + q.second*j;
 }
 
-// CHECK: void fn4_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void fn4_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     pairdd _d_p({});
 // CHECK-NEXT:     pairdd _d_q({});
 // CHECK-NEXT:     pairdd p(1, 3);
 // CHECK-NEXT:     pairdd q({7, 5});
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_p.first += 1 * i;
-// CHECK-NEXT:         *_d_i += p.first * 1;
-// CHECK-NEXT:         _d_p.second += 1 * j;
-// CHECK-NEXT:         *_d_j += p.second * 1;
-// CHECK-NEXT:         _d_q.first += 1 * i;
-// CHECK-NEXT:         *_d_i += q.first * 1;
-// CHECK-NEXT:         _d_q.second += 1 * j;
-// CHECK-NEXT:         *_d_j += q.second * 1;
+// CHECK-NEXT:         _d_p.first += _d_y * i;
+// CHECK-NEXT:         *_d_i += p.first * _d_y;
+// CHECK-NEXT:         _d_p.second += _d_y * j;
+// CHECK-NEXT:         *_d_j += p.second * _d_y;
+// CHECK-NEXT:         _d_q.first += _d_y * i;
+// CHECK-NEXT:         *_d_i += q.first * _d_y;
+// CHECK-NEXT:         _d_q.second += _d_y * j;
+// CHECK-NEXT:         *_d_j += q.second * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void someMemFn_grad(double i, double j, Tangent *_d_this, double *_d_i, double *_d_j) {
+// CHECK: void someMemFn_pullback(double i, double j, double _d_y, Tangent *_d_this, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_this).data[0] += 1 * i;
-// CHECK-NEXT:         *_d_i += this->data[0] * 1;
-// CHECK-NEXT:         (*_d_this).data[1] += 1 * j;
-// CHECK-NEXT:         *_d_j += this->data[1] * 1;
-// CHECK-NEXT:         (*_d_this).data[2] += 3 * 1;
-// CHECK-NEXT:         (*_d_this).data[3] += 1 * this->data[4];
-// CHECK-NEXT:         (*_d_this).data[4] += this->data[3] * 1;
+// CHECK-NEXT:         (*_d_this).data[0] += _d_y * i;
+// CHECK-NEXT:         *_d_i += this->data[0] * _d_y;
+// CHECK-NEXT:         (*_d_this).data[1] += _d_y * j;
+// CHECK-NEXT:         *_d_j += this->data[1] * _d_y;
+// CHECK-NEXT:         (*_d_this).data[2] += 3 * _d_y;
+// CHECK-NEXT:         (*_d_this).data[3] += _d_y * this->data[4];
+// CHECK-NEXT:         (*_d_this).data[4] += this->data[3] * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -170,13 +170,13 @@ double fn5(const Tangent& t, double i) {
 
 // CHECK: void someMemFn2_pullback(double i, double j, double _d_y, Tangent *_d_this, double *_d_i, double *_d_j) const;
 
-// CHECK: void fn5_grad(const Tangent &t, double i, Tangent *_d_t, double *_d_i) {
+// CHECK: void fn5_pullback(const Tangent &t, double i, double _d_y, Tangent *_d_t, double *_d_i) {
 // CHECK-NEXT:     Tangent _t0;
 // CHECK-NEXT:     _t0 = t;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;
-// CHECK-NEXT:         _t0.someMemFn2_pullback(i, i, 1, &(*_d_t), &_r0, &_r1);
+// CHECK-NEXT:         _t0.someMemFn2_pullback(i, i, _d_y, &(*_d_t), &_r0, &_r1);
 // CHECK-NEXT:         *_d_i += _r0;
 // CHECK-NEXT:         *_d_i += _r1;
 // CHECK-NEXT:     }
@@ -196,7 +196,7 @@ double fn6(dcomplex c, double i) {
 
 // CHECK: constexpr void imag_pullback(double _d_y, std{{(::__1)?}}::complex<double> *_d_this){{.*}};
 
-// CHECK: void fn6_grad(dcomplex c, double i, dcomplex *_d_c, double *_d_i) {
+// CHECK: void fn6_pullback(dcomplex c, double i, double _d_y, dcomplex *_d_c, double *_d_i) {
 // CHECK-NEXT:     dcomplex _t0;
 // CHECK-NEXT:     dcomplex _t1;
 // CHECK-NEXT:     double _t2;
@@ -215,7 +215,7 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT:     _t6 = c;
 // CHECK-NEXT:     _t5 = c.real();
 // CHECK-NEXT:     res += 4 * _t5;
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t4;
 // CHECK-NEXT:         double _r_d0 = _d_res;
@@ -238,7 +238,7 @@ double fn7(dcomplex c1, dcomplex c2) {
     return c1.real() + 3*c1.imag();
 }
 
-// CHECK: void fn7_grad(dcomplex c1, dcomplex c2, dcomplex *_d_c1, dcomplex *_d_c2) {
+// CHECK: void fn7_pullback(dcomplex c1, dcomplex c2, double _d_y, dcomplex *_d_c1, dcomplex *_d_c2) {
 // CHECK-NEXT:     dcomplex _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     dcomplex _t2;
@@ -255,8 +255,8 @@ double fn7(dcomplex c1, dcomplex c2) {
 // CHECK-NEXT:     _t6 = c1;
 // CHECK-NEXT:     _t5 = c1.imag();
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _t4.real_pullback(1, &(*_d_c1));
-// CHECK-NEXT:         _t6.imag_pullback(3 * 1, &(*_d_c1));
+// CHECK-NEXT:         _t4.real_pullback(_d_y, &(*_d_c1));
+// CHECK-NEXT:         _t6.imag_pullback(3 * _d_y, &(*_d_c1));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
@@ -273,7 +273,7 @@ double fn8(Tangent t, dcomplex c) {
 
 // CHECK: void updateTo_pullback(double d, Tangent *_d_this, double *_d_d);
 
-// CHECK: void fn8_grad(Tangent t, dcomplex c, Tangent *_d_t, dcomplex *_d_c) {
+// CHECK: void fn8_pullback(Tangent t, dcomplex c, double _d_y, Tangent *_d_t, dcomplex *_d_c) {
 // CHECK-NEXT:     dcomplex _t0;
 // CHECK-NEXT:     Tangent _t1;
 // CHECK-NEXT:     Tangent _t2;
@@ -283,7 +283,7 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK-NEXT:     _t2 = t;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t = _t2;
-// CHECK-NEXT:         sum_pullback(_t2, 1, &(*_d_t));
+// CHECK-NEXT:         sum_pullback(_t2, _d_y, &(*_d_t));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
@@ -301,7 +301,7 @@ double fn9(Tangent t, dcomplex c) {
   return res;
 }
 
-// CHECK: void fn9_grad(Tangent t, dcomplex c, Tangent *_d_t, dcomplex *_d_c) {
+// CHECK: void fn9_pullback(Tangent t, dcomplex c, double _d_y, Tangent *_d_t, dcomplex *_d_c) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
@@ -328,7 +328,7 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     _t5 = res;
 // CHECK-NEXT:     _t6 = t;
 // CHECK-NEXT:     res += sum(t);
-// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t5;
 // CHECK-NEXT:         double _r_d1 = _d_res;

--- a/test/Gradient/constexprTest.C
+++ b/test/Gradient/constexprTest.C
@@ -12,10 +12,10 @@ constexpr double mul (double a, double b, double c) {
     return result;
 }
 
-//CHECK: constexpr void mul_grad(double a, double b, double c, double *_d_a, double *_d_b, double *_d_c) {
+//CHECK: constexpr void mul_pullback(double a, double b, double c, double _d_y, double *_d_a, double *_d_b, double *_d_c) {
 //CHECK-NEXT:    double _d_result = 0;
 //CHECK-NEXT:    double result = a * b * c;
-//CHECK-NEXT:    _d_result += 1;
+//CHECK-NEXT:    _d_result += _d_y;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        *_d_a += _d_result * c * b;
 //CHECK-NEXT:        *_d_b += a * _d_result * c;
@@ -29,12 +29,12 @@ constexpr double fn( double a, double b, double c) {
     return result;
 }
 
-//CHECK: constexpr void fn_grad(double a, double b, double c, double *_d_a, double *_d_b, double *_d_c) {
+//CHECK: constexpr void fn_pullback(double a, double b, double c, double _d_y, double *_d_a, double *_d_b, double *_d_c) {
 //CHECK-NEXT:    double _d_val = 0;
 //CHECK-NEXT:    double _d_result = 0;
 //CHECK-NEXT:    double val = 98.;
 //CHECK-NEXT:    double result = a * b / c * (a + b) * 100 + c;
-//CHECK-NEXT:    _d_result += 1;
+//CHECK-NEXT:    _d_result += _d_y;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        *_d_a += _d_result * 100 * (a + b) / c * b;
 //CHECK-NEXT:        *_d_b += a * _d_result * 100 * (a + b) / c;

--- a/test/Hessian/Arrays.C
+++ b/test/Hessian/Arrays.C
@@ -9,16 +9,16 @@
 
 double f(double i, double j[2]) { return i * j[0] * j[1]; }
 // CHECK: void f_hessian(double i, double j[2], double *hessianMatrix) {
-// CHECK-NEXT:     f_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:     f_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL}}, hessianMatrix + {{4U|4UL}});
-// CHECK-NEXT:     f_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL}}, hessianMatrix + {{7U|7UL}});
+// CHECK-NEXT:     f_darg0_pullback(i, j, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+// CHECK-NEXT:     f_darg1_0_pullback(i, j, 1, hessianMatrix + {{3U|3UL}}, hessianMatrix + {{4U|4UL}});
+// CHECK-NEXT:     f_darg1_1_pullback(i, j, 1, hessianMatrix + {{6U|6UL}}, hessianMatrix + {{7U|7UL}});
 // CHECK-NEXT: }
 
 double g(double i, double j[2]) { return i * (j[0] + j[1]); }
 // CHECK: void g_hessian(double i, double j[2], double *hessianMatrix) {
-// CHECK-NEXT:   g_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:   g_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL}}, hessianMatrix + {{4U|4UL}});
-// CHECK-NEXT:   g_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL}}, hessianMatrix + {{7U|7UL}});
+// CHECK-NEXT:   g_darg0_pullback(i, j, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+// CHECK-NEXT:   g_darg1_0_pullback(i, j, 1, hessianMatrix + {{3U|3UL}}, hessianMatrix + {{4U|4UL}});
+// CHECK-NEXT:   g_darg1_1_pullback(i, j, 1, hessianMatrix + {{6U|6UL}}, hessianMatrix + {{7U|7UL}});
 // CHECK-NEXT: }
 
 double h(double arr[3], double weights[3], double multiplier) {

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -15,10 +15,10 @@ float f1(float x) {
 
 // CHECK: float f1_darg0(float x);
 
-// CHECK: void f1_darg0_grad(float x, float *_d_x);
+// CHECK: void f1_darg0_pullback(float x, float _d_y, float *_d_x);
 
 // CHECK: void f1_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f1_darg0_grad(x, hessianMatrix + {{0U|0UL}});
+// CHECK-NEXT:     f1_darg0_pullback(x, 1, hessianMatrix + {{0U|0UL}});
 // CHECK-NEXT: }
 
 float f2(float x) {
@@ -27,10 +27,10 @@ float f2(float x) {
 
 // CHECK: float f2_darg0(float x);
 
-// CHECK: void f2_darg0_grad(float x, float *_d_x);
+// CHECK: void f2_darg0_pullback(float x, float _d_y, float *_d_x);
 
 // CHECK: void f2_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f2_darg0_grad(x, hessianMatrix + {{0U|0UL}});
+// CHECK-NEXT:     f2_darg0_pullback(x, 1, hessianMatrix + {{0U|0UL}});
 // CHECK-NEXT: }
 
 
@@ -40,10 +40,10 @@ float f3(float x) {
 
 // CHECK: float f3_darg0(float x);
 
-// CHECK: void f3_darg0_grad(float x, float *_d_x);
+// CHECK: void f3_darg0_pullback(float x, float _d_y, float *_d_x);
 
 // CHECK: void f3_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f3_darg0_grad(x, hessianMatrix + {{0U|0UL}});
+// CHECK-NEXT:     f3_darg0_pullback(x, 1, hessianMatrix + {{0U|0UL}});
 // CHECK-NEXT: }
 
 
@@ -53,10 +53,10 @@ float f4(float x) {
 
 // CHECK: float f4_darg0(float x);
 
-// CHECK: void f4_darg0_grad(float x, float *_d_x);
+// CHECK: void f4_darg0_pullback(float x, float _d_y, float *_d_x);
 
 // CHECK: void f4_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f4_darg0_grad(x, hessianMatrix + {{0U|0UL}});
+// CHECK-NEXT:     f4_darg0_pullback(x, 1, hessianMatrix + {{0U|0UL}});
 // CHECK-NEXT: }
 
 
@@ -66,10 +66,10 @@ float f5(float x) {
 
 // CHECK: float f5_darg0(float x);
 
-// CHECK: void f5_darg0_grad(float x, float *_d_x);
+// CHECK: void f5_darg0_pullback(float x, float _d_y, float *_d_x);
 
 // CHECK: void f5_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f5_darg0_grad(x, hessianMatrix + {{0U|0UL}});
+// CHECK-NEXT:     f5_darg0_pullback(x, 1, hessianMatrix + {{0U|0UL}});
 // CHECK-NEXT: }
 
 
@@ -79,15 +79,15 @@ float f6(float x, float y) {
 
 // CHECK: float f6_darg0(float x, float y);
 
-// CHECK: void f6_darg0_grad(float x, float y, float *_d_x, float *_d_y);
+// CHECK: void f6_darg0_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y);
 
 // CHECK: float f6_darg1(float x, float y);
 
-// CHECK: void f6_darg1_grad(float x, float y, float *_d_x, float *_d_y);
+// CHECK: void f6_darg1_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y);
 
 // CHECK: void f6_hessian(float x, float y, float *hessianMatrix) {
-// CHECK-NEXT:     f6_darg0_grad(x, y, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:     f6_darg1_grad(x, y, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT:     f6_darg0_pullback(x, y, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+// CHECK-NEXT:     f6_darg1_pullback(x, y, 1, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
 // CHECK-NEXT: }
 
 namespace clad {
@@ -100,7 +100,7 @@ namespace clad {
       return exp(y);
     }
 
-    void f7_darg1_grad(float x, float y, float *d_x, float *d_y) {
+    void f7_darg1_pullback(float x, float y, float _d_y0, float *d_x, float *d_y) {
       *d_y += exp(y);
     }
 
@@ -121,19 +121,19 @@ float f7(float x, float y) {
 // CHECK-NEXT:     return cos(x);
 // CHECK-NEXT: }
 
-// CHECK: void f7_darg0_grad(float x, float y, float *_d_x, float *_d_y);
+// CHECK: void f7_darg0_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y);
 
 // CHECK: float f7_darg1(float x, float y) {
 // CHECK-NEXT:     return exp(y);
 // CHECK-NEXT: }
 
-// CHECK: void f7_darg1_grad(float x, float y, float *d_x, float *d_y) {
+// CHECK: void f7_darg1_pullback(float x, float y, float _d_y0, float *d_x, float *d_y) {
 // CHECK-NEXT:     *d_y += exp(y);
 // CHECK-NEXT: }
 
 // CHECK: void f7_hessian(float x, float y, float *hessianMatrix) {
-// CHECK-NEXT:     f7_darg0_grad(x, y, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:     f7_darg1_grad(x, y, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT:     f7_darg0_pullback(x, y, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+// CHECK-NEXT:     f7_darg1_pullback(x, y, 1, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
 // CHECK-NEXT: }
 
 float f8(float x, float y) {
@@ -185,7 +185,7 @@ int main() {
 
 // CHECK: void cos_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
-// CHECK: void f1_darg0_grad(float x, float *_d_x) {
+// CHECK: void f1_darg0_pullback(float x, float _d_y, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d__t1 = {};
@@ -193,8 +193,8 @@ int main() {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x0);
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t10 = clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, _d_x0);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d__t0.pushforward += 1;
-// CHECK-NEXT:         _d__t1.pushforward += 1;
+// CHECK-NEXT:         _d__t0.pushforward += _d_y;
+// CHECK-NEXT:         _d__t1.pushforward += _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r2 = 0;
@@ -220,12 +220,12 @@ int main() {
 
 // CHECK: void exp_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
-// CHECK: void f2_darg0_grad(float x, float *_d_x) {
+// CHECK: void f2_darg0_pullback(float x, float _d_y, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, _d_x0);
-// CHECK-NEXT:     _d__t0.pushforward += 1;
+// CHECK-NEXT:     _d__t0.pushforward += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         float _r1 = 0;
@@ -243,12 +243,12 @@ int main() {
 
 // CHECK: void log_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
-// CHECK: void f3_darg0_grad(float x, float *_d_x) {
+// CHECK: void f3_darg0_pullback(float x, float _d_y, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::log_pushforward(x, _d_x0);
-// CHECK-NEXT:     _d__t0.pushforward += 1;
+// CHECK-NEXT:     _d__t0.pushforward += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         float _r1 = 0;
@@ -266,12 +266,12 @@ int main() {
 
 // CHECK: void pow_pushforward_pullback(float x, float exponent, float d_x, float d_exponent, ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d_y, float *_d_x, float *_d_exponent, float *_d_d_x, float *_d_d_exponent);
 
-// CHECK: void f4_darg0_grad(float x, float *_d_x) {
+// CHECK: void f4_darg0_pullback(float x, float _d_y, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 4.F, _d_x0, 0.F);
-// CHECK-NEXT:     _d__t0.pushforward += 1;
+// CHECK-NEXT:     _d__t0.pushforward += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         float _r1 = 0;
@@ -289,12 +289,12 @@ int main() {
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
-// CHECK: void f5_darg0_grad(float x, float *_d_x) {
+// CHECK: void f5_darg0_pullback(float x, float _d_y, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(2.F, x, 0.F, _d_x0);
-// CHECK-NEXT:     _d__t0.pushforward += 1;
+// CHECK-NEXT:     _d__t0.pushforward += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         float _r1 = 0;
@@ -313,20 +313,20 @@ int main() {
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
-// CHECK: void f6_darg0_grad(float x, float y, float *_d_x, float *_d_y) {
+// CHECK: void f6_darg0_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y) {
 // CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     float _d__d_y = 0;
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     float _d_y0 = 0;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y0);
-// CHECK-NEXT:     _d__t0.pushforward += 1;
+// CHECK-NEXT:     float _d_y1 = 0;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y1);
+// CHECK-NEXT:     _d__t0.pushforward += _d_y0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         float _r1 = 0;
 // CHECK-NEXT:         float _r2 = 0;
 // CHECK-NEXT:         float _r3 = 0;
-// CHECK-NEXT:         pow_pushforward_pullback(x, y, _d_x0, _d_y0, _d__t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         pow_pushforward_pullback(x, y, _d_x0, _d_y1, _d__t0, &_r0, &_r1, &_r2, &_r3);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         *_d_y += _r1;
 // CHECK-NEXT:         _d__d_x += _r2;
@@ -341,20 +341,20 @@ int main() {
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
-// CHECK: void f6_darg1_grad(float x, float y, float *_d_x, float *_d_y) {
+// CHECK: void f6_darg1_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y) {
 // CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     float _d__d_y = 0;
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 0;
-// CHECK-NEXT:     float _d_y0 = 1;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y0);
-// CHECK-NEXT:     _d__t0.pushforward += 1;
+// CHECK-NEXT:     float _d_y1 = 1;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y1);
+// CHECK-NEXT:     _d__t0.pushforward += _d_y0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         float _r1 = 0;
 // CHECK-NEXT:         float _r2 = 0;
 // CHECK-NEXT:         float _r3 = 0;
-// CHECK-NEXT:         pow_pushforward_pullback(x, y, _d_x0, _d_y0, _d__t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         pow_pushforward_pullback(x, y, _d_x0, _d_y1, _d__t0, &_r0, &_r1, &_r2, &_r3);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         *_d_y += _r1;
 // CHECK-NEXT:         _d__d_x += _r2;
@@ -362,10 +362,10 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void f7_darg0_grad(float x, float y, float *_d_x, float *_d_y) {
+// CHECK: void f7_darg0_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
-// CHECK-NEXT:         _r0 += 1 * clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, 1.F).pushforward; 
+// CHECK-NEXT:         _r0 += _d_y0 * clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, 1.F).pushforward; 
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Hessian/Functors.C
+++ b/test/Hessian/Functors.C
@@ -18,9 +18,9 @@ struct Experiment {
 
   // CHECK: void operator_call_hessian(double i, double j, double *hessianMatrix) {
   // CHECK-NEXT:     Experiment _d_this;
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->operator_call_darg0_pullback(i, j, 1, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
   // CHECK-NEXT:     Experiment _d_this0;
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->operator_call_darg1_pullback(i, j, 1, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
   // CHECK-NEXT: }
 };
 
@@ -36,9 +36,9 @@ struct ExperimentConst {
 
   // CHECK: void operator_call_hessian(double i, double j, double *hessianMatrix) const {
   // CHECK-NEXT:     ExperimentConst _d_this;
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->operator_call_darg0_pullback(i, j, 1, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
   // CHECK-NEXT:     ExperimentConst _d_this0;
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->operator_call_darg1_pullback(i, j, 1, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
   // CHECK-NEXT: }
 };
 
@@ -54,9 +54,9 @@ struct ExperimentVolatile {
 
   // CHECK: void operator_call_hessian(double i, double j, double *hessianMatrix) volatile {
   // CHECK-NEXT:     volatile ExperimentVolatile _d_this;
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->operator_call_darg0_pullback(i, j, 1, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
   // CHECK-NEXT:     volatile ExperimentVolatile _d_this0;
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->operator_call_darg1_pullback(i, j, 1, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
   // CHECK-NEXT: }
 };
 
@@ -72,9 +72,9 @@ struct ExperimentConstVolatile {
 
   // CHECK: void operator_call_hessian(double i, double j, double *hessianMatrix) const volatile {
   // CHECK-NEXT:     volatile ExperimentConstVolatile _d_this;
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->operator_call_darg0_pullback(i, j, 1, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
   // CHECK-NEXT:     volatile ExperimentConstVolatile _d_this0;
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->operator_call_darg1_pullback(i, j, 1, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
   // CHECK-NEXT: }
 };
 
@@ -92,9 +92,9 @@ namespace outer {
 
       // CHECK: void operator_call_hessian(double i, double j, double *hessianMatrix) {
       // CHECK-NEXT:     outer::inner::ExperimentNNS _d_this;
-      // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+      // CHECK-NEXT:     this->operator_call_darg0_pullback(i, j, 1, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
       // CHECK-NEXT:     outer::inner::ExperimentNNS _d_this0;
-      // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+      // CHECK-NEXT:     this->operator_call_darg1_pullback(i, j, 1, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
       // CHECK-NEXT: }
     };
 
@@ -103,8 +103,8 @@ namespace outer {
     };
 
     // CHECK: inline void operator_call_hessian(double i, double j, double *hessianMatrix) const {
-    // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-    // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+    // CHECK-NEXT:     this->operator_call_darg0_pullback(i, j, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+    // CHECK-NEXT:     this->operator_call_darg1_pullback(i, j, 1, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
     // CHECK-NEXT: }
   }
 }
@@ -139,8 +139,8 @@ int main() {
   };
 
   // CHECK: inline void operator_call_hessian(double i, double j, double *hessianMatrix) const {
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->operator_call_darg0_pullback(i, j, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->operator_call_darg1_pullback(i, j, 1, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
   // CHECK-NEXT: }
 
   auto lambdaWithCapture = [&](double i, double jj) {
@@ -148,8 +148,8 @@ int main() {
   };
 
   // CHECK: inline void operator_call_hessian(double i, double jj, double *hessianMatrix) const {
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, jj, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, jj, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->operator_call_darg0_pullback(i, jj, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->operator_call_darg1_pullback(i, jj, 1, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
   // CHECK-NEXT: }
 
   auto lambdaNNS = outer::inner::lambdaNNS;

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -12,13 +12,13 @@ __attribute__((always_inline)) double f_cubed_add1(double a, double b) {
 }
 //CHECK:{{[__attribute__((always_inline)) ]*}}double f_cubed_add1_darg0(double a, double b){{[ __attribute__((always_inline))]*}};
 
-//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}};
+//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg0_pullback(double a, double b, double _d_y, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}};
 
-//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg1_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}};
+//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg1_pullback(double a, double b, double _d_y, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}};
 
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_hessian(double a, double b, double *hessianMatrix){{[ __attribute__((always_inline))]*}} {
-//CHECK-NEXT:    f_cubed_add1_darg0_grad(a, b, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:    f_cubed_add1_darg1_grad(a, b, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+//CHECK-NEXT:    f_cubed_add1_darg0_pullback(a, b, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+//CHECK-NEXT:    f_cubed_add1_darg1_pullback(a, b, 1, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
 //CHECK-NEXT: }
 
 double f_suvat1(double u, double t) {
@@ -26,8 +26,8 @@ double f_suvat1(double u, double t) {
 }
 
 //CHECK:void f_suvat1_hessian(double u, double t, double *hessianMatrix) {
-//CHECK-NEXT:    f_suvat1_darg0_grad(u, t, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:    f_suvat1_darg1_grad(u, t, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+//CHECK-NEXT:    f_suvat1_darg0_pullback(u, t, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+//CHECK-NEXT:    f_suvat1_darg1_pullback(u, t, 1, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
 //CHECK-NEXT:}
 
 double f_cond3(double x, double c) {
@@ -40,8 +40,8 @@ double f_cond3(double x, double c) {
 }
 
 //CHECK:void f_cond3_hessian(double x, double c, double *hessianMatrix) {
-//CHECK-NEXT:    f_cond3_darg0_grad(x, c, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:    f_cond3_darg1_grad(x, c, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+//CHECK-NEXT:    f_cond3_darg0_pullback(x, c, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+//CHECK-NEXT:    f_cond3_darg1_pullback(x, c, 1, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
 //CHECK-NEXT:}
 
 double f_power10(double x) {
@@ -49,7 +49,7 @@ double f_power10(double x) {
 }
 
 //CHECK: void f_power10_hessian(double x, double *hessianMatrix) {
-//CHECK-NEXT:     f_power10_darg0_grad(x, hessianMatrix + {{0U|0UL}});
+//CHECK-NEXT:     f_power10_darg0_pullback(x, 1, hessianMatrix + {{0U|0UL}});
 //CHECK-NEXT: }
 
 struct Experiment {
@@ -61,9 +61,9 @@ struct Experiment {
 
   // CHECK: void someMethod_hessian(double i, double j, double *hessianMatrix) {
   // CHECK-NEXT:     Experiment _d_this;
-  // CHECK-NEXT:     this->someMethod_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->someMethod_darg0_pullback(i, j, 1, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
   // CHECK-NEXT:     Experiment _d_this0;
-  // CHECK-NEXT:     this->someMethod_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->someMethod_darg1_pullback(i, j, 1, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
   // CHECK-NEXT: }
 };
 
@@ -76,9 +76,9 @@ struct Widget {
 
   // CHECK: void memFn_1_hessian(double i, double j, double *hessianMatrix) {
   // CHECK-NEXT:     Widget _d_this;
-  // CHECK-NEXT:     this->memFn_1_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->memFn_1_darg0_pullback(i, j, 1, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
   // CHECK-NEXT:     Widget _d_this0;
-  // CHECK-NEXT:     this->memFn_1_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->memFn_1_darg1_pullback(i, j, 1, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
   // CHECK-NEXT: }
 
   double memFn_2(double i, double j) {
@@ -89,9 +89,9 @@ struct Widget {
 
   // CHECK: void memFn_2_hessian(double i, double j, double *hessianMatrix) {
   // CHECK-NEXT:     Widget _d_this;
-  // CHECK-NEXT:     this->memFn_2_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->memFn_2_darg0_pullback(i, j, 1, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
   // CHECK-NEXT:     Widget _d_this0;
-  // CHECK-NEXT:     this->memFn_2_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->memFn_2_darg1_pullback(i, j, 1, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
   // CHECK-NEXT: }
 };
 
@@ -155,7 +155,7 @@ int main() {
 //CHECK-NEXT:    return (_d_a * a + a * _d_a) * a + _t0 * _d_a + (_d_b * b + b * _d_b) * b + _t1 * _d_b;
 //CHECK-NEXT:}
 
-//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
+//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg0_pullback(double a, double b, double _d_y, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
 //CHECK-NEXT:    double _d__d_a = 0;
 //CHECK-NEXT:    double _d__d_b = 0;
 //CHECK-NEXT:    double _d__t0 = 0;
@@ -165,20 +165,20 @@ int main() {
 //CHECK-NEXT:    double _t00 = a * a;
 //CHECK-NEXT:    double _t10 = b * b;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        _d__d_a += 1 * a * a;
-//CHECK-NEXT:        *_d_a += _d_a0 * 1 * a;
-//CHECK-NEXT:        *_d_a += 1 * a * _d_a0;
-//CHECK-NEXT:        _d__d_a += a * 1 * a;
-//CHECK-NEXT:        *_d_a += (_d_a0 * a + a * _d_a0) * 1;
-//CHECK-NEXT:        _d__t0 += 1 * _d_a0;
-//CHECK-NEXT:        _d__d_a += _t00 * 1;
-//CHECK-NEXT:        _d__d_b += 1 * b * b;
-//CHECK-NEXT:        *_d_b += _d_b0 * 1 * b;
-//CHECK-NEXT:        *_d_b += 1 * b * _d_b0;
-//CHECK-NEXT:        _d__d_b += b * 1 * b;
-//CHECK-NEXT:        *_d_b += (_d_b0 * b + b * _d_b0) * 1;
-//CHECK-NEXT:        _d__t1 += 1 * _d_b0;
-//CHECK-NEXT:        _d__d_b += _t10 * 1;
+//CHECK-NEXT:        _d__d_a += _d_y * a * a;
+//CHECK-NEXT:        *_d_a += _d_a0 * _d_y * a;
+//CHECK-NEXT:        *_d_a += _d_y * a * _d_a0;
+//CHECK-NEXT:        _d__d_a += a * _d_y * a;
+//CHECK-NEXT:        *_d_a += (_d_a0 * a + a * _d_a0) * _d_y;
+//CHECK-NEXT:        _d__t0 += _d_y * _d_a0;
+//CHECK-NEXT:        _d__d_a += _t00 * _d_y;
+//CHECK-NEXT:        _d__d_b += _d_y * b * b;
+//CHECK-NEXT:        *_d_b += _d_b0 * _d_y * b;
+//CHECK-NEXT:        *_d_b += _d_y * b * _d_b0;
+//CHECK-NEXT:        _d__d_b += b * _d_y * b;
+//CHECK-NEXT:        *_d_b += (_d_b0 * b + b * _d_b0) * _d_y;
+//CHECK-NEXT:        _d__t1 += _d_y * _d_b0;
+//CHECK-NEXT:        _d__d_b += _t10 * _d_y;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
 //CHECK-NEXT:        *_d_b += _d__t1 * b;
@@ -190,7 +190,7 @@ int main() {
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
-//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg1_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
+//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg1_pullback(double a, double b, double _d_y, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
 //CHECK-NEXT:    double _d__d_a = 0;
 //CHECK-NEXT:    double _d__d_b = 0;
 //CHECK-NEXT:    double _d__t0 = 0;
@@ -200,20 +200,20 @@ int main() {
 //CHECK-NEXT:    double _t00 = a * a;
 //CHECK-NEXT:    double _t10 = b * b;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        _d__d_a += 1 * a * a;
-//CHECK-NEXT:        *_d_a += _d_a0 * 1 * a;
-//CHECK-NEXT:        *_d_a += 1 * a * _d_a0;
-//CHECK-NEXT:        _d__d_a += a * 1 * a;
-//CHECK-NEXT:        *_d_a += (_d_a0 * a + a * _d_a0) * 1;
-//CHECK-NEXT:        _d__t0 += 1 * _d_a0;
-//CHECK-NEXT:        _d__d_a += _t00 * 1;
-//CHECK-NEXT:        _d__d_b += 1 * b * b;
-//CHECK-NEXT:        *_d_b += _d_b0 * 1 * b;
-//CHECK-NEXT:        *_d_b += 1 * b * _d_b0;
-//CHECK-NEXT:        _d__d_b += b * 1 * b;
-//CHECK-NEXT:        *_d_b += (_d_b0 * b + b * _d_b0) * 1;
-//CHECK-NEXT:        _d__t1 += 1 * _d_b0;
-//CHECK-NEXT:        _d__d_b += _t10 * 1;
+//CHECK-NEXT:        _d__d_a += _d_y * a * a;
+//CHECK-NEXT:        *_d_a += _d_a0 * _d_y * a;
+//CHECK-NEXT:        *_d_a += _d_y * a * _d_a0;
+//CHECK-NEXT:        _d__d_a += a * _d_y * a;
+//CHECK-NEXT:        *_d_a += (_d_a0 * a + a * _d_a0) * _d_y;
+//CHECK-NEXT:        _d__t0 += _d_y * _d_a0;
+//CHECK-NEXT:        _d__d_a += _t00 * _d_y;
+//CHECK-NEXT:        _d__d_b += _d_y * b * b;
+//CHECK-NEXT:        *_d_b += _d_b0 * _d_y * b;
+//CHECK-NEXT:        *_d_b += _d_y * b * _d_b0;
+//CHECK-NEXT:        _d__d_b += b * _d_y * b;
+//CHECK-NEXT:        *_d_b += (_d_b0 * b + b * _d_b0) * _d_y;
+//CHECK-NEXT:        _d__t1 += _d_y * _d_b0;
+//CHECK-NEXT:        _d__d_b += _t10 * _d_y;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
 //CHECK-NEXT:        *_d_b += _d__t1 * b;

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -12,13 +12,10 @@ __attribute__((always_inline)) double f_cubed_add1(double a, double b) {
 }
 //CHECK:{{[__attribute__((always_inline)) ]*}}double f_cubed_add1_darg0(double a, double b){{[ __attribute__((always_inline))]*}};
 
-void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b);
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}};
 
-void f_cubed_add1_darg1_grad(double a, double b, double *_d_a, double *_d_b);
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg1_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}};
 
-void f_cubed_add1_hessian(double a, double b, double *hessianMatrix);
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_hessian(double a, double b, double *hessianMatrix){{[ __attribute__((always_inline))]*}} {
 //CHECK-NEXT:    f_cubed_add1_darg0_grad(a, b, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
 //CHECK-NEXT:    f_cubed_add1_darg1_grad(a, b, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
@@ -28,10 +25,6 @@ double f_suvat1(double u, double t) {
   return ((u * t) + ((0.5) * (9.81) * (t * t)));
 }
 
-void f_suvat1_darg0_grad(double u, double t, double *_d_u, double *_d_t);
-void f_suvat1_darg1_grad(double u, double t, double *_d_u, double *_d_t);
-
-void f_suvat1_hessian(double u, double t, double *hessianMatrix);
 //CHECK:void f_suvat1_hessian(double u, double t, double *hessianMatrix) {
 //CHECK-NEXT:    f_suvat1_darg0_grad(u, t, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
 //CHECK-NEXT:    f_suvat1_darg1_grad(u, t, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
@@ -46,10 +39,6 @@ double f_cond3(double x, double c) {
   }
 }
 
-void f_cond3_darg0_grad(double x, double c, double *_d_x, double *_d_c);
-void f_cond3_darg1_grad(double x, double c, double *_d_x, double *_d_c);
-
-void f_cond3_hessian(double x, double c, double *hessianMatrix);
 //CHECK:void f_cond3_hessian(double x, double c, double *hessianMatrix) {
 //CHECK-NEXT:    f_cond3_darg0_grad(x, c, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
 //CHECK-NEXT:    f_cond3_darg1_grad(x, c, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
@@ -59,9 +48,6 @@ double f_power10(double x) {
   return x * x * x * x * x * x * x * x * x * x;
 }
 
-void f_power10_darg0_grad(double x, double *_d_x);
-
-void f_power10_hessian(double x, double *hessianMatrix);
 //CHECK: void f_power10_hessian(double x, double *hessianMatrix) {
 //CHECK-NEXT:     f_power10_darg0_grad(x, hessianMatrix + {{0U|0UL}});
 //CHECK-NEXT: }
@@ -73,16 +59,6 @@ struct Experiment {
     return i*i*j + j*j*i;
   }
 
-  void someMethod_darg0_grad(double i,
-                             double j,
-                             double *_d_i,
-                             double *_d_j);
-  void someMethod_darg1_grad(double i,
-                             double j,
-                             double *_d_i,
-                             double *_d_j);
-
-  void someMethod_hessian(double x, double *hessianMatrix);
   // CHECK: void someMethod_hessian(double i, double j, double *hessianMatrix) {
   // CHECK-NEXT:     Experiment _d_this;
   // CHECK-NEXT:     this->someMethod_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
@@ -98,18 +74,6 @@ struct Widget {
     return x*y*i*j;
   }
 
-  void memFn_1_darg0_grad(double i,
-                          double j,
-                          double *_d_i,
-                          double *_d_j);
-  void memFn_1_darg1_grad(double i,
-                          double j,
-                          double *_d_i,
-                          double *_d_j);
-
-  void memFn_1_hessian(double i,
-                       double j,
-                       double *hessianMatrix);
   // CHECK: void memFn_1_hessian(double i, double j, double *hessianMatrix) {
   // CHECK-NEXT:     Widget _d_this;
   // CHECK-NEXT:     this->memFn_1_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
@@ -123,18 +87,6 @@ struct Widget {
     return b*y*y*i;
   }
 
-  void memFn_2_darg0_grad(double i,
-                          double j,
-                          double *_d_i,
-                          double *_d_j);
-  void memFn_2_darg1_grad(double i,
-                          double j,
-                          double *_d_i,
-                          double *_d_j);
-
-  void memFn_2_hessian(double i,
-                       double j,
-                       double *hessianMatrix);
   // CHECK: void memFn_2_hessian(double i, double j, double *hessianMatrix) {
   // CHECK-NEXT:     Widget _d_this;
   // CHECK-NEXT:     this->memFn_2_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
@@ -147,19 +99,11 @@ double fn_def_arg(double i=0, double j=0) {
   return 2*i*j;
 }
 
-void fn_def_arg_darg0_grad(double, double, double*,
-                           double*);
-void fn_def_arg_darg1_grad(double, double, double*,
-                           double*);
-void fn_def_arg_hessian(double, double, double*);
-
 #define TEST1(F, x) { \
   result[0] = 0;\
   auto h = clad::hessian(F);\
   h.execute(x, result);\
   printf("Result is = {%.2f}\n", result[0]); \
-  F##_hessian(x, result);\
-  F##_darg0_grad(x, result);\
 }
 
 #define TEST2(F, x, y)                                                         \
@@ -175,9 +119,6 @@ void fn_def_arg_hessian(double, double, double*);
            result[1],                                                          \
            result[2],                                                          \
            result[3]);                                                         \
-    F##_darg0_grad(x, y, &result[0], &result[1]);                              \
-    F##_darg1_grad(x, y, &result[2], &result[3]);                              \
-    F##_hessian(x, y, result);                                                 \
 }
 
 #define TEST3(F, Obj, ...) { \

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -18,13 +18,13 @@ double f2(double x, double y){
 }
 
 // CHECK: double f2_darg0(double x, double y);
-// CHECK: void f2_darg0_grad(double x, double y, double *_d_x, double *_d_y);
+// CHECK: void f2_darg0_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 // CHECK: double f2_darg1(double x, double y);
-// CHECK: void f2_darg1_grad(double x, double y, double *_d_x, double *_d_y);
+// CHECK: void f2_darg1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
 // CHECK: void f2_hessian(double x, double y, double *hessianMatrix) {
-// CHECK-NEXT:     f2_darg0_grad(x, y, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:     f2_darg1_grad(x, y, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT:     f2_darg0_pullback(x, y, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+// CHECK-NEXT:     f2_darg1_pullback(x, y, 1, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndPushforward<double, double> f_pushforward(double x, double y, double _d_x, double _d_y);
@@ -40,18 +40,18 @@ double f2(double x, double y){
 
 // CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x, double *_d_y, double *_d__d_x, double *_d__d_y);
 
-// CHECK: void f2_darg0_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: void f2_darg0_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     double _d__d_x = 0;
 // CHECK-NEXT:     double _d__d_y = 0;
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {};
 // CHECK-NEXT:     double _d__d_ans = 0;
 // CHECK-NEXT:     double _d_ans0 = 0;
 // CHECK-NEXT:     double _d_x0 = 1;
-// CHECK-NEXT:     double _d_y0 = 0;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
+// CHECK-NEXT:     double _d_y1 = 0;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y1);
 // CHECK-NEXT:     double _d_ans = _t00.pushforward;
 // CHECK-NEXT:     double ans = _t00.value;
-// CHECK-NEXT:     _d__d_ans += 1;
+// CHECK-NEXT:     _d__d_ans += _d_y0;
 // CHECK-NEXT:     _d__t0.value += _d_ans0;
 // CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
 // CHECK-NEXT:     {
@@ -59,7 +59,7 @@ double f2(double x, double y){
 // CHECK-NEXT:         double _r1 = 0;
 // CHECK-NEXT:         double _r2 = 0;
 // CHECK-NEXT:         double _r3 = 0;
-// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y0, _d__t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y1, _d__t0, &_r0, &_r1, &_r2, &_r3);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         *_d_y += _r1;
 // CHECK-NEXT:         _d__d_x += _r2;
@@ -76,18 +76,18 @@ double f2(double x, double y){
 // CHECK-NEXT:     return _d_ans;
 // CHECK-NEXT: }
 
-// CHECK: void f2_darg1_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: void f2_darg1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     double _d__d_x = 0;
 // CHECK-NEXT:     double _d__d_y = 0;
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {};
 // CHECK-NEXT:     double _d__d_ans = 0;
 // CHECK-NEXT:     double _d_ans0 = 0;
 // CHECK-NEXT:     double _d_x0 = 0;
-// CHECK-NEXT:     double _d_y0 = 1;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
+// CHECK-NEXT:     double _d_y1 = 1;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y1);
 // CHECK-NEXT:     double _d_ans = _t00.pushforward;
 // CHECK-NEXT:     double ans = _t00.value;
-// CHECK-NEXT:     _d__d_ans += 1;
+// CHECK-NEXT:     _d__d_ans += _d_y0;
 // CHECK-NEXT:     _d__t0.value += _d_ans0;
 // CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
 // CHECK-NEXT:     {
@@ -95,7 +95,7 @@ double f2(double x, double y){
 // CHECK-NEXT:         double _r1 = 0;
 // CHECK-NEXT:         double _r2 = 0;
 // CHECK-NEXT:         double _r3 = 0;
-// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y0, _d__t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y1, _d__t0, &_r0, &_r1, &_r2, &_r3);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         *_d_y += _r1;
 // CHECK-NEXT:         _d__d_x += _r2;

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -11,13 +11,13 @@ double nonMemFn(double i, double j) {
 }
 
 // CHECK: double nonMemFn_darg0(double i, double j);
-// CHECK: void nonMemFn_darg0_grad(double i, double j, double *_d_i, double *_d_j);
+// CHECK: void nonMemFn_darg0_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j);
 // CHECK: double nonMemFn_darg1(double i, double j);
-// CHECK: void nonMemFn_darg1_grad(double i, double j, double *_d_i, double *_d_j);
+// CHECK: void nonMemFn_darg1_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j);
 
 // CHECK: void nonMemFn_hessian(double i, double j, double *hessianMatrix) {
-// CHECK-NEXT:     nonMemFn_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:     nonMemFn_darg1_grad(i, j, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT:     nonMemFn_darg0_pullback(i, j, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+// CHECK-NEXT:     nonMemFn_darg1_pullback(i, j, 1, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
 // CHECK-NEXT: }
 
 // CHECK: double nonMemFn_darg0(double i, double j) {
@@ -26,16 +26,16 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:     return _d_i * j + i * _d_j;
 // CHECK-NEXT: }
 
-// CHECK: void nonMemFn_darg0_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void nonMemFn_darg0_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _d__d_j = 0;
 // CHECK-NEXT:     double _d_i0 = 1;
 // CHECK-NEXT:     double _d_j0 = 0;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d__d_i += 1 * j;
-// CHECK-NEXT:         *_d_j += _d_i0 * 1;
-// CHECK-NEXT:         *_d_i += 1 * _d_j0;
-// CHECK-NEXT:         _d__d_j += i * 1;
+// CHECK-NEXT:         _d__d_i += _d_y * j;
+// CHECK-NEXT:         *_d_j += _d_i0 * _d_y;
+// CHECK-NEXT:         *_d_i += _d_y * _d_j0;
+// CHECK-NEXT:         _d__d_j += i * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -45,16 +45,16 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT:     return _d_i * j + i * _d_j;
 // CHECK-NEXT: }
 
-// CHECK: void nonMemFn_darg1_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK: void nonMemFn_darg1_pullback(double i, double j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _d__d_j = 0;
 // CHECK-NEXT:     double _d_i0 = 0;
 // CHECK-NEXT:     double _d_j0 = 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d__d_i += 1 * j;
-// CHECK-NEXT:         *_d_j += _d_i0 * 1;
-// CHECK-NEXT:         *_d_i += 1 * _d_j0;
-// CHECK-NEXT:         _d__d_j += i * 1;
+// CHECK-NEXT:         _d__d_i += _d_y * j;
+// CHECK-NEXT:         *_d_j += _d_i0 * _d_y;
+// CHECK-NEXT:         *_d_i += _d_y * _d_j0;
+// CHECK-NEXT:         _d__d_j += i * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Hessian/TemplateFunctors.C
+++ b/test/Hessian/TemplateFunctors.C
@@ -15,9 +15,9 @@ template <typename T> struct Experiment {
 
 // CHECK: void operator_call_hessian(double i, double j, double *hessianMatrix) {
 // CHECK-NEXT:     Experiment<double> _d_this;
-// CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+// CHECK-NEXT:     this->operator_call_darg0_pullback(i, j, 1, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
 // CHECK-NEXT:     Experiment<double> _d_this0;
-// CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT:     this->operator_call_darg1_pullback(i, j, 1, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
 // CHECK-NEXT: }
 
 template <> struct Experiment<long double> {
@@ -31,9 +31,9 @@ template <> struct Experiment<long double> {
 
 // CHECK: void operator_call_hessian(long double i, long double j, long double *hessianMatrix) {
 // CHECK-NEXT:     Experiment<long double> _d_this;
-// CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+// CHECK-NEXT:     this->operator_call_darg0_pullback(i, j, 1, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
 // CHECK-NEXT:     Experiment<long double> _d_this0;
-// CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT:     this->operator_call_darg1_pullback(i, j, 1, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
 // CHECK-NEXT: }
 
 #define INIT(E)                   \

--- a/test/Hessian/constexprTest.C
+++ b/test/Hessian/constexprTest.C
@@ -18,16 +18,16 @@ clad::array_ref<double>mat_ref_f1(mat_ref1, 9);
 constexpr double fn(double x, double y) { return x * y; }
 
 //CHECK: constexpr void fn_hessian(double x, double y, double *hessianMatrix) {
-//CHECK-NEXT:    fn_darg0_grad(x, y, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:    fn_darg1_grad(x, y, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+//CHECK-NEXT:    fn_darg0_pullback(x, y, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+//CHECK-NEXT:    fn_darg1_pullback(x, y, 1, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
 //CHECK-NEXT:}
 
 constexpr double g(double i, double j[2]) { return i * (j[0] + j[1]); }
 
 //CHECK: constexpr void g_hessian(double i, double j[2], double *hessianMatrix) {
-//CHECK-NEXT:    g_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:    g_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL}}, hessianMatrix + {{4U|4UL}});
-//CHECK-NEXT:    g_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL}}, hessianMatrix + {{7U|7UL}});
+//CHECK-NEXT:    g_darg0_pullback(i, j, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+//CHECK-NEXT:    g_darg1_0_pullback(i, j, 1, hessianMatrix + {{3U|3UL}}, hessianMatrix + {{4U|4UL}});
+//CHECK-NEXT:    g_darg1_1_pullback(i, j, 1, hessianMatrix + {{6U|6UL}}, hessianMatrix + {{7U|7UL}});
 //CHECK-NEXT:}
 
 int main() {

--- a/test/Hessian/testhessUtility.C
+++ b/test/Hessian/testhessUtility.C
@@ -18,16 +18,16 @@ clad::array_ref<double>mat_ref_f1(mat_ref1, 9);
 double fn(double x, double y) { return x * y; }
 
 //CHECK: void fn_hessian(double x, double y, double *hessianMatrix) {
-//CHECK-NEXT:    fn_darg0_grad(x, y, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:    fn_darg1_grad(x, y, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+//CHECK-NEXT:    fn_darg0_pullback(x, y, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+//CHECK-NEXT:    fn_darg1_pullback(x, y, 1, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
 //CHECK-NEXT:}
 
 double g(double i, double j[2]) { return i * (j[0] + j[1]); }
 
 //CHECK: void g_hessian(double i, double j[2], double *hessianMatrix) {
-//CHECK-NEXT:   g_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:   g_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL}}, hessianMatrix + {{4U|4UL}});
-//CHECK-NEXT:   g_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL}}, hessianMatrix + {{7U|7UL}});
+//CHECK-NEXT:   g_darg0_pullback(i, j, 1, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+//CHECK-NEXT:   g_darg1_0_pullback(i, j, 1, hessianMatrix + {{3U|3UL}}, hessianMatrix + {{4U|4UL}});
+//CHECK-NEXT:   g_darg1_1_pullback(i, j, 1, hessianMatrix + {{6U|6UL}}, hessianMatrix + {{7U|7UL}});
 //CHECK-NEXT: }
 
 int main() {

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -106,7 +106,7 @@
 // RUN: %cladclang %S/../../demos/ErrorEstimation/FloatSum.cpp -I%S/../../include 2>&1  | FileCheck -check-prefix CHECK_FLOAT_SUM %s
 //CHECK_FLOAT_SUM-NOT: {{.*error|warning|note:.*}}
 
-//CHECK_FLOAT_SUM: void vanillaSum_grad(float x, unsigned int n, float *_d_x, unsigned int *_d_n, double &_final_error) {
+//CHECK_FLOAT_SUM: void vanillaSum_grad(float x, unsigned int n, float *_d_x, unsigned int *_d_n, double *_final_error) {
 //CHECK_FLOAT_SUM:    float _d_sum = 0;
 //CHECK_FLOAT_SUM:    unsigned {{int|long}} _t0;
 //CHECK_FLOAT_SUM:    unsigned int _d_i = 0;
@@ -131,7 +131,7 @@
 //CHECK_FLOAT_SUM:        }
 //CHECK_FLOAT_SUM:        i--;
 //CHECK_FLOAT_SUM:        {
-//CHECK_FLOAT_SUM:            _final_error += std::abs(_d_sum * sum * 1.1920928955078125E-7);
+//CHECK_FLOAT_SUM:            *_final_error += std::abs(_d_sum * sum * 1.1920928955078125E-7);
 //CHECK_FLOAT_SUM:            sum = clad::pop(_t1);
 //CHECK_FLOAT_SUM:            float _r_d0 = _d_sum;
 //CHECK_FLOAT_SUM:            _d_sum = 0;
@@ -139,8 +139,8 @@
 //CHECK_FLOAT_SUM:            *_d_x += _r_d0;
 //CHECK_FLOAT_SUM:        }
 //CHECK_FLOAT_SUM:    }
-//CHECK_FLOAT_SUM:    _final_error += std::abs(_d_sum * sum * 1.1920928955078125E-7);
-//CHECK_FLOAT_SUM:    _final_error += std::abs(*_d_x * x * 1.1920928955078125E-7);
+//CHECK_FLOAT_SUM:    *_final_error += std::abs(_d_sum * sum * 1.1920928955078125E-7);
+//CHECK_FLOAT_SUM:    *_final_error += std::abs(*_d_x * x * 1.1920928955078125E-7);
 //CHECK_FLOAT_SUM:}
 
 //-----------------------------------------------------------------------------/
@@ -156,7 +156,7 @@
 // RUN: ./CustomModelTest.out | FileCheck -check-prefix CHECK_CUSTOM_MODEL_EXEC %s
 // CHECK_CUSTOM_MODEL_EXEC-NOT:{{.*error|warning|note:.*}}
 // CHECK_CUSTOM_MODEL_EXEC: The code is:
-// CHECK_CUSTOM_MODEL_EXEC-NEXT: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+// CHECK_CUSTOM_MODEL_EXEC-NEXT: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _t0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float z;
@@ -164,15 +164,15 @@
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    z = x + y;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    _d_z += 1;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    {
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:        _final_error += _d_z * z;
+// CHECK_CUSTOM_MODEL_EXEC-NEXT:        *_final_error += _d_z * z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        z = _t0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        float _r_d0 = _d_z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        _d_z = 0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        *_d_x += _r_d0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        *_d_y += _r_d0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    }
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:    _final_error += *_d_x * x;
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:    _final_error += *_d_y * y;
+// CHECK_CUSTOM_MODEL_EXEC-NEXT:    *_final_error += *_d_x * x;
+// CHECK_CUSTOM_MODEL_EXEC-NEXT:    *_final_error += *_d_y * y;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT: }
 
 //-----------------------------------------------------------------------------/
@@ -188,7 +188,7 @@
 // RUN: ./PrintModelTest.out | FileCheck -check-prefix CHECK_PRINT_MODEL_EXEC %s
 // CHECK_PRINT_MODEL_EXEC-NOT:{{.*error|warning|note:.*}}
 // CHECK_PRINT_MODEL_EXEC: The code is:
-// CHECK_PRINT_MODEL_EXEC-NEXT: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
+// CHECK_PRINT_MODEL_EXEC-NEXT: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
 // CHECK_PRINT_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    float _t0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    float z;
@@ -196,15 +196,15 @@
 // CHECK_PRINT_MODEL_EXEC-NEXT:    z = x + y;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    _d_z += 1;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    {
-// CHECK_PRINT_MODEL_EXEC-NEXT:        _final_error += clad::getErrorVal(_d_z, z, "z");
+// CHECK_PRINT_MODEL_EXEC-NEXT:        *_final_error += clad::getErrorVal(_d_z, z, "z");
 // CHECK_PRINT_MODEL_EXEC-NEXT:        z = _t0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:        float _r_d0 = _d_z;
 // CHECK_PRINT_MODEL_EXEC-NEXT:        _d_z = 0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:        *_d_x += _r_d0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:        *_d_y += _r_d0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    }
-// CHECK_PRINT_MODEL_EXEC-NEXT:    _final_error += clad::getErrorVal(*_d_x, x, "x");
-// CHECK_PRINT_MODEL_EXEC-NEXT:    _final_error += clad::getErrorVal(*_d_y, y, "y");
+// CHECK_PRINT_MODEL_EXEC-NEXT:    *_final_error += clad::getErrorVal(*_d_x, x, "x");
+// CHECK_PRINT_MODEL_EXEC-NEXT:    *_final_error += clad::getErrorVal(*_d_y, y, "y");
 // CHECK_PRINT_MODEL_EXEC-NEXT: }
 // CHECK_PRINT_MODEL_EXEC: Error in z : {{.+}}
 // CHECK_PRINT_MODEL_EXEC-NEXT: Error in x : {{.+}}

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -106,7 +106,7 @@
 // RUN: %cladclang %S/../../demos/ErrorEstimation/FloatSum.cpp -I%S/../../include 2>&1  | FileCheck -check-prefix CHECK_FLOAT_SUM %s
 //CHECK_FLOAT_SUM-NOT: {{.*error|warning|note:.*}}
 
-//CHECK_FLOAT_SUM: void vanillaSum_grad(float x, unsigned int n, float *_d_x, unsigned int *_d_n, double *_final_error) {
+//CHECK_FLOAT_SUM: void vanillaSum_pullback(float x, unsigned int n, float _d_y, float *_d_x, unsigned int *_d_n, double *_final_error) {
 //CHECK_FLOAT_SUM:    float _d_sum = 0;
 //CHECK_FLOAT_SUM:    unsigned {{int|long}} _t0;
 //CHECK_FLOAT_SUM:    unsigned int _d_i = 0;
@@ -123,7 +123,7 @@
 //CHECK_FLOAT_SUM:        clad::push(_t1, sum);
 //CHECK_FLOAT_SUM:        sum = sum + x;
 //CHECK_FLOAT_SUM:    }
-//CHECK_FLOAT_SUM:    _d_sum += 1;
+//CHECK_FLOAT_SUM:    _d_sum += _d_y;
 //CHECK_FLOAT_SUM:    for (;; _t0--) {
 //CHECK_FLOAT_SUM:        {
 //CHECK_FLOAT_SUM:            if (!_t0)
@@ -156,13 +156,13 @@
 // RUN: ./CustomModelTest.out | FileCheck -check-prefix CHECK_CUSTOM_MODEL_EXEC %s
 // CHECK_CUSTOM_MODEL_EXEC-NOT:{{.*error|warning|note:.*}}
 // CHECK_CUSTOM_MODEL_EXEC: The code is:
-// CHECK_CUSTOM_MODEL_EXEC-NEXT: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+// CHECK_CUSTOM_MODEL_EXEC-NEXT: void func_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _t0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    _t0 = z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    z = x + y;
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:    _d_z += 1;
+// CHECK_CUSTOM_MODEL_EXEC-NEXT:    _d_z += _d_y0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    {
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        *_final_error += _d_z * z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        z = _t0;
@@ -188,13 +188,13 @@
 // RUN: ./PrintModelTest.out | FileCheck -check-prefix CHECK_PRINT_MODEL_EXEC %s
 // CHECK_PRINT_MODEL_EXEC-NOT:{{.*error|warning|note:.*}}
 // CHECK_PRINT_MODEL_EXEC: The code is:
-// CHECK_PRINT_MODEL_EXEC-NEXT: void func_grad(float x, float y, float *_d_x, float *_d_y, double *_final_error) {
+// CHECK_PRINT_MODEL_EXEC-NEXT: void func_pullback(float x, float y, float _d_y0, float *_d_x, float *_d_y, double *_final_error) {
 // CHECK_PRINT_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    float _t0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    float z;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    _t0 = z;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    z = x + y;
-// CHECK_PRINT_MODEL_EXEC-NEXT:    _d_z += 1;
+// CHECK_PRINT_MODEL_EXEC-NEXT:    _d_z += _d_y0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    {
 // CHECK_PRINT_MODEL_EXEC-NEXT:        *_final_error += clad::getErrorVal(_d_z, z, "z");
 // CHECK_PRINT_MODEL_EXEC-NEXT:        z = _t0;
@@ -217,14 +217,14 @@
 
 //CHECK_GRADIENT_DESCENT: void f_pullback(double theta_0, double theta_1, double x, double _d_y, double *_d_theta_0, double *_d_theta_1, double *_d_x);
 
-//CHECK_GRADIENT_DESCENT-NEXT: void cost_grad(double theta_0, double theta_1, double x, double y, double *_d_theta_0, double *_d_theta_1, double *_d_x, double *_d_y) {
+//CHECK_GRADIENT_DESCENT-NEXT: void cost_pullback(double theta_0, double theta_1, double x, double y, double _d_y0, double *_d_theta_0, double *_d_theta_1, double *_d_x, double *_d_y) {
 //CHECK_GRADIENT_DESCENT-NEXT:     double _d_f_x = 0;
 //CHECK_GRADIENT_DESCENT-NEXT:     double f_x = f(theta_0, theta_1, x);
 //CHECK_GRADIENT_DESCENT-NEXT:     {
-//CHECK_GRADIENT_DESCENT-NEXT:         _d_f_x += 1 * (f_x - y);
-//CHECK_GRADIENT_DESCENT-NEXT:         *_d_y += -1 * (f_x - y);
-//CHECK_GRADIENT_DESCENT-NEXT:         _d_f_x += (f_x - y) * 1;
-//CHECK_GRADIENT_DESCENT-NEXT:         *_d_y += -(f_x - y) * 1;
+//CHECK_GRADIENT_DESCENT-NEXT:         _d_f_x += _d_y0 * (f_x - y);
+//CHECK_GRADIENT_DESCENT-NEXT:         *_d_y += -_d_y0 * (f_x - y);
+//CHECK_GRADIENT_DESCENT-NEXT:         _d_f_x += (f_x - y) * _d_y0;
+//CHECK_GRADIENT_DESCENT-NEXT:         *_d_y += -(f_x - y) * _d_y0;
 //CHECK_GRADIENT_DESCENT-NEXT:     }
 //CHECK_GRADIENT_DESCENT-NEXT:     {
 //CHECK_GRADIENT_DESCENT-NEXT:         double _r0 = 0;

--- a/test/NestedCalls/NestedCalls.C
+++ b/test/NestedCalls/NestedCalls.C
@@ -31,12 +31,12 @@ double f(double x, double y) {
 
 //CHECK:   void one_pullback(double x, double _d_y, double *_d_x);
 
-//CHECK:   void f_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK:   void f_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = one(x);
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _d_t += 1 * y;
-//CHECK-NEXT:           *_d_y += t * 1;
+//CHECK-NEXT:           _d_t += _d_y0 * y;
+//CHECK-NEXT:           *_d_y += t * _d_y0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 0;

--- a/test/NumericalDiff/GradientMultiArg.C
+++ b/test/NumericalDiff/GradientMultiArg.C
@@ -14,14 +14,14 @@ double test_1(double x, double y){
    return std::hypot(x, y);
 }
 // CHECK: warning: Falling back to numerical differentiation for 'hypot' since no suitable overload was found and clad could not derive it. To disable this feature, compile your programs with -DCLAD_NO_NUM_DIFF.
-// CHECK: void test_1_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: void test_1_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;
 // CHECK-NEXT:         double _grad0[2] = {0};
 // CHECK-NEXT:         numerical_diff::central_difference(std::hypot, _grad0, 0, x, y);
-// CHECK-NEXT:         _r0 += 1 * _grad0[0];
-// CHECK-NEXT:         _r1 += 1 * _grad0[1];
+// CHECK-NEXT:         _r0 += _d_y0 * _grad0[0];
+// CHECK-NEXT:         _r1 += _d_y0 * _grad0[1];
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         *_d_y += _r1;
 // CHECK-NEXT:     }

--- a/test/NumericalDiff/NoNumDiff.C
+++ b/test/NumericalDiff/NoNumDiff.C
@@ -15,7 +15,7 @@ double func(double x) { return std::tanh(x); }
 //CHECK-NEXT:     return 0;
 //CHECK-NEXT: }
 
-//CHECK: void func_grad(double x, double *_d_x) {
+//CHECK: void func_pullback(double x, double _d_y, double *_d_x) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0;
 //CHECK-NEXT:         *_d_x += _r0;

--- a/test/NumericalDiff/NumDiff.C
+++ b/test/NumericalDiff/NumDiff.C
@@ -11,10 +11,10 @@ double test_1(double x){
 //CHECK: warning: Falling back to numerical differentiation for 'tanh' since no suitable overload was found and clad could not derive it. To disable this feature, compile your programs with -DCLAD_NO_NUM_DIFF.
 //CHECK: warning: Falling back to numerical differentiation for 'log10' since no suitable overload was found and clad could not derive it. To disable this feature, compile your programs with -DCLAD_NO_NUM_DIFF.
 
-//CHECK: void test_1_grad(double x, double *_d_x) {
+//CHECK: void test_1_pullback(double x, double _d_y, double *_d_x) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0;
-//CHECK-NEXT:         _r0 += 1 * numerical_diff::forward_central_difference(tanh, x, 0, 0, x);
+//CHECK-NEXT:         _r0 += _d_y * numerical_diff::forward_central_difference(tanh, x, 0, 0, x);
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -36,7 +36,7 @@ double test_3(double x) {
     }
     return 0;
 }
-//CHECK: void test_3_grad(double x, double *_d_x) {
+//CHECK: void test_3_pullback(double x, double _d_y, double *_d_x) {
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     double _d_constant = 0;
 //CHECK-NEXT:     double constant = 0;
@@ -54,8 +54,8 @@ double test_3(double x) {
 //CHECK-NEXT:             double _r1 = 0;
 //CHECK-NEXT:             double _grad0[2] = {0};
 //CHECK-NEXT:             numerical_diff::central_difference(std::hypot, _grad0, 0, x, constant);
-//CHECK-NEXT:             _r0 += 1 * _grad0[0];
-//CHECK-NEXT:             _r1 += 1 * _grad0[1];
+//CHECK-NEXT:             _r0 += _d_y * _grad0[0];
+//CHECK-NEXT:             _r1 += _d_y * _grad0[1];
 //CHECK-NEXT:             *_d_x += _r0;
 //CHECK-NEXT:             _d_constant += _r1;
 //CHECK-NEXT:         }

--- a/test/NumericalDiff/PrintErrorNumDiff.C
+++ b/test/NumericalDiff/PrintErrorNumDiff.C
@@ -16,10 +16,10 @@ double test_1(double x){
 }
 
 //CHECK: warning: Falling back to numerical differentiation for 'tanh' since no suitable overload was found and clad could not derive it. To disable this feature, compile your programs with -DCLAD_NO_NUM_DIFF.
-//CHECK: void test_1_grad(double x, double *_d_x) {
+//CHECK: void test_1_pullback(double x, double _d_y, double *_d_x) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0;
-//CHECK-NEXT:         _r0 += 1 * numerical_diff::forward_central_difference(tanh, x, 0, 1, x);
+//CHECK-NEXT:         _r0 += _d_y * numerical_diff::forward_central_difference(tanh, x, 0, 1, x);
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }

--- a/test/ROOT/Interface.C
+++ b/test/ROOT/Interface.C
@@ -20,12 +20,10 @@ Double_t f(Double_t* x, Double_t* p) {
   return p[0] + x[0] * p[1];
 }
 
-void f_grad_1(Double_t* x, Double_t* p, Double_t *_d_p);
-
-// CHECK: void f_grad_1(Double_t *x, Double_t *p, Double_t *_d_p) {
+// CHECK: void f_pullback_1(Double_t *x, Double_t *p, Double_t _d_y, Double_t *_d_p) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_p[0] += 1;
-// CHECK-NEXT:         _d_p[1] += x[0] * 1;
+// CHECK-NEXT:         _d_p[0] += _d_y;
+// CHECK-NEXT:         _d_p[1] += x[0] * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -34,7 +32,7 @@ int main() {
   Double_t p[] = { 2, 3 };
   Double_t result[2] = { 0 };
 
-  clad::gradient(f, "p");
+  auto df = clad::gradient(f, "p");
 
   // We create a struct of "array_ref_interface" type and store its address in
   // a void pointer. When the grad function is called this void pointer is
@@ -42,7 +40,7 @@ int main() {
   // to reinterpret_cast.
   array_ref_interface ari = array_ref_interface{result, 2};
   void *arg = &ari;
-  f_grad_1(x, p, *(Double_t **)arg);
+  df.execute(x, p, *(Double_t **)arg);
 
   printf("Result is = {%.2f, %.2f}\n", result[0], result[1]); // CHECK-EXEC: Result is = {1.00, 2.00}
 }

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -39,17 +39,16 @@ Double_t TFormula_example(Double_t* x, Double_t* p) {
 }
 // _grad = { x[0] + (-1) * Exp_darg0(-p[0]), x[0] + Abs_darg0(p[1]), x[0] }
 
-void TFormula_example_grad_1(Double_t* x, Double_t* p, Double_t* _d_p);
-//CHECK:   void TFormula_example_grad_1(Double_t *x, Double_t *p, Double_t *_d_p) {
+//CHECK:   void TFormula_example_pullback_1(Double_t *x, Double_t *p, Double_t _d_y, Double_t *_d_p) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _d_p[0] += x[0] * 1;
-//CHECK-NEXT:           _d_p[1] += x[0] * 1;
-//CHECK-NEXT:           _d_p[2] += x[0] * 1;
+//CHECK-NEXT:           _d_p[0] += x[0] * _d_y;
+//CHECK-NEXT:           _d_p[1] += x[0] * _d_y;
+//CHECK-NEXT:           _d_p[2] += x[0] * _d_y;
 //CHECK-NEXT:           Double_t _r0 = 0;
-//CHECK-NEXT:           _r0 += 1 * clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(-p[0], 1.).pushforward;
+//CHECK-NEXT:           _r0 += _d_y * clad::custom_derivatives{{(::std)?}}::TMath::Exp_pushforward(-p[0], 1.).pushforward;
 //CHECK-NEXT:           _d_p[0] += -_r0;
 //CHECK-NEXT:           Double_t _r1 = 0;
-//CHECK-NEXT:           _r1 += 1 * clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(p[1], 1.).pushforward;
+//CHECK-NEXT:           _r1 += _d_y * clad::custom_derivatives{{(::std)?}}::TMath::Abs_pushforward(p[1], 1.).pushforward;
 //CHECK-NEXT:           _d_p[1] += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }

--- a/unittests/Misc/CallDeclOnly.cpp
+++ b/unittests/Misc/CallDeclOnly.cpp
@@ -23,7 +23,7 @@ TEST(CallDeclOnly, CheckNumDiff) {
 
   // Check the generated code from grad.dump()
   std::string expected = R"(The code is: 
-void wrapper1_grad(double *params, double *_d_params) {
+void wrapper1_pullback(double *params, double _d_y, double *_d_params) {
     double _d_ix = 0;
     const double ix = 1 + params[0];
     {
@@ -33,10 +33,10 @@ void wrapper1_grad(double *params, double *_d_params) {
         double _r3 = 0;
         double _grad0[4] = {0};
         numerical_diff::central_difference(foo, _grad0, 0, 10., ix, 1., 0);
-        _r0 += 1 * _grad0[0];
-        _r1 += 1 * _grad0[1];
-        _r2 += 1 * _grad0[2];
-        _r3 += 1 * _grad0[3];
+        _r0 += _d_y * _grad0[0];
+        _r1 += _d_y * _grad0[1];
+        _r2 += _d_y * _grad0[2];
+        _r3 += _d_y * _grad0[3];
         _d_ix += _r1;
     }
     _d_params[0] += _d_ix;
@@ -70,7 +70,8 @@ namespace clad {
 namespace custom_derivatives {
 float custom_fn_darg0(float x, float y);
 
-void custom_fn_darg0_grad(float x, float y, float* d_x, float* d_y);
+void custom_fn_darg0_pullback(float x, float y, float _d_y0, float* d_x,
+                              float* d_y);
 
 float custom_fn_darg1(float x, float y) { return exp(y); }
 } // namespace custom_derivatives

--- a/unittests/Misc/Defs.cpp
+++ b/unittests/Misc/Defs.cpp
@@ -23,7 +23,8 @@ void sq_pushforward_pullback(double x, double _dx,
 
 float custom_fn_darg0(float x, float y) { return cos(x); }
 
-void custom_fn_darg0_grad(float x, float y, float* d_x, float* d_y) {
+void custom_fn_darg0_pullback(float x, float y, float _d_y0, float* d_x,
+                              float* d_y) {
   *d_x -= sin(x);
 }
 


### PR DESCRIPTION
Currently, on master, we have two reverse diff modes: ``DiffMode::reverse`` for gradients and ``DiffMode::experimental_pullback`` for pullbacks. In this PR, they are essentially merged into ``DiffMode::reverse``. This has been achieved by placing a pullback in the gradient overload instead of a gradient function.
Let's consider an example:
```cpp
// Original code:
double f(double a, double b) {
    ...
}

int main() {
    auto df = clad::gradient(f);
    ...
}
```
->
On master:
```cpp
// Generated derivative code:
double f_grad(double a, double b, double *_d_a, double *_d_b) {
    ...
}

// This overload is placed in the clad::gradient call
double f_grad(double a, double b, void *_temp_d_a, void *_temp_d_b) {
    double *_d_a = (double *)_temp_d_a;
    double *_d_b = (double *)_temp_d_b;
    f_grad(a, b, _d_a, _d_b);
}
```
In this PR:
```cpp
// Generated derivative code:
double f_pullback(double a, double b, double _d_y, double *_d_a, double *_d_b) {
    ...
}

// This is placed in the clad::gradient call
double f_grad(double a, double b, void *_temp_d_a, void *_temp_d_b) {
    double *_d_a = (double *)_temp_d_a;
    double *_d_b = (double *)_temp_d_b;
    f_pullback(a, b, 1, _d_a, _d_b);
}
```

Note: To make this system work with error estimation, I had to enable overloads there. To do that, I had to change the type of ``_final_error`` parameters from ``double&`` to ``double*``.

Advantages:
1) On master, we have 11 DiffModes, many of which use the same visitors. Having a unified reverse DiffMode makes the system easier to understand.
2) In RMV, ``Derive`` and ``DerivePullback`` do almost the same job. This PR removes ``DerivePullback`` completely.
3) With this PR, clad does not use overloads for the reverse mode anymore: just one gradient function and one pullback function. This is a great step towards supporting C, which does not have overloads.
4) Differentiating recursive functions used to generate both the gradient and the pullback. Now only the pullback is generated.

Disadvantages:
1) Now gradient forward declaration is only supported with ``void*`` adjoint parameter types. e.g. for a function ``double f(double a, double b)``, it doesn't make sense anymore to forward declare ``void f_grad(double a, double b, double *_d_a, double *_d_b)``. The options ``void f_grad(double a, double b, void *_d_a, void *_d_b)`` and ``void f_pullback(double a, double b, double _d_y, void *_d_a, void *_d_b)`` still work.
However, forward declarations don't seem to be that widely used. For example, when we changed all array_ref adjoint types to pointers in the gradient signature, this didn't break a single ROOT test. The main way to execute derivatives (with ``CladFunction``) works as before.
2) Now all differentiated functions have the pullback ``_d_y`` parameter. This may make it harder to understand the derivative code. Moreover, every time the function has a parameter named ``y``, the pullback parameter will be renamed to ``_d_y0`` to avoid name collisions. This could make the code even more confusing. However, we can fix the last problem by giving the pullback parameter a different name.