### PR TITLE
[cmake] Enable building clad within the LLVM monorepo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,37 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/)
 
   set( CLAD_BUILT_STANDALONE 1 )
+else()
+  # Not standalone; we are building within llvm
+  if (NOT "clang" IN_LIST LLVM_ENABLE_PROJECTS)
+    message(FATAL_ERROR "Clang is not enabled; consider enabling it in LLVM_ENABLED_PROJECTS")
+  endif()
+
+  message(STATUS "Building Clad as part of LLVM")
+
+  # Try finding the LLVMConfig.cmake if we build against prebuilt LLVM
+  set(LLVM_CMAKE_PATH "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
+  set(LLVMCONFIG_FILE "${LLVM_CMAKE_PATH}/LLVMConfig.cmake")
+  if(EXISTS ${LLVMCONFIG_FILE})
+    list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_PATH}")
+    include(${LLVMCONFIG_FILE})
+  endif()
+
+  if (NOT CLANG_INCLUDE_DIRS)
+    set (CLANG_INCLUDE_DIRS "${LLVM_MAIN_SRC_DIR}/tools/clang/include")
+    if (NOT EXISTS ${CLANG_INCLUDE_DIRS})
+      # Otherwise assume the monorepo layout.
+      set (CLANG_INCLUDE_DIRS ${LLVM_MAIN_SRC_DIR}/../clang/include )
+    endif()
+    set (CLANG_INCLUDE_DIRS "${CLANG_INCLUDE_DIRS}" "${LLVM_BINARY_DIR}/tools/clang/include")
+  endif()
+  if (NOT LLVM_INCLUDE_DIRS)
+    set (LLVM_INCLUDE_DIRS "${LLVM_MAIN_SRC_DIR}/include" "${LLVM_BINARY_DIR}/include")
+  endif()
 endif()
+
+include_directories(SYSTEM ${CLANG_INCLUDE_DIRS})
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 
 ## Code Coverage Configuration
 add_library(coverage_config INTERFACE)

--- a/cmake/modules/AddClad.cmake
+++ b/cmake/modules/AddClad.cmake
@@ -46,6 +46,12 @@ function(ENABLE_CLAD_FOR_TARGET executable)
   set_property(TARGET ${executable} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
   add_dependencies(${executable} clad)
+
+  # We are probably building clad with clang.
+  if (NOT CLAD_BUILT_STANDALONE)
+    add_dependencies(${executable} clad)
+  endif()
+
   # If clad.so changes we don't need to relink but to rebuild the source files.
   # $<TARGET_FILE:clad> does not work for OBJECT_DEPENDS.
   set (CLAD_SO_PATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/clad${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/cmake/modules/CladGoogleTest.cmake
+++ b/cmake/modules/CladGoogleTest.cmake
@@ -1,5 +1,5 @@
 set(_gtest_byproduct_binary_dir
-  ${CMAKE_BINARY_DIR}/unittests/googletest-prefix/src/googletest-build)
+  ${CLAD_BINARY_DIR}/unittests/googletest-prefix/src/googletest-build)
 set(_gtest_byproducts
   ${_gtest_byproduct_binary_dir}/lib/libgtest.a
   ${_gtest_byproduct_binary_dir}/lib/libgtest_main.a


### PR DESCRIPTION
This patch allows us to build with `cmake -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_EXTERNAL_PROJECTS=clad -DLLVM_EXTERNAL_CLAD_SOURCE_DIR=<path_to_clad> ...