### PR TITLE
Introduce placeholders in the reverse mode to correctly handle multiplication

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -400,6 +400,8 @@ namespace clad {
     virtual StmtDiff VisitReturnStmt(const clang::ReturnStmt* RS);
     StmtDiff VisitStmt(const clang::Stmt* S);
     virtual StmtDiff VisitUnaryOperator(const clang::UnaryOperator* UnOp);
+    StmtDiff
+    VisitUnaryExprOrTypeTraitExpr(const clang::UnaryExprOrTypeTraitExpr* UE);
     StmtDiff VisitExprWithCleanups(const clang::ExprWithCleanups* EWC);
     /// Decl is not Stmt, so it cannot be visited directly.
     StmtDiff VisitWhileStmt(const clang::WhileStmt* WS);

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -278,13 +278,14 @@ namespace clad {
       bool isInsideLoop;
       bool isFnScope;
       bool needsUpdate;
+      clang::Expr* Placeholder;
       DelayedStoreResult(ReverseModeVisitor& pV, StmtDiff pResult,
-                         clang::VarDecl* pDeclaration, bool pIsConstant,
-                         bool pIsInsideLoop, bool pIsFnScope,
-                         bool pNeedsUpdate = false)
+                         clang::VarDecl* pDeclaration, bool pIsInsideLoop,
+                         bool pIsFnScope, bool pNeedsUpdate = false,
+                         clang::Expr* pPlaceholder = nullptr)
           : V(pV), Result(pResult), Declaration(pDeclaration),
-            isConstant(pIsConstant), isInsideLoop(pIsInsideLoop),
-            isFnScope(pIsFnScope), needsUpdate(pNeedsUpdate) {}
+            isInsideLoop(pIsInsideLoop), isFnScope(pIsFnScope),
+            needsUpdate(pNeedsUpdate), Placeholder(pPlaceholder) {}
       void Finalize(clang::Expr* New);
     };
 
@@ -297,7 +298,8 @@ namespace clad {
     /// This is what DelayedGlobalStoreAndRef does. E is expected to be the
     /// original (uncloned) expression.
     DelayedStoreResult DelayedGlobalStoreAndRef(clang::Expr* E,
-                                                llvm::StringRef prefix = "_t");
+                                                llvm::StringRef prefix = "_t",
+                                                bool forceStore = false);
 
     struct CladTapeResult {
       ReverseModeVisitor& V;

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4107,6 +4107,11 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     return Visit(NTTP->getReplacement());
   }
 
