### PR TITLE
Store and restore outputaArray elements for jacobians

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2518,8 +2518,6 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
       // For x, ResultRef is _d_x, for x[i] its _d_x[i], for reference exprs
       // like (x = y) it propagates recursively, so _d_x is also returned.
       ResultRef = Ldiff.getExpr_dx();
-      if (!ResultRef)
-        return Clone(BinOp);
       // If assigned expr is dependent, first update its derivative;
       if (dfdx() && !Lblock.empty()) {
         addToCurrentBlock(*Lblock.begin(), direction::reverse);
@@ -2534,6 +2532,8 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
         addToCurrentBlock(pushPop.getStmt_dx(), direction::reverse);
       }
 
+      if (!ResultRef)
+        return Clone(BinOp);
       // We need to store values of derivative pointer variables in forward pass
       // and restore them in reverse pass.
       if (isPointerOp) {

--- a/test/Jacobian/FunctionCalls.C
+++ b/test/Jacobian/FunctionCalls.C
@@ -14,21 +14,29 @@ void fn1(double i, double j, double* output) {
 }
 
 // CHECK: void fn1_jac(double i, double j, double *output, double *jacobianMatrix) {
+// CHECK-NEXT:     double _t0 = output[0];
 // CHECK-NEXT:     output[0] = std::pow(i, j);
+// CHECK-NEXT:     double _t1 = output[1];
 // CHECK-NEXT:     output[1] = std::pow(j, i);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r2 = 0.;
-// CHECK-NEXT:         double _r3 = 0.;
-// CHECK-NEXT:         clad::custom_derivatives::pow_pullback(j, i, 1, &_r2, &_r3);
-// CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += _r2;
-// CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += _r3;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             double _r2 = 0.;
+// CHECK-NEXT:             double _r3 = 0.;
+// CHECK-NEXT:             clad::custom_derivatives::pow_pullback(j, i, 1, &_r2, &_r3);
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += _r2;
+// CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += _r3;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[1] = _t1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         double _r1 = 0.;
-// CHECK-NEXT:         clad::custom_derivatives::pow_pullback(i, j, 1, &_r0, &_r1);
-// CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += _r0;
-// CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += _r1;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             double _r0 = 0.;
+// CHECK-NEXT:             double _r1 = 0.;
+// CHECK-NEXT:             clad::custom_derivatives::pow_pullback(i, j, 1, &_r0, &_r1);
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += _r0;
+// CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += _r1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[0] = _t0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -59,3 +67,4 @@ int main() {
   
   test<2>(DERIVED_FN(fn1), 3, 5); // CHECK-EXEC: {405.00, 266.96, 201.18, 75.00}
 }
+

--- a/test/Jacobian/Functors.C
+++ b/test/Jacobian/Functors.C
@@ -17,19 +17,28 @@ struct Experiment {
   }
 
   // CHECK: void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) {
