### PR TITLE
Support pointer-valued functions in the reverse mode

### DIFF
--- a/include/clad/Differentiator/ReverseModeForwPassVisitor.h
+++ b/include/clad/Differentiator/ReverseModeForwPassVisitor.h
@@ -18,8 +18,6 @@ private:
   ComputeParamTypes(const DiffParams& diffParams);
   clang::QualType ComputeReturnType();
   llvm::SmallVector<clang::ParmVarDecl*, 8> BuildParams(DiffParams& diffParams);
-  clang::QualType GetParameterDerivativeType(clang::QualType yType,
-                                             clang::QualType xType);
 
 public:
   ReverseModeForwPassVisitor(DerivativeBuilder& builder,

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -204,7 +204,7 @@ void fill_pushforward(::std::array<T, N>* a, const T& u,
 
 template <typename T, typename U>
 void push_back_reverse_forw(::std::vector<T>* v, U val, ::std::vector<T>* d_v,
-                            U* d_val) {
+                            U d_val) {
   v->push_back(val);
   d_v->push_back(0);
 }
@@ -219,7 +219,7 @@ void push_back_pullback(::std::vector<T>* v, U val, ::std::vector<T>* d_v,
 template <typename T>
 clad::ValueAndAdjoint<T&, T&> operator_subscript_reverse_forw(
     ::std::vector<T>* vec, typename ::std::vector<T>::size_type idx,
-    ::std::vector<T>* d_vec, typename ::std::vector<T>::size_type* d_idx) {
+    ::std::vector<T>* d_vec, typename ::std::vector<T>::size_type d_idx) {
   return {(*vec)[idx], (*d_vec)[idx]};
 }
 

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -228,8 +228,8 @@ double& identity(double& i) {
 
 namespace clad{
 namespace custom_derivatives{
-  clad::ValueAndAdjoint<double &, double &> custom_identity_reverse_forw(double &i, double *d_i) {
-    return {i, *d_i};
+  clad::ValueAndAdjoint<double &, double &> custom_identity_reverse_forw(double &i, double &d_i) {
+    return {i, d_i};
   }
 } // namespace custom_derivatives
 } // namespace clad
@@ -256,21 +256,21 @@ double fn7(double i, double j) {
 
 // CHECK: void identity_pullback(double &i, double _d_y, double *_d_i);
 
-// CHECK: clad::ValueAndAdjoint<double &, double &> identity_forw(double &i, double *_d_i);
+// CHECK: clad::ValueAndAdjoint<double &, double &> identity_forw(double &i, double &_d_i);
 
 // CHECK: void custom_identity_pullback(double &i, double _d_y, double *_d_i);
 
 // CHECK: void fn7_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _t0 = i;
-// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = identity_forw(i, &*_d_i);
+// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = identity_forw(i, *_d_i);
 // CHECK-NEXT:     double &_d_k = _t1.adjoint;
 // CHECK-NEXT:     double &k = _t1.value;
 // CHECK-NEXT:     double _t2 = j;
-// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t3 = identity_forw(j, &*_d_j);
+// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t3 = identity_forw(j, *_d_j);
 // CHECK-NEXT:     double &_d_l = _t3.adjoint;
 // CHECK-NEXT:     double &l = _t3.value;
 // CHECK-NEXT:     double _t4 = i;
-// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t5 = {{.*}}custom_derivatives::custom_identity_reverse_forw(i, &*_d_i);
+// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t5 = {{.*}}custom_derivatives::custom_identity_reverse_forw(i, *_d_i);
 // CHECK-NEXT:     double &_d_temp = _t5.adjoint;
 // CHECK-NEXT:     double &temp = _t5.value;
 // CHECK-NEXT:     double _t6 = k;
@@ -923,13 +923,13 @@ double sq_defined_later(double x) {
 // CHECK-NEXT:     *_d_i += _d__d_i;
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndAdjoint<double &, double &> identity_forw(double &i, double *_d_i) {
+// CHECK: clad::ValueAndAdjoint<double &, double &> identity_forw(double &i, double &_d_i) {
 // CHECK-NEXT:     MyStruct::myFunction();
 // CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _d_i0 = i;
 // CHECK-NEXT:     double _t0 = _d_i0;
 // CHECK-NEXT:     _d_i0 += 1;
-// CHECK-NEXT:     return {i, *_d_i};
+// CHECK-NEXT:     return {i, _d_i};
 // CHECK-NEXT: }
 
 // CHECK: void custom_identity_pullback(double &i, double _d_y, double *_d_i) {

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -432,11 +432,11 @@ double fn2(SimpleFunctions& sf, double i) {
 
 // CHECK: void ref_mem_fn_pullback(double i, double _d_y, SimpleFunctions *_d_this, double *_d_i);
 
-// CHECK: clad::ValueAndAdjoint<double &, double &> ref_mem_fn_forw(double i, SimpleFunctions *_d_this, double *_d_i);
+// CHECK: clad::ValueAndAdjoint<double &, double &> ref_mem_fn_forw(double i, SimpleFunctions *_d_this, double _d_i);
 
 // CHECK: void fn2_grad(SimpleFunctions &sf, double i, SimpleFunctions *_d_sf, double *_d_i) {
 // CHECK-NEXT:     SimpleFunctions _t0 = sf;
-// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = _t0.ref_mem_fn_forw(i, &(*_d_sf), nullptr);
+// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = _t0.ref_mem_fn_forw(i, &(*_d_sf), *_d_i);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
 // CHECK-NEXT:         _t0.ref_mem_fn_pullback(i, 1, &(*_d_sf), &_r0);
@@ -456,11 +456,11 @@ double fn5(SimpleFunctions& v, double value) {
 
 // CHECK: void operator_plus_equal_pullback(double value, SimpleFunctions _d_y, SimpleFunctions *_d_this, double *_d_value);
 
-// CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_equal_forw(double value, SimpleFunctions *_d_this, SimpleFunctions *_d_value);
+// CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_equal_forw(double value, SimpleFunctions *_d_this, double _d_value);
 
 // CHECK: void fn5_grad(SimpleFunctions &v, double value, SimpleFunctions *_d_v, double *_d_value) {
 // CHECK-NEXT:     SimpleFunctions _t0 = v;
-// CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = _t0.operator_plus_equal_forw(value, &(*_d_v), nullptr);
+// CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = _t0.operator_plus_equal_forw(value, &(*_d_v), *_d_value);
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0;
@@ -602,7 +602,7 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndAdjoint<double &, double &> ref_mem_fn_forw(double i, SimpleFunctions *_d_this, double *_d_i) {
+// CHECK: clad::ValueAndAdjoint<double &, double &> ref_mem_fn_forw(double i, SimpleFunctions *_d_this, double _d_i) {
 // CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x = +i;
 // CHECK-NEXT:     double _t1 = this->x;
@@ -620,7 +620,7 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_equal_forw(double value, SimpleFunctions *_d_this, SimpleFunctions *_d_value) {
+// CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_equal_forw(double value, SimpleFunctions *_d_this, double _d_value) {
 // CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x += value;
 // CHECK-NEXT:     return {*this, (*_d_this)};

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -37,7 +37,7 @@ namespace clad {
             void resize_reverse_forw(::std::vector<T> *v,
                         typename ::std::vector<T>::size_type sz,
                         ::std::vector<T> *d_v,
-                        typename ::std::vector<T>::size_type *d_sz) {
+                        typename ::std::vector<T>::size_type d_sz) {
               size_update_stack.push_back(v->size());
               v->resize(sz);
               d_v->resize(sz, 0);
@@ -111,14 +111,14 @@ int main() {
 // CHECK-NEXT:     std::vector<double> vec;
 // CHECK-NEXT:     double _t0 = u;
 // CHECK-NEXT:     std::vector<double> _t1 = vec;
-// CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, &*_d_u);
+// CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
 // CHECK-NEXT:     double _t2 = v;
 // CHECK-NEXT:     std::vector<double> _t3 = vec;
-// CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, v, &_d_vec, &*_d_v);
+// CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, v, &_d_vec, *_d_v);
 // CHECK-NEXT:     std::vector<double> _t4 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, &_r0);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, _r0);
 // CHECK-NEXT:     std::vector<double> _t6 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t7 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, &_r1);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t7 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, _r1);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = 0;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t4, 0, 1, &_d_vec, &_r0);
@@ -140,20 +140,20 @@ int main() {
 // CHECK-NEXT:     std::vector<double> vec;
 // CHECK-NEXT:     double _t0 = u;
 // CHECK-NEXT:     std::vector<double> _t1 = vec;
-// CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, &*_d_u);
+// CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
 // CHECK-NEXT:     double _t2 = v;
 // CHECK-NEXT:     std::vector<double> _t3 = vec;
-// CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, v, &_d_vec, &*_d_v);
+// CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, v, &_d_vec, *_d_v);
 // CHECK-NEXT:     std::vector<double> _t4 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, &_r0);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, _r0);
 // CHECK-NEXT:     double &_d_ref = _t5.adjoint;
 // CHECK-NEXT:     double &ref = _t5.value;
 // CHECK-NEXT:     double _t6 = ref;
 // CHECK-NEXT:     ref += u;
 // CHECK-NEXT:     std::vector<double> _t7 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t8 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, &_r1);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t8 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, _r1);
 // CHECK-NEXT:     std::vector<double> _t9 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t10 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, &_r2);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t10 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, _r2);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r1 = 0;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t7, 0, 1, &_d_vec, &_r1);
@@ -205,18 +205,18 @@ int main() {
 // CHECK-NEXT:     std::vector<double> _d_vec({});
 // CHECK-NEXT:     std::vector<double> vec;
 // CHECK-NEXT:     std::vector<double> _t0 = vec;
-// CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 3, &_d_vec, &_r0);
+// CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 3, &_d_vec, _r0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t1 = vec;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, &_r1);
+// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, _r1);
 // CHECK-NEXT:         _d_ref0 = &_t2.adjoint;
 // CHECK-NEXT:         ref0 = &_t2.value;
 // CHECK-NEXT:         _t3 = vec;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, &_r2);
+// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, _r2);
 // CHECK-NEXT:         _d_ref1 = &_t4.adjoint;
 // CHECK-NEXT:         ref1 = &_t4.value;
 // CHECK-NEXT:         _t5 = vec;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, &_r3);
+// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, _r3);
 // CHECK-NEXT:         _d_ref2 = &_t6.adjoint;
 // CHECK-NEXT:         ref2 = &_t6.value;
 // CHECK-NEXT:         _t7 = *ref0;
@@ -228,23 +228,23 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     double _t10 = res;
 // CHECK-NEXT:     std::vector<double> _t11 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t12 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, &_r4);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t12 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, _r4);
 // CHECK-NEXT:     std::vector<double> _t13 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t14 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, &_r5);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t14 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, _r5);
 // CHECK-NEXT:     std::vector<double> _t15 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t16 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, &_r6);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t16 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, _r6);
 // CHECK-NEXT:     res = _t12.value + _t14.value + _t16.value;
 // CHECK-NEXT:     std::vector<double> _t17 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::clear_reverse_forw(&vec, &_d_vec);
 // CHECK-NEXT:     std::vector<double> _t18 = vec;
-// CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 2, &_d_vec, &_r7);
+// CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 2, &_d_vec, _r7);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t19 = vec;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t20 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, &_r8);
+// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t20 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, _r8);
 // CHECK-NEXT:         _d_ref00 = &_t20.adjoint;
 // CHECK-NEXT:         ref00 = &_t20.value;
 // CHECK-NEXT:         _t21 = vec;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t22 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, &_r9);
+// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t22 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, _r9);
 // CHECK-NEXT:         _d_ref10 = &_t22.adjoint;
 // CHECK-NEXT:         ref10 = &_t22.value;
 // CHECK-NEXT:         _t23 = *ref00;
@@ -254,9 +254,9 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     double _t25 = res;
 // CHECK-NEXT:     std::vector<double> _t26 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t27 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, &_r10);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t27 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, _r10);
 // CHECK-NEXT:     std::vector<double> _t28 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t29 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, &_r11);
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t29 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, _r11);
 // CHECK-NEXT:     res += _t27.value + _t29.value;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {


### PR DESCRIPTION
This PR enables support of pointer-valued functions in the reverse mode by creating ``_forw`` functions for them (as we already do with reference-type functions).

Note: the first commit simplifies how we pass adjoints to ``_forw`` functions. The types used to be converted from ref-types to the corresponding pointer types. There's no need to change the type because the function represents the forward pass. Moreover, non-ref types (like pointer types in this PR) were not handed properly.