### PR TITLE
Directly set the adjoint of the LHS to 0 in assignments

### DIFF
--- a/demos/ErrorEstimation/CustomModel/README.md
+++ b/demos/ErrorEstimation/CustomModel/README.md
@@ -53,7 +53,7 @@ The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double &
         _final_error += _d_z * z;
         z = _t0;
         float _r_d0 = _d_z;
-        _d_z -= _r_d0;
+        _d_z = 0;
         *_d_x += _r_d0;
         *_d_y += _r_d0;
     }

--- a/demos/ErrorEstimation/PrintModel/README.md
+++ b/demos/ErrorEstimation/PrintModel/README.md
@@ -52,7 +52,7 @@ The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double &
         _final_error += _d_z * z;
         z = _t0;
         float _r_d0 = _d_z;
-        _d_z -= _r_d0;
+        _d_z = 0;
         *_d_x += _r_d0;
         *_d_y += _r_d0;
     }

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -72,7 +72,7 @@ float func(float* a, float* b) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             a[i] = clad::pop(_t1);
 //CHECK-NEXT:             float _r_d0 = _d_a[i];
-//CHECK-NEXT:             _d_a[i] -= _r_d0;
+//CHECK-NEXT:             _d_a[i] = 0;
 //CHECK-NEXT:             _d_a[i] += _r_d0 * b[i];
 //CHECK-NEXT:             _d_b[i] += a[i] * _r_d0;
 //CHECK-NEXT:         }
@@ -293,7 +293,7 @@ double func5(int k) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             arr[i] = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_arr[i];
-//CHECK-NEXT:             _d_arr[i] -= _r_d0;
+//CHECK-NEXT:             _d_arr[i] = 0;
 //CHECK-NEXT:             *_d_k += _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
@@ -401,7 +401,7 @@ double func7(double *params) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             out = clad::pop(_t2);
 //CHECK-NEXT:             double _r_d0 = _d_out;
-//CHECK-NEXT:             _d_out -= _r_d0;
+//CHECK-NEXT:             _d_out = 0;
 //CHECK-NEXT:             _d_out += _r_d0;
 //CHECK-NEXT:             inv_square_pullback(paramsPrime, _r_d0, _d_paramsPrime);
 //CHECK-NEXT:         }
@@ -443,12 +443,12 @@ double func8(double i, double *arr, int n) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         arr[0] = _t2;
 //CHECK-NEXT:         double _r_d2 = _d_arr[0];
-//CHECK-NEXT:         _d_arr[0] -= _r_d2;
+//CHECK-NEXT:         _d_arr[0] = 0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         res = _t1;
 //CHECK-NEXT:         double _r_d1 = _d_res;
-//CHECK-NEXT:         _d_res -= _r_d1;
+//CHECK-NEXT:         _d_res = 0;
 //CHECK-NEXT:         double _r0 = 0;
 //CHECK-NEXT:         int _r1 = 0;
 //CHECK-NEXT:         helper2_pullback(i, arr, n, _r_d1, &_r0, _d_arr, &_r1);
@@ -458,7 +458,7 @@ double func8(double i, double *arr, int n) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         arr[0] = _t0;
 //CHECK-NEXT:         double _r_d0 = _d_arr[0];
-//CHECK-NEXT:         _d_arr[0] -= _r_d0;
+//CHECK-NEXT:         _d_arr[0] = 0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -695,7 +695,7 @@ int main() {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         elem = _t0;
 //CHECK-NEXT:         double _r_d0 = *_d_elem;
-//CHECK-NEXT:         *_d_elem -= _r_d0;
+//CHECK-NEXT:         *_d_elem = 0;
 //CHECK-NEXT:         *_d_val += _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -708,7 +708,7 @@ int main() {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         elem = _t0;
 //CHECK-NEXT:         double _r_d0 = *_d_elem;
-//CHECK-NEXT:         *_d_elem -= _r_d0;
+//CHECK-NEXT:         *_d_elem = 0;
 //CHECK-NEXT:         *_d_elem += _r_d0 * elem;
 //CHECK-NEXT:         *_d_elem += elem * _r_d0;
 //CHECK-NEXT:     }

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -74,7 +74,7 @@ __device__ __host__ double gauss(double* x, double* p, double sigma, int dim) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         t = _t2;
 //CHECK-NEXT:         double _r_d1 = _d_t;
