### PR TITLE
Don't use original stmts in the generated code

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2325,15 +2325,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
              BinOp->getEndLoc(),
              "derivative of an assignment attempts to assign to unassignable "
              "expr, assignment ignored");
-        auto* LDRE = dyn_cast<DeclRefExpr>(L);
-        auto* RDRE = dyn_cast<DeclRefExpr>(R);
-
-        if (!LDRE && !RDRE)
-          return Clone(BinOp);
-        Expr* LExpr = LDRE ? Visit(L).getRevSweepAsExpr() : L;
-        Expr* RExpr = RDRE ? Visit(R).getRevSweepAsExpr() : R;
-
-        return BuildOp(opCode, LExpr, RExpr);
+        return Clone(BinOp);
       }
 
       // Visit LHS, but delay emission of its derivative statements, save them


### PR DESCRIPTION
It's not correct to use the original expressions ``L`` and ``R`` in the generated code. Also, it doesn't make sense why we exclusively differentiate ``DeclRefExpr``.