### PR TITLE
Don't set init and init style of a declaration manually

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -194,26 +194,22 @@ namespace clad {
     /// direct references in intermediate variables)
     clang::Expr* StoreAndRef(clang::Expr* E, direction d = direction::forward,
                              llvm::StringRef prefix = "_t",
-                             bool forceDeclCreation = false,
-                             clang::VarDecl::InitializationStyle IS =
-                                 clang::VarDecl::InitializationStyle::CInit) {
+                             bool forceDeclCreation = false) {
       assert(E && "cannot infer type from null expression");
       return StoreAndRef(E, getNonConstType(E->getType(), m_Context, m_Sema), d,
-                         prefix, forceDeclCreation, IS);
+                         prefix, forceDeclCreation);
     }
 
     /// An overload allowing to specify the type for the variable.
     clang::Expr* StoreAndRef(clang::Expr* E, clang::QualType Type,
                              direction d = direction::forward,
                              llvm::StringRef prefix = "_t",
-                             bool forceDeclCreation = false,
-                             clang::VarDecl::InitializationStyle IS =
-                                 clang::VarDecl::InitializationStyle::CInit) {
+                             bool forceDeclCreation = false) {
       // Name reverse temporaries as "_r" instead of "_t".
       if ((d == direction::reverse) && (prefix == "_t"))
         prefix = "_r";
       return VisitorBase::StoreAndRef(E, Type, getCurrentBlock(d), prefix,
-                                      forceDeclCreation, IS);
+                                      forceDeclCreation);
     }
 
     /// For an expr E, decides if it is useful to store it in a global temporary

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -273,6 +273,15 @@ namespace clad {
     /// \returns Expression with correct Unary Operator placement.
     clang::Expr* ResolveUnaryMinus(clang::Expr* E, clang::SourceLocation OpLoc);
     clang::Expr* BuildParens(clang::Expr* E);
+    /// Sets Init as the initializer of the declaration VD and compute its
+    /// initialization kind.
+    ///\param[in] VD - variable declaration
+    ///\param[in] Init - can be nullptr, then only initialization kind is
+    /// computed.
+    ///\param[in] DirectInit - tells whether the initialization is
+    /// direct.
+    void SetDeclInit(clang::VarDecl* VD, clang::Expr* Init = nullptr,
+                     bool DirectInit = false);
     /// Builds variable declaration to be used inside the derivative
     /// body.
     /// \param[in] Type The type of variable declaration to build.
@@ -478,7 +487,7 @@ namespace clad {
                                      clang::Sema::AA_Casting);
       assert(!ICAR.isInvalid() && "Invalid implicit conversion!");
       // Assign the resulting expression to the variable declaration
-      VD->setInit(ICAR.get());
+      SetDeclInit(VD, ICAR.get());
     }
 
     /// Build a call to member function through Base expr and using the function

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -15,6 +15,9 @@
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/Sema.h"
+#include <clang/AST/Type.h>
+#include <llvm/ADT/StringRef.h>
+
 #include <array>
 #include <stack>
 #include <unordered_map>
@@ -284,9 +287,7 @@ namespace clad {
     clang::VarDecl*
     BuildVarDecl(clang::QualType Type, clang::IdentifierInfo* Identifier,
                  clang::Scope* scope, clang::Expr* Init = nullptr,
-                 bool DirectInit = false, clang::TypeSourceInfo* TSI = nullptr,
-                 clang::VarDecl::InitializationStyle IS =
-                     clang::VarDecl::InitializationStyle::CInit);
+                 bool DirectInit = false, clang::TypeSourceInfo* TSI = nullptr);
     /// Builds variable declaration to be used inside the derivative
     /// body.
     /// \param[in] Type The type of variable declaration to build.
