### PR TITLE
Update FileCheck test lines for number literals and types generated on windows

### DIFF
--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -44,7 +44,7 @@ float func(float* a, float* b) {
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -97,7 +97,7 @@ float func2(float* a) {
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -136,7 +136,7 @@ float func3(float* a, float* b) {
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -180,7 +180,7 @@ double func4(double x) {
 //CHECK-NEXT:     double arr[3] = {x, 2 * x, x * x};
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -241,7 +241,7 @@ double func5(int k) {
 //CHECK-NEXT:     double _d_arr[n];
 //CHECK-NEXT:     clad::zero_init(_d_arr, n);
 //CHECK-NEXT:     double arr[n];
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -253,7 +253,7 @@ double func5(int k) {
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t2 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t2 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i0 = 0; ; i0++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i0 < 3))
@@ -308,11 +308,11 @@ double func6(double seed) {
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
 //CHECK-NEXT:     double _d_arr[3] = {0};
-//CHECK-NEXT:     clad::array<double> arr({{3U|3UL}});
+//CHECK-NEXT:     clad::array<double> arr({{3U|3UL|3ULL}});
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -368,11 +368,11 @@ double func7(double *params) {
 //CHECK-NEXT:     std::size_t i = 0;
 //CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
 //CHECK-NEXT:     double _d_paramsPrime[1] = {0};
-//CHECK-NEXT:     clad::array<double> paramsPrime({{1U|1UL}});
+//CHECK-NEXT:     clad::array<double> paramsPrime({{1U|1UL|1ULL}});
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     double _d_out = 0;
 //CHECK-NEXT:     double out = 0.;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 1))
@@ -472,7 +472,7 @@ double func9(double i, double j) {
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_arr[5] = {0};
 //CHECK-NEXT:     double arr[5] = {};
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (idx = 0; ; ++idx) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(idx < 5))
@@ -528,7 +528,7 @@ double func10(double *arr, int n) {
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double res = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -628,7 +628,7 @@ int main() {
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_ret = 0;
 //CHECK-NEXT:     double ret = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))

--- a/test/Arrays/ArrayInputsVectorForwardMode.C
+++ b/test/Arrays/ArrayInputsVectorForwardMode.C
@@ -12,11 +12,11 @@ double multiply(const double *arr) {
 }
 
 // CHECK: void multiply_dvec(const double *arr, clad::array_ref<double> _d_arr) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = _d_arr.size();
-// CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = _d_arr.size();
+// CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, (_d_vector_arr[0]) * arr[1] + arr[0] * (_d_vector_arr[1])));
-// CHECK-NEXT:     _d_arr = _d_vector_return.slice({{0U|0UL}}, _d_arr.size());
+// CHECK-NEXT:     _d_arr = _d_vector_return.slice({{0U|0UL|0ULL}}, _d_arr.size());
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -26,11 +26,11 @@ double divide(double *arr) {
 }
 
 // CHECK: void divide_dvec(double *arr, clad::array_ref<double> _d_arr) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = _d_arr.size();
-// CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = _d_arr.size();
+// CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, ((_d_vector_arr[0]) * arr[1] - arr[0] * (_d_vector_arr[1])) / (arr[1] * arr[1])));
-// CHECK-NEXT:     _d_arr = _d_vector_return.slice({{0U|0UL}}, _d_arr.size());
+// CHECK-NEXT:     _d_arr = _d_vector_return.slice({{0U|0UL|0ULL}}, _d_arr.size());
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -44,8 +44,8 @@ double addArr(const double *arr, int n) {
 }
 
 // CHECK: void addArr_dvec_0(const double *arr, int n, clad::array_ref<double> _d_arr) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = _d_arr.size();
-// CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = _d_arr.size();
+// CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:   clad::array<int> _d_vector_n = clad::zero_vector(indepVarCount);
 // CHECK-NEXT:   clad::array<double> _d_vector_ret(clad::array<double>(indepVarCount, 0));
 // CHECK-NEXT:   double ret = 0;
@@ -58,7 +58,7 @@ double addArr(const double *arr, int n) {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, _d_vector_ret));
-// CHECK-NEXT:     _d_arr = _d_vector_return.slice({{0U|0UL}}, _d_arr.size());
+// CHECK-NEXT:     _d_arr = _d_vector_return.slice({{0U|0UL|0ULL}}, _d_arr.size());
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -76,11 +76,11 @@ double maskedSum(const double *arr, int n, int *signedMask, double alpha, double
 }
 
 // CHECK: void maskedSum_dvec_0_3_4(const double *arr, int n, int *signedMask, double alpha, double beta, clad::array_ref<double> _d_arr, double *_d_alpha, double *_d_beta) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = _d_arr.size() + {{2U|2UL}};
-// CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = _d_arr.size() + {{2U|2UL|2ULL}};
+// CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:   clad::array<int> _d_vector_n = clad::zero_vector(indepVarCount);
 // CHECK-NEXT:   clad::array<double> _d_vector_alpha = clad::one_hot_vector(indepVarCount, _d_arr.size());
-// CHECK-NEXT:   clad::array<double> _d_vector_beta = clad::one_hot_vector(indepVarCount, _d_arr.size() + {{1U|1UL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_beta = clad::one_hot_vector(indepVarCount, _d_arr.size() + {{1U|1UL|1ULL}});
 // CHECK-NEXT:   clad::array<double> _d_vector_ret(clad::array<double>(indepVarCount, 0));
 // CHECK-NEXT:   double ret = 0;
 // CHECK-NEXT:   {
@@ -97,9 +97,9 @@ double maskedSum(const double *arr, int n, int *signedMask, double alpha, double
 // CHECK-NEXT:   }
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, _d_vector_ret));
-// CHECK-NEXT:     _d_arr = _d_vector_return.slice({{0U|0UL}}, _d_arr.size());
+// CHECK-NEXT:     _d_arr = _d_vector_return.slice({{0U|0UL|0ULL}}, _d_arr.size());
 // CHECK-NEXT:     *_d_alpha = _d_vector_return[_d_arr.size()];
-// CHECK-NEXT:     *_d_beta = _d_vector_return[_d_arr.size() + {{1U|1UL}}];
+// CHECK-NEXT:     *_d_beta = _d_vector_return[_d_arr.size() + {{1U|1UL|1ULL}}];
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -36,7 +36,7 @@ __device__ __host__ double gauss(double* x, double* p, double sigma, int dim) {
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_t = 0;
 //CHECK-NEXT:     double t = 0;
-//CHECK-NEXT:     unsigned long _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned long _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             if (!(i < dim))

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -18,10 +18,10 @@ float func(float* p, int n) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
-//CHECK-NEXT:     unsigned {{int|long}} p_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} p_size = 0;
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -71,7 +71,7 @@ float func2(float x) {
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float _d_z = 0;
 //CHECK-NEXT:     float z;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 9))
@@ -166,13 +166,13 @@ float func4(float x[10], float y[10]) {
 //CHECK: void func4_grad(float x[10], float y[10], float *_d_x, float *_d_y, double &_final_error) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     unsigned {{int|long}} x_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} x_size = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
-//CHECK-NEXT:     unsigned {{int|long}} y_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} y_size = 0;
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 10))
@@ -225,9 +225,9 @@ double func5(double* x, double* y, double* output) {
 }
 
 //CHECK: void func5_grad(double *x, double *y, double *output, double *_d_x, double *_d_y, double *_d_output, double &_final_error) {
-//CHECK-NEXT:     unsigned {{int|long}} output_size = 0;
-//CHECK-NEXT:     unsigned {{int|long}} x_size = 0;
-//CHECK-NEXT:     unsigned {{int|long}} y_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} output_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} x_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} y_size = 0;
 //CHECK-NEXT:     double _ret_value0 = 0;
 //CHECK-NEXT:     double _t0 = output[0];
 //CHECK-NEXT:     output[0] = x[1] * y[2] - x[2] * y[1];

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -19,10 +19,10 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
-//CHECK-NEXT:     unsigned {{int|long}} f_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} f_size = 0;
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 1; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -67,23 +67,23 @@ double mulSum(float* a, float* b, int n) {
 //CHECK: void mulSum_grad(float *a, float *b, int n, float *_d_a, float *_d_b, int *_d_n, double &_final_error) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+//CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 //CHECK-NEXT:     clad::tape<int> _t2 = {};
 //CHECK-NEXT:     int _d_j = 0;
 //CHECK-NEXT:     int j = 0;
 //CHECK-NEXT:     clad::tape<double> _t3 = {};
-//CHECK-NEXT:     unsigned {{int|long}} a_size = 0;
-//CHECK-NEXT:     unsigned {{int|long}} b_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} a_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} b_size = 0;
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, {{0U|0UL}});
+//CHECK-NEXT:         clad::push(_t1, {{0U|0UL|0ULL}});
 //CHECK-NEXT:         for (clad::push(_t2, j) , j = 0; ; j++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(j < n))
@@ -144,11 +144,11 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
-//CHECK-NEXT:     unsigned {{int|long}} b_size = 0;
-//CHECK-NEXT:     unsigned {{int|long}} a_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} b_size = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} a_size = 0;
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))

--- a/test/FirstDerivative/BasicArithmeticMulDiv.C
+++ b/test/FirstDerivative/BasicArithmeticMulDiv.C
@@ -115,9 +115,9 @@ double m_11(double x) {
 // CHECK-NEXT:   double _d_x = 1;
 // CHECK-NEXT:   const size_t _d_maxN = 0;
 // CHECK-NEXT:   const size_t maxN = 53;
-// CHECK-NEXT:   bool _t0 = maxN < {{64U|64UL}};
-// CHECK-NEXT:   const size_t _d_m = _t0 ? _d_maxN : {{0U|0UL}};
-// CHECK-NEXT:   const size_t m = _t0 ? maxN : {{64U|64UL}};
+// CHECK-NEXT:   bool _t0 = maxN < {{64U|64UL|64ULL}};
+// CHECK-NEXT:   const size_t _d_m = _t0 ? _d_maxN : {{0U|0UL|0ULL}};
+// CHECK-NEXT:   const size_t m = _t0 ? maxN : {{64U|64UL|64ULL}};
 // CHECK-NEXT:   return _d_x * m + x * _d_m;
 // CHECK-NEXT: }
 

--- a/test/ForwardMode/VectorMode.C
+++ b/test/ForwardMode/VectorMode.C
@@ -14,15 +14,15 @@ double f1(double x, double y) {
 void f1_dvec(double x, double y, double *_d_x, double *_d_y);
 
 // CHECK: void f1_dvec(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = {{2U|2UL}};
-// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
-// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = {{2U|2UL|2ULL}};
+// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:   double _t0 = x * y;
 // CHECK-NEXT:   double _t1 = (x + y + 1);
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, (_d_vector_x * y + x * _d_vector_y) * _t1 + _t0 * (_d_vector_x + _d_vector_y + 0)));
-// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL}}];
-// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL}}];
+// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL|0ULL}}];
+// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL|1ULL}}];
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -37,17 +37,17 @@ double f2(double x, double y) {
 void f2_dvec(double x, double y, double *_d_x, double *_d_y);
 
 // CHECK: void f2_dvec(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = {{2U|2UL}};
-// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
-// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = {{2U|2UL|2ULL}};
+// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:   clad::array<double> _d_vector_temp1(clad::array<double>(indepVarCount, _d_vector_x * y + x * _d_vector_y));
 // CHECK-NEXT:   double temp1 = x * y;
 // CHECK-NEXT:   clad::array<double> _d_vector_temp2(clad::array<double>(indepVarCount, _d_vector_x + _d_vector_y + 0));
 // CHECK-NEXT:   double temp2 = x + y + 1;
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, _d_vector_temp1 * temp2 + temp1 * _d_vector_temp2));
-// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL}}];
-// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL}}];
+// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL|0ULL}}];
+// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL|1ULL}}];
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -63,9 +63,9 @@ double f3(double x, double y) {
 void f3_dvec(double x, double y, double *_d_x, double *_d_y);
 
 // CHECK: void f3_dvec(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = {{2U|2UL}};
-// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
-// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = {{2U|2UL|2ULL}};
+// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:   if (y < 0) {
 // CHECK-NEXT:     _d_vector_y = - _d_vector_y;
 // CHECK-NEXT:     y = -y;
@@ -74,8 +74,8 @@ void f3_dvec(double x, double y, double *_d_x, double *_d_y);
 // CHECK-NEXT:   y += 1;
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, _d_vector_x * y + x * _d_vector_y));
-// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL}}];
-// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL}}];
+// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL|0ULL}}];
+// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL|1ULL}}];
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -94,9 +94,9 @@ double f4(double lower, double upper) {
 void f4_dvec(double lower, double upper, double *_d_lower, double *_d_upper);
 
 // CHECK: void f4_dvec(double lower, double upper, double *_d_lower, double *_d_upper) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = {{2U|2UL}};
-// CHECK-NEXT:   clad::array<double> _d_vector_lower = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
-// CHECK-NEXT:   clad::array<double> _d_vector_upper = clad::one_hot_vector(indepVarCount, {{1U|1UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = {{2U|2UL|2ULL}};
+// CHECK-NEXT:   clad::array<double> _d_vector_lower = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_upper = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:   clad::array<double> _d_vector_sum(clad::array<double>(indepVarCount, 0));
 // CHECK-NEXT:   double sum = 0;
 // CHECK-NEXT:   clad::array<double> _d_vector_num_points(clad::array<double>(indepVarCount, 0));
@@ -114,8 +114,8 @@ void f4_dvec(double lower, double upper, double *_d_lower, double *_d_upper);
 // CHECK-NEXT:   }
 // CHECK-NEXT:   {
 // CHECK-NEXT:       clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, _d_vector_sum));
-// CHECK-NEXT:       *_d_lower = _d_vector_return[{{0U|0UL}}];
-// CHECK-NEXT:       *_d_upper = _d_vector_return[{{1U|1UL}}];
+// CHECK-NEXT:       *_d_lower = _d_vector_return[{{0U|0UL|0ULL}}];
+// CHECK-NEXT:       *_d_upper = _d_vector_return[{{1U|1UL|1ULL}}];
 // CHECK-NEXT:       return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -126,70 +126,70 @@ double f5(double x, double y, double z) {
 
 // all
 // CHECK: void f5_dvec(double x, double y, double z, double *_d_x, double *_d_y, double *_d_z) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = {{3U|3UL}};
-// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
-// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL}});
-// CHECK-NEXT:   clad::array<double> _d_vector_z = clad::one_hot_vector(indepVarCount, {{2U|2UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = {{3U|3UL|3ULL}};
+// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_z = clad::one_hot_vector(indepVarCount, {{2U|2UL|2ULL}});
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, 0. * x + 1. * _d_vector_x + 0. * y + 2. * _d_vector_y + 0. * z + 3. * _d_vector_z));
-// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL}}];
-// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL}}];
-// CHECK-NEXT:     *_d_z = _d_vector_return[{{2U|2UL}}];
+// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL|0ULL}}];
+// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL|1ULL}}];
+// CHECK-NEXT:     *_d_z = _d_vector_return[{{2U|2UL|2ULL}}];
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
 // x, y
 // CHECK: void f5_dvec_0_1(double x, double y, double z, double *_d_x, double *_d_y) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = {{2U|2UL}};
-// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
-// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = {{2U|2UL|2ULL}};
+// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:   clad::array<double> _d_vector_z = clad::zero_vector(indepVarCount);
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, 0. * x + 1. * _d_vector_x + 0. * y + 2. * _d_vector_y + 0. * z + 3. * _d_vector_z));
-// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL}}];
-// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL}}];
+// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL|0ULL}}];
+// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL|1ULL}}];
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
 // x, z
 // CHECK: void f5_dvec_0_2(double x, double y, double z, double *_d_x, double *_d_z) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = {{2U|2UL}};
-// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = {{2U|2UL|2ULL}};
+// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:   clad::array<double> _d_vector_y = clad::zero_vector(indepVarCount);
-// CHECK-NEXT:   clad::array<double> _d_vector_z = clad::one_hot_vector(indepVarCount, {{1U|1UL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_z = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, 0. * x + 1. * _d_vector_x + 0. * y + 2. * _d_vector_y + 0. * z + 3. * _d_vector_z));
-// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL}}];
-// CHECK-NEXT:     *_d_z = _d_vector_return[{{1U|1UL}}];
+// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL|0ULL}}];
+// CHECK-NEXT:     *_d_z = _d_vector_return[{{1U|1UL|1ULL}}];
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
 // y, z
 // CHECK: void f5_dvec_1_2(double x, double y, double z, double *_d_y, double *_d_z) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = {{2U|2UL}};
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = {{2U|2UL|2ULL}};
 // CHECK-NEXT:   clad::array<double> _d_vector_x = clad::zero_vector(indepVarCount);
-// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
-// CHECK-NEXT:   clad::array<double> _d_vector_z = clad::one_hot_vector(indepVarCount, {{1U|1UL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_z = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, 0. * x + 1. * _d_vector_x + 0. * y + 2. * _d_vector_y + 0. * z + 3. * _d_vector_z));
-// CHECK-NEXT:     *_d_y = _d_vector_return[{{0U|0UL}}];
-// CHECK-NEXT:     *_d_z = _d_vector_return[{{1U|1UL}}];
+// CHECK-NEXT:     *_d_y = _d_vector_return[{{0U|0UL|0ULL}}];
+// CHECK-NEXT:     *_d_z = _d_vector_return[{{1U|1UL|1ULL}}];
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
 // z
 // CHECK: void f5_dvec_2(double x, double y, double z, double *_d_z) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = {{1U|1UL}};
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = {{1U|1UL|1ULL}};
 // CHECK-NEXT:   clad::array<double> _d_vector_x = clad::zero_vector(indepVarCount);
 // CHECK-NEXT:   clad::array<double> _d_vector_y = clad::zero_vector(indepVarCount);
-// CHECK-NEXT:   clad::array<double> _d_vector_z = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_z = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, 0. * x + 1. * _d_vector_x + 0. * y + 2. * _d_vector_y + 0. * z + 3. * _d_vector_z));
-// CHECK-NEXT:     *_d_z = _d_vector_return[{{0U|0UL}}];
+// CHECK-NEXT:     *_d_z = _d_vector_return[{{0U|0UL|0ULL}}];
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -206,15 +206,15 @@ double f6(double x, double y) {
 }
 
 // CHECK: void f6_dvec(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:    unsigned {{int|long}} indepVarCount = {{2U|2UL}};
-// CHECK-NEXT:    clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
-// CHECK-NEXT:    clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL}});
+// CHECK-NEXT:    unsigned {{int|long|long long}} indepVarCount = {{2U|2UL|2ULL}};
+// CHECK-NEXT:    clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:    clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:    clad::ValueAndPushforward<double, clad::array<double> > _t0 = square_vector_pushforward(x, _d_vector_x);
 // CHECK-NEXT:    clad::ValueAndPushforward<double, clad::array<double> > _t1 = square_vector_pushforward(y, _d_vector_y);
 // CHECK-NEXT:    {
 // CHECK-NEXT:        clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, _t0.pushforward + _t1.pushforward));
-// CHECK-NEXT:        *_d_x = _d_vector_return[{{0U|0UL}}];
-// CHECK-NEXT:        *_d_y = _d_vector_return[{{1U|1UL}}];
+// CHECK-NEXT:        *_d_x = _d_vector_return[{{0U|0UL|0ULL}}];
+// CHECK-NEXT:        *_d_y = _d_vector_return[{{1U|1UL|1ULL}}];
 // CHECK-NEXT:        return;
 // CHECK-NEXT:    }
 // CHECK-NEXT: }
@@ -233,14 +233,14 @@ double f7(const double* arr, double w, int n) {
 // CHECK: clad::ValueAndPushforward<double, clad::array<double> > weighted_array_squared_sum_vector_pushforward(const double *arr, double w, int n, clad::matrix<double> &_d_arr, clad::array<double> _d_w, clad::array<int> _d_n);
 
 // CHECK: void f7_dvec_0_1(const double *arr, double w, int n, clad::array_ref<double> _d_arr, double *_d_w) {
-// CHECK-NEXT:    unsigned {{int|long}} indepVarCount = _d_arr.size() + {{1U|1UL}};
-// CHECK-NEXT:    clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL}});
+// CHECK-NEXT:    unsigned {{int|long|long long}} indepVarCount = _d_arr.size() + {{1U|1UL|1ULL}};
+// CHECK-NEXT:    clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:    clad::array<double> _d_vector_w = clad::one_hot_vector(indepVarCount, _d_arr.size());
 // CHECK-NEXT:    clad::array<int> _d_vector_n = clad::zero_vector(indepVarCount);
 // CHECK-NEXT:    clad::ValueAndPushforward<double, clad::array<double> > _t0 = weighted_array_squared_sum_vector_pushforward(arr, w, n, _d_vector_arr, _d_vector_w, _d_vector_n);
 // CHECK-NEXT:    {
 // CHECK-NEXT:        clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, _t0.pushforward));
-// CHECK-NEXT:        _d_arr = _d_vector_return.slice({{0U|0UL}}, _d_arr.size());
+// CHECK-NEXT:        _d_arr = _d_vector_return.slice({{0U|0UL|0ULL}}, _d_arr.size());
 // CHECK-NEXT:        *_d_w = _d_vector_return[_d_arr.size()];
 // CHECK-NEXT:        return;
 // CHECK-NEXT:    }
@@ -262,15 +262,15 @@ double f8(int n, const double* arr) {
 }
 
 // CHECK: void f8_dvec_1(int n, const double *arr, clad::array_ref<double> _d_arr) {
-// CHECK-NEXT:     unsigned {{int|long}} indepVarCount = _d_arr.size();
+// CHECK-NEXT:     unsigned {{int|long|long long}} indepVarCount = _d_arr.size();
 // CHECK-NEXT:     clad::array<int> _d_vector_n = clad::zero_vector(indepVarCount);
-// CHECK-NEXT:     clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL}});
+// CHECK-NEXT:     clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_res(clad::array<double>(indepVarCount, 0));
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     sum_ref_vector_pushforward(res, n, arr, _d_vector_res, _d_vector_n, _d_vector_arr);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, _d_vector_res));
-// CHECK-NEXT:         _d_arr = _d_vector_return.slice({{0U|0UL}}, _d_arr.size());
+// CHECK-NEXT:         _d_arr = _d_vector_return.slice({{0U|0UL|0ULL}}, _d_arr.size());
 // CHECK-NEXT:         return;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/ForwardMode/VectorModeInterface.C
+++ b/test/ForwardMode/VectorModeInterface.C
@@ -11,13 +11,13 @@ double f1(double x, double y) {
 }
 
 // CHECK: void f1_dvec(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = {{2U|2UL}};
-// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
-// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = {{2U|2UL|2ULL}};
+// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, _d_vector_x * y + x * _d_vector_y));
-// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL}}];
-// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL}}];
+// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL|0ULL}}];
+// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL|1ULL}}];
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -29,13 +29,13 @@ double f2(double x, double y) {
 void f2_dvec(double x, double y, double *_d_x, double *_d_y);
 
 // CHECK: void f2_dvec(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = {{2U|2UL}};
-// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
-// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = {{2U|2UL|2ULL}};
+// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:   {
 // CHECK-NEXT:     clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, _d_vector_x + _d_vector_y));
-// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL}}];
-// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL}}];
+// CHECK-NEXT:     *_d_x = _d_vector_return[{{0U|0UL|0ULL}}];
+// CHECK-NEXT:     *_d_y = _d_vector_return[{{1U|1UL|1ULL}}];
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -49,9 +49,9 @@ double f_try_catch(double x, double y)
   }
 
 // CHECK: void f_try_catch_dvec(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:   unsigned {{int|long}} indepVarCount = {{2U|2UL}};
-// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL}});
-// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL}});
+// CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = {{2U|2UL|2ULL}};
+// CHECK-NEXT:   clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:   clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:    try {
 // CHECK-NEXT:        return x;
 // CHECK-NEXT:    } catch (int) {

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -153,7 +153,7 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     double _t0 = res;
 // CHECK-NEXT:     res += sum(arr, n);
-// CHECK-NEXT:     unsigned {{int|long}} _t1 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t1 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:          if (!(i < n))
@@ -475,7 +475,7 @@ double fn13(double* x, const double* w) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_wCopy[2] = {0};
 // CHECK-NEXT:     double wCopy[2];
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 2))
@@ -860,7 +860,7 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
 // CHECK-NEXT:     float _d_res = 0;
 // CHECK-NEXT:     float res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -642,7 +642,7 @@ float running_sum(float* p, int n) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 1; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -711,9 +711,9 @@ double fn_template_non_type(double x) {
 // CHECK: void fn_template_non_type_grad(double x, double *_d_x) {
 // CHECK-NEXT:     size_t _d_maxN = 0;
 // CHECK-NEXT:     const size_t maxN = 53;
-// CHECK-NEXT:     bool _cond0 = maxN < {{15U|15UL}};
+// CHECK-NEXT:     bool _cond0 = maxN < {{15U|15UL|15ULL}};
 // CHECK-NEXT:     size_t _d_m = 0;
