### PR TITLE
Fix clang-format workflow

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -30,10 +30,6 @@ jobs:
           echo "deb https://apt.llvm.org/${os_codename}/ llvm-toolchain-${os_codename}-18 main" | sudo tee -a /etc/apt/sources.list
           sudo apt update
           sudo apt install -y clang-format-18
-      - name: Download git-clang-format
-        run: |
-          wget https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/git-clang-format
-          chmod +x git-clang-format
       - name: Run git-clang-format
         run: |
           PR_BASE=$(git rev-list ${{ github.event.pull_request.head.sha }} ^${{ github.event.pull_request.base.sha }} | tail --lines 1 | xargs -I {} git rev-parse {}~1)

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -4,7 +4,6 @@
 //------------------------------------------------------------------------------
 //
 // File originates from the Scout project (http://scout.zih.tu-dresden.de/)
-
 #include "clad/Differentiator/StmtClone.h"
 
 #include "clang/Sema/Lookup.h"


### PR DESCRIPTION
The clang format workflow is broken because it tries to get a git-clang-format by wgetting it. Git-clang-format is not used as far as I can tell from the workflow, so should be safe to just remove the 'Download git-clang-format' section of the workflow.