### PR TITLE
No need to check if InitListExpr of a RecordType is a struct

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1175,9 +1175,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       Expr* clonedILE = m_Sema.ActOnInitList(noLoc, clonedExprs, noLoc).get();
       return StmtDiff(clonedILE);
     }
-    // Check if type is a CXXRecordDecl and a struct.
+    // Check if type is a CXXRecordDecl
     if (!utils::IsCladValueAndPushforwardType(ILEType) &&
-        ILEType->isRecordType() && ILEType->getAsCXXRecordDecl()->isStruct()) {
+        ILEType->isRecordType()) {
       for (unsigned i = 0, e = ILE->getNumInits(); i < e; i++) {
         // fetch ith field of the struct.
         auto field_iterator = ILEType->getAsCXXRecordDecl()->field_begin();


### PR DESCRIPTION
If a ``RecordType`` can be initialized with an ``InitListExpr``, it's an aggregate and its fields are accessible. Checking if it is a struct is redundant.
Also, we handle ``InitListExpr`` of type ``ValueAndPushforward`` as a special case. This is unnecessary since the general logic for ``RecordType`` works fine with ``ValueAndPushforward``.
Fixes #685.