### PR TITLE
Add support for `std::string` variables and functions with implicit constructor calls in their arguments

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -2012,17 +2012,17 @@ BaseForwardModeVisitor::VisitCXXConstructExpr(const CXXConstructExpr* CE) {
   // forward mode derived constructor that would require same arguments as of
   // a pushforward function, that is, `{a, 1, b, _d_a, 0., _d_b}`.
   if (CE->getNumArgs() != 1) {
-    if (CE->isListInitialization()) {
-      clonedArgsE = m_Sema.ActOnInitList(noLoc, clonedArgs, noLoc).get();
-      derivedArgsE = m_Sema.ActOnInitList(noLoc, derivedArgs, noLoc).get();
-    } else if (CE->getNumArgs() == 0) {
+    if (CE->getNumArgs() == 0 && !CE->isListInitialization()) {
       // ParenList is empty -- default initialisation.
       // Passing empty parenList here will silently cause 'most vexing
       // parse' issue.
       return StmtDiff();
     } else {
-      clonedArgsE = m_Sema.ActOnParenListExpr(noLoc, noLoc, clonedArgs).get();
-      derivedArgsE = m_Sema.ActOnParenListExpr(noLoc, noLoc, derivedArgs).get();
+      // Rely on the initializer list expressions as they seem to be more
+      // flexible in terms of conversions and other similar scenarios where a
+      // constructor is called implicitly.
+      clonedArgsE = m_Sema.ActOnInitList(noLoc, clonedArgs, noLoc).get();
+      derivedArgsE = m_Sema.ActOnInitList(noLoc, derivedArgs, noLoc).get();
     }
   } else {
     clonedArgsE = clonedArgs[0];

--- a/test/FirstDerivative/FunctionCallsWithResults.C
+++ b/test/FirstDerivative/FunctionCallsWithResults.C
@@ -301,8 +301,8 @@ double fn10(double x) {
 // CHECK-NEXT:   double _d_x = 1;
 // CHECK-NEXT:   std::mt19937 _d_gen64;
 // CHECK-NEXT:   std::mt19937 gen64;
-// CHECK-NEXT:   std::uniform_real_distribution<{{(double)?}}> _d_distribution(0., 0.);
-// CHECK-NEXT:   std::uniform_real_distribution<{{(double)?}}> distribution(0., 1.);
+// CHECK-NEXT:   std::uniform_real_distribution<{{(double)?}}> _d_distribution({0., 0.});
+// CHECK-NEXT:   std::uniform_real_distribution<{{(double)?}}> distribution({0., 1.});
 // CHECK-NEXT:   clad::ValueAndPushforward<result_type, result_type> _t0 = distribution.operator_call_pushforward(gen64, &_d_distribution, _d_gen64);
 // CHECK-NEXT:   double _d_rand = _t0.pushforward;
 // CHECK-NEXT:   double rand0 = _t0.value;

--- a/test/ForwardMode/NonDifferentiable.C
+++ b/test/ForwardMode/NonDifferentiable.C
@@ -154,8 +154,8 @@ int main() {
   // CHECK: double fn_s1_mem_fn_darg0(double i, double j) {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
-  // CHECK-NEXT:     SimpleFunctions1 _d_obj(0, 0);
-  // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
+  // CHECK-NEXT:     SimpleFunctions1 _d_obj({0, 0});
+  // CHECK-NEXT:     SimpleFunctions1 obj({2, 3});
   // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = obj.mem_fn_1_pushforward(i, j, &_d_obj, _d_i, _d_j);
   // CHECK-NEXT:     return _t0.pushforward + _d_i * j + i * _d_j;
   // CHECK-NEXT: }
@@ -163,8 +163,8 @@ int main() {
   // CHECK: double fn_s1_field_darg0(double i, double j) {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
-  // CHECK-NEXT:     SimpleFunctions1 _d_obj(0, 0);
-  // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
+  // CHECK-NEXT:     SimpleFunctions1 _d_obj({0, 0});
+  // CHECK-NEXT:     SimpleFunctions1 obj({2, 3});
   // CHECK-NEXT:     double &_t0 = obj.x;
   // CHECK-NEXT:     double &_t1 = obj.y;
   // CHECK-NEXT:     return _d_obj.x * _t1 + _t0 * 0. + _d_i * j + i * _d_j;
@@ -175,10 +175,10 @@ int main() {
   // CHECK: double fn_s1_operator_darg0(double i, double j) {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
-  // CHECK-NEXT:     SimpleFunctions1 _d_obj1(0, 0);
-  // CHECK-NEXT:     SimpleFunctions1 obj1(2, 3);
-  // CHECK-NEXT:     SimpleFunctions1 _d_obj2(0, 0);
-  // CHECK-NEXT:     SimpleFunctions1 obj2(3, 5);
+  // CHECK-NEXT:     SimpleFunctions1 _d_obj1({0, 0});
+  // CHECK-NEXT:     SimpleFunctions1 obj1({2, 3});
+  // CHECK-NEXT:     SimpleFunctions1 _d_obj2({0, 0});
+  // CHECK-NEXT:     SimpleFunctions1 obj2({3, 5});
   // CHECK-NEXT:     clad::ValueAndPushforward<SimpleFunctions1, SimpleFunctions1> _t0 = obj1.operator_plus_pushforward(obj2, &_d_obj1, _d_obj2);
   // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = _t0.value.mem_fn_1_pushforward(i, j, &_t0.pushforward, _d_i, _d_j);
   // CHECK-NEXT:     return _t1.pushforward;

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -30,8 +30,8 @@ std::pair<double, double> fn1(double i, double j) {
 // CHECK: std::pair<double, double> fn1_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     std::pair<double, double> _d_c(0, 0), _d_d({0., 0.});
-// CHECK-NEXT:     std::pair<double, double> c(3, 5), d({7., 9.});
+// CHECK-NEXT:     std::pair<double, double> _d_c({0, 0}), _d_d({0., 0.});
+// CHECK-NEXT:     std::pair<double, double> c({3, 5}), d({7., 9.});
 // CHECK-NEXT:     std::pair<double, double> _d_e = _d_d;
 // CHECK-NEXT:     std::pair<double, double> e = d;
 // CHECK-NEXT:     _d_c.first += _d_i;
@@ -498,8 +498,8 @@ complexD fn8(double i, TensorD5 t) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     TensorD5 _d_t;
 // CHECK-NEXT:     t.updateTo_pushforward(i * i, & _d_t, _d_i * i + i * _d_i);
-// CHECK-NEXT:     complexD _d_c(0., 0.);
-// CHECK-NEXT:     complexD c(0., 0.);
+// CHECK-NEXT:     complexD _d_c({0., 0.});
+// CHECK-NEXT:     complexD c({0., 0.});
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = t.sum_pushforward(& _d_t);
 // CHECK-NEXT:     double &_t1 = _t0.value;
 // CHECK-NEXT:     c.real_pushforward(7 * _t1, &_d_c, 0 * _t1 + 7 * _t0.pushforward);
@@ -525,8 +525,8 @@ complexD fn9(double i, complexD c) {
 // CHECK: complexD fn9_darg0(double i, complexD c) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     complexD _d_c;
-// CHECK-NEXT:     complexD _d_r(0., 0.);
-// CHECK-NEXT:     complexD r(0., 0.);
+// CHECK-NEXT:     complexD _d_r({0., 0.});
+// CHECK-NEXT:     complexD r({0., 0.});
 // CHECK-NEXT:     c.real_pushforward(i * i, &_d_c, _d_i * i + i * _d_i);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = c.real_pushforward(&_d_c);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = c.real_pushforward(&_d_c);
@@ -558,8 +558,8 @@ std::complex<double> fn10(double i, double j) {
 // CHECK: std::complex<double> fn10_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     std::complex<double> _d_c1(0., 0.), _d_c2(0., 0.);
-// CHECK-NEXT:     std::complex<double> c1(0., 0.), c2(0., 0.);
+// CHECK-NEXT:     std::complex<double> _d_c1({0., 0.}), _d_c2({0., 0.});
+// CHECK-NEXT:     std::complex<double> c1({0., 0.}), c2({0., 0.});
 // CHECK-NEXT:     c1.real_pushforward(2 * i, &_d_c1, 0 * i + 2 * _d_i);
 // CHECK-NEXT:     c1.imag_pushforward(5 * i, &_d_c1, 0 * i + 5 * _d_i);
 // CHECK-NEXT:     c2.real_pushforward(5 * i, &_d_c2, 0 * i + 5 * _d_i);


### PR DESCRIPTION
Previously, Clad failed to differentiate functions with `std::string` variables in them or function calls that call a constructor implicitly. For instance, a call
```
f(x, "text");
```
to a function `double f(double, const std::string&)` would have caused a segmentation fault before this commit. Same applies to other user defined arguments, not only those of the `std::string` type.

Fixes: #974