### PR TITLE
Fix appendage of nullptrs to args of a CUDA kernel

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -125,8 +125,17 @@ CUDA_HOST_DEVICE T push(tape<T>& to, ArgsT... val) {
                             CUDA_ARGS CUDA_REST_ARGS Args&&... args) {
 #if defined(__CUDACC__) && !defined(__CUDA_ARCH__)
     if (CUDAkernel) {
-      void* argPtrs[] = {(void*)&args..., (void*)static_cast<Rest>(nullptr)...};
-      cudaLaunchKernel((void*)f, grid, block, argPtrs, shared_mem, stream);
+      constexpr size_t totalArgs = sizeof...(args) + sizeof...(Rest);
+      std::vector<void*> argPtrs;
+      argPtrs.reserve(totalArgs);
+      (argPtrs.push_back(static_cast<void*>(&args)), ...);
+
+      void* null_param = nullptr;
+      for (size_t i = sizeof...(args); i < totalArgs; ++i)
+        argPtrs[i] = &null_param;
+
+      cudaLaunchKernel((void*)f, grid, block, argPtrs.data(), shared_mem, stream);
+      return return_type_t<F>();
     } else {
       return f(static_cast<Args>(args)..., static_cast<Rest>(nullptr)...);
     }

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -134,7 +134,8 @@ CUDA_HOST_DEVICE T push(tape<T>& to, ArgsT... val) {
       for (size_t i = sizeof...(args); i < totalArgs; ++i)
         argPtrs[i] = &null_param;
 
-      cudaLaunchKernel((void*)f, grid, block, argPtrs.data(), shared_mem, stream);
+      cudaLaunchKernel((void*)f, grid, block, argPtrs.data(), shared_mem,
+                       stream);
       return return_type_t<F>();
     } else {
       return f(static_cast<Args>(args)..., static_cast<Rest>(nullptr)...);


### PR DESCRIPTION
Previously, we were appending `nullptr` to the rest of the args, whose addresses are accessed when `cudaLaunchKernel` was used, but `nullptr` cannot be referenced. This PR fixes that by pushing back the address of a param initialized to `nullptr` as many times needed.

This PR will include changes to the tests of #1092 once merged, to show that the problem is solved before it's ready for merging.