### PR TITLE
Improve derivative registration.

### DIFF
--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -82,13 +82,6 @@ DerivativeAndOverload ReverseModeForwPassVisitor::Derive() {
     Stmt* fnBody = endBlock();
     m_Derivative->setBody(fnBody);
     endScope();
-
-    // Size >= current derivative order means that there exists a declaration
-    // or prototype for the currently derived function.
-    if (m_DiffReq.DerivedFDPrototypes.size() >=
-        m_DiffReq.CurrentDerivativeOrder)
-      m_Derivative->setPreviousDeclaration(
-          m_DiffReq.DerivedFDPrototypes[m_DiffReq.CurrentDerivativeOrder - 1]);
   }
   m_Sema.PopFunctionScopeInfo();
   m_Sema.PopDeclContext();

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -298,19 +298,33 @@ Expr* getArraySizeExpr(const ArrayType* AT, ASTContext& context,
 
       Stmt* fnBody = endBlock();
       m_Derivative->setBody(fnBody);
-      endScope(); // Function body scope
 
-      // Size >= current derivative order means that there exists a declaration
-      // or prototype for the currently derived function.
-      if (m_DiffReq.DerivedFDPrototypes.size() >=
-          m_DiffReq.CurrentDerivativeOrder)
-        m_Derivative->setPreviousDeclaration(
-            m_DiffReq
-                .DerivedFDPrototypes[m_DiffReq.CurrentDerivativeOrder - 1]);
+      endScope(); // Function body scope
     }
+
     m_Sema.PopFunctionScopeInfo();
     m_Sema.PopDeclContext();
     endScope(); // Function decl scope
+
+    if (auto* RD = dyn_cast<RecordDecl>(m_Derivative->getDeclContext())) {
+      DeclContext::lookup_result R =
+          RD->getPrimaryContext()->lookup(m_Derivative->getDeclName());
+      FunctionDecl* FoundFD =
+          R.empty() ? nullptr : dyn_cast<FunctionDecl>(R.front());
+      if (!RD->isLambda() && !R.empty() &&
+          !m_Builder.m_DFC.IsCladDerivative(FoundFD)) {
+        Sema::NestedNameSpecInfo IdInfo(RD->getIdentifier(), noLoc, noLoc,
+                                        /*ObjectType=*/nullptr);
+        // FIXME: Address nested classes where SS should be set.
+        CXXScopeSpec SS;
+        m_Sema.BuildCXXNestedNameSpecifier(getCurrentScope(), IdInfo,
+                                           /*EnteringContext=*/true, SS,
+                                           /*ScopeLookupResult=*/nullptr,
+                                           /*ErrorRecoveryLookup=*/false);
+        m_Derivative->setQualifierInfo(SS.getWithLocInContext(m_Context));
+        m_Derivative->setLexicalDeclContext(RD->getParent());
+      }
+    }
 
     if (!shouldCreateOverload)
       return DerivativeAndOverload{result.first, /*overload=*/nullptr};

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -666,8 +666,9 @@ namespace clad {
                      .get();
       isArrow = false;
     }
-    NestedNameSpecifierLoc NNS(FD->getQualifier(),
-                               /*Data=*/nullptr);
+    // Leads to printing this->Class::Function(x, y).
+    // FIXME: Enable for static functions.
+    NestedNameSpecifierLoc NNS /* = FD->getQualifierLoc()*/;
     auto DAP = DeclAccessPair::make(FD, FD->getAccess());
     auto* memberExpr = MemberExpr::Create(
         m_Context, thisExpr, isArrow, Loc, NNS, noLoc, FD, DAP,

--- a/test/FirstDerivative/ClassMethodCall.C
+++ b/test/FirstDerivative/ClassMethodCall.C
@@ -72,7 +72,7 @@ public:
   }
 
   float vm_darg0(float x, float y);
-  //CHECK:   float vm_darg0(float x, float y) {
+  //CHECK:   float A::vm_darg0(float x, float y) {
   //CHECK-NEXT:       float _d_x = 1;
   //CHECK-NEXT:       float _d_y = 0;
   //CHECK-NEXT:       A _d_this_obj;
@@ -91,7 +91,7 @@ public:
   }
 
   float vm_darg0(float x, float y);
