### PR TITLE
[ci] llvm18.1.8 is broken, turn off the ci for it. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,10 +457,11 @@ jobs:
             extra_packages: 'libtrilinos-kokkos-dev ninja-build'
             extra_cmake_options: '-G Ninja'
 
-          - name: ubu22-clang16-runtime18
-            os: ubuntu-22.04
-            compiler: clang-16
-            clang-runtime: '18'
+          # FIXME: Turn on llvm18 once https://github.com/llvm/llvm-project/issues/99453 is fixed.
+          #- name: ubu22-clang16-runtime18
+          #  os: ubuntu-22.04
+          #  compiler: clang-16
+          #  clang-runtime: '18'
 
           # Оld, still supported versions
 


### PR DESCRIPTION
We can re-enable only after https://github.com/llvm/llvm-project/issues/99453 is resolved.