+  StmtDiff ReverseModeVisitor::VisitUnaryExprOrTypeTraitExpr(
+      const clang::UnaryExprOrTypeTraitExpr* UE) {
+    return {Clone(UE), Clone(UE)};
+  }
+
   DeclDiff<StaticAssertDecl> ReverseModeVisitor::DifferentiateStaticAssertDecl(
       const clang::StaticAssertDecl* SAD) {
     return DeclDiff<StaticAssertDecl>(nullptr, nullptr);

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -226,8 +226,8 @@ double func5(double* x, double* y, double* output) {
 
 //CHECK: void func5_grad(double *x, double *y, double *output, double *_d_x, double *_d_y, double *_d_output, double &_final_error) {
 //CHECK-NEXT:     unsigned {{int|long|long long}} output_size = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} x_size = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} y_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} x_size = 0;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     double _t0 = output[0];
 //CHECK-NEXT:     output[0] = x[1] * y[2] - x[2] * y[1];
@@ -249,10 +249,12 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         output[2] = _t2;
 //CHECK-NEXT:         double _r_d2 = _d_output[2];
 //CHECK-NEXT:         _d_output[2] = 0;
+//CHECK-NEXT:         y_size = std::max(y_size, 1);
 //CHECK-NEXT:         _d_x[0] += _r_d2 * y[1];
 //CHECK-NEXT:         x_size = std::max(x_size, 0);
 //CHECK-NEXT:         _d_y[1] += x[0] * _r_d2;
 //CHECK-NEXT:         y_size = std::max(y_size, 1);
+//CHECK-NEXT:         x_size = std::max(x_size, 1);
 //CHECK-NEXT:         _d_y[0] += -_r_d2 * x[1];
 //CHECK-NEXT:         y_size = std::max(y_size, 0);
 //CHECK-NEXT:         _d_x[1] += y[0] * -_r_d2;
@@ -264,10 +266,12 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         output[1] = _t1;
 //CHECK-NEXT:         double _r_d1 = _d_output[1];
 //CHECK-NEXT:         _d_output[1] = 0;
+//CHECK-NEXT:         y_size = std::max(y_size, 0);
 //CHECK-NEXT:         _d_x[2] += _r_d1 * y[0];
 //CHECK-NEXT:         x_size = std::max(x_size, 2);
 //CHECK-NEXT:         _d_y[0] += x[2] * _r_d1;
 //CHECK-NEXT:         y_size = std::max(y_size, 0);
+//CHECK-NEXT:         y_size = std::max(y_size, 2);
 //CHECK-NEXT:         _d_x[0] += -_r_d1 * y[2];
 //CHECK-NEXT:         x_size = std::max(x_size, 0);
 //CHECK-NEXT:         _d_y[2] += x[0] * -_r_d1;
@@ -279,10 +283,12 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         output[0] = _t0;
 //CHECK-NEXT:         double _r_d0 = _d_output[0];
 //CHECK-NEXT:         _d_output[0] = 0;
+//CHECK-NEXT:         y_size = std::max(y_size, 2);
 //CHECK-NEXT:         _d_x[1] += _r_d0 * y[2];
 //CHECK-NEXT:         x_size = std::max(x_size, 1);
 //CHECK-NEXT:         _d_y[2] += x[1] * _r_d0;
 //CHECK-NEXT:         y_size = std::max(y_size, 2);
+//CHECK-NEXT:         y_size = std::max(y_size, 1);
 //CHECK-NEXT:         _d_x[2] += -_r_d0 * y[1];
 //CHECK-NEXT:         x_size = std::max(x_size, 2);
 //CHECK-NEXT:         _d_y[1] += x[2] * -_r_d0;

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -72,8 +72,8 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:     int _d_j = 0;
 //CHECK-NEXT:     int j = 0;
 //CHECK-NEXT:     clad::tape<double> _t3 = {};
-//CHECK-NEXT:     unsigned {{int|long|long long}} a_size = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} b_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} a_size = 0;
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
@@ -111,6 +111,7 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:                 _final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:                 sum = clad::pop(_t3);
 //CHECK-NEXT:                 double _r_d0 = _d_sum;
+//CHECK-NEXT:                 b_size = std::max(b_size, j);
 //CHECK-NEXT:                 _d_a[i] += _r_d0 * b[j];
 //CHECK-NEXT:                 a_size = std::max(a_size, i);
 //CHECK-NEXT:                 _d_b[j] += a[i] * _r_d0;

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -714,7 +714,10 @@ double fn_template_non_type(double x) {
 // CHECK-NEXT:     bool _cond0 = maxN < {{15U|15UL|15ULL}};
 // CHECK-NEXT:     size_t _d_m = 0;
 // CHECK-NEXT:     const size_t m = _cond0 ? maxN : {{15U|15UL|15ULL}};
-// CHECK-NEXT:     *_d_x += 1 * m;
+// CHECK-NEXT:     {
+// CHECK-NEXT:       *_d_x += 1 * m;
+// CHECK-NEXT:       _d_m += x * 1;
+// CHECK-NEXT:     }
 // CHECK-NEXT:     if (_cond0)
 // CHECK-NEXT:         _d_maxN += _d_m;
 // CHECK-NEXT: }
@@ -1070,6 +1073,78 @@ double fn_cond_add_assign(double i, double j) {
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 
+double f_mult3(double i, double j) {
+  i = (i + j) * (i < 10 ? i : j);
+  return i;
+}
+
+//CHECK: void f_mult3_grad(double i, double j, double *_d_i, double *_d_j) {
+//CHECK-NEXT:     double _t0 = i;
+//CHECK-NEXT:     bool _cond0 = i < 10;
+//CHECK-NEXT:     i = (i + j) * (_cond0 ? i : j);
+//CHECK-NEXT:     *_d_i += 1;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         i = _t0;
+//CHECK-NEXT:         double _r_d0 = *_d_i;
+//CHECK-NEXT:         *_d_i = 0;
+//CHECK-NEXT:         *_d_i += _r_d0 * (_cond0 ? i : j);
+//CHECK-NEXT:         *_d_j += _r_d0 * (_cond0 ? i : j);
+//CHECK-NEXT:         if (_cond0)
+//CHECK-NEXT:             *_d_i += (i + j) * _r_d0;
+//CHECK-NEXT:         else
+//CHECK-NEXT:             *_d_j += (i + j) * _r_d0;
+//CHECK-NEXT:     }
+//CHECK-NEXT: }
+
+double f_const_denom(double x, double y) {
+  const double m = 0.5;
+  return x * y / m;
+}
+
+//CHECK: void f_const_denom_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK-NEXT:     double _d_m = 0;
+//CHECK-NEXT:     const double m = 0.5;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         *_d_x += 1 / m * y;
+//CHECK-NEXT:         *_d_y += x * 1 / m;
+//CHECK-NEXT:     }
+//CHECK-NEXT: }
+
+double f_ref_in_rhs(double x, double y) {
+  if (x != 55) {
+    double& ref_x = x;
+    double& ref_y = y;
+    return ref_y * (ref_x + y);
+  }
+  return 1;
+}
+
+//CHECK: void f_ref_in_rhs_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK-NEXT:     bool _cond0;
+//CHECK-NEXT:     double *_d_ref_x = 0;
+//CHECK-NEXT:     double *ref_x = {};
+//CHECK-NEXT:     double *_d_ref_y = 0;
+//CHECK-NEXT:     double *ref_y = {};
+//CHECK-NEXT:     {
+//CHECK-NEXT:         _cond0 = x != 55;
+//CHECK-NEXT:         if (_cond0) {
+//CHECK-NEXT:             _d_ref_x = &*_d_x;
+//CHECK-NEXT:             ref_x = &x;
+//CHECK-NEXT:             _d_ref_y = &*_d_y;
+//CHECK-NEXT:             ref_y = &y;
+//CHECK-NEXT:             goto _label0;
+//CHECK-NEXT:         }
+//CHECK-NEXT:     }
+//CHECK-NEXT:     if (_cond0) {
+//CHECK-NEXT:       _label0:
+//CHECK-NEXT:         {
+//CHECK-NEXT:             *_d_ref_y += 1 * (*ref_x + y);
+//CHECK-NEXT:             *_d_ref_x += *ref_y * 1;
+//CHECK-NEXT:             *_d_y += *ref_y * 1;
+//CHECK-NEXT:         }
+//CHECK-NEXT:     }
+//CHECK-NEXT: }
+
 #define TEST(F, x, y)                                                          \
   {                                                                            \
     result[0] = 0;                                                             \
@@ -1158,5 +1233,12 @@ int main() {
   INIT_GRADIENT(fn_cond_add_assign);
   TEST_GRADIENT(fn_cond_add_assign, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {80.00, 48.00}
 
+  INIT_GRADIENT(f_mult3);
+  TEST_GRADIENT(f_mult3, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {11.00, 3.00}
 
+  INIT_GRADIENT(f_const_denom);
+  TEST_GRADIENT(f_const_denom, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {10.00, 6.00}
+
+  INIT_GRADIENT(f_ref_in_rhs);
+  TEST_GRADIENT(f_ref_in_rhs, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {5.00, 13.00}
 }

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -3113,7 +3113,7 @@ double fn39(double x) {
 //CHECK-NEXT:         }
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, res);
-//CHECK-NEXT:         res += x * (*i);
+//CHECK-NEXT:         res += x * *i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_res += 1;
 //CHECK-NEXT:     for (;; _t0--) {
@@ -3128,7 +3128,7 @@ double fn39(double x) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             res = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_res;
-//CHECK-NEXT:             *_d_x += _r_d0 * (*i);
+//CHECK-NEXT:             *_d_x += _r_d0 * *i;
 //CHECK-NEXT:             *_d_i += x * _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -154,7 +154,7 @@ int main() {
     // CHECK-NEXT:     SimpleFunctions1 _d_obj({});
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
     // CHECK-NEXT:     {
-    // CHECK-NEXT:         *_d_obj.x_pointer += 1 * (*obj.y_pointer);
+    // CHECK-NEXT:         *_d_obj.x_pointer += 1 * *obj.y_pointer;
     // CHECK-NEXT:         *_d_i += 1 * j;
     // CHECK-NEXT:         *_d_j += i * 1;
     // CHECK-NEXT:     }

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -28,13 +28,13 @@ double minimalPointer(double x) {
 // CHECK-NEXT:     double *_d_p = &*_d_x;
 // CHECK-NEXT:     double *const p = &x;
 // CHECK-NEXT:     double _t0 = *p;
-// CHECK-NEXT:     *p = *p * (*p);
+// CHECK-NEXT:     *p = *p * *p;
 // CHECK-NEXT:     *_d_p += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *p = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_p;
 // CHECK-NEXT:         *_d_p = 0;
-// CHECK-NEXT:         *_d_p += _r_d0 * (*p);
+// CHECK-NEXT:         *_d_p += _r_d0 * *p;
 // CHECK-NEXT:         *_d_p += *p * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -87,7 +87,7 @@ double arrayPointer(const double* arr) {
 // CHECK-NEXT:     _d_p = _d_p - 2;
 // CHECK-NEXT:     p = p - 2;
 // CHECK-NEXT:     double _t11 = sum;
-// CHECK-NEXT:     sum += 5 * (*p);
+// CHECK-NEXT:     sum += 5 * *p;
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         sum = _t11;
@@ -170,7 +170,7 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:         clad::push(_t1, _d_j);
 // CHECK-NEXT:         clad::push(_t3, j) , j = &i;
 // CHECK-NEXT:         clad::push(_t4, sum);
-// CHECK-NEXT:         sum += arr[0] * (*j);
+// CHECK-NEXT:         sum += arr[0] * *j;
 // CHECK-NEXT:         clad::push(_t5, arr);
 // CHECK-NEXT:         clad::push(_t6, _d_arr);
 // CHECK-NEXT:         _d_arr = _d_arr + 1;
@@ -191,7 +191,7 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             sum = clad::pop(_t4);
 // CHECK-NEXT:             double _r_d0 = _d_sum;
-// CHECK-NEXT:             _d_arr[0] += _r_d0 * (*j);
+// CHECK-NEXT:             _d_arr[0] += _r_d0 * *j;
 // CHECK-NEXT:             *_t2 += arr[0] * _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         j = clad::pop(_t3);


### PR DESCRIPTION
Currently, when differentiating multiplication in the reverse mode, we need to pass the differentiated LHS when visiting the RHS and vice versa (i.e. ``Visit(R, dR)`` and ``Visit(L, dL)`` where ``dR = LDiff * dfdx`` and ``dL = dfdx * RDiff``). This creates a loop that we break in one of two ways:
1) Create a variable to represent the result of the RHS visitation, use it to visit the LHS, visit the RHS, and then set the value of the variable introduced before to the result of the RHS visitation.
2) Clone the RHS, use it to visit the LHS, then visit the RHS.

The 1st approach is bad because it introduces a new variable that is usually unnecessary.

The 2nd approach is used more frequently but its downside is that cloning is not the same as visiting, some expressions cannot be cloned. e.g.
a) ``x > 0 ? a : b`` is cloned as ``x > 0 ? a : b`` but differentiated as ``_cond ? a : b``, where ``_cond`` is a variable to save the condition ``x > 0``.
b) References are often turned into pointers in the reverse mode. Because of that, ``x`` should be differentiated as ``*x``  and not as just ``x``, which ``Clone`` does. We already have an exception to handle ref-type decl refs as RHS of multiplication, which is removed in this PR.

This PR solves this problem in a third way: by passing a literal expression when visiting LHS and replacing it when the differentiated RHS is known. All of the new logic is sunk into existing functions ``DelayedGlobalStoreAndRef`` and ``Finalize``.