### PR TITLE
Support bitwise, shift, comparison, and remainder operators in fwd mode

### DIFF
--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -102,6 +102,8 @@ public:
   StmtDiff VisitCXXThisExpr(const clang::CXXThisExpr* CTE);
   StmtDiff VisitCXXNewExpr(const clang::CXXNewExpr* CNE);
   StmtDiff VisitCXXDeleteExpr(const clang::CXXDeleteExpr* CDE);
+  StmtDiff
+  VisitCXXScalarValueInitExpr(const clang::CXXScalarValueInitExpr* SVIE);
   StmtDiff VisitCXXStaticCastExpr(const clang::CXXStaticCastExpr* CSE);
   StmtDiff VisitCXXFunctionalCastExpr(const clang::CXXFunctionalCastExpr* FCE);
   StmtDiff VisitCXXBindTemporaryExpr(const clang::CXXBindTemporaryExpr* BTE);

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -2271,6 +2271,11 @@ StmtDiff BaseForwardModeVisitor::VisitCXXStdInitializerListExpr(
   return Visit(ILE->getSubExpr());
 }
 
+StmtDiff BaseForwardModeVisitor::VisitCXXScalarValueInitExpr(
+    const CXXScalarValueInitExpr* SVIE) {
+  return {Clone(SVIE), Clone(SVIE)};
+}
+
 clang::Expr* BaseForwardModeVisitor::BuildCustomDerivativeConstructorPFCall(
     const clang::CXXConstructExpr* CE,
     llvm::SmallVectorImpl<clang::Expr*>& clonedArgs,

--- a/test/FirstDerivative/UnsupportedOpsWarn.C
+++ b/test/FirstDerivative/UnsupportedOpsWarn.C
@@ -6,12 +6,10 @@
 //CHECK-NOT: {{.*error|warning|note:.*}}
 
 int binOpWarn_0(int x){
-    return x << 1;  // expected-warning {{attempt to differentiate unsupported operator,  derivative                          set to 0}}
+    return x << 1;  // expected-warning {{attempt to differentiate unsupported operator, ignored.}}                        set to 0}}
 }
 
-// CHECK: int binOpWarn_0_darg0(int x) {
-// CHECK-NEXT:    int _d_x = 1;
-// CHECK-NEXT:    return 0;
+// CHECK: void binOpWarn_0_grad(int x, int *_d_x) {
 // CHECK-NEXT: }
 
 
@@ -23,17 +21,14 @@ int binOpWarn_1(int x){
 // CHECK-NEXT: }
 
 int unOpWarn_0(int x){
-    return ~x;  // expected-warning {{attempt to differentiate unsupported operator,  derivative                          set to 0}}
+    return ~x;  // expected-warning {{attempt to differentiate unsupported operator, ignored.}}                        set to 0}}
 }
 
-// CHECK: int unOpWarn_0_darg0(int x) {
-// CHECK-NEXT:   int _d_x = 1;
-// CHECK-NEXT:   return 0;
+// CHECK: void unOpWarn_0_grad(int x, int *_d_x) {
 // CHECK-NEXT: }
 
 int main(){
-
-    clad::differentiate(binOpWarn_0, 0);
+    clad::gradient(binOpWarn_0);
     clad::gradient(binOpWarn_1);
-    clad::differentiate(unOpWarn_0, 0);
+    clad::gradient(unOpWarn_0);
 }


### PR DESCRIPTION
This PR adds support for bitwise, shift, comparison, remainder, and bitwise not operators. Shift operators are considered differentiable since they essentially represent multiplication by ``2^n`` or ``2^-n``, where ``n`` is the RHS of the shift operators ``<<`` and ``>>``. Not operators are considered differentiable as well because they represent ``2^n - 1 - x`` or ``- 1 - x`` (depending on whether the type is signed) so the derivative is ``-_d_x``. Other operators have unclear differentiable effects and so they are considered non-differentiable.
Fixes #381.