### PR TITLE
Don't create pullbacks for function with not varied parameters

### DIFF
--- a/lib/Differentiator/ActivityAnalyzer.cpp
+++ b/lib/Differentiator/ActivityAnalyzer.cpp
@@ -122,15 +122,11 @@ bool VariedAnalyzer::VisitCallExpr(CallExpr* CE) {
   bool noHiddenParam = (CE->getNumArgs() == FD->getNumParams());
   if (noHiddenParam) {
     MutableArrayRef<ParmVarDecl*> FDparam = FD->parameters();
-    m_Varied = true;
-    m_Marking = true;
     for (std::size_t i = 0, e = CE->getNumArgs(); i != e; ++i) {
       clang::Expr* par = CE->getArg(i);
       TraverseStmt(par);
       m_VariedDecls.insert(FDparam[i]);
     }
-    m_Varied = false;
-    m_Marking = false;
   }
   return true;
 }
@@ -141,7 +137,8 @@ bool VariedAnalyzer::VisitDeclStmt(DeclStmt* DS) {
       m_Varied = false;
       TraverseStmt(init);
       m_Marking = true;
-      if (m_Varied)
+      QualType VDTy = cast<VarDecl>(D)->getType();
+      if (m_Varied || utils::isArrayOrPointerType(VDTy))
         copyVarToCurBlock(cast<VarDecl>(D));
       m_Marking = false;
     }

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -624,7 +624,19 @@ namespace clad {
       return true;
 
     if (!m_ActivityRunInfo.HasAnalysisRun) {
-      std::copy(Function->param_begin(), Function->param_end(),
+      ArrayRef<ParmVarDecl*> FDparam = Function->parameters();
+      std::vector<ParmVarDecl*> derivedParam;
+
+      for(auto* parameter: FDparam){
+        QualType parType = parameter->getType();
+        if(parType->isPointerType()){
+          if(!parType->getPointeeType().isConstQualified())
+            derivedParam.push_back(parameter);
+        }else if(!parType.isConstQualified())
+            derivedParam.push_back(parameter);
+      }
+
+      std::copy(derivedParam.begin(), derivedParam.end(),
                 std::inserter(m_ActivityRunInfo.ToBeRecorded,
                               m_ActivityRunInfo.ToBeRecorded.end()));
 

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -620,20 +620,16 @@ namespace clad {
     if (!EnableVariedAnalysis)
       return true;
 
-    if (VD->getType()->isPointerType() || isa<ArrayType>(VD->getType()))
-      return true;
-
     if (!m_ActivityRunInfo.HasAnalysisRun) {
       ArrayRef<ParmVarDecl*> FDparam = Function->parameters();
       std::vector<ParmVarDecl*> derivedParam;
 
-      for(auto* parameter: FDparam){
+      for (auto* parameter : FDparam) {
         QualType parType = parameter->getType();
-        if(parType->isPointerType()){
-          if(!parType->getPointeeType().isConstQualified())
-            derivedParam.push_back(parameter);
-        }else if(!parType.isConstQualified())
-            derivedParam.push_back(parameter);
+        while (parType->isPointerType())
+          parType = parType->getPointeeType();
+        if (!parType.isConstQualified())
+          derivedParam.push_back(parameter);
       }
 
       std::copy(derivedParam.begin(), derivedParam.end(),

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1800,6 +1800,9 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
         // subexpression.
         if (const auto* MTE = dyn_cast<MaterializeTemporaryExpr>(arg))
           arg = clad_compat::GetSubExpr(MTE)->IgnoreImpCasts();
+        // FIXME: We should consider moving this code in the VariedAnalysis
+        // where we could decide to remove pullback requests from the
+        // diff graph.
         class VariedChecker : public RecursiveASTVisitor<VariedChecker> {
           const DiffRequest& Request;
 


### PR DESCRIPTION
This PR enables clad not to create pullbacks if the parameters are either constant or not varied. 

We should revert the changes once Varied Analysis is redesigned to track varied expression/statements and not only declarations. 

Fixes: #642, Fixes #682 