### PR TITLE
Add support of variadic functions as call exprs in Forward mode

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -312,8 +312,8 @@ void BaseForwardModeVisitor::SetupDerivativeParameters(
     if (PVD == m_IndependentVar)
       m_IndependentVar = newPVD;
 
-    if (PVD->getDeclName() !=
-        newPVD->getDeclName()) // We can't use lookup-based replacements
+    // We can't use lookup-based replacements
+    if (PVD->getDeclName() != newPVD->getDeclName())
       m_DeclReplacements[PVD] = newPVD;
 
     params.push_back(newPVD);

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -142,64 +142,66 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
       returnedFD->setAccess(FD->getAccess());
 
       // Check if we're dealing with a template specialization
-      if (FD->isFunctionTemplateSpecialization() && !FD->getTemplateInstantiationPattern()->isVariadic()) {
+      if (FD->isFunctionTemplateSpecialization() &&
+          !FD->getTemplateInstantiationPattern()->isVariadic()) {
         bool isVariadic = 0;
-        for (auto param : FD->getPrimaryTemplate()->getTemplateParameters()->asArray()) {
+        for (auto param :
+             FD->getPrimaryTemplate()->getTemplateParameters()->asArray()) {
           if (param->isParameterPack()) {
             isVariadic = true;
             break;
           }
         }
         if (!isVariadic) {
-        const TemplateArgumentList *TAL = FD->getTemplateSpecializationArgs();
-        FunctionTemplateDecl* OriginalFTD = FD->getPrimaryTemplate();
+          const TemplateArgumentList* TAL = FD->getTemplateSpecializationArgs();
+          FunctionTemplateDecl* OriginalFTD = FD->getPrimaryTemplate();
 
-        // Check if returnedFD is already associated with a template
-        if (!returnedFD->getDescribedFunctionTemplate() &&
-            !returnedFD->isFunctionTemplateSpecialization()) {
+          // Check if returnedFD is already associated with a template
+          if (!returnedFD->getDescribedFunctionTemplate() &&
+              !returnedFD->isFunctionTemplateSpecialization()) {
 
-          // Look for existing template in current context
-          FunctionTemplateDecl* ExistingFTD = nullptr;
-          DeclContext::lookup_result Lookup =
-              m_Sema.CurContext->lookup(name.getName());
+            // Look for existing template in current context
+            FunctionTemplateDecl* ExistingFTD = nullptr;
+            DeclContext::lookup_result Lookup =
+                m_Sema.CurContext->lookup(name.getName());
 
-          for (NamedDecl* ND : Lookup) {
-            if (auto* FTD = dyn_cast<FunctionTemplateDecl>(ND)) {
-              // Check if this template matches what we need
-              FunctionDecl* FD1 = FTD->getTemplatedDecl();
+            for (NamedDecl* ND : Lookup) {
+              if (auto* FTD = dyn_cast<FunctionTemplateDecl>(ND)) {
+                // Check if this template matches what we need
+                FunctionDecl* FD1 = FTD->getTemplatedDecl();
 
-              // Compare return types
-              if (!m_Context.hasSameType(FD1->getReturnType(),
-                                         FD->getReturnType()))
-                continue;
+                // Compare return types
+                if (!m_Context.hasSameType(FD1->getReturnType(),
+                                           FD->getReturnType()))
+                  continue;
 
-              ExistingFTD = FTD->getCanonicalDecl();
-              break;
+                ExistingFTD = FTD->getCanonicalDecl();
+                break;
+              }
             }
+
+            // Create a template declaration only if needed
+            if (!ExistingFTD) {
+              TemplateParameterList* TemplateParams =
+                  OriginalFTD->getTemplateParameters();
+
+              ExistingFTD = FunctionTemplateDecl::Create(
+                  m_Context, m_Sema.CurContext, noLoc, name.getName(),
+                  TemplateParams, returnedFD);
+
+              // Add to context to make it findable
+              m_Sema.CurContext->addDecl(ExistingFTD);
+            }
+
+            // Now specialize the function correctly
+            TemplateArgumentList* TALCopy =
+                TemplateArgumentList::CreateCopy(m_Context, TAL->asArray());
+
+            returnedFD->setFunctionTemplateSpecialization(
+                ExistingFTD, TALCopy, nullptr,
+                FD->getTemplateSpecializationKindForInstantiation());
           }
-
-          // Create a template declaration only if needed
-          if (!ExistingFTD) {
-            TemplateParameterList* TemplateParams =
-                OriginalFTD->getTemplateParameters();
-
-            ExistingFTD = FunctionTemplateDecl::Create(
-                m_Context, m_Sema.CurContext, noLoc, name.getName(),
-                TemplateParams, returnedFD);
-
-            // Add to context to make it findable
-            m_Sema.CurContext->addDecl(ExistingFTD);
-          }
-
-          // Now specialize the function correctly
-          TemplateArgumentList* TALCopy =
-              TemplateArgumentList::CreateCopy(m_Context, TAL->asArray());
-
-          returnedFD->setFunctionTemplateSpecialization(
-              ExistingFTD, TALCopy, nullptr,
-              FD->getTemplateSpecializationKindForInstantiation());
         }
-       }
       }
     }
     returnedFD->setImplicitlyInline(FD->isInlined());

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -142,8 +142,16 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
       returnedFD->setAccess(FD->getAccess());
 
       // Check if we're dealing with a template specialization
-      if (FD->isFunctionTemplateSpecialization()) {
-        const TemplateArgumentList* TAL = FD->getTemplateSpecializationArgs();
+      if (FD->isFunctionTemplateSpecialization() && !FD->getTemplateInstantiationPattern()->isVariadic()) {
+        bool isVariadic = 0;
+        for (auto param : FD->getPrimaryTemplate()->getTemplateParameters()->asArray()) {
+          if (param->isParameterPack()) {
+            isVariadic = true;
+            break;
+          }
+        }
+        if (!isVariadic) {
+        const TemplateArgumentList *TAL = FD->getTemplateSpecializationArgs();
         FunctionTemplateDecl* OriginalFTD = FD->getPrimaryTemplate();
 
         // Check if returnedFD is already associated with a template
@@ -191,6 +199,7 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
               ExistingFTD, TALCopy, nullptr,
               FD->getTemplateSpecializationKindForInstantiation());
         }
+       }
       }
     }
     returnedFD->setImplicitlyInline(FD->isInlined());

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -144,8 +144,8 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
       // Check if we're dealing with a template specialization
       if (FD->isFunctionTemplateSpecialization() &&
           !FD->getTemplateInstantiationPattern()->isVariadic()) {
-        bool isVariadic = 0;
-        for (auto param :
+        bool isVariadic = false;
+        for (auto* param :
              FD->getPrimaryTemplate()->getTemplateParameters()->asArray()) {
           if (param->isParameterPack()) {
             isVariadic = true;

--- a/test/ForwardMode/VariadicCall.C
+++ b/test/ForwardMode/VariadicCall.C
@@ -1,3 +1,6 @@
+// RUN: %cladclang -std=c++17 %s -I%S/../../include -oVariadicCall.out 2>&1 | %filecheck %s
+// RUN: ./VariadicCall.out | %filecheck_exec %s
+
 #include "clad/Differentiator/Differentiator.h"
 
 #include "../TestUtils.h"

--- a/test/ForwardMode/VariadicCall.C
+++ b/test/ForwardMode/VariadicCall.C
@@ -1,0 +1,48 @@
+#include "clad/Differentiator/Differentiator.h"
+
+#include "../TestUtils.h"
+
+template <typename... T>
+double fn1(double x, T... y) {
+    return (x * ... * y);
+}
+
+double fn2(double x, double y) {
+    return fn1(x, y);
+}
+
+// CHECK: double fn2_darg0(double x, double y) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     double _d_y = 0;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn1_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT: }
+
+double fn3(double x, double y) {
+    return fn1(x, y, y);
+}
+
+// CHECK: double fn3_darg0(double x, double y) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     double _d_y = 0;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn1_pushforward(x, y, y, _d_x, _d_y, _d_y);
+// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT: }
+
+
+int main() {
+  INIT_DIFFERENTIATE(fn2, "x");
+  TEST_DIFFERENTIATE(fn2, 1.0, 2.0); // CHECK-EXEC: {2.00}
+  INIT_DIFFERENTIATE(fn3, "x");
+  TEST_DIFFERENTIATE(fn3, 1.0, 2.0); // CHECK-EXEC: {4.00}
+  return 0;
+}
+
+// CHECK: clad::ValueAndPushforward<double, double> fn1_pushforward(double x, double y, double _d_x, double _d_y) {
+// CHECK-NEXT:    return {x * y, _d_x * y + x * _d_y};
+// CHECK-NEXT:}
+
+// CHECK: clad::ValueAndPushforward<double, double> fn1_pushforward(double x, double y, double y2, double _d_x, double _d_y, double _d_y2) {
+// CHECK-NEXT:    double _t0 = x * y;
+// CHECK-NEXT:    return {_t0 * y2, (_d_x * y + x * _d_y) * y2 + _t0 * _d_y2};
+// CHECK-NEXT:}

--- a/test/ForwardMode/VariadicCall.C
+++ b/test/ForwardMode/VariadicCall.C
@@ -1,10 +1,7 @@
-// RUN: %cladclang -std=c++17 %s -I%S/../../include -oVariadicCall.out 2>&1 | %filecheck %s
+// RUN: %cladclang -std=c++17 %s -I%S/../../include -oVariadicCall.out -Xclang -verify 2>&1 | %filecheck %s
 // RUN: ./VariadicCall.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
-
-// CHECK: warning: function 'printf' was not differentiated because clad failed to differentiate it and no suitable overload was found in namespace 'custom_derivatives'
-// CHECK: note: fallback to numerical differentiation is disabled by the 'CLAD_NO_NUM_DIFF' macro; considering 'printf' as 0   
 
 template <typename... T>
 double fn1(double x, T... y) {
@@ -12,7 +9,8 @@ double fn1(double x, T... y) {
 }
 
 double fn2(double x, double y) {
-    printf("x is %f, y is %f\n", x, y);
+    printf("x is %f, y is %f\n", x, y); // expected-warning {{function 'printf' was not differentiated because clad failed to differentiate it and no suitable overload was found in namespace 'custom_derivatives'}}
+                                        // expected-note@-1 {{fallback to numerical differentiation is disabled by the 'CLAD_NO_NUM_DIFF' macro; considering 'printf' as 0}}
     return fn1(x, y);
 }
 

--- a/test/ForwardMode/VariadicCall.C
+++ b/test/ForwardMode/VariadicCall.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -std=c++17 %s -I%S/../../include -oVariadicCall.out | %filecheck %s
+// RUN: %cladclang -std=c++17 %s -I%S/../../include -oVariadicCall.out -Xclang -verify 2>&1 | %filecheck %s
 // RUN: ./VariadicCall.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
@@ -9,6 +9,9 @@ double fn1(double x, T... y) {
 }
 
 double fn2(double x, double y) {
+    // FIXME: Replace `printf` call with a proper variadic function without template
+    printf("x is %f, y is %f\n", x, y); // expected-warning {{function 'printf' was not differentiated because clad failed to differentiate it and no suitable overload was found in namespace 'custom_derivatives'}}
+                                    // expected-note@-1 {{fallback to numerical differentiation is disabled by the 'CLAD_NO_NUM_DIFF' macro; considering 'printf' as 0}}
     return fn1(x, y);
 }
 
@@ -19,6 +22,7 @@ double fn2(double x, double y) {
 // CHECK: double fn2_darg0(double x, double y) {
 // CHECK-NEXT:     double _d_x = 1;
 // CHECK-NEXT:     double _d_y = 0;
+// CHECK-NEXT:     printf("x is %f, y is %f\n", x, y);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn1_pushforward(x, y, _d_x, _d_y);
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
@@ -41,7 +45,8 @@ double fn3(double x, double y) {
 
 int main() {
     auto d_fn2 = clad::differentiate(fn2, "x");
-    printf("{%.2f}\n", d_fn2.execute(1.0, 2.0)); // CHECK-EXEC: {2.00}
+    printf("{%.2f}\n", d_fn2.execute(1.0, 2.0)); // CHECK-EXEC: x is 1.000000, y is 2.000000
+    // CHECK-EXEC: {2.00}
     auto d_fn3 = clad::differentiate(fn3, "x");
     printf("{%.2f}\n", d_fn3.execute(1.0, 2.0)); // CHECK-EXEC: {4.00}
     return 0;

--- a/test/ForwardMode/VariadicCall.C
+++ b/test/ForwardMode/VariadicCall.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -std=c++17 %s -I%S/../../include -oVariadicCall.out -Xclang -verify 2>&1 | %filecheck %s
+// RUN: %cladclang -std=c++17 %s -I%S/../../include -oVariadicCall.out | %filecheck %s
 // RUN: ./VariadicCall.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
@@ -9,8 +9,6 @@ double fn1(double x, T... y) {
 }
 
 double fn2(double x, double y) {
-    printf("x is %f, y is %f\n", x, y); // expected-warning {{function 'printf' was not differentiated because clad failed to differentiate it and no suitable overload was found in namespace 'custom_derivatives'}}
-                                        // expected-note@-1 {{fallback to numerical differentiation is disabled by the 'CLAD_NO_NUM_DIFF' macro; considering 'printf' as 0}}
     return fn1(x, y);
 }
 
@@ -21,7 +19,6 @@ double fn2(double x, double y) {
 // CHECK: double fn2_darg0(double x, double y) {
 // CHECK-NEXT:     double _d_x = 1;
 // CHECK-NEXT:     double _d_y = 0;
-// CHECK-NEXT:     printf("x is %f, y is %f\n", x, y);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn1_pushforward(x, y, _d_x, _d_y);
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
@@ -44,8 +41,7 @@ double fn3(double x, double y) {
 
 int main() {
     auto d_fn2 = clad::differentiate(fn2, "x");
-    printf("{%.2f}\n", d_fn2.execute(1.0, 2.0)); // CHECK-EXEC: x is 1.000000, y is 2.000000
-    // CHECK-EXEC: {2.00}
+    printf("{%.2f}\n", d_fn2.execute(1.0, 2.0)); // CHECK-EXEC: {2.00}
     auto d_fn3 = clad::differentiate(fn3, "x");
     printf("{%.2f}\n", d_fn3.execute(1.0, 2.0)); // CHECK-EXEC: {4.00}
     return 0;

--- a/test/ForwardMode/VariadicCall.C
+++ b/test/ForwardMode/VariadicCall.C
@@ -14,6 +14,10 @@ double fn2(double x, double y) {
     return fn1(x, y);
 }
 
+// CHECK: clad::ValueAndPushforward<double, double> fn1_pushforward(double x, double y, double _d_x, double _d_y) {
+// CHECK-NEXT:    return {x * y, _d_x * y + x * _d_y};
+// CHECK-NEXT:}
+
 // CHECK: double fn2_darg0(double x, double y) {
 // CHECK-NEXT:     double _d_x = 1;
 // CHECK-NEXT:     double _d_y = 0;
@@ -25,6 +29,11 @@ double fn2(double x, double y) {
 double fn3(double x, double y) {
     return fn1(x, y, y);
 }
+
+// CHECK: clad::ValueAndPushforward<double, double> fn1_pushforward(double x, double y, double y2, double _d_x, double _d_y, double _d_y2) {
+// CHECK-NEXT:    double _t0 = x * y;
+// CHECK-NEXT:    return {_t0 * y2, (_d_x * y + x * _d_y) * y2 + _t0 * _d_y2};
+// CHECK-NEXT:}
 
 // CHECK: double fn3_darg0(double x, double y) {
 // CHECK-NEXT:     double _d_x = 1;
@@ -41,12 +50,3 @@ int main() {
     printf("{%.2f}\n", d_fn3.execute(1.0, 2.0)); // CHECK-EXEC: {4.00}
     return 0;
 }
-
-// CHECK: clad::ValueAndPushforward<double, double> fn1_pushforward(double x, double y, double _d_x, double _d_y) {
-// CHECK-NEXT:    return {x * y, _d_x * y + x * _d_y};
-// CHECK-NEXT:}
-
-// CHECK: clad::ValueAndPushforward<double, double> fn1_pushforward(double x, double y, double y2, double _d_x, double _d_y, double _d_y2) {
-// CHECK-NEXT:    double _t0 = x * y;
-// CHECK-NEXT:    return {_t0 * y2, (_d_x * y + x * _d_y) * y2 + _t0 * _d_y2};
-// CHECK-NEXT:}

--- a/test/ForwardMode/VariadicCall.C
+++ b/test/ForwardMode/VariadicCall.C
@@ -3,7 +3,8 @@
 
 #include "clad/Differentiator/Differentiator.h"
 
-#include "../TestUtils.h"
+// CHECK: warning: function 'printf' was not differentiated because clad failed to differentiate it and no suitable overload was found in namespace 'custom_derivatives'
+// CHECK: note: fallback to numerical differentiation is disabled by the 'CLAD_NO_NUM_DIFF' macro; considering 'printf' as 0   
 
 template <typename... T>
 double fn1(double x, T... y) {
@@ -11,12 +12,14 @@ double fn1(double x, T... y) {
 }
 
 double fn2(double x, double y) {
+    printf("x is %f, y is %f\n", x, y);
     return fn1(x, y);
 }
 
 // CHECK: double fn2_darg0(double x, double y) {
 // CHECK-NEXT:     double _d_x = 1;
 // CHECK-NEXT:     double _d_y = 0;
+// CHECK-NEXT:     printf("x is %f, y is %f\n", x, y);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn1_pushforward(x, y, _d_x, _d_y);
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
@@ -32,13 +35,13 @@ double fn3(double x, double y) {
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
-
 int main() {
-  INIT_DIFFERENTIATE(fn2, "x");
-  TEST_DIFFERENTIATE(fn2, 1.0, 2.0); // CHECK-EXEC: {2.00}
-  INIT_DIFFERENTIATE(fn3, "x");
-  TEST_DIFFERENTIATE(fn3, 1.0, 2.0); // CHECK-EXEC: {4.00}
-  return 0;
+    auto d_fn2 = clad::differentiate(fn2, "x");
+    printf("{%.2f}\n", d_fn2.execute(1.0, 2.0)); // CHECK-EXEC: x is 1.000000, y is 2.000000
+    // CHECK-EXEC: {2.00}
+    auto d_fn3 = clad::differentiate(fn3, "x");
+    printf("{%.2f}\n", d_fn3.execute(1.0, 2.0)); // CHECK-EXEC: {4.00}
+    return 0;
 }
 
 // CHECK: clad::ValueAndPushforward<double, double> fn1_pushforward(double x, double y, double _d_x, double _d_y) {


### PR DESCRIPTION
Changes applied:
* Use Call arg instead of Function param to store differentiation call's args
* Create Unique Identifier for each param expanded from the pack of a variadic function
* Add test