### PR TITLE
Revert "[ci] llvm18.1.8 is broken, turn off the ci for it."

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,11 +457,10 @@ jobs:
             extra_packages: 'libtrilinos-kokkos-dev ninja-build'
             extra_cmake_options: '-G Ninja'
 
-          # FIXME: Turn on llvm18 once https://github.com/llvm/llvm-project/issues/99453 is fixed.
-          #- name: ubu22-clang16-runtime18
-          #  os: ubuntu-22.04
-          #  compiler: clang-16
-          #  clang-runtime: '18'
+          - name: ubu22-clang16-runtime18
+            os: ubuntu-22.04
+            compiler: clang-16
+            clang-runtime: '18'
 
           # Оld, still supported versions
 


### PR DESCRIPTION
This reverts commit 7f201c6cd82637ba0c24b18f06d12b0a6dbe3af5.

According to someone in [llvm-project#99453](https://github.com/llvm/llvm-project/issues/99453) the issue with LLVM 18 packages for Ubuntu is now fixed, so we can re-enable the CI tests for it.