+  // CHECK-NEXT:     double _t0 = output[0];
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
+  // CHECK-NEXT:     double _t1 = output[1];
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * j * 1;
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * j * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[1] = _t1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * i * i * 1;
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * i * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * i * i * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[0] = _t0;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
+
 };
 
 struct ExperimentConst {
@@ -44,19 +53,28 @@ struct ExperimentConst {
   }
 
   // CHECK: void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) const {
+  // CHECK-NEXT:     double _t0 = output[0];
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
+  // CHECK-NEXT:     double _t1 = output[1];
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * j * 1;
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * j * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[1] = _t1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * i * i * 1;
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * i * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * i * i * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[0] = _t0;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
+
 };
 
 struct ExperimentVolatile {
@@ -72,20 +90,29 @@ struct ExperimentVolatile {
 
   // CHECK: void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) volatile {
   // CHECK-NEXT:     double _t0 = this->x * i;
+  // CHECK-NEXT:     double _t1 = output[0];
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
-  // CHECK-NEXT:     double _t1 = this->y * i;
+  // CHECK-NEXT:     double _t2 = this->y * i;
+  // CHECK-NEXT:     double _t3 = output[1];
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += _t1 * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += _t1 * j * 1;
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += _t2 * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += _t2 * j * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[1] = _t3;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += _t0 * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += _t0 * i * 1;
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += _t0 * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += _t0 * i * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[0] = _t1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
+
 };
 
 struct ExperimentConstVolatile {
@@ -101,20 +128,29 @@ struct ExperimentConstVolatile {
 
   // CHECK: void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) const volatile {
   // CHECK-NEXT:     double _t0 = this->x * i;
+  // CHECK-NEXT:     double _t1 = output[0];
   // CHECK-NEXT:     output[0] = this->x * i * i * j;
-  // CHECK-NEXT:     double _t1 = this->y * i;
+  // CHECK-NEXT:     double _t2 = this->y * i;
+  // CHECK-NEXT:     double _t3 = output[1];
   // CHECK-NEXT:     output[1] = this->y * i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += _t1 * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += _t1 * j * 1;
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += _t2 * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += _t2 * j * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[1] = _t3;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += _t0 * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += _t0 * i * 1;
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += _t0 * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += _t0 * i * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[0] = _t1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
+
 };
 
 namespace outer {
@@ -130,20 +166,29 @@ namespace outer {
         x = val;
       }
       
-      // CHECK: void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) {
-      // CHECK-NEXT:     output[0] = this->x * i * i * j;
-      // CHECK-NEXT:     output[1] = this->y * i * j * j;
-      // CHECK-NEXT:     {
-      // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
-      // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * 1 * j;
-      // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * j * 1;
-      // CHECK-NEXT:     }
-      // CHECK-NEXT:     {
-      // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
-      // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * i * 1 * j;
-      // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * i * i * 1;
-      // CHECK-NEXT:     }
-      // CHECK-NEXT: }
+  // CHECK: void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) {
+  // CHECK-NEXT:     double _t0 = output[0];
+  // CHECK-NEXT:     output[0] = this->x * i * i * j;
+  // CHECK-NEXT:     double _t1 = output[1];
+  // CHECK-NEXT:     output[1] = this->y * i * j * j;
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += this->y * 1 * j * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += this->y * i * j * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[1] = _t1;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * 1 * j * i;
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * i * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * i * i * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[0] = _t0;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
     };
 
     auto lambdaNNS = [](double i, double j, double *output) {
@@ -151,20 +196,29 @@ namespace outer {
       output[1] = i*j*j;
     };
 
-    // CHECK: inline void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) const {
-    // CHECK-NEXT:     output[0] = i * i * j;
-    // CHECK-NEXT:     output[1] = i * j * j;
-    // CHECK-NEXT:     {
-    // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += 1 * j * j;
-    // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += i * 1 * j;
-    // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += i * j * 1;
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     {
-    // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * j * i;
-    // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += i * 1 * j;
-    // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += i * i * 1;
-    // CHECK-NEXT:     }
-    // CHECK-NEXT: }
+  // CHECK: inline void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) const {
+  // CHECK-NEXT:     double _t0 = output[0];
+  // CHECK-NEXT:     output[0] = i * i * j;
+  // CHECK-NEXT:     double _t1 = output[1];
+  // CHECK-NEXT:     output[1] = i * j * j;
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += 1 * j * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += i * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += i * j * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[1] = _t1;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * j * i;
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += i * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += i * i * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[0] = _t0;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
+
   }
 }
 
@@ -201,17 +255,25 @@ int main() {
   };
 
   // CHECK: inline void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) const {
+  // CHECK-NEXT:     double _t0 = output[0];
   // CHECK-NEXT:     output[0] = i * i * j;
+  // CHECK-NEXT:     double _t1 = output[1];
   // CHECK-NEXT:     output[1] = i * j * j;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += 1 * j * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += i * j * 1;
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += 1 * j * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += i * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += i * j * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[1] = _t1;
   // CHECK-NEXT:     }
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * j * i;
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += i * 1 * j;
-  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += i * i * 1;
+  // CHECK-NEXT:         {
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * j * i;
+  // CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += i * 1 * j;
+  // CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += i * i * 1;
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:         output[0] = _t0;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -220,20 +282,28 @@ int main() {
     output[1] = y*i*jj*jj;
   };
 
-  // CHECK: inline void operator_call_jac(double i, double jj, double *output, double *jacobianMatrix) const {
-  // CHECK-NEXT:     output[0] = x * i * i * jj;
-  // CHECK-NEXT:     output[1] = y * i * jj * jj;
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += y * 1 * jj * jj;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += y * i * 1 * jj;
-  // CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += y * i * jj * 1;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT:     {
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += x * 1 * jj * i;
-  // CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += x * i * 1 * jj;
-  // CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += x * i * i * 1;
-  // CHECK-NEXT:     }
-  // CHECK-NEXT: }
+// CHECK: inline void operator_call_jac(double i, double jj, double *output, double *jacobianMatrix) const {
+// CHECK-NEXT:     double _t0 = output[0];
+// CHECK-NEXT:     output[0] = x * i * i * jj;
+// CHECK-NEXT:     double _t1 = output[1];
+// CHECK-NEXT:     output[1] = y * i * jj * jj;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += y * 1 * jj * jj;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += y * i * 1 * jj;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += y * i * jj * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[1] = _t1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += x * 1 * jj * i;
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += x * i * 1 * jj;
+// CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += x * i * i * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[0] = _t0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
   auto lambdaNNS = outer::inner::lambdaNNS;
 
@@ -277,3 +347,4 @@ int main() {
   TEST(E_NNS_Again);        // CHECK-EXEC: {756.00, 294.00, 405.00, 630.00}, {756.00, 294.00, 405.00, 630.00}
   TEST(lambdaWithCapture);  // CHECK-EXEC: {756.00, 294.00, 405.00, 630.00}, {756.00, 294.00, 405.00, 630.00}
 }
+

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -13,31 +13,43 @@ void f_1(double a, double b, double c, double output[]) {
 }
 
 void f_1_jac(double a, double b, double c, double output[], double *_result);
-//CHECK:void f_1_jac(double a, double b, double c, double output[], double *jacobianMatrix) {
-//CHECK-NEXT:  output[0] = a * a * a;
-//CHECK-NEXT:  output[1] = a * a * a + b * b * b;
-//CHECK-NEXT:  output[2] = c * c * 10 - a * a;
-//CHECK-NEXT:  {
-//CHECK-NEXT:    jacobianMatrix[{{8U|8UL|8ULL}}] += 1 * 10 * c;
-//CHECK-NEXT:    jacobianMatrix[{{8U|8UL|8ULL}}] += c * 1 * 10;
-//CHECK-NEXT:    jacobianMatrix[{{6U|6UL|6ULL}}] += -1 * a;
-//CHECK-NEXT:    jacobianMatrix[{{6U|6UL|6ULL}}] += a * -1;
-//CHECK-NEXT:  }
-//CHECK-NEXT:  {
-//CHECK-NEXT:    jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * a * a;
-//CHECK-NEXT:    jacobianMatrix[{{3U|3UL|3ULL}}] += a * 1 * a;
-//CHECK-NEXT:    jacobianMatrix[{{3U|3UL|3ULL}}] += a * a * 1;
-//CHECK-NEXT:    jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * b * b;
-//CHECK-NEXT:    jacobianMatrix[{{4U|4UL|4ULL}}] += b * 1 * b;
-//CHECK-NEXT:    jacobianMatrix[{{4U|4UL|4ULL}}] += b * b * 1;
-//CHECK-NEXT:  }
-//CHECK-NEXT:  {
-//CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * a * a;
-//CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += a * 1 * a;
-//CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += a * a * 1;
-//CHECK-NEXT:  }
-//CHECK-NEXT:}
 
+// CHECK: void f_1_jac(double a, double b, double c, double output[], double *jacobianMatrix) {
+// CHECK-NEXT:     double _t0 = output[0];
+// CHECK-NEXT:     output[0] = a * a * a;
+// CHECK-NEXT:     double _t1 = output[1];
+// CHECK-NEXT:     output[1] = a * a * a + b * b * b;
+// CHECK-NEXT:     double _t2 = output[2];
+// CHECK-NEXT:     output[2] = c * c * 10 - a * a;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{8U|8UL|8ULL}}] += 1 * 10 * c;
+// CHECK-NEXT:             jacobianMatrix[{{8U|8UL|8ULL}}] += c * 1 * 10;
+// CHECK-NEXT:             jacobianMatrix[{{6U|6UL|6ULL}}] += -1 * a;
+// CHECK-NEXT:             jacobianMatrix[{{6U|6UL|6ULL}}] += a * -1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[2] = _t2;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * a * a;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += a * 1 * a;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += a * a * 1;
+// CHECK-NEXT:             jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * b * b;
+// CHECK-NEXT:             jacobianMatrix[{{4U|4UL|4ULL}}] += b * 1 * b;
+// CHECK-NEXT:             jacobianMatrix[{{4U|4UL|4ULL}}] += b * b * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[1] = _t1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * a * a;
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += a * 1 * a;
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += a * a * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[0] = _t0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 void f_3(double x, double y, double z, double *_result) {
   double constant = 42;
@@ -48,32 +60,44 @@ void f_3(double x, double y, double z, double *_result) {
 }
 
 void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatrix);
-//CHECK: void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatrix) {
-//CHECK-NEXT:  double _d_constant = 0.;
-//CHECK-NEXT:  double constant = 42;
-//CHECK-NEXT:  double _t0 = sin(x);
-//CHECK-NEXT:  _result[0] = sin(x) * constant;
-//CHECK-NEXT:  double _t1 = sin(y);
-//CHECK-NEXT:  _result[1] = sin(y) * constant;
-//CHECK-NEXT:  double _t2 = sin(z);
-//CHECK-NEXT:  _result[2] = sin(z) * constant;
-//CHECK-NEXT:  {
-//CHECK-NEXT:    double _r2 = 0.;
-//CHECK-NEXT:    _r2 += 1 * constant * clad::custom_derivatives::sin_pushforward(z, 1.).pushforward;
-//CHECK-NEXT:    jacobianMatrix[{{8U|8UL|8ULL}}] += _r2;
-//CHECK-NEXT:  }
-//CHECK-NEXT:  {
-//CHECK-NEXT:    double _r1 = 0.;
-//CHECK-NEXT:    _r1 += 1 * constant * clad::custom_derivatives::sin_pushforward(y, 1.).pushforward;
-//CHECK-NEXT:    jacobianMatrix[{{4U|4UL|4ULL}}] += _r1;
-//CHECK-NEXT:  }
-//CHECK-NEXT:  {
-//CHECK-NEXT:    double _r0 = 0.;
-//CHECK-NEXT:    _r0 += 1 * constant * clad::custom_derivatives::sin_pushforward(x, 1.).pushforward;
-//CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += _r0;
-//CHECK-NEXT:  }
-//CHECK-NEXT:}
 
+// CHECK: void f_3_jac(double x, double y, double z, double *_result, double *jacobianMatrix) {
+// CHECK-NEXT:     double _d_constant = 0.;
+// CHECK-NEXT:     double constant = 42;
+// CHECK-NEXT:     double _t0 = sin(x);
+// CHECK-NEXT:     double _t1 = _result[0];
+// CHECK-NEXT:     _result[0] = sin(x) * constant;
+// CHECK-NEXT:     double _t2 = sin(y);
+// CHECK-NEXT:     double _t3 = _result[1];
+// CHECK-NEXT:     _result[1] = sin(y) * constant;
+// CHECK-NEXT:     double _t4 = sin(z);
+// CHECK-NEXT:     double _t5 = _result[2];
+// CHECK-NEXT:     _result[2] = sin(z) * constant;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             double _r2 = 0.;
+// CHECK-NEXT:             _r2 += 1 * constant * clad::custom_derivatives::sin_pushforward(z, 1.).pushforward;
+// CHECK-NEXT:             jacobianMatrix[{{8U|8UL|8ULL}}] += _r2;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _result[2] = _t5;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             double _r1 = 0.;
+// CHECK-NEXT:             _r1 += 1 * constant * clad::custom_derivatives::sin_pushforward(y, 1.).pushforward;
+// CHECK-NEXT:             jacobianMatrix[{{4U|4UL|4ULL}}] += _r1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _result[1] = _t3;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             double _r0 = 0.;
+// CHECK-NEXT:             _r0 += 1 * constant * clad::custom_derivatives::sin_pushforward(x, 1.).pushforward;
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += _r0;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _result[0] = _t1;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 double multiply(double x, double y) { return x * y; }
 //CHECK: void multiply_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 
@@ -86,75 +110,108 @@ void f_4(double x, double y, double z, double *_result) {
 }
 
 void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatrix);
-//CHECK: void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatrix) {
-//CHECK-NEXT:    double _d_constant = 0.;
-//CHECK-NEXT:    double constant = 42;
-//CHECK-NEXT:    double _t0 = multiply(x, y);
-//CHECK-NEXT:    _result[0] = multiply(x, y) * constant;
-//CHECK-NEXT:    double _t1 = multiply(y, z);
-//CHECK-NEXT:    _result[1] = multiply(y, z) * constant;
-//CHECK-NEXT:    double _t2 = multiply(z, x);
-//CHECK-NEXT:    _result[2] = multiply(z, x) * constant;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        double _r4 = 0.;
-//CHECK-NEXT:        double _r5 = 0.;
-//CHECK-NEXT:        multiply_pullback(z, x, 1 * constant, &_r4, &_r5);
-//CHECK-NEXT:        jacobianMatrix[{{8U|8UL|8ULL}}] += _r4;
-//CHECK-NEXT:        jacobianMatrix[{{6U|6UL|6ULL}}] += _r5;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        double _r2 = 0.;
-//CHECK-NEXT:        double _r3 = 0.;
-//CHECK-NEXT:        multiply_pullback(y, z, 1 * constant, &_r2, &_r3);
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += _r2;
-//CHECK-NEXT:        jacobianMatrix[{{5U|5UL|5ULL}}] += _r3;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = 0.;
-//CHECK-NEXT:        double _r1 = 0.;
-//CHECK-NEXT:        multiply_pullback(x, y, 1 * constant, &_r0, &_r1);
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += _r0;
-//CHECK-NEXT:        jacobianMatrix[{{1U|1UL|1ULL}}] += _r1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
+// CHECK: void f_4_jac(double x, double y, double z, double *_result, double *jacobianMatrix) {
+// CHECK-NEXT:     double _d_constant = 0.;
+// CHECK-NEXT:     double constant = 42;
+// CHECK-NEXT:     double _t0 = multiply(x, y);
+// CHECK-NEXT:     double _t1 = _result[0];
+// CHECK-NEXT:     _result[0] = multiply(x, y) * constant;
+// CHECK-NEXT:     double _t2 = multiply(y, z);
+// CHECK-NEXT:     double _t3 = _result[1];
+// CHECK-NEXT:     _result[1] = multiply(y, z) * constant;
+// CHECK-NEXT:     double _t4 = multiply(z, x);
+// CHECK-NEXT:     double _t5 = _result[2];
+// CHECK-NEXT:     _result[2] = multiply(z, x) * constant;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             double _r4 = 0.;
+// CHECK-NEXT:             double _r5 = 0.;
+// CHECK-NEXT:             multiply_pullback(z, x, 1 * constant, &_r4, &_r5);
+// CHECK-NEXT:             jacobianMatrix[{{8U|8UL|8ULL}}] += _r4;
+// CHECK-NEXT:             jacobianMatrix[{{6U|6UL|6ULL}}] += _r5;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _result[2] = _t5;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             double _r2 = 0.;
+// CHECK-NEXT:             double _r3 = 0.;
+// CHECK-NEXT:             multiply_pullback(y, z, 1 * constant, &_r2, &_r3);
+// CHECK-NEXT:             jacobianMatrix[{{4U|4UL|4ULL}}] += _r2;
+// CHECK-NEXT:             jacobianMatrix[{{5U|5UL|5ULL}}] += _r3;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _result[1] = _t3;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             double _r0 = 0.;
+// CHECK-NEXT:             double _r1 = 0.;
+// CHECK-NEXT:             multiply_pullback(x, y, 1 * constant, &_r0, &_r1);
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += _r0;
+// CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += _r1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _result[0] = _t1;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 void f_1_jac_0(double a, double b, double c, double output[], double *jacobianMatrix);
 // CHECK: void f_1_jac_0(double a, double b, double c, double output[], double *jacobianMatrix) {
-// CHECK-NEXT:  double _d_b = 0.;
-// CHECK-NEXT:  double _d_c = 0.;
-// CHECK-NEXT:  output[0] = a * a * a;
-// CHECK-NEXT:  output[1] = a * a * a + b * b * b;
-// CHECK-NEXT:  output[2] = c * c * 10 - a * a;
-// CHECK-NEXT:  {
-// CHECK-NEXT:    jacobianMatrix[{{2U|2UL|2ULL}}] += -1 * a;
-// CHECK-NEXT:    jacobianMatrix[{{2U|2UL|2ULL}}] += a * -1;
-// CHECK-NEXT:  }
-// CHECK-NEXT:  {
-// CHECK-NEXT:    jacobianMatrix[{{1U|1UL|1ULL}}] += 1 * a * a;
-// CHECK-NEXT:    jacobianMatrix[{{1U|1UL|1ULL}}] += a * 1 * a;
-// CHECK-NEXT:    jacobianMatrix[{{1U|1UL|1ULL}}] += a * a * 1;
-// CHECK-NEXT:  }
-// CHECK-NEXT:  {
-// CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * a * a;
-// CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += a * 1 * a;
-// CHECK-NEXT:    jacobianMatrix[{{0U|0UL|0ULL}}] += a * a * 1;
-// CHECK-NEXT:  }
-// CHECK-NEXT:}
+// CHECK-NEXT:     double _d_b = 0.;
+// CHECK-NEXT:     double _d_c = 0.;
+// CHECK-NEXT:     double _t0 = output[0];
+// CHECK-NEXT:     output[0] = a * a * a;
+// CHECK-NEXT:     double _t1 = output[1];
+// CHECK-NEXT:     output[1] = a * a * a + b * b * b;
+// CHECK-NEXT:     double _t2 = output[2];
+// CHECK-NEXT:     output[2] = c * c * 10 - a * a;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += -1 * a;
+// CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += a * -1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[2] = _t2;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += 1 * a * a;
+// CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += a * 1 * a;
+// CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += a * a * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[1] = _t1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * a * a;
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += a * 1 * a;
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += a * a * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[0] = _t0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 void f_5(float a, double output[]){
   output[1]=a;
   output[0]=a*a;  
 }
 
-//CHECK: void f_5_jac(float a, double output[], double *jacobianMatrix) {
-//CHECK-NEXT:    output[1] = a;
-//CHECK-NEXT:    output[0] = a * a;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * a;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += a * 1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    jacobianMatrix[{{1U|1UL|1ULL}}] += 1;
-//CHECK-NEXT:}
+// CHECK: void f_5_jac(float a, double output[], double *jacobianMatrix) {
+// CHECK-NEXT:     double _t0 = output[1];
+// CHECK-NEXT:     output[1] = a;
+// CHECK-NEXT:     double _t1 = output[0];
+// CHECK-NEXT:     output[0] = a * a;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * a;
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += a * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[0] = _t1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += 1;
+// CHECK-NEXT:         output[1] = _t0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
 
 #define TEST(F, x, y, z) { \
   result[0] = 0; result[1] = 0; result[2] = 0;\

--- a/test/Jacobian/Pointers.C
+++ b/test/Jacobian/Pointers.C
@@ -11,12 +11,19 @@ void nonMemFn(double i, double j, double* out) {
 }
 
 // CHECK: void nonMemFn_jac(double i, double j, double *out, double *jacobianMatrix) {
+// CHECK-NEXT:     double _t0 = out[0];
 // CHECK-NEXT:     out[0] = i;
+// CHECK-NEXT:     double _t1 = out[1];
 // CHECK-NEXT:     out[1] = j;
-// CHECK-NEXT:     jacobianMatrix[{{3U|3UL|3ULL}}] += 1;
-// CHECK-NEXT:     jacobianMatrix[{{0U|0UL|0ULL}}] += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += 1;
+// CHECK-NEXT:         out[1] = _t1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += 1;
+// CHECK-NEXT:         out[0] = _t0;
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
-
 
 #define NON_MEM_FN_TEST(var)\
 res[0]=res[1]=res[2]=res[3]=0;\
@@ -45,3 +52,4 @@ int main() {
 
   NON_MEM_FN_TEST(d_nonMemFnPtrToPtrPar); // CHECK-EXEC: {1.00 0.00 0.00 1.00}
 }
+

--- a/test/Jacobian/TemplateFunctors.C
+++ b/test/Jacobian/TemplateFunctors.C
@@ -16,15 +16,23 @@ template <typename T> struct Experiment {
 };
 
 // CHECK: void operator_call_jac(double i, double j, double *output, double *jacobianMatrix) {
+// CHECK-NEXT:     double _t0 = output[0];
 // CHECK-NEXT:     output[0] = this->x * this->y * i * j;
+// CHECK-NEXT:     double _t1 = output[1];
 // CHECK-NEXT:     output[1] = 2 * this->x * this->y * i * j;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += 2 * this->x * this->y * 1 * j;
-// CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += 2 * this->x * this->y * i * 1;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += 2 * this->x * this->y * 1 * j;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += 2 * this->x * this->y * i * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[1] = _t1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * this->y * 1 * j;
-// CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * this->y * i * 1;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * this->y * 1 * j;
+// CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * this->y * i * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[0] = _t0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -39,17 +47,25 @@ template <> struct Experiment<long double> {
 };
 
 // CHECK: void operator_call_jac(long double i, long double j, long double *output, long double *jacobianMatrix) {