-  //CHECK:   float vm_darg0(float x, float y) override {
+  //CHECK:   float B::vm_darg0(float x, float y) {
   //CHECK-NEXT:       float _d_x = 1;
   //CHECK-NEXT:       float _d_y = 0;
   //CHECK-NEXT:       B _d_this_obj;
@@ -117,7 +117,7 @@ int main () {
   auto vm_darg0_B = clad::differentiate(&B::vm, 0);
   printf("Result is = %f\n", vm_darg0_B.execute(b, 2, 3)); // CHECK-EXEC: Result is = 4.0000
   printf("%s\n", vm_darg0_B.getCode());
-  //CHECK-EXEC:   float vm_darg0(float x, float y) override {
+  //CHECK-EXEC:   float B::vm_darg0(float x, float y) {
   //CHECK-EXEC-NEXT:       float _d_x = 1;
   //CHECK-EXEC-NEXT:       float _d_y = 0;
   //CHECK-EXEC-NEXT:       B _d_this_obj;

--- a/test/FirstDerivative/VirtualMethodsCall.C
+++ b/test/FirstDerivative/VirtualMethodsCall.C
@@ -1,6 +1,5 @@
 // RUN: %cladclang %s -I%S/../../include -oVirtualMethodsCall.out 2>&1 | %filecheck %s
 // RUN: ./VirtualMethodsCall.out | %filecheck_exec %s
-// XFAIL: asserts
 
 #include "clad/Differentiator/Differentiator.h"
 
@@ -41,7 +40,7 @@ public:
     // TODO: Remove call forward when execute works with polymorphic methods
     auto vm_darg0_cf = clad::differentiate(&A::vm, 0);
 // FIXME: We need to make this out-of-line
-//CHECK: float vm_darg0(float x, float y) {
+//CHECK: float A::vm_darg0(float x, float y) {
 //CHECK-NEXT:       float _d_x = 1;
 //CHECK-NEXT:       float _d_y = 0;
 //CHECK-NEXT:      A _d_this_obj;
@@ -49,7 +48,7 @@ public:
 //CHECK-NEXT:       return _d_x + _d_y;
 //CHECK-NEXT: }
     auto vm_darg1_cf = clad::differentiate(&A::vm, 1);
-//CHECK:   float vm_darg1(float x, float y) {
+//CHECK:   float A::vm_darg1(float x, float y) {
 //CHECK-NEXT:       float _d_x = 0;
 //CHECK-NEXT:       float _d_y = 1;
 //CHECK-NEXT:       A _d_this_obj;
@@ -130,6 +129,9 @@ public:
     return x*y + x*y;
   }
 
+  float vm_darg0(float x, float y) override; // forward
+  float vm_darg1(float x, float y) override; // forward
+
   // Inherited from A
   // float vm1(float x, float y)...
 
