### PR TITLE
Add primitive support for `std::unique_ptr<T>`

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -11,6 +11,7 @@
 #include "clang/AST/Type.h"
 #include "llvm/ADT/StringRef.h"
 
+#include <clang/AST/DeclCXX.h>
 #include <string>
 
 namespace clang {
@@ -334,6 +335,9 @@ namespace clad {
 
     /// Returns true if QT is a non-const reference type.
     bool isNonConstReferenceType(clang::QualType QT);
+
+    bool isCopyable(const clang::CXXRecordDecl* RD);
+
     } // namespace utils
     } // namespace clad
 

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -6,6 +6,7 @@
 #include <clad/Differentiator/BuiltinDerivatives.h>
 #include <clad/Differentiator/FunctionTraits.h>
 #include <initializer_list>
+#include <memory>
 #include <tuple>
 #include <vector>
 
@@ -605,6 +606,26 @@ operator_equal_pushforward(::std::tuple<Args1...>* tu,
   ::std::tuple<Args1...> t1 = (*tu = in);
   ::std::tuple<Args1...> t2 = (*d_tu = d_in);
   return {t1, t2};
+}
+
+// std::unique_ptr<T> custom derivatives...
+template <typename T, typename U>
+clad::ValueAndAdjoint<::std::unique_ptr<T>, ::std::unique_ptr<T>>
+constructor_reverse_forw(clad::ConstructorReverseForwTag<::std::unique_ptr<T>>,
+                         U* p, U* d_p) {
+  return {::std::unique_ptr<T>(p), ::std::unique_ptr<T>(d_p)};
+}
+
+template <typename T>
+clad::ValueAndAdjoint<T&, T&>
+operator_star_reverse_forw(::std::unique_ptr<T>* u, ::std::unique_ptr<T>* d_u) {
+  return {**u, **d_u};
+}
+
+template <typename T, typename U>
+void operator_star_pullback(::std::unique_ptr<T>* u, U pullback,
+                            ::std::unique_ptr<T>* d_u) {
+  **d_u += pullback;
 }
 
 } // namespace class_functions

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -729,5 +729,18 @@ namespace clad {
       return QT->isReferenceType() &&
              !QT.getNonReferenceType().isConstQualified();
     }
+
+    bool isCopyable(const clang::CXXRecordDecl* RD) {
+      if (RD->defaultedCopyConstructorIsDeleted())
+        return false;
+      if (RD->hasUserDeclaredCopyConstructor()) {
+        std::string qualifiedName = RD->getQualifiedNameAsString();
+        // FIXME: I don't know why Clang things that unique_ptr has
+        // user-declared copy constructor.
+        if (qualifiedName == "std::unique_ptr")
+          return false;
+      }
+      return true;
+    }
   } // namespace utils
 } // namespace clad


### PR DESCRIPTION
This commit adds primitive support for std::unique_ptr<T>. Important changes introduced:

- Custom derivatives are added for std::unique_ptr<T> constructor, and operator* member function.
- `constructor_reverse_forw` has been modified to use move constructor in-case the object is not copyable.
- Variable-restore is disabled for non-copyable types.