@@ -298,12 +299,11 @@ namespace clad {
     /// C style initalization.
     /// \param[in] TSI The type source information of the variable declaration.
     /// \returns The newly built variable declaration.
-    clang::VarDecl*
-    BuildVarDecl(clang::QualType Type, clang::IdentifierInfo* Identifier,
-                 clang::Expr* Init = nullptr, bool DirectInit = false,
-                 clang::TypeSourceInfo* TSI = nullptr,
-                 clang::VarDecl::InitializationStyle IS =
-                     clang::VarDecl::InitializationStyle::CInit);
+    clang::VarDecl* BuildVarDecl(clang::QualType Type,
+                                 clang::IdentifierInfo* Identifier,
+                                 clang::Expr* Init = nullptr,
+                                 bool DirectInit = false,
+                                 clang::TypeSourceInfo* TSI = nullptr);
     /// Builds variable declaration to be used inside the derivative
     /// body.
     /// \param[in] Type The type of variable declaration to build.
@@ -314,20 +314,18 @@ namespace clad {
     /// C style initalization.
     /// \param[in] TSI The type source information of the variable declaration.
     /// \returns The newly built variable declaration.
-    clang::VarDecl*
-    BuildVarDecl(clang::QualType Type, llvm::StringRef prefix = "_t",
-                 clang::Expr* Init = nullptr, bool DirectInit = false,
-                 clang::TypeSourceInfo* TSI = nullptr,
-                 clang::VarDecl::InitializationStyle IS =
-                     clang::VarDecl::InitializationStyle::CInit);
+    clang::VarDecl* BuildVarDecl(clang::QualType Type,
+                                 llvm::StringRef prefix = "_t",
+                                 clang::Expr* Init = nullptr,
+                                 bool DirectInit = false,
+                                 clang::TypeSourceInfo* TSI = nullptr);
     /// Builds variable declaration to be used inside the derivative
     /// body in the derivative function global scope.
-    clang::VarDecl*
-    BuildGlobalVarDecl(clang::QualType Type, llvm::StringRef prefix = "_t",
-                       clang::Expr* Init = nullptr, bool DirectInit = false,
-                       clang::TypeSourceInfo* TSI = nullptr,
-                       clang::VarDecl::InitializationStyle IS =
-                           clang::VarDecl::InitializationStyle::CInit);
+    clang::VarDecl* BuildGlobalVarDecl(clang::QualType Type,
+                                       llvm::StringRef prefix = "_t",
+                                       clang::Expr* Init = nullptr,
+                                       bool DirectInit = false,
+                                       clang::TypeSourceInfo* TSI = nullptr);
     /// Creates a namespace declaration and enters its context. All subsequent
     /// Stmts are built inside that namespace, until
     /// m_Sema.PopDeclContextIsUsed.
@@ -368,20 +366,14 @@ namespace clad {
     /// direct references in intermediate variables)
     clang::Expr* StoreAndRef(clang::Expr* E, Stmts& block,
                              llvm::StringRef prefix = "_t",
-                             bool forceDeclCreation = false,
-                             clang::VarDecl::InitializationStyle IS =
-                                 clang::VarDecl::InitializationStyle::CInit);
+                             bool forceDeclCreation = false);
     /// A shorthand to store directly to the current block.
     clang::Expr* StoreAndRef(clang::Expr* E, llvm::StringRef prefix = "_t",
-                             bool forceDeclCreation = false,
-                             clang::VarDecl::InitializationStyle IS =
-                                 clang::VarDecl::InitializationStyle::CInit);
+                             bool forceDeclCreation = false);
     /// An overload allowing to specify the type for the variable.
     clang::Expr* StoreAndRef(clang::Expr* E, clang::QualType Type, Stmts& block,
                              llvm::StringRef prefix = "_t",
-                             bool forceDeclCreation = false,
-                             clang::VarDecl::InitializationStyle IS =
-                                 clang::VarDecl::InitializationStyle::CInit);
+                             bool forceDeclCreation = false);
     /// For an expr E, decides if it is useful to store it in a temporary
     /// variable and replace E's further usage by a reference to that variable
     /// to avoid recomputation.

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -696,7 +696,7 @@ StmtDiff BaseForwardModeVisitor::VisitForStmt(const ForStmt* FS) {
     if (condVarResult.getDecl_dx())
       addToCurrentBlock(BuildDeclStmt(condVarResult.getDecl_dx()));
     auto condInit = condVarClone->getInit();
-    condVarClone->setInit(nullptr);
+    SetDeclInit(condVarClone);
     cond = BuildOp(BO_Assign, BuildDeclRef(condVarClone), condInit);
     addToCurrentBlock(BuildDeclStmt(condVarClone));
   }
