### PR TITLE
 Add primitive support of reverse-mode constructor custom derivatives

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -54,6 +54,8 @@ template <typename T, typename U> struct ValueAndAdjoint {
 /// class for which constructor pushforward is defined.
 template <class T> class ConstructorPushforwardTag {};
 
+template <class T> class ConstructorReverseForwTag {};
+
 namespace custom_derivatives {
 #ifdef __CUDACC__
 template <typename T>
@@ -329,6 +331,16 @@ using std::pow_pullback;
 using std::pow_pushforward;
 using std::sin_pushforward;
 using std::sqrt_pushforward;
+
+namespace class_functions {
+template <typename T, typename U>
+void constructor_pullback(ValueAndPushforward<T, U>* lhs,
+                          ValueAndPushforward<T, U> rhs,
+                          ValueAndPushforward<T, U>* d_lhs,
+                          ValueAndPushforward<T, U>* d_rhs) {
+  d_rhs->pushforward += d_lhs->pushforward;
+}
+} // namespace class_functions
 } // namespace custom_derivatives
 } // namespace clad
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -103,11 +103,6 @@ namespace clad {
         const clang::FunctionDecl* FD, llvm::ArrayRef<clang::Expr*> primalArgs,
         llvm::ArrayRef<clang::Expr*> derivedArgs, clang::Expr* baseExpr);
 
