### PR TITLE
Update README with clang version note for macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ make && make install
 make check-clad
 ```
 
-> **NOTE**: If you are using clad as a clang plugin after building it from source, use the version of clang from your llvm@12 installation directory(/opt/homebrew/opt/llvm@12/bin/clang). Using the systemwide clang binary may not work.
+> **NOTE**: If you are using clad as a clang plugin after building it from source, please make sure that you uses the same compiler version you built clad against. Apple distributed clang does not work because Apple has disabled clang plugins.
 
 ### Developer Environment - Build LLVM, Clang and Clad from source:
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,11 @@ cmake ../clad -DLLVM_DIR=/opt/homebrew/opt/llvm@12/lib/cmake/llvm -DClang_DIR=/o
 make && make install
 make check-clad
 ```
-###  Developer Environment - Build LLVM, Clang and Clad from source:
+
+> **NOTE**: If you are using clad as a clang plugin after building it from source, use the version of clang from your llvm@12 installation directory(/opt/homebrew/opt/llvm@12/bin/clang). Using the systemwide clang binary may not work.
+
+### Developer Environment - Build LLVM, Clang and Clad from source:
+
 ```
 pip3 install lit
 ```


### PR DESCRIPTION
Adding instructions in the README for mac users, to not use their systemwide clang installation while using clad and instead use the version of clang inside homebrew llvm-12.

Using the systemwide clang(15.0.0) installation leads to the following issue:  #1199 