-// CHECK-NEXT:     const size_t m = _cond0 ? maxN : {{15U|15UL}};
+// CHECK-NEXT:     const size_t m = _cond0 ? maxN : {{15U|15UL|15ULL}};
 // CHECK-NEXT:     *_d_x += 1 * m;
 // CHECK-NEXT:     if (_cond0)
 // CHECK-NEXT:         _d_maxN += _d_m;

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -22,7 +22,7 @@ double f1(double x) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -58,21 +58,21 @@ double f2(double x) {
 // CHECK: void f2_grad(double x, double *_d_x) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     int _d_j = 0;
 // CHECK-NEXT:     int j = 0;
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:        clad::push(_t1, {{0U|0UL}});
+// CHECK-NEXT:        clad::push(_t1, {{0U|0UL|0ULL}});
 // CHECK-NEXT:         for (clad::push(_t2, j) , j = 0; ; j++) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 if (!(j < 3))
@@ -127,7 +127,7 @@ double f3(double x) {
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -178,7 +178,7 @@ double f4(double x) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; clad::push(_t1, t) , (t *= x)) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -213,7 +213,7 @@ double f5(double x){
 // CHECK: void f5_grad(double x, double *_d_x) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 10))
@@ -251,7 +251,7 @@ double f_const_local(double x) {
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 3))
@@ -298,7 +298,7 @@ double f_sum(double *p, int n) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_s = 0;
 // CHECK-NEXT:     double s = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -338,7 +338,7 @@ double f_sum_squares(double *p, int n) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_s = 0;
 // CHECK-NEXT:     double s = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -380,7 +380,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_power = 0;
 // CHECK-NEXT:     double power = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -459,7 +459,7 @@ void f_const_grad(const double, const double, double*, double*);
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     int _d_r = 0;
 // CHECK-NEXT:     int r = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < a))
@@ -515,7 +515,7 @@ double f6 (double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (counter = 0; ; ++counter) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(counter < 3))
@@ -577,7 +577,7 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     while (counter--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -609,17 +609,17 @@ double fn8(double i, double j) {
 }
 
 // CHECK: void fn8_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     while (counter > 0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
-// CHECK-NEXT:             clad::push(_t1, {{0U|0UL}});
+// CHECK-NEXT:             clad::push(_t1, {{0U|0UL|0ULL}});
 // CHECK-NEXT:             do {
 // CHECK-NEXT:                 clad::back(_t1)++;
 // CHECK-NEXT:                 clad::push(_t2, a);
@@ -663,7 +663,7 @@ double fn9(double i, double j) {
 
 // CHECK: void fn9_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     clad::tape<int> _t3 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t4 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t4 = {};
 // CHECK-NEXT:     clad::tape<double> _t5 = {};
 // CHECK-NEXT:     int _d_counter = 0, _d_counter_again = 0;
 // CHECK-NEXT:     int counter, counter_again;
@@ -672,13 +672,13 @@ double fn9(double i, double j) {
 // CHECK-NEXT:     counter = counter_again = 3;
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t2 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t2 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     while (counter--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t2++;
 // CHECK-NEXT:             clad::push(_t3, counter_again);
 // CHECK-NEXT:             counter_again = 3;
-// CHECK-NEXT:             clad::push(_t4, {{0U|0UL}});
+// CHECK-NEXT:             clad::push(_t4, {{0U|0UL|0ULL}});
 // CHECK-NEXT:             while (counter_again--)
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     clad::back(_t4)++;
@@ -747,7 +747,7 @@ double fn10(double i, double j) {
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     while (clad::push(_t1, b) , b = counter)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -805,7 +805,7 @@ double fn11(double i, double j) {
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, a);
@@ -853,28 +853,28 @@ double fn12(double i, double j) {
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_counter_again = 0;
 // CHECK-NEXT:     int counter_again = 0;
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<int> _t4 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t5 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t5 = {};
 // CHECK-NEXT:     clad::tape<double> _t6 = {};
 // CHECK-NEXT:     clad::tape<int> _t7 = {};
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, counter_again) , counter_again = 3;
-// CHECK-NEXT:         clad::push(_t2, {{0U|0UL}});
+// CHECK-NEXT:         clad::push(_t2, {{0U|0UL|0ULL}});
 // CHECK-NEXT:         do {
 // CHECK-NEXT:             clad::back(_t2)++;
 // CHECK-NEXT:             clad::push(_t3, a);
 // CHECK-NEXT:             a += i * i + j;
 // CHECK-NEXT:             clad::push(_t4, counter_again);
 // CHECK-NEXT:             counter_again -= 1;
-// CHECK-NEXT:             clad::push(_t5, {{0U|0UL}});
+// CHECK-NEXT:             clad::push(_t5, {{0U|0UL|0ULL}});
 // CHECK-NEXT:             do {
 // CHECK-NEXT:                 clad::back(_t5)++;
 // CHECK-NEXT:                 clad::push(_t6, a);
@@ -955,7 +955,7 @@ double fn13(double i, double j) {
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (;; clad::push(_t2, counter) , (counter -= 1)) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(clad::push(_t1, k) , k = counter))
@@ -1028,7 +1028,7 @@ double fn14(double i, double j) {
 // CHECK: void fn14_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond2 = {};
@@ -1037,7 +1037,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     while (choice--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -1047,7 +1047,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                     clad::push(_t1, res);
 // CHECK-NEXT:                     res += i;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         clad::push(_t2, {{1U|1UL}});
+// CHECK-NEXT:                         clad::push(_t2, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                         continue;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
@@ -1058,7 +1058,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                     clad::push(_t3, res);
 // CHECK-NEXT:                     res += j;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         clad::push(_t2, {{2U|2UL}});
+// CHECK-NEXT:                         clad::push(_t2, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                         continue;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
@@ -1069,22 +1069,22 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                     clad::push(_t4, res);
 // CHECK-NEXT:                     res += i * j;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         clad::push(_t2, {{3U|3UL}});
+// CHECK-NEXT:                         clad::push(_t2, {{3U|3UL|3ULL}});
 // CHECK-NEXT:                         continue;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t2, {{4U|4UL}});
+// CHECK-NEXT:             clad::push(_t2, {{4U|4UL|4ULL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             switch (clad::pop(_t2)) {
-// CHECK-NEXT:               case {{4U|4UL}}:
+// CHECK-NEXT:               case {{4U|4UL|4ULL}}:
 // CHECK-NEXT:                 ;
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     if (clad::back(_cond2)) {
-// CHECK-NEXT:                       case {{3U|3UL}}:
+// CHECK-NEXT:                       case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:                         ;
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             res = clad::pop(_t4);
@@ -1097,7 +1097,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     if (clad::back(_cond1)) {
-// CHECK-NEXT:                       case {{2U|2UL}}:
+// CHECK-NEXT:                       case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                         ;
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             res = clad::pop(_t3);
@@ -1109,7 +1109,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     if (clad::back(_cond0)) {
-// CHECK-NEXT:                       case {{1U|1UL}}:
+// CHECK-NEXT:                       case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                         ;
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             res = clad::pop(_t1);
@@ -1146,33 +1146,33 @@ double fn15(double i, double j) {
 
 // CHECK: void fn15_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     int _d_another_choice = 0;
 // CHECK-NEXT:     int another_choice = 0;
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t5 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t5 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond2 = {};
 // CHECK-NEXT:     clad::tape<double> _t6 = {};
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     while (choice--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 clad::push(_cond0, choice > 2);
 // CHECK-NEXT:                 if (clad::back(_cond0)) {
-// CHECK-NEXT:                     clad::push(_t1, {{1U|1UL}});
+// CHECK-NEXT:                     clad::push(_t1, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                     continue;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             clad::push(_t2, another_choice) , another_choice = 3;
-// CHECK-NEXT:             clad::push(_t3, {{0U|0UL}});
+// CHECK-NEXT:             clad::push(_t3, {{0U|0UL|0ULL}});
 // CHECK-NEXT:             while (another_choice--)
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     clad::back(_t3)++;
@@ -1182,7 +1182,7 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                             clad::push(_t4, res);
 // CHECK-NEXT:                             res += i;
 // CHECK-NEXT:                             {
-// CHECK-NEXT:                                 clad::push(_t5, {{1U|1UL}});
+// CHECK-NEXT:                                 clad::push(_t5, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                                 continue;
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                         }
@@ -1194,21 +1194,21 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                             res += j;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
-// CHECK-NEXT:                     clad::push(_t5, {{2U|2UL}});
+// CHECK-NEXT:                     clad::push(_t5, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                 }
-// CHECK-NEXT:             clad::push(_t1, {{2U|2UL}});
+// CHECK-NEXT:             clad::push(_t1, {{2U|2UL|2ULL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             switch (clad::pop(_t1)) {
-// CHECK-NEXT:               case {{2U|2UL}}:
+// CHECK-NEXT:               case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                 ;
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     while (clad::back(_t3))
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             switch (clad::pop(_t5)) {
-// CHECK-NEXT:                               case {{2U|2UL}}:
+// CHECK-NEXT:                               case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                                 ;
 // CHECK-NEXT:                                 {
 // CHECK-NEXT:                                     if (clad::back(_cond2)) {
@@ -1222,7 +1222,7 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                                 }
 // CHECK-NEXT:                                 {
 // CHECK-NEXT:                                     if (clad::back(_cond1)) {
-// CHECK-NEXT:                                       case {{1U|1UL}}:
+// CHECK-NEXT:                                       case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                                         ;
 // CHECK-NEXT:                                         {
 // CHECK-NEXT:                                             res = clad::pop(_t4);
@@ -1243,7 +1243,7 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     if (clad::back(_cond0))
-// CHECK-NEXT:                       case {{1U|1UL}}:
+// CHECK-NEXT:                       case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                         ;
 // CHECK-NEXT:                     clad::pop(_cond0);
 // CHECK-NEXT:                 }
@@ -1274,7 +1274,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:     int ii = 0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
@@ -1282,7 +1282,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:     int counter = 5;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (ii = 0; ; ++ii) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(ii < counter))
@@ -1295,7 +1295,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:                 clad::push(_t1, res);
 // CHECK-NEXT:                 res += i * j;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_t2, {{1U|1UL}});
+// CHECK-NEXT:                     clad::push(_t2, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
@@ -1306,14 +1306,14 @@ double fn16(double i, double j) {
 // CHECK-NEXT:                 clad::push(_t3, res);
 // CHECK-NEXT:                 res += 2 * i;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_t2, {{2U|2UL}});
+// CHECK-NEXT:                     clad::push(_t2, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                     continue;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:         clad::push(_t4, res);
 // CHECK-NEXT:         res += i + j;
-// CHECK-NEXT:         clad::push(_t2, {{3U|3UL}});
+// CHECK-NEXT:         clad::push(_t2, {{3U|3UL|3ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (;; _t0--) {
@@ -1322,7 +1322,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
-// CHECK-NEXT:           case {{3U|3UL}}:
+// CHECK-NEXT:           case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             --ii;
 // CHECK-NEXT:             {
@@ -1333,7 +1333,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 if (clad::back(_cond1)) {
-// CHECK-NEXT:                   case {{2U|2UL}}:
+// CHECK-NEXT:                   case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         res = clad::pop(_t3);
@@ -1345,7 +1345,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 if (clad::back(_cond0)) {
-// CHECK-NEXT:                   case {{1U|1UL}}:
+// CHECK-NEXT:                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         res = clad::pop(_t1);
@@ -1387,17 +1387,17 @@ double fn17(double i, double j) {
 // CHECK-NEXT:     int _d_jj = 0;
 // CHECK-NEXT:     int jj = 0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t5 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t5 = {};
 // CHECK-NEXT:     clad::tape<double> _t6 = {};
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 5;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (ii = 0; ; ++ii) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(ii < counter))
@@ -1408,11 +1408,11 @@ double fn17(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, ii < 2);
 // CHECK-NEXT:             if (clad::back(_cond0)) {
-// CHECK-NEXT:                 clad::push(_t2, {{1U|1UL}});
+// CHECK-NEXT:                 clad::push(_t2, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                 continue;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t3, {{0U|0UL}});
+// CHECK-NEXT:         clad::push(_t3, {{0U|0UL|0ULL}});
 // CHECK-NEXT:         while (jj--)
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 clad::back(_t3)++;
@@ -1422,21 +1422,21 @@ double fn17(double i, double j) {
 // CHECK-NEXT:                         clad::push(_t4, res);
 // CHECK-NEXT:                         res += i * j;
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             clad::push(_t5, {{1U|1UL}});
+// CHECK-NEXT:                             clad::push(_t5, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                             break;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     } else {
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             clad::push(_t5, {{2U|2UL}});
+// CHECK-NEXT:                             clad::push(_t5, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                             continue;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 clad::push(_t6, res);
 // CHECK-NEXT:                 res += i * i * j * j;
-// CHECK-NEXT:                 clad::push(_t5, {{3U|3UL}});
+// CHECK-NEXT:                 clad::push(_t5, {{3U|3UL|3ULL}});
 // CHECK-NEXT:             }
-// CHECK-NEXT:         clad::push(_t2, {{2U|2UL}});
+// CHECK-NEXT:         clad::push(_t2, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (;; _t0--) {
@@ -1445,14 +1445,14 @@ double fn17(double i, double j) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
-// CHECK-NEXT:           case {{2U|2UL}}:
+// CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             --ii;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 while (clad::back(_t3))
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         switch (clad::pop(_t5)) {
-// CHECK-NEXT:                           case {{3U|3UL}}:
+// CHECK-NEXT:                           case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:                             ;
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                                 res = clad::pop(_t6);
@@ -1464,7 +1464,7 @@ double fn17(double i, double j) {
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                                 if (clad::back(_cond1)) {
-// CHECK-NEXT:                                   case {{1U|1UL}}:
+// CHECK-NEXT:                                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                                     ;
 // CHECK-NEXT:                                     {
 // CHECK-NEXT:                                         res = clad::pop(_t4);
@@ -1473,7 +1473,7 @@ double fn17(double i, double j) {
 // CHECK-NEXT:                                         *_d_j += i * _r_d0;
 // CHECK-NEXT:                                     }
 // CHECK-NEXT:                                 } else {
-// CHECK-NEXT:                                   case {{2U|2UL}}:
+// CHECK-NEXT:                                   case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                                     ;
 // CHECK-NEXT:                                 }
 // CHECK-NEXT:                                 clad::pop(_cond1);
@@ -1485,7 +1485,7 @@ double fn17(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 if (clad::back(_cond0))
-// CHECK-NEXT:                   case {{1U|1UL}}:
+// CHECK-NEXT:                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                 clad::pop(_cond0);
 // CHECK-NEXT:             }
@@ -1519,13 +1519,13 @@ double fn18(double i, double j) {
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (counter = 0; ; ++counter) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(counter < choice))
@@ -1540,19 +1540,19 @@ double fn18(double i, double j) {
 // CHECK-NEXT:             } else {
 // CHECK-NEXT:                 clad::push(_cond1, counter < 4);
 // CHECK-NEXT:                 if (clad::back(_cond1)) {
-// CHECK-NEXT:                     clad::push(_t2, {{1U|1UL}});
+// CHECK-NEXT:                     clad::push(_t2, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                     continue;
 // CHECK-NEXT:                 } else {
 // CHECK-NEXT:                     clad::push(_t3, res);
 // CHECK-NEXT:                     res += 2 * i + 2 * j;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         clad::push(_t2, {{2U|2UL}});
+// CHECK-NEXT:                         clad::push(_t2, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                         break;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t2, {{3U|3UL}});
+// CHECK-NEXT:         clad::push(_t2, {{3U|3UL|3ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (;; _t0--) {
@@ -1561,7 +1561,7 @@ double fn18(double i, double j) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
-// CHECK-NEXT:           case {{3U|3UL}}:
+// CHECK-NEXT:           case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             --counter;
 // CHECK-NEXT:             if (clad::back(_cond0)) {
@@ -1571,10 +1571,10 @@ double fn18(double i, double j) {
 // CHECK-NEXT:                 *_d_j += _r_d0;
 // CHECK-NEXT:             } else {
 // CHECK-NEXT:                 if (clad::back(_cond1))
-// CHECK-NEXT:                   case {{1U|1UL}}:
+// CHECK-NEXT:                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                 else {
-// CHECK-NEXT:                   case {{2U|2UL}}:
+// CHECK-NEXT:                   case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         res = clad::pop(_t3);
@@ -1610,7 +1610,7 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -1661,7 +1661,7 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:     double num_points = 10000;
 // CHECK-NEXT:     double _d_interval = 0;
 // CHECK-NEXT:     double interval = (upper - lower) / num_points;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (x = lower; ; clad::push(_t1, x) , (x += interval)) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(x <= upper))
@@ -1716,7 +1716,7 @@ double fn20(double *arr, int n) {
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))
@@ -1761,11 +1761,11 @@ double fn21(double x) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
 // CHECK-NEXT:     double _d_arr[3] = {0};
-// CHECK-NEXT:     clad::array<double> arr({{3U|3UL}});
+// CHECK-NEXT:     clad::array<double> arr({{3U|3UL|3ULL}});
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 5))
@@ -1812,12 +1812,12 @@ double fn22(double param) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
 // CHECK-NEXT:     double _d_arr[1] = {0};
-// CHECK-NEXT:     clad::array<double> arr({{1U|1UL}});
+// CHECK-NEXT:     clad::array<double> arr({{1U|1UL|1ULL}});
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_out = 0;
 // CHECK-NEXT:     double out = 0.;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 1))
@@ -1864,10 +1864,10 @@ double fn23(double i, double j) {
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -1880,11 +1880,11 @@ double fn23(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, c == 1);
 // CHECK-NEXT:             if (clad::back(_cond0)) {
-// CHECK-NEXT:                 clad::push(_t2, {{1U|1UL}});
+// CHECK-NEXT:                 clad::push(_t2, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t2, {{2U|2UL}});
+// CHECK-NEXT:         clad::push(_t2, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (;; _t0--) {
@@ -1900,12 +1900,12 @@ double fn23(double i, double j) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
-// CHECK-NEXT:           case {{2U|2UL}}:
+// CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             --c;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 if (clad::back(_cond0))
-// CHECK-NEXT:                   case {{1U|1UL}}:
+// CHECK-NEXT:                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                 clad::pop(_cond0);
 // CHECK-NEXT:             }
@@ -1926,7 +1926,7 @@ double fn24(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -1971,10 +1971,10 @@ double fn25(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -1990,12 +1990,12 @@ double fn25(double i, double j) {
 // CHECK-NEXT:                 clad::push(_t2, res);
 // CHECK-NEXT:                 res = 8 * i * j;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_t3, {{1U|1UL}});
+// CHECK-NEXT:                     clad::push(_t3, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t3, {{2U|2UL}});
+// CHECK-NEXT:         clad::push(_t3, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (;; _t0--) {
@@ -2011,12 +2011,12 @@ double fn25(double i, double j) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         switch (clad::pop(_t3)) {
-// CHECK-NEXT:           case {{2U|2UL}}:
+// CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             --c;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 if (clad::back(_cond0)) {
-// CHECK-NEXT:                   case {{1U|1UL}}:
+// CHECK-NEXT:                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         res = clad::pop(_t2);
@@ -2047,10 +2047,10 @@ double fn26(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; clad::push(_t2, res) , (++c , res = 7 * i * j)) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2063,11 +2063,11 @@ double fn26(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, c == 0);
 // CHECK-NEXT:             if (clad::back(_cond0)) {
-// CHECK-NEXT:                 clad::push(_t3, {{1U|1UL}});
+// CHECK-NEXT:                 clad::push(_t3, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t3, {{2U|2UL}});
+// CHECK-NEXT:         clad::push(_t3, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (;; _t0--) {
@@ -2082,7 +2082,7 @@ double fn26(double i, double j) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         switch (clad::pop(_t3)) {
-// CHECK-NEXT:           case {{2U|2UL}}:
+// CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 res = clad::pop(_t2);
@@ -2095,7 +2095,7 @@ double fn26(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 if (clad::back(_cond0))
-// CHECK-NEXT:                   case {{1U|1UL}}:
+// CHECK-NEXT:                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                 clad::pop(_cond0);
 // CHECK-NEXT:             }
@@ -2119,11 +2119,11 @@ double fn27(double i, double j) {
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2136,13 +2136,13 @@ double fn27(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, c == 2);
 // CHECK-NEXT:             if (clad::back(_cond0)) {
-// CHECK-NEXT:                 clad::push(_t2, {{1U|1UL}});
+// CHECK-NEXT:                 clad::push(_t2, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:         clad::push(_t3, res);
 // CHECK-NEXT:         res = c * i * j;
-// CHECK-NEXT:         clad::push(_t2, {{2U|2UL}});
+// CHECK-NEXT:         clad::push(_t2, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (;; _t0--) {
@@ -2157,7 +2157,7 @@ double fn27(double i, double j) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
-// CHECK-NEXT:           case {{2U|2UL}}:
+// CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             --c;
 // CHECK-NEXT:             {
@@ -2170,7 +2170,7 @@ double fn27(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 if (clad::back(_cond0))
-// CHECK-NEXT:                   case {{1U|1UL}}:
+// CHECK-NEXT:                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                 clad::pop(_cond0);
 // CHECK-NEXT:             }
@@ -2193,7 +2193,7 @@ double fn28(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2244,7 +2244,7 @@ double fn29(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; clad::push(_t2, res) , (++c , res = 3 * i * j)) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2298,7 +2298,7 @@ double fn30(double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
@@ -2353,7 +2353,7 @@ double fn31(double i, double j) {
 //CHECK-NEXT:    clad::tape<double> _t2 = {};
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
-//CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:    for (c = 0; ; ++c) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            {
@@ -2410,20 +2410,20 @@ double fn32(double i, double j) {
 //CHECK-NEXT:    int _d_c = 0;
 //CHECK-NEXT:    int c = 0;
 //CHECK-NEXT:    clad::tape<double> _t1 = {};
-//CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t2 = {};
+//CHECK-NEXT:    clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 //CHECK-NEXT:    clad::tape<int> _t3 = {};
 //CHECK-NEXT:    int _d_d = 0;
 //CHECK-NEXT:    int d = 0;
 //CHECK-NEXT:    clad::tape<double> _t4 = {};
 //CHECK-NEXT:    clad::tape<bool> _cond0 = {};
 //CHECK-NEXT:    clad::tape<double> _t5 = {};
-//CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t6 = {};
+//CHECK-NEXT:    clad::tape<unsigned {{int|long|long long}}> _t6 = {};
 //CHECK-NEXT:    clad::tape<bool> _cond1 = {};
 //CHECK-NEXT:    clad::tape<double> _t7 = {};
-//CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t8 = {};
+//CHECK-NEXT:    clad::tape<unsigned {{int|long|long long}}> _t8 = {};
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
-//CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:    for (c = 0; ; ++c) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            {
@@ -2433,7 +2433,7 @@ double fn32(double i, double j) {
 //CHECK-NEXT:                break;
 //CHECK-NEXT:        }
 //CHECK-NEXT:        _t0++;
-//CHECK-NEXT:        clad::push(_t2, {{0U|0UL}});
+//CHECK-NEXT:        clad::push(_t2, {{0U|0UL|0ULL}});
 //CHECK-NEXT:        for (clad::push(_t3, d) , d = 0; ; ++d) {
 //CHECK-NEXT:            {
 //CHECK-NEXT:                {
@@ -2449,12 +2449,12 @@ double fn32(double i, double j) {
 //CHECK-NEXT:                    clad::push(_t5, res);
 //CHECK-NEXT:                    res += i * j;
 //CHECK-NEXT:                    {
-//CHECK-NEXT:                        clad::push(_t6, {{1U|1UL}});
+//CHECK-NEXT:                        clad::push(_t6, {{1U|1UL|1ULL}});
 //CHECK-NEXT:                        break;
 //CHECK-NEXT:                    }
 //CHECK-NEXT:                }
 //CHECK-NEXT:            }
-//CHECK-NEXT:            clad::push(_t6, {{2U|2UL}});
+//CHECK-NEXT:            clad::push(_t6, {{2U|2UL|2ULL}});
 //CHECK-NEXT:        }
 //CHECK-NEXT:        {
 //CHECK-NEXT:            clad::push(_cond1, c == 1);
@@ -2462,12 +2462,12 @@ double fn32(double i, double j) {
 //CHECK-NEXT:                clad::push(_t7, res);
 //CHECK-NEXT:                res += i * j;
 //CHECK-NEXT:                {
-//CHECK-NEXT:                    clad::push(_t8, {{1U|1UL}});
+//CHECK-NEXT:                    clad::push(_t8, {{1U|1UL|1ULL}});
 //CHECK-NEXT:                    break;
 //CHECK-NEXT:                }
 //CHECK-NEXT:            }
 //CHECK-NEXT:        }
-//CHECK-NEXT:        clad::push(_t8, {{2U|2UL}});
+//CHECK-NEXT:        clad::push(_t8, {{2U|2UL|2ULL}});
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_res += 1;
 //CHECK-NEXT:    for (;; _t0--) {
@@ -2482,12 +2482,12 @@ double fn32(double i, double j) {
 //CHECK-NEXT:                break;
 //CHECK-NEXT:        }
 //CHECK-NEXT:        switch (clad::pop(_t8)) {
-//CHECK-NEXT:          case {{2U|2UL}}:
+//CHECK-NEXT:          case {{2U|2UL|2ULL}}:
 //CHECK-NEXT:            ;
 //CHECK-NEXT:            --c;
 //CHECK-NEXT:            {
 //CHECK-NEXT:                if (clad::back(_cond1)) {
-//CHECK-NEXT:                  case {{1U|1UL}}:
+//CHECK-NEXT:                  case {{1U|1UL|1ULL}}:
 //CHECK-NEXT:                    ;
 //CHECK-NEXT:                    {
 //CHECK-NEXT:                        res = clad::pop(_t7);
@@ -2511,12 +2511,12 @@ double fn32(double i, double j) {
 //CHECK-NEXT:                            break;
 //CHECK-NEXT:                    }
 //CHECK-NEXT:                    switch (clad::pop(_t6)) {
-//CHECK-NEXT:                      case {{2U|2UL}}:
+//CHECK-NEXT:                      case {{2U|2UL|2ULL}}:
 //CHECK-NEXT:                        ;
 //CHECK-NEXT:                        --d;
 //CHECK-NEXT:                        {
 //CHECK-NEXT:                            if (clad::back(_cond0)) {
-//CHECK-NEXT:                              case {{1U|1UL}}:
+//CHECK-NEXT:                              case {{1U|1UL|1ULL}}:
 //CHECK-NEXT:                                ;
 //CHECK-NEXT:                                {
 //CHECK-NEXT:                                    res = clad::pop(_t5);
@@ -2563,7 +2563,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:    clad::tape<double> _cond1 = {};
 //CHECK-NEXT:    clad::tape<bool> _t3 = {};
 //CHECK-NEXT:    clad::tape<bool> _cond2 = {};
-//CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t4 = {};
+//CHECK-NEXT:    clad::tape<unsigned {{int|long|long long}}> _t4 = {};
 //CHECK-NEXT:    bool _cond3;
 //CHECK-NEXT:    double _d_cond3;
 //CHECK-NEXT:    _d_cond3 = 0.;
@@ -2573,7 +2573,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:    clad::tape<bool> _cond5 = {};
 //CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
-//CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:    for (c = 0; ; ++c) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            {
@@ -2595,7 +2595,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:            clad::push(_cond2, clad::back(_cond1) && _cond0);
 //CHECK-NEXT:            if (clad::back(_cond2)) {
 //CHECK-NEXT:                {
-//CHECK-NEXT:                    clad::push(_t4, {{1U|1UL}});
+//CHECK-NEXT:                    clad::push(_t4, {{1U|1UL|1ULL}});
 //CHECK-NEXT:                    break;
 //CHECK-NEXT:                }
 //CHECK-NEXT:            }
@@ -2612,12 +2612,12 @@ double fn33(double i, double j) {
 //CHECK-NEXT:            clad::push(_cond5, clad::back(_cond4) && _cond3);
 //CHECK-NEXT:            if (clad::back(_cond5)) {
 //CHECK-NEXT:                {
-//CHECK-NEXT:                    clad::push(_t4, {{2U|2UL}});
+//CHECK-NEXT:                    clad::push(_t4, {{2U|2UL|2ULL}});
 //CHECK-NEXT:                    break;
 //CHECK-NEXT:                }
 //CHECK-NEXT:            }
 //CHECK-NEXT:        }
-//CHECK-NEXT:        clad::push(_t4, {{3U|3UL}});
+//CHECK-NEXT:        clad::push(_t4, {{3U|3UL|3ULL}});
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_res += 1;
 //CHECK-NEXT:    for (;; _t0--) {
@@ -2633,12 +2633,12 @@ double fn33(double i, double j) {
 //CHECK-NEXT:                break;
 //CHECK-NEXT:        }
 //CHECK-NEXT:        switch (clad::pop(_t4)) {
-//CHECK-NEXT:          case {{3U|3UL}}:
+//CHECK-NEXT:          case {{3U|3UL|3ULL}}:
 //CHECK-NEXT:            ;
 //CHECK-NEXT:            --c;
 //CHECK-NEXT:            {
 //CHECK-NEXT:                if (clad::back(_cond5)) {
-//CHECK-NEXT:                  case {{2U|2UL}}:
+//CHECK-NEXT:                  case {{2U|2UL|2ULL}}:
 //CHECK-NEXT:                    ;
 //CHECK-NEXT:                }
 //CHECK-NEXT:                clad::pop(_cond5);
@@ -2660,7 +2660,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:            }
 //CHECK-NEXT:            {
 //CHECK-NEXT:                if (clad::back(_cond2)) {
-//CHECK-NEXT:                  case {{1U|1UL}}:
+//CHECK-NEXT:                  case {{1U|1UL|1ULL}}:
 //CHECK-NEXT:                    ;
 //CHECK-NEXT:                }
 //CHECK-NEXT:                clad::pop(_cond2);
@@ -2702,7 +2702,7 @@ double fn34(double x, double y){
 //CHECK-NEXT:     double r = 0;
 //CHECK-NEXT:     double _d_a[3] = {0};
 //CHECK-NEXT:     double a[3] = {y, x * y, x * x + y};
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     double (*__range10)[3] = &a;
 //CHECK-NEXT:     double (*_d___range1)[3] = &_d_a;
 //CHECK-NEXT:     double *__begin10 = *__range10;
@@ -2765,11 +2765,11 @@ double fn35(double x, double y){
 }
 
 //CHECK: void fn35_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+//CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 //CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     clad::tape<bool> _cond1 = {};
-//CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+//CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 //CHECK-NEXT:     clad::tape<double *> _t4 = {};
 //CHECK-NEXT:     clad::tape<double *> _t5 = {};
 //CHECK-NEXT:     clad::tape<double *> _t6 = {};
@@ -2778,7 +2778,7 @@ double fn35(double x, double y){
 //CHECK-NEXT:     double r = 0;
 //CHECK-NEXT:     double _d_a[3] = {0};
 //CHECK-NEXT:     double a[3] = {x, x * y, 0};
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     double (*__range10)[3] = &a;
 //CHECK-NEXT:     double (*_d___range1)[3] = &_d_a;
 //CHECK-NEXT:     double *__begin10 = *__range10;
@@ -2796,7 +2796,7 @@ double fn35(double x, double y){
 //CHECK-NEXT:             clad::push(_t7, _d_i);
 //CHECK-NEXT:         }
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, {{0U|0UL}});
+//CHECK-NEXT:         clad::push(_t1, {{0U|0UL|0ULL}});
 //CHECK-NEXT:         double (*__range20)[3] = &a;
 //CHECK-NEXT:         double (*_d___range2)[3] = &_d_a;
 //CHECK-NEXT:         double *__begin20 = *__range20;
@@ -2823,13 +2823,13 @@ double fn35(double x, double y){
 //CHECK-NEXT:                     clad::push(_cond1, r > x * x);
 //CHECK-NEXT:                     if (clad::back(_cond1)) {
 //CHECK-NEXT:                         {
-//CHECK-NEXT:                             clad::push(_t3, {{1U|1UL}});
+//CHECK-NEXT:                             clad::push(_t3, {{1U|1UL|1ULL}});
 //CHECK-NEXT:                             break;
 //CHECK-NEXT:                         }
 //CHECK-NEXT:                     }
 //CHECK-NEXT:                 }
 //CHECK-NEXT:             }
-//CHECK-NEXT:             clad::push(_t3, {{2U|2UL}});
+//CHECK-NEXT:             clad::push(_t3, {{2U|2UL|2ULL}});
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_r += 1;
@@ -2849,7 +2849,7 @@ double fn35(double x, double y){
 //CHECK-NEXT:                             _d_j = clad::pop(_t5);
 //CHECK-NEXT:                         }
 //CHECK-NEXT:                         switch (clad::pop(_t3)) {
-//CHECK-NEXT:                           case {{2U|2UL}}:
+//CHECK-NEXT:                           case {{2U|2UL|2ULL}}:
 //CHECK-NEXT:                             ;
 //CHECK-NEXT:                             {
 //CHECK-NEXT:                                 if (clad::back(_cond0)) {
@@ -2861,7 +2861,7 @@ double fn35(double x, double y){
 //CHECK-NEXT:                                     }
 //CHECK-NEXT:                                 } else {
 //CHECK-NEXT:                                     if (clad::back(_cond1)) {
-//CHECK-NEXT:                                       case {{1U|1UL}}:
+//CHECK-NEXT:                                       case {{1U|1UL|1ULL}}:
 //CHECK-NEXT:                                         ;
 //CHECK-NEXT:                                     }
 //CHECK-NEXT:                                     clad::pop(_cond1);
@@ -2897,7 +2897,7 @@ double fn36(double x, double y){
 
 //CHECK: void fn36_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-//CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+//CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     clad::tape<double> _t4 = {};
@@ -2906,7 +2906,7 @@ double fn36(double x, double y){
 //CHECK-NEXT:     double a[3] = {1, 2, 3};
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     double (*__range10)[3] = &a;
 //CHECK-NEXT:     double (*_d___range1)[3] = &_d_a;
 //CHECK-NEXT:     double *__begin10 = *__range10;
@@ -2928,7 +2928,7 @@ double fn36(double x, double y){
 //CHECK-NEXT:             clad::push(_cond0, sum > x);
 //CHECK-NEXT:             if (clad::back(_cond0)) {
 //CHECK-NEXT:                 {
-//CHECK-NEXT:                     clad::push(_t1, {{1U|1UL}});
+//CHECK-NEXT:                     clad::push(_t1, {{1U|1UL|1ULL}});
 //CHECK-NEXT:                     continue;
 //CHECK-NEXT:                 }
 //CHECK-NEXT:             } else if (1) {
@@ -2937,7 +2937,7 @@ double fn36(double x, double y){
 //CHECK-NEXT:                 sum += clad::back(_t3) * x;
 //CHECK-NEXT:             }
 //CHECK-NEXT:         }
-//CHECK-NEXT:         clad::push(_t1, {{2U|2UL}});
+//CHECK-NEXT:         clad::push(_t1, {{2U|2UL|2ULL}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
@@ -2948,11 +2948,11 @@ double fn36(double x, double y){
 //CHECK-NEXT:                 _d_i = clad::pop(_t5);
 //CHECK-NEXT:             }
 //CHECK-NEXT:             switch (clad::pop(_t1)) {
-//CHECK-NEXT:               case {{2U|2UL}}:
+//CHECK-NEXT:               case {{2U|2UL|2ULL}}:
 //CHECK-NEXT:                 ;
 //CHECK-NEXT:                 {
 //CHECK-NEXT:                     if (clad::back(_cond0)) {
-//CHECK-NEXT:                       case {{1U|1UL}}:
+//CHECK-NEXT:                       case {{1U|1UL|1ULL}}:
 //CHECK-NEXT:                         ;
 //CHECK-NEXT:                     } else if (1) {
 //CHECK-NEXT:                         {
@@ -2989,7 +2989,7 @@ double fn37(double x, double y) {
 //CHECK-NEXT:     double range[3] = {x, 4., y};
 //CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     double (*__range10)[3] = &range;
 //CHECK-NEXT:     double (*_d___range1)[3] = &_d_range;
 //CHECK-NEXT:     double *__begin10 = *__range10;

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -159,7 +159,7 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:     clad::tape<double *> _t6 = {};
 // CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < n))

--- a/test/Gradient/Switch.C
+++ b/test/Gradient/Switch.C
@@ -21,7 +21,7 @@ double fn1(double i, double j) {
 // CHECK: void fn1_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _cond0;
 // CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     double _t3;
 // CHECK-NEXT:     double _t4;
@@ -38,7 +38,7 @@ double fn1(double i, double j) {
 // CHECK-NEXT:                 _t0 = res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t1, {{1U|1UL}});
+// CHECK-NEXT:                 clad::push(_t1, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
@@ -58,13 +58,13 @@ double fn1(double i, double j) {
 // CHECK-NEXT:                 res += i * i * j * j;
 // CHECK-NEXT:                 _t4 = res;
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t1, {{2U|2UL}});
+// CHECK-NEXT:             clad::push(_t1, {{2U|2UL|2ULL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t1)) {
-// CHECK-NEXT:           case {{2U|2UL}}:
+// CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
@@ -100,7 +100,7 @@ double fn1(double i, double j) {
 // CHECK-NEXT:                 if (1 == _cond0)
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:             }
-// CHECK-NEXT:           case {{1U|1UL}}:
+// CHECK-NEXT:           case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
@@ -136,7 +136,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     double _t1;
 // CHECK-NEXT:     double _t2;
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 // CHECK-NEXT:     double _t4;
 // CHECK-NEXT:     double _t5;
 // CHECK-NEXT:     double _t6;
@@ -156,7 +156,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:                 _t2 = res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t3, {{1U|1UL}});
+// CHECK-NEXT:                 clad::push(_t3, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
@@ -170,7 +170,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:                 _t5 = res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t3, {{2U|2UL}});
+// CHECK-NEXT:                 clad::push(_t3, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
@@ -178,13 +178,13 @@ double fn2(double i, double j) {
 // CHECK-NEXT:                 res += i + j;
 // CHECK-NEXT:                 _t6 = res;
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t3, {{3U|3UL}});
+// CHECK-NEXT:             clad::push(_t3, {{3U|3UL|3ULL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t3)) {
-// CHECK-NEXT:           case {{3U|3UL}}:
+// CHECK-NEXT:           case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
@@ -196,7 +196,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:                 if (_cond0 != 0 && _cond0 != 1 && _cond0 != 2)
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:             }
-// CHECK-NEXT:           case {{2U|2UL}}:
+// CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
@@ -217,7 +217,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:                 if (1 == _cond0)
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:             }
-// CHECK-NEXT:           case {{1U|1UL}}:
+// CHECK-NEXT:           case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
@@ -265,14 +265,14 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     clad::tape<int> _cond0 = {};
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     clad::tape<double> _t5 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 2;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     while (counter--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
@@ -292,7 +292,7 @@ double fn3(double i, double j) {
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         clad::push(_t3, {{1U|1UL}});
+// CHECK-NEXT:                         clad::push(_t3, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                         break;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     {
@@ -305,7 +305,7 @@ double fn3(double i, double j) {
 // CHECK-NEXT:                         res += i + j;
 // CHECK-NEXT:                         clad::push(_t5, res);
 // CHECK-NEXT:                     }
-// CHECK-NEXT:                     clad::push(_t3, {{2U|2UL}});
+// CHECK-NEXT:                     clad::push(_t3, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
@@ -315,7 +315,7 @@ double fn3(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     switch (clad::pop(_t3)) {
-// CHECK-NEXT:                       case {{2U|2UL}}:
+// CHECK-NEXT:                       case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                         ;
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             {
@@ -337,7 +337,7 @@ double fn3(double i, double j) {
 // CHECK-NEXT:                             if (2 == clad::back(_cond0))
 // CHECK-NEXT:                                 break;
 // CHECK-NEXT:                         }
-// CHECK-NEXT:                       case {{1U|1UL}}:
+// CHECK-NEXT:                       case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                         ;
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             {
@@ -387,10 +387,10 @@ double fn4(double i, double j) {
 
 // CHECK: void fn4_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t2;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t2;
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
@@ -402,14 +402,14 @@ double fn4(double i, double j) {
 // CHECK-NEXT:                 _t0 = res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t1, {{1U|1UL}});
+// CHECK-NEXT:                 clad::push(_t1, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:               case 1:
 // CHECK-NEXT:                 counter = 2;
 // CHECK-NEXT:             }
-// CHECK-NEXT:             _t2 = {{0U|0UL}};
+// CHECK-NEXT:             _t2 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:             while (counter--)
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     _t2++;
@@ -417,18 +417,18 @@ double fn4(double i, double j) {
 // CHECK-NEXT:                     res += i * j;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t1, {{2U|2UL}});
+// CHECK-NEXT:                 clad::push(_t1, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t1, {{3U|3UL}});
+// CHECK-NEXT:             clad::push(_t1, {{3U|3UL|3ULL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t1)) {
-// CHECK-NEXT:           case {{3U|3UL}}:
+// CHECK-NEXT:           case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:             ;
-// CHECK-NEXT:           case {{2U|2UL}}:
+// CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             while (_t2)
 // CHECK-NEXT:                 {
@@ -446,7 +446,7 @@ double fn4(double i, double j) {
 // CHECK-NEXT:                 if (1 == 1)
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:             }
-// CHECK-NEXT:           case {{1U|1UL}}:
+// CHECK-NEXT:           case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
@@ -477,7 +477,7 @@ double fn5(double i, double j) {
 // CHECK-NEXT:     int count = 0;
 // CHECK-NEXT:     int _cond0;
 // CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     {
@@ -487,13 +487,13 @@ double fn5(double i, double j) {
 // CHECK-NEXT:           case 1:
 // CHECK-NEXT:             res += i * j;
 // CHECK-NEXT:             _t0 = res;
-// CHECK-NEXT:             clad::push(_t1, {{1U|1UL}});
+// CHECK-NEXT:             clad::push(_t1, {{1U|1UL|1ULL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t1)) {
-// CHECK-NEXT:           case {{1U|1UL}}:
+// CHECK-NEXT:           case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 res = _t0;
@@ -521,7 +521,7 @@ double fn6(double u, double v) {
 // CHECK-NEXT:     int _t0;
 // CHECK-NEXT:     int _cond0;
 // CHECK-NEXT:     double _t1;
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 // CHECK-NEXT:     int _d_res = 0;
 // CHECK-NEXT:     int res = 0;
 // CHECK-NEXT:     double _d_temp = 0;
@@ -536,13 +536,13 @@ double fn6(double u, double v) {
 // CHECK-NEXT:                 temp = 1;
 // CHECK-NEXT:                 _t1 = temp;
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t2, {{1U|1UL}});
+// CHECK-NEXT:             clad::push(_t2, {{1U|1UL|1ULL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
-// CHECK-NEXT:           case {{1U|1UL}}:
+// CHECK-NEXT:           case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
@@ -587,11 +587,11 @@ double fn7(double u, double v) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<int> _cond0 = {};
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:          if (!(i < 5))
@@ -613,7 +613,7 @@ double fn7(double u, double v) {
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_t2, {{1U|1UL}});
+// CHECK-NEXT:                     clad::push(_t2, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 {
@@ -625,10 +625,10 @@ double fn7(double u, double v) {
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_t2, {{2U|2UL}});
+// CHECK-NEXT:                     clad::push(_t2, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 clad::push(_t2, {{3U|3UL}});
+// CHECK-NEXT:                 clad::push(_t2, {{3U|3UL|3ULL}});
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
@@ -641,9 +641,9 @@ double fn7(double u, double v) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             switch (clad::pop(_t2)) {
-// CHECK-NEXT:               case {{3U|3UL}}:
+// CHECK-NEXT:               case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:                 ;
-// CHECK-NEXT:               case {{2U|2UL}}:
+// CHECK-NEXT:               case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                 ;
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     {
@@ -658,7 +658,7 @@ double fn7(double u, double v) {
 // CHECK-NEXT:                     if (3 == clad::back(_cond0))
 // CHECK-NEXT:                         break;
 // CHECK-NEXT:                 }
-// CHECK-NEXT:               case {{1U|1UL}}:
+// CHECK-NEXT:               case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                 ;
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     {

--- a/test/Gradient/SwitchInit.C
+++ b/test/Gradient/SwitchInit.C
@@ -21,7 +21,7 @@ double fn1(double i, double j) {
 // CHECK-NEXT:     int count = 0;
 // CHECK-NEXT:     int _cond0;
 // CHECK-NEXT:     double _t0;
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     double _t3;
 // CHECK-NEXT:     double _t4;
@@ -37,7 +37,7 @@ double fn1(double i, double j) {
 // CHECK-NEXT:                 _t0 = res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t1, {{1U|1UL}});
+// CHECK-NEXT:                 clad::push(_t1, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
@@ -57,13 +57,13 @@ double fn1(double i, double j) {
 // CHECK-NEXT:                 res += i * i * j * j;
 // CHECK-NEXT:                 _t4 = res;
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t1, {{2U|2UL}});
+// CHECK-NEXT:             clad::push(_t1, {{2U|2UL|2ULL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (clad::pop(_t1)) {
-// CHECK-NEXT:           case {{2U|2UL}}:
+// CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
@@ -99,7 +99,7 @@ double fn1(double i, double j) {
 // CHECK-NEXT:                 if (1 == _cond0)
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:             }
-// CHECK-NEXT:           case {{1U|1UL}}:
+// CHECK-NEXT:           case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -22,7 +22,7 @@ void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a);
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 1; ; i++) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < a))

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -287,7 +287,7 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     clad::tape<dcomplex> _t4 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:          if (!(i < 5))
@@ -372,7 +372,7 @@ int main() {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 5))
@@ -401,7 +401,7 @@ int main() {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 5))
@@ -457,7 +457,7 @@ int main() {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; ; ++i) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!(i < 5))

--- a/test/Hessian/Arrays.C
+++ b/test/Hessian/Arrays.C
@@ -9,16 +9,16 @@
 
 double f(double i, double j[2]) { return i * j[0] * j[1]; }
 // CHECK: void f_hessian(double i, double j[2], double *hessianMatrix) {
-// CHECK-NEXT:     f_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:     f_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL}}, hessianMatrix + {{4U|4UL}});
-// CHECK-NEXT:     f_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL}}, hessianMatrix + {{7U|7UL}});
+// CHECK-NEXT:     f_darg0_grad(i, j, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     f_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL|3ULL}}, hessianMatrix + {{4U|4UL|4ULL}});
+// CHECK-NEXT:     f_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL|6ULL}}, hessianMatrix + {{7U|7UL|7ULL}});
 // CHECK-NEXT: }
 
 double g(double i, double j[2]) { return i * (j[0] + j[1]); }
 // CHECK: void g_hessian(double i, double j[2], double *hessianMatrix) {
-// CHECK-NEXT:   g_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:   g_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL}}, hessianMatrix + {{4U|4UL}});
-// CHECK-NEXT:   g_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL}}, hessianMatrix + {{7U|7UL}});
+// CHECK-NEXT:   g_darg0_grad(i, j, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:   g_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL|3ULL}}, hessianMatrix + {{4U|4UL|4ULL}});
+// CHECK-NEXT:   g_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL|6ULL}}, hessianMatrix + {{7U|7UL|7ULL}});
 // CHECK-NEXT: }
 
 double h(double arr[3], double weights[3], double multiplier) {

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -18,7 +18,7 @@ float f1(float x) {
 // CHECK: void f1_darg0_grad(float x, float *_d_x);
 
 // CHECK: void f1_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f1_darg0_grad(x, hessianMatrix + {{0U|0UL}});
+// CHECK-NEXT:     f1_darg0_grad(x, hessianMatrix + {{0U|0UL|0ULL}});
 // CHECK-NEXT: }
 
 float f2(float x) {
@@ -30,7 +30,7 @@ float f2(float x) {
 // CHECK: void f2_darg0_grad(float x, float *_d_x);
 
 // CHECK: void f2_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f2_darg0_grad(x, hessianMatrix + {{0U|0UL}});
+// CHECK-NEXT:     f2_darg0_grad(x, hessianMatrix + {{0U|0UL|0ULL}});
 // CHECK-NEXT: }
 
 
@@ -43,7 +43,7 @@ float f3(float x) {
 // CHECK: void f3_darg0_grad(float x, float *_d_x);
 
 // CHECK: void f3_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f3_darg0_grad(x, hessianMatrix + {{0U|0UL}});
+// CHECK-NEXT:     f3_darg0_grad(x, hessianMatrix + {{0U|0UL|0ULL}});
 // CHECK-NEXT: }
 
 
@@ -56,7 +56,7 @@ float f4(float x) {
 // CHECK: void f4_darg0_grad(float x, float *_d_x);
 
 // CHECK: void f4_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f4_darg0_grad(x, hessianMatrix + {{0U|0UL}});
+// CHECK-NEXT:     f4_darg0_grad(x, hessianMatrix + {{0U|0UL|0ULL}});
 // CHECK-NEXT: }
 
 
@@ -69,7 +69,7 @@ float f5(float x) {
 // CHECK: void f5_darg0_grad(float x, float *_d_x);
 
 // CHECK: void f5_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f5_darg0_grad(x, hessianMatrix + {{0U|0UL}});
+// CHECK-NEXT:     f5_darg0_grad(x, hessianMatrix + {{0U|0UL|0ULL}});
 // CHECK-NEXT: }
 
 
@@ -86,8 +86,8 @@ float f6(float x, float y) {
 // CHECK: void f6_darg1_grad(float x, float y, float *_d_x, float *_d_y);
 
 // CHECK: void f6_hessian(float x, float y, float *hessianMatrix) {
-// CHECK-NEXT:     f6_darg0_grad(x, y, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:     f6_darg1_grad(x, y, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT:     f6_darg0_grad(x, y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     f6_darg1_grad(x, y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
 // CHECK-NEXT: }
 
 namespace clad {
@@ -132,8 +132,8 @@ float f7(float x, float y) {
 // CHECK-NEXT: }
 
 // CHECK: void f7_hessian(float x, float y, float *hessianMatrix) {
-// CHECK-NEXT:     f7_darg0_grad(x, y, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:     f7_darg1_grad(x, y, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT:     f7_darg0_grad(x, y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     f7_darg1_grad(x, y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
 // CHECK-NEXT: }
 
 float f8(float x, float y) {

--- a/test/Hessian/Functors.C
+++ b/test/Hessian/Functors.C
@@ -18,9 +18,9 @@ struct Experiment {
 
   // CHECK: void operator_call_hessian(double i, double j, double *hessianMatrix) {
   // CHECK-NEXT:     Experiment _d_this;
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
   // CHECK-NEXT:     Experiment _d_this0;
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
   // CHECK-NEXT: }
 };
 
@@ -36,9 +36,9 @@ struct ExperimentConst {
 
   // CHECK: void operator_call_hessian(double i, double j, double *hessianMatrix) const {
   // CHECK-NEXT:     ExperimentConst _d_this;
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
   // CHECK-NEXT:     ExperimentConst _d_this0;
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
   // CHECK-NEXT: }
 };
 
@@ -54,9 +54,9 @@ struct ExperimentVolatile {
 
   // CHECK: void operator_call_hessian(double i, double j, double *hessianMatrix) volatile {
   // CHECK-NEXT:     volatile ExperimentVolatile _d_this;
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
   // CHECK-NEXT:     volatile ExperimentVolatile _d_this0;
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
   // CHECK-NEXT: }
 };
 
@@ -72,9 +72,9 @@ struct ExperimentConstVolatile {
 
   // CHECK: void operator_call_hessian(double i, double j, double *hessianMatrix) const volatile {
   // CHECK-NEXT:     volatile ExperimentConstVolatile _d_this;
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
   // CHECK-NEXT:     volatile ExperimentConstVolatile _d_this0;
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
   // CHECK-NEXT: }
 };
 
@@ -92,9 +92,9 @@ namespace outer {
 
       // CHECK: void operator_call_hessian(double i, double j, double *hessianMatrix) {
       // CHECK-NEXT:     outer::inner::ExperimentNNS _d_this;
-      // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+      // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
       // CHECK-NEXT:     outer::inner::ExperimentNNS _d_this0;
-      // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+      // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
       // CHECK-NEXT: }
     };
 
@@ -103,8 +103,8 @@ namespace outer {
     };
 
     // CHECK: inline void operator_call_hessian(double i, double j, double *hessianMatrix) const {
-    // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-    // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+    // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+    // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
     // CHECK-NEXT: }
   }
 }
@@ -139,8 +139,8 @@ int main() {
   };
 
   // CHECK: inline void operator_call_hessian(double i, double j, double *hessianMatrix) const {
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->operator_call_darg0_grad(i, j, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+  // CHECK-NEXT:     this->operator_call_darg1_grad(i, j, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
   // CHECK-NEXT: }
 
   auto lambdaWithCapture = [&](double i, double jj) {
@@ -148,8 +148,8 @@ int main() {
   };
 
   // CHECK: inline void operator_call_hessian(double i, double jj, double *hessianMatrix) const {
-  // CHECK-NEXT:     this->operator_call_darg0_grad(i, jj, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-  // CHECK-NEXT:     this->operator_call_darg1_grad(i, jj, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->operator_call_darg0_grad(i, jj, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+  // CHECK-NEXT:     this->operator_call_darg1_grad(i, jj, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
   // CHECK-NEXT: }
 
   auto lambdaNNS = outer::inner::lambdaNNS;

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -20,8 +20,8 @@ void f_cubed_add1_darg1_grad(double a, double b, double *_d_a, double *_d_b);
 
 void f_cubed_add1_hessian(double a, double b, double *hessianMatrix);
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_hessian(double a, double b, double *hessianMatrix){{[ __attribute__((always_inline))]*}} {
-//CHECK-NEXT:    f_cubed_add1_darg0_grad(a, b, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:    f_cubed_add1_darg1_grad(a, b, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+//CHECK-NEXT:    f_cubed_add1_darg0_grad(a, b, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+//CHECK-NEXT:    f_cubed_add1_darg1_grad(a, b, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
 //CHECK-NEXT: }
 
 double f_suvat1(double u, double t) {
@@ -33,8 +33,8 @@ void f_suvat1_darg1_grad(double u, double t, double *_d_u, double *_d_t);
 
 void f_suvat1_hessian(double u, double t, double *hessianMatrix);
 //CHECK:void f_suvat1_hessian(double u, double t, double *hessianMatrix) {
-//CHECK-NEXT:    f_suvat1_darg0_grad(u, t, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:    f_suvat1_darg1_grad(u, t, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+//CHECK-NEXT:    f_suvat1_darg0_grad(u, t, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+//CHECK-NEXT:    f_suvat1_darg1_grad(u, t, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
 //CHECK-NEXT:}
 
 double f_cond3(double x, double c) {
@@ -51,8 +51,8 @@ void f_cond3_darg1_grad(double x, double c, double *_d_x, double *_d_c);
 
 void f_cond3_hessian(double x, double c, double *hessianMatrix);
 //CHECK:void f_cond3_hessian(double x, double c, double *hessianMatrix) {
-//CHECK-NEXT:    f_cond3_darg0_grad(x, c, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:    f_cond3_darg1_grad(x, c, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+//CHECK-NEXT:    f_cond3_darg0_grad(x, c, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+//CHECK-NEXT:    f_cond3_darg1_grad(x, c, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
 //CHECK-NEXT:}
 
 double f_power10(double x) {
@@ -63,7 +63,7 @@ void f_power10_darg0_grad(double x, double *_d_x);
 
 void f_power10_hessian(double x, double *hessianMatrix);
 //CHECK: void f_power10_hessian(double x, double *hessianMatrix) {
-//CHECK-NEXT:     f_power10_darg0_grad(x, hessianMatrix + {{0U|0UL}});
+//CHECK-NEXT:     f_power10_darg0_grad(x, hessianMatrix + {{0U|0UL|0ULL}});
 //CHECK-NEXT: }
 
 struct Experiment {
@@ -85,9 +85,9 @@ struct Experiment {
   void someMethod_hessian(double x, double *hessianMatrix);
   // CHECK: void someMethod_hessian(double i, double j, double *hessianMatrix) {
   // CHECK-NEXT:     Experiment _d_this;
-  // CHECK-NEXT:     this->someMethod_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->someMethod_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
   // CHECK-NEXT:     Experiment _d_this0;
-  // CHECK-NEXT:     this->someMethod_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->someMethod_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
   // CHECK-NEXT: }
 };
 
@@ -112,9 +112,9 @@ struct Widget {
                        double *hessianMatrix);
   // CHECK: void memFn_1_hessian(double i, double j, double *hessianMatrix) {
   // CHECK-NEXT:     Widget _d_this;
-  // CHECK-NEXT:     this->memFn_1_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->memFn_1_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
   // CHECK-NEXT:     Widget _d_this0;
-  // CHECK-NEXT:     this->memFn_1_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->memFn_1_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
   // CHECK-NEXT: }
 
   double memFn_2(double i, double j) {
@@ -137,9 +137,9 @@ struct Widget {
                        double *hessianMatrix);
   // CHECK: void memFn_2_hessian(double i, double j, double *hessianMatrix) {
   // CHECK-NEXT:     Widget _d_this;
-  // CHECK-NEXT:     this->memFn_2_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+  // CHECK-NEXT:     this->memFn_2_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
   // CHECK-NEXT:     Widget _d_this0;
-  // CHECK-NEXT:     this->memFn_2_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+  // CHECK-NEXT:     this->memFn_2_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
   // CHECK-NEXT: }
 };
 

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -23,8 +23,8 @@ double f2(double x, double y){
 // CHECK: void f2_darg1_grad(double x, double y, double *_d_x, double *_d_y);
 
 // CHECK: void f2_hessian(double x, double y, double *hessianMatrix) {
-// CHECK-NEXT:     f2_darg0_grad(x, y, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:     f2_darg1_grad(x, y, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT:     f2_darg0_grad(x, y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     f2_darg1_grad(x, y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndPushforward<double, double> f_pushforward(double x, double y, double _d_x, double _d_y);

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -16,8 +16,8 @@ double nonMemFn(double i, double j) {
 // CHECK: void nonMemFn_darg1_grad(double i, double j, double *_d_i, double *_d_j);
 
 // CHECK: void nonMemFn_hessian(double i, double j, double *hessianMatrix) {
-// CHECK-NEXT:     nonMemFn_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-// CHECK-NEXT:     nonMemFn_darg1_grad(i, j, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT:     nonMemFn_darg0_grad(i, j, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     nonMemFn_darg1_grad(i, j, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
 // CHECK-NEXT: }
 
 // CHECK: double nonMemFn_darg0(double i, double j) {

--- a/test/Hessian/TemplateFunctors.C
+++ b/test/Hessian/TemplateFunctors.C
@@ -15,9 +15,9 @@ template <typename T> struct Experiment {
 
 // CHECK: void operator_call_hessian(double i, double j, double *hessianMatrix) {
 // CHECK-NEXT:     Experiment<double> _d_this;
-// CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+// CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
 // CHECK-NEXT:     Experiment<double> _d_this0;
-// CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
 // CHECK-NEXT: }
 
 template <> struct Experiment<long double> {
@@ -31,9 +31,9 @@ template <> struct Experiment<long double> {
 
 // CHECK: void operator_call_hessian(long double i, long double j, long double *hessianMatrix) {
 // CHECK-NEXT:     Experiment<long double> _d_this;
-// CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
+// CHECK-NEXT:     this->operator_call_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
 // CHECK-NEXT:     Experiment<long double> _d_this0;
-// CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+// CHECK-NEXT:     this->operator_call_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
 // CHECK-NEXT: }
 
 #define INIT(E)                   \

--- a/test/Hessian/constexprTest.C
+++ b/test/Hessian/constexprTest.C
@@ -18,16 +18,16 @@ clad::array_ref<double>mat_ref_f1(mat_ref1, 9);
 constexpr double fn(double x, double y) { return x * y; }
 
 //CHECK: constexpr void fn_hessian(double x, double y, double *hessianMatrix) {
-//CHECK-NEXT:    fn_darg0_grad(x, y, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:    fn_darg1_grad(x, y, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+//CHECK-NEXT:    fn_darg0_grad(x, y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+//CHECK-NEXT:    fn_darg1_grad(x, y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
 //CHECK-NEXT:}
 
 constexpr double g(double i, double j[2]) { return i * (j[0] + j[1]); }
 
 //CHECK: constexpr void g_hessian(double i, double j[2], double *hessianMatrix) {
-//CHECK-NEXT:    g_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:    g_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL}}, hessianMatrix + {{4U|4UL}});
-//CHECK-NEXT:    g_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL}}, hessianMatrix + {{7U|7UL}});
+//CHECK-NEXT:    g_darg0_grad(i, j, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+//CHECK-NEXT:    g_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL|3ULL}}, hessianMatrix + {{4U|4UL|4ULL}});
+//CHECK-NEXT:    g_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL|6ULL}}, hessianMatrix + {{7U|7UL|7ULL}});
 //CHECK-NEXT:}
 
 int main() {

--- a/test/Hessian/testhessUtility.C
+++ b/test/Hessian/testhessUtility.C
@@ -18,16 +18,16 @@ clad::array_ref<double>mat_ref_f1(mat_ref1, 9);
 double fn(double x, double y) { return x * y; }
 
 //CHECK: void fn_hessian(double x, double y, double *hessianMatrix) {
-//CHECK-NEXT:    fn_darg0_grad(x, y, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:    fn_darg1_grad(x, y, hessianMatrix + {{2U|2UL}}, hessianMatrix + {{3U|3UL}});
+//CHECK-NEXT:    fn_darg0_grad(x, y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+//CHECK-NEXT:    fn_darg1_grad(x, y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
 //CHECK-NEXT:}
 
 double g(double i, double j[2]) { return i * (j[0] + j[1]); }
 
 //CHECK: void g_hessian(double i, double j[2], double *hessianMatrix) {
-//CHECK-NEXT:   g_darg0_grad(i, j, hessianMatrix + {{0U|0UL}}, hessianMatrix + {{1U|1UL}});
-//CHECK-NEXT:   g_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL}}, hessianMatrix + {{4U|4UL}});
-//CHECK-NEXT:   g_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL}}, hessianMatrix + {{7U|7UL}});
+//CHECK-NEXT:   g_darg0_grad(i, j, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+//CHECK-NEXT:   g_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL|3ULL}}, hessianMatrix + {{4U|4UL|4ULL}});
+//CHECK-NEXT:   g_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL|6ULL}}, hessianMatrix + {{7U|7UL|7ULL}});
 //CHECK-NEXT: }
 
 int main() {

--- a/test/Jacobian/FunctionCalls.C
+++ b/test/Jacobian/FunctionCalls.C
@@ -22,15 +22,15 @@ void fn1(double i, double j, double* output) {
 // CHECK-NEXT:         double _r2 = 0;
 // CHECK-NEXT:         double _r3 = 0;
 // CHECK-NEXT:         clad::custom_derivatives::pow_pullback(j, i, 1, &_r2, &_r3);
-// CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += _r2;
-// CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += _r3;
+// CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += _r2;
+// CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += _r3;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;
 // CHECK-NEXT:         clad::custom_derivatives::pow_pullback(i, j, 1, &_r0, &_r1);
-// CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += _r0;
-// CHECK-NEXT:         jacobianMatrix[{{1U|1UL}}] += _r1;
+// CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += _r0;
+// CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Jacobian/Functors.C
+++ b/test/Jacobian/Functors.C
@@ -21,14 +21,14 @@ struct Experiment {
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += this->y * 1 * j * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += this->y * i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += this->y * i * j * 1;
+  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
+  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * j * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += this->x * 1 * j * i;
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += this->x * i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL}}] += this->x * i * i * 1;
+  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
+  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * i * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -48,14 +48,14 @@ struct ExperimentConst {
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += this->y * 1 * j * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += this->y * i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += this->y * i * j * 1;
+  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
+  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * j * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += this->x * 1 * j * i;
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += this->x * i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL}}] += this->x * i * i * 1;
+  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
+  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * i * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -77,14 +77,14 @@ struct ExperimentVolatile {
   // CHECK-NEXT:     double _t1 = this->y * i;
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += this->y * 1 * j * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += _t1 * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += _t1 * j * 1;
+  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
+  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += _t1 * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += _t1 * j * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += this->x * 1 * j * i;
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += _t0 * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL}}] += _t0 * i * 1;
+  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
+  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += _t0 * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += _t0 * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -106,14 +106,14 @@ struct ExperimentConstVolatile {
   // CHECK-NEXT:     double _t1 = this->y * i;
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += this->y * 1 * j * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += _t1 * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += _t1 * j * 1;
+  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
+  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += _t1 * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += _t1 * j * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += this->x * 1 * j * i;
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += _t0 * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL}}] += _t0 * i * 1;
+  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
+  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += _t0 * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += _t0 * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 };
@@ -135,14 +135,14 @@ namespace outer {
       // CHECK-NEXT:     output[0] = this->x * i * i * j;
       // CHECK-NEXT:     output[1] = this->y * i * j * j;
       // CHECK-NEXT:     {
-      // CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += this->y * 1 * j * j;
-      // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += this->y * i * 1 * j;
-      // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += this->y * i * j * 1;
+      // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
+      // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * 1 * j;
+      // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * j * 1;
       // CHECK-NEXT:     }
       // CHECK-NEXT:     {
-      // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += this->x * 1 * j * i;
-      // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += this->x * i * 1 * j;
-      // CHECK-NEXT:         jacobianMatrix[{{1U|1UL}}] += this->x * i * i * 1;
+      // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
+      // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * i * 1 * j;
+      // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * i * i * 1;
       // CHECK-NEXT:     }
       // CHECK-NEXT: }
     };
@@ -156,14 +156,14 @@ namespace outer {
     // CHECK-NEXT:     output[0] = i * i * j;
     // CHECK-NEXT:     output[1] = i * j * j;
     // CHECK-NEXT:     {
-    // CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += 1 * j * j;
-    // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += i * 1 * j;
-    // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += i * j * 1;
+    // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += 1 * j * j;
+    // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += i * 1 * j;
+    // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += i * j * 1;
     // CHECK-NEXT:     }
     // CHECK-NEXT:     {
-    // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += 1 * j * i;
-    // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += i * 1 * j;
-    // CHECK-NEXT:         jacobianMatrix[{{1U|1UL}}] += i * i * 1;
+    // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * j * i;
+    // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += i * 1 * j;
+    // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += i * i * 1;
     // CHECK-NEXT:     }
     // CHECK-NEXT: }
   }
@@ -205,14 +205,14 @@ int main() {
   // CHECK-NEXT:     output[0] = i * i * j;
   // CHECK-NEXT:     output[1] = i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += 1 * j * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += i * j * 1;
+  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += 1 * j * j;
+  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += i * j * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += 1 * j * i;
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL}}] += i * i * 1;
+  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * j * i;
+  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += i * 1 * j;
+  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += i * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -225,14 +225,14 @@ int main() {
   // CHECK-NEXT:     output[0] = x * i * i * jj;
   // CHECK-NEXT:     output[1] = y * i * jj * jj;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += y * 1 * jj * jj;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += y * i * 1 * jj;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += y * i * jj * 1;
+  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += y * 1 * jj * jj;
+  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += y * i * 1 * jj;
+  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += y * i * jj * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += x * 1 * jj * i;
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += x * i * 1 * jj;
-  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL}}] += x * i * i * 1;
+  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += x * 1 * jj * i;
+  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += x * i * 1 * jj;
+  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += x * i * i * 1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -20,23 +20,23 @@ void f_1_jac(double a, double b, double c, double output[], double *_result);
 //CHECK-NEXT:  output[1] = a * a * a + b * b * b;
 //CHECK-NEXT:  output[2] = c * c * 10 - a * a;
 //CHECK-NEXT:  {
-//CHECK-NEXT:    jacobianMatrix[{{8U|8UL}}] += 1 * 10 * c;
-//CHECK-NEXT:    jacobianMatrix[{{8U|8UL}}] += c * 1 * 10;
-//CHECK-NEXT:    jacobianMatrix[{{6U|6UL}}] += -1 * a;
-//CHECK-NEXT:    jacobianMatrix[{{6U|6UL}}] += a * -1;
+//CHECK-NEXT:    jacobianMatrix[{{8U|8UL|8ULL}}] += 1 * 10 * c;
+//CHECK-NEXT:    jacobianMatrix[{{8U|8UL|8ULL}}] += c * 1 * 10;
+//CHECK-NEXT:    jacobianMatrix[{{6U|6UL|6ULL}}] += -1 * a;
+//CHECK-NEXT:    jacobianMatrix[{{6U|6UL|6ULL}}] += a * -1;
 //CHECK-NEXT:  }
 //CHECK-NEXT:  {
-//CHECK-NEXT:    jacobianMatrix[{{3U|3UL}}] += 1 * a * a;
-//CHECK-NEXT:    jacobianMatrix[{{3U|3UL}}] += a * 1 * a;
-//CHECK-NEXT:    jacobianMatrix[{{3U|3UL}}] += a * a * 1;
-//CHECK-NEXT:    jacobianMatrix[{{4U|4UL}}] += 1 * b * b;
-//CHECK-NEXT:    jacobianMatrix[{{4U|4UL}}] += b * 1 * b;
-//CHECK-NEXT:    jacobianMatrix[{{4U|4UL}}] += b * b * 1;
+//CHECK-NEXT:    jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * a * a;
+//CHECK-NEXT:    jacobianMatrix[{{3U|3UL|3ULL}}] += a * 1 * a;
+//CHECK-NEXT:    jacobianMatrix[{{3U|3UL|3ULL}}] += a * a * 1;
+//CHECK-NEXT:    jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * b * b;
+//CHECK-NEXT:    jacobianMatrix[{{4U|4UL|4ULL}}] += b * 1 * b;
+//CHECK-NEXT:    jacobianMatrix[{{4U|4UL|4ULL}}] += b * b * 1;
 //CHECK-NEXT:  }
 //CHECK-NEXT:  {
-//CHECK-NEXT:    jacobianMatrix[{{0U|0UL}}] += 1 * a * a;
-//CHECK-NEXT:    jacobianMatrix[{{0U|0UL}}] += a * 1 * a;
-//CHECK-NEXT:    jacobianMatrix[{{0U|0UL}}] += a * a * 1;
+//CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * a * a;
+//CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += a * 1 * a;
+//CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += a * a * 1;
 //CHECK-NEXT:  }
 //CHECK-NEXT:}
 
@@ -62,17 +62,17 @@ void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatr
 //CHECK-NEXT:  {
 //CHECK-NEXT:    double _r2 = 0;
 //CHECK-NEXT:    _r2 += 1 * constant * clad::custom_derivatives::sin_pushforward(z, 1.).pushforward;
-//CHECK-NEXT:    jacobianMatrix[{{8U|8UL}}] += _r2;
+//CHECK-NEXT:    jacobianMatrix[{{8U|8UL|8ULL}}] += _r2;
 //CHECK-NEXT:  }
 //CHECK-NEXT:  {
 //CHECK-NEXT:    double _r1 = 0;
 //CHECK-NEXT:    _r1 += 1 * constant * clad::custom_derivatives::sin_pushforward(y, 1.).pushforward;
-//CHECK-NEXT:    jacobianMatrix[{{4U|4UL}}] += _r1;
+//CHECK-NEXT:    jacobianMatrix[{{4U|4UL|4ULL}}] += _r1;
 //CHECK-NEXT:  }
 //CHECK-NEXT:  {
 //CHECK-NEXT:    double _r0 = 0;
 //CHECK-NEXT:    _r0 += 1 * constant * clad::custom_derivatives::sin_pushforward(x, 1.).pushforward;
-//CHECK-NEXT:    jacobianMatrix[{{0U|0UL}}] += _r0;
+//CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += _r0;
 //CHECK-NEXT:  }
 //CHECK-NEXT:}
 
@@ -101,22 +101,22 @@ void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatr
 //CHECK-NEXT:        double _r4 = 0;
 //CHECK-NEXT:        double _r5 = 0;
 //CHECK-NEXT:        multiply_pullback(z, x, 1 * constant, &_r4, &_r5);
-//CHECK-NEXT:        jacobianMatrix[{{8U|8UL}}] += _r4;
-//CHECK-NEXT:        jacobianMatrix[{{6U|6UL}}] += _r5;
+//CHECK-NEXT:        jacobianMatrix[{{8U|8UL|8ULL}}] += _r4;
+//CHECK-NEXT:        jacobianMatrix[{{6U|6UL|6ULL}}] += _r5;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _r2 = 0;
 //CHECK-NEXT:        double _r3 = 0;
 //CHECK-NEXT:        multiply_pullback(y, z, 1 * constant, &_r2, &_r3);
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL}}] += _r2;
-//CHECK-NEXT:        jacobianMatrix[{{5U|5UL}}] += _r3;
+//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += _r2;
+//CHECK-NEXT:        jacobianMatrix[{{5U|5UL|5ULL}}] += _r3;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _r0 = 0;
 //CHECK-NEXT:        double _r1 = 0;
 //CHECK-NEXT:        multiply_pullback(x, y, 1 * constant, &_r0, &_r1);
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += _r0;
-//CHECK-NEXT:        jacobianMatrix[{{1U|1UL}}] += _r1;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += _r0;
+//CHECK-NEXT:        jacobianMatrix[{{1U|1UL|1ULL}}] += _r1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
@@ -128,18 +128,18 @@ void f_1_jac_0(double a, double b, double c, double output[], double *jacobianMa
 // CHECK-NEXT:  output[1] = a * a * a + b * b * b;
 // CHECK-NEXT:  output[2] = c * c * 10 - a * a;
 // CHECK-NEXT:  {
-// CHECK-NEXT:    jacobianMatrix[{{2U|2UL}}] += -1 * a;
-// CHECK-NEXT:    jacobianMatrix[{{2U|2UL}}] += a * -1;
+// CHECK-NEXT:    jacobianMatrix[{{2U|2UL|2ULL}}] += -1 * a;
+// CHECK-NEXT:    jacobianMatrix[{{2U|2UL|2ULL}}] += a * -1;
 // CHECK-NEXT:  }
 // CHECK-NEXT:  {
-// CHECK-NEXT:    jacobianMatrix[{{1U|1UL}}] += 1 * a * a;
-// CHECK-NEXT:    jacobianMatrix[{{1U|1UL}}] += a * 1 * a;
-// CHECK-NEXT:    jacobianMatrix[{{1U|1UL}}] += a * a * 1;
+// CHECK-NEXT:    jacobianMatrix[{{1U|1UL|1ULL}}] += 1 * a * a;
+// CHECK-NEXT:    jacobianMatrix[{{1U|1UL|1ULL}}] += a * 1 * a;
+// CHECK-NEXT:    jacobianMatrix[{{1U|1UL|1ULL}}] += a * a * 1;
 // CHECK-NEXT:  }
 // CHECK-NEXT:  {
-// CHECK-NEXT:    jacobianMatrix[{{0U|0UL}}] += 1 * a * a;
-// CHECK-NEXT:    jacobianMatrix[{{0U|0UL}}] += a * 1 * a;
-// CHECK-NEXT:    jacobianMatrix[{{0U|0UL}}] += a * a * 1;
+// CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * a * a;
+// CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += a * 1 * a;
+// CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += a * a * 1;
 // CHECK-NEXT:  }
 // CHECK-NEXT:}
 
@@ -152,10 +152,10 @@ void f_5(float a, double output[]){
 //CHECK-NEXT:    output[1] = a;
 //CHECK-NEXT:    output[0] = a * a;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += 1 * a;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += a * 1;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * a;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += a * 1;
 //CHECK-NEXT:    }
-//CHECK-NEXT:    jacobianMatrix[{{1U|1UL}}] += 1;
+//CHECK-NEXT:    jacobianMatrix[{{1U|1UL|1ULL}}] += 1;
 //CHECK-NEXT:}
 
 #define TEST(F, x, y, z) { \

--- a/test/Jacobian/Pointers.C
+++ b/test/Jacobian/Pointers.C
@@ -14,8 +14,8 @@ void nonMemFn(double i, double j, double* out) {
 // CHECK: void nonMemFn_jac(double i, double j, double *out, double *jacobianMatrix) {
 // CHECK-NEXT:     out[0] = i;
 // CHECK-NEXT:     out[1] = j;
-// CHECK-NEXT:     jacobianMatrix[{{3U|3UL}}] += 1;
-// CHECK-NEXT:     jacobianMatrix[{{0U|0UL}}] += 1;
+// CHECK-NEXT:     jacobianMatrix[{{3U|3UL|3ULL}}] += 1;
+// CHECK-NEXT:     jacobianMatrix[{{0U|0UL|0ULL}}] += 1;
 // CHECK-NEXT: }
 
 

--- a/test/Jacobian/TemplateFunctors.C
+++ b/test/Jacobian/TemplateFunctors.C
@@ -20,12 +20,12 @@ template <typename T> struct Experiment {
 // CHECK-NEXT:     output[0] = this->x * this->y * i * j;
 // CHECK-NEXT:     output[1] = 2 * this->x * this->y * i * j;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += 2 * this->x * this->y * 1 * j;
-// CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += 2 * this->x * this->y * i * 1;
+// CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += 2 * this->x * this->y * 1 * j;
+// CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += 2 * this->x * this->y * i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += this->x * this->y * 1 * j;
-// CHECK-NEXT:         jacobianMatrix[{{1U|1UL}}] += this->x * this->y * i * 1;
+// CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * this->y * 1 * j;
+// CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * this->y * i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -43,14 +43,14 @@ template <> struct Experiment<long double> {
 // CHECK-NEXT:     output[0] = this->x * this->y * i * i * j;
 // CHECK-NEXT:     output[1] = 2 * this->x * this->y * i * i * j;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += 2 * this->x * this->y * 1 * j * i;
-// CHECK-NEXT:         jacobianMatrix[{{2U|2UL}}] += 2 * this->x * this->y * i * 1 * j;
-// CHECK-NEXT:         jacobianMatrix[{{3U|3UL}}] += 2 * this->x * this->y * i * i * 1;
+// CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += 2 * this->x * this->y * 1 * j * i;
+// CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += 2 * this->x * this->y * i * 1 * j;
+// CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += 2 * this->x * this->y * i * i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += this->x * this->y * 1 * j * i;
-// CHECK-NEXT:         jacobianMatrix[{{0U|0UL}}] += this->x * this->y * i * 1 * j;
-// CHECK-NEXT:         jacobianMatrix[{{1U|1UL}}] += this->x * this->y * i * i * 1;
+// CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * this->y * 1 * j * i;
+// CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * this->y * i * 1 * j;
+// CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * this->y * i * i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Jacobian/constexprTest.C
+++ b/test/Jacobian/constexprTest.C
@@ -24,16 +24,16 @@ constexpr void fn_mul(double i, double j, double *res) {
 //CHECK-NEXT:    res[1] = j * j;
 //CHECK-NEXT:    res[2] = i * j;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL}}] += 1 * j;
-//CHECK-NEXT:        jacobianMatrix[{{5U|5UL}}] += i * 1;
+//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * j;
+//CHECK-NEXT:        jacobianMatrix[{{5U|5UL|5ULL}}] += i * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL}}] += 1 * j;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL}}] += j * 1;
+//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * j;
+//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += j * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += 1 * i;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += i * 1;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * i;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += i * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
@@ -48,23 +48,23 @@ constexpr void f_1(double x, double y, double z, double output[]) {
 //CHECK-NEXT:    output[1] = x * y * x + y * x * x;
 //CHECK-NEXT:    output[2] = z * x * 10 - y * z;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{8U|8UL}}] += 1 * 10 * x;
-//CHECK-NEXT:        jacobianMatrix[{{6U|6UL}}] += z * 1 * 10;
-//CHECK-NEXT:        jacobianMatrix[{{7U|7UL}}] += -1 * z;
-//CHECK-NEXT:        jacobianMatrix[{{8U|8UL}}] += y * -1;
+//CHECK-NEXT:        jacobianMatrix[{{8U|8UL|8ULL}}] += 1 * 10 * x;
+//CHECK-NEXT:        jacobianMatrix[{{6U|6UL|6ULL}}] += z * 1 * 10;
+//CHECK-NEXT:        jacobianMatrix[{{7U|7UL|7ULL}}] += -1 * z;
+//CHECK-NEXT:        jacobianMatrix[{{8U|8UL|8ULL}}] += y * -1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL}}] += 1 * x * y;
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL}}] += x * 1 * x;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL}}] += x * y * 1;
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL}}] += 1 * x * x;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL}}] += y * 1 * x;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL}}] += y * x * 1;
+//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * x * y;
+//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += x * 1 * x;
+//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += x * y * 1;
+//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * x * x;
+//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += y * 1 * x;
+//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += y * x * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += 1 * x * x;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += x * 1 * x;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += x * x * 1;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * x * x;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += x * 1 * x;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += x * x * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 

--- a/test/Jacobian/testUtility.C
+++ b/test/Jacobian/testUtility.C
@@ -24,16 +24,16 @@ void fn_mul(double i, double j, double *res) {
 //CHECK-NEXT:    res[1] = j * j;
 //CHECK-NEXT:    res[2] = i * j;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL}}] += 1 * j;
-//CHECK-NEXT:        jacobianMatrix[{{5U|5UL}}] += i * 1;
+//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * j;
+//CHECK-NEXT:        jacobianMatrix[{{5U|5UL|5ULL}}] += i * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL}}] += 1 * j;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL}}] += j * 1;
+//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * j;
+//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += j * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += 1 * i;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += i * 1;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * i;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += i * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
@@ -49,23 +49,23 @@ void f_1(double x, double y, double z, double output[]) {
 //CHECK-NEXT:    output[1] = x * y * x + y * x * x;
 //CHECK-NEXT:    output[2] = z * x * 10 - y * z;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{8U|8UL}}] += 1 * 10 * x;
-//CHECK-NEXT:        jacobianMatrix[{{6U|6UL}}] += z * 1 * 10;
-//CHECK-NEXT:        jacobianMatrix[{{7U|7UL}}] += -1 * z;
-//CHECK-NEXT:        jacobianMatrix[{{8U|8UL}}] += y * -1;
+//CHECK-NEXT:        jacobianMatrix[{{8U|8UL|8ULL}}] += 1 * 10 * x;
+//CHECK-NEXT:        jacobianMatrix[{{6U|6UL|6ULL}}] += z * 1 * 10;
+//CHECK-NEXT:        jacobianMatrix[{{7U|7UL|7ULL}}] += -1 * z;
+//CHECK-NEXT:        jacobianMatrix[{{8U|8UL|8ULL}}] += y * -1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL}}] += 1 * x * y;
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL}}] += x * 1 * x;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL}}] += x * y * 1;
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL}}] += 1 * x * x;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL}}] += y * 1 * x;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL}}] += y * x * 1;
+//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * x * y;
+//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += x * 1 * x;
+//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += x * y * 1;
+//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * x * x;
+//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += y * 1 * x;
+//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += y * x * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += 1 * x * x;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += x * 1 * x;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL}}] += x * x * 1;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * x * x;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += x * 1 * x;
+//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += x * x * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -112,7 +112,7 @@
 //CHECK_FLOAT_SUM:    clad::tape<float> _t1 = {};
 //CHECK_FLOAT_SUM:    float _d_sum = 0;
 //CHECK_FLOAT_SUM:    float sum = 0.;
-//CHECK_FLOAT_SUM:    unsigned {{int|long}} _t0 = {{0U|0UL}};
+//CHECK_FLOAT_SUM:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK_FLOAT_SUM:    for (i = 0; ; i++) {
 //CHECK_FLOAT_SUM:        {
 //CHECK_FLOAT_SUM:            if (!(i < n))
@@ -281,8 +281,8 @@
 //-----------------------------------------------------------------------------/
 // RUN: %cladclang %S/../../demos/VectorForwardMode.cpp -I%S/../../include -oVectorForwardMode.out 2>&1 | FileCheck -check-prefix CHECK_VECTOR_FORWARD_MODE %s
 // CHECK_VECTOR_FORWARD_MODE: void weighted_sum_dvec_0_1(double *arr, double *weights, int n, clad::array_ref<double> _d_arr, clad::array_ref<double> _d_weights) {
-// CHECK_VECTOR_FORWARD_MODE-NEXT    unsigned {{int|long}} indepVarCount = _d_arr.size() + _d_weights.size();
-// CHECK_VECTOR_FORWARD_MODE-NEXT    clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL}});
+// CHECK_VECTOR_FORWARD_MODE-NEXT    unsigned {{int|long|long long}} indepVarCount = _d_arr.size() + _d_weights.size();
+// CHECK_VECTOR_FORWARD_MODE-NEXT    clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL|0ULL}});
 // CHECK_VECTOR_FORWARD_MODE-NEXT    clad::matrix<double> _d_vector_weights = clad::identity_matrix(_d_weights.size(), indepVarCount, _d_arr.size());
 // CHECK_VECTOR_FORWARD_MODE-NEXT    clad::array<int> _d_vector_n = clad::zero_vector(indepVarCount);
 // CHECK_VECTOR_FORWARD_MODE-NEXT    clad::array<double> _d_vector_res(clad::array<double>(indepVarCount, 0));
@@ -296,7 +296,7 @@
 // CHECK_VECTOR_FORWARD_MODE-NEXT    }
 // CHECK_VECTOR_FORWARD_MODE-NEXT    {
 // CHECK_VECTOR_FORWARD_MODE-NEXT        clad::array<double> _d_vector_return(clad::array<double>(indepVarCount, _d_vector_res));
-// CHECK_VECTOR_FORWARD_MODE-NEXT        _d_arr = _d_vector_return.slice({{0U|0UL}}, _d_arr.size());
+// CHECK_VECTOR_FORWARD_MODE-NEXT        _d_arr = _d_vector_return.slice({{0U|0UL|0ULL}}, _d_arr.size());
 // CHECK_VECTOR_FORWARD_MODE-NEXT        _d_weights = _d_vector_return.slice(_d_arr.size(), _d_weights.size());
 // CHECK_VECTOR_FORWARD_MODE-NEXT        return;
 // CHECK_VECTOR_FORWARD_MODE-NEXT    }


### PR DESCRIPTION
Update FileCheck test lines for number literals and types generated on windows that were checking for `int` or `long` before to `long long` since `long` on 64 bit windows is only 32 bit so size types have to be long long.
This fixes about 20 tests failing on windows with clang-cl.