### PR TITLE
Fix for Parenthesis issue in gradients

### DIFF
--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -274,7 +274,12 @@ namespace clad {
     /// either LHS or RHS is null.
     clang::Expr* BuildOp(clang::BinaryOperatorKind OpCode, clang::Expr* L,
                          clang::Expr* R, clang::SourceLocation OpLoc = noLoc);
-
+    /// Function to resolve Unary Minus. If the leftmost operand
+    /// has a Unary Minus then adds parens before adding the unary minus.
+    /// \param[in] E Expression fed to the recursive call.
+    /// \param[in] OpLoc Location to add Unary Minus if needed.
+    /// \returns Expression with correct Unary Operator placement.
+    clang::Expr* ResolveUnaryMinus(clang::Expr* E, clang::SourceLocation OpLoc);
     clang::Expr* BuildParens(clang::Expr* E);
     /// Builds variable declaration to be used inside the derivative
     /// body.

--- a/test/Gradient/UnaryMinus.C
+++ b/test/Gradient/UnaryMinus.C
@@ -1,0 +1,42 @@
+// RUN: %cladclang %s -I%S/../../include -oUnaryMinus.out 2>&1 | %filecheck %s
+// RUN: ./UnaryMinus.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-tbr %s -I%S/../../include -oUnaryMinus.out
+// RUN: ./UnaryMinus.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include "../TestUtils.h"
+
+double f1(double x)
+{
+    return -(-(-1))*-(-(-x));
+}
+
+//CHECK: void f1_grad(double x, double *_d_x) {
+//CHECK-NEXT:    *_d_x += -(-1 * 1);
+//CHECK-NEXT: }
+
+double f2(double x, double y)
+{
+    return -2*-(-(-x))*-y - 1*(-y)*(-(-x));
+}
+
+//CHECK: void f2_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK-NEXT:    {
+//CHECK-NEXT:        *_d_x += -(-2 * 1 * -y);
+//CHECK-NEXT:        *_d_y += -(-2 * -x * 1);
+//CHECK-NEXT:        *_d_y += -1 * -1 * x;
+//CHECK-NEXT:        *_d_x += 1 * -y * -1;
+//CHECK-NEXT:    }
+//CHECK-NEXT: }
+
+double dx;
+double arr[2] = {};
+int main(){
+
+    INIT_GRADIENT(f1);
+    INIT_GRADIENT(f2);
+
+    TEST_GRADIENT(f1, 1, 5, &dx); // CHECK-EXEC: 1.00
+    TEST_GRADIENT(f2, 2, 3, 4, &arr[0], &arr[1]) // CHECK-EXEC: {-4.00, -3.00}
+}


### PR DESCRIPTION
This resolves the issue with two or more consecutive negative signs while dumping the code.
While copying the code to m_Code, changes include iterating the loop and checking when there are two or more consecutive negative signs and resolves them to be either '-' or ' ' depending on the parity.

Eg.
-(-(-1))*(x) 
Before :  _d_x += - - -1 * 1;
After : _d_x += -1 * 1;

The differentiate remains intact.
Fixes : #1098 