+// CHECK-NEXT:     long double _t0 = output[0];
 // CHECK-NEXT:     output[0] = this->x * this->y * i * i * j;
+// CHECK-NEXT:     long double _t1 = output[1];
 // CHECK-NEXT:     output[1] = 2 * this->x * this->y * i * i * j;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += 2 * this->x * this->y * 1 * j * i;
-// CHECK-NEXT:         jacobianMatrix[{{2U|2UL|2ULL}}] += 2 * this->x * this->y * i * 1 * j;
-// CHECK-NEXT:         jacobianMatrix[{{3U|3UL|3ULL}}] += 2 * this->x * this->y * i * i * 1;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += 2 * this->x * this->y * 1 * j * i;
+// CHECK-NEXT:             jacobianMatrix[{{2U|2UL|2ULL}}] += 2 * this->x * this->y * i * 1 * j;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += 2 * this->x * this->y * i * i * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[1] = _t1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * this->y * 1 * j * i;
-// CHECK-NEXT:         jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * this->y * i * 1 * j;
-// CHECK-NEXT:         jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * this->y * i * i * 1;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * this->y * 1 * j * i;
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += this->x * this->y * i * 1 * j;
+// CHECK-NEXT:             jacobianMatrix[{{1U|1UL|1ULL}}] += this->x * this->y * i * i * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[0] = _t0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -99,3 +115,4 @@ int main() {
   TEST_DOUBLE(E, 7, 9);           // CHECK-EXEC: {225.00, 175.00, 450.00, 350.00} {225.00, 175.00, 450.00, 350.00}
   TEST_LONG_DOUBLE(E_ld, 7, 9);   // CHECK-EXEC: {3150.00, 1225.00, 6300.00, 2450.00} {3150.00, 1225.00, 6300.00, 2450.00}
 }
