### PR TITLE
Force differentiation w.r.t. all non-const pointer/array type parameters

### DIFF
--- a/benchmark/AlgorithmicComplexity.cpp
+++ b/benchmark/AlgorithmicComplexity.cpp
@@ -11,7 +11,8 @@
 // FIXME: Make the benchmark work with a range of inputs. That's currently
 // problematic for reverse mode.
 
-// inline double gaus(double* x, double* p /*means*/, double sigma, int dim);
+// inline double gaus(const double* x, double* p /*means*/, double sigma, int
+// dim);
 static void BM_NumericGausP(benchmark::State& state) {
   using namespace numerical_diff;
   long double sum = 0;

--- a/benchmark/BenchmarkedFunctions.h
+++ b/benchmark/BenchmarkedFunctions.h
@@ -13,7 +13,7 @@ inline double sum(double* p, int dim) {
 ///\returns the gaussian distribution. We need always_inline to improve the
 /// performance of reverse mode.
 __attribute__((always_inline)) inline double
-gaus(double* x, double* p /*means*/, double sigma, int dim) {
+gaus(const double* x, double* p /*means*/, double sigma, int dim) {
   double t = 0;
   for (int i = 0; i < dim; i++)
     t += (x[i] - p[i]) * (x[i] - p[i]);

--- a/demos/Arrays.cpp
+++ b/demos/Arrays.cpp
@@ -19,7 +19,7 @@
 // Necessary for clad to work include
 #include "clad/Differentiator/Differentiator.h"
 
-double weighted_avg(double* arr, double* weights) {
+double weighted_avg(double* arr, const double* weights) {
   return (arr[0] * weights[0] + arr[1] * weights[1] + arr[2] * weights[2]) / 3;
 }
 

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -223,6 +223,9 @@ namespace clad {
     /// is neither an array nor a pointer type, then simply returns `T`.
     clang::QualType GetValueType(clang::QualType T);
 
+    /// Returns the same type as GetValueType but without const qualifier.
+    clang::QualType GetNonConstValueType(clang::QualType T);
+
     /// Builds and returns the init expression to initialise `clad::array` and
     /// `clad::array_ref` from a constant array.
     ///

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -16,6 +16,7 @@
 #include "clang/Sema/Sema.h"
 
 #include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/SmallVector.h>
 
 #include <array>
 #include <limits>
@@ -43,6 +44,7 @@ namespace clad {
     // a separate namespace, as well as add getters/setters function of
     // several private/protected members of the visitor classes.
     friend class ErrorEstimationHandler;
+    llvm::SmallVector<const clang::ParmVarDecl*, 16> m_NonIndepParams;
     /// In addition to a sequence of forward-accumulated Stmts (m_Blocks), in
     /// the reverse mode we also accumulate Stmts for the reverse pass which
     /// will be executed on return.

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -43,7 +43,6 @@ namespace clad {
     // a separate namespace, as well as add getters/setters function of
     // several private/protected members of the visitor classes.
     friend class ErrorEstimationHandler;
-    llvm::SmallVector<const clang::ValueDecl*, 16> m_IndependentVars;
     /// In addition to a sequence of forward-accumulated Stmts (m_Blocks), in
     /// the reverse mode we also accumulate Stmts for the reverse pass which
     /// will be executed on return.

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -7,6 +7,9 @@
 
 #include "clang/AST/Decl.h"
 
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
+
 using namespace clang;
 
 namespace clad {
@@ -339,9 +342,8 @@ void ErrorEstimationHandler::ActAfterProcessingArraySubscriptExpr(
         return;
 
       // We only need to know the size of independent arrays.
-      auto& indVars = m_RMV->m_IndependentVars;
-      auto* it = std::find(indVars.begin(), indVars.end(), VD);
-      if (it == indVars.end())
+      auto params = m_RMV->m_Derivative->parameters();
+      if (llvm::find(params, VD) == params.end())
         return;
 
       // Construct `var_size = max(var_size, idx);`
@@ -351,8 +353,8 @@ void ErrorEstimationHandler::ActAfterProcessingArraySubscriptExpr(
       idx =
           m_RMV->m_Sema.ImpCastExprToType(idx, size->getType(), CK_IntegralCast)
               .get();
-      llvm::SmallVector<clang::Expr*, 2> params{size, idx};
-      Expr* extendedSize = m_EstModel->GetFunctionCall("max", "std", params);
+      llvm::SmallVector<clang::Expr*, 2> args{size, idx};
+      Expr* extendedSize = m_EstModel->GetFunctionCall("max", "std", args);
       size = m_RMV->Clone(size);
       Stmt* updateSize = m_RMV->BuildOp(BO_Assign, size, extendedSize);
       m_RMV->addToCurrentBlock(updateSize, direction::reverse);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1404,8 +1404,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         if (const auto* DRE = dyn_cast<DeclRefExpr>(Arg->IgnoreImpCasts())) {
           // If the arg is used as independent variable, then we cannot free it
           // as it holds the result to be returned to the user.
-          if (std::find(m_DiffReq.DVI.begin(), m_DiffReq.DVI.end(),
-                        DRE->getDecl()) == m_DiffReq.DVI.end())
+          if (llvm::find(m_DiffReq.DVI, DRE->getDecl()) == m_DiffReq.DVI.end())
             DerivedCallArgs.push_back(ArgDiff.getExpr_dx());
         }
       }
@@ -4343,9 +4342,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       auto* newPVD = CloneParmVarDecl(PVD, PVDII,
                                       /*pushOnScopeChains=*/true,
                                       /*cloneDefaultArg=*/false);
-
-      // Point m_IndependentVars to the argument of the newly created param.
-      m_IndependentVars.push_back(newPVD);
 
       if (!PVD->getDeclName()) // We can't use lookup-based replacements
         m_DeclReplacements[PVD] = newPVD;

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4244,10 +4244,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   }
 
   QualType ReverseModeVisitor::GetParameterDerivativeType(QualType Type) {
-
-    QualType ValueType = utils::GetValueType(Type);
-    // derivative variables should always be of non-const type.
-    ValueType.removeLocalConst();
+    QualType ValueType = utils::GetNonConstValueType(Type);
     QualType nonRefValueType = ValueType.getNonReferenceType();
     return m_Context.getPointerType(nonRefValueType);
   }
@@ -4266,8 +4263,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
   clang::QualType ReverseModeVisitor::ComputeAdjointType(clang::QualType T) {
     if (T->isReferenceType()) {
-      QualType TValueType = utils::GetValueType(T);
-      TValueType.removeLocalConst();
+      QualType TValueType = utils::GetNonConstValueType(T);
       return m_Context.getPointerType(TValueType);
     }
     T.removeLocalConst();

--- a/test/Arrays/ArrayErrorsReverseMode.C
+++ b/test/Arrays/ArrayErrorsReverseMode.C
@@ -1,0 +1,20 @@
+// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1
+
+#include "clad/Differentiator/Differentiator.h"
+
+float func11(float* a, float b) { // expected-error {{Non-differentiable non-const pointer and array parameters are not supported. Please differentiate w.r.t. 'a' or mark it const.}}
+  float sum = 0;
+  sum += a[0] *= b;
+  return sum;
+}
+
+float func12(float a, float b[]) { // expected-error {{Non-differentiable non-const pointer and array parameters are not supported. Please differentiate w.r.t. 'b' or mark it const.}}
+  float sum = 0;
+  sum += a *= b[1];
+  return sum;
+}
+
+int main() {
+  clad::gradient(func11, "b");
+  clad::gradient(func12, "a");
+}

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -19,7 +19,7 @@
 
 #define N 3
 
-__device__ __host__ double gauss(double* x, double* p, double sigma, int dim) {
+__device__ __host__ double gauss(const double* x, double* p, double sigma, int dim) {
    double t = 0;
    for (int i = 0; i< dim; i++)
        t += (x[i] - p[i]) * (x[i] - p[i]);
@@ -28,7 +28,7 @@ __device__ __host__ double gauss(double* x, double* p, double sigma, int dim) {
 }
 
 
-// CHECK: __attribute__((device)) __attribute__((host)) void gauss_grad_1(double *x, double *p, double sigma, int dim, double *_d_p) {
+// CHECK: __attribute__((device)) __attribute__((host)) void gauss_grad_1(const double *x, double *p, double sigma, int dim, double *_d_p) {
 //CHECK-NEXT:     double _d_sigma = 0.;
 //CHECK-NEXT:     int _d_dim = 0;
 //CHECK-NEXT:     int _d_i = 0;

--- a/test/CUDA/GradientKernels.cu
+++ b/test/CUDA/GradientKernels.cu
@@ -288,16 +288,16 @@ __global__ void add_kernel_7(double *a, double *b) {
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
-__device__ double device_fn(double in, double val) {
+__device__ double device_fn(const double in, double val) {
   return in + val;
 }
 
-__global__ void kernel_with_device_call(double *out, double *in, double val) {
+__global__ void kernel_with_device_call(double *out, const double *in, double val) {
   int index = threadIdx.x;
   out[index] = device_fn(in[index], val);
 }
 
-// CHECK: void kernel_with_device_call_grad_0_2(double *out, double *in, double val, double *_d_out, double *_d_val) {
+// CHECK: void kernel_with_device_call_grad_0_2(double *out, const double *in, double val, double *_d_out, double *_d_val) {
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x;
 //CHECK-NEXT:    double _t0 = out[index0];
@@ -313,22 +313,22 @@ __global__ void kernel_with_device_call(double *out, double *in, double val) {
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
-__device__ double device_fn_2(double *in, double val) {
+__device__ double device_fn_2(const double *in, double val) {
   int index = threadIdx.x + blockIdx.x * blockDim.x;
   return in[index] + val;
 }
 
-__global__ void kernel_with_device_call_2(double *out, double *in, double val) {
+__global__ void kernel_with_device_call_2(double *out, const double *in, double val) {
   int index = threadIdx.x;
   out[index] = device_fn_2(in, val);
 } 
 
-__global__ void dup_kernel_with_device_call_2(double *out, double *in, double val) {
+__global__ void dup_kernel_with_device_call_2(double *out, const double *in, double val) {
   int index = threadIdx.x;
   out[index] = device_fn_2(in, val);
 } 
 
-// CHECK: void kernel_with_device_call_2_grad_0_2(double *out, double *in, double val, double *_d_out, double *_d_val) {
+// CHECK: void kernel_with_device_call_2_grad_0_2(double *out, const double *in, double val, double *_d_out, double *_d_val) {
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x;
 //CHECK-NEXT:    double _t0 = out[index0];
@@ -343,7 +343,7 @@ __global__ void dup_kernel_with_device_call_2(double *out, double *in, double va
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
-// CHECK: void kernel_with_device_call_2_grad_0_1(double *out, double *in, double val, double *_d_out, double *_d_in) {
+// CHECK: void kernel_with_device_call_2_grad_0_1(double *out, const double *in, double val, double *_d_out, double *_d_in) {
 //CHECK-NEXT:    double _d_val = 0.;
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x;
@@ -570,14 +570,14 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
 //CHECK-NEXT:    cudaFree(_d_out_dev);
 //CHECK-NEXT:}
 
-// CHECK: __attribute__((device)) void device_fn_pullback_1(double in, double val, double _d_y, double *_d_in, double *_d_val) {
+// CHECK: __attribute__((device)) void device_fn_pullback_1(const double in, double val, double _d_y, double *_d_in, double *_d_val) {
 //CHECK-NEXT:    {
 //CHECK-NEXT:                *_d_in += _d_y;
 //CHECK-NEXT:                *_d_val += _d_y;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
-// CHECK: __attribute__((device)) void device_fn_2_pullback_0_1(double *in, double val, double _d_y, double *_d_val) {
+// CHECK: __attribute__((device)) void device_fn_2_pullback_0_1(const double *in, double val, double _d_y, double *_d_val) {
 //CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
 //CHECK-NEXT:    unsigned int _t0 = blockDim.x;
 //CHECK-NEXT:    int _d_index = 0;
@@ -585,7 +585,7 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
 //CHECK-NEXT:    *_d_val += _d_y;
 //CHECK-NEXT:}
 
-// CHECK: __attribute__((device)) void device_fn_2_pullback_0_1_3(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+// CHECK: __attribute__((device)) void device_fn_2_pullback_0_1_3(const double *in, double val, double _d_y, double *_d_in, double *_d_val) {
 //CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
 //CHECK-NEXT:    unsigned int _t0 = blockDim.x;
 //CHECK-NEXT:    int _d_index = 0;

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -542,22 +542,22 @@ double fn16(double x, double y) {
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
-double add(double a, double* b) {
+double add(double a, const double* b) {
     return a + b[0];
 }
 
 
-//CHECK: void add_pullback(double a, double *b, double _d_y, double *_d_a);
+//CHECK: void add_pullback(double a, const double *b, double _d_y, double *_d_a);
 
-//CHECK: void add_pullback(double a, double *b, double _d_y, double *_d_a, double *_d_b);
+//CHECK: void add_pullback(double a, const double *b, double _d_y, double *_d_a, double *_d_b);
 
-double fn17 (double x, double* y) {
+double fn17 (double x, const double* y) {
     x = add(x, y);
     x = add(x, &x);
     return x;
 }
 
-//CHECK: void fn17_grad_0(double x, double *y, double *_d_x) {
+//CHECK: void fn17_grad_0(double x, const double *y, double *_d_x) {
 //CHECK-NEXT:     double _t0 = x;
 //CHECK-NEXT:     x = add(x, y);
 //CHECK-NEXT:     double _t1 = x;
@@ -1020,11 +1020,11 @@ double sq_defined_later(double x) {
 //CHECK-NEXT:         }
 //CHECK-NEXT: }
 
-//CHECK: void add_pullback(double a, double *b, double _d_y, double *_d_a) {
+//CHECK: void add_pullback(double a, const double *b, double _d_y, double *_d_a) {
 //CHECK-NEXT:     *_d_a += _d_y;
 //CHECK-NEXT: }
 
-//CHECK: void add_pullback(double a, double *b, double _d_y, double *_d_a, double *_d_b) {
+//CHECK: void add_pullback(double a, const double *b, double _d_y, double *_d_a, double *_d_b) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_a += _d_y;
 //CHECK-NEXT:         _d_b[0] += _d_y;

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -363,7 +363,7 @@ double f_sum_squares(double *p, int n) {
 // CHECK-NEXT: }
 
 // log-likelihood of n-dimensional gaussian distribution with covariance sigma^2*I
-double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
+double f_log_gaus(const double* x, double* p /*means*/, double n, double sigma) {
   double power = 0;
   for (int i = 0; i < n; i++)
     power += sq(x[i] - p[i]);
@@ -371,7 +371,7 @@ double f_log_gaus(double* x, double* p /*means*/, double n, double sigma) {
   double gaus = 1./std::sqrt(std::pow(2*M_PI, n) * sigma) * std::exp(power);
   return std::log(gaus);
 }
-// CHECK: void f_log_gaus_grad_1(double *x, double *p, double n, double sigma, double *_d_p) {
+// CHECK: void f_log_gaus_grad_1(const double *x, double *p, double n, double sigma, double *_d_p) {
 // CHECK-NEXT:     double _d_n = 0.;
 // CHECK-NEXT:     double _d_sigma = 0.;
 // CHECK-NEXT:     int _d_i = 0;

--- a/test/ROOT/Hessian.C
+++ b/test/ROOT/Hessian.C
@@ -14,7 +14,7 @@ namespace TMath {
   Double_t Sin(Double_t x) { return ::std::sin(x); }
 }
 
-Double_t TFormula_example(Double_t* x, Double_t* p) {
+Double_t TFormula_example(const Double_t* x, Double_t* p) {
   return x[0]*(p[0] + p[1] + p[2]) + TMath::Exp(-p[0]) + TMath::Abs(p[1]);
 }
 

--- a/test/ROOT/Interface.C
+++ b/test/ROOT/Interface.C
@@ -14,13 +14,13 @@ struct array_ref_interface {
   std::size_t size;
 };
 
-Double_t f(Double_t* x, Double_t* p) {
+Double_t f(const Double_t* x, Double_t* p) {
   return p[0] + x[0] * p[1];
 }
 
-void f_grad_1(Double_t* x, Double_t* p, Double_t *_d_p);
+void f_grad_1(const Double_t* x, Double_t* p, Double_t *_d_p);
 
-// CHECK: void f_grad_1(Double_t *x, Double_t *p, Double_t *_d_p) {
+// CHECK: void f_grad_1(const Double_t *x, Double_t *p, Double_t *_d_p) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_p[0] += 1;
 // CHECK-NEXT:         _d_p[1] += x[0] * 1;

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -32,13 +32,13 @@ clad::ValueAndPushforward<Double_t, Double_t> Sin_pushforward(Double_t x, Double
 } // namespace custom_derivatives
 } // namespace clad
 
-Double_t TFormula_example(Double_t* x, Double_t* p) {
+Double_t TFormula_example(const Double_t* x, Double_t* p) {
   return x[0]*(p[0] + p[1] + p[2]) + TMath::Exp(-p[0]) + TMath::Abs(p[1]);
 }
 // _grad = { x[0] + (-1) * Exp_darg0(-p[0]), x[0] + Abs_darg0(p[1]), x[0] }
 
-void TFormula_example_grad_1(Double_t* x, Double_t* p, Double_t* _d_p);
-//CHECK:   void TFormula_example_grad_1(Double_t *x, Double_t *p, Double_t *_d_p) {
+void TFormula_example_grad_1(const Double_t* x, Double_t* p, Double_t* _d_p);
+//CHECK:   void TFormula_example_grad_1(const Double_t *x, Double_t *p, Double_t *_d_p) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _d_p[0] += x[0] * 1;
 //CHECK-NEXT:           _d_p[1] += x[0] * 1;
@@ -52,28 +52,28 @@ void TFormula_example_grad_1(Double_t* x, Double_t* p, Double_t* _d_p);
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
-//CHECK:   Double_t TFormula_example_darg1_0(Double_t *x, Double_t *p) {
+//CHECK:   Double_t TFormula_example_darg1_0(const Double_t *x, Double_t *p) {
 //CHECK-NEXT:       {{double|Double_t}} _t0 = (p[0] + p[1] + p[2]);
 //CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives::TMath::Exp_pushforward(-p[0], -1.);
 //CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t2 = clad::custom_derivatives::TMath::Abs_pushforward(p[1], 0.);
 //CHECK-NEXT:       return 0. * _t0 + x[0] * (1. + 0. + 0.) + _t1.pushforward + _t2.pushforward;
 //CHECK-NEXT:   }
 
-//CHECK:   Double_t TFormula_example_darg1_1(Double_t *x, Double_t *p) {
+//CHECK:   Double_t TFormula_example_darg1_1(const Double_t *x, Double_t *p) {
 //CHECK-NEXT:       {{double|Double_t}} _t0 = (p[0] + p[1] + p[2]);
 //CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives::TMath::Exp_pushforward(-p[0], -0.);
 //CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t2 = clad::custom_derivatives::TMath::Abs_pushforward(p[1], 1.);
 //CHECK-NEXT:       return 0. * _t0 + x[0] * (0. + 1. + 0.) + _t1.pushforward + _t2.pushforward;
 //CHECK-NEXT:   }
 
-//CHECK:   Double_t TFormula_example_darg1_2(Double_t *x, Double_t *p) {
+//CHECK:   Double_t TFormula_example_darg1_2(const Double_t *x, Double_t *p) {
 //CHECK-NEXT:       {{double|Double_t}} _t0 = (p[0] + p[1] + p[2]);
 //CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives::TMath::Exp_pushforward(-p[0], -0.);
 //CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t2 = clad::custom_derivatives::TMath::Abs_pushforward(p[1], 0.);
 //CHECK-NEXT:       return 0. * _t0 + x[0] * (0. + 0. + 1.) + _t1.pushforward + _t2.pushforward;
 //CHECK-NEXT:   }
 
-Double_t TFormula_hess1(Double_t *x, Double_t *p) {
+Double_t TFormula_hess1(const Double_t *x, Double_t *p) {
     return x[0] * std::sin(p[0]) - x[1] * std::cos(p[1]);
 }
 


### PR DESCRIPTION
We have an old problem that we need the user to differentiate w.r.t. pointer/array parameters. In those cases, the user does not provide an adjoint for the parameters and we have to initialize them ourselves. And while it's clear how to deal with numerical types, e.g.
```
f_grad_0(double x, double y, double* _d_x) { // the user only wants the derivative w.r.t. x
    double _d_y = 0; // so we initialize _d_y ourselves
...
```
we cannot do the same with array/pointer types:
```
f_grad_0(double x, double* y, double* _d_x) { // the user only wants the derivative w.r.t. x
    double* _d_y = ???; // we don't know the size of y and, therefore, cannot initialize _d_y
...
```

It's worth noting that while the user is not directly interested in ``_d_y`` from the last example, ``_d_y`` can be used in the derivative internally. However, we can guarantee that ``_d_y`` will not be useful if ``y`` is const. Here's why this is the case:
In the reverse mode, "``y`` depends on ``x``" results in "``_d_x`` depends on ``_d_y``", e.g.
```
y = x;  -->  _d_x += _d_y;
```
Therefore, if ``y`` cannot be modified (i.e. is const), ``_d_y`` will not be used in the reverse pass.

This PR makes a compromise and forces differentiation w.r.t. non-const array/pointer parameters while allowing not differentiating w.r.t. const ones.