-//CHECK-NEXT:         _d_t -= _r_d1;
+//CHECK-NEXT:         _d_t = 0;
 //CHECK-NEXT:         _d_t += -_r_d1 / _t3;
 //CHECK-NEXT:         double _r0 = _r_d1 * -(-t / (_t3 * _t3));
 //CHECK-NEXT:         _d_sigma += 2 * _r0 * sigma;

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -23,14 +23,14 @@ float func(float x, float y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t1;
 //CHECK-NEXT:         float _r_d1 = *_d_y;
-//CHECK-NEXT:         *_d_y -= _r_d1;
+//CHECK-NEXT:         *_d_y = 0;
 //CHECK-NEXT:         *_d_x += _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d0;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_x += _r_d0;
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
@@ -52,7 +52,7 @@ float func2(float x, int y) {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d0;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_y += _r_d0 * x;
 //CHECK-NEXT:         *_d_x += y * _r_d0;
 //CHECK-NEXT:         *_d_x += _r_d0 * x;
@@ -74,7 +74,7 @@ float func3(int x, int y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         int _r_d0 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d0;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -96,7 +96,7 @@ float func4(float x, float y) {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d0;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         _d_z += _r_d0;
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
@@ -122,7 +122,7 @@ float func5(float x, float y) {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d0;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         _d_z += _r_d0;
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
@@ -164,7 +164,7 @@ float func8(int x, int y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         int _r_d0 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d0;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_y += _r_d0 * y;
 //CHECK-NEXT:         *_d_y += y * _r_d0;
 //CHECK-NEXT:     }

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -33,7 +33,7 @@ float func(float x, float y) {
 //CHECK-NEXT:         _final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT:         y = _t1;
 //CHECK-NEXT:         float _r_d1 = *_d_y;
-//CHECK-NEXT:         *_d_y -= _r_d1;
+//CHECK-NEXT:         *_d_y = 0;
 //CHECK-NEXT:         *_d_y += _r_d1;
 //CHECK-NEXT:         *_d_y += _r_d1;
 //CHECK-NEXT:         y--;
@@ -43,7 +43,7 @@ float func(float x, float y) {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d0;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_x += _r_d0;
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
@@ -76,7 +76,7 @@ float func2(float x, float y) {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d0;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_x += _r_d0;
 //CHECK-NEXT:         *_d_y += -_r_d0;
 //CHECK-NEXT:         *_d_y += -_r_d0 * y;
@@ -116,7 +116,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:         *_d_y += x * z * _d_t;
 //CHECK-NEXT:         y = _t2;
 //CHECK-NEXT:         float _r_d1 = *_d_y;
-//CHECK-NEXT:         *_d_y -= _r_d1;
+//CHECK-NEXT:         *_d_y = 0;
 //CHECK-NEXT:         *_d_x += _r_d1;
 //CHECK-NEXT:         *_d_x += _r_d1;
 //CHECK-NEXT:     }
@@ -125,7 +125,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d0;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_x += _r_d0;
 //CHECK-NEXT:         *_d_y += -_r_d0;
 //CHECK-NEXT:         *_d_y += -_r_d0 * y;
@@ -173,7 +173,7 @@ float func5(float x, float y) {
 //CHECK-NEXT:         _final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT:         y = _t0;
 //CHECK-NEXT:         float _r_d0 = *_d_y;
-//CHECK-NEXT:         *_d_y -= _r_d0;
+//CHECK-NEXT:         *_d_y = 0;
 //CHECK-NEXT:         float _r0 = 0;
 //CHECK-NEXT:         _r0 += _r_d0 * clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, 1.F).pushforward;
 //CHECK-NEXT:         *_d_x += _r0;
@@ -273,7 +273,7 @@ float func8(float x, float y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         z = _t0;
 //CHECK-NEXT:         float _r_d0 = _d_z;
-//CHECK-NEXT:         _d_z -= _r_d0;
+//CHECK-NEXT:         _d_z = 0;
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _t2 = 0;

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -48,7 +48,7 @@ float func(float x, float y) {
 //CHECK-NEXT:             _final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT:             y = _t0;
 //CHECK-NEXT:             float _r_d0 = *_d_y;
-//CHECK-NEXT:             *_d_y -= _r_d0;
+//CHECK-NEXT:             *_d_y = 0;
 //CHECK-NEXT:             *_d_y += _r_d0 * x;
 //CHECK-NEXT:             *_d_x += y * _r_d0;
 //CHECK-NEXT:         }
@@ -56,14 +56,14 @@ float func(float x, float y) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             x = _t2;
 //CHECK-NEXT:             float _r_d2 = *_d_x;
-//CHECK-NEXT:             *_d_x -= _r_d2;
+//CHECK-NEXT:             *_d_x = 0;
 //CHECK-NEXT:             *_d_y += _r_d2;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_temp * temp * {{.+}});
 //CHECK-NEXT:             temp = _t1;
 //CHECK-NEXT:             float _r_d1 = _d_temp;
-//CHECK-NEXT:             _d_temp -= _r_d1;
+//CHECK-NEXT:             _d_temp = 0;
 //CHECK-NEXT:             *_d_y += _r_d1 * y;
 //CHECK-NEXT:             *_d_y += y * _r_d1;
 //CHECK-NEXT:         }
@@ -171,7 +171,7 @@ float func4(float x, float y) {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         float _r_d1 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d1;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_x += _r_d1 * x;
 //CHECK-NEXT:         *_d_x += x * _r_d1;
 //CHECK-NEXT:     }

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -95,7 +95,7 @@ float func2(float x) {
 //CHECK-NEXT:             _final_error += std::abs(_d_z * z * {{.+}});
 //CHECK-NEXT:             z = clad::pop(_t2);
 //CHECK-NEXT:             float _r_d0 = _d_z;
-//CHECK-NEXT:             _d_z -= _r_d0;
+//CHECK-NEXT:             _d_z = 0;
 //CHECK-NEXT:             _d_m += _r_d0;
 //CHECK-NEXT:             _d_m += _r_d0;
 //CHECK-NEXT:         }
@@ -135,7 +135,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:         _final_error += std::abs(_d_arr[2] * arr[2] * {{.+}});
 //CHECK-NEXT:         arr[2] = _t2;
 //CHECK-NEXT:         double _r_d2 = _d_arr[2];
-//CHECK-NEXT:         _d_arr[2] -= _r_d2;
+//CHECK-NEXT:         _d_arr[2] = 0;
 //CHECK-NEXT:         _d_arr[0] += _r_d2;
 //CHECK-NEXT:         _d_arr[1] += _r_d2;
 //CHECK-NEXT:     }
@@ -143,7 +143,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:         _final_error += std::abs(_d_arr[1] * arr[1] * {{.+}});
 //CHECK-NEXT:         arr[1] = _t1;
 //CHECK-NEXT:         double _r_d1 = _d_arr[1];
-//CHECK-NEXT:         _d_arr[1] -= _r_d1;
+//CHECK-NEXT:         _d_arr[1] = 0;
 //CHECK-NEXT:         *_d_x += _r_d1 * x;
 //CHECK-NEXT:         *_d_x += x * _r_d1;
 //CHECK-NEXT:     }
@@ -151,7 +151,7 @@ float func3(float x, float y) {
 //CHECK-NEXT:         _final_error += std::abs(_d_arr[0] * arr[0] * {{.+}});
 //CHECK-NEXT:         arr[0] = _t0;
 //CHECK-NEXT:         double _r_d0 = _d_arr[0];
-//CHECK-NEXT:         _d_arr[0] -= _r_d0;
+//CHECK-NEXT:         _d_arr[0] = 0;
 //CHECK-NEXT:         *_d_x += _r_d0;
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
@@ -257,7 +257,7 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         _final_error += std::abs(_d_output[2] * output[2] * {{.+}});
 //CHECK-NEXT:         output[2] = _t2;
 //CHECK-NEXT:         double _r_d2 = _d_output[2];
-//CHECK-NEXT:         _d_output[2] -= _r_d2;
+//CHECK-NEXT:         _d_output[2] = 0;
 //CHECK-NEXT:         _d_x[0] += _r_d2 * y[1];
 //CHECK-NEXT:         x_size = std::max(x_size, 0);
 //CHECK-NEXT:         _d_y[1] += x[0] * _r_d2;
@@ -272,7 +272,7 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         _final_error += std::abs(_d_output[1] * output[1] * {{.+}});
 //CHECK-NEXT:         output[1] = _t1;
 //CHECK-NEXT:         double _r_d1 = _d_output[1];
-//CHECK-NEXT:         _d_output[1] -= _r_d1;
+//CHECK-NEXT:         _d_output[1] = 0;
 //CHECK-NEXT:         _d_x[2] += _r_d1 * y[0];
 //CHECK-NEXT:         x_size = std::max(x_size, 2);
 //CHECK-NEXT:         _d_y[0] += x[2] * _r_d1;
@@ -287,7 +287,7 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         _final_error += std::abs(_d_output[0] * output[0] * {{.+}});
 //CHECK-NEXT:         output[0] = _t0;
 //CHECK-NEXT:         double _r_d0 = _d_output[0];
-//CHECK-NEXT:         _d_output[0] -= _r_d0;
+//CHECK-NEXT:         _d_output[0] = 0;
 //CHECK-NEXT:         _d_x[1] += _r_d0 * y[2];
 //CHECK-NEXT:         x_size = std::max(x_size, 1);
 //CHECK-NEXT:         _d_y[2] += x[1] * _r_d0;

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -21,7 +21,7 @@ double f1(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t0;
 //CHECK-NEXT:           double _r_d0 = *_d_x;
-//CHECK-NEXT:           *_d_x -= _r_d0;
+//CHECK-NEXT:           *_d_x = 0;
 //CHECK-NEXT:           *_d_y += _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -47,7 +47,7 @@ double f2(double x, double y) {
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           x = _t0;
 //CHECK-NEXT:           double _r_d0 = *_d_x;
-//CHECK-NEXT:           *_d_x -= _r_d0;
+//CHECK-NEXT:           *_d_x = 0;
 //CHECK-NEXT:           *_d_y += _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -78,27 +78,27 @@ double f3(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t3;
 //CHECK-NEXT:           double _r_d3 = *_d_x;
-//CHECK-NEXT:           *_d_x -= _r_d3;
+//CHECK-NEXT:           *_d_x = 0;
 //CHECK-NEXT:           *_d_y += _r_d3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           y = _t2;
 //CHECK-NEXT:           double _r_d2 = *_d_y;
-//CHECK-NEXT:           *_d_y -= _r_d2;
+//CHECK-NEXT:           *_d_y = 0;
 //CHECK-NEXT:           *_d_x += _r_d2 * x;
 //CHECK-NEXT:           *_d_x += x * _r_d2;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t1;
 //CHECK-NEXT:           double _r_d1 = *_d_x;
-//CHECK-NEXT:           *_d_x -= _r_d1;
+//CHECK-NEXT:           *_d_x = 0;
 //CHECK-NEXT:           *_d_x += _r_d1 * x;
 //CHECK-NEXT:           *_d_x += x * _r_d1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t0;
 //CHECK-NEXT:           double _r_d0 = *_d_x;
-//CHECK-NEXT:           *_d_x -= _r_d0;
+//CHECK-NEXT:           *_d_x = 0;
 //CHECK-NEXT:           *_d_x += _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -121,12 +121,12 @@ double f4(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t1;
 //CHECK-NEXT:           double _r_d1 = *_d_x;
-//CHECK-NEXT:           *_d_x -= _r_d1;
+//CHECK-NEXT:           *_d_x = 0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           y = _t0;
 //CHECK-NEXT:           double _r_d0 = *_d_y;
-//CHECK-NEXT:           *_d_y -= _r_d0;
+//CHECK-NEXT:           *_d_y = 0;
 //CHECK-NEXT:           *_d_x += _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -175,7 +175,7 @@ double f5(double x, double y) {
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = _t1;
 //CHECK-NEXT:               double _r_d1 = _d_t;
-//CHECK-NEXT:               _d_t -= _r_d1;
+//CHECK-NEXT:               _d_t = 0;
 //CHECK-NEXT:               _d_t += -_r_d1;
 //CHECK-NEXT:           }
 //CHECK-NEXT:           _d_t += _d_z;
@@ -186,7 +186,7 @@ double f5(double x, double y) {
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = _t0;
 //CHECK-NEXT:               double _r_d0 = _d_t;
-//CHECK-NEXT:               _d_t -= _r_d0;
+//CHECK-NEXT:               _d_t = 0;
 //CHECK-NEXT:               _d_t += -_r_d0;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
@@ -240,7 +240,7 @@ double f6(double x, double y) {
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = _t1;
 //CHECK-NEXT:               double _r_d1 = _d_t;
-//CHECK-NEXT:               _d_t -= _r_d1;
+//CHECK-NEXT:               _d_t = 0;
 //CHECK-NEXT:               _d_t += -_r_d1;
 //CHECK-NEXT:           }
 //CHECK-NEXT:           _d_t += _d_z;
@@ -251,7 +251,7 @@ double f6(double x, double y) {
 //CHECK-NEXT:           {
 //CHECK-NEXT:               t = _t0;
 //CHECK-NEXT:               double _r_d0 = _d_t;
-//CHECK-NEXT:               _d_t -= _r_d0;
+//CHECK-NEXT:               _d_t = 0;
 //CHECK-NEXT:               _d_t += -_r_d0;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
@@ -309,7 +309,7 @@ double f7(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t6;
 //CHECK-NEXT:           double _r_d6 = *_d_x;
-//CHECK-NEXT:           *_d_x -= _r_d6;
+//CHECK-NEXT:           *_d_x = 0;
 //CHECK-NEXT:           _d_t[0] += _r_d6;
 //CHECK-NEXT:           --t[0];
 //CHECK-NEXT:       }
@@ -321,7 +321,7 @@ double f7(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[0] = _t4;
 //CHECK-NEXT:           double _r_d4 = _d_t[0];
-//CHECK-NEXT:           _d_t[0] -= _r_d4;
+//CHECK-NEXT:           _d_t[0] = 0;
 //CHECK-NEXT:           _d_t[0] += _r_d4 / t[1];
 //CHECK-NEXT:           double _r0 = _r_d4 * -t[0] / (t[1] * t[1]);
 //CHECK-NEXT:           _d_t[1] += _r0;
@@ -329,7 +329,7 @@ double f7(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[0] = _t3;
 //CHECK-NEXT:           double _r_d3 = _d_t[0];
-//CHECK-NEXT:           _d_t[0] -= _r_d3;
+//CHECK-NEXT:           _d_t[0] = 0;
 //CHECK-NEXT:           _d_t[0] += _r_d3 * t[1];
 //CHECK-NEXT:           _d_t[1] += t[0] * _r_d3;
 //CHECK-NEXT:       }
@@ -341,13 +341,13 @@ double f7(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t1;
 //CHECK-NEXT:           double _r_d1 = *_d_x;
-//CHECK-NEXT:           *_d_x -= _r_d1;
+//CHECK-NEXT:           *_d_x = 0;
 //CHECK-NEXT:           *_d_y += _r_d1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[0] = _t0;
 //CHECK-NEXT:           double _r_d0 = _d_t[0];
-//CHECK-NEXT:           _d_t[0] -= _r_d0;
+//CHECK-NEXT:           _d_t[0] = 0;
 //CHECK-NEXT:           *_d_x += _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       ++t[0];
@@ -383,20 +383,20 @@ double f8(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[3] = _t0;
 //CHECK-NEXT:           double _r_d0 = _d_t[3];
-//CHECK-NEXT:           _d_t[3] -= _r_d0;
+//CHECK-NEXT:           _d_t[3] = 0;
 //CHECK-NEXT:           *_d_y += _r_d0;
 //CHECK-NEXT:           y = _t1;
 //CHECK-NEXT:           double _r_d1 = *_d_y;
-//CHECK-NEXT:           *_d_y -= _r_d1;
+//CHECK-NEXT:           *_d_y = 0;
 //CHECK-NEXT:           *_d_y += _r_d1 * t[2];
 //CHECK-NEXT:           _d_t[0] += y * _r_d1;
 //CHECK-NEXT:           t[0] = _t2;
 //CHECK-NEXT:           double _r_d2 = _d_t[0];
-//CHECK-NEXT:           _d_t[0] -= _r_d2;
+//CHECK-NEXT:           _d_t[0] = 0;
 //CHECK-NEXT:           _d_t[1] += _r_d2;
 //CHECK-NEXT:           t[1] = _t3;
 //CHECK-NEXT:           double _r_d3 = _d_t[1];
-//CHECK-NEXT:           _d_t[1] -= _r_d3;
+//CHECK-NEXT:           _d_t[1] = 0;
 //CHECK-NEXT:           _d_t[2] += _r_d3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
@@ -424,12 +424,12 @@ double f9(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t2;
 //CHECK-NEXT:           double _r_d1 = _d_t;
-//CHECK-NEXT:           _d_t -= _r_d1;
+//CHECK-NEXT:           _d_t = 0;
 //CHECK-NEXT:           _d_t += _r_d1 * y;
 //CHECK-NEXT:           *_d_y += _t1 * _r_d1;
 //CHECK-NEXT:           t = _t0;
 //CHECK-NEXT:           double _r_d0 = _d_t;
-//CHECK-NEXT:           _d_t -= _r_d0;
+//CHECK-NEXT:           _d_t = 0;
 //CHECK-NEXT:           _d_t += _r_d0 * x;
 //CHECK-NEXT:           *_d_x += t * _r_d0;
 //CHECK-NEXT:       }
@@ -454,11 +454,11 @@ double f10(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t0;
 //CHECK-NEXT:           double _r_d0 = _d_t;
-//CHECK-NEXT:           _d_t -= _r_d0;
+//CHECK-NEXT:           _d_t = 0;
 //CHECK-NEXT:           *_d_x += _r_d0;
 //CHECK-NEXT:           x = _t1;
 //CHECK-NEXT:           double _r_d1 = *_d_x;
-//CHECK-NEXT:           *_d_x -= _r_d1;
+//CHECK-NEXT:           *_d_x = 0;
 //CHECK-NEXT:           *_d_y += _r_d1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       *_d_x += _d_t;
@@ -483,11 +483,11 @@ double f11(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t2;
 //CHECK-NEXT:           double _r_d1 = _d_t;
-//CHECK-NEXT:           _d_t -= _r_d1;
+//CHECK-NEXT:           _d_t = 0;
 //CHECK-NEXT:           *_d_y += _r_d1;
 //CHECK-NEXT:           t = _t0;
 //CHECK-NEXT:           double _r_d0 = _d_t;
-//CHECK-NEXT:           _d_t -= _r_d0;
+//CHECK-NEXT:           _d_t = 0;
 //CHECK-NEXT:           *_d_x += _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       *_d_x += _d_t;
@@ -521,18 +521,18 @@ double f12(double x, double y) {
 //CHECK-NEXT:           t = _t3;
 //CHECK-NEXT:           t = _t4;
 //CHECK-NEXT:           double _r_d2 = (_cond0 ? _d_t : _d_t);
-//CHECK-NEXT:           (_cond0 ? _d_t : _d_t) -= _r_d2;
+//CHECK-NEXT:           (_cond0 ? _d_t : _d_t) = 0;
 //CHECK-NEXT:           (_cond0 ? _d_t : _d_t) += _r_d2 * y;
 //CHECK-NEXT:           *_d_y += _t2 * _r_d2;
 //CHECK-NEXT:           if (_cond0) {
 //CHECK-NEXT:               t = _t0;
 //CHECK-NEXT:               double _r_d0 = _d_t;
-//CHECK-NEXT:               _d_t -= _r_d0;
+//CHECK-NEXT:               _d_t = 0;
 //CHECK-NEXT:               *_d_x += _r_d0;
 //CHECK-NEXT:           } else {
 //CHECK-NEXT:               t = _t1;
 //CHECK-NEXT:               double _r_d1 = _d_t;
-//CHECK-NEXT:               _d_t -= _r_d1;
+//CHECK-NEXT:               _d_t = 0;
 //CHECK-NEXT:               *_d_y += _r_d1;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
@@ -559,7 +559,7 @@ double f13(double x, double y) {
 //CHECK-NEXT:           *_d_y += x * _d_t;
 //CHECK-NEXT:           y = _t1;
 //CHECK-NEXT:           double _r_d0 = *_d_y;
-//CHECK-NEXT:           *_d_y -= _r_d0;
+//CHECK-NEXT:           *_d_y = 0;
 //CHECK-NEXT:           *_d_x += _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -589,7 +589,7 @@ double f14(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t2;
 // CHECK-NEXT:         double _r_d2 = *_d_a;
-// CHECK-NEXT:         *_d_a -= _r_d2;
+// CHECK-NEXT:         *_d_a = 0;
 // CHECK-NEXT:         *_d_a += _r_d2 * i;
 // CHECK-NEXT:         *_d_i += a * _r_d2;
 // CHECK-NEXT:     }
@@ -601,7 +601,7 @@ double f14(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_a;
-// CHECK-NEXT:         *_d_a -= _r_d0;
+// CHECK-NEXT:         *_d_a = 0;
 // CHECK-NEXT:         *_d_i += 2 * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -650,7 +650,7 @@ double f15(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         d = _t3;
 // CHECK-NEXT:         double _r_d3 = *_d_d;
-// CHECK-NEXT:         *_d_d -= _r_d3;
+// CHECK-NEXT:         *_d_d = 0;
 // CHECK-NEXT:         *_d_d += _r_d3 * 3 * j;
 // CHECK-NEXT:         *_d_j += 3 * d * _r_d3;
 // CHECK-NEXT:     }
@@ -667,7 +667,7 @@ double f15(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_a;
-// CHECK-NEXT:         *_d_a -= _r_d0;
+// CHECK-NEXT:         *_d_a = 0;
 // CHECK-NEXT:         *_d_a += _r_d0 * i;
 // CHECK-NEXT:         *_d_i += a * _r_d0;
 // CHECK-NEXT:     }
@@ -702,7 +702,7 @@ double f16(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         c = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_c;
-// CHECK-NEXT:         *_d_c -= _r_d0;
+// CHECK-NEXT:         *_d_c = 0;
 // CHECK-NEXT:         *_d_c += _r_d0 * 4 * j;
 // CHECK-NEXT:         *_d_j += 4 * c * _r_d0;
 // CHECK-NEXT:     }
@@ -723,7 +723,7 @@ double f17(double i, double j, double k) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         j = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_j;
-// CHECK-NEXT:         _d_j -= _r_d0;
+// CHECK-NEXT:         _d_j = 0;
 // CHECK-NEXT:         *_d_i += 2 * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -751,7 +751,7 @@ double f18(double i, double j, double k) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         k = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_k;
-// CHECK-NEXT:         _d_k -= _r_d0;
+// CHECK-NEXT:         _d_k = 0;
 // CHECK-NEXT:         *_d_i += 2 * _r_d0;
 // CHECK-NEXT:         *_d_j += 2 * _r_d0;
 // CHECK-NEXT:     }
@@ -794,14 +794,14 @@ double f20(double x, double y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _r_d1 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d1;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_r += _r_d1 * y;
 //CHECK-NEXT:         *_d_y += r * _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         r = _t0;
 //CHECK-NEXT:         double _r_d0 = *_d_r;
-//CHECK-NEXT:         *_d_r -= _r_d0;
+//CHECK-NEXT:         *_d_r = 0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -818,7 +818,7 @@ double f21 (double x, double y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t0;
 //CHECK-NEXT:         double _r_d0 = *_d_y;
-//CHECK-NEXT:         *_d_y -= _r_d0;
+//CHECK-NEXT:         *_d_y = 0;
 //CHECK-NEXT:         *_d_x += _r_d0;
 //CHECK-NEXT:         *_d_y += 0;
 //CHECK-NEXT:         y--;

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -76,7 +76,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         temp = _t3;
 // CHECK-NEXT:         double _r_d1 = _d_temp;
-// CHECK-NEXT:         _d_temp -= _r_d1;
+// CHECK-NEXT:         _d_temp = 0;
 // CHECK-NEXT:         i = _t4;
 // CHECK-NEXT:         j = _t5;
 // CHECK-NEXT:         modify1_pullback(_t4, _t5, _r_d1, &*_d_i, &*_d_j);
@@ -84,7 +84,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         temp = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_temp;
-// CHECK-NEXT:         _d_temp -= _r_d0;
+// CHECK-NEXT:         _d_temp = 0;
 // CHECK-NEXT:         i = _t1;
 // CHECK-NEXT:         j = _t2;
 // CHECK-NEXT:         modify1_pullback(_t1, _t2, _r_d0, &*_d_i, &*_d_j);
@@ -413,7 +413,7 @@ double fn10(double x, double y) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        out = _t4;
 // CHECK-NEXT:        double _r_d2 = _d_out;
-// CHECK-NEXT:        _d_out -= _r_d2;
+// CHECK-NEXT:        _d_out = 0;
 // CHECK-NEXT:        out = _t5;
 // CHECK-NEXT:        double _r2 = 0;
 // CHECK-NEXT:        double _r3 = 0;
@@ -422,7 +422,7 @@ double fn10(double x, double y) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        out = _t2;
 // CHECK-NEXT:        double _r_d1 = _d_out;
-// CHECK-NEXT:        _d_out -= _r_d1;
+// CHECK-NEXT:        _d_out = 0;
 // CHECK-NEXT:        out = _t3;
 // CHECK-NEXT:        double _r1 = 0;
 // CHECK-NEXT:        clad::custom_derivatives::std::min_pullback(_t3, 10., _r_d1, &_d_out, &_r1);
@@ -430,7 +430,7 @@ double fn10(double x, double y) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        out = _t0;
 // CHECK-NEXT:        double _r_d0 = _d_out;
-// CHECK-NEXT:        _d_out -= _r_d0;
+// CHECK-NEXT:        _d_out = 0;
 // CHECK-NEXT:        out = _t1;
 // CHECK-NEXT:        double _r0 = 0;
 // CHECK-NEXT:        clad::custom_derivatives::std::max_pullback(_t1, 0., _r_d0, &_d_out, &_r0);
@@ -528,7 +528,7 @@ double fn13(double* x, const double* w) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             wCopy[i] = clad::pop(_t1);
 // CHECK-NEXT:             double _r_d0 = _d_wCopy[i];
-// CHECK-NEXT:             _d_wCopy[i] -= _r_d0;
+// CHECK-NEXT:             _d_wCopy[i] = 0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -623,7 +623,7 @@ double fn17 (double x, double* y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _r_d1 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d1;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         double _r1 = 0;
 //CHECK-NEXT:         add_pullback(x, &x, _r_d1, &_r1, &*_d_x);
 //CHECK-NEXT:         *_d_x += _r1;
@@ -631,7 +631,7 @@ double fn17 (double x, double* y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         double _r_d0 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d0;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         double _r0 = 0;
 //CHECK-NEXT:         add_pullback(x, y, _r_d0, &_r0);
 //CHECK-NEXT:         *_d_x += _r0;
@@ -942,7 +942,7 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         d = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_d;
-// CHECK-NEXT:         *_d_d -= _r_d0;
+// CHECK-NEXT:         *_d_d = 0;
 // CHECK-NEXT:         *_d_d += 2 * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -954,7 +954,7 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         arr[0] = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_arr[0];
-// CHECK-NEXT:         _d_arr[0] -= _r_d0;
+// CHECK-NEXT:         _d_arr[0] = 0;
 // CHECK-NEXT:         _d_arr[0] += 5 * _r_d0;
 // CHECK-NEXT:         _d_arr[1] += _r_d0;
 // CHECK-NEXT:     }
@@ -1016,7 +1016,7 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:            if (_cond1) {
 // CHECK-NEXT:                _cond0 = _t0;
 // CHECK-NEXT:                double _r_d0 = _d_cond0;
-// CHECK-NEXT:                _d_cond0 -= _r_d0;
+// CHECK-NEXT:                _d_cond0 = 0;
 // CHECK-NEXT:            }
 // CHECK-NEXT:        }
 // CHECK-NEXT:    }

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -147,7 +147,7 @@ double f_div3(double x, double y) {
 //CHECK-NEXT:         *_d_x += 1 / _t0;
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _r_d0 = *_d_x;
-//CHECK-NEXT:         *_d_x -= _r_d0;
+//CHECK-NEXT:         *_d_x = 0;
 //CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:         double _r0 = 1 * -(_t2 / (_t0 * _t0));
 //CHECK-NEXT:         *_d_y += _r0 * y;
@@ -279,7 +279,7 @@ double f_cond4(double x, double y) {
 //CHECK-NEXT:           {
 //CHECK-NEXT:               y = _t0;
 //CHECK-NEXT:               double _r_d0 = *_d_y;
-//CHECK-NEXT:               *_d_y -= _r_d0;
+//CHECK-NEXT:               *_d_y = 0;
 //CHECK-NEXT:               _d_arr[i] += _r_d0 * x;
 //CHECK-NEXT:               *_d_x += arr[i] * _r_d0;
 //CHECK-NEXT:           }
@@ -920,14 +920,14 @@ double fn_empty_if_else(double x) {
 //CHECK-NEXT:            {
 //CHECK-NEXT:                res = _t1;
 //CHECK-NEXT:                double _r_d1 = _d_res;
-//CHECK-NEXT:                _d_res -= _r_d1;
+//CHECK-NEXT:                _d_res = 0;
 //CHECK-NEXT:                *_d_x += 5 * _r_d1;
 //CHECK-NEXT:            }
 //CHECK-NEXT:        }
 //CHECK-NEXT:        {
 //CHECK-NEXT:            res = _t0;
 //CHECK-NEXT:            double _r_d0 = _d_res;
-//CHECK-NEXT:            _d_res -= _r_d0;
+//CHECK-NEXT:            _d_res = 0;
 //CHECK-NEXT:        }
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
@@ -970,7 +970,7 @@ double fn_cond_false(double i, double j) {
 // CHECK-NEXT:            {
 // CHECK-NEXT:                res = _t1;
 // CHECK-NEXT:                double _r_d1 = _d_res;
-// CHECK-NEXT:                _d_res -= _r_d1;
+// CHECK-NEXT:                _d_res = 0;
 // CHECK-NEXT:                *_d_i += 6 * _r_d1 * j;
 // CHECK-NEXT:                *_d_j += 6 * i * _r_d1;
 // CHECK-NEXT:            }
@@ -979,7 +979,7 @@ double fn_cond_false(double i, double j) {
 // CHECK-NEXT:            if (_cond1) {
 // CHECK-NEXT:                _cond0 = _t0;
 // CHECK-NEXT:                double _r_d0 = _d_cond0;
-// CHECK-NEXT:                _d_cond0 -= _r_d0;
+// CHECK-NEXT:                _d_cond0 = 0;
 // CHECK-NEXT:            }
 // CHECK-NEXT:        }
 // CHECK-NEXT:    }
@@ -1050,7 +1050,7 @@ double fn_cond_add_assign(double i, double j) {
 // CHECK-NEXT:                if (_cond3) {
 // CHECK-NEXT:                    _cond0 = _t3;
 // CHECK-NEXT:                    double _r_d3 = _d_cond0;
-// CHECK-NEXT:                    _d_cond0 -= _r_d3;
+// CHECK-NEXT:                    _d_cond0 = 0;
 // CHECK-NEXT:                    _d_res += _r_d3;
 // CHECK-NEXT:                    res = _t4;
 // CHECK-NEXT:                    double _r_d4 = _d_res;
@@ -1062,7 +1062,7 @@ double fn_cond_add_assign(double i, double j) {
 // CHECK-NEXT:                        if (_cond2) {
 // CHECK-NEXT:                            _cond1 = _t1;
 // CHECK-NEXT:                            double _r_d1 = _d_cond1;
-// CHECK-NEXT:                            _d_cond1 -= _r_d1;
+// CHECK-NEXT:                            _d_cond1 = 0;
 // CHECK-NEXT:                            _d_res += _r_d1;
 // CHECK-NEXT:                            res = _t2;
 // CHECK-NEXT:                            double _r_d2 = _d_res;
@@ -1072,7 +1072,7 @@ double fn_cond_add_assign(double i, double j) {
 // CHECK-NEXT:                        {
 // CHECK-NEXT:                            res = _t0;
 // CHECK-NEXT:                            double _r_d0 = _d_res;
-// CHECK-NEXT:                            _d_res -= _r_d0;
+// CHECK-NEXT:                            _d_res = 0;
 // CHECK-NEXT:                            *_d_i += 2 * _r_d0 * j;
 // CHECK-NEXT:                            *_d_j += 2 * i * _r_d0;
 // CHECK-NEXT:                        }

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -42,7 +42,7 @@ double f1(double x) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         t = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_t;
-// CHECK-NEXT:         _d_t -= _r_d0;
+// CHECK-NEXT:         _d_t = 0;
 // CHECK-NEXT:         _d_t += _r_d0 * x;
 // CHECK-NEXT:         *_d_x += t * _r_d0;
 // CHECK-NEXT:     }
@@ -100,7 +100,7 @@ double f2(double x) {
 // CHECK-NEXT:             j--;
 // CHECK-NEXT:             t = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_t;
-// CHECK-NEXT:             _d_t -= _r_d0;
+// CHECK-NEXT:             _d_t = 0;
 // CHECK-NEXT:             _d_t += _r_d0 * x;
 // CHECK-NEXT:             *_d_x += t * _r_d0;
 // CHECK-NEXT:         }
@@ -161,7 +161,7 @@ double f3(double x) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             t = clad::pop(_t1);
 // CHECK-NEXT:             double _r_d0 = _d_t;
-// CHECK-NEXT:             _d_t -= _r_d0;
+// CHECK-NEXT:             _d_t = 0;
 // CHECK-NEXT:             _d_t += _r_d0 * x;
 // CHECK-NEXT:             *_d_x += t * _r_d0;
 // CHECK-NEXT:         }
@@ -200,7 +200,7 @@ double f4(double x) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             t = clad::pop(_t1);
 // CHECK-NEXT:             double _r_d0 = _d_t;
-// CHECK-NEXT:             _d_t -= _r_d0;
+// CHECK-NEXT:             _d_t = 0;
 // CHECK-NEXT:             _d_t += _r_d0 * x;
 // CHECK-NEXT:             *_d_x += t * _r_d0;
 // CHECK-NEXT:         }
@@ -435,7 +435,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         power = _t2;
 // CHECK-NEXT:         double _r_d1 = _d_power;
-// CHECK-NEXT:         _d_power -= _r_d1;
+// CHECK-NEXT:         _d_power = 0;
 // CHECK-NEXT:         _d_power += -_r_d1 / _t3;
 // CHECK-NEXT:         double _r1 = _r_d1 * -(-power / (_t3 * _t3));
 // CHECK-NEXT:         double _r2 = 0;
@@ -731,7 +731,7 @@ double fn9(double i, double j) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     counter_again = clad::pop(_t3);
 // CHECK-NEXT:                     int _r_d2 = _d_counter_again;
-// CHECK-NEXT:                     _d_counter_again -= _r_d2;
+// CHECK-NEXT:                     _d_counter_again = 0;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _t2--;
@@ -739,11 +739,11 @@ double fn9(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         counter = _t0;
 // CHECK-NEXT:         int _r_d0 = _d_counter;
-// CHECK-NEXT:         _d_counter -= _r_d0;
+// CHECK-NEXT:         _d_counter = 0;
 // CHECK-NEXT:         _d_counter_again += _r_d0;
 // CHECK-NEXT:         counter_again = _t1;
 // CHECK-NEXT:         int _r_d1 = _d_counter_again;
-// CHECK-NEXT:         _d_counter_again -= _r_d1;
+// CHECK-NEXT:         _d_counter_again = 0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -1774,7 +1774,7 @@ double fn20(double *arr, int n) {
 // CHECK-NEXT:             _d_arr[i] += _r_d0;
 // CHECK-NEXT:             arr[i] = clad::pop(_t2);
 // CHECK-NEXT:             double _r_d1 = _d_arr[i];
-// CHECK-NEXT:             _d_arr[i] -= _r_d1;
+// CHECK-NEXT:             _d_arr[i] = 0;
 // CHECK-NEXT:             _d_arr[i] += _r_d1 * 5;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
@@ -1929,7 +1929,7 @@ double fn23(double i, double j) {
 // CHECK-NEXT:             if (!_t0 || (clad::back(_t2) != 1)) {
 // CHECK-NEXT:                 res = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_res;
-// CHECK-NEXT:                 _d_res -= _r_d0;
+// CHECK-NEXT:                 _d_res = 0;
 // CHECK-NEXT:                 *_d_i += _r_d0 * j;
 // CHECK-NEXT:                 *_d_j += i * _r_d0;
 // CHECK-NEXT:             }
@@ -2060,7 +2060,7 @@ double fn25(double i, double j) {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         res = clad::pop(_t2);
 // CHECK-NEXT:                         double _r_d1 = _d_res;
-// CHECK-NEXT:                         _d_res -= _r_d1;
+// CHECK-NEXT:                         _d_res = 0;
 // CHECK-NEXT:                         *_d_i += 8 * _r_d1 * j;
 // CHECK-NEXT:                         *_d_j += 8 * i * _r_d1;
 // CHECK-NEXT:                     }
@@ -2127,7 +2127,7 @@ double fn26(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 res = clad::pop(_t2);
 // CHECK-NEXT:                 double _r_d1 = _d_res;
-// CHECK-NEXT:                 _d_res -= _r_d1;
+// CHECK-NEXT:                 _d_res = 0;
 // CHECK-NEXT:                 *_d_i += 7 * _r_d1 * j;
 // CHECK-NEXT:                 *_d_j += 7 * i * _r_d1;
 // CHECK-NEXT:                 _d_c += 0;
@@ -2204,7 +2204,7 @@ double fn27(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 res = clad::pop(_t3);
 // CHECK-NEXT:                 double _r_d1 = _d_res;
-// CHECK-NEXT:                 _d_res -= _r_d1;
+// CHECK-NEXT:                 _d_res = 0;
 // CHECK-NEXT:                 _d_c += _r_d1 * j * i;
 // CHECK-NEXT:                 *_d_i += c * _r_d1 * j;
 // CHECK-NEXT:                 *_d_j += c * i * _r_d1;
@@ -2255,7 +2255,7 @@ double fn28(double i, double j) {
 // CHECK-NEXT:                 _d_res += 0;
 // CHECK-NEXT:                 res = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_res;
-// CHECK-NEXT:                 _d_res -= _r_d0;
+// CHECK-NEXT:                 _d_res = 0;
 // CHECK-NEXT:                 *_d_i += _r_d0 * j;
 // CHECK-NEXT:                 *_d_j += i * _r_d0;
 // CHECK-NEXT:             }
@@ -2266,7 +2266,7 @@ double fn28(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t2);
 // CHECK-NEXT:             double _r_d1 = _d_res;
-// CHECK-NEXT:             _d_res -= _r_d1;
+// CHECK-NEXT:             _d_res = 0;
 // CHECK-NEXT:             *_d_i += 3 * _r_d1 * j;
 // CHECK-NEXT:             *_d_j += 3 * i * _r_d1;
 // CHECK-NEXT:         }
@@ -2305,7 +2305,7 @@ double fn29(double i, double j) {
 // CHECK-NEXT:                 _d_res += 0;
 // CHECK-NEXT:                 res = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_res;
-// CHECK-NEXT:                 _d_res -= _r_d0;
+// CHECK-NEXT:                 _d_res = 0;
 // CHECK-NEXT:                 *_d_i += _r_d0 * j;
 // CHECK-NEXT:                 *_d_j += i * _r_d0;
 // CHECK-NEXT:             }
@@ -2315,7 +2315,7 @@ double fn29(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t2);
 // CHECK-NEXT:             double _r_d1 = _d_res;
-// CHECK-NEXT:             _d_res -= _r_d1;
+// CHECK-NEXT:             _d_res = 0;
 // CHECK-NEXT:             *_d_i += 3 * _r_d1 * j;
 // CHECK-NEXT:             *_d_j += 3 * i * _r_d1;
 // CHECK-NEXT:             _d_c += 0;
@@ -2367,11 +2367,11 @@ double fn30(double i, double j) {
 // CHECK-NEXT:                 if (clad::back(_cond1)) {
 // CHECK-NEXT:                     _cond0 = clad::pop(_t1);
 // CHECK-NEXT:                     double _r_d0 = _d_cond0;
-// CHECK-NEXT:                     _d_cond0 -= _r_d0;
+// CHECK-NEXT:                     _d_cond0 = 0;
 // CHECK-NEXT:                     _d_res += _r_d0;
 // CHECK-NEXT:                     res = clad::pop(_t2);
 // CHECK-NEXT:                     double _r_d1 = _d_res;
-// CHECK-NEXT:                     _d_res -= _r_d1;
+// CHECK-NEXT:                     _d_res = 0;
 // CHECK-NEXT:                     *_d_i += _r_d1 * j;
 // CHECK-NEXT:                     *_d_j += i * _r_d1;
 // CHECK-NEXT:                 }
@@ -2417,13 +2417,13 @@ double fn31(double i, double j) {
 //CHECK-NEXT:                _d_res += 0;
 //CHECK-NEXT:                res = clad::pop(_t1);
 //CHECK-NEXT:                double _r_d0 = _d_res;
-//CHECK-NEXT:                _d_res -= _r_d0;
+//CHECK-NEXT:                _d_res = 0;
 //CHECK-NEXT:                *_d_i += 2 * _r_d0 * j;
 //CHECK-NEXT:                *_d_j += 2 * i * _r_d0;
 //CHECK-NEXT:                _d_res += 0;
 //CHECK-NEXT:                res = clad::pop(_t2);
 //CHECK-NEXT:                double _r_d1 = _d_res;
-//CHECK-NEXT:                _d_res -= _r_d1;
+//CHECK-NEXT:                _d_res = 0;
 //CHECK-NEXT:                *_d_i += _r_d1 * j;
 //CHECK-NEXT:                *_d_j += i * _r_d1;
 //CHECK-NEXT:            }
@@ -2672,7 +2672,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:            if (!_t0 || (clad::back(_t4) != 1 && clad::back(_t4) != 2)) {
 //CHECK-NEXT:                res = clad::pop(_t1);
 //CHECK-NEXT:                double _r_d0 = _d_res;
-//CHECK-NEXT:                _d_res -= _r_d0;
+//CHECK-NEXT:                _d_res = 0;
 //CHECK-NEXT:                *_d_i += _r_d0 * j;
 //CHECK-NEXT:                *_d_j += i * _r_d0;
 //CHECK-NEXT:            }
@@ -2694,7 +2694,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:                        if (clad::back(_cond4)) {
 //CHECK-NEXT:                            _cond3 = clad::pop(_t5);
 //CHECK-NEXT:                            double _r_d3 = _d_cond3;
-//CHECK-NEXT:                            _d_cond3 -= _r_d3;
+//CHECK-NEXT:                            _d_cond3 = 0;
 //CHECK-NEXT:                            _d_res += _r_d3;
 //CHECK-NEXT:                            res = clad::pop(_t6);
 //CHECK-NEXT:                            double _r_d4 = _d_res;
@@ -2716,7 +2716,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:                        if (clad::back(_cond1)) {
 //CHECK-NEXT:                            _cond0 = clad::pop(_t3);
 //CHECK-NEXT:                            double _r_d2 = _d_cond0;
-//CHECK-NEXT:                            _d_cond0 -= _r_d2;
+//CHECK-NEXT:                            _d_cond0 = 0;
 //CHECK-NEXT:                        }
 //CHECK-NEXT:                        clad::pop(_cond1);
 //CHECK-NEXT:                        {

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -611,13 +611,13 @@ int main() {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t1;
 // CHECK-NEXT:         double _r_d1 = (*_d_this).x;
-// CHECK-NEXT:         (*_d_this).x -= _r_d1;
+// CHECK-NEXT:         (*_d_this).x = 0;
 // CHECK-NEXT:         *_d_i += -_r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t0;
 // CHECK-NEXT:         double _r_d0 = (*_d_this).x;
-// CHECK-NEXT:         (*_d_this).x -= _r_d0;
+// CHECK-NEXT:         (*_d_this).x = 0;
 // CHECK-NEXT:         *_d_i += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -35,7 +35,7 @@ double minimalPointer(double x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *p = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_p;
-// CHECK-NEXT:         *_d_p -= _r_d0;
+// CHECK-NEXT:         *_d_p = 0;
 // CHECK-NEXT:         *_d_p += _r_d0 * (*p);
 // CHECK-NEXT:         *_d_p += *p * _r_d0;
 // CHECK-NEXT:     }
@@ -375,14 +375,14 @@ double newAndDeletePointer(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         r[1] = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_r[1];
-// CHECK-NEXT:         _d_r[1] -= _r_d1;
+// CHECK-NEXT:         _d_r[1] = 0;
 // CHECK-NEXT:         *_d_i += _r_d1 * j;
 // CHECK-NEXT:         *_d_j += i * _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         r[0] = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_r[0];
-// CHECK-NEXT:         _d_r[0] -= _r_d0;
+// CHECK-NEXT:         _d_r[0] = 0;
 // CHECK-NEXT:         *_d_i += _r_d0;
 // CHECK-NEXT:         *_d_j += _r_d0;
 // CHECK-NEXT:     }
@@ -475,7 +475,7 @@ double cStyleMemoryAlloc(double x, size_t n) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         p[1] = _t4;
 // CHECK-NEXT:         double _r_d2 = _d_p[1];
-// CHECK-NEXT:         _d_p[1] -= _r_d2;
+// CHECK-NEXT:         _d_p[1] = 0;
 // CHECK-NEXT:         *_d_x += 2 * _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -489,13 +489,13 @@ double cStyleMemoryAlloc(double x, size_t n) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *p = _t1;
 // CHECK-NEXT:         double _r_d1 = *_d_p;
-// CHECK-NEXT:         *_d_p -= _r_d1;
+// CHECK-NEXT:         *_d_p = 0;
 // CHECK-NEXT:         *_d_x += _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t->x = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_t->x;
-// CHECK-NEXT:         _d_t->x -= _r_d0;
+// CHECK-NEXT:         _d_t->x = 0;
 // CHECK-NEXT:         *_d_x += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     free(p);

--- a/test/Gradient/Switch.C
+++ b/test/Gradient/Switch.C
@@ -549,7 +549,7 @@ double fn6(double u, double v) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     temp = _t1;
 // CHECK-NEXT:                     double _r_d1 = _d_temp;
-// CHECK-NEXT:                     _d_temp -= _r_d1;
+// CHECK-NEXT:                     _d_temp = 0;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (true)
 // CHECK-NEXT:                     break;
@@ -558,7 +558,7 @@ double fn6(double u, double v) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = _t0;
 // CHECK-NEXT:             int _r_d0 = _d_res;
-// CHECK-NEXT:             _d_res -= _r_d0;
+// CHECK-NEXT:             _d_res = 0;
 // CHECK-NEXT:             *_d_u += _r_d0 * v;
 // CHECK-NEXT:             *_d_v += u * _r_d0;
 // CHECK-NEXT:         }

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -43,7 +43,7 @@ void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a);
 // CHECK-NEXT:         {
 // CHECK-NEXT:             z = clad::pop(_t1);
 // CHECK-NEXT:             float _r_d0 = *_d_z;
-// CHECK-NEXT:             *_d_z -= _r_d0;
+// CHECK-NEXT:             *_d_z = 0;
 // CHECK-NEXT:             *_d_z += _r_d0 * a;
 // CHECK-NEXT:             *_d_a += z * _r_d0;
 // CHECK-NEXT:         }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -117,14 +117,14 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t.data[1] = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_t.data[1];
-// CHECK-NEXT:         _d_t.data[1] -= _r_d1;
+// CHECK-NEXT:         _d_t.data[1] = 0;
 // CHECK-NEXT:         *_d_i += 5 * _r_d1;
 // CHECK-NEXT:         *_d_j += 3 * _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t.data[0] = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_t.data[0];
-// CHECK-NEXT:         _d_t.data[0] -= _r_d0;
+// CHECK-NEXT:         _d_t.data[0] = 0;
 // CHECK-NEXT:         *_d_i += 2 * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -469,7 +469,7 @@ int main() {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{(__real)?}} this->[[_M_value:.*]] = _t0;
 // CHECK-NEXT:         double _r_d0 ={{( __real)?}} (*_d_this).[[_M_value]];
-// CHECK-NEXT:         {{(__real)?}} (*_d_this).[[_M_value]] -= _r_d0;
+// CHECK-NEXT:         {{(__real)?}} (*_d_this).[[_M_value]] = 0;
 // CHECK-NEXT:         *[[_d___val]] += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -505,7 +505,7 @@ int main() {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         this->data[i] = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = (*_d_this).data[i];
-// CHECK-NEXT:         (*_d_this).data[i] -= _r_d0;
+// CHECK-NEXT:         (*_d_this).data[i] = 0;
 // CHECK-NEXT:         *_d_d += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -134,7 +134,7 @@
 //CHECK_FLOAT_SUM:            _final_error += std::abs(_d_sum * sum * 1.1920928955078125E-7);
 //CHECK_FLOAT_SUM:            sum = clad::pop(_t1);
 //CHECK_FLOAT_SUM:            float _r_d0 = _d_sum;
-//CHECK_FLOAT_SUM:            _d_sum -= _r_d0;
+//CHECK_FLOAT_SUM:            _d_sum = 0;
 //CHECK_FLOAT_SUM:            _d_sum += _r_d0;
 //CHECK_FLOAT_SUM:            *_d_x += _r_d0;
 //CHECK_FLOAT_SUM:        }
@@ -167,7 +167,7 @@
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        _final_error += _d_z * z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        z = _t0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        float _r_d0 = _d_z;
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:        _d_z -= _r_d0;
+// CHECK_CUSTOM_MODEL_EXEC-NEXT:        _d_z = 0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        *_d_x += _r_d0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        *_d_y += _r_d0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    }
@@ -199,7 +199,7 @@
 // CHECK_PRINT_MODEL_EXEC-NEXT:        _final_error += clad::getErrorVal(_d_z, z, "z");
 // CHECK_PRINT_MODEL_EXEC-NEXT:        z = _t0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:        float _r_d0 = _d_z;
-// CHECK_PRINT_MODEL_EXEC-NEXT:        _d_z -= _r_d0;
+// CHECK_PRINT_MODEL_EXEC-NEXT:        _d_z = 0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:        *_d_x += _r_d0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:        *_d_y += _r_d0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    }


### PR DESCRIPTION
Currently, when we set the LHS of an assignment to 0 in the reverse mode, we do this by
```
float _r_d1 = *_d_y;
*_d_y -= _r_d1;
```
This PR simplifies this process to
```
float _r_d1 = *_d_y;
*_d_y = 0;
```