### PR TITLE
Improve graph printing.

### DIFF
--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -608,8 +608,10 @@ namespace clad {
 
   void DiffRequest::print(llvm::raw_ostream& Out) const {
     Out << '<';
-    PrintingPolicy Policy(Function->getASTContext().getLangOpts());
-    Function->getNameForDiagnostic(Out, Policy, /*Qualified=*/true);
+    PrintingPolicy P(Function->getASTContext().getLangOpts());
+    P.TerseOutput = true;
+    P.FullyQualifiedName = true;
+    Function->print(Out, P, /*Indentation=*/0, /*PrintInstantiation=*/true);
     Out << ">[name=" << BaseFunctionName << ", "
         << "order=" << CurrentDerivativeOrder << ", "
         << "mode=" << DiffModeToString(Mode);

--- a/test/Misc/TimingsReport.C
+++ b/test/Misc/TimingsReport.C
@@ -5,14 +5,14 @@
 #include "clad/Differentiator/Differentiator.h"
 // CHECK: Timers for Clad Funcs
 // CHECK_STATS: *** INFORMATION ABOUT THE DIFF REQUESTS
-// CHECK_STATS-NEXT: <test1>[name=test1, order=1, mode=forward]: #0 (source), (done)
-// CHECK_STATS-NEXT: <test2>[name=test2, order=1, mode=reverse]: #1 (source), (done)
-// CHECK_STATS-NEXT: <nested1>[name=nested1, order=1, mode=pushforward]: #2, (done)
-// CHECK_STATS-NEXT: <nested2>[name=nested2, order=1, mode=pullback]: #3, (done)
+// CHECK_STATS-NEXT: <double test1(double x, double y)>[name=test1, order=1, mode=forward]: #0 (source), (done)
+// CHECK_STATS-NEXT: <double test2(double a, double b)>[name=test2, order=1, mode=reverse]: #1 (source), (done)
+// CHECK_STATS-NEXT: <double nested1(double c)>[name=nested1, order=1, mode=pushforward]: #2, (done)
+// CHECK_STATS-NEXT: <double nested2(double z)>[name=nested2, order=1, mode=pullback]: #3, (done)
 // CHECK_STATS-NEXT: 0 -> 2
 // CHECK_STATS-NEXT: 1 -> 3
 
-// CHECK_STATS_TBR: <test1>[name=test1, order=1, mode=forward, tbr]: #0 (source), (done)
+// CHECK_STATS_TBR: <double test1(double x, double y)>[name=test1, order=1, mode=forward, tbr]: #0 (source), (done)
 
 double nested1(double c){
   return c*3*c;

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -527,7 +527,7 @@ namespace clad {
 
       // Print the graph of the diff requests.
       llvm::errs() << "\n*** INFORMATION ABOUT THE DIFF REQUESTS\n";
-      m_DiffRequestGraph.print(std::cerr);
+      m_DiffRequestGraph.dump();
 
       m_Multiplexer->PrintStats();
     }


### PR DESCRIPTION
This patch forces DynamicGraph::dump to be used and thus present in the binary where we can use it from a debugger.