### PR TITLE
Enable computation of CUDA global kernels derivative in reverse mode

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -171,12 +171,13 @@ inline CUDA_HOST_DEVICE unsigned int GetLength(const char* code) {
     CladFunctionType m_Function;
     char* m_Code;
     FunctorType *m_Functor = nullptr;
+    bool m_CUDAkernel = false;
 
   public:
-    CUDA_HOST_DEVICE CladFunction(CladFunctionType f,
-                                  const char* code,
-                                  FunctorType* functor = nullptr)
-        : m_Functor(functor) {
+    CUDA_HOST_DEVICE CladFunction(CladFunctionType f, const char* code,
+                                  FunctorType* functor = nullptr,
+                                  bool CUDAkernel = false)
+        : m_Functor(functor), m_CUDAkernel(CUDAkernel) {
       assert(f && "Must pass a non-0 argument.");
       if (size_t length = GetLength(code)) {
         m_Function = f;
@@ -397,10 +398,10 @@ inline CUDA_HOST_DEVICE unsigned int GetLength(const char* code) {
       annotate("G"))) CUDA_HOST_DEVICE
   gradient(F f, ArgSpec args = "",
            DerivedFnType derivedFn = static_cast<DerivedFnType>(nullptr),
-           const char* code = "") {
-      assert(f && "Must pass in a non-0 argument");
-      return CladFunction<DerivedFnType, ExtractFunctorTraits_t<F>, true>(
-          derivedFn /* will be replaced by gradient*/, code);
+           const char* code = "", bool CUDAkernel = false) {
+    assert(f && "Must pass in a non-0 argument");
+    return CladFunction<DerivedFnType, ExtractFunctorTraits_t<F>, true>(
+        derivedFn /* will be replaced by gradient*/, code, nullptr, CUDAkernel);
   }
 
   /// Specialization for differentiating functors.

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -177,9 +177,6 @@ namespace clad {
   void DiffRequest::updateCall(FunctionDecl* FD, FunctionDecl* OverloadedFD,
                                Sema& SemaRef) {
     CallExpr* call = this->CallContext;
-    // Index of "code" parameter:
-    auto codeArgIdx = static_cast<int>(call->getNumArgs()) - 1;
-    auto derivedFnArgIdx = codeArgIdx - 1;
 
     assert(call && "Must be set");
     assert(FD && "Trying to update with null FunctionDecl");
@@ -191,6 +188,19 @@ namespace clad {
     ASTContext& C = SemaRef.getASTContext();
 
     FunctionDecl* replacementFD = OverloadedFD ? OverloadedFD : FD;
+
+    // Index of "CUDAkernel" parameter:
+    int numArgs = static_cast<int>(call->getNumArgs());
+    if (numArgs > 4) {
+      auto kernelArgIdx = numArgs - 1;
+      auto cudaKernelFlag = new (C) CXXBoolLiteralExpr(
+          replacementFD->hasAttr<CUDAGlobalAttr>(), C.BoolTy, noLoc);
+      call->setArg(kernelArgIdx, cudaKernelFlag);
+      numArgs--;
+    }
+    auto codeArgIdx = numArgs - 1;
+    auto derivedFnArgIdx = numArgs - 2;
+
     // Create ref to generated FD.
     DeclRefExpr* DRE =
         DeclRefExpr::Create(C, oldDRE->getQualifierLoc(), noLoc, replacementFD,

--- a/test/CUDA/GradientKernels.cu
+++ b/test/CUDA/GradientKernels.cu
@@ -1,0 +1,58 @@
+// RUN: %cladclang_cuda -I%S/../../include  %s -fsyntax-only \
+// RUN: %cudasmlevel --cuda-path=%cudapath  -Xclang -verify 2>&1 | %filecheck %s
+
+// RUN: %cladclang_cuda -I%S/../../include %s -xc++ %cudasmlevel \
+// RUN: --cuda-path=%cudapath -L/usr/local/cuda/lib64 -lcudart_static \
+// RUN: -L%cudapath/lib64/stubs \
+// RUN: -ldl -lrt -pthread -lm -lstdc++ -lcuda -lnvrtc
+
+// REQUIRES: cuda-runtime
+
+// expected-no-diagnostics
+
+// XFAIL: clang-15
+
+#include "clad/Differentiator/Differentiator.h"
+
+__global__ void kernel(int *a) {
+  *a *= *a;
+}
+
+// CHECK:    void kernel_grad(int *a, int *_d_a) {
+//CHECK-NEXT:    int _t0 = *a;
+//CHECK-NEXT:    *a *= *a;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        *a = _t0;
+//CHECK-NEXT:        int _r_d0 = *_d_a;
+//CHECK-NEXT:        *_d_a = 0;
+//CHECK-NEXT:        *_d_a += _r_d0 * *a;
+//CHECK-NEXT:       *_d_a += *a * _r_d0;
+//CHECK-NEXT:    }
+//CHECK-NEXT: }
+
+int main(void) {
+  int *a = (int*)malloc(sizeof(int));
+  *a = 2;
+  int *d_a;
+  cudaMalloc(&d_a, sizeof(int));
+  cudaMemcpy(d_a, a, sizeof(int), cudaMemcpyHostToDevice);
+
+  int *asquare = (int*)malloc(sizeof(int));
+  *asquare = 1;
+  int *d_square;
+  cudaMalloc(&d_square, sizeof(int));
+  cudaMemcpy(d_square, asquare, sizeof(int), cudaMemcpyHostToDevice);
+
+  auto test = clad::gradient(kernel);
+  dim3 grid(1);
+  dim3 block(1);
+  test.execute_kernel(grid, block, 0, nullptr, d_a, d_square);
+
+  cudaDeviceSynchronize();
+
+  cudaMemcpy(asquare, d_square, sizeof(int), cudaMemcpyDeviceToHost);
+  cudaMemcpy(a, d_a, sizeof(int), cudaMemcpyDeviceToHost);
+  printf("a = %d, a^2 = %d\n", *a, *asquare);
+
+  return 0;
+}

--- a/unittests/Misc/CallDeclOnly.cpp
+++ b/unittests/Misc/CallDeclOnly.cpp
@@ -59,10 +59,10 @@ double sq(double x) { return x * x; }
 double wrapper2(double* params) { return sq(params[0]); }
 
 TEST(CallDeclOnly, CheckCustomDiff) {
-  auto grad = clad::hessian(wrapper2, "params[0]");
+  auto hess = clad::hessian(wrapper2, "params[0]");
   double x = 4.0;
   double dx = 0.0;
-  grad.execute(&x, &dx);
+  hess.execute(&x, &dx);
   EXPECT_DOUBLE_EQ(dx, 2.0);
 }
 


### PR DESCRIPTION
This PR closes #1036. The CUDA kernels can now be an arg to a clad::gradient function and the derived kernels can be executed successfully. 

Details on issues faced and the final approach can be found here: https://github.com/vgvassilev/clad/issues/1036#issuecomment-2308891416.

[Old PR's](#1041)  approach involved the use of CUDA API libs to compile and load the computed kernel on the GPU.