### PR TITLE
Use initialization instead of assignment when possible in the reverse mode

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -268,14 +268,18 @@ namespace clad {
     struct DelayedStoreResult {
       ReverseModeVisitor& V;
       StmtDiff Result;
+      clang::VarDecl* Declaration;
       bool isConstant;
       bool isInsideLoop;
+      bool isFnScope;
       bool needsUpdate;
       DelayedStoreResult(ReverseModeVisitor& pV, StmtDiff pResult,
-                         bool pIsConstant, bool pIsInsideLoop,
+                         clang::VarDecl* pDeclaration, bool pIsConstant,
+                         bool pIsInsideLoop, bool pIsFnScope,
                          bool pNeedsUpdate = false)
-          : V(pV), Result(pResult), isConstant(pIsConstant),
-            isInsideLoop(pIsInsideLoop), needsUpdate(pNeedsUpdate) {}
+          : V(pV), Result(pResult), Declaration(pDeclaration),
+            isConstant(pIsConstant), isInsideLoop(pIsInsideLoop),
+            isFnScope(pIsFnScope), needsUpdate(pNeedsUpdate) {}
       void Finalize(clang::Expr* New);
     };
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -81,9 +81,15 @@ namespace clad {
     /// type.
     static clang::QualType
     getNonConstType(clang::QualType T, clang::ASTContext& C, clang::Sema& S) {
-        clang::Qualifiers quals(T.getQualifiers());
-        quals.removeConst();
-        return S.BuildQualifiedType(T.getUnqualifiedType(), noLoc, quals);
+      bool isLValueRefType = T->isLValueReferenceType();
+      T = T.getNonReferenceType();
+      clang::Qualifiers quals(T.getQualifiers());
+      quals.removeConst();
+      clang::QualType nonConstType =
+          S.BuildQualifiedType(T.getUnqualifiedType(), noLoc, quals);
+      if (isLValueRefType)
+        return C.getLValueReferenceType(nonConstType);
+      return nonConstType;
     }
     // Function to Differentiate with Clad as Backend
     void DifferentiateWithClad();

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2789,7 +2789,8 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
           derivedVDE = BuildDeclRef(reverseSweepDerivativePointerE);
         }
       } else {
-        VDDerived->setInit(initDiff.getExpr_dx());
+        m_Sema.AddInitializerToDecl(VDDerived, initDiff.getExpr_dx(), true);
+        VDDerived->setInitStyle(VarDecl::InitializationStyle::CInit);
       }
     }
     if (derivedVDE)
@@ -2951,7 +2952,9 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
                   decl, Clone(getArraySizeExpr(AT, m_Context, *this)), true);
               decl->setInitStyle(VarDecl::InitializationStyle::CallInit);
             } else {
-              decl->setInit(getZeroInit(VD->getType()));
+              m_Sema.AddInitializerToDecl(decl, getZeroInit(VD->getType()),
+                                          /*DirectInit=*/true);
+              decl->setInitStyle(VarDecl::InitializationStyle::CInit);
             }
           }
         }

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -38,12 +38,12 @@ float func(float* a, float* b) {
 }
 
 //CHECK: void func_grad(float *a, float *b, float *_d_a, float *_d_b) {
-//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
+//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
@@ -93,11 +93,11 @@ float func2(float* a) {
 }
 
 //CHECK: void func2_grad(float *a, float *_d_a) {
-//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
+//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
@@ -132,12 +132,12 @@ float func3(float* a, float* b) {
 }
 
 //CHECK: void func3_grad(float *a, float *b, float *_d_a, float *_d_b) {
-//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
+//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
@@ -176,13 +176,13 @@ double func4(double x) {
 }
 
 //CHECK: void func4_grad(double x, double *_d_x) {
-//CHECK-NEXT:     double _d_arr[3] = {0};
-//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     double arr[3] = {x, 2 * x, x * x};
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
@@ -234,16 +234,15 @@ double func5(int k) {
 }
 
 //CHECK: void func5_grad(int k, int *_d_k) {
-//CHECK-NEXT:     int _d_n = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
-//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t2;
 //CHECK-NEXT:     int _d_i0 = 0;
 //CHECK-NEXT:     int i0 = 0;
 //CHECK-NEXT:     clad::tape<double> _t3 = {};
+//CHECK-NEXT:     int _d_n = 0;
 //CHECK-NEXT:     int n = k;
 //CHECK-NEXT:     double _d_arr[n];
 //CHECK-NEXT:     clad::zero_init(_d_arr, n);
