### PR TITLE
Prevent Clad from trying to create a void zero literal

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1216,8 +1216,7 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
                                validLoc, llvm::MutableArrayRef<Expr*>(CallArgs),
                                validLoc)
                 .get();
-        auto* zero = ConstantFolder::synthesizeLiteral(CE->getType(), m_Context,
-                                                       /*val=*/0);
+        auto* zero = getZeroInit(CE->getType());
         return StmtDiff(call, zero);
       }
     }

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -376,6 +376,8 @@ namespace clad {
 
   Expr* VisitorBase::getZeroInit(QualType T) {
     // FIXME: Consolidate other uses of synthesizeLiteral for creation 0 or 1.
+    if (T->isVoidType())
+      return nullptr;
     if (T->isScalarType()) {
       ExprResult Zero =
           ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, 0);

--- a/test/FirstDerivative/CallArguments.C
+++ b/test/FirstDerivative/CallArguments.C
@@ -148,7 +148,7 @@ float f_literal_args_func(float x, float y, float *z) {
 // CHECK-NEXT: float _d_y = 0;
 // CHECK-NEXT: printf("hello world ");
 // CHECK-NEXT: float _t0 = f_literal_helper(0.5, 'a', z, nullptr);
-// CHECK-NEXT: return _d_x * _t0 + x * 0.F;
+// CHECK-NEXT: return _d_x * _t0 + x * 0;
 // CHECK-NEXT: }
 
 inline unsigned int getBin(double low, double high, double val, unsigned int numBins) {

--- a/test/FirstDerivative/FunctionCalls.C
+++ b/test/FirstDerivative/FunctionCalls.C
@@ -184,7 +184,7 @@ double test_9(double x) {
 // CHECK-NEXT: }
 
 void some_important_void_func(double y) {
-    assert(y < 1);
+    assert(y >= 1);
 }
 
 double test_10(double x) {

--- a/test/FirstDerivative/FunctionCalls.C
+++ b/test/FirstDerivative/FunctionCalls.C
@@ -183,6 +183,21 @@ double test_9(double x) {
 // CHECK-NEXT: return _t0.pushforward;
 // CHECK-NEXT: }
 
+void some_important_void_func(double y) {
+    assert(y < 1);
+}
+
+double test_10(double x) {
+  some_important_void_func(1);
+  return x;
+}
+
+// CHECK:      double test_10_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     some_important_void_func(1);
+// CHECK-NEXT:     return _d_x;
+// CHECK-NEXT: }
+
 int main () {
   clad::differentiate(test_1, 0);
   clad::differentiate(test_2, 0);
@@ -196,6 +211,7 @@ int main () {
   clad::differentiate<clad::opts::enable_tbr, clad::opts::disable_tbr>(test_8); // expected-error {{Both enable and disable TBR options are specified.}}
   clad::differentiate<clad::opts::diagonal_only>(test_8); // expected-error {{Diagonal only option is only valid for Hessian mode.}}
   clad::differentiate(test_9);
+  clad::differentiate(test_10);
   return 0;
 
 // CHECK: void increment_pushforward(int &i, int &_d_i) {

--- a/test/FirstDerivative/FunctionCallsWithResults.C
+++ b/test/FirstDerivative/FunctionCallsWithResults.C
@@ -165,7 +165,7 @@ double fn4(double i, double j) {
 // CHECK: double fn4_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = nonRealParamFn(0, 0);
 // CHECK-NEXT:     _d_res += _d_i;
 // CHECK-NEXT:     res += i;
@@ -266,7 +266,7 @@ double fn8(double i, double j) {
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = check_and_return_pushforward(_t0.value, 'a', _t0.pushforward, 0);
 // CHECK-NEXT:     double &_t2 = _t1.value;
 // CHECK-NEXT:     double _t3 = std::tanh(1.);
-// CHECK-NEXT:     return _t1.pushforward * _t3 + _t2 * 0.;
+// CHECK-NEXT:     return _t1.pushforward * _t3 + _t2 * 0;
 // CHECK-NEXT: }
 
 double g (double x) { return x; }


### PR DESCRIPTION
Previously, clad used to try to create a void zero literal when differentiating a call to a void function with literal arguments in the forward mode. This caused it to crash.

Fixes: #988