+

--- a/test/Jacobian/constexprTest.C
+++ b/test/Jacobian/constexprTest.C
@@ -18,23 +18,36 @@ constexpr void fn_mul(double i, double j, double *res) {
    res[2] = i*j;
 }
 
-//CHECK: constexpr void fn_mul_jac(double i, double j, double *res, double *jacobianMatrix) {
-//CHECK-NEXT:    res[0] = i * i;
-//CHECK-NEXT:    res[1] = j * j;
-//CHECK-NEXT:    res[2] = i * j;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * j;
-//CHECK-NEXT:        jacobianMatrix[{{5U|5UL|5ULL}}] += i * 1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * j;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += j * 1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * i;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += i * 1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
+// CHECK: void fn_mul_jac(double i, double j, double *res, double *jacobianMatrix) {
+// CHECK-NEXT:     double _t0 = res[0];
+// CHECK-NEXT:     res[0] = i * i;
+// CHECK-NEXT:     double _t1 = res[1];
+// CHECK-NEXT:     res[1] = j * j;
+// CHECK-NEXT:     double _t2 = res[2];
+// CHECK-NEXT:     res[2] = i * j;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * j;
+// CHECK-NEXT:             jacobianMatrix[{{5U|5UL|5ULL}}] += i * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         res[2] = _t2;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * j;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += j * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         res[1] = _t1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * i;
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += i * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         res[0] = _t0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
 
 constexpr void f_1(double x, double y, double z, double output[]) {
   output[0] = x * x * x;
@@ -42,30 +55,42 @@ constexpr void f_1(double x, double y, double z, double output[]) {
   output[2] = z * x * 10 - y * z;
 }
 
-//CHECK: constexpr void f_1_jac(double x, double y, double z, double output[], double *jacobianMatrix) {
-//CHECK-NEXT:    output[0] = x * x * x;
-//CHECK-NEXT:    output[1] = x * y * x + y * x * x;
-//CHECK-NEXT:    output[2] = z * x * 10 - y * z;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{8U|8UL|8ULL}}] += 1 * 10 * x;
-//CHECK-NEXT:        jacobianMatrix[{{6U|6UL|6ULL}}] += z * 1 * 10;
-//CHECK-NEXT:        jacobianMatrix[{{7U|7UL|7ULL}}] += -1 * z;
-//CHECK-NEXT:        jacobianMatrix[{{8U|8UL|8ULL}}] += y * -1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * x * y;
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += x * 1 * x;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += x * y * 1;
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * x * x;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += y * 1 * x;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += y * x * 1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * x * x;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += x * 1 * x;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += x * x * 1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
+// CHECK: constexpr void f_1_jac(double x, double y, double z, double output[], double *jacobianMatrix) {
+// CHECK-NEXT:     double _t0 = output[0];
+// CHECK-NEXT:     output[0] = x * x * x; 
+// CHECK-NEXT:     double _t1 = output[1];
+// CHECK-NEXT:     output[1] = x * y * x + y * x * x; 
+// CHECK-NEXT:     double _t2 = output[2];
+// CHECK-NEXT:     output[2] = z * x * 10 - y * z; 
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{8U|8UL|8ULL}}] += 1 * 10 * x; 
+// CHECK-NEXT:             jacobianMatrix[{{6U|6UL|6ULL}}] += z * 1 * 10; 
+// CHECK-NEXT:             jacobianMatrix[{{7U|7UL|7ULL}}] += -1 * z;     
+// CHECK-NEXT:             jacobianMatrix[{{8U|8UL|8ULL}}] += y * -1;     
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[2] = _t2; 
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * x * y; 
+// CHECK-NEXT:             jacobianMatrix[{{4U|4UL|4ULL}}] += x * 1 * x;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += x * y * 1;
+// CHECK-NEXT:             jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * x * x;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += y * 1 * x; 
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += y * x * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[1] = _t1; 
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * x * x; 
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += x * 1 * x; 
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += x * x * 1; 
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[0] = _t0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 int main() {
     
@@ -75,3 +100,4 @@ int main() {
     TEST_JACOBIAN(fn_mul, 2, 6, 3, 1, result, jacobianou); // CHECK-EXEC: {6.00, 0.00, 0.00, 2.00, 1.00, 3.00}
     TEST_JACOBIAN(f_1, 3, 9, 4, 5, 6, result1, jacobianou1); // CHECK-EXEC: {48.00, 0.00, 0.00, 80.00, 32.00, 0.00, 60.00, -6.00, 35.00}
 }
+

--- a/test/Jacobian/testUtility.C
+++ b/test/Jacobian/testUtility.C
@@ -18,23 +18,36 @@ void fn_mul(double i, double j, double *res) {
    res[2] = i*j;
 }
 
-//CHECK: void fn_mul_jac(double i, double j, double *res, double *jacobianMatrix) {
-//CHECK-NEXT:    res[0] = i * i;
-//CHECK-NEXT:    res[1] = j * j;
-//CHECK-NEXT:    res[2] = i * j;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * j;
-//CHECK-NEXT:        jacobianMatrix[{{5U|5UL|5ULL}}] += i * 1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * j;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += j * 1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * i;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += i * 1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
+// CHECK: void fn_mul_jac(double i, double j, double *res, double *jacobianMatrix) {
+// CHECK-NEXT:     double _t0 = res[0];
+// CHECK-NEXT:     res[0] = i * i;
+// CHECK-NEXT:     double _t1 = res[1];
+// CHECK-NEXT:     res[1] = j * j;
+// CHECK-NEXT:     double _t2 = res[2];
+// CHECK-NEXT:     res[2] = i * j;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * j;
+// CHECK-NEXT:             jacobianMatrix[{{5U|5UL|5ULL}}] += i * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         res[2] = _t2;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * j;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += j * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         res[1] = _t1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * i;
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += i * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         res[0] = _t0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
 
 
 void f_1(double x, double y, double z, double output[]) {
@@ -43,30 +56,43 @@ void f_1(double x, double y, double z, double output[]) {
   output[2] = z * x * 10 - y * z;
 }
 
-//CHECK: void f_1_jac(double x, double y, double z, double output[], double *jacobianMatrix) {
-//CHECK-NEXT:    output[0] = x * x * x;
-//CHECK-NEXT:    output[1] = x * y * x + y * x * x;
-//CHECK-NEXT:    output[2] = z * x * 10 - y * z;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{8U|8UL|8ULL}}] += 1 * 10 * x;
-//CHECK-NEXT:        jacobianMatrix[{{6U|6UL|6ULL}}] += z * 1 * 10;
-//CHECK-NEXT:        jacobianMatrix[{{7U|7UL|7ULL}}] += -1 * z;
-//CHECK-NEXT:        jacobianMatrix[{{8U|8UL|8ULL}}] += y * -1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * x * y;
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += x * 1 * x;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += x * y * 1;
-//CHECK-NEXT:        jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * x * x;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += y * 1 * x;
-//CHECK-NEXT:        jacobianMatrix[{{3U|3UL|3ULL}}] += y * x * 1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * x * x;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += x * 1 * x;
-//CHECK-NEXT:        jacobianMatrix[{{0U|0UL|0ULL}}] += x * x * 1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
+// CHECK: void f_1_jac(double x, double y, double z, double output[], double *jacobianMatrix) {
+// CHECK-NEXT:     double _t0 = output[0];
+// CHECK-NEXT:     output[0] = x * x * x;
+// CHECK-NEXT:     double _t1 = output[1];
+// CHECK-NEXT:     output[1] = x * y * x + y * x * x;
+// CHECK-NEXT:     double _t2 = output[2];
+// CHECK-NEXT:     output[2] = z * x * 10 - y * z;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{8U|8UL|8ULL}}] += 1 * 10 * x;
+// CHECK-NEXT:             jacobianMatrix[{{6U|6UL|6ULL}}] += z * 1 * 10;
+// CHECK-NEXT:             jacobianMatrix[{{7U|7UL|7ULL}}] += -1 * z;
+// CHECK-NEXT:             jacobianMatrix[{{8U|8UL|8ULL}}] += y * -1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[2] = _t2;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += 1 * x * y;
+// CHECK-NEXT:             jacobianMatrix[{{4U|4UL|4ULL}}] += x * 1 * x;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3ULL}}] += x * y * 1;
+// CHECK-NEXT:             jacobianMatrix[{{4U|4UL|4ULL}}] += 1 * x * x;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3OLL}}] += y * 1 * x;
+// CHECK-NEXT:             jacobianMatrix[{{3U|3UL|3OLL}}] += y * x * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[1] = _t1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += 1 * x * x;
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += x * 1 * x;
+// CHECK-NEXT:             jacobianMatrix[{{0U|0UL|0ULL}}] += x * x * 1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         output[0] = _t0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
 
 int main(){
     INIT_JACOBIAN(fn_mul);
@@ -76,4 +102,3 @@ int main(){
     TEST_JACOBIAN(f_1, 3, 9, 4, 5, 6, output1, jacobian1); // CHECK-EXEC: {48.00, 0.00, 0.00, 80.00, 32.00, 0.00, 60.00, -6.00, 35.00}
 
 }
-


### PR DESCRIPTION
Before this PR, outputArray's elements weren't stored if they were changed. It would also fix an issue with enabling activity analysis.