@@ -258,6 +257,7 @@ double func5(int k) {
 //CHECK-NEXT:         clad::push(_t1, arr[i]);
 //CHECK-NEXT:         arr[i] = k;
 //CHECK-NEXT:     }
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _t2 = {{0U|0UL}};
 //CHECK-NEXT:     for (i0 = 0; ; i0++) {
@@ -310,7 +310,6 @@ double func6(double seed) {
 }
 
 //CHECK: void func6_grad(double seed, double *_d_seed) {
-//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
@@ -318,6 +317,7 @@ double func6(double seed) {
 //CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     clad::array<double> arr({{3U|3UL}});
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
@@ -371,7 +371,6 @@ double func7(double *params) {
 }
 
 //CHECK: void func7_grad(double *params, double *_d_params) {
-//CHECK-NEXT:     double _d_out = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     std::size_t _d_i = 0;
 //CHECK-NEXT:     std::size_t i = 0;
@@ -379,6 +378,7 @@ double func7(double *params) {
 //CHECK-NEXT:     double _d_paramsPrime[1] = {0};
 //CHECK-NEXT:     clad::array<double> paramsPrime({{1U|1UL}});
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
+//CHECK-NEXT:     double _d_out = 0;
 //CHECK-NEXT:     double out = 0.;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
@@ -428,10 +428,10 @@ double func8(double i, double *arr, int n) {
 }
 
 //CHECK: void func8_grad(double i, double *arr, int n, double *_d_i, double *_d_arr, int *_d_n) {
-//CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     double _t1;
 //CHECK-NEXT:     double _t2;
+//CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     _t0 = arr[0];
 //CHECK-NEXT:     arr[0] = 1;
@@ -478,11 +478,11 @@ double func9(double i, double j) {
 
 
 //CHECK: void func9_grad(double i, double j, double *_d_i, double *_d_j) {
-//CHECK-NEXT:     double _d_arr[5] = {0};
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_idx = 0;
 //CHECK-NEXT:     int idx = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     double _d_arr[5] = {0};
 //CHECK-NEXT:     double arr[5] = {};
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (idx = 0; ; ++idx) {
@@ -534,12 +534,12 @@ double func10(double *arr, int n) {
 
 //CHECK: void func10_grad_0(double *arr, int n, double *_d_arr) {
 //CHECK-NEXT:     int _d_n = 0;
-//CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
+//CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
@@ -636,11 +636,11 @@ int main() {
 }
 
 //CHECK: void addArr_pullback(const double *arr, int n, double _d_y, double *_d_arr, int *_d_n) {
-//CHECK-NEXT:     double _d_ret = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     double _d_ret = 0;
 //CHECK-NEXT:     double ret = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -38,14 +38,13 @@ float func(float* a, float* b) {
 }
 
 //CHECK: void func_grad(float *a, float *b, float *_d_a, float *_d_b) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -93,13 +92,12 @@ float func2(float* a) {
 }
 
 //CHECK: void func2_grad(float *a, float *_d_a) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -132,14 +130,13 @@ float func3(float* a, float* b) {
 }
 
 //CHECK: void func3_grad(float *a, float *b, float *_d_a, float *_d_b) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -176,7 +173,6 @@ double func4(double x) {
 }
 
 //CHECK: void func4_grad(double x, double *_d_x) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
@@ -184,7 +180,7 @@ double func4(double x) {
 //CHECK-NEXT:     double arr[3] = {x, 2 * x, x * x};
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -234,11 +230,9 @@ double func5(int k) {
 }
 
 //CHECK: void func5_grad(int k, int *_d_k) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
-//CHECK-NEXT:     unsigned {{int|long}} _t2;
 //CHECK-NEXT:     int _d_i0 = 0;
 //CHECK-NEXT:     int i0 = 0;
 //CHECK-NEXT:     clad::tape<double> _t3 = {};
@@ -247,7 +241,7 @@ double func5(int k) {
 //CHECK-NEXT:     double _d_arr[n];
 //CHECK-NEXT:     clad::zero_init(_d_arr, n);
 //CHECK-NEXT:     double arr[n];
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -259,7 +253,7 @@ double func5(int k) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t2 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t2 = {{0U|0UL}};
 //CHECK-NEXT:     for (i0 = 0; ; i0++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i0 < 3))
@@ -310,7 +304,6 @@ double func6(double seed) {
 }
 
 //CHECK: void func6_grad(double seed, double *_d_seed) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
@@ -319,7 +312,7 @@ double func6(double seed) {
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -371,7 +364,6 @@ double func7(double *params) {
 }
 
 //CHECK: void func7_grad(double *params, double *_d_params) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     std::size_t _d_i = 0;
 //CHECK-NEXT:     std::size_t i = 0;
 //CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
@@ -380,7 +372,7 @@ double func7(double *params) {
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     double _d_out = 0;
 //CHECK-NEXT:     double out = 0.;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 1))
@@ -428,16 +420,13 @@ double func8(double i, double *arr, int n) {
 }
 
 //CHECK: void func8_grad(double i, double *arr, int n, double *_d_i, double *_d_arr, int *_d_n) {
-//CHECK-NEXT:     double _t0;
-//CHECK-NEXT:     double _t1;
-//CHECK-NEXT:     double _t2;
 //CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double res = 0;
-//CHECK-NEXT:     _t0 = arr[0];
+//CHECK-NEXT:     double _t0 = arr[0];
 //CHECK-NEXT:     arr[0] = 1;
-//CHECK-NEXT:     _t1 = res;
+//CHECK-NEXT:     double _t1 = res;
 //CHECK-NEXT:     res = helper2(i, arr, n);
-//CHECK-NEXT:     _t2 = arr[0];
+//CHECK-NEXT:     double _t2 = arr[0];
 //CHECK-NEXT:     arr[0] = 5;
 //CHECK-NEXT:     _d_res += 1;
 //CHECK-NEXT:     {
@@ -478,13 +467,12 @@ double func9(double i, double j) {
 
 
 //CHECK: void func9_grad(double i, double j, double *_d_i, double *_d_j) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_idx = 0;
 //CHECK-NEXT:     int idx = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_arr[5] = {0};
 //CHECK-NEXT:     double arr[5] = {};
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (idx = 0; ; ++idx) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(idx < 5))
@@ -534,14 +522,13 @@ double func10(double *arr, int n) {
 
 //CHECK: void func10_grad_0(double *arr, int n, double *_d_arr) {
 //CHECK-NEXT:     int _d_n = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double res = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -636,13 +623,12 @@ int main() {
 }
 
 //CHECK: void addArr_pullback(const double *arr, int n, double _d_y, double *_d_arr, int *_d_n) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_ret = 0;
 //CHECK-NEXT:     double ret = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -672,8 +658,7 @@ int main() {
 // CHECK-NEXT: }
 
 //CHECK: void inv_square_pullback(double *params, double _d_y, double *_d_params) {
-//CHECK-NEXT:     double _t0;
-//CHECK-NEXT:     _t0 = (params[0] * params[0]);
+//CHECK-NEXT:     double _t0 = (params[0] * params[0]);
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = _d_y * -(1 / (_t0 * _t0));
 //CHECK-NEXT:         _d_params[0] += _r0 * params[0];
@@ -689,8 +674,7 @@ int main() {
 //CHECK-NEXT: }
 
 //CHECK: void modify_pullback(double &elem, double val, double *_d_elem, double *_d_val) {
-//CHECK-NEXT:     double _t0;
-//CHECK-NEXT:     _t0 = elem;
+//CHECK-NEXT:     double _t0 = elem;
 //CHECK-NEXT:     elem = val;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         elem = _t0;
@@ -701,8 +685,7 @@ int main() {
 //CHECK-NEXT: }
 
 //CHECK: void sq_pullback(double &elem, double _d_y, double *_d_elem) {
-//CHECK-NEXT:     double _t0;
-//CHECK-NEXT:     _t0 = elem;
+//CHECK-NEXT:     double _t0 = elem;
 //CHECK-NEXT:     elem = elem * elem;
 //CHECK-NEXT:     *_d_elem += _d_y;
 //CHECK-NEXT:     {

--- a/test/Arrays/Arrays.C
+++ b/test/Arrays/Arrays.C
@@ -93,8 +93,8 @@ double const_dot_product(double x, double y, double z) {
 
 //CHECK:   void const_dot_product_grad(double x, double y, double z, double *_d_x, double *_d_y, double *_d_z) {
 //CHECK-NEXT:       double _d_vars[3] = {0};
-//CHECK-NEXT:       double _d_consts[3] = {0};
 //CHECK-NEXT:       double vars[3] = {x, y, z};
+//CHECK-NEXT:       double _d_consts[3] = {0};
 //CHECK-NEXT:       double consts[3] = {1, 2, 3};
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_vars[0] += 1 * consts[0];

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -31,18 +31,12 @@ __device__ __host__ double gauss(double* x, double* p, double sigma, int dim) {
 // CHECK:    void gauss_grad_1(double *x, double *p, double sigma, int dim, double *_d_p) __attribute__((device)) __attribute__((host)) {
 //CHECK-NEXT:     double _d_sigma = 0;
 //CHECK-NEXT:     int _d_dim = 0;
-//CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
-//CHECK-NEXT:     double _t2;
-//CHECK-NEXT:     double _t3;
-//CHECK-NEXT:     double _t4;
-//CHECK-NEXT:     double _t5;
-//CHECK-NEXT:     double _t6;
 //CHECK-NEXT:     double _d_t = 0;
 //CHECK-NEXT:     double t = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned long _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             if (!(i < dim))
@@ -52,12 +46,12 @@ __device__ __host__ double gauss(double* x, double* p, double sigma, int dim) {
 //CHECK-NEXT:         clad::push(_t1, t);
 //CHECK-NEXT:         t += (x[i] - p[i]) * (x[i] - p[i]);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _t2 = t;
-//CHECK-NEXT:     _t3 = (2 * sigma * sigma);
+//CHECK-NEXT:     double _t2 = t;
+//CHECK-NEXT:     double _t3 = (2 * sigma * sigma);
 //CHECK-NEXT:     t = -t / _t3;
-//CHECK-NEXT:     _t6 = std::pow(2 * 3.1415926535897931, -dim / 2.);
-//CHECK-NEXT:     _t5 = std::pow(sigma, -0.5);
-//CHECK-NEXT:     _t4 = std::exp(t);
+//CHECK-NEXT:     double _t6 = std::pow(2 * 3.1415926535897931, -dim / 2.);
+//CHECK-NEXT:     double _t5 = std::pow(sigma, -0.5);
+//CHECK-NEXT:     double _t4 = std::exp(t);
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r1 = 0;
 //CHECK-NEXT:         double _r2 = 0;

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -31,7 +31,6 @@ __device__ __host__ double gauss(double* x, double* p, double sigma, int dim) {
 // CHECK:    void gauss_grad_1(double *x, double *p, double sigma, int dim, double *_d_p) __attribute__((device)) __attribute__((host)) {
 //CHECK-NEXT:     double _d_sigma = 0;
 //CHECK-NEXT:     int _d_dim = 0;
-//CHECK-NEXT:     double _d_t = 0;
 //CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
@@ -41,6 +40,7 @@ __device__ __host__ double gauss(double* x, double* p, double sigma, int dim) {
 //CHECK-NEXT:     double _t4;
 //CHECK-NEXT:     double _t5;
 //CHECK-NEXT:     double _t6;
+//CHECK-NEXT:     double _d_t = 0;
 //CHECK-NEXT:     double t = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -86,8 +86,8 @@ float func4(float x, float y) {
 }
 
 //CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     double _d_z = 0;
 //CHECK-NEXT:     float _t0;
+//CHECK-NEXT:     double _d_z = 0;
 //CHECK-NEXT:     double z = y;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = z + y;
@@ -112,8 +112,8 @@ float func5(float x, float y) {
 }
 
 //CHECK: void func5_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     int _d_z = 0;
 //CHECK-NEXT:     float _t0;
+//CHECK-NEXT:     int _d_z = 0;
 //CHECK-NEXT:     int z = 56;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = z + y;

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -13,11 +13,9 @@ float func(float x, float y) {
 }
 
 //CHECK: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _t0;
-//CHECK-NEXT:     float _t1;
-//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     float _t0 = x;
 //CHECK-NEXT:     x = x + y;
-//CHECK-NEXT:     _t1 = y;
+//CHECK-NEXT:     float _t1 = y;
 //CHECK-NEXT:     y = x;
 //CHECK-NEXT:     *_d_y += 1;
 //CHECK-NEXT:     {
@@ -44,8 +42,7 @@ float func2(float x, int y) {
 }
 
 //CHECK: void func2_grad(float x, int y, float *_d_x, int *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _t0;
-//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     float _t0 = x;
 //CHECK-NEXT:     x = y * x + x * x;
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
@@ -67,8 +64,7 @@ float func3(int x, int y) {
 }
 
 //CHECK: void func3_grad(int x, int y, int *_d_x, int *_d_y, double &_final_error) {
-//CHECK-NEXT:     int _t0;
-//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     int _t0 = x;
 //CHECK-NEXT:     x = y;
 //CHECK-NEXT:     *_d_y += 1;
 //CHECK-NEXT:     {
@@ -86,10 +82,9 @@ float func4(float x, float y) {
 }
 
 //CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     double _d_z = 0;
 //CHECK-NEXT:     double z = y;
-//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     float _t0 = x;
 //CHECK-NEXT:     x = z + y;
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
@@ -112,10 +107,9 @@ float func5(float x, float y) {
 }
 
 //CHECK: void func5_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     int _d_z = 0;
 //CHECK-NEXT:     int z = 56;
-//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     float _t0 = x;
 //CHECK-NEXT:     x = z + y;
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
@@ -157,8 +151,7 @@ float func8(int x, int y) {
 }
 
 //CHECK: void func8_grad(int x, int y, int *_d_x, int *_d_y, double &_final_error) {
-//CHECK-NEXT:     int _t0;
-//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     int _t0 = x;
 //CHECK-NEXT:     x = y * y;
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -14,11 +14,9 @@ float func(float x, float y) {
 }
 
 //CHECK: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _t0;
-//CHECK-NEXT:     float _t1;
-//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     float _t0 = x;
 //CHECK-NEXT:     x = x + y;
-//CHECK-NEXT:     _t1 = y;
+//CHECK-NEXT:     float _t1 = y;
 //CHECK-NEXT:     y = y + y++ + y;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z = y * x;
@@ -60,8 +58,7 @@ float func2(float x, float y) {
 }
 
 //CHECK: void func2_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _t0;
-//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     float _t0 = x;
 //CHECK-NEXT:     x = x - y - y * y;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z = y / x;
@@ -96,15 +93,12 @@ float func3(float x, float y) {
 }
 
 //CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _t0;
-//CHECK-NEXT:     float _t1;
-//CHECK-NEXT:     float _t2;
-//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     float _t0 = x;
 //CHECK-NEXT:     x = x - y - y * y;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z = y;
-//CHECK-NEXT:     _t2 = y;
-//CHECK-NEXT:     _t1 = (y = x + x);
+//CHECK-NEXT:     float _t2 = y;
+//CHECK-NEXT:     float _t1 = (y = x + x);
 //CHECK-NEXT:     float _d_t = 0;
 //CHECK-NEXT:     float t = x * z * _t1;
 //CHECK-NEXT:     _d_t += 1;
@@ -160,9 +154,8 @@ float func5(float x, float y) {
 }
 
 //CHECK: void func5_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     double _ret_value0 = 0;
-//CHECK-NEXT:     _t0 = y;
+//CHECK-NEXT:     float _t0 = y;
 //CHECK-NEXT:     y = std::sin(x);
 //CHECK-NEXT:     _ret_value0 = y * y;
 //CHECK-NEXT:     {
@@ -262,12 +255,10 @@ float func8(float x, float y) {
 }
 
 //CHECK: void func8_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _t0;
-//CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z;
-//CHECK-NEXT:     _t0 = z;
-//CHECK-NEXT:     _t1 = x;
+//CHECK-NEXT:     float _t0 = z;
+//CHECK-NEXT:     float _t1 = x;
 //CHECK-NEXT:     z = y + helper2(x);
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
@@ -292,20 +283,14 @@ float func9(float x, float y) {
 }
 
 //CHECK: void func9_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _t1;
-//CHECK-NEXT:     float _t3;
-//CHECK-NEXT:     double _t4;
-//CHECK-NEXT:     float _t5;
-//CHECK-NEXT:     double _t7;
-//CHECK-NEXT:     float _t8;
-//CHECK-NEXT:     _t1 = x;
+//CHECK-NEXT:     float _t1 = x;
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z = helper(x, y) + helper2(x);
-//CHECK-NEXT:     _t3 = z;
-//CHECK-NEXT:     _t5 = x;
-//CHECK-NEXT:     _t7 = helper2(x);
-//CHECK-NEXT:     _t8 = y;
-//CHECK-NEXT:     _t4 = helper2(y);
+//CHECK-NEXT:     float _t3 = z;
+//CHECK-NEXT:     float _t5 = x;
+//CHECK-NEXT:     double _t7 = helper2(x);
+//CHECK-NEXT:     float _t8 = y;
+//CHECK-NEXT:     double _t4 = helper2(y);
 //CHECK-NEXT:     z += _t7 * _t4;
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -16,11 +16,11 @@ float func(float x, float y) {
 //CHECK: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = x + y;
 //CHECK-NEXT:     _t1 = y;
 //CHECK-NEXT:     y = y + y++ + y;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z = y * x;
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
@@ -61,9 +61,9 @@ float func2(float x, float y) {
 
 //CHECK: void func2_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
 //CHECK-NEXT:     float _t0;
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = x - y - y * y;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z = y / x;
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
@@ -97,15 +97,15 @@ float func3(float x, float y) {
 
 //CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
 //CHECK-NEXT:     float _t0;
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     float _t2;
-//CHECK-NEXT:     float _d_t = 0;
 //CHECK-NEXT:     _t0 = x;
 //CHECK-NEXT:     x = x - y - y * y;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z = y;
 //CHECK-NEXT:     _t2 = y;
 //CHECK-NEXT:     _t1 = (y = x + x);
+//CHECK-NEXT:     float _d_t = 0;
 //CHECK-NEXT:     float t = x * z * _t1;
 //CHECK-NEXT:     _d_t += 1;
 //CHECK-NEXT:     {
@@ -204,8 +204,8 @@ float func6(float x, float y) {
 }
 
 //CHECK: void func6_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     double _ret_value0 = 0;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z = helper(x, y);
 //CHECK-NEXT:     _ret_value0 = z * z;
 //CHECK-NEXT:     {
@@ -262,9 +262,9 @@ float func8(float x, float y) {
 }
 
 //CHECK: void func8_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z;
 //CHECK-NEXT:     _t0 = z;
 //CHECK-NEXT:     _t1 = x;
@@ -293,13 +293,13 @@ float func9(float x, float y) {
 
 //CHECK: void func9_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
 //CHECK-NEXT:     float _t1;
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float _t3;
 //CHECK-NEXT:     double _t4;
 //CHECK-NEXT:     float _t5;
 //CHECK-NEXT:     double _t7;
 //CHECK-NEXT:     float _t8;
 //CHECK-NEXT:     _t1 = x;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z = helper(x, y) + helper2(x);
 //CHECK-NEXT:     _t3 = z;
 //CHECK-NEXT:     _t5 = x;

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -87,9 +87,9 @@ float func2(float x) {
 }
 
 //CHECK: void func2_grad(float x, float *_d_x, double &_final_error) {
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     double _ret_value0 = 0;
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z = x * x;
 //CHECK-NEXT:     {
 //CHECK-NEXT:     _cond0 = z > 9;

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -125,9 +125,8 @@ float func2(float x) {
 float func3(float x, float y) { return x > 30 ? x * y : x + y; }
 
 //CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     double _ret_value0 = 0;
-//CHECK-NEXT:     _cond0 = x > 30;
+//CHECK-NEXT:     bool _cond0 = x > 30;
 //CHECK-NEXT:     _ret_value0 = _cond0 ? x * y : x + y;
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         *_d_x += 1 * y;
@@ -147,11 +146,10 @@ float func4(float x, float y) {
 }
 
 //CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     float _t0;
 //CHECK-NEXT:     float _t1;
 //CHECK-NEXT:     double _ret_value0 = 0;
-//CHECK-NEXT:     _cond0 = !x;
+//CHECK-NEXT:     bool _cond0 = !x;
 //CHECK-NEXT:     if (_cond0)
 //CHECK-NEXT:         _t0 = x;
 //CHECK-NEXT:     else

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -15,12 +15,12 @@ float func(float* p, int n) {
 }
 
 //CHECK: void func_grad(float *p, int n, float *_d_p, int *_d_n, double &_final_error) {
-//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     unsigned {{int|long}} p_size = 0;
+//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
@@ -64,7 +64,6 @@ float func2(float x) {
 }
 
 //CHECK: void func2_grad(float x, float *_d_x, double &_final_error) {
-//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
@@ -72,6 +71,7 @@ float func2(float x) {
 //CHECK-NEXT:     float _d_m = 0;
 //CHECK-NEXT:     float m = 0;
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
+//CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
@@ -119,10 +119,10 @@ float func3(float x, float y) {
 }
 
 //CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     double _t1;
 //CHECK-NEXT:     double _t2;
+//CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     double arr[3];
 //CHECK-NEXT:     _t0 = arr[0];
 //CHECK-NEXT:     arr[0] = x + y;
@@ -169,7 +169,6 @@ float func4(float x[10], float y[10]) {
 }
 
 //CHECK: void func4_grad(float x[10], float y[10], float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
@@ -177,6 +176,7 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     unsigned {{int|long}} y_size = 0;
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
+//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -15,14 +15,13 @@ float func(float* p, int n) {
 }
 
 //CHECK: void func_grad(float *p, int n, float *_d_p, int *_d_n, double &_final_error) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     unsigned {{int|long}} p_size = 0;
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -64,7 +63,6 @@ float func2(float x) {
 }
 
 //CHECK: void func2_grad(float x, float *_d_x, double &_final_error) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
@@ -73,7 +71,7 @@ float func2(float x) {
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 9))
@@ -119,16 +117,13 @@ float func3(float x, float y) {
 }
 
 //CHECK: void func3_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     double _t0;
-//CHECK-NEXT:     double _t1;
-//CHECK-NEXT:     double _t2;
 //CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     double arr[3];
-//CHECK-NEXT:     _t0 = arr[0];
+//CHECK-NEXT:     double _t0 = arr[0];
 //CHECK-NEXT:     arr[0] = x + y;
-//CHECK-NEXT:     _t1 = arr[1];
+//CHECK-NEXT:     double _t1 = arr[1];
 //CHECK-NEXT:     arr[1] = x * x;
-//CHECK-NEXT:     _t2 = arr[2];
+//CHECK-NEXT:     double _t2 = arr[2];
 //CHECK-NEXT:     arr[2] = arr[0] + arr[1];
 //CHECK-NEXT:     _d_arr[2] += 1;
 //CHECK-NEXT:     {
@@ -169,7 +164,6 @@ float func4(float x[10], float y[10]) {
 }
 
 //CHECK: void func4_grad(float x[10], float y[10], float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     unsigned {{int|long}} x_size = 0;
@@ -178,7 +172,7 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 10))
@@ -232,17 +226,14 @@ double func5(double* x, double* y, double* output) {
 
 //CHECK: void func5_grad(double *x, double *y, double *output, double *_d_x, double *_d_y, double *_d_output, double &_final_error) {
 //CHECK-NEXT:     unsigned {{int|long}} output_size = 0;
-//CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     unsigned {{int|long}} x_size = 0;
 //CHECK-NEXT:     unsigned {{int|long}} y_size = 0;
-//CHECK-NEXT:     double _t1;
-//CHECK-NEXT:     double _t2;
 //CHECK-NEXT:     double _ret_value0 = 0;
-//CHECK-NEXT:     _t0 = output[0];
+//CHECK-NEXT:     double _t0 = output[0];
 //CHECK-NEXT:     output[0] = x[1] * y[2] - x[2] * y[1];
-//CHECK-NEXT:     _t1 = output[1];
+//CHECK-NEXT:     double _t1 = output[1];
 //CHECK-NEXT:     output[1] = x[2] * y[0] - x[0] * y[2];
-//CHECK-NEXT:     _t2 = output[2];
+//CHECK-NEXT:     double _t2 = output[2];
 //CHECK-NEXT:     output[2] = x[0] * y[1] - y[0] * x[1];
 //CHECK-NEXT:     _ret_value0 = output[0] + output[1] + output[2];
 //CHECK-NEXT:     {

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -16,12 +16,12 @@ double runningSum(float* f, int n) {
 }
 
 //CHECK: void runningSum_grad(float *f, int n, float *_d_f, int *_d_n, double &_final_error) {
-//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     unsigned {{int|long}} f_size = 0;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 1; ; i++) {
@@ -66,7 +66,6 @@ double mulSum(float* a, float* b, int n) {
 }
 
 //CHECK: void mulSum_grad(float *a, float *b, int n, float *_d_a, float *_d_b, int *_d_n, double &_final_error) {
-//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
@@ -77,6 +76,7 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     unsigned {{int|long}} a_size = 0;
 //CHECK-NEXT:     unsigned {{int|long}} b_size = 0;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
@@ -143,13 +143,13 @@ double divSum(float* a, float* b, int n) {
 }
 
 //CHECK: void divSum_grad(float *a, float *b, int n, float *_d_a, float *_d_b, int *_d_n, double &_final_error) {
-//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     unsigned {{int|long}} b_size = 0;
 //CHECK-NEXT:     unsigned {{int|long}} a_size = 0;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -16,14 +16,13 @@ double runningSum(float* f, int n) {
 }
 
 //CHECK: void runningSum_grad(float *f, int n, float *_d_f, int *_d_n, double &_final_error) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     unsigned {{int|long}} f_size = 0;
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 1; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -66,7 +65,6 @@ double mulSum(float* a, float* b, int n) {
 }
 
 //CHECK: void mulSum_grad(float *a, float *b, int n, float *_d_a, float *_d_b, int *_d_n, double &_final_error) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
@@ -78,7 +76,7 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:     unsigned {{int|long}} b_size = 0;
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -143,7 +141,6 @@ double divSum(float* a, float* b, int n) {
 }
 
 //CHECK: void divSum_grad(float *a, float *b, int n, float *_d_a, float *_d_b, int *_d_n, double &_final_error) {
-//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
@@ -151,7 +148,7 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:     unsigned {{int|long}} a_size = 0;
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -188,8 +188,7 @@ double f11(double x, double y) {
 }
 
 // CHECK: void f11_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     typename {{.*}} _t0;
-// CHECK-NEXT:     _t0 = std::pow(y - std::pow(x, 2), 2);
+// CHECK-NEXT:     typename {{.*}} _t0 = std::pow(y - std::pow(x, 2), 2);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         int _r1 = 0;

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -14,8 +14,7 @@ double f1(double x, double y) {
 }
 
 //CHECK:   void f1_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       _t0 = x;
+//CHECK-NEXT:       double _t0 = x;
 //CHECK-NEXT:       x = y;
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       {
@@ -62,17 +61,13 @@ double f3(double x, double y) {
 }
 
 //CHECK:   void f3_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       double _t3;
-//CHECK-NEXT:       _t0 = x;
+//CHECK-NEXT:       double _t0 = x;
 //CHECK-NEXT:       x = x;
-//CHECK-NEXT:       _t1 = x;
+//CHECK-NEXT:       double _t1 = x;
 //CHECK-NEXT:       x = x * x;
-//CHECK-NEXT:       _t2 = y;
+//CHECK-NEXT:       double _t2 = y;
 //CHECK-NEXT:       y = x * x;
-//CHECK-NEXT:       _t3 = x;
+//CHECK-NEXT:       double _t3 = x;
 //CHECK-NEXT:       x = y;
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       {
@@ -111,11 +106,9 @@ double f4(double x, double y) {
 }
 
 //CHECK:   void f4_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       _t0 = y;
+//CHECK-NEXT:       double _t0 = y;
 //CHECK-NEXT:       y = x;
-//CHECK-NEXT:       _t1 = x;
+//CHECK-NEXT:       double _t1 = x;
 //CHECK-NEXT:       x = 0;
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       {
@@ -278,32 +271,25 @@ double f7(double x, double y) {
 }
 
 //CHECK:   void f7_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       double _t3;
-//CHECK-NEXT:       double _t4;
-//CHECK-NEXT:       double _t5;
-//CHECK-NEXT:       double _t6;
 //CHECK-NEXT:       double _d_t[3] = {0};
 //CHECK-NEXT:       double t[3] = {1, x, x * x};
 //CHECK-NEXT:       t[0]++;
 //CHECK-NEXT:       t[0]--;
 //CHECK-NEXT:       ++t[0];
 //CHECK-NEXT:       --t[0];
-//CHECK-NEXT:       _t0 = t[0];
+//CHECK-NEXT:       double _t0 = t[0];
 //CHECK-NEXT:       t[0] = x;
-//CHECK-NEXT:       _t1 = x;
+//CHECK-NEXT:       double _t1 = x;
 //CHECK-NEXT:       x = y;
-//CHECK-NEXT:       _t2 = t[0];
+//CHECK-NEXT:       double _t2 = t[0];
 //CHECK-NEXT:       t[0] += t[1];
-//CHECK-NEXT:       _t3 = t[0];
+//CHECK-NEXT:       double _t3 = t[0];
 //CHECK-NEXT:       t[0] *= t[1];
-//CHECK-NEXT:       _t4 = t[0];
+//CHECK-NEXT:       double _t4 = t[0];
 //CHECK-NEXT:       t[0] /= t[1];
-//CHECK-NEXT:       _t5 = t[0];
+//CHECK-NEXT:       double _t5 = t[0];
 //CHECK-NEXT:       t[0] -= t[1];
-//CHECK-NEXT:       _t6 = x;
+//CHECK-NEXT:       double _t6 = x;
 //CHECK-NEXT:       x = ++t[0];
 //CHECK-NEXT:       _d_t[0] += 1;
 //CHECK-NEXT:       {
@@ -368,16 +354,12 @@ double f8(double x, double y) {
 }
 
 //CHECK: void f8_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       double _t2;
-//CHECK-NEXT:       double _t3;
 //CHECK-NEXT:       double _d_t[4] = {0};
 //CHECK-NEXT:       double t[4] = {1, x, y, 1};
-//CHECK-NEXT:       _t0 = t[3];
-//CHECK-NEXT:       _t1 = y;
-//CHECK-NEXT:       _t2 = t[0];
-//CHECK-NEXT:       _t3 = t[1];
+//CHECK-NEXT:       double _t0 = t[3];
+//CHECK-NEXT:       double _t1 = y;
+//CHECK-NEXT:       double _t2 = t[0];
+//CHECK-NEXT:       double _t3 = t[1];
 //CHECK-NEXT:       t[3] = (y *= (t[0] = t[1] = t[2]));
 //CHECK-NEXT:       _d_t[3] += 1;
 //CHECK-NEXT:       {
@@ -412,13 +394,11 @@ double f9(double x, double y) {
 }
 
 //CHECK:   void f9_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x;
-//CHECK-NEXT:       _t0 = t;
+//CHECK-NEXT:       double _t0 = t;
 //CHECK-NEXT:       (t *= x);
-//CHECK-NEXT:       _t1 = t;
+//CHECK-NEXT:       double _t1 = t;
 //CHECK-NEXT:       t *= y;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
@@ -443,12 +423,10 @@ double f10(double x, double y) {
 }
 
 //CHECK:   void f10_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x;
-//CHECK-NEXT:       _t0 = t;
-//CHECK-NEXT:       _t1 = x;
+//CHECK-NEXT:       double _t0 = t;
+//CHECK-NEXT:       double _t1 = x;
 //CHECK-NEXT:       t = x = y;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
@@ -471,13 +449,11 @@ double f11(double x, double y) {
 }
 
 //CHECK:   void f11_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x;
-//CHECK-NEXT:       _t0 = t;
+//CHECK-NEXT:       double _t0 = t;
 //CHECK-NEXT:       (t = x);
-//CHECK-NEXT:       _t1 = t;
+//CHECK-NEXT:       double _t1 = t;
 //CHECK-NEXT:       t = y;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
@@ -500,20 +476,17 @@ double f12(double x, double y) {
 }
 
 //CHECK:   void f12_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       double *_t2;
-//CHECK-NEXT:       double _t3;
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t;
-//CHECK-NEXT:       _cond0 = x > y;
+//CHECK-NEXT:       bool _cond0 = x > y;
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:           _t0 = t;
 //CHECK-NEXT:       else
 //CHECK-NEXT:           _t1 = t;
-//CHECK-NEXT:       _t2 = &(_cond0 ? (t = x) : (t = y));
-//CHECK-NEXT:       _t3 = *_t2;
+//CHECK-NEXT:       double *_t2 = &(_cond0 ? (t = x) : (t = y));
+//CHECK-NEXT:       double _t3 = *_t2;
 //CHECK-NEXT:       *_t2 *= y;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
@@ -542,10 +515,8 @@ double f13(double x, double y) {
 }
 
 //CHECK:   void f13_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       _t1 = y;
-//CHECK-NEXT:       _t0 = (y = x);
+//CHECK-NEXT:       double _t1 = y;
+//CHECK-NEXT:       double _t0 = (y = x);
 //CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x * _t0;
 //CHECK-NEXT:       {
@@ -571,16 +542,13 @@ double f14(double i, double j) {
 }
 
 // CHECK: void f14_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     double &_d_a = *_d_i;
 // CHECK-NEXT:     double &a = i;
-// CHECK-NEXT:     _t0 = a;
+// CHECK-NEXT:     double _t0 = a;
 // CHECK-NEXT:     a = 2 * i;
-// CHECK-NEXT:     _t1 = a;
+// CHECK-NEXT:     double _t1 = a;
 // CHECK-NEXT:     a += i;
-// CHECK-NEXT:     _t2 = a;
+// CHECK-NEXT:     double _t2 = a;
 // CHECK-NEXT:     a *= i;
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
@@ -616,10 +584,6 @@ double f15(double i, double j) {
 }
 
 // CHECK: void f15_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     double _t2;
-// CHECK-NEXT:     double _t3;
 // CHECK-NEXT:     double _d_b = 0;
 // CHECK-NEXT:     double b = i * j;
 // CHECK-NEXT:     double &_d_a = _d_b;
@@ -628,13 +592,13 @@ double f15(double i, double j) {
 // CHECK-NEXT:     double &c = i;
 // CHECK-NEXT:     double &_d_d = *_d_j;
 // CHECK-NEXT:     double &d = j;
-// CHECK-NEXT:     _t0 = a;
+// CHECK-NEXT:     double _t0 = a;
 // CHECK-NEXT:     a *= i;
-// CHECK-NEXT:     _t1 = b;
+// CHECK-NEXT:     double _t1 = b;
 // CHECK-NEXT:     b += 2 * i;
-// CHECK-NEXT:     _t2 = c;
+// CHECK-NEXT:     double _t2 = c;
 // CHECK-NEXT:     c += 3 * i;
-// CHECK-NEXT:     _t3 = d;
+// CHECK-NEXT:     double _t3 = d;
 // CHECK-NEXT:     d *= 3 * j;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_a += 1;
@@ -680,14 +644,13 @@ double f16(double i, double j) {
 }
 
 // CHECK: void f16_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double &_d_a = *_d_i;
 // CHECK-NEXT:     double &a = i;
 // CHECK-NEXT:     double &_d_b = _d_a;
 // CHECK-NEXT:     double &b = a;
 // CHECK-NEXT:     double &_d_c = _d_b;
 // CHECK-NEXT:     double &c = b;
-// CHECK-NEXT:     _t0 = c;
+// CHECK-NEXT:     double _t0 = c;
 // CHECK-NEXT:     c *= 4 * j;
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
@@ -707,8 +670,7 @@ double f17(double i, double j, double k) {
 // CHECK: void f17_grad_0(double i, double j, double k, double *_d_i) {
 // CHECK-NEXT:     double _d_j = 0;
 // CHECK-NEXT:     double _d_k = 0;
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _t0 = j;
+// CHECK-NEXT:     double _t0 = j;
 // CHECK-NEXT:     j = 2 * i;
 // CHECK-NEXT:     _d_j += 1;
 // CHECK-NEXT:     {
@@ -727,11 +689,9 @@ double f18(double i, double j, double k) {
 
 // CHECK: void f18_grad_0_1(double i, double j, double k, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_k = 0;
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     _t0 = k;
+// CHECK-NEXT:     double _t0 = k;
 // CHECK-NEXT:     k = 2 * i + 2 * j;
-// CHECK-NEXT:     _t1 = k;
+// CHECK-NEXT:     double _t1 = k;
 // CHECK-NEXT:     k += i;
 // CHECK-NEXT:     _d_k += 1;
 // CHECK-NEXT:     {
@@ -772,13 +732,11 @@ double f20(double x, double y) {
 }
 
 //CHECK: void f20_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     double _t0;
-//CHECK-NEXT:     double _t1;
 //CHECK-NEXT:     double &_d_r = *_d_x;
 //CHECK-NEXT:     double &r = x;
-//CHECK-NEXT:     _t0 = r;
+//CHECK-NEXT:     double _t0 = r;
 //CHECK-NEXT:     r = 3;
-//CHECK-NEXT:     _t1 = x;
+//CHECK-NEXT:     double _t1 = x;
 //CHECK-NEXT:     x = r * y;
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
@@ -801,8 +759,7 @@ double f21 (double x, double y) {
 }
 
 //CHECK: void f21_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     double _t0;
-//CHECK-NEXT:     _t0 = y;
+//CHECK-NEXT:     double _t0 = y;
 //CHECK-NEXT:     y = (y++ , x);
 //CHECK-NEXT:     *_d_y += 1;
 //CHECK-NEXT:     {

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -146,13 +146,13 @@ double f5(double x, double y) {
 }
 
 //CHECK:   void f5_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       double _d_z = 0;
 //CHECK-NEXT:       double z = 0;
 //CHECK-NEXT:       double _t1;
+//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x * x;
 //CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x < 0;
@@ -211,13 +211,13 @@ double f6(double x, double y) {
 }
 
 //CHECK:   void f6_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       double _d_z = 0;
 //CHECK-NEXT:       double z = 0;
 //CHECK-NEXT:       double _t1;
+//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x * x;
 //CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x < 0;
@@ -278,7 +278,6 @@ double f7(double x, double y) {
 }
 
 //CHECK:   void f7_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _d_t[3] = {0};
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
@@ -286,6 +285,7 @@ double f7(double x, double y) {
 //CHECK-NEXT:       double _t4;
 //CHECK-NEXT:       double _t5;
 //CHECK-NEXT:       double _t6;
+//CHECK-NEXT:       double _d_t[3] = {0};
 //CHECK-NEXT:       double t[3] = {1, x, x * x};
 //CHECK-NEXT:       t[0]++;
 //CHECK-NEXT:       t[0]--;
@@ -368,11 +368,11 @@ double f8(double x, double y) {
 }
 
 //CHECK: void f8_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _d_t[4] = {0};
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _t2;
 //CHECK-NEXT:       double _t3;
+//CHECK-NEXT:       double _d_t[4] = {0};
 //CHECK-NEXT:       double t[4] = {1, x, y, 1};
 //CHECK-NEXT:       _t0 = t[3];
 //CHECK-NEXT:       _t1 = y;
@@ -412,9 +412,9 @@ double f9(double x, double y) {
 }
 
 //CHECK:   void f9_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
+//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x;
 //CHECK-NEXT:       _t0 = t;
 //CHECK-NEXT:       (t *= x);
@@ -443,9 +443,9 @@ double f10(double x, double y) {
 }
 
 //CHECK:   void f10_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
+//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x;
 //CHECK-NEXT:       _t0 = t;
 //CHECK-NEXT:       _t1 = x;
@@ -471,9 +471,9 @@ double f11(double x, double y) {
 }
 
 //CHECK:   void f11_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
+//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x;
 //CHECK-NEXT:       _t0 = t;
 //CHECK-NEXT:       (t = x);
@@ -500,12 +500,12 @@ double f12(double x, double y) {
 }
 
 //CHECK:   void f12_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double *_t2;
 //CHECK-NEXT:       double _t3;
+//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t;
 //CHECK-NEXT:       _cond0 = x > y;
 //CHECK-NEXT:       if (_cond0)
@@ -544,9 +544,9 @@ double f13(double x, double y) {
 //CHECK:   void f13_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       double _t1;
-//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       _t1 = y;
 //CHECK-NEXT:       _t0 = (y = x);
+//CHECK-NEXT:       double _d_t = 0;
 //CHECK-NEXT:       double t = x * _t0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_t += 1 * y;
@@ -571,11 +571,10 @@ double f14(double i, double j) {
 }
 
 // CHECK: void f14_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double *_d_a = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _t2;
-// CHECK-NEXT:     _d_a = &*_d_i;
+// CHECK-NEXT:     double &_d_a = *_d_i;
 // CHECK-NEXT:     double &a = i;
 // CHECK-NEXT:     _t0 = a;
 // CHECK-NEXT:     a = 2 * i;
@@ -586,20 +585,20 @@ double f14(double i, double j) {
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t2;
-// CHECK-NEXT:         double _r_d2 = *_d_a;
-// CHECK-NEXT:         *_d_a = 0;
-// CHECK-NEXT:         *_d_a += _r_d2 * i;
+// CHECK-NEXT:         double _r_d2 = _d_a;
+// CHECK-NEXT:         _d_a = 0;
+// CHECK-NEXT:         _d_a += _r_d2 * i;
 // CHECK-NEXT:         *_d_i += a * _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t1;
-// CHECK-NEXT:         double _r_d1 = *_d_a;
+// CHECK-NEXT:         double _r_d1 = _d_a;
 // CHECK-NEXT:         *_d_i += _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t0;
-// CHECK-NEXT:         double _r_d0 = *_d_a;
-// CHECK-NEXT:         *_d_a = 0;
+// CHECK-NEXT:         double _r_d0 = _d_a;
+// CHECK-NEXT:         _d_a = 0;
 // CHECK-NEXT:         *_d_i += 2 * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -617,20 +616,17 @@ double f15(double i, double j) {
 }
 
 // CHECK: void f15_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_b = 0;
-// CHECK-NEXT:     double *_d_a = 0;
-// CHECK-NEXT:     double *_d_c = 0;
-// CHECK-NEXT:     double *_d_d = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     double _t3;
+// CHECK-NEXT:     double _d_b = 0;
 // CHECK-NEXT:     double b = i * j;
-// CHECK-NEXT:     _d_a = &_d_b;
+// CHECK-NEXT:     double &_d_a = _d_b;
 // CHECK-NEXT:     double &a = b;
-// CHECK-NEXT:     _d_c = &*_d_i;
+// CHECK-NEXT:     double &_d_c = *_d_i;
 // CHECK-NEXT:     double &c = i;
-// CHECK-NEXT:     _d_d = &*_d_j;
+// CHECK-NEXT:     double &_d_d = *_d_j;
 // CHECK-NEXT:     double &d = j;
 // CHECK-NEXT:     _t0 = a;
 // CHECK-NEXT:     a *= i;
@@ -641,20 +637,20 @@ double f15(double i, double j) {
 // CHECK-NEXT:     _t3 = d;
 // CHECK-NEXT:     d *= 3 * j;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_a += 1;
-// CHECK-NEXT:         *_d_c += 1;
-// CHECK-NEXT:         *_d_d += 1;
+// CHECK-NEXT:         _d_a += 1;
+// CHECK-NEXT:         _d_c += 1;
+// CHECK-NEXT:         _d_d += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         d = _t3;
-// CHECK-NEXT:         double _r_d3 = *_d_d;
-// CHECK-NEXT:         *_d_d = 0;
-// CHECK-NEXT:         *_d_d += _r_d3 * 3 * j;
+// CHECK-NEXT:         double _r_d3 = _d_d;
+// CHECK-NEXT:         _d_d = 0;
+// CHECK-NEXT:         _d_d += _r_d3 * 3 * j;
 // CHECK-NEXT:         *_d_j += 3 * d * _r_d3;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         c = _t2;
-// CHECK-NEXT:         double _r_d2 = *_d_c;
+// CHECK-NEXT:         double _r_d2 = _d_c;
 // CHECK-NEXT:         *_d_i += 3 * _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -664,9 +660,9 @@ double f15(double i, double j) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t0;
-// CHECK-NEXT:         double _r_d0 = *_d_a;
-// CHECK-NEXT:         *_d_a = 0;
-// CHECK-NEXT:         *_d_a += _r_d0 * i;
+// CHECK-NEXT:         double _r_d0 = _d_a;
+// CHECK-NEXT:         _d_a = 0;
+// CHECK-NEXT:         _d_a += _r_d0 * i;
 // CHECK-NEXT:         *_d_i += a * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -684,24 +680,21 @@ double f16(double i, double j) {
 }
 
 // CHECK: void f16_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double *_d_a = 0;
-// CHECK-NEXT:     double *_d_b = 0;
-// CHECK-NEXT:     double *_d_c = 0;
 // CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _d_a = &*_d_i;
+// CHECK-NEXT:     double &_d_a = *_d_i;
 // CHECK-NEXT:     double &a = i;
-// CHECK-NEXT:     _d_b = &*_d_a;
+// CHECK-NEXT:     double &_d_b = _d_a;
 // CHECK-NEXT:     double &b = a;
-// CHECK-NEXT:     _d_c = &*_d_b;
+// CHECK-NEXT:     double &_d_c = _d_b;
 // CHECK-NEXT:     double &c = b;
 // CHECK-NEXT:     _t0 = c;
 // CHECK-NEXT:     c *= 4 * j;
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         c = _t0;
-// CHECK-NEXT:         double _r_d0 = *_d_c;
-// CHECK-NEXT:         *_d_c = 0;
-// CHECK-NEXT:         *_d_c += _r_d0 * 4 * j;
+// CHECK-NEXT:         double _r_d0 = _d_c;
+// CHECK-NEXT:         _d_c = 0;
+// CHECK-NEXT:         _d_c += _r_d0 * 4 * j;
 // CHECK-NEXT:         *_d_j += 4 * c * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -779,10 +772,9 @@ double f20(double x, double y) {
 }
 
 //CHECK: void f20_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     double *_d_r = 0;
 //CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     double _t1;
-//CHECK-NEXT:     _d_r = &*_d_x;
+//CHECK-NEXT:     double &_d_r = *_d_x;
 //CHECK-NEXT:     double &r = x;
 //CHECK-NEXT:     _t0 = r;
 //CHECK-NEXT:     r = 3;
@@ -793,13 +785,13 @@ double f20(double x, double y) {
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _r_d1 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
-//CHECK-NEXT:         *_d_r += _r_d1 * y;
+//CHECK-NEXT:         _d_r += _r_d1 * y;
 //CHECK-NEXT:         *_d_y += r * _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         r = _t0;
-//CHECK-NEXT:         double _r_d0 = *_d_r;
-//CHECK-NEXT:         *_d_r = 0;
+//CHECK-NEXT:         double _r_d0 = _d_r;
+//CHECK-NEXT:         _d_r = 0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -24,8 +24,8 @@ double fn1(float i) {
 
 // CHECK: void fn1_grad(float i, float *_d_i) {
 // CHECK-NEXT:     float _d_res = 0;
-// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     float res = A::constantFn(i);
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = res * i;
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     {
@@ -56,13 +56,13 @@ double fn2(double i, double j) {
 }
 
 // CHECK: void fn2_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     double _t3;
 // CHECK-NEXT:     double _t4;
 // CHECK-NEXT:     double _t5;
+// CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double temp = 0;
 // CHECK-NEXT:     _t0 = temp;
 // CHECK-NEXT:     _t1 = i;
@@ -155,13 +155,13 @@ double fn4(double* arr, int n) {
 }
 
 // CHECK: void fn4_grad(double *arr, int n, double *_d_arr, int *_d_n) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     unsigned {{int|long}} _t1;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = res;
 // CHECK-NEXT:     res += sum(arr, n);
@@ -278,24 +278,21 @@ double fn7(double i, double j) {
 
 // CHECK: void fn7_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double *_d_k = 0;
 // CHECK-NEXT:     double _t2;
-// CHECK-NEXT:     double *_d_l = 0;
 // CHECK-NEXT:     double _t4;
-// CHECK-NEXT:     double *_d_temp = 0;
 // CHECK-NEXT:     double _t6
 // CHECK-NEXT:     double _t7;
 // CHECK-NEXT:     _t0 = i;
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = identity_forw(i, &*_d_i);
-// CHECK-NEXT:     _d_k = &_t1.adjoint;
+// CHECK-NEXT:     double &_d_k = _t1.adjoint;
 // CHECK-NEXT:     double &k = _t1.value;
 // CHECK-NEXT:     _t2 = j;
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t3 = identity_forw(j, &*_d_j);
-// CHECK-NEXT:     _d_l = &_t3.adjoint;
+// CHECK-NEXT:     double &_d_l = _t3.adjoint;
 // CHECK-NEXT:     double &l = _t3.value;
 // CHECK-NEXT:     _t4 = i;
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t5 = custom_identity_forw(i, &*_d_i);
-// CHECK-NEXT:     _d_temp = &_t5.adjoint;
+// CHECK-NEXT:     double &_d_temp = _t5.adjoint;
 // CHECK-NEXT:     double &temp = _t5.value;
 // CHECK-NEXT:     _t6 = k;
 // CHECK-NEXT:     k += 7 * j;
@@ -308,12 +305,12 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         l = _t7;
-// CHECK-NEXT:         double _r_d1 = *_d_l;
+// CHECK-NEXT:         double _r_d1 = _d_l;
 // CHECK-NEXT:         *_d_i += 9 * _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         k = _t6;
-// CHECK-NEXT:         double _r_d0 = *_d_k;
+// CHECK-NEXT:         double _r_d0 = _d_k;
 // CHECK-NEXT:         *_d_j += 7 * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -389,13 +386,13 @@ double fn10(double x, double y) {
 }
 
 // CHECK: void fn10_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:    double _d_out = 0;
 // CHECK-NEXT:    double _t0;
 // CHECK-NEXT:    double _t1;
 // CHECK-NEXT:    double _t2;
 // CHECK-NEXT:    double _t3;
 // CHECK-NEXT:    double _t4;
 // CHECK-NEXT:    double _t5;
+// CHECK-NEXT:    double _d_out = 0;
 // CHECK-NEXT:    double out = x;
 // CHECK-NEXT:    _t0 = out;
 // CHECK-NEXT:    _t1 = out;
@@ -502,11 +499,11 @@ double fn13(double* x, const double* w) {
 }
 
 // CHECK: void fn13_grad_0(double *x, const double *w, double *_d_x) {
-// CHECK-NEXT:     double _d_wCopy[2] = {0};
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     std::size_t _d_i = 0;
 // CHECK-NEXT:     std::size_t i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     double _d_wCopy[2] = {0};
 // CHECK-NEXT:     double wCopy[2];
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
@@ -706,9 +703,8 @@ double fn21(double x) {
 }
 
 // CHECK: void fn21_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double *_d_ptr = 0;
 // CHECK-NEXT:     double *_t0;
-// CHECK-NEXT:     _d_ptr = &*_d_x;
+// CHECK-NEXT:     double *_d_ptr = &*_d_x;
 // CHECK-NEXT:     double *ptr = &x;
 // CHECK-NEXT:     _t0 = ptr;
 // CHECK-NEXT:     {
@@ -855,11 +851,11 @@ double sq_defined_later(double x) {
 // CHECK: void modify1_pullback(double &i, double &j, double _d_y, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     _t0 = i;
 // CHECK-NEXT:     i += j;
 // CHECK-NEXT:     _t1 = j;
 // CHECK-NEXT:     j += j;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = i + j;
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
@@ -898,12 +894,12 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: void sum_pullback(double *arr, int n, float _d_y, double *_d_arr, int *_d_n) {
-// CHECK-NEXT:     float _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
 // CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     float _d_res = 0;
 // CHECK-NEXT:     float res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
@@ -961,9 +957,9 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: void identity_pullback(double &i, double _d_y, double *_d_i) {
-// CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     MyStruct::myFunction();
+// CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _d_i0 = i;
 // CHECK-NEXT:     _t0 = _d_i0;
 // CHECK-NEXT:     _d_i0 += 1;
@@ -976,9 +972,9 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndAdjoint<double &, double &> identity_forw(double &i, double *_d_i) {
-// CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     MyStruct::myFunction();
+// CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _d_i0 = i;
 // CHECK-NEXT:     _t0 = _d_i0;
 // CHECK-NEXT:     _d_i0 += 1;

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -56,21 +56,15 @@ double fn2(double i, double j) {
 }
 
 // CHECK: void fn2_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     double _t2;
-// CHECK-NEXT:     double _t3;
-// CHECK-NEXT:     double _t4;
-// CHECK-NEXT:     double _t5;
 // CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double temp = 0;
-// CHECK-NEXT:     _t0 = temp;
-// CHECK-NEXT:     _t1 = i;
-// CHECK-NEXT:     _t2 = j;
+// CHECK-NEXT:     double _t0 = temp;
+// CHECK-NEXT:     double _t1 = i;
+// CHECK-NEXT:     double _t2 = j;
 // CHECK-NEXT:     temp = modify1(i, j);
-// CHECK-NEXT:     _t3 = temp;
-// CHECK-NEXT:     _t4 = i;
-// CHECK-NEXT:     _t5 = j;
+// CHECK-NEXT:     double _t3 = temp;
+// CHECK-NEXT:     double _t4 = i;
+// CHECK-NEXT:     double _t5 = j;
 // CHECK-NEXT:     temp = modify1(i, j);
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
@@ -105,15 +99,11 @@ double fn3(double i, double j) {
 }
 
 // CHECK: void fn3_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     double _t2;
-// CHECK-NEXT:     double _t3;
-// CHECK-NEXT:     _t0 = i;
-// CHECK-NEXT:     _t1 = j;
+// CHECK-NEXT:     double _t0 = i;
+// CHECK-NEXT:     double _t1 = j;
 // CHECK-NEXT:     update1(i, j);
-// CHECK-NEXT:     _t2 = i;
-// CHECK-NEXT:     _t3 = j;
+// CHECK-NEXT:     double _t2 = i;
+// CHECK-NEXT:     double _t3 = j;
 // CHECK-NEXT:     update1(i, j);
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
@@ -155,17 +145,15 @@ double fn4(double* arr, int n) {
 }
 
 // CHECK: void fn4_grad(double *arr, int n, double *_d_arr, int *_d_n) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     unsigned {{int|long}} _t1;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = res;
+// CHECK-NEXT:     double _t0 = res;
 // CHECK-NEXT:     res += sum(arr, n);
-// CHECK-NEXT:     _t1 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t1 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:          if (!(i < n))
@@ -277,26 +265,21 @@ double fn7(double i, double j) {
 // CHECK-NEXT: }
 
 // CHECK: void fn7_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t2;
-// CHECK-NEXT:     double _t4;
-// CHECK-NEXT:     double _t6
-// CHECK-NEXT:     double _t7;
-// CHECK-NEXT:     _t0 = i;
+// CHECK-NEXT:     double _t0 = i;
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = identity_forw(i, &*_d_i);
 // CHECK-NEXT:     double &_d_k = _t1.adjoint;
 // CHECK-NEXT:     double &k = _t1.value;
-// CHECK-NEXT:     _t2 = j;
+// CHECK-NEXT:     double _t2 = j;
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t3 = identity_forw(j, &*_d_j);
 // CHECK-NEXT:     double &_d_l = _t3.adjoint;
 // CHECK-NEXT:     double &l = _t3.value;
-// CHECK-NEXT:     _t4 = i;
+// CHECK-NEXT:     double _t4 = i;
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t5 = custom_identity_forw(i, &*_d_i);
 // CHECK-NEXT:     double &_d_temp = _t5.adjoint;
 // CHECK-NEXT:     double &temp = _t5.value;
-// CHECK-NEXT:     _t6 = k;
+// CHECK-NEXT:     double _t6 = k;
 // CHECK-NEXT:     k += 7 * j;
-// CHECK-NEXT:     _t7 = l;
+// CHECK-NEXT:     double _t7 = l;
 // CHECK-NEXT:     l += 9 * i;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += 1;
@@ -340,12 +323,9 @@ double fn8(double x, double y) {
 }
 
 // CHECK: void fn8_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     double _t2;
-// CHECK-NEXT:     _t2 = check_and_return(x, 'a', "aa");
-// CHECK-NEXT:     _t1 = std::tanh(1.);
-// CHECK-NEXT:     _t0 = std::max(1., 2.);
+// CHECK-NEXT:     double _t2 = check_and_return(x, 'a', "aa");
+// CHECK-NEXT:     double _t1 = std::tanh(1.);
+// CHECK-NEXT:     double _t0 = std::max(1., 2.);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         char _r1 = 0;
@@ -366,8 +346,7 @@ double fn9(double x, double y) {
 }
 
 // CHECK:void fn9_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:    double _t0;
-// CHECK-NEXT:    _t0 = y;
+// CHECK-NEXT:    double _t0 = y;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        y = _t0;
 // CHECK-NEXT:        double _r0 = 0;
@@ -386,22 +365,16 @@ double fn10(double x, double y) {
 }
 
 // CHECK: void fn10_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:    double _t0;
-// CHECK-NEXT:    double _t1;
-// CHECK-NEXT:    double _t2;
-// CHECK-NEXT:    double _t3;
-// CHECK-NEXT:    double _t4;
-// CHECK-NEXT:    double _t5;
 // CHECK-NEXT:    double _d_out = 0;
 // CHECK-NEXT:    double out = x;
-// CHECK-NEXT:    _t0 = out;
-// CHECK-NEXT:    _t1 = out;
+// CHECK-NEXT:    double _t0 = out;
+// CHECK-NEXT:    double _t1 = out;
 // CHECK-NEXT:    out = std::max(out, 0.);
-// CHECK-NEXT:    _t2 = out;
-// CHECK-NEXT:    _t3 = out;
+// CHECK-NEXT:    double _t2 = out;
+// CHECK-NEXT:    double _t3 = out;
 // CHECK-NEXT:    out = std::min(out, 10.);
-// CHECK-NEXT:    _t4 = out;
-// CHECK-NEXT:    _t5 = out;
+// CHECK-NEXT:    double _t4 = out;
+// CHECK-NEXT:    double _t5 = out;
 // CHECK-NEXT:    out = std::clamp(out, 3., 7.);
 // CHECK-NEXT:    {
 // CHECK-NEXT:        _d_out += 1 * y;
@@ -461,10 +434,8 @@ double fn11(double x, double y) {
 }
 
 // CHECK: void fn11_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:    double _t0;
-// CHECK-NEXT:    double _t1;
-// CHECK-NEXT:    _t0 = x;
-// CHECK-NEXT:    _t1 = y;
+// CHECK-NEXT:    double _t0 = x;
+// CHECK-NEXT:    double _t1 = y;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        x = _t0;
 // CHECK-NEXT:        y = _t1;
@@ -499,13 +470,12 @@ double fn13(double* x, const double* w) {
 }
 
 // CHECK: void fn13_grad_0(double *x, const double *w, double *_d_x) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     std::size_t _d_i = 0;
 // CHECK-NEXT:     std::size_t i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_wCopy[2] = {0};
 // CHECK-NEXT:     double wCopy[2];
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 2))
@@ -540,8 +510,7 @@ double fn14(double x, double y) {
 }
 
 // CHECK: void fn14_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _t0 = x;
+// CHECK-NEXT:     double _t0 = x;
 // CHECK-NEXT:     emptyFn(x, y);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_x += 1;
@@ -561,8 +530,7 @@ double fn15(double x, double y) {
 }
 
 //CHECK: void fn15_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     double _t0;
-//CHECK-NEXT:     _t0 = y;
+//CHECK-NEXT:     double _t0 = y;
 //CHECK-NEXT:     A::constantFn(y += x);
 //CHECK-NEXT:     *_d_y += 1;
 //CHECK-NEXT:     {
@@ -610,11 +578,9 @@ double fn17 (double x, double* y) {
 }
 
 //CHECK: void fn17_grad_0(double x, double *y, double *_d_x) {
-//CHECK-NEXT:     double _t0;
-//CHECK-NEXT:     double _t1;
-//CHECK-NEXT:     _t0 = x;
+//CHECK-NEXT:     double _t0 = x;
 //CHECK-NEXT:     x = add(x, y);
-//CHECK-NEXT:     _t1 = x;
+//CHECK-NEXT:     double _t1 = x;
 //CHECK-NEXT:     x = add(x, &x);
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
@@ -703,10 +669,9 @@ double fn21(double x) {
 }
 
 // CHECK: void fn21_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double *_t0;
 // CHECK-NEXT:     double *_d_ptr = &*_d_x;
 // CHECK-NEXT:     double *ptr = &x;
-// CHECK-NEXT:     _t0 = ptr;
+// CHECK-NEXT:     double *_t0 = ptr;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         ptr = _t0;
 // CHECK-NEXT:         ptrRef_pullback(_t0, 1, &_d_ptr);
@@ -849,11 +814,9 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: void modify1_pullback(double &i, double &j, double _d_y, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     _t0 = i;
+// CHECK-NEXT:     double _t0 = i;
 // CHECK-NEXT:     i += j;
-// CHECK-NEXT:     _t1 = j;
+// CHECK-NEXT:     double _t1 = j;
 // CHECK-NEXT:     j += j;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = i + j;
@@ -875,11 +838,9 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: void update1_pullback(double &i, double &j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     _t0 = i;
+// CHECK-NEXT:     double _t0 = i;
 // CHECK-NEXT:     i += j;
-// CHECK-NEXT:     _t1 = j;
+// CHECK-NEXT:     double _t1 = j;
 // CHECK-NEXT:     j += j;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         j = _t1;
@@ -894,14 +855,12 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: void sum_pullback(double *arr, int n, float _d_y, double *_d_arr, int *_d_n) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
-// CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     float _d_res = 0;
 // CHECK-NEXT:     float res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -911,7 +870,7 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += arr[i];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _t2 = arr[0];
+// CHECK-NEXT:     double _t2 = arr[0];
 // CHECK-NEXT:     arr[0] += 10 * arr[0];
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
@@ -932,8 +891,7 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: void twice_pullback(double &d, double *_d_d) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _t0 = d;
+// CHECK-NEXT:     double _t0 = d;
 // CHECK-NEXT:     d = 2 * d;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         d = _t0;
@@ -944,8 +902,7 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: void modify2_pullback(double *arr, double _d_y, double *_d_arr) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _t0 = arr[0];
+// CHECK-NEXT:     double _t0 = arr[0];
 // CHECK-NEXT:     arr[0] = 5 * arr[0] + arr[1];
 // CHECK-NEXT:     {
 // CHECK-NEXT:         arr[0] = _t0;
@@ -957,11 +914,10 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: void identity_pullback(double &i, double _d_y, double *_d_i) {
-// CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     MyStruct::myFunction();
 // CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _d_i0 = i;
-// CHECK-NEXT:     _t0 = _d_i0;
+// CHECK-NEXT:     double _t0 = _d_i0;
 // CHECK-NEXT:     _d_i0 += 1;
 // CHECK-NEXT:     *_d_i += _d_y;
 // CHECK-NEXT:     {
@@ -972,11 +928,10 @@ double sq_defined_later(double x) {
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndAdjoint<double &, double &> identity_forw(double &i, double *_d_i) {
-// CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     MyStruct::myFunction();
 // CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _d_i0 = i;
-// CHECK-NEXT:     _t0 = _d_i0;
+// CHECK-NEXT:     double _t0 = _d_i0;
 // CHECK-NEXT:     _d_i0 += 1;
 // CHECK-NEXT:     return {i, *_d_i};
 // CHECK-NEXT: }
@@ -1019,8 +974,7 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:}
 
 // CHECK: void custom_max_pullback(const double &a, const double &b, double _d_y, double *_d_a, double *_d_b) {
-// CHECK-NEXT:     bool _cond0;
-// CHECK-NEXT:     _cond0 = a > b;
+// CHECK-NEXT:     bool _cond0 = a > b;
 // CHECK-NEXT:     if (_cond0)
 // CHECK-NEXT:         *_d_a += _d_y;
 // CHECK-NEXT:     else

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -225,8 +225,8 @@ int main() {
                                               // CHECK-EXEC: 54.00 42.00
 
   // CHECK: void CallFunctor_grad(double i, double j, double *_d_i, double *_d_j) {
-  // CHECK-NEXT:     Experiment _d_E({});
   // CHECK-NEXT:     Experiment _t0;
+  // CHECK-NEXT:     Experiment _d_E({});
   // CHECK-NEXT:     Experiment E(3, 5);
   // CHECK-NEXT:     _t0 = E;
   // CHECK-NEXT:     {

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -53,8 +53,7 @@ struct ExperimentVolatile {
   };
 
   // CHECK: void operator_call_grad(double i, double j, volatile ExperimentVolatile *_d_this, double *_d_i, double *_d_j) volatile {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = this->x * i;
+  // CHECK-NEXT:     double _t0 = this->x * i;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
   // CHECK-NEXT:         *_d_i += this->x * 1 * j;
@@ -77,8 +76,7 @@ struct ExperimentConstVolatile {
   };
 
   // CHECK: void operator_call_grad(double i, double j, volatile ExperimentConstVolatile *_d_this, double *_d_i, double *_d_j) const volatile {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = this->x * i;
+  // CHECK-NEXT:     double _t0 = this->x * i;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
   // CHECK-NEXT:         *_d_i += this->x * 1 * j;
@@ -225,10 +223,9 @@ int main() {
                                               // CHECK-EXEC: 54.00 42.00
 
   // CHECK: void CallFunctor_grad(double i, double j, double *_d_i, double *_d_j) {
-  // CHECK-NEXT:     Experiment _t0;
   // CHECK-NEXT:     Experiment _d_E({});
   // CHECK-NEXT:     Experiment E(3, 5);
-  // CHECK-NEXT:     _t0 = E;
+  // CHECK-NEXT:     Experiment _t0 = E;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0;
   // CHECK-NEXT:         double _r1 = 0;
@@ -245,8 +242,7 @@ int main() {
   printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 27.00 21.00
 
   // CHECK: void FunctorAsArg_grad(Experiment fn, double i, double j, Experiment *_d_fn, double *_d_i, double *_d_j) {
-  // CHECK-NEXT:     Experiment _t0;
-  // CHECK-NEXT:     _t0 = fn;
+  // CHECK-NEXT:     Experiment _t0 = fn;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0;
   // CHECK-NEXT:         double _r1 = 0;
@@ -286,8 +282,7 @@ int main() {
 }
 
 // CHECK: void FunctorAsArg_pullback(Experiment fn, double i, double j, double _d_y, Experiment *_d_fn, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     Experiment _t0;
-// CHECK-NEXT:     _t0 = fn;
+// CHECK-NEXT:     Experiment _t0 = fn;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -121,8 +121,7 @@ double f_div2(double x, double y) {
 }
 
 //CHECK:   void f_div2_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       _t0 = (4 * y);
+//CHECK-NEXT:       double _t0 = (4 * y);
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 3 * 1 / _t0;
 //CHECK-NEXT:           double _r0 = 1 * -(3 * x / (_t0 * _t0));
@@ -137,12 +136,9 @@ double f_div3(double x, double y) {
 }
 
 //CHECK: void f_div3_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     double _t0;
-//CHECK-NEXT:     double _t1;
-//CHECK-NEXT:     double _t2;
-//CHECK-NEXT:     _t1 = x;
-//CHECK-NEXT:     _t2 = (x = y);
-//CHECK-NEXT:     _t0 = (y * y);
+//CHECK-NEXT:     double _t1 = x;
+//CHECK-NEXT:     double _t2 = (x = y);
+//CHECK-NEXT:     double _t0 = (y * y);
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += 1 / _t0;
 //CHECK-NEXT:         x = _t1;
@@ -201,8 +197,7 @@ double f_cond1(double x, double y) {
 }
 
 //CHECK:   void f_cond1_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       bool _cond0;
-//CHECK-NEXT:       _cond0 = x > y;
+//CHECK-NEXT:       bool _cond0 = x > y;
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:           *_d_x += 1;
 //CHECK-NEXT:       else
@@ -216,9 +211,8 @@ double f_cond2(double x, double y) {
 }
 
 //CHECK:   void f_cond2_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       bool _cond1;
-//CHECK-NEXT:       _cond0 = x > y;
+//CHECK-NEXT:       bool _cond0 = x > y;
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:           ;
 //CHECK-NEXT:       else
@@ -238,8 +232,7 @@ double f_cond3(double x, double c) {
 }
 
 //CHECK:   void f_cond3_grad(double x, double c, double *_d_x, double *_d_c) {
-//CHECK-NEXT:       bool _cond0;
-//CHECK-NEXT:       _cond0 = c > 0;
+//CHECK-NEXT:       bool _cond0 = c > 0;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           *_d_x += 1;
 //CHECK-NEXT:           *_d_c += 1;
@@ -436,8 +429,7 @@ double f_sin(double x, double y) {
 
 void f_sin_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK:   void f_sin_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       _t0 = (std::sin(x) + std::sin(y));
+//CHECK-NEXT:       double _t0 = (std::sin(x) + std::sin(y));
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r0 = 0;
 //CHECK-NEXT:           _r0 += 1 * (x + y) * clad::custom_derivatives::sin_pushforward(x, 1.).pushforward;
@@ -647,11 +639,10 @@ float running_sum(float* p, int n) {
 }
 
 // CHECK: void running_sum_grad(float *p, int n, float *_d_p, int *_d_n) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 1; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -699,10 +690,9 @@ double fn_increment_in_return(double i, double j) {
 void fn_increment_in_return_grad(double i, double j, double *_d_i, double *_d_j);
 
 // CHECK: void fn_increment_in_return_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double temp = i;
-// CHECK-NEXT:     _t0 = ++i;
+// CHECK-NEXT:     double _t0 = ++i;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += 1 * temp;
 // CHECK-NEXT:         --i;
@@ -719,10 +709,9 @@ double fn_template_non_type(double x) {
 }
 
 // CHECK: void fn_template_non_type_grad(double x, double *_d_x) {
-// CHECK-NEXT:     bool _cond0;
 // CHECK-NEXT:     size_t _d_maxN = 0;
 // CHECK-NEXT:     const size_t maxN = 53;
-// CHECK-NEXT:     _cond0 = maxN < {{15U|15UL}};
+// CHECK-NEXT:     bool _cond0 = maxN < {{15U|15UL}};
 // CHECK-NEXT:     size_t _d_m = 0;
 // CHECK-NEXT:     const size_t m = _cond0 ? maxN : {{15U|15UL}};
 // CHECK-NEXT:     *_d_x += 1 * m;
@@ -859,8 +848,7 @@ double fn_const_cond_op(double x) {
 }
 
 //CHECK:               void fn_const_cond_op_grad(double x, double *_d_x) {
-//CHECK-NEXT:              bool _cond0;
-//CHECK-NEXT:              _cond0 = x > 0;
+//CHECK-NEXT:              bool _cond0 = x > 0;
 //CHECK-NEXT:              *_d_x += 1;
 //CHECK-NEXT:          }
 

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -261,11 +261,11 @@ double f_cond4(double x, double y) {
 }
 
 //CHECK:   void f_cond4_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       int _d_i = 0;
-//CHECK-NEXT:       double _d_arr[2] = {0};
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       double _t0;
+//CHECK-NEXT:       int _d_i = 0;
 //CHECK-NEXT:       int i = 0;
+//CHECK-NEXT:       double _d_arr[2] = {0};
 //CHECK-NEXT:       double arr[2] = {x, y};
 //CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x > 0;
@@ -478,10 +478,10 @@ double f_decls1(double x, double y) {
 void f_decls1_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK:   void f_decls1_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_a = 0;
-//CHECK-NEXT:       double _d_b = 0;
-//CHECK-NEXT:       double _d_c = 0;
 //CHECK-NEXT:       double a = 3 * x;
+//CHECK-NEXT:       double _d_b = 0;
 //CHECK-NEXT:       double b = 5 * y;
+//CHECK-NEXT:       double _d_c = 0;
 //CHECK-NEXT:       double c = a + b;
 //CHECK-NEXT:       _d_c += 2 * 1;
 //CHECK-NEXT:       {
@@ -502,10 +502,10 @@ double f_decls2(double x, double y) {
 void f_decls2_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK:   void f_decls2_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_a = 0;
-//CHECK-NEXT:       double _d_b = 0;
-//CHECK-NEXT:       double _d_c = 0;
 //CHECK-NEXT:       double a = x * x;
+//CHECK-NEXT:       double _d_b = 0;
 //CHECK-NEXT:       double b = x * y;
+//CHECK-NEXT:       double _d_c = 0;
 //CHECK-NEXT:       double c = y * y;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_a += 1;
@@ -539,12 +539,11 @@ double f_decls3(double x, double y) {
 
 void f_decls3_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK:   void f_decls3_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _d_a = 0;
-//CHECK-NEXT:       double _d_c = 0;
 //CHECK-NEXT:       bool _cond0;
 //CHECK-NEXT:       bool _cond1;
-//CHECK-NEXT:       double _d_b = 0;
+//CHECK-NEXT:       double _d_a = 0;
 //CHECK-NEXT:       double a = 3 * x;
+//CHECK-NEXT:       double _d_c = 0;
 //CHECK-NEXT:       double c = 333 * y;
 //CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x > 1;
@@ -556,6 +555,7 @@ void f_decls3_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK-NEXT:               goto _label1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
+//CHECK-NEXT:       double _d_b = 0;
 //CHECK-NEXT:       double b = a * a;
 //CHECK-NEXT:       _d_b += 1;
 //CHECK-NEXT:       {
@@ -614,14 +614,13 @@ double f_const_reference(double i, double j) {
 void f_const_reference_grad(double i, double j, double *_d_i, double *_d_j);
 //CHECK: void f_const_reference_grad(double i, double j, double *_d_i, double *_d_j) {
 //CHECK-NEXT:    double _d_a = 0;
-//CHECK-NEXT:    double *_d_ar = 0;
-//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double a = i;
-//CHECK-NEXT:    _d_ar = &_d_a;
+//CHECK-NEXT:    double &_d_ar = _d_a;
 //CHECK-NEXT:    const double &ar = a;
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 2 * ar;
 //CHECK-NEXT:    _d_res += 1;
-//CHECK-NEXT:    *_d_ar += 2 * _d_res;
+//CHECK-NEXT:    _d_ar += 2 * _d_res;
 //CHECK-NEXT:    *_d_i += _d_a;
 //CHECK-NEXT:}
 double f_const02(double i, double j) {
@@ -632,8 +631,8 @@ double f_const02(double i, double j) {
 void f_const02_grad(double i, double j, double *_d_i, double *_d_j);
 //CHECK:  void f_const02_grad(double i, double j, double *_d_i, double *_d_j) {
 //CHECK-NEXT:       double _d_a = 0;
-//CHECK-NEXT:       double _d_res = 0;
 //CHECK-NEXT:       const double a = i;
+//CHECK-NEXT:       double _d_res = 0;
 //CHECK-NEXT:       double res = a;
 //CHECK-NEXT:       _d_res += 1;
 //CHECK-NEXT:       _d_a += _d_res;
@@ -700,8 +699,8 @@ double fn_increment_in_return(double i, double j) {
 void fn_increment_in_return_grad(double i, double j, double *_d_i, double *_d_j);
 
 // CHECK: void fn_increment_in_return_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double _t0;
+// CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double temp = i;
 // CHECK-NEXT:     _t0 = ++i;
 // CHECK-NEXT:     {
@@ -720,11 +719,11 @@ double fn_template_non_type(double x) {
 }
 
 // CHECK: void fn_template_non_type_grad(double x, double *_d_x) {
-// CHECK-NEXT:     size_t _d_maxN = 0;
 // CHECK-NEXT:     bool _cond0;
-// CHECK-NEXT:     size_t _d_m = 0;
+// CHECK-NEXT:     size_t _d_maxN = 0;
 // CHECK-NEXT:     const size_t maxN = 53;
 // CHECK-NEXT:     _cond0 = maxN < {{15U|15UL}};
+// CHECK-NEXT:     size_t _d_m = 0;
 // CHECK-NEXT:     const size_t m = _cond0 ? maxN : {{15U|15UL}};
 // CHECK-NEXT:     *_d_x += 1 * m;
 // CHECK-NEXT:     if (_cond0)
@@ -750,10 +749,10 @@ double fn_cond_decl(double x, double y) {
 } // = y^2
 
 //CHECK:        void fn_cond_decl_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:            int _d_flag = 0;
 //CHECK-NEXT:            int _d_cond = 0;
 //CHECK-NEXT:            int cond = 0;
 //CHECK-NEXT:            bool _cond0;
+//CHECK-NEXT:            int _d_flag = 0;
 //CHECK-NEXT:            int flag = 1;
 //CHECK-NEXT:            {
 //CHECK-NEXT:                _cond0 = cond = flag;
@@ -874,8 +873,8 @@ double fn_empty_if_block(double x) {
 }
 
 //CHECK:void fn_empty_if_block_grad(double x, double *_d_x) {
-//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    bool _cond0;
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _cond0 = x > 0;
@@ -897,10 +896,10 @@ double fn_empty_if_else(double x) {
 }
 
 //CHECK: void fn_empty_if_else_grad(double x, double *_d_x) {
-//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double _t0;
 //CHECK-NEXT:    bool _cond0;
 //CHECK-NEXT:    double _t1;
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _t0 = res;
@@ -941,7 +940,6 @@ double fn_cond_false(double i, double j) {
 }
 
 // CHECK: void fn_cond_false_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:    double _d_res = 0;
 // CHECK-NEXT:    bool _cond0;
 // CHECK-NEXT:    double _d_cond0;
 // CHECK-NEXT:    _d_cond0 = 0.;
@@ -949,6 +947,7 @@ double fn_cond_false(double i, double j) {
 // CHECK-NEXT:    bool _t0;
 // CHECK-NEXT:    bool _cond2;
 // CHECK-NEXT:    double _t1;
+// CHECK-NEXT:    double _d_res = 0;
 // CHECK-NEXT:    double res = 0;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        {
@@ -994,7 +993,6 @@ double fn_cond_add_assign(double i, double j) {
 }
 
 // CHECK: void fn_cond_add_assign_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:    double _d_res = 0;
 // CHECK-NEXT:    bool _cond0;
 // CHECK-NEXT:    double _d_cond0;
 // CHECK-NEXT:    _d_cond0 = 0.;
@@ -1010,6 +1008,7 @@ double fn_cond_add_assign(double i, double j) {
 // CHECK-NEXT:    double _t4;
 // CHECK-NEXT:    bool _cond4;
 // CHECK-NEXT:    double _t5;
+// CHECK-NEXT:    double _d_res = 0;
 // CHECK-NEXT:    double res = 0;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        {

--- a/test/Gradient/Lambdas.C
+++ b/test/Gradient/Lambdas.C
@@ -36,11 +36,11 @@ double f2(double i, double j) {
 
 // CHECK:     inline void operator_call_pullback(double t, double k, double _d_y, double *_d_t, double *_d_k) const;
 // CHECK-NEXT:     void f2_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:         double _d_x = 0;
 // CHECK-NEXT:             auto _f = []{{ ?}}(double t, double k) {
 // CHECK-NEXT:                 return t + k;
 // CHECK-NEXT:             }{{;?}}
-// CHECK:             double x = operator()(i + j, i);
+// CHECK:        double _d_x = 0;
+// CHECK-NEXT:             double x = operator()(i + j, i);
 // CHECK-NEXT:             _d_x += 1;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 double _r0 = 0;

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -17,13 +17,12 @@ double f1(double x) {
 } // == x^3
 
 // CHECK: void f1_grad(double x, double *_d_x) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -57,7 +56,6 @@ double f2(double x) {
 } // == x^9
 
 // CHECK: void f2_grad(double x, double *_d_x) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
@@ -67,7 +65,7 @@ double f2(double x) {
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -123,14 +121,13 @@ double f3(double x) {
 } // == x^2
 
 // CHECK: void f3_grad(double x, double *_d_x) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -176,13 +173,12 @@ double f4(double x) {
 } // == x^3
 
 // CHECK: void f4_grad(double x, double *_d_x) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; clad::push(_t1, t) , (t *= x)) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -215,10 +211,9 @@ double f5(double x){
 } // == x + 10
 
 // CHECK: void f5_grad(double x, double *_d_x) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 10))
@@ -248,7 +243,6 @@ double f_const_local(double x) {
 } // == 3x^2 + 3x
 
 // CHECK: void f_const_local_grad(double x, double *_d_x) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
@@ -257,7 +251,7 @@ double f_const_local(double x) {
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -299,13 +293,12 @@ double f_sum(double *p, int n) {
 
 // CHECK: void f_sum_grad_0(double *p, int n, double *_d_p) {
 // CHECK-NEXT:     int _d_n = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_s = 0;
 // CHECK-NEXT:     double s = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -340,13 +333,12 @@ double f_sum_squares(double *p, int n) {
 
 // CHECK: void f_sum_squares_grad_0(double *p, int n, double *_d_p) {
 // CHECK-NEXT:     int _d_n = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_s = 0;
 // CHECK-NEXT:     double s = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -383,19 +375,12 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 // CHECK: void f_log_gaus_grad_1(double *x, double *p, double n, double sigma, double *_d_p) {
 // CHECK-NEXT:     double _d_n = 0;
 // CHECK-NEXT:     double _d_sigma = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     double _t2;
-// CHECK-NEXT:     double _t3;
-// CHECK-NEXT:     double _t4;
-// CHECK-NEXT:     double _t5;
-// CHECK-NEXT:     double _t6;
-// CHECK-NEXT:     double _t7;
 // CHECK-NEXT:     double _d_power = 0;
 // CHECK-NEXT:     double power = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -405,13 +390,13 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 // CHECK-NEXT:         clad::push(_t1, power);
 // CHECK-NEXT:         power += sq(x[i] - p[i]);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _t2 = power;
-// CHECK-NEXT:     _t4 = sq(sigma);
-// CHECK-NEXT:     _t3 = (2 * _t4);
+// CHECK-NEXT:     double _t2 = power;
+// CHECK-NEXT:     double _t4 = sq(sigma);
+// CHECK-NEXT:     double _t3 = (2 * _t4);
 // CHECK-NEXT:     power = -power / _t3;
-// CHECK-NEXT:     _t7 = std::pow(2 * 3.1415926535897931, n);
-// CHECK-NEXT:     _t6 = std::sqrt(_t7 * sigma);
-// CHECK-NEXT:     _t5 = std::exp(power);
+// CHECK-NEXT:     double _t7 = std::pow(2 * 3.1415926535897931, n);
+// CHECK-NEXT:     double _t6 = std::sqrt(_t7 * sigma);
+// CHECK-NEXT:     double _t5 = std::exp(power);
 // CHECK-NEXT:     double _d_gaus = 0;
 // CHECK-NEXT:     double gaus = 1. / _t6 * _t5;
 // CHECK-NEXT:     {
@@ -466,7 +451,6 @@ double f_const(const double a, const double b) {
 
 void f_const_grad(const double, const double, double*, double*);
 // CHECK: void f_const_grad(const double a, const double b, double *_d_a, double *_d_b) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
@@ -475,7 +459,7 @@ void f_const_grad(const double, const double, double*, double*);
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     int _d_r = 0;
 // CHECK-NEXT:     int r = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < a))
@@ -519,7 +503,6 @@ double f6 (double i, double j) {
 }
 
 // CHECK: void f6_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
@@ -532,7 +515,7 @@ double f6 (double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (counter = 0; ; ++counter) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(counter < 3))
@@ -589,13 +572,12 @@ double fn7(double i, double j) {
 }
 
 // CHECK: void fn7_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (counter--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -627,14 +609,13 @@ double fn8(double i, double j) {
 }
 
 // CHECK: void fn8_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (counter > 0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -681,20 +662,17 @@ double fn9(double i, double j) {
 }
 
 // CHECK: void fn9_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     int _t0;
-// CHECK-NEXT:     int _t1;
-// CHECK-NEXT:     unsigned {{int|long}} _t2;
 // CHECK-NEXT:     clad::tape<int> _t3 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t4 = {};
 // CHECK-NEXT:     clad::tape<double> _t5 = {};
 // CHECK-NEXT:     int _d_counter = 0, _d_counter_again = 0;
 // CHECK-NEXT:     int counter, counter_again;
-// CHECK-NEXT:     _t0 = counter;
-// CHECK-NEXT:     _t1 = counter_again;
+// CHECK-NEXT:     int _t0 = counter;
+// CHECK-NEXT:     int _t1 = counter_again;
 // CHECK-NEXT:     counter = counter_again = 3;
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     _t2 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t2 = {{0U|0UL}};
 // CHECK-NEXT:     while (counter--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t2++;
@@ -759,7 +737,6 @@ double fn10(double i, double j) {
 }
 
 // CHECK: void fn10_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_b = 0;
 // CHECK-NEXT:     int b = 0;
@@ -770,7 +747,7 @@ double fn10(double i, double j) {
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (clad::push(_t1, b) , b = counter)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -822,14 +799,13 @@ double fn11(double i, double j) {
 }
 
 // CHECK: void fn11_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, a);
@@ -874,7 +850,6 @@ double fn12(double i, double j) {
 }
 
 // CHECK: void fn12_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_counter_again = 0;
 // CHECK-NEXT:     int counter_again = 0;
@@ -888,7 +863,7 @@ double fn12(double i, double j) {
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, counter_again) , counter_again = 3;
@@ -967,7 +942,6 @@ double fn13(double i, double j) {
 }
 
 // CHECK: void fn13_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_k = 0;
 // CHECK-NEXT:     int k = 0;
@@ -981,7 +955,7 @@ double fn13(double i, double j) {
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (;; clad::push(_t2, counter) , (counter -= 1)) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(clad::push(_t1, k) , k = counter))
@@ -1052,7 +1026,6 @@ double fn14(double i, double j) {
 }
 
 // CHECK: void fn14_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
@@ -1064,7 +1037,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (choice--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -1172,7 +1145,6 @@ double fn15(double i, double j) {
 }
 
 // CHECK: void fn15_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
@@ -1188,7 +1160,7 @@ double fn15(double i, double j) {
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (choice--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -1298,7 +1270,6 @@ double fn16(double i, double j) {
 }
 
 // CHECK: void fn16_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_ii = 0;
 // CHECK-NEXT:     int ii = 0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
@@ -1311,7 +1282,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:     int counter = 5;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (ii = 0; ; ++ii) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(ii < counter))
@@ -1410,7 +1381,6 @@ double fn17(double i, double j) {
 }
 
 // CHECK: void fn17_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_ii = 0;
 // CHECK-NEXT:     int ii = 0;
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
@@ -1427,7 +1397,7 @@ double fn17(double i, double j) {
 // CHECK-NEXT:     int counter = 5;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (ii = 0; ; ++ii) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(ii < counter))
@@ -1544,7 +1514,6 @@ double fn18(double i, double j) {
 }
 
 // CHECK: void fn18_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
@@ -1556,7 +1525,7 @@ double fn18(double i, double j) {
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (counter = 0; ; ++counter) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(counter < choice))
@@ -1632,7 +1601,6 @@ double fn19(double* arr, int n) {
 
 // CHECK: void fn19_grad_0(double *arr, int n, double *_d_arr) {
 // CHECK-NEXT:     int _d_n = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double *> _t1 = {};
@@ -1642,7 +1610,7 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -1683,7 +1651,6 @@ double f_loop_init_var(double lower, double upper) {
 }
 
 // CHECK: void f_loop_init_var_grad(double lower, double upper, double *_d_lower, double *_d_upper) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     double _d_x = 0;
 // CHECK-NEXT:     double x = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
@@ -1694,7 +1661,7 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:     double num_points = 10000;
 // CHECK-NEXT:     double _d_interval = 0;
 // CHECK-NEXT:     double interval = (upper - lower) / num_points;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (x = lower; ; clad::push(_t1, x) , (x += interval)) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(x <= upper))
@@ -1743,14 +1710,13 @@ double fn20(double *arr, int n) {
 
 // CHECK: void fn20_grad_0(double *arr, int n, double *_d_arr) {
 // CHECK-NEXT:     int _d_n = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -1791,7 +1757,6 @@ double fn21(double x) {
 
 
 // CHECK: void fn21_grad(double x, double *_d_x) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
@@ -1800,7 +1765,7 @@ double fn21(double x) {
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 5))
@@ -1843,7 +1808,6 @@ double fn22(double param) {
 
 
 // CHECK: void fn22_grad(double param, double *_d_param) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
@@ -1853,7 +1817,7 @@ double fn22(double param) {
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_out = 0;
 // CHECK-NEXT:     double out = 0.;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 1))
@@ -1896,7 +1860,6 @@ double fn23(double i, double j) {
 }
 
 // CHECK: void fn23_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
@@ -1904,7 +1867,7 @@ double fn23(double i, double j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -1958,13 +1921,12 @@ double fn24(double i, double j) {
 }
 
 // CHECK: void fn24_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2004,7 +1966,6 @@ double fn25(double i, double j) {
 }
 
 // CHECK: void fn25_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
@@ -2013,7 +1974,7 @@ double fn25(double i, double j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2081,7 +2042,6 @@ double fn26(double i, double j) {
 }
 
 // CHECK: void fn26_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
@@ -2090,7 +2050,7 @@ double fn26(double i, double j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; clad::push(_t2, res) , (++c , res = 7 * i * j)) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2155,7 +2115,6 @@ double fn27(double i, double j) {
 }
 
 // CHECK: void fn27_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
@@ -2164,7 +2123,7 @@ double fn27(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2228,14 +2187,13 @@ double fn28(double i, double j) {
 }
 
 // CHECK: void fn28_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2280,14 +2238,13 @@ double fn29(double i, double j) {
 }
 
 // CHECK: void fn29_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; clad::push(_t2, res) , (++c , res = 3 * i * j)) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2331,7 +2288,6 @@ double fn30(double i, double j) {
 }
 
 // CHECK: void fn30_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     bool _cond0;
@@ -2342,7 +2298,7 @@ double fn30(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2391,14 +2347,13 @@ double fn31(double i, double j) {
 }
 
 //CHECK:void fn31_grad(double i, double j, double *_d_i, double *_d_j) {
-//CHECK-NEXT:    unsigned {{int|long}} _t0;
 //CHECK-NEXT:    int _d_c = 0;
 //CHECK-NEXT:    int c = 0;
 //CHECK-NEXT:    clad::tape<double> _t1 = {};
 //CHECK-NEXT:    clad::tape<double> _t2 = {};
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
-//CHECK-NEXT:    _t0 = {{0U|0UL}};
+//CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:    for (c = 0; ; ++c) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            {
@@ -2452,7 +2407,6 @@ double fn32(double i, double j) {
 }
 
 //CHECK:void fn32_grad(double i, double j, double *_d_i, double *_d_j) {
-//CHECK-NEXT:    unsigned {{int|long}} _t0;
 //CHECK-NEXT:    int _d_c = 0;
 //CHECK-NEXT:    int c = 0;
 //CHECK-NEXT:    clad::tape<double> _t1 = {};
@@ -2469,7 +2423,7 @@ double fn32(double i, double j) {
 //CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t8 = {};
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
-//CHECK-NEXT:    _t0 = {{0U|0UL}};
+//CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:    for (c = 0; ; ++c) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            {
@@ -2599,7 +2553,6 @@ double fn33(double i, double j) {
 }
 
 //CHECK: void fn33_grad(double i, double j, double *_d_i, double *_d_j) {
-//CHECK-NEXT:    unsigned {{int|long}} _t0;
 //CHECK-NEXT:    int _d_c = 0;
 //CHECK-NEXT:    int c = 0;
 //CHECK-NEXT:    clad::tape<double> _t1 = {};
@@ -2620,7 +2573,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:    clad::tape<bool> _cond5 = {};
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
-//CHECK-NEXT:    _t0 = {{0U|0UL}};
+//CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:    for (c = 0; ; ++c) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            {

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -17,11 +17,11 @@ double f1(double x) {
 } // == x^3
 
 // CHECK: void f1_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
@@ -57,7 +57,6 @@ double f2(double x) {
 } // == x^9
 
 // CHECK: void f2_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
@@ -66,6 +65,7 @@ double f2(double x) {
 // CHECK-NEXT:     int _d_j = 0;
 // CHECK-NEXT:     int j = 0;
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
@@ -123,12 +123,12 @@ double f3(double x) {
 } // == x^2
 
 // CHECK: void f3_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
+// CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
@@ -176,11 +176,11 @@ double f4(double x) {
 } // == x^3
 
 // CHECK: void f4_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; clad::push(_t1, t) , (t *= x)) {
@@ -248,7 +248,6 @@ double f_const_local(double x) {
 } // == 3x^2 + 3x
 
 // CHECK: void f_const_local_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
@@ -256,6 +255,7 @@ double f_const_local(double x) {
 // CHECK-NEXT:     double _d_n = 0;
 // CHECK-NEXT:     double n = 0;
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
@@ -299,11 +299,11 @@ double f_sum(double *p, int n) {
 
 // CHECK: void f_sum_grad_0(double *p, int n, double *_d_p) {
 // CHECK-NEXT:     int _d_n = 0;
-// CHECK-NEXT:     double _d_s = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     double _d_s = 0;
 // CHECK-NEXT:     double s = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
@@ -340,11 +340,11 @@ double f_sum_squares(double *p, int n) {
 
 // CHECK: void f_sum_squares_grad_0(double *p, int n, double *_d_p) {
 // CHECK-NEXT:     int _d_n = 0;
-// CHECK-NEXT:     double _d_s = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     double _d_s = 0;
 // CHECK-NEXT:     double s = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
@@ -383,7 +383,6 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 // CHECK: void f_log_gaus_grad_1(double *x, double *p, double n, double sigma, double *_d_p) {
 // CHECK-NEXT:     double _d_n = 0;
 // CHECK-NEXT:     double _d_sigma = 0;
-// CHECK-NEXT:     double _d_power = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
@@ -394,7 +393,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 // CHECK-NEXT:     double _t5;
 // CHECK-NEXT:     double _t6;
 // CHECK-NEXT:     double _t7;
-// CHECK-NEXT:     double _d_gaus = 0;
+// CHECK-NEXT:     double _d_power = 0;
 // CHECK-NEXT:     double power = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
@@ -413,6 +412,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 // CHECK-NEXT:     _t7 = std::pow(2 * 3.1415926535897931, n);
 // CHECK-NEXT:     _t6 = std::sqrt(_t7 * sigma);
 // CHECK-NEXT:     _t5 = std::exp(power);
+// CHECK-NEXT:     double _d_gaus = 0;
 // CHECK-NEXT:     double gaus = 1. / _t6 * _t5;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r8 = 0;
@@ -466,7 +466,6 @@ double f_const(const double a, const double b) {
 
 void f_const_grad(const double, const double, double*, double*);
 // CHECK: void f_const_grad(const double a, const double b, double *_d_a, double *_d_b) {
-// CHECK-NEXT:     int _d_r = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
@@ -474,6 +473,7 @@ void f_const_grad(const double, const double, double*, double*);
 // CHECK-NEXT:     int _d_sq = 0;
 // CHECK-NEXT:     int sq0 = 0;
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
+// CHECK-NEXT:     int _d_r = 0;
 // CHECK-NEXT:     int r = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
@@ -519,7 +519,6 @@ double f6 (double i, double j) {
 }
 
 // CHECK: void f6_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 0;
@@ -531,6 +530,7 @@ double f6 (double i, double j) {
 // CHECK-NEXT:     double c = 0;
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (counter = 0; ; ++counter) {
@@ -589,11 +589,11 @@ double fn7(double i, double j) {
 }
 
 // CHECK: void fn7_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_a = 0;
-// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
+// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (counter--)
@@ -627,12 +627,12 @@ double fn8(double i, double j) {
 }
 
 // CHECK: void fn8_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_a = 0;
-// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
+// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (counter > 0)
@@ -681,18 +681,18 @@ double fn9(double i, double j) {
 }
 
 // CHECK: void fn9_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     int _d_counter = 0, _d_counter_again = 0;
 // CHECK-NEXT:     int _t0;
 // CHECK-NEXT:     int _t1;
-// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t2;
 // CHECK-NEXT:     clad::tape<int> _t3 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t4 = {};
 // CHECK-NEXT:     clad::tape<double> _t5 = {};
+// CHECK-NEXT:     int _d_counter = 0, _d_counter_again = 0;
 // CHECK-NEXT:     int counter, counter_again;
 // CHECK-NEXT:     _t0 = counter;
 // CHECK-NEXT:     _t1 = counter_again;
 // CHECK-NEXT:     counter = counter_again = 3;
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     _t2 = {{0U|0UL}};
 // CHECK-NEXT:     while (counter--)
@@ -759,8 +759,6 @@ double fn10(double i, double j) {
 }
 
 // CHECK: void fn10_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_a = 0;
-// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_b = 0;
@@ -768,7 +766,9 @@ double fn10(double i, double j) {
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<int> _t4 = {};
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
+// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (clad::push(_t1, b) , b = counter)
@@ -822,12 +822,12 @@ double fn11(double i, double j) {
 }
 
 // CHECK: void fn11_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     int _d_counter = 0;
-// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
+// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     do {
@@ -874,8 +874,6 @@ double fn12(double i, double j) {
 }
 
 // CHECK: void fn12_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     int _d_counter = 0;
-// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_counter_again = 0;
@@ -886,7 +884,9 @@ double fn12(double i, double j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t5 = {};
 // CHECK-NEXT:     clad::tape<double> _t6 = {};
 // CHECK-NEXT:     clad::tape<int> _t7 = {};
+// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     do {
@@ -967,8 +967,6 @@ double fn13(double i, double j) {
 }
 
 // CHECK: void fn13_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
-// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_k = 0;
@@ -979,7 +977,9 @@ double fn13(double i, double j) {
 // CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double temp = 0;
 // CHECK-NEXT:     clad::tape<double> _t5 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (;; clad::push(_t2, counter) , (counter -= 1)) {
@@ -1052,8 +1052,6 @@ double fn14(double i, double j) {
 }
 
 // CHECK: void fn14_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     int _d_choice = 0;
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
@@ -1062,7 +1060,9 @@ double fn14(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond2 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
+// CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     int choice = 5;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (choice--)
@@ -1172,8 +1172,6 @@ double fn15(double i, double j) {
 }
 
 // CHECK: void fn15_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     int _d_choice = 0;
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
@@ -1186,7 +1184,9 @@ double fn15(double i, double j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t5 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond2 = {};
 // CHECK-NEXT:     clad::tape<double> _t6 = {};
+// CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     int choice = 5;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (choice--)
@@ -1298,8 +1298,6 @@ double fn16(double i, double j) {
 }
 
 // CHECK: void fn16_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     int _d_counter = 0;
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_ii = 0;
 // CHECK-NEXT:     int ii = 0;
@@ -1309,7 +1307,9 @@ double fn16(double i, double j) {
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
+// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 5;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (ii = 0; ; ++ii) {
@@ -1410,8 +1410,6 @@ double fn17(double i, double j) {
 }
 
 // CHECK: void fn17_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     int _d_counter = 0;
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_ii = 0;
 // CHECK-NEXT:     int ii = 0;
@@ -1425,7 +1423,9 @@ double fn17(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t5 = {};
 // CHECK-NEXT:     clad::tape<double> _t6 = {};
+// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 5;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (ii = 0; ; ++ii) {
@@ -1544,8 +1544,6 @@ double fn18(double i, double j) {
 }
 
 // CHECK: void fn18_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     int _d_choice = 0;
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 0;
@@ -1554,7 +1552,9 @@ double fn18(double i, double j) {
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     int choice = 5;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (counter = 0; ; ++counter) {
@@ -1632,7 +1632,6 @@ double fn19(double* arr, int n) {
 
 // CHECK: void fn19_grad_0(double *arr, int n, double *_d_arr) {
 // CHECK-NEXT:     int _d_n = 0;
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
@@ -1641,6 +1640,7 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:     double *_d_ref = 0;
 // CHECK-NEXT:     double *ref = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
@@ -1683,16 +1683,16 @@ double f_loop_init_var(double lower, double upper) {
 }
 
 // CHECK: void f_loop_init_var_grad(double lower, double upper, double *_d_lower, double *_d_upper) {
-// CHECK-NEXT:     double _d_sum = 0;
-// CHECK-NEXT:     double _d_num_points = 0;
-// CHECK-NEXT:     double _d_interval = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     double _d_x = 0;
 // CHECK-NEXT:     double x = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = 0;
+// CHECK-NEXT:     double _d_num_points = 0;
 // CHECK-NEXT:     double num_points = 10000;
+// CHECK-NEXT:     double _d_interval = 0;
 // CHECK-NEXT:     double interval = (upper - lower) / num_points;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (x = lower; ; clad::push(_t1, x) , (x += interval)) {
@@ -1743,12 +1743,12 @@ double fn20(double *arr, int n) {
 
 // CHECK: void fn20_grad_0(double *arr, int n, double *_d_arr) {
 // CHECK-NEXT:     int _d_n = 0;
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
@@ -1791,7 +1791,6 @@ double fn21(double x) {
 
 
 // CHECK: void fn21_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
@@ -1799,6 +1798,7 @@ double fn21(double x) {
 // CHECK-NEXT:     double _d_arr[3] = {0};
 // CHECK-NEXT:     clad::array<double> arr({{3U|3UL}});
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
@@ -1843,7 +1843,6 @@ double fn22(double param) {
 
 
 // CHECK: void fn22_grad(double param, double *_d_param) {
-// CHECK-NEXT:     double _d_out = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
@@ -1852,6 +1851,7 @@ double fn22(double param) {
 // CHECK-NEXT:     clad::array<double> arr({{1U|1UL}});
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     double _d_out = 0;
 // CHECK-NEXT:     double out = 0.;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
@@ -1896,13 +1896,13 @@ double fn23(double i, double j) {
 }
 
 // CHECK: void fn23_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
@@ -1958,11 +1958,11 @@ double fn24(double i, double j) {
 }
 
 // CHECK: void fn24_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
@@ -2004,7 +2004,6 @@ double fn25(double i, double j) {
 }
 
 // CHECK: void fn25_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
@@ -2012,6 +2011,7 @@ double fn25(double i, double j) {
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
@@ -2081,7 +2081,6 @@ double fn26(double i, double j) {
 }
 
 // CHECK: void fn26_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
@@ -2089,6 +2088,7 @@ double fn26(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; clad::push(_t2, res) , (++c , res = 7 * i * j)) {
@@ -2155,7 +2155,6 @@ double fn27(double i, double j) {
 }
 
 // CHECK: void fn27_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
@@ -2163,6 +2162,7 @@ double fn27(double i, double j) {
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
@@ -2228,12 +2228,12 @@ double fn28(double i, double j) {
 }
 
 // CHECK: void fn28_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
@@ -2280,12 +2280,12 @@ double fn29(double i, double j) {
 }
 
 // CHECK: void fn29_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; clad::push(_t2, res) , (++c , res = 3 * i * j)) {
@@ -2331,7 +2331,6 @@ double fn30(double i, double j) {
 }
 
 // CHECK: void fn30_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
@@ -2341,6 +2340,7 @@ double fn30(double i, double j) {
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
 // CHECK-NEXT:     clad::tape<bool> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
@@ -2391,12 +2391,12 @@ double fn31(double i, double j) {
 }
 
 //CHECK:void fn31_grad(double i, double j, double *_d_i, double *_d_j) {
-//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    unsigned {{int|long}} _t0;
 //CHECK-NEXT:    int _d_c = 0;
 //CHECK-NEXT:    int c = 0;
 //CHECK-NEXT:    clad::tape<double> _t1 = {};
 //CHECK-NEXT:    clad::tape<double> _t2 = {};
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    _t0 = {{0U|0UL}};
 //CHECK-NEXT:    for (c = 0; ; ++c) {
@@ -2452,7 +2452,6 @@ double fn32(double i, double j) {
 }
 
 //CHECK:void fn32_grad(double i, double j, double *_d_i, double *_d_j) {
-//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    unsigned {{int|long}} _t0;
 //CHECK-NEXT:    int _d_c = 0;
 //CHECK-NEXT:    int c = 0;
@@ -2468,6 +2467,7 @@ double fn32(double i, double j) {
 //CHECK-NEXT:    clad::tape<bool> _cond1 = {};
 //CHECK-NEXT:    clad::tape<double> _t7 = {};
 //CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t8 = {};
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    _t0 = {{0U|0UL}};
 //CHECK-NEXT:    for (c = 0; ; ++c) {
@@ -2599,7 +2599,6 @@ double fn33(double i, double j) {
 }
 
 //CHECK: void fn33_grad(double i, double j, double *_d_i, double *_d_j) {
-//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    unsigned {{int|long}} _t0;
 //CHECK-NEXT:    int _d_c = 0;
 //CHECK-NEXT:    int c = 0;
@@ -2619,6 +2618,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:    clad::tape<bool> _t5 = {};
 //CHECK-NEXT:    clad::tape<double> _t6 = {};
 //CHECK-NEXT:    clad::tape<bool> _cond5 = {};
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    _t0 = {{0U|0UL}};
 //CHECK-NEXT:    for (c = 0; ; ++c) {

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -49,8 +49,7 @@ public:
   }
 
   // CHECK: void volatile_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -65,8 +64,7 @@ public:
   }
 
   // CHECK: void const_volatile_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -107,8 +105,7 @@ public:
   }
 
   // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -123,8 +120,7 @@ public:
   }
 
   // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -165,8 +161,7 @@ public:
   }
 
   // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -181,8 +176,7 @@ public:
   }
 
   // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -225,8 +219,7 @@ public:
   }
 
   // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile noexcept {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -241,8 +234,7 @@ public:
   }
 
   // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile noexcept {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -285,8 +277,7 @@ public:
   }
 
   // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & noexcept {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -301,8 +292,7 @@ public:
   }
 
   // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & noexcept {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -345,8 +335,7 @@ public:
   }
 
   // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && noexcept {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -361,8 +350,7 @@ public:
   }
 
   // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && noexcept {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     _t0 = (this->x + this->y);
+  // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -447,8 +435,7 @@ double fn2(SimpleFunctions& sf, double i) {
 // CHECK: clad::ValueAndAdjoint<double &, double &> ref_mem_fn_forw(double i, SimpleFunctions *_d_this, double *_d_i);
 
 // CHECK: void fn2_grad(SimpleFunctions &sf, double i, SimpleFunctions *_d_sf, double *_d_i) {
-// CHECK-NEXT:     SimpleFunctions _t0;
-// CHECK-NEXT:     _t0 = sf;
+// CHECK-NEXT:     SimpleFunctions _t0 = sf;
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = _t0.ref_mem_fn_forw(i, &(*_d_sf), nullptr);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
@@ -472,8 +459,7 @@ double fn5(SimpleFunctions& v, double value) {
 // CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_equal_forw(double value, SimpleFunctions *_d_this, SimpleFunctions *_d_value);
 
 // CHECK: void fn5_grad(SimpleFunctions &v, double value, SimpleFunctions *_d_v, double *_d_value) {
-// CHECK-NEXT:     SimpleFunctions _t0;
-// CHECK-NEXT:     _t0 = v;
+// CHECK-NEXT:     SimpleFunctions _t0 = v;
 // CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = _t0.operator_plus_equal_forw(value, &(*_d_v), nullptr);
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
@@ -493,8 +479,7 @@ double fn4(SimpleFunctions& v) {
 // CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_plus_forw(SimpleFunctions *_d_this);
 
 // CHECK: void fn4_grad(SimpleFunctions &v, SimpleFunctions *_d_v) {
-// CHECK-NEXT:     SimpleFunctions _t0;
-// CHECK-NEXT:     _t0 = v;
+// CHECK-NEXT:     SimpleFunctions _t0 = v;
 // CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = _t0.operator_plus_plus_forw(&(*_d_v));
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     _t0.operator_plus_plus_pullback({}, &(*_d_v));
@@ -553,8 +538,7 @@ int main() {
 
   // CHECK:   void const_volatile_lval_ref_mem_fn_grad_0(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i) const volatile & {
   // CHECK-NEXT:       double _d_j = 0;
-  // CHECK-NEXT:       double _t0;
-  // CHECK-NEXT:       _t0 = (this->x + this->y);
+  // CHECK-NEXT:       double _t0 = (this->x + this->y);
   // CHECK-NEXT:       {
   // CHECK-NEXT:           (*_d_this).x += 1 * i;
   // CHECK-NEXT:           (*_d_this).y += 1 * i;
@@ -568,8 +552,7 @@ int main() {
 
   // CHECK:   void const_volatile_rval_ref_mem_fn_grad_1(double i, double j, volatile SimpleFunctions *_d_this, double *_d_j) const volatile && {
   // CHECK-NEXT:       double _d_i = 0;
-  // CHECK-NEXT:       double _t0;
-  // CHECK-NEXT:       _t0 = (this->x + this->y);
+  // CHECK-NEXT:       double _t0 = (this->x + this->y);
   // CHECK-NEXT:       {
   // CHECK-NEXT:           (*_d_this).x += 1 * i;
   // CHECK-NEXT:           (*_d_this).y += 1 * i;
@@ -587,10 +570,9 @@ int main() {
 // CHECK: void fn3_grad_2_3(double x, double y, double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_x = 0;
 // CHECK-NEXT:     double _d_y = 0;
-// CHECK-NEXT:     SimpleFunctions _t0;
 // CHECK-NEXT:     SimpleFunctions _d_sf({});
 // CHECK-NEXT:     SimpleFunctions sf(x, y);
-// CHECK-NEXT:     _t0 = sf;
+// CHECK-NEXT:     SimpleFunctions _t0 = sf;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;
@@ -601,11 +583,9 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void ref_mem_fn_pullback(double i, double _d_y, SimpleFunctions *_d_this, double *_d_i) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     _t0 = this->x;
+// CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x = +i;
-// CHECK-NEXT:     _t1 = this->x;
+// CHECK-NEXT:     double _t1 = this->x;
 // CHECK-NEXT:     this->x = -i;
 // CHECK-NEXT:     (*_d_this).x += _d_y;
 // CHECK-NEXT:     {
@@ -623,18 +603,15 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndAdjoint<double &, double &> ref_mem_fn_forw(double i, SimpleFunctions *_d_this, double *_d_i) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     _t0 = this->x;
+// CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x = +i;
-// CHECK-NEXT:     _t1 = this->x;
+// CHECK-NEXT:     double _t1 = this->x;
 // CHECK-NEXT:     this->x = -i;
 // CHECK-NEXT:     return {this->x, (*_d_this).x};
 // CHECK-NEXT: }
 
 // CHECK: void operator_plus_equal_pullback(double value, SimpleFunctions _d_y, SimpleFunctions *_d_this, double *_d_value) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _t0 = this->x;
+// CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x += value;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t0;
@@ -644,15 +621,13 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_equal_forw(double value, SimpleFunctions *_d_this, SimpleFunctions *_d_value) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _t0 = this->x;
+// CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x += value;
 // CHECK-NEXT:     return {*this, (*_d_this)};
 // CHECK-NEXT: }
 
 // CHECK: void operator_plus_plus_pullback(SimpleFunctions _d_y, SimpleFunctions *_d_this) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _t0 = this->x;
+// CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x += 1.;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t0;
@@ -661,8 +636,7 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_plus_forw(SimpleFunctions *_d_this) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _t0 = this->x;
+// CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x += 1.;
 // CHECK-NEXT:     return {*this, (*_d_this)};
 // CHECK-NEXT: }

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -587,8 +587,8 @@ int main() {
 // CHECK: void fn3_grad_2_3(double x, double y, double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_x = 0;
 // CHECK-NEXT:     double _d_y = 0;
-// CHECK-NEXT:     SimpleFunctions _d_sf({});
 // CHECK-NEXT:     SimpleFunctions _t0;
+// CHECK-NEXT:     SimpleFunctions _d_sf({});
 // CHECK-NEXT:     SimpleFunctions sf(x, y);
 // CHECK-NEXT:     _t0 = sf;
 // CHECK-NEXT:     {

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -126,10 +126,9 @@ int main() {
     // CHECK: void mem_fn_1_pullback(double i, double j, double _d_y, SimpleFunctions1 *_d_this, double *_d_i, double *_d_j);
 
     // CHECK: void fn_s1_mem_fn_grad(double i, double j, double *_d_i, double *_d_j) {
-    // CHECK-NEXT:     SimpleFunctions1 _t0;
     // CHECK-NEXT:     SimpleFunctions1 _d_obj({});
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
-    // CHECK-NEXT:     _t0 = obj;
+    // CHECK-NEXT:     SimpleFunctions1 _t0 = obj;
     // CHECK-NEXT:     {
     // CHECK-NEXT:         double _r0 = 0;
     // CHECK-NEXT:         double _r1 = 0;

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -126,8 +126,8 @@ int main() {
     // CHECK: void mem_fn_1_pullback(double i, double j, double _d_y, SimpleFunctions1 *_d_this, double *_d_i, double *_d_j);
 
     // CHECK: void fn_s1_mem_fn_grad(double i, double j, double *_d_i, double *_d_j) {
-    // CHECK-NEXT:     SimpleFunctions1 _d_obj({});
     // CHECK-NEXT:     SimpleFunctions1 _t0;
+    // CHECK-NEXT:     SimpleFunctions1 _d_obj({});
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
     // CHECK-NEXT:     _t0 = obj;
     // CHECK-NEXT:     {

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -25,10 +25,9 @@ double minimalPointer(double x) {
 }
 
 // CHECK: void minimalPointer_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double *_d_p = &*_d_x;
 // CHECK-NEXT:     double *const p = &x;
-// CHECK-NEXT:     _t0 = *p;
+// CHECK-NEXT:     double _t0 = *p;
 // CHECK-NEXT:     *p = *p * (*p);
 // CHECK-NEXT:     *_d_p += 1;
 // CHECK-NEXT:     {
@@ -57,49 +56,37 @@ double arrayPointer(const double* arr) {
 }
 
 // CHECK: void arrayPointer_grad(const double *arr, double *_d_arr) {
-// CHECK-NEXT:     const double *_t0;
-// CHECK-NEXT:     double *_t1;
-// CHECK-NEXT:     double _t2;
-// CHECK-NEXT:     const double *_t3;
-// CHECK-NEXT:     double *_t4;
-// CHECK-NEXT:     double _t5;
-// CHECK-NEXT:     double _t6;
-// CHECK-NEXT:     const double *_t7;
-// CHECK-NEXT:     double *_t8;
-// CHECK-NEXT:     const double *_t9;
-// CHECK-NEXT:     double *_t10;
-// CHECK-NEXT:     double _t11;
 // CHECK-NEXT:     double *_d_p = _d_arr;
 // CHECK-NEXT:     const double *p = arr;
-// CHECK-NEXT:     _t0 = p;
-// CHECK-NEXT:     _t1 = _d_p;
+// CHECK-NEXT:     const double *_t0 = p;
+// CHECK-NEXT:     double *_t1 = _d_p;
 // CHECK-NEXT:     _d_p = _d_p + 1;
 // CHECK-NEXT:     p = p + 1;
 // CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = *p;
 // CHECK-NEXT:     _d_p++;
 // CHECK-NEXT:     p++;
-// CHECK-NEXT:     _t2 = sum;
+// CHECK-NEXT:     double _t2 = sum;
 // CHECK-NEXT:     sum += *p * 2;
-// CHECK-NEXT:     _t3 = p;
-// CHECK-NEXT:     _t4 = _d_p;
+// CHECK-NEXT:     const double *_t3 = p;
+// CHECK-NEXT:     double *_t4 = _d_p;
 // CHECK-NEXT:     _d_p += 1;
 // CHECK-NEXT:     p += 1;
-// CHECK-NEXT:     _t5 = sum;
+// CHECK-NEXT:     double _t5 = sum;
 // CHECK-NEXT:     sum += *p * 4;
 // CHECK-NEXT:     ++_d_p;
 // CHECK-NEXT:     ++p;
-// CHECK-NEXT:     _t6 = sum;
+// CHECK-NEXT:     double _t6 = sum;
 // CHECK-NEXT:     sum += *p * 3;
-// CHECK-NEXT:     _t7 = p;
-// CHECK-NEXT:     _t8 = _d_p;
+// CHECK-NEXT:     const double *_t7 = p;
+// CHECK-NEXT:     double *_t8 = _d_p;
 // CHECK-NEXT:     _d_p -= 2;
 // CHECK-NEXT:     p -= 2;
-// CHECK-NEXT:     _t9 = p;
-// CHECK-NEXT:     _t10 = _d_p;
+// CHECK-NEXT:     const double *_t9 = p;
+// CHECK-NEXT:     double *_t10 = _d_p;
 // CHECK-NEXT:     _d_p = _d_p - 2;
 // CHECK-NEXT:     p = p - 2;
-// CHECK-NEXT:     _t11 = sum;
+// CHECK-NEXT:     double _t11 = sum;
 // CHECK-NEXT:     sum += 5 * (*p);
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
@@ -161,7 +148,6 @@ double pointerParam(const double* arr, size_t n) {
 
 // CHECK: void pointerParam_grad_0(const double *arr, size_t n, double *_d_arr) {
 // CHECK-NEXT:     size_t _d_n = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     size_t _d_i = 0;
 // CHECK-NEXT:     size_t i = 0;
 // CHECK-NEXT:     clad::tape<size_t *> _t1 = {};
@@ -173,7 +159,7 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:     clad::tape<double *> _t6 = {};
 // CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -228,45 +214,37 @@ double pointerMultipleParams(const double* a, const double* b) {
 }
 
 // CHECK: void pointerMultipleParams_grad(const double *a, const double *b, double *_d_a, double *_d_b) {
-// CHECK-NEXT:     const double *_t0;
-// CHECK-NEXT:     double *_t1;
-// CHECK-NEXT:     const double *_t2;
-// CHECK-NEXT:     double *_t3;
-// CHECK-NEXT:     double _t4;
-// CHECK-NEXT:     double _t5;
-// CHECK-NEXT:     double _t6;
-// CHECK-NEXT:     double _t7;
 // CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = b[2];
-// CHECK-NEXT:     _t0 = b;
-// CHECK-NEXT:     _t1 = _d_b;
+// CHECK-NEXT:     const double *_t0 = b;
+// CHECK-NEXT:     double *_t1 = _d_b;
 // CHECK-NEXT:     _d_b = _d_a;
 // CHECK-NEXT:     b = a;
-// CHECK-NEXT:     _t2 = a;
-// CHECK-NEXT:     _t3 = _d_a;
+// CHECK-NEXT:     const double *_t2 = a;
+// CHECK-NEXT:     double *_t3 = _d_a;
 // CHECK-NEXT:     _d_a = 1 + _d_a;
 // CHECK-NEXT:     a = 1 + a;
 // CHECK-NEXT:     ++_d_b;
 // CHECK-NEXT:     ++b;
-// CHECK-NEXT:     _t4 = sum;
+// CHECK-NEXT:     double _t4 = sum;
 // CHECK-NEXT:     sum += a[0] + b[0];
 // CHECK-NEXT:     _d_b++;
 // CHECK-NEXT:     b++;
 // CHECK-NEXT:     _d_a++;
 // CHECK-NEXT:     a++;
-// CHECK-NEXT:     _t5 = sum;
+// CHECK-NEXT:     double _t5 = sum;
 // CHECK-NEXT:     sum += a[0] + b[0];
 // CHECK-NEXT:     _d_b--;
 // CHECK-NEXT:     b--;
 // CHECK-NEXT:     _d_a--;
 // CHECK-NEXT:     a--;
-// CHECK-NEXT:     _t6 = sum;
+// CHECK-NEXT:     double _t6 = sum;
 // CHECK-NEXT:     sum += a[0] + b[0];
 // CHECK-NEXT:     --_d_b;
 // CHECK-NEXT:     --b;
 // CHECK-NEXT:     --_d_a;
 // CHECK-NEXT:     --a;
-// CHECK-NEXT:     _t7 = sum;
+// CHECK-NEXT:     double _t7 = sum;
 // CHECK-NEXT:     sum += a[0] + b[0];
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
@@ -346,17 +324,15 @@ double newAndDeletePointer(double i, double j) {
 }
 
 // CHECK: void newAndDeletePointer_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double *_d_p = new double(*_d_i);
 // CHECK-NEXT:     double *p = new double(i);
 // CHECK-NEXT:     double *_d_q = new double(*_d_j);
 // CHECK-NEXT:     double *q = new double(j);
 // CHECK-NEXT:     double *_d_r = new double [2](/*implicit*/(double{{[ ]?}}[2])0);
 // CHECK-NEXT:     double *r = new double [2];
-// CHECK-NEXT:     _t0 = r[0];
+// CHECK-NEXT:     double _t0 = r[0];
 // CHECK-NEXT:     r[0] = i + j;
-// CHECK-NEXT:     _t1 = r[1];
+// CHECK-NEXT:     double _t1 = r[1];
 // CHECK-NEXT:     r[1] = i * j;
 // CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = *p + *q + r[0] + r[1];
@@ -432,31 +408,25 @@ double cStyleMemoryAlloc(double x, size_t n) {
 
 // CHECK: void cStyleMemoryAlloc_grad_0(double x, size_t n, double *_d_x) {
 // CHECK-NEXT:     size_t _d_n = 0;
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     double *_t2;
-// CHECK-NEXT:     double *_t3;
-// CHECK-NEXT:     double _t4;
-// CHECK-NEXT:     double _t5;
 // CHECK-NEXT:     T *_d_t = (T *)malloc(n * sizeof(T));
 // CHECK-NEXT:     T *t = (T *)malloc(n * sizeof(T));
 // CHECK-NEXT:     memset(_d_t, 0, n * sizeof(T));
 // CHECK-NEXT:     memset(t, 0, n * sizeof(T));
-// CHECK-NEXT:     _t0 = t->x;
+// CHECK-NEXT:     double _t0 = t->x;
 // CHECK-NEXT:     t->x = x;
 // CHECK-NEXT:     double *_d_p = (double *)calloc(1, sizeof(double));
 // CHECK-NEXT:     double *p = (double *)calloc(1, sizeof(double));
-// CHECK-NEXT:     _t1 = *p;
+// CHECK-NEXT:     double _t1 = *p;
 // CHECK-NEXT:     *p = x;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = t->x + *p;
-// CHECK-NEXT:     _t2 = p;
-// CHECK-NEXT:     _t3 = _d_p;
+// CHECK-NEXT:     double *_t2 = p;
+// CHECK-NEXT:     double *_t3 = _d_p;
 // CHECK-NEXT:     _d_p = (double *)realloc(_d_p, 2 * sizeof(double));
 // CHECK-NEXT:     p = (double *)realloc(p, 2 * sizeof(double));
-// CHECK-NEXT:     _t4 = p[1];
+// CHECK-NEXT:     double _t4 = p[1];
 // CHECK-NEXT:     p[1] = 2 * x;
-// CHECK-NEXT:     _t5 = res;
+// CHECK-NEXT:     double _t5 = res;
 // CHECK-NEXT:     res += p[1];
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -25,9 +25,8 @@ double minimalPointer(double x) {
 }
 
 // CHECK: void minimalPointer_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double *_d_p = 0;
 // CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _d_p = &*_d_x;
+// CHECK-NEXT:     double *_d_p = &*_d_x;
 // CHECK-NEXT:     double *const p = &x;
 // CHECK-NEXT:     _t0 = *p;
 // CHECK-NEXT:     *p = *p * (*p);
@@ -58,10 +57,8 @@ double arrayPointer(const double* arr) {
 }
 
 // CHECK: void arrayPointer_grad(const double *arr, double *_d_arr) {
-// CHECK-NEXT:     double *_d_p = 0;
 // CHECK-NEXT:     const double *_t0;
 // CHECK-NEXT:     double *_t1;
-// CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     const double *_t3;
 // CHECK-NEXT:     double *_t4;
@@ -72,12 +69,13 @@ double arrayPointer(const double* arr) {
 // CHECK-NEXT:     const double *_t9;
 // CHECK-NEXT:     double *_t10;
 // CHECK-NEXT:     double _t11;
-// CHECK-NEXT:     _d_p = _d_arr;
+// CHECK-NEXT:     double *_d_p = _d_arr;
 // CHECK-NEXT:     const double *p = arr;
 // CHECK-NEXT:     _t0 = p;
 // CHECK-NEXT:     _t1 = _d_p;
 // CHECK-NEXT:     _d_p = _d_p + 1;
 // CHECK-NEXT:     p = p + 1;
+// CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = *p;
 // CHECK-NEXT:     _d_p++;
 // CHECK-NEXT:     p++;
@@ -163,7 +161,6 @@ double pointerParam(const double* arr, size_t n) {
 
 // CHECK: void pointerParam_grad_0(const double *arr, size_t n, double *_d_arr) {
 // CHECK-NEXT:     size_t _d_n = 0;
-// CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     size_t _d_i = 0;
 // CHECK-NEXT:     size_t i = 0;
@@ -174,6 +171,7 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     clad::tape<const double *> _t5 = {};
 // CHECK-NEXT:     clad::tape<double *> _t6 = {};
+// CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
@@ -230,7 +228,6 @@ double pointerMultipleParams(const double* a, const double* b) {
 }
 
 // CHECK: void pointerMultipleParams_grad(const double *a, const double *b, double *_d_a, double *_d_b) {
-// CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     const double *_t0;
 // CHECK-NEXT:     double *_t1;
 // CHECK-NEXT:     const double *_t2;
@@ -239,6 +236,7 @@ double pointerMultipleParams(const double* a, const double* b) {
 // CHECK-NEXT:     double _t5;
 // CHECK-NEXT:     double _t6;
 // CHECK-NEXT:     double _t7;
+// CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = b[2];
 // CHECK-NEXT:     _t0 = b;
 // CHECK-NEXT:     _t1 = _d_b;
@@ -348,22 +346,19 @@ double newAndDeletePointer(double i, double j) {
 }
 
 // CHECK: void newAndDeletePointer_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double *_d_p = 0;
-// CHECK-NEXT:     double *_d_q = 0;
-// CHECK-NEXT:     double *_d_r = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     double _d_sum = 0;
-// CHECK-NEXT:     _d_p = new double(*_d_i);
+// CHECK-NEXT:     double *_d_p = new double(*_d_i);
 // CHECK-NEXT:     double *p = new double(i);
-// CHECK-NEXT:     _d_q = new double(*_d_j);
+// CHECK-NEXT:     double *_d_q = new double(*_d_j);
 // CHECK-NEXT:     double *q = new double(j);
-// CHECK-NEXT:     _d_r = new double [2](/*implicit*/(double{{[ ]?}}[2])0);
+// CHECK-NEXT:     double *_d_r = new double [2](/*implicit*/(double{{[ ]?}}[2])0);
 // CHECK-NEXT:     double *r = new double [2];
 // CHECK-NEXT:     _t0 = r[0];
 // CHECK-NEXT:     r[0] = i + j;
 // CHECK-NEXT:     _t1 = r[1];
 // CHECK-NEXT:     r[1] = i * j;
+// CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = *p + *q + r[0] + r[1];
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
@@ -409,10 +404,9 @@ double structPointer (double x) {
 }
 
 // CHECK: void structPointer_grad(double x, double *_d_x) {
-// CHECK-NEXT:     T *_d_t = 0;
-// CHECK-NEXT:     double _d_res = 0;
-// CHECK-NEXT:     _d_t = new T();
+// CHECK-NEXT:     T *_d_t = new T();
 // CHECK-NEXT:     T *t = new T({x, /*implicit*/(int)0});
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = t->x;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     _d_t->x += _d_res;
@@ -438,25 +432,23 @@ double cStyleMemoryAlloc(double x, size_t n) {
 
 // CHECK: void cStyleMemoryAlloc_grad_0(double x, size_t n, double *_d_x) {
 // CHECK-NEXT:     size_t _d_n = 0;
-// CHECK-NEXT:     T *_d_t = 0;
 // CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double *_d_p = 0;
 // CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double *_t2;
 // CHECK-NEXT:     double *_t3;
 // CHECK-NEXT:     double _t4;
 // CHECK-NEXT:     double _t5;
-// CHECK-NEXT:     _d_t = (T *)malloc(n * sizeof(T));
+// CHECK-NEXT:     T *_d_t = (T *)malloc(n * sizeof(T));
 // CHECK-NEXT:     T *t = (T *)malloc(n * sizeof(T));
 // CHECK-NEXT:     memset(_d_t, 0, n * sizeof(T));
 // CHECK-NEXT:     memset(t, 0, n * sizeof(T));
 // CHECK-NEXT:     _t0 = t->x;
 // CHECK-NEXT:     t->x = x;
-// CHECK-NEXT:     _d_p = (double *)calloc(1, sizeof(double));
+// CHECK-NEXT:     double *_d_p = (double *)calloc(1, sizeof(double));
 // CHECK-NEXT:     double *p = (double *)calloc(1, sizeof(double));
 // CHECK-NEXT:     _t1 = *p;
 // CHECK-NEXT:     *p = x;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = t->x + *p;
 // CHECK-NEXT:     _t2 = p;
 // CHECK-NEXT:     _t3 = _d_p;

--- a/test/Gradient/Switch.C
+++ b/test/Gradient/Switch.C
@@ -19,15 +19,15 @@ double fn1(double i, double j) {
 }
 
 // CHECK: void fn1_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
-// CHECK-NEXT:     int _d_count = 0;
 // CHECK-NEXT:     int _cond0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     double _t3;
 // CHECK-NEXT:     double _t4;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     int _d_count = 0;
 // CHECK-NEXT:     int count = 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _cond0 = count;
@@ -130,7 +130,6 @@ double fn2(double i, double j) {
 }
 
 // CHECK: void fn2_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     int _d_count = 0;
 // CHECK-NEXT:     int count = 0;
 // CHECK-NEXT:     int _cond0;
@@ -141,6 +140,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:     double _t4;
 // CHECK-NEXT:     double _t5;
 // CHECK-NEXT:     double _t6;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         count = 2;
@@ -262,8 +262,6 @@ double fn3(double i, double j) {
 }
 
 // CHECK: void fn3_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
-// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<int> _cond0 = {};
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
@@ -271,7 +269,9 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     clad::tape<double> _t5 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 2;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (counter--)
@@ -387,13 +387,13 @@ double fn4(double i, double j) {
 }
 
 // CHECK: void fn4_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t2;
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (1) {
@@ -474,12 +474,12 @@ double fn5(double i, double j) {
 }
 
 // CHECK: void fn5_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     int _d_count = 0;
 // CHECK-NEXT:     int count = 0;
 // CHECK-NEXT:     int _cond0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         count = 1;
@@ -519,13 +519,13 @@ double fn6(double u, double v) {
 }
 
 // CHECK: void fn6_grad(double u, double v, double *_d_u, double *_d_v) {
-// CHECK-NEXT:     int _d_res = 0;
-// CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     int _t0;
 // CHECK-NEXT:     int _cond0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     int _d_res = 0;
 // CHECK-NEXT:     int res = 0;
+// CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double temp = 0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t0 = res;
@@ -584,7 +584,6 @@ double fn7(double u, double v) {
 }
 
 // CHECK: void fn7_grad(double u, double v, double *_d_u, double *_d_v) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
@@ -592,6 +591,7 @@ double fn7(double u, double v) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {

--- a/test/Gradient/Switch.C
+++ b/test/Gradient/Switch.C
@@ -262,7 +262,6 @@ double fn3(double i, double j) {
 }
 
 // CHECK: void fn3_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     clad::tape<int> _cond0 = {};
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
@@ -273,7 +272,7 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 2;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     while (counter--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -584,7 +583,6 @@ double fn7(double u, double v) {
 }
 
 // CHECK: void fn7_grad(double u, double v, double *_d_u, double *_d_v) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<int> _cond0 = {};
@@ -593,7 +591,7 @@ double fn7(double u, double v) {
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:          if (!(i < 5))

--- a/test/Gradient/SwitchInit.C
+++ b/test/Gradient/SwitchInit.C
@@ -17,7 +17,6 @@ double fn1(double i, double j) {
 }
 
 // CHECK: void fn1_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     int _d_count = 0;
 // CHECK-NEXT:     int count = 0;
 // CHECK-NEXT:     int _cond0;
@@ -26,6 +25,7 @@ double fn1(double i, double j) {
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     double _t3;
 // CHECK-NEXT:     double _t4;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         count = 1;

--- a/test/Gradient/TemplateFunctors.C
+++ b/test/Gradient/TemplateFunctors.C
@@ -55,8 +55,7 @@ template <typename T> struct ExperimentConstVolatile {
 };
 
 // CHECK: void operator_call_grad(double i, double j, volatile ExperimentConstVolatile<double> *_d_this, double *_d_i, double *_d_j) const volatile {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _t0 = this->x * i;
+// CHECK-NEXT:     double _t0 = this->x * i;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (*_d_this).x += 1 * i * i;
 // CHECK-NEXT:         *_d_i += this->x * 1 * i;
@@ -77,10 +76,8 @@ template <> struct ExperimentConstVolatile<long double> {
 };
 
 // CHECK: void operator_call_grad(long double i, long double j, volatile ExperimentConstVolatile<long double> *_d_this, long double  *_d_i, long double  *_d_j) const volatile {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     _t0 = this->x * i;
-// CHECK-NEXT:     _t1 = this->y * j;
+// CHECK-NEXT:     double _t0 = this->x * i;
+// CHECK-NEXT:     double _t1 = this->y * j;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (*_d_this).x += 1 * j * i * i;
 // CHECK-NEXT:         *_d_i += this->x * 1 * j * i;

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -19,11 +19,10 @@ float fn_type_conversion(float z, int a) {
 
 void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a);
 // CHECK: void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 1; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < a))

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -72,9 +72,9 @@ double fn2(Tangent t, double i) {
 
 // CHECK: void fn2_grad(Tangent t, double i, Tangent *_d_t, double *_d_i) {
 // CHECK-NEXT:     Tangent _t0;
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     _t0 = t;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = sum(t);
 // CHECK-NEXT:     _t1 = res;
 // CHECK-NEXT:     res += sum(t.data) + i + 2 * t.data[0];
@@ -100,10 +100,10 @@ double fn3(double i, double j) {
 }
 
 // CHECK: void fn3_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     Tangent _d_t({});
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     Tangent _t2;
+// CHECK-NEXT:     Tangent _d_t({});
 // CHECK-NEXT:     Tangent t;
 // CHECK-NEXT:     _t0 = t.data[0];
 // CHECK-NEXT:     t.data[0] = 2 * i;
@@ -137,8 +137,8 @@ double fn4(double i, double j) {
 
 // CHECK: void fn4_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     pairdd _d_p({});
-// CHECK-NEXT:     pairdd _d_q({});
 // CHECK-NEXT:     pairdd p(1, 3);
+// CHECK-NEXT:     pairdd _d_q({});
 // CHECK-NEXT:     pairdd q({7, 5});
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_p.first += 1 * i;
@@ -201,7 +201,6 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT:     dcomplex _t1;
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     dcomplex _t3;
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double _t4;
 // CHECK-NEXT:     double _t5;
 // CHECK-NEXT:     dcomplex _t6;
@@ -210,6 +209,7 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT:     _t1 = c;
 // CHECK-NEXT:     _t3 = c;
 // CHECK-NEXT:     _t2 = c.imag();
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = c.real() + 3 * _t2 + 6 * i;
 // CHECK-NEXT:     _t4 = res;
 // CHECK-NEXT:     _t6 = c;
@@ -302,7 +302,6 @@ double fn9(Tangent t, dcomplex c) {
 }
 
 // CHECK: void fn9_grad(Tangent t, dcomplex c, Tangent *_d_t, dcomplex *_d_c) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
@@ -312,6 +311,7 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     clad::tape<dcomplex> _t4 = {};
 // CHECK-NEXT:     double _t5;
 // CHECK-NEXT:     Tangent _t6;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
@@ -393,11 +393,11 @@ int main() {
 }
 
 // CHECK: void sum_pullback(Tangent &t, double _d_y, Tangent *_d_t) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
@@ -423,11 +423,11 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void sum_pullback(double *data, double _d_y, double *_d_data) {
-// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -71,12 +71,10 @@ double fn2(Tangent t, double i) {
 }
 
 // CHECK: void fn2_grad(Tangent t, double i, Tangent *_d_t, double *_d_i) {
-// CHECK-NEXT:     Tangent _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     _t0 = t;
+// CHECK-NEXT:     Tangent _t0 = t;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = sum(t);
-// CHECK-NEXT:     _t1 = res;
+// CHECK-NEXT:     double _t1 = res;
 // CHECK-NEXT:     res += sum(t.data) + i + 2 * t.data[0];
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
@@ -100,16 +98,13 @@ double fn3(double i, double j) {
 }
 
 // CHECK: void fn3_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     Tangent _t2;
 // CHECK-NEXT:     Tangent _d_t({});
 // CHECK-NEXT:     Tangent t;
-// CHECK-NEXT:     _t0 = t.data[0];
+// CHECK-NEXT:     double _t0 = t.data[0];
 // CHECK-NEXT:     t.data[0] = 2 * i;
-// CHECK-NEXT:     _t1 = t.data[1];
+// CHECK-NEXT:     double _t1 = t.data[1];
 // CHECK-NEXT:     t.data[1] = 5 * i + 3 * j;
-// CHECK-NEXT:     _t2 = t;
+// CHECK-NEXT:     Tangent _t2 = t;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t = _t2;
 // CHECK-NEXT:         sum_pullback(_t2, 1, &_d_t);
@@ -171,8 +166,7 @@ double fn5(const Tangent& t, double i) {
 // CHECK: void someMemFn2_pullback(double i, double j, double _d_y, Tangent *_d_this, double *_d_i, double *_d_j) const;
 
 // CHECK: void fn5_grad(const Tangent &t, double i, Tangent *_d_t, double *_d_i) {
-// CHECK-NEXT:     Tangent _t0;
-// CHECK-NEXT:     _t0 = t;
+// CHECK-NEXT:     Tangent _t0 = t;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;
@@ -197,23 +191,16 @@ double fn6(dcomplex c, double i) {
 // CHECK: constexpr void imag_pullback(double _d_y, std{{(::__1)?}}::complex<double> *_d_this){{.*}};
 
 // CHECK: void fn6_grad(dcomplex c, double i, dcomplex *_d_c, double *_d_i) {
-// CHECK-NEXT:     dcomplex _t0;
-// CHECK-NEXT:     dcomplex _t1;
-// CHECK-NEXT:     double _t2;
-// CHECK-NEXT:     dcomplex _t3;
-// CHECK-NEXT:     double _t4;
-// CHECK-NEXT:     double _t5;
-// CHECK-NEXT:     dcomplex _t6;
-// CHECK-NEXT:     _t0 = c;
+// CHECK-NEXT:     dcomplex _t0 = c;
 // CHECK-NEXT:     c.real(5 * i);
-// CHECK-NEXT:     _t1 = c;
-// CHECK-NEXT:     _t3 = c;
-// CHECK-NEXT:     _t2 = c.imag();
+// CHECK-NEXT:     dcomplex _t1 = c;
+// CHECK-NEXT:     dcomplex _t3 = c;
+// CHECK-NEXT:     double _t2 = c.imag();
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = c.real() + 3 * _t2 + 6 * i;
-// CHECK-NEXT:     _t4 = res;
-// CHECK-NEXT:     _t6 = c;
-// CHECK-NEXT:     _t5 = c.real();
+// CHECK-NEXT:     double _t4 = res;
+// CHECK-NEXT:     dcomplex _t6 = c;
+// CHECK-NEXT:     double _t5 = c.real();
 // CHECK-NEXT:     res += 4 * _t5;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
@@ -239,21 +226,14 @@ double fn7(dcomplex c1, dcomplex c2) {
 }
 
 // CHECK: void fn7_grad(dcomplex c1, dcomplex c2, dcomplex *_d_c1, dcomplex *_d_c2) {
-// CHECK-NEXT:     dcomplex _t0;
-// CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     dcomplex _t2;
-// CHECK-NEXT:     dcomplex _t3;
-// CHECK-NEXT:     dcomplex _t4;
-// CHECK-NEXT:     double _t5;
-// CHECK-NEXT:     dcomplex _t6;
-// CHECK-NEXT:     _t0 = c2;
-// CHECK-NEXT:     _t2 = c2;
-// CHECK-NEXT:     _t1 = c2.real();
-// CHECK-NEXT:     _t3 = c1;
+// CHECK-NEXT:     dcomplex _t0 = c2;
+// CHECK-NEXT:     dcomplex _t2 = c2;
+// CHECK-NEXT:     double _t1 = c2.real();
+// CHECK-NEXT:     dcomplex _t3 = c1;
 // CHECK-NEXT:     c1.real(c2.imag() + 5 * _t1);
-// CHECK-NEXT:     _t4 = c1;
-// CHECK-NEXT:     _t6 = c1;
-// CHECK-NEXT:     _t5 = c1.imag();
+// CHECK-NEXT:     dcomplex _t4 = c1;
+// CHECK-NEXT:     dcomplex _t6 = c1;
+// CHECK-NEXT:     double _t5 = c1.imag();
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t4.real_pullback(1, &(*_d_c1));
 // CHECK-NEXT:         _t6.imag_pullback(3 * 1, &(*_d_c1));
@@ -274,13 +254,10 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK: void updateTo_pullback(double d, Tangent *_d_this, double *_d_d);
 
 // CHECK: void fn8_grad(Tangent t, dcomplex c, Tangent *_d_t, dcomplex *_d_c) {
-// CHECK-NEXT:     dcomplex _t0;
-// CHECK-NEXT:     Tangent _t1;
-// CHECK-NEXT:     Tangent _t2;
-// CHECK-NEXT:     _t0 = c;
-// CHECK-NEXT:     _t1 = t;
+// CHECK-NEXT:     dcomplex _t0 = c;
+// CHECK-NEXT:     Tangent _t1 = t;
 // CHECK-NEXT:     t.updateTo(c.real());
-// CHECK-NEXT:     _t2 = t;
+// CHECK-NEXT:     Tangent _t2 = t;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         t = _t2;
 // CHECK-NEXT:         sum_pullback(_t2, 1, &(*_d_t));
@@ -302,18 +279,15 @@ double fn9(Tangent t, dcomplex c) {
 }
 
 // CHECK: void fn9_grad(Tangent t, dcomplex c, Tangent *_d_t, dcomplex *_d_c) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<dcomplex> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<dcomplex> _t4 = {};
-// CHECK-NEXT:     double _t5;
-// CHECK-NEXT:     Tangent _t6;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:          if (!(i < 5))
@@ -325,8 +299,8 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:         clad::push(_t4, c);
 // CHECK-NEXT:         res += c.real() + 2 * clad::push(_t3, c.imag());
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _t5 = res;
-// CHECK-NEXT:     _t6 = t;
+// CHECK-NEXT:     double _t5 = res;
+// CHECK-NEXT:     Tangent _t6 = t;
 // CHECK-NEXT:     res += sum(t);
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
@@ -393,13 +367,12 @@ int main() {
 }
 
 // CHECK: void sum_pullback(Tangent &t, double _d_y, Tangent *_d_t) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 5))
@@ -423,13 +396,12 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void sum_pullback(double *data, double _d_y, double *_d_data) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 5))
@@ -463,8 +435,7 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void real_pullback({{.*}} [[__val:.*]], std{{(::__1)?}}::complex<double> *_d_this, {{.*}} *[[_d___val:[a-zA-Z_]*]]){{.*}} {
-// CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     _t0 ={{( __real)?}} this->[[_M_value:.*]];
+// CHECK-NEXT:     double _t0 ={{( __real)?}} this->[[_M_value:.*]];
 // CHECK-NEXT:     {{(__real)?}} this->[[_M_value:.*]] = [[__val]];
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{(__real)?}} this->[[_M_value:.*]] = _t0;
@@ -483,11 +454,10 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void updateTo_pullback(double d, Tangent *_d_this, double *_d_d) {
-// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 5))

--- a/test/Gradient/constexprTest.C
+++ b/test/Gradient/constexprTest.C
@@ -31,8 +31,8 @@ constexpr double fn( double a, double b, double c) {
 
 //CHECK: constexpr void fn_grad(double a, double b, double c, double *_d_a, double *_d_b, double *_d_c) {
 //CHECK-NEXT:    double _d_val = 0;
-//CHECK-NEXT:    double _d_result = 0;
 //CHECK-NEXT:    double val = 98.;
+//CHECK-NEXT:    double _d_result = 0;
 //CHECK-NEXT:    double result = a * b / c * (a + b) * 100 + c;
 //CHECK-NEXT:    _d_result += 1;
 //CHECK-NEXT:    {

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -371,8 +371,7 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void sin_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
-// CHECK-NEXT:     float _t0;
-// CHECK-NEXT:     _t0 = ::std::cos(x);
+// CHECK-NEXT:     float _t0 = ::std::cos(x);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         _r0 += _d_y.value * clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, 1.F).pushforward;
@@ -385,8 +384,7 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void cos_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
-// CHECK-NEXT:     float _t0;
-// CHECK-NEXT:     _t0 = ::std::sin(x);
+// CHECK-NEXT:     float _t0 = ::std::sin(x);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         _r0 += _d_y.value * clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, 1.F).pushforward;
@@ -399,8 +397,7 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void exp_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
-// CHECK-NEXT:     float _t0;
-// CHECK-NEXT:     _t0 = ::std::exp(x);
+// CHECK-NEXT:     float _t0 = ::std::exp(x);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0;
 // CHECK-NEXT:         _r0 += _d_y.value * clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, 1.F).pushforward;
@@ -424,14 +421,13 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void pow_pushforward_pullback(float x, float exponent, float d_x, float d_exponent, ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d_y, float *_d_x, float *_d_exponent, float *_d_d_x, float *_d_d_exponent) {
-// CHECK-NEXT:     float _t0;
 // CHECK-NEXT:     bool _cond0;
 // CHECK-NEXT:     float _t1;
 // CHECK-NEXT:     float _t2;
 // CHECK-NEXT:     float _t3;
 // CHECK-NEXT:     float _d_val = 0;
 // CHECK-NEXT:     float val = ::std::pow(x, exponent);
-// CHECK-NEXT:     _t0 = ::std::pow(x, exponent - 1);
+// CHECK-NEXT:     float _t0 = ::std::pow(x, exponent - 1);
 // CHECK-NEXT:     float _d_derivative = 0;
 // CHECK-NEXT:     float derivative = (exponent * _t0) * d_x;
 // CHECK-NEXT:     {

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -187,10 +187,10 @@ int main() {
 
 // CHECK: void f1_darg0_grad(float x, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
-// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t1 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x0);
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t1 = {};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t10 = clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, _d_x0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d__t0.pushforward += 1;
@@ -222,8 +222,8 @@ int main() {
 
 // CHECK: void f2_darg0_grad(float x, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, _d_x0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
@@ -245,8 +245,8 @@ int main() {
 
 // CHECK: void f3_darg0_grad(float x, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::log_pushforward(x, _d_x0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
@@ -268,8 +268,8 @@ int main() {
 
 // CHECK: void f4_darg0_grad(float x, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 4.F, _d_x0, 0.F);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
@@ -291,8 +291,8 @@ int main() {
 
 // CHECK: void f5_darg0_grad(float x, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(2.F, x, 0.F, _d_x0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
@@ -315,10 +315,10 @@ int main() {
 
 // CHECK: void f6_darg0_grad(float x, float y, float *_d_x, float *_d_y) {
 // CHECK-NEXT:     float _d__d_x = 0;
-// CHECK-NEXT:     float _d__d_y = 0;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 1;
+// CHECK-NEXT:     float _d__d_y = 0;
 // CHECK-NEXT:     float _d_y0 = 0;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
@@ -343,10 +343,10 @@ int main() {
 
 // CHECK: void f6_darg1_grad(float x, float y, float *_d_x, float *_d_y) {
 // CHECK-NEXT:     float _d__d_x = 0;
-// CHECK-NEXT:     float _d__d_y = 0;
-// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     float _d_x0 = 0;
+// CHECK-NEXT:     float _d__d_y = 0;
 // CHECK-NEXT:     float _d_y0 = 1;
+// CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d__t0 = {};
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
@@ -424,15 +424,15 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void pow_pushforward_pullback(float x, float exponent, float d_x, float d_exponent, ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _d_y, float *_d_x, float *_d_exponent, float *_d_d_x, float *_d_d_exponent) {
-// CHECK-NEXT:     float _d_val = 0;
 // CHECK-NEXT:     float _t0;
-// CHECK-NEXT:     float _d_derivative = 0;
 // CHECK-NEXT:     bool _cond0;
 // CHECK-NEXT:     float _t1;
 // CHECK-NEXT:     float _t2;
 // CHECK-NEXT:     float _t3;
+// CHECK-NEXT:     float _d_val = 0;
 // CHECK-NEXT:     float val = ::std::pow(x, exponent);
 // CHECK-NEXT:     _t0 = ::std::pow(x, exponent - 1);
+// CHECK-NEXT:     float _d_derivative = 0;
 // CHECK-NEXT:     float derivative = (exponent * _t0) * d_x;
 // CHECK-NEXT:     {
 // CHECK-NEXT:     _cond0 = d_exponent;

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -216,12 +216,12 @@ int main() {
 
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
 //CHECK-NEXT:    double _d__d_a = 0;
-//CHECK-NEXT:    double _d__d_b = 0;
-//CHECK-NEXT:    double _d__t0 = 0;
-//CHECK-NEXT:    double _d__t1 = 0;
 //CHECK-NEXT:    double _d_a0 = 1;
+//CHECK-NEXT:    double _d__d_b = 0;
 //CHECK-NEXT:    double _d_b0 = 0;
+//CHECK-NEXT:    double _d__t0 = 0;
 //CHECK-NEXT:    double _t00 = a * a;
+//CHECK-NEXT:    double _d__t1 = 0;
 //CHECK-NEXT:    double _t10 = b * b;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _d__d_a += 1 * a * a;
@@ -251,12 +251,12 @@ int main() {
 
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg1_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
 //CHECK-NEXT:    double _d__d_a = 0;
-//CHECK-NEXT:    double _d__d_b = 0;
-//CHECK-NEXT:    double _d__t0 = 0;
-//CHECK-NEXT:    double _d__t1 = 0;
 //CHECK-NEXT:    double _d_a0 = 0;
+//CHECK-NEXT:    double _d__d_b = 0;
 //CHECK-NEXT:    double _d_b0 = 1;
+//CHECK-NEXT:    double _d__t0 = 0;
 //CHECK-NEXT:    double _t00 = a * a;
+//CHECK-NEXT:    double _d__t1 = 0;
 //CHECK-NEXT:    double _t10 = b * b;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _d__d_a += 1 * a * a;

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -42,14 +42,14 @@ double f2(double x, double y){
 
 // CHECK: void f2_darg0_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     double _d__d_x = 0;
-// CHECK-NEXT:     double _d__d_y = 0;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {};
-// CHECK-NEXT:     double _d__d_ans = 0;
-// CHECK-NEXT:     double _d_ans0 = 0;
 // CHECK-NEXT:     double _d_x0 = 1;
+// CHECK-NEXT:     double _d__d_y = 0;
 // CHECK-NEXT:     double _d_y0 = 0;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {};
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
+// CHECK-NEXT:     double _d__d_ans = 0;
 // CHECK-NEXT:     double _d_ans = _t00.pushforward;
+// CHECK-NEXT:     double _d_ans0 = 0;
 // CHECK-NEXT:     double ans = _t00.value;
 // CHECK-NEXT:     _d__d_ans += 1;
 // CHECK-NEXT:     _d__t0.value += _d_ans0;
@@ -78,14 +78,14 @@ double f2(double x, double y){
 
 // CHECK: void f2_darg1_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     double _d__d_x = 0;
-// CHECK-NEXT:     double _d__d_y = 0;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {};
-// CHECK-NEXT:     double _d__d_ans = 0;
-// CHECK-NEXT:     double _d_ans0 = 0;
 // CHECK-NEXT:     double _d_x0 = 0;
+// CHECK-NEXT:     double _d__d_y = 0;
 // CHECK-NEXT:     double _d_y0 = 1;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {};
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
+// CHECK-NEXT:     double _d__d_ans = 0;
 // CHECK-NEXT:     double _d_ans = _t00.pushforward;
+// CHECK-NEXT:     double _d_ans0 = 0;
 // CHECK-NEXT:     double ans = _t00.value;
 // CHECK-NEXT:     _d__d_ans += 1;
 // CHECK-NEXT:     _d__t0.value += _d_ans0;

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -28,8 +28,8 @@ double nonMemFn(double i, double j) {
 
 // CHECK: void nonMemFn_darg0_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d__d_i = 0;
-// CHECK-NEXT:     double _d__d_j = 0;
 // CHECK-NEXT:     double _d_i0 = 1;
+// CHECK-NEXT:     double _d__d_j = 0;
 // CHECK-NEXT:     double _d_j0 = 0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d__d_i += 1 * j;
@@ -47,8 +47,8 @@ double nonMemFn(double i, double j) {
 
 // CHECK: void nonMemFn_darg1_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d__d_i = 0;
-// CHECK-NEXT:     double _d__d_j = 0;
 // CHECK-NEXT:     double _d_i0 = 0;
+// CHECK-NEXT:     double _d__d_j = 0;
 // CHECK-NEXT:     double _d_j0 = 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d__d_i += 1 * j;

--- a/test/Jacobian/Functors.C
+++ b/test/Jacobian/Functors.C
@@ -72,11 +72,9 @@ struct ExperimentVolatile {
   }
 
   // CHECK: void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) volatile {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     _t0 = this->x * i;
+  // CHECK-NEXT:     double _t0 = this->x * i;
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
-  // CHECK-NEXT:     _t1 = this->y * i;
+  // CHECK-NEXT:     double _t1 = this->y * i;
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += this->y * 1 * j * j;
@@ -103,11 +101,9 @@ struct ExperimentConstVolatile {
   }
 
   // CHECK: void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) const volatile {
-  // CHECK-NEXT:     double _t0;
-  // CHECK-NEXT:     double _t1;
-  // CHECK-NEXT:     _t0 = this->x * i;
+  // CHECK-NEXT:     double _t0 = this->x * i;
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
-  // CHECK-NEXT:     _t1 = this->y * i;
+  // CHECK-NEXT:     double _t1 = this->y * i;
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += this->y * 1 * j * j;

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -51,10 +51,10 @@ void f_3(double x, double y, double z, double *_result) {
 
 void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatrix);
 //CHECK: void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatrix) {
-//CHECK-NEXT:  double _d_constant = 0;
 //CHECK-NEXT:  double _t0;
 //CHECK-NEXT:  double _t1;
 //CHECK-NEXT:  double _t2;
+//CHECK-NEXT:  double _d_constant = 0;
 //CHECK-NEXT:  double constant = 42;
 //CHECK-NEXT:  _t0 = sin(x);
 //CHECK-NEXT:  _result[0] = sin(x) * constant;
@@ -92,10 +92,10 @@ void f_4(double x, double y, double z, double *_result) {
 
 void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatrix);
 //CHECK: void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatrix) {
-//CHECK-NEXT:    double _d_constant = 0;
 //CHECK-NEXT:    double _t0;
 //CHECK-NEXT:    double _t1;
 //CHECK-NEXT:    double _t2;
+//CHECK-NEXT:    double _d_constant = 0;
 //CHECK-NEXT:    double constant = 42;
 //CHECK-NEXT:    _t0 = multiply(x, y);
 //CHECK-NEXT:    _result[0] = multiply(x, y) * constant;
@@ -145,7 +145,6 @@ void f_1_jac_0(double a, double b, double c, double output[], double *jacobianMa
 // CHECK-NEXT:  {
 // CHECK-NEXT:    jacobianMatrix[{{0U|0UL}}] += 1 * a * a;
 // CHECK-NEXT:    jacobianMatrix[{{0U|0UL}}] += a * 1 * a;
-
 // CHECK-NEXT:    jacobianMatrix[{{0U|0UL}}] += a * a * 1;
 // CHECK-NEXT:  }
 // CHECK-NEXT:}

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -51,16 +51,13 @@ void f_3(double x, double y, double z, double *_result) {
 
 void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatrix);
 //CHECK: void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatrix) {
-//CHECK-NEXT:  double _t0;
-//CHECK-NEXT:  double _t1;
-//CHECK-NEXT:  double _t2;
 //CHECK-NEXT:  double _d_constant = 0;
 //CHECK-NEXT:  double constant = 42;
-//CHECK-NEXT:  _t0 = sin(x);
+//CHECK-NEXT:  double _t0 = sin(x);
 //CHECK-NEXT:  _result[0] = sin(x) * constant;
-//CHECK-NEXT:  _t1 = sin(y);
+//CHECK-NEXT:  double _t1 = sin(y);
 //CHECK-NEXT:  _result[1] = sin(y) * constant;
-//CHECK-NEXT:  _t2 = sin(z);
+//CHECK-NEXT:  double _t2 = sin(z);
 //CHECK-NEXT:  _result[2] = sin(z) * constant;
 //CHECK-NEXT:  {
 //CHECK-NEXT:    double _r2 = 0;
@@ -92,16 +89,13 @@ void f_4(double x, double y, double z, double *_result) {
 
 void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatrix);
 //CHECK: void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatrix) {
-//CHECK-NEXT:    double _t0;
-//CHECK-NEXT:    double _t1;
-//CHECK-NEXT:    double _t2;
 //CHECK-NEXT:    double _d_constant = 0;
 //CHECK-NEXT:    double constant = 42;
-//CHECK-NEXT:    _t0 = multiply(x, y);
+//CHECK-NEXT:    double _t0 = multiply(x, y);
 //CHECK-NEXT:    _result[0] = multiply(x, y) * constant;
-//CHECK-NEXT:    _t1 = multiply(y, z);
+//CHECK-NEXT:    double _t1 = multiply(y, z);
 //CHECK-NEXT:    _result[1] = multiply(y, z) * constant;
-//CHECK-NEXT:    _t2 = multiply(z, x);
+//CHECK-NEXT:    double _t2 = multiply(z, x);
 //CHECK-NEXT:    _result[2] = multiply(z, x) * constant;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _r4 = 0;

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -107,11 +107,11 @@
 //CHECK_FLOAT_SUM-NOT: {{.*error|warning|note:.*}}
 
 //CHECK_FLOAT_SUM: void vanillaSum_grad(float x, unsigned int n, float *_d_x, unsigned int *_d_n, double &_final_error) {
-//CHECK_FLOAT_SUM:    float _d_sum = 0;
 //CHECK_FLOAT_SUM:    unsigned {{int|long}} _t0;
 //CHECK_FLOAT_SUM:    unsigned int _d_i = 0;
 //CHECK_FLOAT_SUM:    unsigned int i = 0;
 //CHECK_FLOAT_SUM:    clad::tape<float> _t1 = {};
+//CHECK_FLOAT_SUM:    float _d_sum = 0;
 //CHECK_FLOAT_SUM:    float sum = 0.;
 //CHECK_FLOAT_SUM:    _t0 = {{0U|0UL}};
 //CHECK_FLOAT_SUM:    for (i = 0; ; i++) {
@@ -157,8 +157,8 @@
 // CHECK_CUSTOM_MODEL_EXEC-NOT:{{.*error|warning|note:.*}}
 // CHECK_CUSTOM_MODEL_EXEC: The code is:
 // CHECK_CUSTOM_MODEL_EXEC-NEXT: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _t0;
+// CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    _t0 = z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    z = x + y;
@@ -189,8 +189,8 @@
 // CHECK_PRINT_MODEL_EXEC-NOT:{{.*error|warning|note:.*}}
 // CHECK_PRINT_MODEL_EXEC: The code is:
 // CHECK_PRINT_MODEL_EXEC-NEXT: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-// CHECK_PRINT_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    float _t0;
+// CHECK_PRINT_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    float z;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    _t0 = z;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    z = x + y;

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -107,13 +107,12 @@
 //CHECK_FLOAT_SUM-NOT: {{.*error|warning|note:.*}}
 
 //CHECK_FLOAT_SUM: void vanillaSum_grad(float x, unsigned int n, float *_d_x, unsigned int *_d_n, double &_final_error) {
-//CHECK_FLOAT_SUM:    unsigned {{int|long}} _t0;
 //CHECK_FLOAT_SUM:    unsigned int _d_i = 0;
 //CHECK_FLOAT_SUM:    unsigned int i = 0;
 //CHECK_FLOAT_SUM:    clad::tape<float> _t1 = {};
 //CHECK_FLOAT_SUM:    float _d_sum = 0;
 //CHECK_FLOAT_SUM:    float sum = 0.;
-//CHECK_FLOAT_SUM:    _t0 = {{0U|0UL}};
+//CHECK_FLOAT_SUM:    unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK_FLOAT_SUM:    for (i = 0; ; i++) {
 //CHECK_FLOAT_SUM:        {
 //CHECK_FLOAT_SUM:            if (!(i < n))
@@ -157,10 +156,9 @@
 // CHECK_CUSTOM_MODEL_EXEC-NOT:{{.*error|warning|note:.*}}
 // CHECK_CUSTOM_MODEL_EXEC: The code is:
 // CHECK_CUSTOM_MODEL_EXEC-NEXT: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _t0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    float z;
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:    _t0 = z;
+// CHECK_CUSTOM_MODEL_EXEC-NEXT:    float _t0 = z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    z = x + y;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    _d_z += 1;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    {
@@ -189,10 +187,9 @@
 // CHECK_PRINT_MODEL_EXEC-NOT:{{.*error|warning|note:.*}}
 // CHECK_PRINT_MODEL_EXEC: The code is:
 // CHECK_PRINT_MODEL_EXEC-NEXT: void func_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-// CHECK_PRINT_MODEL_EXEC-NEXT:    float _t0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    float _d_z = 0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    float z;
-// CHECK_PRINT_MODEL_EXEC-NEXT:    _t0 = z;
+// CHECK_PRINT_MODEL_EXEC-NEXT:    float _t0 = z;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    z = x + y;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    _d_z += 1;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    {


### PR DESCRIPTION
The purpose of this PR is to merge decl stmts (e.g. ``double _t0;``) with their initialization points (e.g.``_t0 = x;``) in the reverse mode whenever this is possible. All of the simplifications happen when the original statement is used on the function global scope because otherwise, the declaration has to be "promoted to the function global scope". The simplification is done in three primary cases:
1) Adjoints of reference-type variables, e.g.
```
double *_d_ref = 0;
double &ref = x;
_d_ref = &_d_x;
```
can be refactored to
```
double &_d_ref = _d_x;
double &ref = x;
```
Notice: there's also no need to change the adjoint type to ``double*`` in this case (like was done previously).

2) Adjoints of pointer-type variables, e.g.
```
double *_d_ptr = 0;
double *ptr = &x;
_d_ptr = &_d_x;
```
can be similarly refactored to
```
double *_d_ptr = &_d_x;
double *ptr = &x;
```
3) ``_t`` variables created by ``GlobalStoreAndRef``, ``DelayedGlobalStoreAndRef``, and ``StoreAndRestore``, e.g.
```
double _t0;
...
_t0 = x;
```
can be refactored to
```
...
double _t0 = x;
```

Also, after this PR, adjoints on a function global scope are generated right before the original (cloned) variables and not at the very beginning of the function. This was done to make points 1) and 2) work correctly. Adjoints are never used before the original variables so this change will not affect anything.
Fixes #525.