### PR TITLE
Add shell.nix with an environment for building and using Clad on NixOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,28 +324,34 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
   add_subdirectory(demos/ErrorEstimation/CustomModel)
   add_subdirectory(demos/ErrorEstimation/PrintModel)
 
-  # Change the default compiler to the clang which we run clad upon. Our unittests
-  # need to use a supported by clad compiler. Note that's a huge hack and it is
-  # not guaranteed to work with cmake.
-  set(stored_cxx_compiler ${CMAKE_CXX_COMPILER})
-  set(stored_cxx_flags ${CMAKE_CXX_FLAGS})
+  if (NOT CLAD_DISABLE_TESTS OR CLAD_ENABLE_BENCHMARKS)
+    # Change the default compiler to the clang which we run clad upon. Our unittests
+    # need to use a supported by clad compiler. Note that's a huge hack and it is
+    # not guaranteed to work with cmake.
+    set(stored_cxx_compiler ${CMAKE_CXX_COMPILER})
+    set(stored_cxx_flags ${CMAKE_CXX_FLAGS})
 
-  set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
-  # Filter some unsupported flags by clang.
-  string(REPLACE "-fno-lifetime-dse" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  string(REPLACE "-Wno-class-memaccess" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
+    # Filter some unsupported flags by clang.
+    string(REPLACE "-fno-lifetime-dse" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    string(REPLACE "-Wno-class-memaccess" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  endif()
 
-  add_subdirectory(unittests)
-  add_subdirectory(test)
+  if (NOT CLAD_DISABLE_TESTS)
+    add_subdirectory(unittests)
+    add_subdirectory(test)
+  endif()
 
   # Add benchmarking infrastructure.
   if (CLAD_ENABLE_BENCHMARKS)
     add_subdirectory(benchmark)
   endif(CLAD_ENABLE_BENCHMARKS)
 
-  # Restore the default compiler.
-  set(CMAKE_CXX_COMPILER ${stored_cxx_compiler})
-  set(CMAKE_CXX_FLAGS ${stored_cxx_flags})
+  if (stored_cxx_compiler)
+    # Restore the default compiler.
+    set(CMAKE_CXX_COMPILER ${stored_cxx_compiler})
+    set(CMAKE_CXX_FLAGS ${stored_cxx_flags})
+  endif()
 endif()
 
 # Workaround for MSVS10 to avoid the Dialog Hell

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,30 @@
+# Declaration of an environment that can be used to build Clad and compile
+# binaries with clang++ using the Clad plugin.
+#
+# Provided environment variables:
+#   - CMAKE_FLAGS : flags for configuring with CMake
+
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    llvmPackages_16.clang-unwrapped # for Clang library
+    llvmPackages_16.clangUseLLVM # for clang wrapper (useful to compile code that tests Cland)
+    llvmPackages_16.libcxxStdenv # standard C++ library for Clang
+    llvmPackages_16.stdenv # standard C library for Clang
+    llvm_16 # using LLVM 16, because this is also what ROOT uses
+  ];
+
+  shellHook =
+    with {
+      cmakeFlags = [
+        "-DCLAD_DISABLE_TESTS=ON"
+        "-DLLVM_DIR=${pkgs.llvm_16.dev}"
+        "-DClang_DIR=${pkgs.llvmPackages_16.clang-unwrapped.dev}"
+      ];
+    }; ''
+      CMAKE_FLAGS="${pkgs.lib.strings.concatStrings (pkgs.lib.strings.intersperse " " cmakeFlags)}"
+    '';
+}


### PR DESCRIPTION
I use this nix environment to build Clad standalone and test the reproducers.

Until recently, I could just use my native Arch Linux environment to do
so, but after Arch dropped LLVM 17 this was not possible anymore (Clad
doesn't work the LLVM 18 yet). Therefore, I had to find another
solution, and nix packages works quite well.

It would be nice to have this in the repo so also other people can work
with Clad in NixOS, without having to waste time figuring out the
dependencies and necessary CMake flags.

Also, add a flag `CLAD_DISABLE_TESTS` to the build system, so that Clad can be built without the hack of resetting the compiler flags temporarily by hand.