### PR TITLE
Initialize object adjoints using a copy of the original

### DIFF
--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -453,36 +453,6 @@ void at_pullback(::std::vector<T>* vec,
 }
 
 template <typename T, typename S, typename U>
-::clad::ValueAndAdjoint<::std::vector<T>, ::std::vector<T>>
-constructor_reverse_forw(::clad::ConstructorReverseForwTag<::std::vector<T>>,
-                         S count, U val,
-                         typename ::std::vector<T>::allocator_type alloc,
-                         S d_count, U d_val,
-                         typename ::std::vector<T>::allocator_type d_alloc) {
-  ::std::vector<T> v(count, val);
-  ::std::vector<T> d_v(count, 0);
-  return {v, d_v};
-}
-
-// A specialization for std::initializer_list (which is replaced with
-// clad::array).
-template <typename T>
-::clad::ValueAndAdjoint<::std::vector<T>, ::std::vector<T>>
-constructor_reverse_forw(
-    ::clad::ConstructorReverseForwTag<::std::vector<T>>,
-    const clad::array<T>& list,
-    const typename ::std::vector<T>::allocator_type& alloc,
-    const clad::array<T>& d_list,
-    const typename ::std::vector<T>::allocator_type& d_alloc) {
-  ::std::vector<T> v(list.size());
-  const T* iter = list.begin();
-  for (T& el : v)
-    el = *(iter++);
-  ::std::vector<T> d_v(list.size(), 0);
-  return {v, d_v};
-}
-
-template <typename T, typename S, typename U>
 void constructor_pullback(::std::vector<T>* v, S count, U val,
                           typename ::std::vector<T>::allocator_type alloc,
                           ::std::vector<T>* d_v, S* d_count, U* d_val,

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -222,8 +222,9 @@ int main() {
                                               // CHECK-EXEC: 54.00 42.00
 
   // CHECK: void CallFunctor_grad(double i, double j, double *_d_i, double *_d_j) {
-  // CHECK-NEXT:     Experiment _d_E({});
   // CHECK-NEXT:     Experiment E(3, 5);
+  // CHECK-NEXT:     Experiment _d_E(E);
+  // CHECK-NEXT:     clad::zero_init(_d_E);
   // CHECK-NEXT:     Experiment _t0 = E;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r2 = 0.;
@@ -265,8 +266,9 @@ int main() {
   // CHECK: void FunctorAsArg_pullback(Experiment fn, double i, double j, double _d_y, Experiment *_d_fn, double *_d_i, double *_d_j);
 
   // CHECK: void FunctorAsArgWrapper_grad(double i, double j, double *_d_i, double *_d_j) {
-  // CHECK-NEXT:     Experiment _d_E({});
   // CHECK-NEXT:     Experiment E(3, 5);
+  // CHECK-NEXT:     Experiment _d_E(E);
+  // CHECK-NEXT:     clad::zero_init(_d_E);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         Experiment _r2 = {};
   // CHECK-NEXT:         double _r3 = 0.;

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -528,17 +528,17 @@ double fn6(double u, double v) {
 // CHECK-NEXT:      double &_d_w = *_d_u;
 // CHECK-NEXT:      double &w = u;
 // CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t0 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>());
-// CHECK-NEXT:      SafeTestClass _d_s1(_t0.adjoint);
 // CHECK-NEXT:      SafeTestClass s1(_t0.value);
+// CHECK-NEXT:      SafeTestClass _d_s1(_t0.adjoint);
 // CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t1 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), u, &v, *_d_u, &*_d_v);
-// CHECK-NEXT:      SafeTestClass _d_s2(_t1.adjoint);
 // CHECK-NEXT:      SafeTestClass s2(_t1.value);
+// CHECK-NEXT:      SafeTestClass _d_s2(_t1.adjoint);
 // CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t2 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), w, _d_w);
+// CHECK-NEXT:      SafeTestClass s3(_t2.value);
 // CHECK-NEXT:      SafeTestClass _d_s3(_t2.adjoint);
-// CHECK-NEXT:          SafeTestClass s3(_t2.value);
-// CHECK-NEXT:          *_d_v += 1;
-// CHECK-NEXT:          {{.*}}constructor_pullback(&s2, u, &v, &_d_s2, &*_d_u, &*_d_v);
-// CHECK-NEXT:      }
+// CHECK-NEXT:      *_d_v += 1;
+// CHECK-NEXT:      {{.*}}constructor_pullback(&s2, u, &v, &_d_s2, &*_d_u, &*_d_v);
+// CHECK-NEXT:  }
 
 
 int main() {
@@ -632,8 +632,9 @@ int main() {
 // CHECK: void fn3_grad_2_3(double x, double y, double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_x = 0.;
 // CHECK-NEXT:     double _d_y = 0.;
-// CHECK-NEXT:     SimpleFunctions _d_sf({});
 // CHECK-NEXT:     SimpleFunctions sf(x, y);
+// CHECK-NEXT:     SimpleFunctions _d_sf(sf);
+// CHECK-NEXT:     clad::zero_init(_d_sf);
 // CHECK-NEXT:     SimpleFunctions _t0 = sf;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r0 = 0.;

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -23,6 +23,15 @@ public:
   }
 };
 
+namespace clad {
+  template <> void zero_init(SimpleFunctions1& f) {
+    f.x = 0;
+    f.y = 0;
+    f.x_pointer = &f.x;
+    f.y_pointer = &f.y;
+  }
+}
+
 double fn_s1_mem_fn(double i, double j) {
   SimpleFunctions1 obj(2, 3);
   return obj.mem_fn_1(i, j) + i * j;
@@ -125,8 +134,9 @@ int main() {
     // CHECK: void mem_fn_1_pullback(double i, double j, double _d_y, SimpleFunctions1 *_d_this, double *_d_i, double *_d_j);
 
     // CHECK: void fn_s1_mem_fn_grad(double i, double j, double *_d_i, double *_d_j) {
-    // CHECK-NEXT:     SimpleFunctions1 _d_obj({});
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
+    // CHECK-NEXT:     SimpleFunctions1 _d_obj(obj);
+    // CHECK-NEXT:     clad::zero_init(_d_obj);
     // CHECK-NEXT:     SimpleFunctions1 _t0 = obj;
     // CHECK-NEXT:     {
     // CHECK-NEXT:         double _r2 = 0.;
@@ -144,8 +154,9 @@ int main() {
     // CHECK-NEXT: }
     
     // CHECK: void fn_s1_field_grad(double i, double j, double *_d_i, double *_d_j) {
-    // CHECK-NEXT:     SimpleFunctions1 _d_obj({});
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
+    // CHECK-NEXT:     SimpleFunctions1 _d_obj(obj);
+    // CHECK-NEXT:     clad::zero_init(_d_obj);
     // CHECK-NEXT:     {
     // CHECK-NEXT:         _d_obj.x += 1 * obj.y;
     // CHECK-NEXT:         *_d_i += 1 * j;
@@ -158,8 +169,9 @@ int main() {
     // CHECK-NEXT: }
     
     // CHECK: void fn_s1_field_pointer_grad(double i, double j, double *_d_i, double *_d_j) {
-    // CHECK-NEXT:     SimpleFunctions1 _d_obj({});
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
+    // CHECK-NEXT:     SimpleFunctions1 _d_obj(obj);
+    // CHECK-NEXT:     clad::zero_init(_d_obj);
     // CHECK-NEXT:     {
     // CHECK-NEXT:         *_d_obj.x_pointer += 1 * *obj.y_pointer;
     // CHECK-NEXT:         *_d_i += 1 * j;

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -222,8 +222,9 @@ int main() {
 }
 
 // CHECK: void fn10_grad(double u, double v, double *_d_u, double *_d_v) {
-// CHECK-NEXT:     std::vector<double> _d_vec({});
 // CHECK-NEXT:     std::vector<double> vec;
+// CHECK-NEXT:     std::vector<double> _d_vec({});
+// CHECK-NEXT:     clad::zero_init(_d_vec);
 // CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
 // CHECK-NEXT:     std::vector<double> _t1 = vec;
@@ -243,8 +244,9 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK-NEXT: void fn11_grad(double u, double v, double *_d_u, double *_d_v) {
-// CHECK-NEXT:     std::vector<double> _d_vec({});
 // CHECK-NEXT:     std::vector<double> vec;
+// CHECK-NEXT:     std::vector<double> _d_vec({});
+// CHECK-NEXT:     clad::zero_init(_d_vec);
 // CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
 // CHECK-NEXT:     std::vector<double> _t1 = vec;
@@ -301,8 +303,9 @@ int main() {
 // CHECK-NEXT:     double _t24;
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     std::vector<double> _d_vec({});
 // CHECK-NEXT:     std::vector<double> vec;
+// CHECK-NEXT:     std::vector<double> _d_vec({});
+// CHECK-NEXT:     clad::zero_init(_d_vec);
 // CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 3, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
@@ -446,34 +449,36 @@ int main() {
 // CHECK-NEXT: void fn13_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = u;
-// CHECK-NEXT:     {{.*}}allocator_type _d_allocator({});
 // CHECK-NEXT:     {{.*}}allocator_type allocator;
+// CHECK-NEXT:     {{.*}}allocator_type _d_allocator({});
+// CHECK-NEXT:     clad::zero_init(_d_allocator);
 // CHECK-NEXT:     {{.*}} _d_count = {{0U|0UL}};
 // CHECK-NEXT:     {{.*}} count = 3;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<{{.*}}vector<{{.*}}>, {{.*}}vector<{{.*}}> > _t0 = {{.*}}class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<vector<{{.*}}> >(), count, u, allocator, _d_count, *_d_u, _d_allocator);
-// CHECK-NEXT:     std::vector<double> _d_vec(_t0.adjoint);
-// CHECK-NEXT:     std::vector<double> vec(_t0.value);
-// CHECK-NEXT:     std::vector<double> _t1 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     std::vector<double> _t3 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     std::vector<double> _t5 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     std::vector<double> vec(count, u, allocator);
+// CHECK-NEXT:     std::vector<double> _d_vec(vec);
+// CHECK-NEXT:     clad::zero_init(_d_vec);
+// CHECK-NEXT:     std::vector<double> _t0 = vec;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     std::vector<double> _t2 = vec;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     std::vector<double> _t4 = vec;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
 // CHECK-NEXT:             {{.*}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t1, 0, 1, &_d_vec, &_r0);
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t0, 0, 1, &_d_vec, &_r0);
 // CHECK-NEXT:             {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t3, 1, 1, &_d_vec, &_r1);
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t2, 1, 1, &_d_vec, &_r1);
 // CHECK-NEXT:             {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t5, 2, 1, &_d_vec, &_r2);
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t4, 2, 1, &_d_vec, &_r2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {{.*}}constructor_pullback(&vec, count, u, allocator, &_d_vec, &_d_count, &*_d_u, &_d_allocator);
 // CHECK-NEXT:        *_d_u += _d_res;
 // CHECK-NEXT:     }
 
 // CHECK:      void fn14_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:          std::vector<double> _d_a({});
 // CHECK-NEXT:          std::vector<double> a;
+// CHECK-NEXT:          std::vector<double> _d_a({});
+// CHECK-NEXT:          clad::zero_init(_d_a);
 // CHECK-NEXT:          std::vector<double> _t0 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, x, &_d_a, *_d_x);
 // CHECK-NEXT:          std::vector<double> _t1 = a;
@@ -691,8 +696,9 @@ int main() {
 // CHECK-NEXT:          {{.*}}tape<{{.*}}vector<double> > _t3 = {};
 // CHECK-NEXT:          {{.*}}tape<double> _t4 = {};
 // CHECK-NEXT:          {{.*}}tape<{{.*}}vector<double> > _t5 = {};
-// CHECK-NEXT:          {{.*}}vector<double> _d_v({});
 // CHECK-NEXT:          {{.*}}vector<double> v;
+// CHECK-NEXT:          {{.*}}vector<double> _d_v({});
+// CHECK-NEXT:          clad::zero_init(_d_v);
 // CHECK-NEXT:          {{.*}} _t0 = {{0U|0UL|0}};
 // CHECK-NEXT:          for (i = 0; ; ++i) {
 // CHECK-NEXT:              {
@@ -781,8 +787,9 @@ int main() {
 // CHECK-NEXT:      }
 
 // CHECK:      void fn20_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:          {{.*}}vector<double> _d_v({});
 // CHECK-NEXT:          {{.*}}vector<double> v;
+// CHECK-NEXT:          {{.*}}vector<double> _d_v({});
+// CHECK-NEXT:          clad::zero_init(_d_v);
 // CHECK-NEXT:          {{.*}}vector<double> _t0 = v;
 // CHECK-NEXT:          v.reserve(10);
 // CHECK-NEXT:          {{.*}}vector<double> _t2 = v;
@@ -821,8 +828,9 @@ int main() {
 // CHECK-NEXT:      }
 
 // CHECK:      void fn21_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:          std::vector<double> _d_a({});
 // CHECK-NEXT:          std::vector<double> a;
+// CHECK-NEXT:          std::vector<double> _d_a({});
+// CHECK-NEXT:          clad::zero_init(_d_a);
 // CHECK-NEXT:          std::vector<double> _t0 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, 0{{.*}}, &_d_a, 0.);
 // CHECK-NEXT:          std::vector<double> _t1 = a;
@@ -851,21 +859,22 @@ int main() {
 // CHECK-NEXT:      }
 
 // CHECK:      void fn22_grad(double u, double v, double *_d_u, double *_d_v) {
-// CHECK-NEXT:      std::vector<double>::allocator_type _d_alloc({});
 // CHECK-NEXT:      std::vector<double>::allocator_type alloc;
-// CHECK-NEXT:      {{.*}} _t0 = {{.*}}::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<{{.*}}>(), {{.*u, v.*}}, alloc, {}, _d_alloc); 
-// CHECK-NEXT:      std::vector<double> _d_ls(_t0.adjoint);
-// CHECK-NEXT:      std::vector<double> ls(_t0.value);
-// CHECK-NEXT:      std::vector<double> _t1 = ls;
-// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}});
-// CHECK-NEXT:      std::vector<double> _t4 = ls;
-// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t5 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}});
-// CHECK-NEXT:      {{.*}}value_type _t3 = _t5.value;
+// CHECK-NEXT:      std::vector<double>::allocator_type _d_alloc({});
+// CHECK-NEXT:      clad::zero_init(_d_alloc);
+// CHECK-NEXT:      std::vector<double> ls({u, v}, alloc);
+// CHECK-NEXT:      std::vector<double> _d_ls(ls);
+// CHECK-NEXT:      clad::zero_init(_d_ls);
+// CHECK-NEXT:      std::vector<double> _t0 = ls;
+// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t1 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}});
+// CHECK-NEXT:      std::vector<double> _t3 = ls;
+// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t4 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}});
+// CHECK-NEXT:      {{.*}}value_type _t2 = _t4.value;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          {{.*}}size_type _r1 = 0{{.*}};
-// CHECK-NEXT:          clad::custom_derivatives::class_functions::operator_subscript_pullback(&_t1, 1, 1, &_d_ls, &_r1);
+// CHECK-NEXT:          clad::custom_derivatives::class_functions::operator_subscript_pullback(&_t0, 1, 1, &_d_ls, &_r1);
 // CHECK-NEXT:          {{.*}}size_type _r2 = 0{{.*}};
-// CHECK-NEXT:          clad::custom_derivatives::class_functions::operator_subscript_pullback(&_t4, 0, 2 * -1, &_d_ls, &_r2);
+// CHECK-NEXT:          clad::custom_derivatives::class_functions::operator_subscript_pullback(&_t3, 0, 2 * -1, &_d_ls, &_r2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          clad::array<double> _r0 = {{2U|2UL|2ULL}};

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -190,6 +190,17 @@ double fn22(double u, double v) {
     return ls[1] - 2 * ls[0];
 }
 
+double fn23(double u, double v) {
+    std::vector<double>::allocator_type alloc;
+    for (int i = 0; i < 3; ++i) {
+      std::vector<double> ls({u, v}, alloc);
+      ls[1] += ls[0];
+      u = ls[1];
+    }
+    return u;
+}
+
+
 int main() {
     double d_i, d_j;
     INIT_GRADIENT(fn10);
@@ -205,6 +216,7 @@ int main() {
     INIT_GRADIENT(fn20);
     INIT_GRADIENT(fn21);
     INIT_GRADIENT(fn22);
+    INIT_GRADIENT(fn23);
 
     TEST_GRADIENT(fn10, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {1.00, 1.00}
     TEST_GRADIENT(fn11, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {2.00, 1.00}
@@ -219,6 +231,7 @@ int main() {
     TEST_GRADIENT(fn20, /*numOfDerivativeArgs=*/2, 3, 4, &d_i, &d_j);  // CHECK-EXEC: {11.00, 1.00}
     TEST_GRADIENT(fn21, /*numOfDerivativeArgs=*/2, 3, 4, &d_i, &d_j);  // CHECK-EXEC: {6.00, 0.00}
     TEST_GRADIENT(fn22, /*numOfDerivativeArgs=*/2, 3, 4, &d_i, &d_j);  // CHECK-EXEC: {-2.00, 1.00}
+    TEST_GRADIENT(fn23, /*numOfDerivativeArgs=*/2, 1, 1, &d_i, &d_j);  // CHECK-EXEC: {1.00, 3.00}
 }
 
 // CHECK: void fn10_grad(double u, double v, double *_d_u, double *_d_v) {
@@ -882,3 +895,75 @@ int main() {
 // CHECK-NEXT:          *_d_u += _r0[0];
 // CHECK-NEXT:          *_d_v += _r0[1];
 // CHECK-NEXT:      }
+// CHECK-NEXT:  }
+
+// CHECK:      void fn23_grad(double u, double v, double *_d_u, double *_d_v) {
+// CHECK-NEXT:      int _d_i = 0;
+// CHECK-NEXT:      int i = 0;
+// CHECK-NEXT:      clad::tape<std::vector<double> > _t1 = {};
+// CHECK-NEXT:      std::vector<double> ls = {};
+// CHECK-NEXT:      std::vector<double> _d_ls{};
+// CHECK-NEXT:      clad::tape<std::vector<double> > _t2 = {};
+// CHECK-NEXT:      clad::tape<double> _t4 = {};
+// CHECK-NEXT:      clad::tape<std::vector<double> > _t5 = {};
+// CHECK-NEXT:      clad::tape<double> _t7 = {};
+// CHECK-NEXT:      clad::tape<std::vector<double> > _t8 = {};
+// CHECK-NEXT:      {{.*}}allocator_type alloc;
+// CHECK-NEXT:      {{.*}}allocator_type _d_alloc({});
+// CHECK-NEXT:      clad::zero_init(_d_alloc);
+// CHECK-NEXT:      unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
+// CHECK-NEXT:      for (i = 0; ; ++i) {
+// CHECK-NEXT:          {
+// CHECK-NEXT:              if (!(i < 3))
+// CHECK-NEXT:                  break;
+// CHECK-NEXT:          }
+// CHECK-NEXT:          _t0++;
+// CHECK-NEXT:          clad::push(_t1, ls) , ls = {u, v}, alloc;
+// CHECK-NEXT:          _d_ls = ls;
+// CHECK-NEXT:          clad::zero_init(_d_ls);
+// CHECK-NEXT:          clad::push(_t2, ls);
+// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t3 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}});
+// CHECK-NEXT:          clad::push(_t4, _t3.value);
+// CHECK-NEXT:          clad::push(_t5, ls);
+// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t6 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}});
+// CHECK-NEXT:          _t3.value += _t6.value;
+// CHECK-NEXT:          clad::push(_t7, u);
+// CHECK-NEXT:          clad::push(_t8, ls);
+// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t9 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}});
+// CHECK-NEXT:          u = _t9.value;
+// CHECK-NEXT:      }
+// CHECK-NEXT:      *_d_u += 1;
+// CHECK-NEXT:      for (;; _t0--) {
+// CHECK-NEXT:          {
+// CHECK-NEXT:              if (!_t0)
+// CHECK-NEXT:                  break;
+// CHECK-NEXT:          }
+// CHECK-NEXT:          --i;
+// CHECK-NEXT:          {
+// CHECK-NEXT:              u = clad::pop(_t7);
+// CHECK-NEXT:              double _r_d1 = *_d_u;
+// CHECK-NEXT:              *_d_u = 0.;
+// CHECK-NEXT:              {{.*}}size_type _r3 = 0{{.*}};
+// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t8), 1, _r_d1, &_d_ls, &_r3);
+// CHECK-NEXT:              clad::pop(_t8);
+// CHECK-NEXT:          }
+// CHECK-NEXT:          {
+// CHECK-NEXT:              _t3.value = clad::pop(_t4);
+// CHECK-NEXT:              double _r_d0 = _t3.adjoint;
+// CHECK-NEXT:              {{.*}}size_type _r2 = 0{{.*}};
+// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t5), 0, _r_d0, &_d_ls, &_r2);
+// CHECK-NEXT:              clad::pop(_t5);
+// CHECK-NEXT:              {{.*}}size_type _r1 = 0{{.*}};
+// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t2), 1, 0., &_d_ls, &_r1);
+// CHECK-NEXT:              clad::pop(_t2);
+// CHECK-NEXT:          }
+// CHECK-NEXT:          {
+// CHECK-NEXT:              clad::array<double> _r0 = {{2U|2UL|2ULL}};
+// CHECK-NEXT:              {{.*}}::class_functions::constructor_pullback(&ls, {u, v}, alloc, &_d_ls, &_r0, &_d_alloc);
+// CHECK-NEXT:              *_d_u += _r0[0];
+// CHECK-NEXT:              *_d_v += _r0[1];
+// CHECK-NEXT:              clad::zero_init(_d_ls);
+// CHECK-NEXT:              ls = clad::pop(_t1);
+// CHECK-NEXT:          }
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -97,8 +97,9 @@ double fn3(double i, double j) {
 }
 
 // CHECK: void fn3_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     Tangent _d_t({});
 // CHECK-NEXT:     Tangent t;
+// CHECK-NEXT:     Tangent _d_t({});
+// CHECK-NEXT:     clad::zero_init(_d_t);
 // CHECK-NEXT:     double _t0 = t.data[0];
 // CHECK-NEXT:     t.data[0] = 2 * i;
 // CHECK-NEXT:     double _t1 = t.data[1];
@@ -130,10 +131,12 @@ double fn4(double i, double j) {
 }
 
 // CHECK: void fn4_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     pairdd _d_p({});
 // CHECK-NEXT:     pairdd p(1, 3);
-// CHECK-NEXT:     pairdd _d_q({});
+// CHECK-NEXT:     pairdd _d_p(p);
+// CHECK-NEXT:     clad::zero_init(_d_p);
 // CHECK-NEXT:     pairdd q({7, 5});
+// CHECK-NEXT:     pairdd _d_q(q);
+// CHECK-NEXT:     clad::zero_init(_d_q);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_p.first += 1 * i;
 // CHECK-NEXT:         *_d_i += p.first * 1;
@@ -370,8 +373,9 @@ double fn11(double x, double y) {
 }
 
 // CHECK: void fn11_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     Tangent _d_t({});
 // CHECK-NEXT:     Tangent t;
+// CHECK-NEXT:     Tangent _d_t({});
+// CHECK-NEXT:     clad::zero_init(_d_t);
 // CHECK-NEXT:     double _t0 = t.data[0];
 // CHECK-NEXT:     t.data[0] = -y;
 // CHECK-NEXT:     operator_plus_pullback(x, t, 1, &*_d_x, &_d_t);


### PR DESCRIPTION
When dealing with objects in reverse mode, we used to initialize the adjoints using default constructors. However, this logic is obviously wrong when dealing with containers of any kind (arrays, maps, etc.). For example, the default-initialized vector is an empty vector while the adjoint needs to be initialized to the zero vector. This PR changes the strategy to the following:
```
std::vector<...> v{x, y, z};
std::vector<...> _d_v{v}; // The length of the vector is preserved
clad::zero_init(_d_v); // All elements are initialized to 0
```
The new ``clad::zero_init`` function relies on the iterators to initialize the elements.

Note: The new implementation still relies on the existence of the copy constructor that preserves the structure of the object., as well as iterator functions that give access to the underlying elements. 
Also, ``clad::zero_init`` is not always capable of handling pointer/reference fields of non-iterable classes (those are initialized to ``nullptr``). In such cases, a custom ``clad::zero_init<T>`` is needed.