### PR TITLE
Remove excessive parameters from Derive functions

### DIFF
--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -30,16 +30,12 @@ public:
 
   ///\brief Produces the first derivative of a given function.
   ///
-  ///\param[in] FD - the function that will be differentiated.
-  ///
   ///\returns The differentiated and potentially created enclosing
   /// context.
   ///
-  DerivativeAndOverload Derive(const clang::FunctionDecl* FD,
-                               const DiffRequest& request);
+  DerivativeAndOverload Derive();
 
-  DerivativeAndOverload DerivePushforward(const clang::FunctionDecl* FD,
-                                          const DiffRequest& request);
+  DerivativeAndOverload DerivePushforward();
 
   /// Returns the return type for the pushforward function of the function
   /// `m_DiffReq->Function`.

--- a/include/clad/Differentiator/HessianModeVisitor.h
+++ b/include/clad/Differentiator/HessianModeVisitor.h
@@ -41,8 +41,6 @@ namespace clad {
     ///\brief Produces the hessian second derivative columns of a given
     /// function.
     ///
-    ///\param[in] FD - the function that will be differentiated.
-    ///
     ///\returns A function containing second derivatives (columns) of a hessian
     /// matrix and potentially created enclosing context.
     ///
@@ -50,8 +48,7 @@ namespace clad {
     /// ReverseModeVisitor to generate second derivatives that correspond to
     /// columns of the Hessian. uses Merge to return a FunctionDecl
     /// containing CallExprs to the generated second derivatives.
-    DerivativeAndOverload Derive(const clang::FunctionDecl* FD,
-                                     const DiffRequest& request);
+    DerivativeAndOverload Derive();
   };
 } // end namespace clad
 

--- a/include/clad/Differentiator/ReverseModeForwPassVisitor.h
+++ b/include/clad/Differentiator/ReverseModeForwPassVisitor.h
@@ -22,8 +22,7 @@ private:
 public:
   ReverseModeForwPassVisitor(DerivativeBuilder& builder,
                              const DiffRequest& request);
