### PR TITLE
Fix collectDataFromPredecessors to collect data from the passed branch

### DIFF
--- a/lib/Differentiator/TBRAnalyzer.cpp
+++ b/lib/Differentiator/TBRAnalyzer.cpp
@@ -484,7 +484,7 @@ TBRAnalyzer::collectDataFromPredecessors(VarsData* varsData,
   std::unordered_map<const clang::VarDecl*, VarData*> result;
   if (varsData != limit) {
     // Copy data from every predecessor.
-    for (auto* pred = varsData->m_Prev; pred != limit; pred = pred->m_Prev) {
+    for (auto* pred = varsData; pred != limit; pred = pred->m_Prev) {
       // If a variable from 'pred' is not present in 'result', place it there.
       for (auto& pair : *pred)
         if (result.find(pair.first) == result.end())

--- a/test/Analyses/TBR.cpp
+++ b/test/Analyses/TBR.cpp
@@ -11,6 +11,16 @@ double f1(double x) {
   return t;
 } // == x^3
 
+double f2(double val) {
+  double res = 0;
+  for (int i=1; i<5; ++i) {
+    if (i == 3)
+      continue;
+    res += i * val;
+  }
+  return res;
+}
+
 #define TEST(F, x) { \
   result[0] = 0; \
   auto F##grad = clad::gradient<clad::opts::enable_tbr>(F);\
@@ -21,5 +31,5 @@ double f1(double x) {
 int main() {
   double result[3] = {};
   TEST(f1, 3); // CHECK-EXEC: {27.00}
-
+  TEST(f2, 3); // CHECK-EXEC: {9.00}
 }


### PR DESCRIPTION
Before the fix, we didn't collect data from varsData at all, and it wasn't merged afterward either. Now, we start collecting data from varsData, ensuring the final data of the CFG block is correct.

For example it used to fail in cases like below, when the LCA is a predecessor of the mergeData in the merge function `TBRAnalyzer::merge(VarsData* targetData, VarsData* mergeData)`.

```cpp
double fn(double x){
  double res = 0;
  double g = 0;
  if(g){
    res+=g*x;
  }
  return res;
}
```
Before this PR the `collectedMergeData` was empty and after it contains data about {res, g, x}, as expected.

Fixes:#855