@@ -1696,7 +1696,7 @@ StmtDiff BaseForwardModeVisitor::VisitWhileStmt(const WhileStmt* WS) {
     if (condVarRes.getDecl_dx())
       addToCurrentBlock(BuildDeclStmt(condVarRes.getDecl_dx()));
     auto* condInit = condVarClone->getInit();
-    condVarClone->setInit(nullptr);
+    SetDeclInit(condVarClone);
     cond = BuildOp(BO_Assign, BuildDeclRef(condVarClone), condInit);
     addToCurrentBlock(BuildDeclStmt(condVarClone));
   }

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1494,9 +1494,8 @@ BaseForwardModeVisitor::DifferentiateVarDecl(const VarDecl* VD,
 
   // Here we are assuming that derived type and the original type are same.
   // This may not necessarily be true in the future.
-  VarDecl* VDClone =
-      BuildVarDecl(VD->getType(), VD->getNameAsString(), initDiff.getExpr(),
-                   VD->isDirectInit(), /*TSI=*/nullptr, VD->getInitStyle());
+  VarDecl* VDClone = BuildVarDecl(VD->getType(), VD->getNameAsString(),
+                                  initDiff.getExpr(), VD->isDirectInit());
   // FIXME: Create unique identifier for derivative.
   Expr* initDx = initDiff.getExpr_dx();
   if (VD->getType()->isPointerType() && !initDx) {
@@ -1506,9 +1505,8 @@ BaseForwardModeVisitor::DifferentiateVarDecl(const VarDecl* VD,
         new (m_Context) CXXNullPtrLiteralExpr(VD->getType(), VD->getBeginLoc());
     // NOLINTEND(cppcoreguidelines-owned-memory)
   }
-  VarDecl* VDDerived =
-      BuildVarDecl(VD->getType(), "_d_" + VD->getNameAsString(), initDx,
-                   VD->isDirectInit(), /*TSI=*/nullptr, VD->getInitStyle());
+  VarDecl* VDDerived = BuildVarDecl(
+      VD->getType(), "_d_" + VD->getNameAsString(), initDx, VD->isDirectInit());
   m_Variables.emplace(VDClone, BuildDeclRef(VDDerived));
   return DeclDiff<VarDecl>(VDClone, VDDerived);
 }

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -356,9 +356,7 @@ DerivativeAndOverload HessianModeVisitor::Derive() {
           // variable is of `const` type. This behaviour is consistent with the built-in
           // scalar numerical types as well.
           thisObjectType.removeLocalConst();
-          auto dThisVD = BuildVarDecl(thisObjectType, "_d_this",
-                                      /*Init=*/nullptr, false, /*TSI=*/nullptr,
-                                      VarDecl::InitializationStyle::CallInit);
+          VarDecl* dThisVD = BuildVarDecl(thisObjectType, "_d_this");
           CompStmtSave.push_back(BuildDeclStmt(dThisVD));
           Expr* dThisExpr = BuildDeclRef(dThisVD);
           DeclRefToParams.push_back(

--- a/lib/Differentiator/JacobianModeVisitor.cpp
+++ b/lib/Differentiator/JacobianModeVisitor.cpp
@@ -239,8 +239,7 @@ DerivativeAndOverload JacobianModeVisitor::DeriveJacobian() {
       addToCurrentBlock(paramAssignment);
     } else {
       auto* paramDecl = cast<VarDecl>(cast<DeclRefExpr>(paramDiff)->getDecl());
-      m_Sema.AddInitializerToDecl(paramDecl, dVectorParam, true);
-      paramDecl->setInitStyle(VarDecl::InitializationStyle::CInit);
+      SetDeclInit(paramDecl, dVectorParam);
     }
   }
 

--- a/test/FirstDerivative/FunctionCallsWithResults.C
+++ b/test/FirstDerivative/FunctionCallsWithResults.C
@@ -304,8 +304,8 @@ double fn10(double x) {
 // CHECK-NEXT:   double _d_x = 1;
 // CHECK-NEXT:   std::mt19937 _d_gen64;
 // CHECK-NEXT:   std::mt19937 gen64;
-// CHECK-NEXT:   std::uniform_real_distribution<{{(double)?}}> _d_distribution({0., 0.});
-// CHECK-NEXT:   std::uniform_real_distribution<{{(double)?}}> distribution({0., 1.});
+// CHECK-NEXT:   std::uniform_real_distribution<{{(double)?}}> _d_distribution{0., 0.};
+// CHECK-NEXT:   std::uniform_real_distribution<{{(double)?}}> distribution{0., 1.};
 // CHECK-NEXT:   clad::ValueAndPushforward<result_type, result_type> _t0 = distribution.operator_call_pushforward(gen64, &_d_distribution, _d_gen64);
 // CHECK-NEXT:   double _d_rand = _t0.pushforward;
 // CHECK-NEXT:   double rand0 = _t0.value;

--- a/test/ForwardMode/NonDifferentiable.C
+++ b/test/ForwardMode/NonDifferentiable.C
@@ -153,8 +153,8 @@ int main() {
   // CHECK: double fn_s1_mem_fn_darg0(double i, double j) {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
-  // CHECK-NEXT:     SimpleFunctions1 _d_obj({0, 0});
-  // CHECK-NEXT:     SimpleFunctions1 obj({2, 3});
+  // CHECK-NEXT:     SimpleFunctions1 _d_obj{0, 0};
+  // CHECK-NEXT:     SimpleFunctions1 obj{2, 3};
   // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = obj.mem_fn_1_pushforward(i, j, &_d_obj, _d_i, _d_j);
   // CHECK-NEXT:     return _t0.pushforward + _d_i * j + i * _d_j;
   // CHECK-NEXT: }
@@ -162,8 +162,8 @@ int main() {
   // CHECK: double fn_s1_field_darg0(double i, double j) {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
-  // CHECK-NEXT:     SimpleFunctions1 _d_obj({0, 0});
-  // CHECK-NEXT:     SimpleFunctions1 obj({2, 3});
+  // CHECK-NEXT:     SimpleFunctions1 _d_obj{0, 0};
+  // CHECK-NEXT:     SimpleFunctions1 obj{2, 3};
   // CHECK-NEXT:     double &_t0 = obj.x;
   // CHECK-NEXT:     double &_t1 = obj.y;
   // CHECK-NEXT:     return _d_obj.x * _t1 + _t0 * 0. + _d_i * j + i * _d_j;
@@ -174,10 +174,10 @@ int main() {
   // CHECK: double fn_s1_operator_darg0(double i, double j) {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
-  // CHECK-NEXT:     SimpleFunctions1 _d_obj1({0, 0});
-  // CHECK-NEXT:     SimpleFunctions1 obj1({2, 3});
-  // CHECK-NEXT:     SimpleFunctions1 _d_obj2({0, 0});
-  // CHECK-NEXT:     SimpleFunctions1 obj2({3, 5});
+  // CHECK-NEXT:     SimpleFunctions1 _d_obj1{0, 0};
+  // CHECK-NEXT:     SimpleFunctions1 obj1{2, 3};
+  // CHECK-NEXT:     SimpleFunctions1 _d_obj2{0, 0};
+  // CHECK-NEXT:     SimpleFunctions1 obj2{3, 5};
   // CHECK-NEXT:     clad::ValueAndPushforward<SimpleFunctions1, SimpleFunctions1> _t0 = obj1.operator_plus_pushforward(obj2, &_d_obj1, _d_obj2);
   // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = _t0.value.mem_fn_1_pushforward(i, j, &_t0.pushforward, _d_i, _d_j);
   // CHECK-NEXT:     return _t1.pushforward;

--- a/test/ForwardMode/STLCustomDerivatives.C
+++ b/test/ForwardMode/STLCustomDerivatives.C
@@ -107,8 +107,8 @@ double fnVec4(double u, double v) {
 // CHECK-NEXT:     double _d_u = 1;
 // CHECK-NEXT:     double _d_v = 0;
 // CHECK-NEXT:     {{.*}}ValueAndPushforward< ::std::vector<double>, ::std::vector<double> > _t0 = clad::custom_derivatives::class_functions::constructor_pushforward(clad::ConstructorPushforwardTag<std::vector<double> >(), {u, v, u * v}, {{.*}}{_d_u, _d_v, _d_u * v + u * _d_v}{{.*}});
-// CHECK-NEXT:     std::vector<double> _d_V_t0.pushforward;
-// CHECK-NEXT:     std::vector<double> V_t0.value;
+// CHECK-NEXT:     std::vector<double> _d_V(_t0.pushforward);
+// CHECK-NEXT:     std::vector<double> V(_t0.value);
 // CHECK-NEXT:     {{.*}}ValueAndPushforward<double &, double &> _t1 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V, 0, &_d_V, 0);
 // CHECK-NEXT:     {{.*}}ValueAndPushforward<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&V, 2, &_d_V, 0);
 // CHECK-NEXT:     double &_t3 = _t1.value;

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -26,8 +26,8 @@ std::pair<double, double> fn1(double i, double j) {
 // CHECK: std::pair<double, double> fn1_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     std::pair<double, double> _d_c({0, 0}), _d_d({0., 0.});
-// CHECK-NEXT:     std::pair<double, double> c({3, 5}), d({7., 9.});
+// CHECK-NEXT:     std::pair<double, double> _d_c{0, 0}, _d_d{0., 0.};
+// CHECK-NEXT:     std::pair<double, double> c{3, 5}, d{7., 9.};
 // CHECK-NEXT:     std::pair<double, double> _d_e = _d_d;
 // CHECK-NEXT:     std::pair<double, double> e = d;
 // CHECK-NEXT:     _d_c.first += _d_i;
@@ -494,8 +494,8 @@ complexD fn8(double i, TensorD5 t) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     TensorD5 _d_t;
 // CHECK-NEXT:     t.updateTo_pushforward(i * i, & _d_t, _d_i * i + i * _d_i);
-// CHECK-NEXT:     complexD _d_c({0., 0.});
-// CHECK-NEXT:     complexD c({0., 0.});
+// CHECK-NEXT:     complexD _d_c{0., 0.};
+// CHECK-NEXT:     complexD c{0., 0.};
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = t.sum_pushforward(& _d_t);
 // CHECK-NEXT:     double &_t1 = _t0.value;
 // CHECK-NEXT:     c.real_pushforward(7 * _t1, &_d_c, 0 * _t1 + 7 * _t0.pushforward);
@@ -521,8 +521,8 @@ complexD fn9(double i, complexD c) {
 // CHECK: complexD fn9_darg0(double i, complexD c) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     complexD _d_c;
-// CHECK-NEXT:     complexD _d_r({0., 0.});
-// CHECK-NEXT:     complexD r({0., 0.});
+// CHECK-NEXT:     complexD _d_r{0., 0.};
+// CHECK-NEXT:     complexD r{0., 0.};
 // CHECK-NEXT:     c.real_pushforward(i * i, &_d_c, _d_i * i + i * _d_i);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = c.real_pushforward(&_d_c);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = c.real_pushforward(&_d_c);
@@ -554,8 +554,8 @@ std::complex<double> fn10(double i, double j) {
 // CHECK: std::complex<double> fn10_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     std::complex<double> _d_c1({0., 0.}), _d_c2({0., 0.});
-// CHECK-NEXT:     std::complex<double> c1({0., 0.}), c2({0., 0.});
+// CHECK-NEXT:     std::complex<double> _d_c1{0., 0.}, _d_c2{0., 0.};
+// CHECK-NEXT:     std::complex<double> c1{0., 0.}, c2{0., 0.};
 // CHECK-NEXT:     c1.real_pushforward(2 * i, &_d_c1, 0 * i + 2 * _d_i);
 // CHECK-NEXT:     c1.imag_pushforward(5 * i, &_d_c1, 0 * i + 5 * _d_i);
 // CHECK-NEXT:     c2.real_pushforward(5 * i, &_d_c2, 0 * i + 5 * _d_i);

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -529,13 +529,13 @@ double fn6(double u, double v) {
 // CHECK-NEXT:      double &w = u;
 // CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t0 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>());
 // CHECK-NEXT:      SafeTestClass s1(_t0.value);
-// CHECK-NEXT:      SafeTestClass _d_s1(_t0.adjoint);
+// CHECK-NEXT:      SafeTestClass _d_s1 = _t0.adjoint;
 // CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t1 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), u, &v, *_d_u, &*_d_v);
 // CHECK-NEXT:      SafeTestClass s2(_t1.value);
-// CHECK-NEXT:      SafeTestClass _d_s2(_t1.adjoint);
+// CHECK-NEXT:      SafeTestClass _d_s2 = _t1.adjoint;
 // CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t2 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), w, _d_w);
 // CHECK-NEXT:      SafeTestClass s3(_t2.value);
-// CHECK-NEXT:      SafeTestClass _d_s3(_t2.adjoint);
+// CHECK-NEXT:      SafeTestClass _d_s3 = _t2.adjoint;
 // CHECK-NEXT:      *_d_v += 1;
 // CHECK-NEXT:      {{.*}}constructor_pullback(&s2, u, &v, &_d_s2, &*_d_u, &*_d_v);
 // CHECK-NEXT:  }

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -236,7 +236,7 @@ int main() {
 
 // CHECK: void fn10_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:     std::vector<double> vec;
-// CHECK-NEXT:     std::vector<double> _d_vec({});
+// CHECK-NEXT:     std::vector<double> _d_vec = {};
 // CHECK-NEXT:     clad::zero_init(_d_vec);
 // CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
@@ -258,7 +258,7 @@ int main() {
 
 // CHECK-NEXT: void fn11_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:     std::vector<double> vec;
-// CHECK-NEXT:     std::vector<double> _d_vec({});
+// CHECK-NEXT:     std::vector<double> _d_vec = {};
 // CHECK-NEXT:     clad::zero_init(_d_vec);
 // CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
@@ -317,7 +317,7 @@ int main() {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     std::vector<double> vec;
-// CHECK-NEXT:     std::vector<double> _d_vec({});
+// CHECK-NEXT:     std::vector<double> _d_vec = {};
 // CHECK-NEXT:     clad::zero_init(_d_vec);
 // CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 3, &_d_vec, {{0U|0UL|0}});
@@ -463,7 +463,7 @@ int main() {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = u;
 // CHECK-NEXT:     {{.*}}allocator_type allocator;
-// CHECK-NEXT:     {{.*}}allocator_type _d_allocator({});
+// CHECK-NEXT:     {{.*}}allocator_type _d_allocator = {};
 // CHECK-NEXT:     clad::zero_init(_d_allocator);
 // CHECK-NEXT:     {{.*}} _d_count = {{0U|0UL}};
 // CHECK-NEXT:     {{.*}} count = 3;
@@ -490,7 +490,7 @@ int main() {
 
 // CHECK:      void fn14_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:          std::vector<double> a;
-// CHECK-NEXT:          std::vector<double> _d_a({});
+// CHECK-NEXT:          std::vector<double> _d_a = {};
 // CHECK-NEXT:          clad::zero_init(_d_a);
 // CHECK-NEXT:          std::vector<double> _t0 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, x, &_d_a, *_d_x);
@@ -525,7 +525,7 @@ int main() {
 // CHECK-NEXT:        clad::tape<std::array<double, 3> > _t2 = {};
 // CHECK-NEXT:        clad::tape<double> _t3 = {};
 // CHECK-NEXT:        clad::tape<std::array<double, 3> > _t4 = {};
-// CHECK-NEXT:        std::array<double, 3> _d_a({{.*}});
+// CHECK-NEXT:        std::array<double, 3> _d_a = {{.*}};
 // CHECK-NEXT:        std::array<double, 3> a;
 // CHECK-NEXT:        std::array<double, 3> _t0 = a;
 // CHECK-NEXT:        {{.*}}fill_reverse_forw(&a, x, &_d_a, *_d_x);
@@ -570,7 +570,7 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK:     void fn16_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:         std::array<double, 2> _d_a({{.*}});
+// CHECK-NEXT:         std::array<double, 2> _d_a = {{.*}};
 // CHECK-NEXT:         std::array<double, 2> a;
 // CHECK-NEXT:         std::array<double, 2> _t0 = a;
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, {{0U|0UL|0}});
@@ -580,7 +580,7 @@ int main() {
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t4 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:         double _t5 = _t4.value;
 // CHECK-NEXT:         _t4.value = y;
-// CHECK-NEXT:         std::array<double, 3> _d__b({{.*}});
+// CHECK-NEXT:         std::array<double, 3> _d__b = {{.*}};
 // CHECK-NEXT:         std::array<double, 3> _b0;
 // CHECK-NEXT:         std::array<double, 3> _t6 = _b0;
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t7 = {{.*}}operator_subscript_reverse_forw(&_b0, 0, &_d__b, {{0U|0UL|0}});
@@ -654,7 +654,7 @@ int main() {
 // CHECK-NEXT:     }
 
 // CHECK:     void fn17_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:         std::array<double, 50> _d_a({{.*}});
+// CHECK-NEXT:         std::array<double, 50> _d_a = {{.*}};
 // CHECK-NEXT:         std::array<double, 50> a;
 // CHECK-NEXT:         std::array<double, 50> _t0 = a;
 // CHECK-NEXT:         {{.*}}fill_reverse_forw(&a, y + x + x, &_d_a, 0.);
@@ -678,7 +678,7 @@ int main() {
 // CHECK-NEXT:     }
 
 // CHECK:     void fn18_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:         std::array<double, 2> _d_a({{.*}});
+// CHECK-NEXT:         std::array<double, 2> _d_a = {{.*}};
 // CHECK-NEXT:         std::array<double, 2> a;
 // CHECK-NEXT:         std::array<double, 2> _t0 = a;
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
@@ -710,7 +710,7 @@ int main() {
 // CHECK-NEXT:          {{.*}}tape<double> _t4 = {};
 // CHECK-NEXT:          {{.*}}tape<{{.*}}vector<double> > _t5 = {};
 // CHECK-NEXT:          {{.*}}vector<double> v;
-// CHECK-NEXT:          {{.*}}vector<double> _d_v({});
+// CHECK-NEXT:          {{.*}}vector<double> _d_v = {};
 // CHECK-NEXT:          clad::zero_init(_d_v);
 // CHECK-NEXT:          {{.*}} _t0 = {{0U|0UL|0}};
 // CHECK-NEXT:          for (i = 0; ; ++i) {
@@ -801,7 +801,7 @@ int main() {
 
 // CHECK:      void fn20_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:          {{.*}}vector<double> v;
-// CHECK-NEXT:          {{.*}}vector<double> _d_v({});
+// CHECK-NEXT:          {{.*}}vector<double> _d_v = {};
 // CHECK-NEXT:          clad::zero_init(_d_v);
 // CHECK-NEXT:          {{.*}}vector<double> _t0 = v;
 // CHECK-NEXT:          v.reserve(10);
@@ -842,7 +842,7 @@ int main() {
 
 // CHECK:      void fn21_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:          std::vector<double> a;
-// CHECK-NEXT:          std::vector<double> _d_a({});
+// CHECK-NEXT:          std::vector<double> _d_a = {};
 // CHECK-NEXT:          clad::zero_init(_d_a);
 // CHECK-NEXT:          std::vector<double> _t0 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, 0{{.*}}, &_d_a, 0.);
@@ -873,7 +873,7 @@ int main() {
 
 // CHECK:      void fn22_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:      std::vector<double>::allocator_type alloc;
-// CHECK-NEXT:      std::vector<double>::allocator_type _d_alloc({});
+// CHECK-NEXT:      std::vector<double>::allocator_type _d_alloc = {};
 // CHECK-NEXT:      clad::zero_init(_d_alloc);
 // CHECK-NEXT:      std::vector<double> ls({u, v}, alloc);
 // CHECK-NEXT:      std::vector<double> _d_ls(ls);
@@ -909,7 +909,7 @@ int main() {
 // CHECK-NEXT:      clad::tape<double> _t7 = {};
 // CHECK-NEXT:      clad::tape<std::vector<double> > _t8 = {};
 // CHECK-NEXT:      {{.*}}allocator_type alloc;
-// CHECK-NEXT:      {{.*}}allocator_type _d_alloc({});
+// CHECK-NEXT:      {{.*}}allocator_type _d_alloc = {};
 // CHECK-NEXT:      clad::zero_init(_d_alloc);
 // CHECK-NEXT:      unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:      for (i = 0; ; ++i) {

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -98,7 +98,7 @@ double fn3(double i, double j) {
 
 // CHECK: void fn3_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     Tangent t;
-// CHECK-NEXT:     Tangent _d_t({});
+// CHECK-NEXT:     Tangent _d_t = {};
 // CHECK-NEXT:     clad::zero_init(_d_t);
 // CHECK-NEXT:     double _t0 = t.data[0];
 // CHECK-NEXT:     t.data[0] = 2 * i;
@@ -126,7 +126,7 @@ double fn3(double i, double j) {
 
 double fn4(double i, double j) {
     pairdd p(1, 3);
-    pairdd q({7, 5});
+    pairdd q{7, 5};
     return p.first*i + p.second*j + q.first*i + q.second*j;
 }
 
@@ -134,7 +134,7 @@ double fn4(double i, double j) {
 // CHECK-NEXT:     pairdd p(1, 3);
 // CHECK-NEXT:     pairdd _d_p(p);
 // CHECK-NEXT:     clad::zero_init(_d_p);
-// CHECK-NEXT:     pairdd q({7, 5});
+// CHECK-NEXT:     pairdd q{7, 5};
 // CHECK-NEXT:     pairdd _d_q(q);
 // CHECK-NEXT:     clad::zero_init(_d_q);
 // CHECK-NEXT:     {
@@ -148,9 +148,8 @@ double fn4(double i, double j) {
 // CHECK-NEXT:         *_d_j += q.second * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}} _r2 = {};
+// CHECK-NEXT:         int _r2 = 0;
 // CHECK-NEXT:         int _r3 = 0;
-// CHECK-NEXT:         int _r4 = 0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         int _r0 = 0;
@@ -374,7 +373,7 @@ double fn11(double x, double y) {
 
 // CHECK: void fn11_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     Tangent t;
-// CHECK-NEXT:     Tangent _d_t({});
+// CHECK-NEXT:     Tangent _d_t = {};
 // CHECK-NEXT:     clad::zero_init(_d_t);
 // CHECK-NEXT:     double _t0 = t.data[0];
 // CHECK-NEXT:     t.data[0] = -y;
@@ -433,7 +432,7 @@ void fn13(double *x, double *y, int size)
 // CHECK-NEXT: Fint _t1;
 // CHECK-NEXT: clad::tape<Fint> _t2 = {};
 // CHECK-NEXT: clad::tape<double> _t3 = {};
-// CHECK-NEXT: Findex _d_p({});
+// CHECK-NEXT: Findex _d_p = {};
 // CHECK-NEXT: Findex p;
 // CHECK-NEXT: unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT: _t1 = p.j;
@@ -513,7 +512,7 @@ double fn15(double x, double y) {
 
 // CHECK:void fn15_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:    ::clad::ValueAndAdjoint<SimpleArray<double, {{2U|2UL|2ULL}}>, SimpleArray<double, {{2U|2UL|2ULL}}> > _t0 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<SimpleArray<double, 2> >());
-// CHECK-NEXT:    SimpleArray<double, 2> _d_arr(_t0.adjoint);
+// CHECK-NEXT:    SimpleArray<double, 2> _d_arr = _t0.adjoint;
 // CHECK-NEXT:    SimpleArray<double, 2> arr(_t0.value);
 // CHECK-NEXT:    _d_arr.elements[0] += 1;
 // CHECK-NEXT:}

--- a/test/ValidCodeGen/ValidCodeGen.C
+++ b/test/ValidCodeGen/ValidCodeGen.C
@@ -62,7 +62,7 @@ int main() {
 //CHECK-NEXT:     }
 
 //CHECK:     void fn2_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:         TN::Test2<double> _d_t({});
+//CHECK-NEXT:         TN::Test2<double> _d_t = {};
 //CHECK-NEXT:         TN::Test2<double> t;
 //CHECK-NEXT:         TN::Test2<double> _t0 = t;
 //CHECK-NEXT:         double _d_q = 0.;


### PR DESCRIPTION
This PR addresses 2 issues:
1) Initialization styles should not be set manually, instead, they should be deduced by clang based on the types of the declaration and init, as well as on whether the declaration is direct.
 e.g. direct initialization of `std::vector vec` with `other` should look like
```
std::vector vec(other);
```
and not
```
std::vector vec = other;
```

2) Sometimes we initialize declarations using ``Decl::setInit``, which is a low-level function used by clang internally. This PR introduces a wrapper of ``Sema::AddInitializerToDecl`` called ``SetDeclInit``.