@@ -180,7 +182,8 @@ int main () {
   printf("---\n"); // CHECK-EXEC: ---
 
   auto vm_darg0_A = clad::differentiate((float(A::*)(float,float))&A::vm, 0);
-//CHECK: float vm_darg0(float x, float y) override {
+  //FIXME: This should select the implementation of vm in A!
+//CHECK: float B::vm_darg0(float x, float y) {
 //CHECK-NEXT:     float _d_x = 1;
 //CHECK-NEXT:     float _d_y = 0;
 // CHECK-NEXT:     B _d_this_obj;
@@ -188,7 +191,7 @@ int main () {
 //CHECK-NEXT:     return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
 //CHECK-NEXT: }
   auto vm_darg0_B = clad::differentiate((float(B::*)(float,float))&B::vm, 0);
-//CHECK: float vm_darg1(float x, float y) override {
+//CHECK: float B::vm_darg1(float x, float y) {
 //CHECK-NEXT:     float _d_x = 0;
 //CHECK-NEXT:     float _d_y = 1;
 // CHECK-NEXT:     B _d_this_obj;
@@ -208,7 +211,7 @@ int main () {
 //CHECK-NEXT:     return _d_x - _d_y;
 //CHECK-NEXT: }
   auto vm1_darg0_B = clad::differentiate((float(B::*)(float,float))&B::vm1, 0);
-//CHECK: float vm1_darg0(float x, float y) override {
+//CHECK: float vm1_darg0(float x, float y) {
 //CHECK-NEXT:    float _d_x = 1;
 //CHECK-NEXT:     float _d_y = 0;
 // CHECK-NEXT:     B _d_this_obj;
@@ -224,7 +227,7 @@ int main () {
 //CHECK-NEXT:     return _d_x - _d_y;
 //CHECK-NEXT: }
   auto vm1_darg1_B = clad::differentiate((float(B::*)(float,float))&B::vm1, 1);
-//CHECK: float vm1_darg1(float x, float y) override {
+//CHECK: float vm1_darg1(float x, float y) {
 //CHECK-NEXT:     float _d_x = 0;
 //CHECK-NEXT:     float _d_y = 1;
 // CHECK-NEXT:     B _d_this_obj;
@@ -255,7 +258,7 @@ int main () {
   printf("---\n"); // CHECK-EXEC: ---
 
   auto vm_darg0_B1 = clad::differentiate(&B1::vm, 0);
-//CHECK: float vm_darg0(float x, float y) override {
+//CHECK: float B1::vm_darg0(float x, float y) {
 //CHECK-NEXT:     float _d_x = 1;
 //CHECK-NEXT:     float _d_y = 0;
 // CHECK-NEXT:     B1 _d_this_obj;
@@ -263,7 +266,7 @@ int main () {
 //CHECK-NEXT:     return _d_x * y + x * _d_y + _d_x * y + x * _d_y;
 //CHECK-NEXT: }
   auto vm_darg1_B1 = clad::differentiate(&B1::vm, 1);
-//CHECK: float vm_darg1(float x, float y) override {
+//CHECK: float B1::vm_darg1(float x, float y) {
 //CHECK-NEXT:     float _d_x = 0;
 //CHECK-NEXT:     float _d_y = 1;
 // CHECK-NEXT:     B1 _d_this_obj;

--- a/test/Functors/Simple.C
+++ b/test/Functors/Simple.C
@@ -32,7 +32,7 @@ public:
   float operator_call_darg0(float x, float y);
 };
 
-// CHECK: float operator_call_darg0(float x, float y) {
+// CHECK: float SimpleExpression::operator_call_darg0(float x, float y) {
 // CHECK-NEXT: float _d_x = 1;
 // CHECK-NEXT: float _d_y = 0;
 // CHECK-NEXT: SimpleExpression _d_this_obj;

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -353,7 +353,7 @@ struct S {
     return c1 * x + c2 * y;
   }
 
-  //CHECK:   void f_grad(double x, double y, S *_d_this, double *_d_x, double *_d_y) {
+  //CHECK:   void S::f_grad(double x, double y, S *_d_this, double *_d_x, double *_d_y) {
   //CHECK-NEXT:       {
   //CHECK-NEXT:           (*_d_this).c1 += 1 * x;
   //CHECK-NEXT:           *_d_x += this->c1 * 1;

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -21,7 +21,7 @@ public:
   double x, y;
   double mem_fn(double i, double j) { return (x + y) * i + i * j; }
 
-  // CHECK: void mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) {
+  // CHECK: void SimpleFunctions::mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -33,7 +33,7 @@ public:
 
   double const_mem_fn(double i, double j) const { return (x + y) * i + i * j; }
 
-  // CHECK: void const_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const {
+  // CHECK: void SimpleFunctions::const_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -47,7 +47,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile {
+  // CHECK: void SimpleFunctions::volatile_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
@@ -62,7 +62,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile {
+  // CHECK: void SimpleFunctions::const_volatile_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
@@ -75,7 +75,7 @@ public:
 
   double lval_ref_mem_fn(double i, double j) & { return (x + y) * i + i * j; }
 
-  // CHECK: void lval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) & {
+  // CHECK: void SimpleFunctions::lval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) & {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -89,7 +89,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_lval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const & {
+  // CHECK: void SimpleFunctions::const_lval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const & {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -103,7 +103,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_lval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & {
+  // CHECK: void SimpleFunctions::volatile_lval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
@@ -118,7 +118,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_lval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & {
+  // CHECK: void SimpleFunctions::const_volatile_lval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
@@ -131,7 +131,7 @@ public:
 
   double rval_ref_mem_fn(double i, double j) && { return (x + y) * i + i * j; }
 
-  // CHECK: void rval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) && {
+  // CHECK: void SimpleFunctions::rval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) && {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -145,7 +145,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_rval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const && {
+  // CHECK: void SimpleFunctions::const_rval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const && {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -159,7 +159,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_rval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && {
+  // CHECK: void SimpleFunctions::volatile_rval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
@@ -174,7 +174,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_rval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && {
+  // CHECK: void SimpleFunctions::const_volatile_rval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
@@ -189,7 +189,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) noexcept {
+  // CHECK: void SimpleFunctions::noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) noexcept {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -203,7 +203,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const noexcept {
+  // CHECK: void SimpleFunctions::const_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const noexcept {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -217,7 +217,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile noexcept {
+  // CHECK: void SimpleFunctions::volatile_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile noexcept {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
@@ -232,7 +232,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile noexcept {
+  // CHECK: void SimpleFunctions::const_volatile_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile noexcept {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
@@ -247,7 +247,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void lval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) & noexcept {
+  // CHECK: void SimpleFunctions::lval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) & noexcept {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -261,7 +261,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_lval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const & noexcept {
+  // CHECK: void SimpleFunctions::const_lval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const & noexcept {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -275,7 +275,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & noexcept {
+  // CHECK: void SimpleFunctions::volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & noexcept {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
@@ -290,7 +290,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & noexcept {
+  // CHECK: void SimpleFunctions::const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & noexcept {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
@@ -305,7 +305,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void rval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) && noexcept {
+  // CHECK: void SimpleFunctions::rval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) && noexcept {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -319,7 +319,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_rval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const && noexcept {
+  // CHECK: void SimpleFunctions::const_rval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const && noexcept {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
   // CHECK-NEXT:         (*_d_this).y += 1 * i;
@@ -333,7 +333,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && noexcept {
+  // CHECK: void SimpleFunctions::volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && noexcept {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;
@@ -348,7 +348,7 @@ public:
     return (x+y)*i + i*j;
   }
 
-  // CHECK: void const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && noexcept {
+  // CHECK: void SimpleFunctions::const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && noexcept {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         (*_d_this).x += 1 * i;

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -4,8 +4,6 @@
 // RUN: %cladclang %S/../../demos/RosenbrockFunction.cpp -I%S/../../include 2>&1
 // RUN: %cladclang %S/../../demos/ComputerGraphics/smallpt/SmallPT.cpp -I%S/../../include 2>&1
 
-// XFAIL: asserts
-
 //-----------------------------------------------------------------------------/
 //  Demo: Gradient.cpp
 //-----------------------------------------------------------------------------/

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -286,7 +286,7 @@ namespace clad {
           // decl or is contained in a namespace decl.
           // FIXME: We could get rid of this by prepending the produced
           // derivatives in CladPlugin::HandleTranslationUnitDecl
-          DeclContext* derivativeDC = DerivativeDecl->getDeclContext();
+          DeclContext* derivativeDC = DerivativeDecl->getLexicalDeclContext();
           bool isTUorND =
               derivativeDC->isTranslationUnit() || derivativeDC->isNamespace();
           if (isTUorND) {


### PR DESCRIPTION
Once the derivative's FunctionDecl is created it needs to be registered properly in the AST. Before this patch `registerDerivative` ignored many checks which make sure the produced code is valid C++. This patch enforces more rigorous checks for some declaration kinds such as standalone functions and some cases of class functions. Lambdas will be handled in subsequent patches.

The challenge is to produce valid C++ code when differentiating classes. Consider:
```cpp
class A1 {
  double f(double x) { return x * x; }
  double f_grad(double x, double *d_x); // forward declaration of the gradient.
};
```

In such cases clad will now produce a correct out-of-line definition of `f_grad`: `double A1::f_grad(double x, double *d_x) { ... }`.

In cases where the gradient function is not declared as part of the class signature (external libraries such as STL), we continue to handle them as before. That will be dealt with in a subsequent patches.

This also fixes assertions in debug mode when there are virtual functions.