### PR TITLE
Initialize adjoints of aggregate types with init lists

### DIFF
--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -585,15 +585,6 @@ template <typename T, ::std::size_t N, typename U>
 void size_pullback(::std::array<T, N>* /*a*/, U /*d_y*/,
                    ::std::array<T, N>* /*d_a*/) noexcept {}
 template <typename T, ::std::size_t N>
-::clad::ValueAndAdjoint<::std::array<T, N>, ::std::array<T, N>>
-constructor_reverse_forw(::clad::ConstructorReverseForwTag<::std::array<T, N>>,
-                         const ::std::array<T, N>& arr,
-                         const ::std::array<T, N>& d_arr) {
-  ::std::array<T, N> a = arr;
-  ::std::array<T, N> d_a = d_arr;
-  return {a, d_a};
-}
-template <typename T, ::std::size_t N>
 void constructor_pullback(::std::array<T, N>* a, const ::std::array<T, N>& arr,
                           ::std::array<T, N>* d_a, ::std::array<T, N>* d_arr) {
   for (size_t i = 0; i < N; ++i)

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4280,10 +4280,14 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
     if (Expr* customReverseForwFnCall = BuildCallToCustomForwPassFn(
             CE->getConstructor(), primalArgs, reverseForwAdjointArgs,
             /*baseExpr=*/nullptr)) {
-      if (RD->isAggregate())
+      if (RD->isAggregate()) {
         diag(DiagnosticsEngine::Note, CE->getConstructor()->getBeginLoc(),
              "No need to provide a custom constructor forward sweep for an "
              "aggregate type.");
+        diag(DiagnosticsEngine::Warning, CE->getBeginLoc(),
+             "No need to provide a custom constructor forward sweep for an "
+             "aggregate type.");
+      }
       Expr* callRes = StoreAndRef(customReverseForwFnCall);
       Expr* val =
           utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -13,8 +13,8 @@
 #include "clad/Differentiator/ErrorEstimator.h"
 #include "clad/Differentiator/Sins.h"
 #include "clad/Differentiator/StmtClone.h"
-
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/Lex/Preprocessor.h"
@@ -26,6 +26,7 @@
 #include "clang/Sema/Template.h"
 
 #include <algorithm>
+#include <llvm/ADT/SmallVector.h>
 #include <numeric>
 
 #include "clad/Differentiator/Compatibility.h"

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -418,6 +418,13 @@ namespace clad {
       Expr* zero = ConstantFolder::synthesizeLiteral(T, m_Context, /*val=*/0);
       return m_Sema.ActOnInitList(noLoc, {zero}, noLoc).get();
     }
+    if (const auto* RD = T->getAsCXXRecordDecl())
+      if (RD->hasDefinition() && !RD->isUnion() && RD->isAggregate()) {
+        llvm::SmallVector<Expr*, 4> adjParams;
+        for (const FieldDecl* FD : RD->fields())
+          adjParams.push_back(getZeroInit(FD->getType()));
+        return m_Sema.ActOnInitList(noLoc, adjParams, noLoc).get();
+      }
     return m_Sema.ActOnInitList(noLoc, {}, noLoc).get();
   }
 

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -499,7 +499,7 @@ int main() {
 // CHECK-NEXT:        clad::tape<std::array<double, 3> > _t2 = {};
 // CHECK-NEXT:        clad::tape<double> _t3 = {};
 // CHECK-NEXT:        clad::tape<std::array<double, 3> > _t4 = {};
-// CHECK-NEXT:        std::array<double, 3> _d_a({});
+// CHECK-NEXT:        std::array<double, 3> _d_a({{.*}});
 // CHECK-NEXT:        std::array<double, 3> a;
 // CHECK-NEXT:        std::array<double, 3> _t0 = a;
 // CHECK-NEXT:        {{.*}}fill_reverse_forw(&a, x, &_d_a, *_d_x);
@@ -544,7 +544,7 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK:     void fn16_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:         std::array<double, 2> _d_a({});
+// CHECK-NEXT:         std::array<double, 2> _d_a({{.*}});
 // CHECK-NEXT:         std::array<double, 2> a;
 // CHECK-NEXT:         std::array<double, 2> _t0 = a;
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, _r0);
@@ -554,7 +554,7 @@ int main() {
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t4 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, _r1);
 // CHECK-NEXT:         double _t5 = _t4.value;
 // CHECK-NEXT:         _t4.value = y;
-// CHECK-NEXT:         std::array<double, 3> _d__b({});
+// CHECK-NEXT:         std::array<double, 3> _d__b({{.*}});
 // CHECK-NEXT:         std::array<double, 3> _b0;
 // CHECK-NEXT:         std::array<double, 3> _t6 = _b0;
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t7 = {{.*}}operator_subscript_reverse_forw(&_b0, 0, &_d__b, _r2);
@@ -568,23 +568,22 @@ int main() {
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t13 = {{.*}}operator_subscript_reverse_forw(&_b0, 2, &_d__b, _r4);
 // CHECK-NEXT:         double _t14 = _t13.value;
 // CHECK-NEXT:         _t13.value = x * x;
-// CHECK-NEXT:         ::clad::ValueAndAdjoint< ::std::array<double, {{3U|3UL}}>, ::std::array<double, {{3U|3UL}}> > _t15 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<array<double, 3> >(), _b0, _d__b);
-// CHECK-NEXT:         std::array<double, 3> _d_b = _t15.adjoint;
-// CHECK-NEXT:         const std::array<double, 3> b = _t15.value;
-// CHECK-NEXT:         std::array<double, 2> _t18 = a;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t19 = {{.*}}back_reverse_forw(&a, &_d_a);
+// CHECK-NEXT:         std::array<double, 3> _d_b = {{.*}};
+// CHECK-NEXT:         const std::array<double, 3> b = _b0;
+// CHECK-NEXT:         std::array<double, 2> _t17 = a;
+// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t18 = {{.*}}back_reverse_forw(&a, &_d_a);
+// CHECK-NEXT:         std::array<double, 3> _t19 = b;
+// CHECK-NEXT:         {{.*}}value_type _t16 = b.front();
 // CHECK-NEXT:         std::array<double, 3> _t20 = b;
-// CHECK-NEXT:         {{.*}}value_type _t17 = b.front();
+// CHECK-NEXT:         {{.*}}value_type _t15 = b.at(2);
 // CHECK-NEXT:         std::array<double, 3> _t21 = b;
-// CHECK-NEXT:         {{.*}}value_type _t16 = b.at(2);
-// CHECK-NEXT:         std::array<double, 3> _t22 = b;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}}back_pullback(&_t18, 1 * _t16 * _t17, &_d_a);
-// CHECK-NEXT:             {{.*}}front_pullback(&_t20, _t19.value * 1 * _t16, &_d_b);
+// CHECK-NEXT:             {{.*}}back_pullback(&_t17, 1 * _t15 * _t16, &_d_a);
+// CHECK-NEXT:             {{.*}}front_pullback(&_t19, _t18.value * 1 * _t15, &_d_b);
 // CHECK-NEXT:             {{.*}}size_type _r5 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}at_pullback(&_t21, 2, _t19.value * _t17 * 1, &_d_b, &_r5);
+// CHECK-NEXT:             {{.*}}at_pullback(&_t20, 2, _t18.value * _t16 * 1, &_d_b, &_r5);
 // CHECK-NEXT:             {{.*}}size_type _r6 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t22, 1, 1, &_d_b, &_r6);
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t21, 1, 1, &_d_b, &_r6);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {{.*}}constructor_pullback(&b, _b0, &_d_b, &_d__b);
 // CHECK-NEXT:         {
@@ -629,7 +628,7 @@ int main() {
 // CHECK-NEXT:     }
 
 // CHECK:     void fn17_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:         std::array<double, 50> _d_a({});
+// CHECK-NEXT:         std::array<double, 50> _d_a({{.*}});
 // CHECK-NEXT:         std::array<double, 50> a;
 // CHECK-NEXT:         std::array<double, 50> _t0 = a;
 // CHECK-NEXT:         {{.*}}fill_reverse_forw(&a, y + x + x, &_d_a, _r0);
@@ -653,7 +652,7 @@ int main() {
 // CHECK-NEXT:     }
 
 // CHECK:     void fn18_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:         std::array<double, 2> _d_a({});
+// CHECK-NEXT:         std::array<double, 2> _d_a({{.*}});
 // CHECK-NEXT:         std::array<double, 2> a;
 // CHECK-NEXT:         std::array<double, 2> _t0 = a;
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, _r0);

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -395,10 +395,10 @@ MyStruct fn12(MyStruct s) {
 
 // CHECK: void fn12_grad(MyStruct s, MyStruct *_d_s) {
 // CHECK-NEXT:     MyStruct _t0 = s;
-// CHECK-NEXT:     clad::ValueAndAdjoint<MyStruct &, MyStruct &> _t1 = _t0.operator_equal_forw({2 * s.a, 2 * s.b + 2}, &(*_d_s), {});
+// CHECK-NEXT:     clad::ValueAndAdjoint<MyStruct &, MyStruct &> _t1 = _t0.operator_equal_forw({2 * s.a, 2 * s.b + 2}, &(*_d_s), {0., 0.});
 // CHECK-NEXT:    {
-// CHECK-NEXT:        MyStruct _r0 = {};
-// CHECK-NEXT:        _t0.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, {}, &(*_d_s), &_r0);
+// CHECK-NEXT:        MyStruct _r0 = {0., 0.};
+// CHECK-NEXT:        _t0.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, {0., 0.}, &(*_d_s), &_r0);
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;
 // CHECK-NEXT:    }
@@ -465,6 +465,24 @@ void fn13(double *x, double *y, int size)
 // CHECK-NEXT:        _d_p.j = 0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
+// CHECK-NEXT:}
+
+double fn14(double x, double y) {
+  MyStruct s = {2 * y, 3 * x + 2};
+  return s.a * s.b;
+}
+
+// CHECK: void fn14_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK-NEXT:     MyStruct _d_s = {0., 0.};
+// CHECK-NEXT:     MyStruct s = {2 * y, 3 * x + 2};
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_s.a += 1 * s.b;
+// CHECK-NEXT:         _d_s.b += s.a * 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_y += 2 * _d_s.a;
+// CHECK-NEXT:         *_d_x += 3 * _d_s.b;
+// CHECK-NEXT:     }
 // CHECK-NEXT:}
 
 void print(const Tangent& t) {
@@ -535,6 +553,9 @@ int main() {
     fn13_test.execute(x, y, 3, d_x, d_y);
     printArray(d_x, size); // CHECK-EXEC: {2.00, 2.00, 2.00}
     printArray(d_y, size); // CHECK-EXEC: {0.00, 0.00, 0.00}
+
+    INIT_GRADIENT(fn14);
+    TEST_GRADIENT(fn14, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);    // CHECK-EXEC: {30.00, 22.00}
 }
 
 // CHECK: void sum_pullback(Tangent &t, double _d_y, Tangent *_d_t) {

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang %s -I%S/../../include -oUserDefinedTypes.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oUserDefinedTypes.out -Xclang -verify 2>&1 | %filecheck %s
 // RUN: ./UserDefinedTypes.out | %filecheck_exec %s
 // RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-tbr %s -I%S/../../include -oUserDefinedTypes.out
 // RUN: ./UserDefinedTypes.out | %filecheck_exec %s
@@ -485,6 +485,35 @@ double fn14(double x, double y) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:}
 
+template <typename T, std::size_t N>
+struct SimpleArray {
+    T elements[N]; // Aggregate initialization
+};
+
+namespace clad {
+namespace custom_derivatives {
+namespace class_functions {
+template<::std::size_t N>
+::clad::ValueAndAdjoint<SimpleArray<double, N>, SimpleArray<double, N>> // expected-note {{'clad::custom_derivatives::class_functions::constructor_reverse_forw<2}}{{' is defined here}}
+constructor_reverse_forw(::clad::ConstructorReverseForwTag<SimpleArray<double, N>>) {
+  SimpleArray<double, N> a;
+  SimpleArray<double, N> d_a;
+  return {a, d_a};
+}
+}}}
+
+double fn15(double x, double y) {
+  SimpleArray<double, 2> arr; // expected-warning {{'SimpleArray<double, 2>' is an aggregate type and its constructor does not require a user-defined forward sweep function}}
+  return arr.elements[0];
+}
+
+// CHECK:void fn15_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK-NEXT:    ::clad::ValueAndAdjoint<SimpleArray<double, {{2U|2UL|2ULL}}>, SimpleArray<double, {{2U|2UL|2ULL}}> > _t0 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<SimpleArray<double, 2> >());
+// CHECK-NEXT:    SimpleArray<double, 2> _d_arr(_t0.adjoint);
+// CHECK-NEXT:    SimpleArray<double, 2> arr(_t0.value);
+// CHECK-NEXT:    _d_arr.elements[0] += 1;
+// CHECK-NEXT:}
+
 void print(const Tangent& t) {
   for (int i = 0; i < 5; ++i) {
     printf("%.2f", t.data[i]);
@@ -556,6 +585,8 @@ int main() {
 
     INIT_GRADIENT(fn14);
     TEST_GRADIENT(fn14, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);    // CHECK-EXEC: {30.00, 22.00}
+
+    INIT_GRADIENT(fn15);
 }
 
 // CHECK: void sum_pullback(Tangent &t, double _d_y, Tangent *_d_t) {

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -186,16 +186,16 @@ int main() {
 // CHECK: void f1_darg0_grad(float x, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0.F;
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::sin_pushforward(x, _d_x0);
-// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t1 = {};
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t1 = {0.F, 0.F};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t10 = clad::custom_derivatives{{(::std)?}}::cos_pushforward(x, _d_x0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d__t0.pushforward += 1;
 // CHECK-NEXT:         _d__t1.pushforward += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r3 = {};
+// CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r3 = {0.F, 0.F};
 // CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(&_t10, {{.*}}cos_pushforward(x, _d_x0), &_d__t1, &_r3);
 // CHECK-NEXT:         float _r4 = 0.F;
 // CHECK-NEXT:         float _r5 = 0.F;
@@ -204,7 +204,7 @@ int main() {
 // CHECK-NEXT:         _d__d_x += _r5;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r0 = {};
+// CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r0 = {0.F, 0.F};
 // CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(&_t00, {{.*}}sin_pushforward(x, _d_x0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
@@ -225,11 +225,11 @@ int main() {
 // CHECK: void f2_darg0_grad(float x, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0.F;
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::exp_pushforward(x, _d_x0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r0 = {};
+// CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r0 = {0.F, 0.F};
 // CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}exp_pushforward(x, _d_x0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
@@ -250,11 +250,11 @@ int main() {
 // CHECK: void f3_darg0_grad(float x, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0.F;
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {};
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::log_pushforward(x, _d_x0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r0 = {};
+// CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r0 = {0.F, 0.F};
 // CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}log_pushforward(x, _d_x0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
@@ -275,11 +275,11 @@ int main() {
 // CHECK: void f4_darg0_grad(float x, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0.F;
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {};
+// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, 4.F, _d_x0, 0.F);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}} _r0 = {};
+// CHECK-NEXT:         {{.*}} _r0 = {0.F, 0.F};
 // CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}pow_pushforward(x, 4.F, _d_x0, 0.F), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
@@ -300,11 +300,11 @@ int main() {
 // CHECK: void f5_darg0_grad(float x, float *_d_x) {
 // CHECK-NEXT:     float _d__d_x = 0.F;
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {};
+// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(2.F, x, 0.F, _d_x0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}} _r0 = {};
+// CHECK-NEXT:         {{.*}} _r0 = {0.F, 0.F};
 // CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}pow_pushforward(2.F, x, 0.F, _d_x0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
@@ -328,11 +328,11 @@ int main() {
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     float _d__d_y = 0.F;
 // CHECK-NEXT:     float _d_y0 = 0;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {};
+// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}} _r0 = {};
+// CHECK-NEXT:         {{.*}} _r0 = {0.F, 0.F};
 // CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}pow_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
@@ -358,11 +358,11 @@ int main() {
 // CHECK-NEXT:     float _d_x0 = 0;
 // CHECK-NEXT:     float _d__d_y = 0.F;
 // CHECK-NEXT:     float _d_y0 = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {};
+// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives{{(::std)?}}::pow_pushforward(x, y, _d_x0, _d_y0);
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}} _r0 = {};
+// CHECK-NEXT:         {{.*}} _r0 = {0.F, 0.F};
 // CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}pow_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -43,7 +43,7 @@ double f2(double x, double y){
 // CHECK-NEXT:     double _d_x0 = 1;
 // CHECK-NEXT:     double _d__d_y = 0.;
 // CHECK-NEXT:     double _d_y0 = 0;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {};
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {0., 0.};
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
 // CHECK-NEXT:     double _d__d_ans = 0.;
 // CHECK-NEXT:     double _d_ans = _t00.pushforward;
@@ -53,7 +53,7 @@ double f2(double x, double y){
 // CHECK-NEXT:     _d__t0.value += _d_ans0;
 // CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}}ValueAndPushforward<double, double> _r0 = {};
+// CHECK-NEXT:         {{.*}}ValueAndPushforward<double, double> _r0 = {0., 0.};
 // CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, f_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
 // CHECK-NEXT:         double _r1 = 0.;
 // CHECK-NEXT:         double _r2 = 0.;
@@ -81,7 +81,7 @@ double f2(double x, double y){
 // CHECK-NEXT:     double _d_x0 = 0;
 // CHECK-NEXT:     double _d__d_y = 0.;
 // CHECK-NEXT:     double _d_y0 = 1;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {};
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {0., 0.};
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
 // CHECK-NEXT:     double _d__d_ans = 0.;
 // CHECK-NEXT:     double _d_ans = _t00.pushforward;
@@ -91,7 +91,7 @@ double f2(double x, double y){
 // CHECK-NEXT:     _d__t0.value += _d_ans0;
 // CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}}ValueAndPushforward<double, double> _r0 = {};
+// CHECK-NEXT:         {{.*}}ValueAndPushforward<double, double> _r0 = {0., 0.};
 // CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, f_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
 // CHECK-NEXT:         double _r1 = 0.;
 // CHECK-NEXT:         double _r2 = 0.;


### PR DESCRIPTION
With aggregate types, we don't have to rely on the default initialization or custom constructor forward passes to zero-initialize its fields:
```
struct aggrStruct {
  double a = 1;
  float b;
  ...
};
```
This option is incorrect since ``_d_x.a`` will be initialized to ``1``:
```
aggrStruct _d_x{};
```
This option could be correct but is just unnecessary:
```
... _t1 = custom_reverse_forward(...);
aggrStruct _d_x = _t1.adjoint; // unnecessary
```
This PR instead implements a simpler solution:
```
aggrStruct _d_x{0., 0.F};
```