### PR TITLE
Don't consider arrays as a special case in DifferentiateVarDecl

### DIFF
--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Post review comments
         id: post-review
-        uses: ZedThree/clang-tidy-review/post@v0.18.0
+        uses: ZedThree/clang-tidy-review/post@v0.20.1
         with:
           max_comments: 10
 

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -30,7 +30,7 @@ jobs:
           git config --global --add safe.directory /github/workspace
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.18.0
+        uses: ZedThree/clang-tidy-review@v0.20.1
         id: review
         with:
           build_dir: build
@@ -47,4 +47,4 @@ jobs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=On
 
       - name: Upload artifacts
-        uses: ZedThree/clang-tidy-review/upload@v0.18.0
+        uses: ZedThree/clang-tidy-review/upload@v0.20.1


### PR DESCRIPTION
This PR improves the support for array types in ``getZeroInit`` and simplifies ``DifferentiateVarDecl`` using that change.

Note: most of the diff comes from the change in indentation