-  DerivativeAndOverload Derive(const clang::FunctionDecl* FD,
-                               const DiffRequest& request);
+  DerivativeAndOverload Derive();
 
   StmtDiff ProcessSingleStmt(const clang::Stmt* S);
   StmtDiff VisitCompoundStmt(const clang::CompoundStmt* CS) override;

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -355,8 +355,6 @@ namespace clad {
 
     ///\brief Produces the gradient of a given function.
     ///
-    ///\param[in] FD - the function that will be differentiated.
-    ///
     ///\returns The gradient of the function, potentially created enclosing
     /// context and if generated, its overload.
     ///
@@ -373,10 +371,8 @@ namespace clad {
     /// Improved naming scheme is required. Hence, we append the indices to of
     /// the requested parameters to 'f_grad', i.e. in the previous example "x,
     /// y" will give 'f_grad_0_1' and "x, z" will give 'f_grad_0_2'.
-    DerivativeAndOverload Derive(const clang::FunctionDecl* FD,
-                                 const DiffRequest& request);
-    DerivativeAndOverload DerivePullback(const clang::FunctionDecl* FD,
-                                         const DiffRequest& request);
+    DerivativeAndOverload Derive();
+    DerivativeAndOverload DerivePullback();
     StmtDiff VisitArraySubscriptExpr(const clang::ArraySubscriptExpr* ASE);
     StmtDiff VisitBinaryOperator(const clang::BinaryOperator* BinOp);
     StmtDiff VisitCallExpr(const clang::CallExpr* CE);

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -132,8 +132,6 @@ namespace clad {
     std::vector<Stmts> m_Blocks;
     /// Stores output variables for vector-valued functions
     VectorOutputs m_VectorOutput;
-    /// The functor type that is currently being differentiated, if any.
-    const clang::CXXRecordDecl* m_Functor = nullptr;
     /// Stores derivative expression of the implicit `this` pointer.
     ///
     /// In the forward mode, `this` pointer derivative expression is of pointer

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -399,44 +399,44 @@ static void registerDerivative(FunctionDecl* derivedFD, Sema& semaRef) {
     DerivativeAndOverload result{};
     if (request.Mode == DiffMode::forward) {
       BaseForwardModeVisitor V(*this, request);
-      result = V.Derive(FD, request);
+      result = V.Derive();
     } else if (request.Mode == DiffMode::experimental_pushforward) {
       PushForwardModeVisitor V(*this, request);
-      result = V.DerivePushforward(FD, request);
+      result = V.DerivePushforward();
     } else if (request.Mode == DiffMode::vector_forward_mode) {
       VectorForwardModeVisitor V(*this, request);
       result = V.DeriveVectorMode(FD, request);
     } else if (request.Mode == DiffMode::experimental_vector_pushforward) {
       VectorPushForwardModeVisitor V(*this, request);
-      result = V.DerivePushforward(FD, request);
+      result = V.DerivePushforward();
     } else if (request.Mode == DiffMode::reverse) {
       ReverseModeVisitor V(*this, request);
-      result = V.Derive(FD, request);
+      result = V.Derive();
     } else if (request.Mode == DiffMode::experimental_pullback) {
       ReverseModeVisitor V(*this, request);
       if (!m_ErrorEstHandler.empty()) {
         InitErrorEstimation(m_ErrorEstHandler, m_EstModel, *this, request);
         V.AddExternalSource(*m_ErrorEstHandler.back());
       }
-      result = V.DerivePullback(FD, request);
+      result = V.DerivePullback();
       if (!m_ErrorEstHandler.empty())
         CleanupErrorEstimation(m_ErrorEstHandler, m_EstModel);
     } else if (request.Mode == DiffMode::reverse_mode_forward_pass) {
       ReverseModeForwPassVisitor V(*this, request);
-      result = V.Derive(FD, request);
+      result = V.Derive();
     } else if (request.Mode == DiffMode::hessian ||
                request.Mode == DiffMode::hessian_diagonal) {
       HessianModeVisitor H(*this, request);
-      result = H.Derive(FD, request);
+      result = H.Derive();
     } else if (request.Mode == DiffMode::jacobian) {
       ReverseModeVisitor R(*this, request);
-      result = R.Derive(FD, request);
+      result = R.Derive();
     } else if (request.Mode == DiffMode::error_estimation) {
       ReverseModeVisitor R(*this, request);
       InitErrorEstimation(m_ErrorEstHandler, m_EstModel, *this, request);
       R.AddExternalSource(*m_ErrorEstHandler.back());
       // Finally begin estimation.
-      result = R.Derive(FD, request);
+      result = R.Derive();
       // Once we are done, we want to clear the model for any further
       // calls to estimate_error.
       CleanupErrorEstimation(m_ErrorEstHandler, m_EstModel);

--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -16,10 +16,8 @@ ReverseModeForwPassVisitor::ReverseModeForwPassVisitor(
     DerivativeBuilder& builder, const DiffRequest& request)
     : ReverseModeVisitor(builder, request) {}
 
-DerivativeAndOverload
-ReverseModeForwPassVisitor::Derive(const FunctionDecl* FD,
-                                   const DiffRequest& request) {
-  assert(m_DiffReq == request);
+DerivativeAndOverload ReverseModeForwPassVisitor::Derive() {
+  const FunctionDecl* FD = m_DiffReq.Function;
 
   assert(m_DiffReq.Mode == DiffMode::reverse_mode_forward_pass);
 
@@ -64,7 +62,7 @@ ReverseModeForwPassVisitor::Derive(const FunctionDecl* FD,
   m_Derivative->setParams(params);
   m_Derivative->setBody(nullptr);
 
-  if (!request.DeclarationOnly) {
+  if (!m_DiffReq.DeclarationOnly) {
     beginScope(Scope::FnScope | Scope::DeclScope);
     m_DerivativeFnScope = getCurrentScope();
 
@@ -87,9 +85,10 @@ ReverseModeForwPassVisitor::Derive(const FunctionDecl* FD,
 
     // Size >= current derivative order means that there exists a declaration
     // or prototype for the currently derived function.
-    if (request.DerivedFDPrototypes.size() >= request.CurrentDerivativeOrder)
+    if (m_DiffReq.DerivedFDPrototypes.size() >=
+        m_DiffReq.CurrentDerivativeOrder)
       m_Derivative->setPreviousDeclaration(
-          request.DerivedFDPrototypes[request.CurrentDerivativeOrder - 1]);
+          m_DiffReq.DerivedFDPrototypes[m_DiffReq.CurrentDerivativeOrder - 1]);
   }
   m_Sema.PopFunctionScopeInfo();
   m_Sema.PopDeclContext();

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -263,12 +263,10 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     return gradientOverloadFD;
   }
 
-  DerivativeAndOverload
-  ReverseModeVisitor::Derive(const FunctionDecl* FD,
-                             const DiffRequest& request) {
+  DerivativeAndOverload ReverseModeVisitor::Derive() {
+    const FunctionDecl* FD = m_DiffReq.Function;
     if (m_ExternalSource)
       m_ExternalSource->ActOnStartOfDerive();
-    assert(m_DiffReq == request);
 
     // FIXME: reverse mode plugins may have request mode other than
     // `DiffMode::reverse`, but they still need the `DiffMode::reverse` mode
@@ -284,31 +282,28 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     assert(m_DiffReq.Function && "Must not be null.");
 
     DiffParams args{};
-    DiffInputVarsInfo DVI;
-    if (request.Args) {
-      DVI = request.DVI;
-      for (const auto& dParam : DVI)
+    if (m_DiffReq.Args)
+      for (const auto& dParam : m_DiffReq.DVI)
         args.push_back(dParam.param);
-    }
     else
       std::copy(FD->param_begin(), FD->param_end(), std::back_inserter(args));
     if (args.empty())
       return {};
 
     if (m_ExternalSource)
-      m_ExternalSource->ActAfterParsingDiffArgs(request, args);
+      m_ExternalSource->ActAfterParsingDiffArgs(m_DiffReq, args);
     // Save the type of the output parameter(s) that is add by clad to the
     // derived function
-    if (request.Mode == DiffMode::jacobian) {
+    if (m_DiffReq.Mode == DiffMode::jacobian) {
       unsigned lastArgN = m_DiffReq->getNumParams() - 1;
       outputArrayStr = m_DiffReq->getParamDecl(lastArgN)->getNameAsString();
     }
 
-    auto derivativeBaseName = request.BaseFunctionName;
+    auto derivativeBaseName = m_DiffReq.BaseFunctionName;
     std::string gradientName = derivativeBaseName + funcPostfix();
     // To be consistent with older tests, nothing is appended to 'f_grad' if
     // we differentiate w.r.t. all the parameters at once.
-    if (request.Mode == DiffMode::jacobian) {
+    if (m_DiffReq.Mode == DiffMode::jacobian) {
       // If Jacobian is asked, the last parameter is the result parameter
       // and should be ignored
       if (args.size() != FD->getNumParams()-1){
@@ -346,9 +341,9 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     bool shouldCreateOverload = false;
     // FIXME: Gradient overload doesn't know how to handle additional parameters
     // added by the plugins yet.
-    if (request.Mode != DiffMode::jacobian && numExtraParam == 0)
+    if (m_DiffReq.Mode != DiffMode::jacobian && numExtraParam == 0)
       shouldCreateOverload = true;
-    if (!request.DeclarationOnly && !request.DerivedFDPrototypes.empty())
+    if (!m_DiffReq.DeclarationOnly && !m_DiffReq.DerivedFDPrototypes.empty())
       // If the overload is already created, we don't need to create it again.
       shouldCreateOverload = false;
 
@@ -411,8 +406,8 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     gradientFD->setParams(paramsRef);
     gradientFD->setBody(nullptr);
 
-    if (!request.DeclarationOnly) {
-      if (request.Mode == DiffMode::jacobian) {
+    if (!m_DiffReq.DeclarationOnly) {
+      if (m_DiffReq.Mode == DiffMode::jacobian) {
         // Reference to the output parameter.
         m_Result = BuildDeclRef(params.back());
         numParams = args.size();
@@ -451,7 +446,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
       m_DerivativeFnScope = getCurrentScope();
       beginBlock();
       if (m_ExternalSource)
-        m_ExternalSource->ActOnStartOfDerivedFnBody(request);
+        m_ExternalSource->ActOnStartOfDerivedFnBody(m_DiffReq);
 
       Stmt* gradientBody = nullptr;
 
@@ -466,9 +461,11 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
 
       // Size >= current derivative order means that there exists a declaration
       // or prototype for the currently derived function.
-      if (request.DerivedFDPrototypes.size() >= request.CurrentDerivativeOrder)
+      if (m_DiffReq.DerivedFDPrototypes.size() >=
+          m_DiffReq.CurrentDerivativeOrder)
         m_Derivative->setPreviousDeclaration(
-            request.DerivedFDPrototypes[request.CurrentDerivativeOrder - 1]);
+            m_DiffReq
+                .DerivedFDPrototypes[m_DiffReq.CurrentDerivativeOrder - 1]);
     }
     m_Sema.PopFunctionScopeInfo();
     m_Sema.PopDeclContext();
@@ -483,22 +480,18 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     return DerivativeAndOverload{result.first, gradientOverloadFD};
   }
 
-  DerivativeAndOverload
-  ReverseModeVisitor::DerivePullback(const clang::FunctionDecl* FD,
-                                     const DiffRequest& request) {
+  DerivativeAndOverload ReverseModeVisitor::DerivePullback() {
+    const clang::FunctionDecl* FD = m_DiffReq.Function;
     // FIXME: Duplication of external source here is a workaround
     // for the two 'Derive's being different functions.
     if (m_ExternalSource)
       m_ExternalSource->ActOnStartOfDerive();
-    // FIXME: We should not use const_cast to get the decl request here.
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    const_cast<DiffRequest&>(m_DiffReq) = request;
     assert(m_DiffReq.Mode == DiffMode::experimental_pullback);
     assert(m_DiffReq.Function && "Must not be null.");
 
     DiffParams args{};
-    if (!request.DVI.empty())
-      for (const auto& dParam : request.DVI)
+    if (!m_DiffReq.DVI.empty())
+      for (const auto& dParam : m_DiffReq.DVI)
         args.push_back(dParam.param);
     else
       std::copy(FD->param_begin(), FD->param_end(), std::back_inserter(args));
@@ -510,7 +503,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
 #endif
 
     if (m_ExternalSource)
-      m_ExternalSource->ActAfterParsingDiffArgs(request, args);
+      m_ExternalSource->ActAfterParsingDiffArgs(m_DiffReq, args);
 
     auto derivativeName =
         utils::ComputeEffectiveFnName(m_DiffReq.Function) + "_pullback";
@@ -557,7 +550,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     m_Derivative->setParams(params);
     m_Derivative->setBody(nullptr);
 
-    if (!request.DeclarationOnly) {
+    if (!m_DiffReq.DeclarationOnly) {
       if (m_ExternalSource)
         m_ExternalSource->ActBeforeCreatingDerivedFnBodyScope();
 
@@ -566,7 +559,7 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
 
       beginBlock();
       if (m_ExternalSource)
-        m_ExternalSource->ActOnStartOfDerivedFnBody(request);
+        m_ExternalSource->ActOnStartOfDerivedFnBody(m_DiffReq);
 
       StmtDiff bodyDiff = Visit(m_DiffReq->getBody());
       Stmt* forward = bodyDiff.getStmt();
@@ -595,9 +588,11 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
 
       // Size >= current derivative order means that there exists a declaration
       // or prototype for the currently derived function.
-      if (request.DerivedFDPrototypes.size() >= request.CurrentDerivativeOrder)
+      if (m_DiffReq.DerivedFDPrototypes.size() >=
+          m_DiffReq.CurrentDerivativeOrder)
         m_Derivative->setPreviousDeclaration(
-            request.DerivedFDPrototypes[request.CurrentDerivativeOrder - 1]);
+            m_DiffReq
+                .DerivedFDPrototypes[m_DiffReq.CurrentDerivativeOrder - 1]);
     }
     m_Sema.PopFunctionScopeInfo();
     m_Sema.PopDeclContext();


### PR DESCRIPTION
``Derive`` functions have access to the original function and the diff request through ``m_DiffRef``, there's no need to pass those as parameters. The same applies to ``m_Functor`` as it's also stored in ``m_DiffRef``.

Partially addresses #721.