-    // clang::Expr* BuildCallToCustomForwPassConstructor(
-    //     const clang::CXXConstructExpr* CE,
-    //     llvm::ArrayRef<clang::Expr*> clonedArgs,
-    //     llvm::ArrayRef<clang::Expr*> derivedArgs);
-
   public:
     using direction = rmv::direction;
     clang::Expr* dfdx() {

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -231,6 +231,28 @@ void operator_subscript_pullback(::std::vector<T>* vec,
   (*d_vec)[idx] += d_y;
 }
 
+template <typename T, typename S, typename U>
+::clad::ValueAndAdjoint<::std::vector<T>, ::std::vector<T>>
+constructor_reverse_forw(::clad::ConstructorReverseForwTag<::std::vector<T>>,
+                         S count, U val,
+                         typename ::std::vector<T>::allocator_type alloc,
+                         S d_count, U d_val,
+                         typename ::std::vector<T>::allocator_type d_alloc) {
+  ::std::vector<T> v(count, val);
+  ::std::vector<T> d_v(count, 0);
+  return {v, d_v};
+}
+
+template <typename T, typename S, typename U>
+void constructor_pullback(::std::vector<T>* v, S count, U val,
+                          typename ::std::vector<T>::allocator_type alloc,
+                          ::std::vector<T>* d_v, S* d_count, U* d_val,
+                          typename ::std::vector<T>::allocator_type* d_alloc) {
+  for (unsigned i = 0; i < count; ++i)
+    *d_val += (*d_v)[i];
+  d_v->clear();
+}
+
 } // namespace class_functions
 } // namespace custom_derivatives
 } // namespace clad

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -614,6 +614,12 @@ namespace clad {
     /// Returns type clad::Identify<T>
     clang::QualType GetCladConstructorPushforwardTagOfType(clang::QualType T);
 
+    /// Returns clad::ConstructorReverseForwTag template declaration.
+    clang::TemplateDecl* GetCladConstructorReverseForwTag();
+
+    /// Returns type clad::ConstructorReverseForwTag<T>
+    clang::QualType GetCladConstructorReverseForwTagOfType(clang::QualType T);
+
   public:
     /// Rebuild a sequence of nested namespaces ending with DC.
     clang::NamespaceDecl* RebuildEnclosingNamespaces(clang::DeclContext* DC);
@@ -661,6 +667,7 @@ namespace clad {
 
   private:
     clang::TemplateDecl* m_CladConstructorPushforwardTag = nullptr;
+    clang::TemplateDecl* m_CladConstructorReverseForwTag = nullptr;
   };
 } // end namespace clad
 

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -247,7 +247,6 @@ static void registerDerivative(FunctionDecl* derivedFD, Sema& semaRef) {
       const std::string& Name, llvm::SmallVectorImpl<Expr*>& CallArgs,
       clang::Scope* S, clang::DeclContext* originalFnDC,
       bool forCustomDerv /*=true*/, bool namespaceShouldExist /*=true*/) {
-
     CXXScopeSpec SS;
     LookupResult R = LookupCustomDerivativeOrNumericalDiff(
         Name, originalFnDC, SS, forCustomDerv, namespaceShouldExist);

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -449,8 +449,8 @@ namespace clad {
   QualType VisitorBase::InstantiateTemplate(TemplateDecl* CladClassDecl,
                                             TemplateArgumentListInfo& TLI) {
     // This will instantiate tape<T> type and return it.
-    QualType TT =
-        m_Sema.CheckTemplateIdType(TemplateName(CladClassDecl), utils::GetValidSLoc(m_Sema), TLI);
+    QualType TT = m_Sema.CheckTemplateIdType(TemplateName(CladClassDecl),
+                                             utils::GetValidSLoc(m_Sema), TLI);
     // Get clad namespace and its identifier clad::.
     CXXScopeSpec CSS;
     CSS.Extend(m_Context, GetCladNamespace(), utils::GetValidSLoc(m_Sema),

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -450,10 +450,11 @@ namespace clad {
                                             TemplateArgumentListInfo& TLI) {
     // This will instantiate tape<T> type and return it.
     QualType TT =
-        m_Sema.CheckTemplateIdType(TemplateName(CladClassDecl), noLoc, TLI);
+        m_Sema.CheckTemplateIdType(TemplateName(CladClassDecl), utils::GetValidSLoc(m_Sema), TLI);
     // Get clad namespace and its identifier clad::.
     CXXScopeSpec CSS;
-    CSS.Extend(m_Context, GetCladNamespace(), noLoc, noLoc);
+    CSS.Extend(m_Context, GetCladNamespace(), utils::GetValidSLoc(m_Sema),
+               utils::GetValidSLoc(m_Sema));
     NestedNameSpecifier* NS = CSS.getScopeRep();
 
     // Create elaborated type with namespace specifier,
@@ -852,5 +853,17 @@ namespace clad {
   clang::QualType
   VisitorBase::GetCladConstructorPushforwardTagOfType(clang::QualType T) {
     return InstantiateTemplate(GetCladConstructorPushforwardTag(), {T});
+  }
+
+  clang::TemplateDecl* VisitorBase::GetCladConstructorReverseForwTag() {
+    if (!m_CladConstructorPushforwardTag)
+      m_CladConstructorReverseForwTag =
+          LookupTemplateDeclInCladNamespace("ConstructorReverseForwTag");
+    return m_CladConstructorReverseForwTag;
+  }
+
+  clang::QualType
+  VisitorBase::GetCladConstructorReverseForwTagOfType(clang::QualType T) {
+    return InstantiateTemplate(GetCladConstructorReverseForwTag(), {T});
   }
 } // end namespace clad

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -227,11 +227,15 @@ int main() {
   // CHECK-NEXT:     Experiment E(3, 5);
   // CHECK-NEXT:     Experiment _t0 = E;
   // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r2 = 0;
+  // CHECK-NEXT:         double _r3 = 0;
+  // CHECK-NEXT:         _t0.operator_call_pullback(i, j, 1, &_d_E, &_r2, &_r3);
+  // CHECK-NEXT:         *_d_i += _r2;
+  // CHECK-NEXT:         *_d_j += _r3;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0;
   // CHECK-NEXT:         double _r1 = 0;
-  // CHECK-NEXT:         _t0.operator_call_pullback(i, j, 1, &_d_E, &_r0, &_r1);
-  // CHECK-NEXT:         *_d_i += _r0;
-  // CHECK-NEXT:         *_d_j += _r1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -265,12 +269,16 @@ int main() {
   // CHECK-NEXT:     Experiment _d_E({});
   // CHECK-NEXT:     Experiment E(3, 5);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         Experiment _r0 = {};
+  // CHECK-NEXT:         Experiment _r2 = {};
+  // CHECK-NEXT:         double _r3 = 0;
+  // CHECK-NEXT:         double _r4 = 0;
+  // CHECK-NEXT:         FunctorAsArg_pullback(E, i, j, 1, &_r2, &_r3, &_r4);
+  // CHECK-NEXT:         *_d_i += _r3;
+  // CHECK-NEXT:         *_d_j += _r4;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 0;
   // CHECK-NEXT:         double _r1 = 0;
-  // CHECK-NEXT:         double _r2 = 0;
-  // CHECK-NEXT:         FunctorAsArg_pullback(E, i, j, 1, &_r0, &_r1, &_r2);
-  // CHECK-NEXT:         *_d_i += _r1;
-  // CHECK-NEXT:         *_d_j += _r2;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -574,11 +574,17 @@ int main() {
 // CHECK-NEXT:     SimpleFunctions sf(x, y);
 // CHECK-NEXT:     SimpleFunctions _t0 = sf;
 // CHECK-NEXT:     {
+// CHECK-NEXT:         double _r2 = 0;
+// CHECK-NEXT:         double _r3 = 0;
+// CHECK-NEXT:         _t0.mem_fn_pullback(i, j, 1, &_d_sf, &_r2, &_r3);
+// CHECK-NEXT:         *_d_i += _r2;
+// CHECK-NEXT:         *_d_j += _r3;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         double _r1 = 0;
-// CHECK-NEXT:         _t0.mem_fn_pullback(i, j, 1, &_d_sf, &_r0, &_r1);
-// CHECK-NEXT:         *_d_i += _r0;
-// CHECK-NEXT:         *_d_j += _r1;
+// CHECK-NEXT:         _d_x += _r0;
+// CHECK-NEXT:         _d_y += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -130,13 +130,17 @@ int main() {
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
     // CHECK-NEXT:     SimpleFunctions1 _t0 = obj;
     // CHECK-NEXT:     {
-    // CHECK-NEXT:         double _r0 = 0;
-    // CHECK-NEXT:         double _r1 = 0;
-    // CHECK-NEXT:         _t0.mem_fn_1_pullback(i, j, 1, &_d_obj, &_r0, &_r1);
-    // CHECK-NEXT:         *_d_i += _r0;
-    // CHECK-NEXT:         *_d_j += _r1;
+    // CHECK-NEXT:         double _r2 = 0;
+    // CHECK-NEXT:         double _r3 = 0;
+    // CHECK-NEXT:         _t0.mem_fn_1_pullback(i, j, 1, &_d_obj, &_r2, &_r3);
+    // CHECK-NEXT:         *_d_i += _r2;
+    // CHECK-NEXT:         *_d_j += _r3;
     // CHECK-NEXT:         *_d_i += 1 * j;
     // CHECK-NEXT:         *_d_j += i * 1;
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:     {
+    // CHECK-NEXT:         double _r0 = 0;
+    // CHECK-NEXT:         double _r1 = 0;
     // CHECK-NEXT:     }
     // CHECK-NEXT: }
     
@@ -148,6 +152,10 @@ int main() {
     // CHECK-NEXT:         *_d_i += 1 * j;
     // CHECK-NEXT:         *_d_j += i * 1;
     // CHECK-NEXT:     }
+    // CHECK-NEXT:     {
+    // CHECK-NEXT:         double _r0 = 0;
+    // CHECK-NEXT:         double _r1 = 0;
+    // CHECK-NEXT:     }
     // CHECK-NEXT: }
     
     // CHECK: void fn_s1_field_pointer_grad(double i, double j, double *_d_i, double *_d_j) {
@@ -157,6 +165,10 @@ int main() {
     // CHECK-NEXT:         *_d_obj.x_pointer += 1 * *obj.y_pointer;
     // CHECK-NEXT:         *_d_i += 1 * j;
     // CHECK-NEXT:         *_d_j += i * 1;
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:     {
+    // CHECK-NEXT:         double _r0 = 0;
+    // CHECK-NEXT:         double _r1 = 0;
     // CHECK-NEXT:     }
     // CHECK-NEXT: }
 

--- a/test/Gradient/PointersWithTBR.C
+++ b/test/Gradient/PointersWithTBR.C
@@ -36,5 +36,5 @@ int main() {
     double arr[5] = {1, 2, 3, 4, 5};
     double d_arr[5] = {0, 0, 0, 0, 0};
     d_pointerParam.execute(arr, 5, d_arr);
-    printf("%.2f %.2f %.2f %.2f %.2f\n", d_arr[0], d_arr[1], d_arr[2], d_arr[3], d_arr[4]); // CHECK-EXEC: 0.00 1.00 2.00 3.00 4.00
+    printf("%.2f %.2f %.2f %.2f %.2f\n", d_arr[0], d_arr[1], d_arr[2], d_arr[3], d_arr[4]); // CHECK-EXEC: 0.00 2.00 6.00 12.00 20.00
 }

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -95,15 +95,25 @@ double fn12(double u, double v) {
   return res;
 }
 
+double fn13(double u, double v) {
+  double res = u;
+  std::vector<double>::allocator_type allocator;
+  typename ::std::vector<double>::size_type count = 3;
+  std::vector<double> vec(count, u, allocator);
+  return vec[0] + vec[1] + vec[2];
+}
+
 int main() {
     double d_i, d_j;
     INIT_GRADIENT(fn10);
     INIT_GRADIENT(fn11);
     INIT_GRADIENT(fn12);
+    INIT_GRADIENT(fn13);
 
     TEST_GRADIENT(fn10, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {1.00, 1.00}
     TEST_GRADIENT(fn11, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {2.00, 1.00}
     TEST_GRADIENT(fn12, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {4.00, 2.00}
+    TEST_GRADIENT(fn13, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {3.00, 0.00}
 }
 
 // CHECK: void fn10_grad(double u, double v, double *_d_u, double *_d_v) {
@@ -342,4 +352,36 @@ int main() {
 // CHECK-NEXT:         {{.*}} _r0 = 0;
 // CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&_t0, 3, &_d_vec, &_r0);
 // CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK-NEXT: void fn13_grad(double u, double v, double *_d_u, double *_d_v) {
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     double res = u;
+// CHECK-NEXT:     {{.*}}allocator_type _d_allocator({});
+// CHECK-NEXT:     {{.*}}allocator_type allocator;
+// CHECK-NEXT:     {{.*}} _d_count = 0;
+// CHECK-NEXT:     {{.*}} count = 3;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<{{.*}}vector<{{.*}}>, {{.*}}vector<{{.*}}> > _t0 = {{.*}}class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<vector<{{.*}}> >(), count, u, allocator, 0, 0, {});
+// CHECK-NEXT:     std::vector<double> _d_vec(_t0.adjoint);
+// CHECK-NEXT:     std::vector<double> vec(_t0.value);
+// CHECK-NEXT:     std::vector<double> _t1 = vec;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, _r1);
+// CHECK-NEXT:     std::vector<double> _t3 = vec;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, _r2);
+// CHECK-NEXT:     std::vector<double> _t5 = vec;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, _r3);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {{.*}} _r1 = 0;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t1, 0, 1, &_d_vec, &_r1);
+// CHECK-NEXT:         {{.*}} _r2 = 0;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t3, 1, 1, &_d_vec, &_r2);
+// CHECK-NEXT:         {{.*}} _r3 = 0;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t5, 2, 1, &_d_vec, &_r3);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {{.*}} _r0 = 0;
+// CHECK-NEXT:         {{.*}}class_functions::constructor_pullback(&vec, count, u, allocator, &_d_vec, &_r0, &*_d_u, &_d_allocator);
+// CHECK-NEXT:         _d_count += _r0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_u += _d_res;
 // CHECK-NEXT: }

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -361,27 +361,23 @@ int main() {
 // CHECK-NEXT:     {{.*}}allocator_type allocator;
 // CHECK-NEXT:     {{.*}} _d_count = 0;
 // CHECK-NEXT:     {{.*}} count = 3;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<{{.*}}vector<{{.*}}>, {{.*}}vector<{{.*}}> > _t0 = {{.*}}class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<vector<{{.*}}> >(), count, u, allocator, 0, 0, {});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<{{.*}}vector<{{.*}}>, {{.*}}vector<{{.*}}> > _t0 = {{.*}}class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<vector<{{.*}}> >(), count, u, allocator, _d_count, *_d_u, _d_allocator);
 // CHECK-NEXT:     std::vector<double> _d_vec(_t0.adjoint);
 // CHECK-NEXT:     std::vector<double> vec(_t0.value);
 // CHECK-NEXT:     std::vector<double> _t1 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, _r1);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, _r0);
 // CHECK-NEXT:     std::vector<double> _t3 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, _r2);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, _r1);
 // CHECK-NEXT:     std::vector<double> _t5 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, _r3);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, _r2);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}} _r1 = 0;
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t1, 0, 1, &_d_vec, &_r1);
-// CHECK-NEXT:         {{.*}} _r2 = 0;
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t3, 1, 1, &_d_vec, &_r2);
-// CHECK-NEXT:         {{.*}} _r3 = 0;
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t5, 2, 1, &_d_vec, &_r3);
+// CHECK-NEXT:             {{.*}} _r0 = 0;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t1, 0, 1, &_d_vec, &_r0);
+// CHECK-NEXT:             {{.*}} _r1 = 0;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t3, 1, 1, &_d_vec, &_r1);
+// CHECK-NEXT:             {{.*}} _r2 = 0;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t5, 2, 1, &_d_vec, &_r2);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {{.*}}constructor_pullback(&vec, count, u, allocator, &_d_vec, &_d_count, &*_d_u, &_d_allocator);
+// CHECK-NEXT:        *_d_u += _d_res;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}} _r0 = 0;
-// CHECK-NEXT:         {{.*}}class_functions::constructor_pullback(&vec, count, u, allocator, &_d_vec, &_r0, &*_d_u, &_d_allocator);
-// CHECK-NEXT:         _d_count += _r0;
-// CHECK-NEXT:     }
-// CHECK-NEXT:     *_d_u += _d_res;
-// CHECK-NEXT: }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -145,6 +145,15 @@ double fn4(double i, double j) {
 // CHECK-NEXT:         _d_q.second += 1 * j;
 // CHECK-NEXT:         *_d_j += q.second * 1;
 // CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {{.*}} _r2 = {};
+// CHECK-NEXT:         int _r3 = 0;
+// CHECK-NEXT:         int _r4 = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r0 = 0;
+// CHECK-NEXT:         int _r1 = 0;
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: void someMemFn_grad(double i, double j, Tangent *_d_this, double *_d_i, double *_d_j) {

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -197,18 +197,22 @@ int main() {
 // CHECK-NEXT:         _d__t1.pushforward += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         float _r2 = 0;
-// CHECK-NEXT:         float _r3 = 0;
-// CHECK-NEXT:         cos_pushforward_pullback(x, _d_x0, _d__t1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r2;
-// CHECK-NEXT:         _d__d_x += _r3;
+// CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r3 = {};
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(&_t10, {{.*}}cos_pushforward(x, _d_x0), &_d__t1, &_r3);
+// CHECK-NEXT:         float _r4 = 0;
+// CHECK-NEXT:         float _r5 = 0;
+// CHECK-NEXT:         cos_pushforward_pullback(x, _d_x0, _r3, &_r4, &_r5);
+// CHECK-NEXT:         *_d_x += _r4;
+// CHECK-NEXT:         _d__d_x += _r5;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         float _r0 = 0;
+// CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r0 = {};
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(&_t00, {{.*}}sin_pushforward(x, _d_x0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0;
-// CHECK-NEXT:         sin_pushforward_pullback(x, _d_x0, _d__t0, &_r0, &_r1);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         _d__d_x += _r1;
+// CHECK-NEXT:         float _r2 = 0;
+// CHECK-NEXT:         sin_pushforward_pullback(x, _d_x0, _r0, &_r1, &_r2);
+// CHECK-NEXT:         *_d_x += _r1;
+// CHECK-NEXT:         _d__d_x += _r2;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -227,11 +231,13 @@ int main() {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, _d_x0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         float _r0 = 0;
+// CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r0 = {};
+// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}exp_pushforward(x, _d_x0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0;
-// CHECK-NEXT:         exp_pushforward_pullback(x, _d_x0, _d__t0, &_r0, &_r1);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         _d__d_x += _r1;
+// CHECK-NEXT:         float _r2 = 0;
+// CHECK-NEXT:         exp_pushforward_pullback(x, _d_x0, _r0, &_r1, &_r2);
+// CHECK-NEXT:         *_d_x += _r1;
+// CHECK-NEXT:         _d__d_x += _r2;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -250,11 +256,13 @@ int main() {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::log_pushforward(x, _d_x0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         float _r0 = 0;
+// CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r0 = {};
+// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}log_pushforward(x, _d_x0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0;
-// CHECK-NEXT:         log_pushforward_pullback(x, _d_x0, _d__t0, &_r0, &_r1);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         _d__d_x += _r1;
+// CHECK-NEXT:         float _r2 = 0;
+// CHECK-NEXT:         log_pushforward_pullback(x, _d_x0, _r0, &_r1, &_r2);
+// CHECK-NEXT:         *_d_x += _r1;
+// CHECK-NEXT:         _d__d_x += _r2;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -273,13 +281,15 @@ int main() {
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 4.F, _d_x0, 0.F);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         float _r0 = 0;
+// CHECK-NEXT:         {{.*}} _r0 = {};
+// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}pow_pushforward(x, 4.F, _d_x0, 0.F), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0;
 // CHECK-NEXT:         float _r2 = 0;
 // CHECK-NEXT:         float _r3 = 0;
-// CHECK-NEXT:         pow_pushforward_pullback(x, 4.F, _d_x0, 0.F, _d__t0, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         _d__d_x += _r2;
+// CHECK-NEXT:         float _r4 = 0;
+// CHECK-NEXT:         pow_pushforward_pullback(x, 4.F, _d_x0, 0.F, _r0, &_r1, &_r2, &_r3, &_r4);
+// CHECK-NEXT:         *_d_x += _r1;
+// CHECK-NEXT:         _d__d_x += _r3;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -296,13 +306,15 @@ int main() {
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(2.F, x, 0.F, _d_x0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         float _r0 = 0;
+// CHECK-NEXT:         {{.*}} _r0 = {};
+// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}pow_pushforward(2.F, x, 0.F, _d_x0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0;
 // CHECK-NEXT:         float _r2 = 0;
 // CHECK-NEXT:         float _r3 = 0;
-// CHECK-NEXT:         pow_pushforward_pullback(2.F, x, 0.F, _d_x0, _d__t0, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r1;
-// CHECK-NEXT:         _d__d_x += _r3;
+// CHECK-NEXT:         float _r4 = 0;
+// CHECK-NEXT:         {{.*}}pow_pushforward_pullback(2.F, x, 0.F, _d_x0, _r0, &_r1, &_r2, &_r3, &_r4);
+// CHECK-NEXT:         *_d_x += _r2;
+// CHECK-NEXT:         _d__d_x += _r4;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -322,15 +334,17 @@ int main() {
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         float _r0 = 0;
+// CHECK-NEXT:         {{.*}} _r0 = {};
+// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}pow_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0;
 // CHECK-NEXT:         float _r2 = 0;
 // CHECK-NEXT:         float _r3 = 0;
-// CHECK-NEXT:         pow_pushforward_pullback(x, y, _d_x0, _d_y0, _d__t0, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         *_d_y += _r1;
-// CHECK-NEXT:         _d__d_x += _r2;
-// CHECK-NEXT:         _d__d_y += _r3;
+// CHECK-NEXT:         float _r4 = 0;
+// CHECK-NEXT:         {{.*}}pow_pushforward_pullback(x, y, _d_x0, _d_y0, _r0, &_r1, &_r2, &_r3, &_r4);
+// CHECK-NEXT:         *_d_x += _r1;
+// CHECK-NEXT:         *_d_y += _r2;
+// CHECK-NEXT:         _d__d_x += _r3;
+// CHECK-NEXT:         _d__d_y += _r4;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -350,15 +364,17 @@ int main() {
 // CHECK-NEXT:     ValueAndPushforward<decltype(::std::pow(float(), float())), decltype(::std::pow(float(), float()))> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         float _r0 = 0;
+// CHECK-NEXT:         {{.*}} _r0 = {};
+// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}pow_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0;
 // CHECK-NEXT:         float _r2 = 0;
 // CHECK-NEXT:         float _r3 = 0;
-// CHECK-NEXT:         pow_pushforward_pullback(x, y, _d_x0, _d_y0, _d__t0, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         *_d_y += _r1;
-// CHECK-NEXT:         _d__d_x += _r2;
-// CHECK-NEXT:         _d__d_y += _r3;
+// CHECK-NEXT:         float _r4 = 0;
+// CHECK-NEXT:         {{.*}}pow_pushforward_pullback(x, y, _d_x0, _d_y0, _r0, &_r1, &_r2, &_r3, &_r4);
+// CHECK-NEXT:         *_d_x += _r1;
+// CHECK-NEXT:         *_d_y += _r2;
+// CHECK-NEXT:         _d__d_x += _r3;
+// CHECK-NEXT:         _d__d_y += _r4;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -55,15 +55,17 @@ double f2(double x, double y){
 // CHECK-NEXT:     _d__t0.value += _d_ans0;
 // CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 0;
+// CHECK-NEXT:         {{.*}}ValueAndPushforward<double, double> _r0 = {};
+// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, f_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
 // CHECK-NEXT:         double _r1 = 0;
 // CHECK-NEXT:         double _r2 = 0;
 // CHECK-NEXT:         double _r3 = 0;
-// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y0, _d__t0, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         *_d_y += _r1;
-// CHECK-NEXT:         _d__d_x += _r2;
-// CHECK-NEXT:         _d__d_y += _r3;
+// CHECK-NEXT:         double _r4 = 0;
+// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y0, _r0, &_r1, &_r2, &_r3, &_r4);
+// CHECK-NEXT:         *_d_x += _r1;
+// CHECK-NEXT:         *_d_y += _r2;
+// CHECK-NEXT:         _d__d_x += _r3;
+// CHECK-NEXT:         _d__d_y += _r4;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -91,15 +93,17 @@ double f2(double x, double y){
 // CHECK-NEXT:     _d__t0.value += _d_ans0;
 // CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 0;
+// CHECK-NEXT:         {{.*}}ValueAndPushforward<double, double> _r0 = {};
+// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, f_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
 // CHECK-NEXT:         double _r1 = 0;
 // CHECK-NEXT:         double _r2 = 0;
 // CHECK-NEXT:         double _r3 = 0;
-// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y0, _d__t0, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         *_d_y += _r1;
-// CHECK-NEXT:         _d__d_x += _r2;
-// CHECK-NEXT:         _d__d_y += _r3;
+// CHECK-NEXT:         double _r4 = 0;
+// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y0, _r0, &_r1, &_r2, &_r3, &_r4);
+// CHECK-NEXT:         *_d_x += _r1;
+// CHECK-NEXT:         *_d_y += _r2;
+// CHECK-NEXT:         _d__d_x += _r3;
+// CHECK-NEXT:         _d__d_y += _r4;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/unittests/Misc/CMakeLists.txt
+++ b/unittests/Misc/CMakeLists.txt
@@ -7,6 +7,6 @@ add_clad_unittest(MiscTests
 
 # Create a library from the Defs.cpp file
 ADD_CLAD_LIBRARY(Defs Defs.cpp)
-
 # Link the library to the test
 target_link_libraries(MiscTests PRIVATE Defs)
+set_property(TARGET MiscTests PROPERTY CXX_STANDARD 11)


### PR DESCRIPTION
This commit adds primitive support of reverse-mode custom derivatives
for constructors.

Constructors can thought of like a special function. A function which also
constructs an object. Therefore, differentiation of a constructor is
very similar to the differentiation of a function call. Please note that
this includes innocent looking initialization such as:

```
SomeClass C1 = C2;
```

This would involve differentiation of copy-constructor of `SomeClass`.

Let's see a concrete example of how differentiation of a constructor call
looks like:

Original code:

```cpp
SomeClass c(u, v, w);
```

Derivative code:

```cpp
// forward-pass
clad::ValueAndAdjoint<SomeClass, SomeClass> _t0 =
  constructor_reverse_forw(clad::ConstructorReverseForwTag<SomeClass>,
    u, v, w, _d_u, _d_v, _d_w);
SomeClass _d_c(_t0.adjoint);
SomeClass c(_t0.value);

// reverse-pass
{
  double _r0 = 0;
  double _r1 = 0;
  double _r2 = 0;
  constructor_pullback(&c, u, v, w, &_d_c, &_r0, &_r1, &_r2);
  _d_u += _r0;
  _d_v += _r1;
  _d_w += _r2;
}
```

Please note the use of `clad::ConstructorReverseForwTag<T>` for
`constructor_reverse_forw` function. The reasoning and motivation for
this is the same as we have for `clad::ConstructorPushforwardTag<T>`

Reverse-mode custom derivatives for constructor can be
specified as:

```cpp
namespace clad {
namespace custom_derivatives {
namespace class_functions {
clad::ValueAndAdjoint<SomeClass, SomeClass>
constructor_reverse_forw(clad::ConstructorReverseForwTag<SomeClass>,
  ...) {
  // ...
  // ...
}

void constructor_pullback(SomeClass *c, ..., SomeClass *d_c, ...) {
  // ...
}
```