### PR TITLE
Remove redundant for error estimation callback. 

### DIFF
--- a/include/clad/Differentiator/ExternalRMVSource.h
+++ b/include/clad/Differentiator/ExternalRMVSource.h
@@ -52,14 +52,6 @@ public:
   /// function.
   virtual void ActOnEndOfDerive() {}
 
-  /// This is called just after differentiation arguments are parsed
-  /// in `ReverseModeVisitor::Derive`.
-  ///
-  ///\param[in] request differentiation request
-  ///\param[in] args differentiation args
-  virtual void ActAfterParsingDiffArgs(const DiffRequest& request,
-                                       DiffParams& args) {}
-
   /// This is called after processing array subscript expressions.
   virtual void
   ActAfterProcessingArraySubscriptExpr(const clang::Expr* revArrSub) {}

--- a/include/clad/Differentiator/MultiplexExternalRMVSource.h
+++ b/include/clad/Differentiator/MultiplexExternalRMVSource.h
@@ -25,8 +25,6 @@ public:
 
   void ActOnStartOfDerive() override;
   void ActOnEndOfDerive() override;
-  void ActAfterParsingDiffArgs(const DiffRequest& request,
-                               DiffParams& args) override;
   void
   ActAfterProcessingArraySubscriptExpr(const clang::Expr* revArrSub) override;
   void ActBeforeCreatingDerivedFnParamTypes(unsigned& numExtraParams) override;

--- a/lib/Differentiator/MultiplexExternalRMVSource.cpp
+++ b/lib/Differentiator/MultiplexExternalRMVSource.cpp
@@ -35,13 +35,6 @@ void MultiplexExternalRMVSource::ActOnEndOfDerive() {
   }
 }
 
-void MultiplexExternalRMVSource::ActAfterParsingDiffArgs(
-    const DiffRequest& request, DiffParams& args) {
-  for (auto source : m_Sources) {
-    source->ActAfterParsingDiffArgs(request, args);
-  }
-}
-
 void MultiplexExternalRMVSource::ActAfterProcessingArraySubscriptExpr(
     const clang::Expr* revArrSub) {
   for (auto source : m_Sources)

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -202,13 +202,6 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
         ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, 1);
     assert(m_DiffReq.Function && "Must not be null.");
 
-    DiffParams args{};
-    for (const auto& dParam : m_DiffReq.DVI)
-      args.push_back(dParam.param);
-
-    if (m_ExternalSource)
-      m_ExternalSource->ActAfterParsingDiffArgs(m_DiffReq, args);
-
     // If reverse mode differentiates only part of the arguments it needs to
     // generate an overload that can take in all the diff variables
     bool shouldCreateOverload = false;
@@ -334,19 +327,6 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
       m_ExternalSource->ActOnStartOfDerive();
     assert(m_DiffReq.Mode == DiffMode::experimental_pullback);
     assert(m_DiffReq.Function && "Must not be null.");
-
-    DiffParams args{};
-    for (const auto& dParam : m_DiffReq.DVI)
-      args.push_back(dParam.param);
-#ifndef NDEBUG
-    bool isStaticMethod = utils::IsStaticMethod(m_DiffReq.Function);
-    assert((!args.empty() || !isStaticMethod) &&
-           "Cannot generate pullback function of a function "
-           "with no differentiable arguments");
-#endif
-
-    if (m_ExternalSource)
-      m_ExternalSource->ActAfterParsingDiffArgs(m_DiffReq, args);
 
     llvm::SaveAndRestore<DeclContext*> saveContext(m_Sema.CurContext);
     llvm::SaveAndRestore<Scope*> saveScope(getCurrentScope(),


### PR DESCRIPTION
The callback was in the wrong place, too. We can re-add a callback similar to this one upon request which happens at the point when the DiffRequest is created.

Depends on #1208.