### PR TITLE
Initialize derivative pointers that are allocated through malloc or realloc

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -450,16 +450,13 @@ namespace clad {
     /// \returns The atomicAdd call expression.
     clang::Expr* BuildCallToCudaAtomicAdd(clang::Expr* LHS, clang::Expr* RHS);
 
-    /// Check whether this is an assignment to a malloc or realloc call for a
-    /// derivative variable and build a call to calloc instead if it's a malloc
-    /// call or add a calloc call after a realloc call, to properly intialize
-    /// the memory to zero. Currently these configurations of size are supported
-    /// in malloc or realloc:
-    /// 1. x * sizeof(T)
-    /// 2. sizeof(T) * x
-    /// \param[in] RHS The right-hand side expression of the assignment.
-    /// @returns The call to calloc if the condition is met, otherwise nullptr.
-    clang::Expr* CheckAndBuildCallToCalloc(clang::Expr* RHS);
+    /// Check whether this is an assignment to a malloc or a realloc call for a
+    /// derivative variable and build a call to memset to follow the memory
+    /// allocation in order to properly intialize the memory to zero. \param[in]
+    /// LHS The left-hand side expression of the assignment. \param[in] RHS The
+    /// right-hand side expression of the assignment.
+    /// @returns The call to memset if the condition is met, otherwise nullptr.
+    clang::Expr* CheckAndBuildCallToMemset(clang::Expr* LHS, clang::Expr* RHS);
 
     static DeclDiff<clang::StaticAssertDecl>
     DifferentiateStaticAssertDecl(const clang::StaticAssertDecl* SAD);

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -450,6 +450,17 @@ namespace clad {
     /// \returns The atomicAdd call expression.
     clang::Expr* BuildCallToCudaAtomicAdd(clang::Expr* LHS, clang::Expr* RHS);
 
+    /// Check whether this is an assignment to a malloc or realloc call for a
+    /// derivative variable and build a call to calloc instead if it's a malloc
+    /// call or add a calloc call after a realloc call, to properly intialize
+    /// the memory to zero. Currently these configurations of size are supported
+    /// in malloc or realloc:
+    /// 1. x * sizeof(T)
+    /// 2. sizeof(T) * x
+    /// \param[in] RHS The right-hand side expression of the assignment.
+    /// @returns The call to calloc if the condition is met, otherwise nullptr.
+    clang::Expr* CheckAndBuildCallToCalloc(clang::Expr* RHS);
+
     static DeclDiff<clang::StaticAssertDecl>
     DifferentiateStaticAssertDecl(const clang::StaticAssertDecl* SAD);
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3389,8 +3389,6 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
       Stmts& block =
           promoteToFnScope ? m_Globals : getCurrentBlock(direction::forward);
       addToBlock(DSDiff, block);
-      if (memsetCalls.empty())
-        printf("memsetCalls is empty\n");
       for (Stmt* memset : memsetCalls)
         addToBlock(memset, block);
     }

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -531,24 +531,21 @@ namespace clad {
   Expr* VisitorBase::GetFunctionCall(const std::string& funcName,
                                      const std::string& nmspace,
                                      llvm::SmallVectorImpl<Expr*>& callArgs) {
-    NamespaceDecl* NSD = nullptr;
     CXXScopeSpec SS;
-
+    DeclContext* DC = m_Context.getTranslationUnitDecl();
     if (!nmspace.empty()) {
-      NSD = utils::LookupNSD(m_Sema, nmspace, /*shouldExist=*/true);
+      NamespaceDecl* NSD =
+          utils::LookupNSD(m_Sema, nmspace, /*shouldExist=*/true);
       SS.Extend(m_Context, NSD, noLoc, noLoc);
+      DC = NSD;
     }
-    DeclContext* DC = NSD;
 
     IdentifierInfo* II = &m_Context.Idents.get(funcName);
     DeclarationName name(II);
     DeclarationNameInfo DNI(name, noLoc);
     LookupResult R(m_Sema, DNI, Sema::LookupOrdinaryName);
 
-    if (DC)
-      m_Sema.LookupQualifiedName(R, DC);
-    else
-      m_Sema.LookupQualifiedName(R, m_Context.getTranslationUnitDecl());
+    m_Sema.LookupQualifiedName(R, DC);
     Expr* UnresolvedLookup = nullptr;
     if (!R.empty())
       UnresolvedLookup =

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -531,11 +531,14 @@ namespace clad {
   Expr* VisitorBase::GetFunctionCall(const std::string& funcName,
                                      const std::string& nmspace,
                                      llvm::SmallVectorImpl<Expr*>& callArgs) {
-    NamespaceDecl* NSD =
-        utils::LookupNSD(m_Sema, nmspace, /*shouldExist=*/true);
-    DeclContext* DC = NSD;
+    NamespaceDecl* NSD = nullptr;
     CXXScopeSpec SS;
-    SS.Extend(m_Context, NSD, noLoc, noLoc);
+
+    if (!nmspace.empty()) {
+      NSD = utils::LookupNSD(m_Sema, nmspace, /*shouldExist=*/true);
+      SS.Extend(m_Context, NSD, noLoc, noLoc);
+    }
+    DeclContext* DC = NSD;
 
     IdentifierInfo* II = &m_Context.Idents.get(funcName);
     DeclarationName name(II);
@@ -544,6 +547,8 @@ namespace clad {
 
     if (DC)
       m_Sema.LookupQualifiedName(R, DC);
+    else
+      m_Sema.LookupQualifiedName(R, m_Context.getTranslationUnitDecl());
     Expr* UnresolvedLookup = nullptr;
     if (!R.empty())
       UnresolvedLookup =

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -391,7 +391,7 @@ double structPointer (double x) {
 // CHECK-NEXT: }
 
 double cStyleMemoryAlloc(double x, size_t n) {
-  T* t = (T*)malloc(n * sizeof(T));
+  T* t = (T*)malloc(sizeof(T) * n);
   memset(t, 0, n * sizeof(T));
   t->x = x;
   double* p = (double*)calloc(1, sizeof(double));
@@ -408,7 +408,7 @@ double cStyleMemoryAlloc(double x, size_t n) {
 // CHECK: void cStyleMemoryAlloc_grad_0(double x, size_t n, double *_d_x) {
 // CHECK-NEXT:     size_t _d_n = 0UL;
 // CHECK-NEXT:     T *_d_t = (T *)calloc(n, sizeof(T));
-// CHECK-NEXT:     T *t = (T *)malloc(n * sizeof(T));
+// CHECK-NEXT:     T *t = (T *)malloc(sizeof(T) * n);
 // CHECK-NEXT:     memset(_d_t, 0, n * sizeof(T));
 // CHECK-NEXT:     memset(t, 0, n * sizeof(T));
 // CHECK-NEXT:     double _t0 = t->x;

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -407,7 +407,7 @@ double cStyleMemoryAlloc(double x, size_t n) {
 
 // CHECK: void cStyleMemoryAlloc_grad_0(double x, size_t n, double *_d_x) {
 // CHECK-NEXT:     size_t _d_n = 0UL;
-// CHECK-NEXT:     T *_d_t = (T *)malloc(n * sizeof(T));
+// CHECK-NEXT:     T *_d_t = (T *)calloc(n, sizeof(T));
 // CHECK-NEXT:     T *t = (T *)malloc(n * sizeof(T));
 // CHECK-NEXT:     memset(_d_t, 0, n * sizeof(T));
 // CHECK-NEXT:     memset(t, 0, n * sizeof(T));
@@ -422,6 +422,7 @@ double cStyleMemoryAlloc(double x, size_t n) {
 // CHECK-NEXT:     double *_t2 = p;
 // CHECK-NEXT:     double *_t3 = _d_p;
 // CHECK-NEXT:     _d_p = (double *)realloc(_d_p, 2 * sizeof(double));
+// CHECK-NEXT:     _d_p = (double *)calloc(2, sizeof(double));
 // CHECK-NEXT:     p = (double *)realloc(p, 2 * sizeof(double));
 // CHECK-NEXT:     double _t4 = p[1];
 // CHECK-NEXT:     p[1] = 2 * x;

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -407,7 +407,8 @@ double cStyleMemoryAlloc(double x, size_t n) {
 
 // CHECK: void cStyleMemoryAlloc_grad_0(double x, size_t n, double *_d_x) {
 // CHECK-NEXT:     size_t _d_n = 0UL;
-// CHECK-NEXT:     T *_d_t = (T *)calloc(n, sizeof(T));
+// CHECK-NEXT:     T *_d_t = (T *)malloc(sizeof(T) * n);
+// CHECK-NEXT:     memset(_d_t, 0, sizeof(T) * n);
 // CHECK-NEXT:     T *t = (T *)malloc(sizeof(T) * n);
 // CHECK-NEXT:     memset(_d_t, 0, n * sizeof(T));
 // CHECK-NEXT:     memset(t, 0, n * sizeof(T));
@@ -422,7 +423,7 @@ double cStyleMemoryAlloc(double x, size_t n) {
 // CHECK-NEXT:     double *_t2 = p;
 // CHECK-NEXT:     double *_t3 = _d_p;
 // CHECK-NEXT:     _d_p = (double *)realloc(_d_p, 2 * sizeof(double));
-// CHECK-NEXT:     _d_p = (double *)calloc(2, sizeof(double));
+// CHECK-NEXT:     memset(_d_p, 0, 2 * sizeof(double));
 // CHECK-NEXT:     p = (double *)realloc(p, 2 * sizeof(double));
 // CHECK-NEXT:     double _t4 = p[1];
 // CHECK-NEXT:     p[1] = 2 * x;


### PR DESCRIPTION
This PR identifies calls to `malloc` or `realloc` and for the derivative pointers it:
* replaces `malloc` with `calloc`
* adds a `calloc` call after `realloc` 