### PR TITLE
Add support for `Kokkos::fence` in the fwd mode

### DIFF
--- a/include/clad/Differentiator/KokkosBuiltins.h
+++ b/include/clad/Differentiator/KokkosBuiltins.h
@@ -67,6 +67,11 @@ inline void resize_pushforward(const I& arg, View& v, const size_t n0,
   ::Kokkos::resize(arg, d_v, n0, n1, n2, n3, n4, n5, n6, n7);
 }
 
+/// Fence
+template <typename S> void fence_pushforward(const S& s, const S& /*d_s*/) {
+  ::Kokkos::fence(s);
+}
+
 /// Parallel for
 template <class... PolicyParams, class FunctorType> // range policy
 void parallel_for_pushforward(


### PR DESCRIPTION
Although this function doesn't need to be differentiated and is correctly used by Clad automatically, this custom pushforward prevents Clad from throwing a warning during that.

P.S. this PR has been developed on top of #1022 and should be merged after that. I just don't want to slow down the review of #1022 any longer by adding new commits to it.