### PR TITLE
Clean up the code computing the parameters and their types.

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -490,15 +490,12 @@ namespace clad {
     }
 
     /// Returns the type that should be used to represent the derivative of a
-    /// variable of type `yType` with respect to a parameter variable of type
-    /// `xType`.
     ///
     /// FIXME: Parameter derivative type rules are different from the derivative
     /// type rules for local variables. We should remove this inconsistency.
     /// See the following issue for more details:
     /// https://github.com/vgvassilev/clad/issues/385
-    clang::QualType GetParameterDerivativeType(clang::QualType yType,
-                                               clang::QualType xType);
+    clang::QualType GetParameterDerivativeType(clang::QualType Type);
 
     /// Allows to easily create and manage a counter for counting the number of
     /// executed iterations of a loop.
@@ -693,7 +690,6 @@ namespace clad {
     void BuildParams(llvm::SmallVectorImpl<clang::ParmVarDecl*>& params);
 
     clang::QualType ComputeAdjointType(clang::QualType T);
-    clang::QualType ComputeParamType(clang::QualType T);
     /// Stores data required for differentiating a switch statement.
     struct SwitchStmtInfo {
       llvm::SmallVector<clang::SwitchCase*, 16> cases;

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -23,6 +23,10 @@
 #include <stack>
 #include <unordered_map>
 
+namespace llvm {
+template <typename T> class SmallVectorImpl;
+}
+
 namespace clad {
   class ErrorEstimationHandler;
   class ExternalRMVSource;
@@ -682,19 +686,11 @@ namespace clad {
     ///\paramp[in] source An external RMV source
     void AddExternalSource(ExternalRMVSource& source);
 
-    /// Computes and returns the sequence of derived function parameter types.
-    ///
-    /// Information about the original function and the differentiation mode
-    /// are taken from the data member variables.
-    llvm::SmallVector<clang::QualType, 8> ComputeParamTypes(const DiffParams& diffParams);
+    /// Computes and returns the derived function prototype.
+    clang::QualType ComputeDerivativeFunctionType();
 
     /// Builds and returns the sequence of derived function parameters.
-    ///
-    /// Information about the original function, derived function, derived
-    /// function parameter types and the differentiation mode are implicitly
-    /// taken from the data member variables.
-    llvm::SmallVector<clang::ParmVarDecl*, 8>
-    BuildParams(DiffParams& diffParams);
+    void BuildParams(llvm::SmallVectorImpl<clang::ParmVarDecl*>& params);
 
     clang::QualType ComputeAdjointType(clang::QualType T);
     clang::QualType ComputeParamType(clang::QualType T);

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -36,7 +36,7 @@ double f2(double x, double y){
 // CHECK-NEXT:     return _d_ans;
 // CHECK-NEXT: }
 
-// CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x, double *_d_y, double *_d__d_x, double *_d__d_y);
+// CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1, double *_d__d_x, double *_d__d_y);
 
 // CHECK: void f2_darg0_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     double _d__d_x = 0.;
@@ -109,19 +109,19 @@ double f2(double x, double y){
 // CHECK-NEXT:     return {x * x + y * y, _d_x * x + x * _d_x + _d_y * y + y * _d_y};
 // CHECK-NEXT: }
 
-// CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x, double *_d_y, double *_d__d_x, double *_d__d_y) {
+// CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1, double *_d__d_x, double *_d__d_y) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_x += _d_y0.value * x;
-// CHECK-NEXT:         *_d_x += x * _d_y0.value;
-// CHECK-NEXT:         *_d_y += _d_y0.value * y;
-// CHECK-NEXT:         *_d_y += y * _d_y0.value;
+// CHECK-NEXT:         *_d_x0 += _d_y0.value * x;
+// CHECK-NEXT:         *_d_x0 += x * _d_y0.value;
+// CHECK-NEXT:         *_d_y1 += _d_y0.value * y;
+// CHECK-NEXT:         *_d_y1 += y * _d_y0.value;
 // CHECK-NEXT:         *_d__d_x += _d_y0.pushforward * x;
-// CHECK-NEXT:         *_d_x += _d_x * _d_y0.pushforward;
-// CHECK-NEXT:         *_d_x += _d_y0.pushforward * _d_x;
+// CHECK-NEXT:         *_d_x0 += _d_x * _d_y0.pushforward;
+// CHECK-NEXT:         *_d_x0 += _d_y0.pushforward * _d_x;
 // CHECK-NEXT:         *_d__d_x += x * _d_y0.pushforward;
 // CHECK-NEXT:         *_d__d_y += _d_y0.pushforward * y;
-// CHECK-NEXT:         *_d_y += _d_y * _d_y0.pushforward;
-// CHECK-NEXT:         *_d_y += _d_y0.pushforward * _d_y;
+// CHECK-NEXT:         *_d_y1 += _d_y * _d_y0.pushforward;
+// CHECK-NEXT:         *_d_y1 += _d_y0.pushforward * _d_y;
 // CHECK-NEXT:         *_d__d_y += y * _d_y0.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }


### PR DESCRIPTION
This patch harmonizes the steps to build the derived function prototype along with its parameters. It refactors a lot of tricky code that grew organically and included many workarounds. This is only a single step in a direction of merging the common code patterns across visitors.

As a bonus we do not generate broken code when we have derivative parameters named `_d_x`. That's common in computing hessians.