### PR TITLE
Move the TBR analysis in DiffRequest and provide an interface to query it.

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -8,21 +8,30 @@
 #include "clad/Differentiator/ParseDiffArgsTypes.h"
 
 namespace clang {
-  class ASTContext;
-  class CallExpr;
-  class CompilerInstance;
-  class DeclGroupRef;
-  class Expr;
-  class FunctionDecl;
-  class ParmVarDecl;
-  class Sema;
-  class Type;
+class CallExpr;
+class CompilerInstance;
+class DeclGroupRef;
+class Expr;
+class FunctionDecl;
+class ParmVarDecl;
+class Sema;
+class Type;
 } // namespace clang
 
 namespace clad {
 
 /// A struct containing information about request to differentiate a function.
 struct DiffRequest {
+private:
+  /// Based on To-Be-Recorded analysis performed before differentiation, tells
+  /// UsefulToStoreGlobal whether a variable with a given SourceLocation has to
+  /// be stored before being changed or not.
+  mutable struct TbrRunInfo {
+    std::set<clang::SourceLocation> ToBeRecorded;
+    bool HasAnalysisRun = false;
+  } m_TbrRunInfo;
+
+public:
   /// Function to be differentiated.
   const clang::FunctionDecl* Function = nullptr;
   /// Name of the base function to be differentiated. Can be different from
@@ -118,6 +127,8 @@ struct DiffRequest {
       res += "__TBR";
     return res;
   }
+
+  bool shouldBeRecorded(clang::Expr* E) const;
 };
 
   using DiffInterval = std::vector<clang::SourceRange>;

--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -224,7 +224,7 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer> {
   enum Mode { kMarkingMode = 1, kNonLinearMode = 2 };
   /// Tells if the variable at a given location is required to store. Basically,
   /// is the result of analysis.
-  std::set<clang::SourceLocation> m_TBRLocs;
+  std::set<clang::SourceLocation>& m_TBRLocs;
 
   /// Stores modes in a stack (used to retrieve the old mode after entering
   /// a new one).
@@ -287,7 +287,8 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer> {
 
 public:
   /// Constructor
-  TBRAnalyzer(ASTContext& Context) : m_Context(Context) {
+  TBRAnalyzer(ASTContext& Context, std::set<clang::SourceLocation>& Locs)
+      : m_TBRLocs(Locs), m_Context(Context) {
     m_ModeStack.push_back(0);
   }
 
@@ -299,9 +300,6 @@ public:
   TBRAnalyzer& operator=(const TBRAnalyzer&) = delete;
   TBRAnalyzer(const TBRAnalyzer&&) = delete;
   TBRAnalyzer& operator=(const TBRAnalyzer&&) = delete;
-
-  /// Returns the result of the whole analysis
-  std::set<clang::SourceLocation> getResult() { return m_TBRLocs; }
 
   /// Visitors
   void Analyze(const clang::FunctionDecl* FD);


### PR DESCRIPTION
The idea of this change is to separate the analysis steps from the building step. That would help us detect unsupported cases and provide useful diagnostics without crashing. The centralization will help with enabling the future activity analysis in other modes, too.

Partially addresses #721.