### PR TITLE
Enable differentiation when functions are defined in transparent contexts

### DIFF
--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -65,6 +65,9 @@ static void registerDerivative(FunctionDecl* derivedFD, Sema& semaRef) {
   // Consider out-of-line virtual functions.
   {
     DeclContext* LookupCtx = derivedFD->getDeclContext();
+    // Find the first non-transparent context to perform the lookup in.
+    while (LookupCtx->isTransparentContext())
+      LookupCtx = LookupCtx->getParent();
     auto R = LookupCtx->noload_lookup(derivedFD->getDeclName());
 
     for (NamedDecl* I : R) {

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -319,6 +319,10 @@ double f17(double x) {
   return 2*y;
 }
 
+extern "C" {
+  double f18(double x) { return x * x; }
+}
+
 int main () { //expected-no-diagnostics
   float f_result[2];
   double d_result[2];
@@ -417,6 +421,9 @@ int main () { //expected-no-diagnostics
   INIT_GRADIENT(f17);
 
   TEST_GRADIENT(f17, /*numOfDerivativeArgs=*/1, -3, &d_result[0]); // CHECK-EXEC: {-2.00}
-  
+
+  auto f18_darg0 = clad::differentiate(f18, 0);
+  printf("Result is = %f\n", f18_darg0.execute(1)); // CHECK-EXEC: Result is = 2
+
   return 0;
 }


### PR DESCRIPTION
This supports differentiating functions defined places such as in extern C contexts.