### PR TITLE
Compute the differentiation plan before differentiation starts.

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -7,7 +7,9 @@
 
 #include "clang/AST/RecursiveASTVisitor.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <iterator>
@@ -120,15 +122,15 @@ public:
   ///      function will be differentiated w.r.t. to its every parameter.
   void UpdateDiffParamsInfo(clang::Sema& semaRef);
 
-  /// Define the == operator for DiffRequest.
+  /// Allow comparing DiffRequests.
   bool operator==(const DiffRequest& other) const {
-    // either function match or previous declaration match
+    // Note that CallContext is always different and we should ignore it.
     return Function == other.Function &&
            BaseFunctionName == other.BaseFunctionName &&
            CurrentDerivativeOrder == other.CurrentDerivativeOrder &&
            RequestedDerivativeOrder == other.RequestedDerivativeOrder &&
-           CallContext == other.CallContext && Args == other.Args &&
-           Mode == other.Mode && EnableTBRAnalysis == other.EnableTBRAnalysis &&
+           Args == other.Args && Mode == other.Mode &&
+           EnableTBRAnalysis == other.EnableTBRAnalysis &&
            EnableVariedAnalysis == other.EnableVariedAnalysis &&
            DVI == other.DVI && use_enzyme == other.use_enzyme &&
            DeclarationOnly == other.DeclarationOnly;
@@ -172,16 +174,27 @@ public:
     /// If set it means that we need to find the called functions and
     /// add them for implicit diff.
     ///
-    const clang::FunctionDecl* m_TopMostFD = nullptr;
+    const DiffRequest* m_TopMostReq = nullptr;
     clang::Sema& m_Sema;
 
     const RequestOptions& m_Options;
+
+    llvm::DenseSet<const clang::FunctionDecl*> m_Traversed;
+
+    bool m_IsTraversingTopLevelDecl = true;
 
   public:
     DiffCollector(clang::DeclGroupRef DGR, DiffInterval& Interval,
                   clad::DynamicGraph<DiffRequest>& requestGraph, clang::Sema& S,
                   RequestOptions& opts);
     bool VisitCallExpr(clang::CallExpr* E);
+    bool TraverseFunctionDeclOnce(const clang::FunctionDecl* FD) {
+      llvm::SaveAndRestore<bool> Saved(m_IsTraversingTopLevelDecl, false);
+      if (m_Traversed.count(FD))
+        return true;
+      m_Traversed.insert(FD);
+      return TraverseDecl(const_cast<clang::FunctionDecl*>(FD));
+    }
 
   private:
     bool isInInterval(clang::SourceLocation Loc) const;

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -151,6 +151,7 @@ public:
   bool shouldBeRecorded(clang::Expr* E) const;
   bool shouldHaveAdjoint(const clang::VarDecl* VD) const;
   std::string ComputeDerivativeName() const;
+  bool HasIndependentParameter(const clang::ParmVarDecl* PVD) const;
 };
 
   using DiffInterval = std::vector<clang::SourceRange>;

--- a/include/clad/Differentiator/ParseDiffArgsTypes.h
+++ b/include/clad/Differentiator/ParseDiffArgsTypes.h
@@ -6,9 +6,12 @@
 #define CLAD_PARSE_DIFF_ARGS_TYPES_H
 
 #include "clang/AST/Decl.h"
+
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <cstddef>
 #include <utility>
@@ -36,8 +39,15 @@ namespace clad {
     bool operator==(const IndexInterval& rhs) const {
       return Start == rhs.Start && Finish == rhs.Finish;
     }
+    void print(llvm::raw_ostream& Out) const {
+      if (!isValid()) {
+        Out << "<invalid>";
+        return;
+      }
+      Out << '[' << Start << ':' << Finish << ']';
+    }
   };
-  
+
   using IndexIntervalTable = llvm::SmallVector<IndexInterval, 16>;
 
   /// `DiffInputVarInfo` is designed to store all the essential information about a
@@ -76,6 +86,17 @@ namespace clad {
              paramIndexInterval == rhs.paramIndexInterval &&
              fields == rhs.fields;
     }
+    void print(llvm::raw_ostream& Out) const {
+      if (!source.empty())
+        Out << source;
+
+      if (param)
+        Out << param->getNameAsString();
+
+      if (paramIndexInterval.isValid())
+        paramIndexInterval.print(Out);
+    }
+    LLVM_DUMP_METHOD void dump() const { print(llvm::errs()); }
   };
 
   using DiffInputVarsInfo = llvm::SmallVector<DiffInputVarInfo, 16>;

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -60,8 +60,6 @@ namespace clad {
     /// that will be put immediately in the beginning of derivative function
     /// block.
     Stmts m_Globals;
-    /// Global GPU args of the function.
-    std::unordered_set<const clang::ParmVarDecl*> m_CUDAGlobalArgs;
     /// A flag indicating if the Stmt we are currently visiting is inside loop.
     bool isInsideLoop = false;
     /// Output variable of vector-valued function

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1036,7 +1036,7 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
   bool isLambda = isLambdaCallOperator(FD);
 
   Expr* CUDAExecConfig = nullptr;
-  if (auto* KCE = dyn_cast<CUDAKernelCallExpr>(CE))
+  if (const auto* KCE = dyn_cast<CUDAKernelCallExpr>(CE))
     CUDAExecConfig = Clone(KCE->getConfig());
 
   // If the function is non_differentiable, return zero derivative.

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -158,9 +158,9 @@ namespace clad {
       ASTContext& C = semaRef.getASTContext();
 
       if (auto ND = dyn_cast<NamespaceDecl>(DC)) {
-        CSS.Extend(C, ND,
-                   /*NamespaceLoc=*/utils::GetValidSLoc(semaRef),
-                   /*ColonColonLoc=*/utils::GetValidSLoc(semaRef));
+        if (!ND->isInline())
+          CSS.Extend(C, ND, /*NamespaceLoc=*/utils::GetValidSLoc(semaRef),
+                     /*ColonColonLoc=*/utils::GetValidSLoc(semaRef));
       } else if (auto RD = dyn_cast<CXXRecordDecl>(DC)) {
         auto RDQType = RD->getTypeForDecl()->getCanonicalTypeInternal();
         auto RDTypeSourceInfo = C.getTrivialTypeSourceInfo(RDQType);

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -263,6 +263,10 @@ namespace clad {
       if (!DC)
         DC = C.getTranslationUnitDecl();
       S.LookupQualifiedName(Result, DC);
+
+      if (auto* CXXRD = dyn_cast<CXXRecordDecl>(DC))
+        Result.setNamingClass(CXXRD);
+
       return Result;
     }
 

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -11,10 +11,12 @@
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/ExprCXX.h"
+#include "clang/AST/OperationKinds.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/LLVM.h" // isa, dyn_cast
 #include "clang/Basic/Specifiers.h"
+#include "clang/Basic/TokenKinds.h"
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Overload.h"
 #include "clang/Sema/Scope.h"
@@ -343,13 +345,14 @@ static void registerDerivative(FunctionDecl* dFD, Sema& S,
           Member.setIdentifier(&m_Context.Idents.get(Name), Loc);
           bool isArrow = Base->getType()->isPointerType();
           // FIXME: update SS here?
-          auto ME = m_Sema
-                        .ActOnMemberAccessExpr(S, Base, Loc,
-                                               isArrow ? tok::TokenKind::arrow
-                                                       : tok::TokenKind::period,
-                                               SS, noLoc, Member,
-                                               /*ObjCImpDecl=*/nullptr)
-                        .get();
+          auto* ME =
+              m_Sema
+                  .ActOnMemberAccessExpr(S, Base, Loc,
+                                         isArrow ? tok::TokenKind::arrow
+                                                 : tok::TokenKind::period,
+                                         SS, noLoc, Member,
+                                         /*ObjCImpDecl=*/nullptr)
+                  .get();
           if (noOverloadExists(ME, MARargs.drop_front()))
             return nullptr;
 

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -6,16 +6,16 @@
 #include "TBRAnalyzer.h"
 
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/ASTLambda.h"
 #include "clang/AST/DeclarationName.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Analysis/CallGraph.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/SemaDiagnostic.h"
 #include "clang/Sema/TemplateDeduction.h"
-
-#include "llvm/Support/SaveAndRestore.h"
 
 #include "clad/Differentiator/CladConfig.h"
 #include "clad/Differentiator/CladUtils.h"
@@ -279,9 +279,11 @@ namespace clad {
     if (Interval.empty())
       return;
 
+    assert(!m_TopMostReq && "Traversal already in flight!");
     for (Decl* D : DGR) {
       TraverseDecl(D);
     }
+    m_TopMostReq = nullptr;
   }
 
   /// Returns true if `FD` is a call operator; otherwise returns false.
@@ -290,7 +292,7 @@ namespace clad {
       DeclarationName
           callOperatorDeclName = Context.DeclarationNames.getCXXOperatorName(
               OverloadedOperatorKind::OO_Call);
-      return method->getNameInfo().getName() == callOperatorDeclName;              
+      return method->getNameInfo().getName() == callOperatorDeclName;
     }
     return false;
   }
@@ -618,6 +620,11 @@ namespace clad {
         << "args='";
     if (Args)
       Args->printPretty(Out, /*Helper=*/nullptr, P);
+    for (unsigned i = 0, e = DVI.size(); i < e; i++) {
+      DVI[i].print(Out);
+      if (i != e - 1)
+        Out << ',';
+    }
     Out << "'";
     if (EnableTBRAnalysis)
       Out << ", tbr";
@@ -874,62 +881,162 @@ namespace clad {
     return false;
   }
 
+  static bool HasCustomDerivativeForDiffReq(Sema& S, const DiffRequest& R) {
+    NamespaceDecl* cladNS = utils::LookupNSD(S, "clad", /*shouldExist=*/true);
+    NamespaceDecl* customDerNS = utils::LookupNSD(
+        S, "custom_derivatives", /*shouldExist=*/false, cladNS);
+    if (!customDerNS)
+      return false;
+
+    const Expr* callSite = R.CallContext;
+    const DeclContext* originalFnDC = nullptr;
+    // Check if the callSite is not associated with a shadow declaration.
+    if (const auto* ME = dyn_cast<CXXMemberCallExpr>(callSite)) {
+      originalFnDC = ME->getMethodDecl()->getParent();
+    } else if (const auto* CE = dyn_cast<CallExpr>(callSite)) {
+      const Expr* Callee = CE->getCallee()->IgnoreParenCasts();
+      if (const auto* DRE = dyn_cast<DeclRefExpr>(Callee))
+        originalFnDC = DRE->getFoundDecl()->getDeclContext();
+      else if (const auto* MemberE = dyn_cast<MemberExpr>(Callee))
+        originalFnDC = MemberE->getFoundDecl().getDecl()->getDeclContext();
+    } else if (const auto* CtorExpr = dyn_cast<CXXConstructExpr>(callSite)) {
+      originalFnDC = CtorExpr->getConstructor()->getDeclContext();
+    }
+
+    DeclContext* DC = customDerNS;
+
+    if (isa<RecordDecl>(originalFnDC)) {
+      return true;
+      // FIXME: Re-enable
+      // DC = utils::LookupNSD(S, "class_functions", /*shouldExist=*/false, DC);
+    } else
+      DC = utils::FindDeclContext(S, DC, originalFnDC);
+
+    if (!DC)
+      return false;
+
+    std::string Name = R.BaseFunctionName;
+    if (R.Mode == DiffMode::experimental_pullback && R->getNumParams() > 1)
+      Name += "_pullback";
+    else // if (Mode == DiffMode::experimental_pullback)
+      Name += "_pushforward";
+
+    IdentifierInfo* II = &S.getASTContext().Idents.get(Name);
+    DeclarationNameInfo DNInfo(II, utils::GetValidSLoc(S));
+    LookupResult Found(S, DNInfo, Sema::LookupOrdinaryName);
+    S.LookupQualifiedName(Found, DC);
+
+    return !Found.empty();
+  }
+
+  // FIXME: Add varied analysis.
+  static bool allArgumentsAreLiterals(const CallExpr* CE) {
+    for (const Expr* A : CE->arguments()) {
+      A = A->IgnoreImpCasts();
+      if (!isa<CXXNullPtrLiteralExpr>(A) && !isa<CharacterLiteral>(A) &&
+          !isa<CXXBoolLiteralExpr>(A) && !isa<FixedPointLiteral>(A) &&
+          !isa<ImaginaryLiteral>(A) && !isa<IntegerLiteral>(A) &&
+          !isa<ObjCBoolLiteralExpr>(A) && !isa<ObjCStringLiteral>(A) &&
+          !isa<FloatingLiteral>(A) && !isa<ObjCArrayLiteral>(A) &&
+          !isa<StringLiteral>(A) && !isa<CompoundLiteralExpr>(A))
+        return false; // non-constant found.
+    }
+    return true; // all constants.
+  }
+
   bool DiffCollector::VisitCallExpr(CallExpr* E) {
     // Check if we should look into this.
-    // FIXME: Generated code does not usually have valid source locations.
-    // In that case we should ask the enclosing ast nodes for a source
-    // location and check if it is within range.
-    SourceLocation endLoc = E->getEndLoc();
-    if (endLoc.isInvalid() || !isInInterval(endLoc))
-        return true;
+    DiffRequest request;
 
     FunctionDecl* FD = E->getDirectCallee();
     if (!FD)
       return true;
 
-    // We need to find our 'special' diff annotated such:
-    // clad::differentiate(...) __attribute__((annotate("D")))
-    // TODO: why not check for its name? clad::differentiate/gradient?
-    const AnnotateAttr* A = FD->getAttr<AnnotateAttr>();
-    if (!A)
-      return true;
-    std::string Annotation = A->getAnnotation().str();
-    if (Annotation != "D" && Annotation != "G" && Annotation != "H" &&
-        Annotation != "J" && Annotation != "E")
-      return true;
+    // FIXME: We might want to support nested calls to differentiate/gradient
+    // inside differentiated functions.
+    if (!m_TopMostReq) {
+      // FIXME: Generated code does not usually have valid source locations.
+      // In that case we should ask the enclosing ast nodes for a source
+      // location and check if it is within range.
+      SourceLocation endLoc = E->getEndLoc();
+      if (endLoc.isInvalid() || !isInInterval(endLoc))
+        return true;
 
-    // A call to clad::differentiate or clad::gradient was found.
-    DeclRefExpr* DRE = getArgFunction(E, m_Sema);
-    if (!DRE)
-      return true;
+      // We need to find our 'special' diff annotated such:
+      // clad::differentiate(...) __attribute__((annotate("D")))
+      // TODO: why not check for its name? clad::differentiate/gradient?
+      const AnnotateAttr* A = FD->getAttr<AnnotateAttr>();
 
-    DiffRequest request;
+      if (!A)
+        return true;
 
-    if (ProcessInvocationArgs(m_Sema, endLoc, m_Options, FD, request))
-      return true;
+      std::string Annotation = A->getAnnotation().str();
+      if (Annotation != "D" && Annotation != "G" && Annotation != "H" &&
+          Annotation != "J" && Annotation != "E")
+        return true;
 
-    request.CallContext = E;
-    request.CallUpdateRequired = true;
-    request.VerboseDiags = true;
-    request.Args = E->getArg(1);
-    auto* derivedFD = cast<FunctionDecl>(DRE->getDecl());
-    request.Function = derivedFD;
-    request.BaseFunctionName = utils::ComputeEffectiveFnName(request.Function);
+      // A call to clad::differentiate or clad::gradient was found.
+      if (DeclRefExpr* DRE = getArgFunction(E, m_Sema))
+        request.Function = cast<FunctionDecl>(DRE->getDecl());
+      else
+        return true;
+
+      if (ProcessInvocationArgs(m_Sema, endLoc, m_Options, FD, request))
+        return true;
+
+      request.VerboseDiags = true;
+      // The root of the differentiation request graph should update the
+      // CladFunction object with the generated call.
+      request.CallUpdateRequired = true;
+
+      request.Args = E->getArg(1);
+      m_TopMostReq = &request;
+    } else {
+      // Don't build propagators for calls that do not contribute in
+      // differentiable way to the result.
+      if (!isa<CXXMemberCallExpr>(E) && !isa<CXXOperatorCallExpr>(E) &&
+          allArgumentsAreLiterals(E))
+        return true;
+
+      request.Function = FD;
+      if (m_TopMostReq->Mode == DiffMode::forward)
+        request.Mode = DiffMode::experimental_pushforward;
+      else if (m_TopMostReq->Mode == DiffMode::reverse)
+        request.Mode = DiffMode::experimental_pullback;
+      else {
+        // propagatorReq.Mode = request.Mode;
+      }
+      request.VerboseDiags = false;
+      request.EnableTBRAnalysis = m_TopMostReq->EnableTBRAnalysis;
+      request.EnableVariedAnalysis = m_TopMostReq->EnableVariedAnalysis;
+      // propagatorReq.CUDAGlobalArgsIndexes = globalCallArgs;
+
+      // const auto* MD = dyn_cast<CXXMethodDecl>(FD);
+      for (size_t i = 0, e = FD->getNumParams(); i < e; ++i) {
+        // if (MD && isLambdaCallOperator(MD)) {
+        if (const auto* paramDecl = FD->getParamDecl(i))
+          request.DVI.push_back(paramDecl);
+        //}
+        // FIXME:
+        // else if (DerivedCallOutputArgs[i + (bool)MD]) {
+        //  propagatorReq.DVI.push_back(FD->getParamDecl(i));
+        //}
+      }
+    }
 
     if (isCallOperator(m_Sema.getASTContext(), request.Function))
       request.Functor = cast<CXXMethodDecl>(request.Function)->getParent();
-    // FIXME: add support for nested calls to clad::differentiate/gradient
-    // inside differentiated functions
-    assert(!m_TopMostFD &&
-           "nested clad::differentiate/gradient are not yet supported");
-    llvm::SaveAndRestore<const FunctionDecl*> saveTopMost = m_TopMostFD;
-    m_TopMostFD = FD;
-    TraverseDecl(derivedFD);
-    m_DiffRequestGraph.addNode(request, /*isSource=*/true);
-    /*else if (m_TopMostFD) {
-      // If another function is called inside differentiated function,
-      // this will be handled by Forward/ReverseModeVisitor::Derive.
-    }*/
-    return true;     // return false to abort visiting.
+    request.CallContext = E;
+    request.BaseFunctionName = utils::ComputeEffectiveFnName(request.Function);
+
+    // Recurse into call graph.
+    TraverseFunctionDeclOnce(request.Function);
+    if (!HasCustomDerivativeForDiffReq(m_Sema, request))
+      m_DiffRequestGraph.addNode(request, /*isSource=*/true);
+
+    if (m_IsTraversingTopLevelDecl)
+      m_TopMostReq = nullptr;
+
+    return true;
   }
 } // end namespace

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1792,10 +1792,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                 globalCallArgs.emplace_back(i);
               }
 
-      if (baseDiff.getExpr())
-        pullbackCallArgs.insert(
-            pullbackCallArgs.begin(),
-            BuildOp(UnaryOperatorKind::UO_AddrOf, baseDiff.getExpr()));
+      if (Expr* Base = baseDiff.getExpr())
+        pullbackCallArgs.insert(pullbackCallArgs.begin(), Base);
 
       OverloadedDerivedFn =
           m_Builder.BuildCallToCustomDerivativeOrNumericalDiff(

--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -168,7 +168,18 @@ double f4(double x){
   double c = f4_1(x, 1);
   return c;
 }
-// CHECK-NEXT: void f4_1_pullback(double v, double u, double _d_y, double *_d_v, double *_d_u);
+// CHECK: void f4_1_pullback(double v, double u, double _d_y, double *_d_v, double *_d_u) {
+// CHECK-NEXT:     double _d_k = 0.;
+// CHECK-NEXT:     double k = 2 * u;
+// CHECK-NEXT:     double _d_n = 0.;
+// CHECK-NEXT:     double n = 2 * v;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_n += _d_y * k;
+// CHECK-NEXT:         _d_k += n * _d_y;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_v += 2 * _d_n;
+// CHECK-NEXT:     *_d_u += 2 * _d_k;
+// CHECK-NEXT: }
 
 // CHECK: void f4_grad(double x, double *_d_x) {
 // CHECK-NEXT:     double _d_c = 0.;
@@ -249,7 +260,9 @@ double f8(double x){
   double f = f8_1(x, 1);
   return f;
 }
-// CHECK: void f8_1_pullback(double v, double u, double _d_y, double *_d_v, double *_d_u);
+// CHECK: void f8_1_pullback(double v, double u, double _d_y, double *_d_v, double *_d_u) {
+// CHECK-NEXT:     *_d_v += _d_y;
+// CHECK-NEXT: }
 
 // CHECK-NEXT: void f8_grad(double x, double *_d_x) {
 // CHECK-NEXT:     double c = f8_1(1, 1);
@@ -328,20 +341,3 @@ int main(){
     grad.execute(3, arr, &dx, darr);
     printf("%.2f\n", dx);// CHECK-EXEC: 2.00
 }
-
-// CHECK: void f4_1_pullback(double v, double u, double _d_y, double *_d_v, double *_d_u) {
-// CHECK-NEXT:     double _d_k = 0.;
-// CHECK-NEXT:     double k = 2 * u;
-// CHECK-NEXT:     double _d_n = 0.;
-// CHECK-NEXT:     double n = 2 * v;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         _d_n += _d_y * k;
-// CHECK-NEXT:         _d_k += n * _d_y;
-// CHECK-NEXT:     }
-// CHECK-NEXT:     *_d_v += 2 * _d_n;
-// CHECK-NEXT:     *_d_u += 2 * _d_k;
-// CHECK-NEXT: }
-
-// CHECK: void f8_1_pullback(double v, double u, double _d_y, double *_d_v, double *_d_u) {
-// CHECK-NEXT:     *_d_v += _d_y;
-// CHECK-NEXT: }

--- a/test/CUDA/GradientKernels.cu
+++ b/test/CUDA/GradientKernels.cu
@@ -338,7 +338,7 @@ __global__ void dup_kernel_with_device_call_2(double *out, const double *in, dou
 //CHECK-NEXT:        double _r_d0 = _d_out[index0];
 //CHECK-NEXT:        _d_out[index0] = 0.;
 //CHECK-NEXT:        double _r0 = 0.;
-//CHECK-NEXT:        device_fn_2_pullback_0_1(in, val, _r_d0, &_r0);
+//CHECK-NEXT:        device_fn_2_pullback_1(in, val, _r_d0, &_r0);
 //CHECK-NEXT:        atomicAdd(_d_val, _r0);
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
@@ -354,7 +354,7 @@ __global__ void dup_kernel_with_device_call_2(double *out, const double *in, dou
 //CHECK-NEXT:        double _r_d0 = _d_out[index0];
 //CHECK-NEXT:        _d_out[index0] = 0.;
 //CHECK-NEXT:        double _r0 = 0.;
-//CHECK-NEXT:        device_fn_2_pullback_0_1_3(in, val, _r_d0, _d_in, &_r0);
+//CHECK-NEXT:        device_fn_2_pullback_0(in, val, _r_d0, _d_in, &_r0);
 //CHECK-NEXT:        _d_val += _r0;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
@@ -378,7 +378,7 @@ __global__ void kernel_with_device_call_3(double *out, double *in, double *val) 
 //CHECK-NEXT:        out[index0] = _t0;
 //CHECK-NEXT:        double _r_d0 = _d_out[index0];
 //CHECK-NEXT:        _d_out[index0] = 0.;
-//CHECK-NEXT:        device_fn_3_pullback_0_1_3_4(in, val, _r_d0, _d_in, _d_val);
+//CHECK-NEXT:        device_fn_3_pullback_0_1(in, val, _r_d0, _d_in, _d_val);
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
@@ -407,7 +407,7 @@ __global__ void kernel_with_nested_device_call(double *out, double *in, double v
 //CHECK-NEXT:       double _r_d0 = _d_out[index0];
 //CHECK-NEXT:        _d_out[index0] = 0.;
 //CHECK-NEXT:        double _r0 = 0.;
-//CHECK-NEXT:        device_with_device_call_pullback_0_1_3(in, val, _r_d0, _d_in, &_r0);
+//CHECK-NEXT:        device_with_device_call_pullback_0(in, val, _r_d0, _d_in, &_r0);
 //CHECK-NEXT:        _d_val += _r0;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
@@ -520,102 +520,7 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
   cudaFree(out_dev);
 }
 
-// CHECK: void launch_add_kernel_4_grad_0_1(int *out, int *in, const int N, int *_d_out, int *_d_in) {
-//CHECK-NEXT:    int _d_N = 0;
-//CHECK-NEXT:    int *_d_in_dev = nullptr;
-//CHECK-NEXT:    int *in_dev = nullptr;
-//CHECK-NEXT:    cudaMalloc(&_d_in_dev, N * sizeof(int));
-//CHECK-NEXT:    cudaMemset(_d_in_dev, 0, N * sizeof(int));
-//CHECK-NEXT:    cudaMalloc(&in_dev, N * sizeof(int));
-//CHECK-NEXT:    cudaMemcpy(in_dev, in, N * sizeof(int), cudaMemcpyHostToDevice);
-//CHECK-NEXT:    int *_d_out_dev = nullptr;
-//CHECK-NEXT:    int *out_dev = nullptr;
-//CHECK-NEXT:    cudaMalloc(&_d_out_dev, N * sizeof(int));
-//CHECK-NEXT:    cudaMemset(_d_out_dev, 0, N * sizeof(int));
-//CHECK-NEXT:    cudaMalloc(&out_dev, N * sizeof(int));
-//CHECK-NEXT:    cudaMemcpy(out_dev, out, N * sizeof(int), cudaMemcpyHostToDevice);
-//CHECK-NEXT:    add_kernel_4<<<1, 5>>>(out_dev, in_dev, N);
-//CHECK-NEXT:    cudaMemcpy(out, out_dev, N * sizeof(int), cudaMemcpyDeviceToHost);
-//CHECK-NEXT:    {
-//CHECK-NEXT:        unsigned long _r6 = 0UL;
-//CHECK-NEXT:        cudaMemcpyKind _r7 = static_cast<cudaMemcpyKind>(0U);
-//CHECK-NEXT:        clad::custom_derivatives::cudaMemcpy_pullback(out, out_dev, N * sizeof(int), cudaMemcpyDeviceToHost, _d_out, _d_out_dev, &_r6, &_r7);
-//CHECK-NEXT:        _d_N += _r6 * sizeof(int);
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        int _r4 = 0;
-//CHECK-NEXT:        int *_r5 = nullptr;
-//CHECK-NEXT:        cudaMalloc(&_r5, 4);
-//CHECK-NEXT:        cudaMemset(_r5, 0, 4);
-//CHECK-NEXT:        add_kernel_4_pullback<<<1, 5>>>(out_dev, in_dev, N, _d_out_dev, _d_in_dev, _r5);
-//CHECK-NEXT:        cudaMemcpy(&_r4, _r5, 4, cudaMemcpyDeviceToHost);
-//CHECK-NEXT:        cudaFree(_r5);
-//CHECK-NEXT:        _d_N += _r4;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        unsigned long _r2 = 0UL;
-//CHECK-NEXT:        cudaMemcpyKind _r3 = static_cast<cudaMemcpyKind>(0U);
-//CHECK-NEXT:        clad::custom_derivatives::cudaMemcpy_pullback(out_dev, out, N * sizeof(int), cudaMemcpyHostToDevice, _d_out_dev, _d_out, &_r2, &_r3);
-//CHECK-NEXT:        _d_N += _r2 * sizeof(int);
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        unsigned long _r0 = 0UL;
-//CHECK-NEXT:        cudaMemcpyKind _r1 = static_cast<cudaMemcpyKind>(0U);
-//CHECK-NEXT:        clad::custom_derivatives::cudaMemcpy_pullback(in_dev, in, N * sizeof(int), cudaMemcpyHostToDevice, _d_in_dev, _d_in, &_r0, &_r1);
-//CHECK-NEXT:        _d_N += _r0 * sizeof(int);
-//CHECK-NEXT:    }
-//CHECK-NEXT:    cudaFree(in_dev);
-//CHECK-NEXT:    cudaFree(_d_in_dev);
-//CHECK-NEXT:    cudaFree(out_dev);
-//CHECK-NEXT:    cudaFree(_d_out_dev);
-//CHECK-NEXT:}
-
-// CHECK: __attribute__((device)) void device_fn_pullback_1(const double in, double val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    {
-//CHECK-NEXT:                *_d_in += _d_y;
-//CHECK-NEXT:                *_d_val += _d_y;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
-
-// CHECK: __attribute__((device)) void device_fn_2_pullback_0_1(const double *in, double val, double _d_y, double *_d_val) {
-//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
-//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
-//CHECK-NEXT:    int _d_index = 0;
-//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
-//CHECK-NEXT:    *_d_val += _d_y;
-//CHECK-NEXT:}
-
-// CHECK: __attribute__((device)) void device_fn_2_pullback_0_1_3(const double *in, double val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
-//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
-//CHECK-NEXT:    int _d_index = 0;
-//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        atomicAdd(&_d_in[index0], _d_y);
-//CHECK-NEXT:        *_d_val += _d_y;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
-
-// CHECK: __attribute__((device)) void device_fn_3_pullback_0_1_3_4(double *in, double *val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
-//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
-//CHECK-NEXT:    int _d_index = 0;
-//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        atomicAdd(&_d_in[index0], _d_y);
-//CHECK-NEXT:        atomicAdd(_d_val, _d_y);
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
-
-// CHECK: __attribute__((device)) void device_with_device_call_pullback_0_1_3(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = 0.;
-//CHECK-NEXT:        device_fn_4_pullback_0_1_3(in, val, _d_y, _d_in, &_r0);
-//CHECK-NEXT:        *_d_val += _r0;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
-
-// CHECK: __attribute__((global)) void add_kernel_4_pullback(int *out, int *in, int N, int *_d_out, int *_d_in, int *_d_N)  {
+// CHECK: __attribute__((global)) void add_kernel_4_pullback(int *out, int *in, int N, int *_d_out, int *_d_in, int *_d_N) {
 //CHECK-NEXT:    bool _cond0;
 //CHECK-NEXT:    int _d_sum = 0;
 //CHECK-NEXT:    int sum = 0;
@@ -675,7 +580,102 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
-// CHECK: __attribute__((device)) void device_fn_4_pullback_0_1_3(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+// CHECK: void launch_add_kernel_4_grad_0_1(int *out, int *in, const int N, int *_d_out, int *_d_in) {
+//CHECK-NEXT:    int _d_N = 0;
+//CHECK-NEXT:    int *_d_in_dev = nullptr;
+//CHECK-NEXT:    int *in_dev = nullptr;
+//CHECK-NEXT:    cudaMalloc(&_d_in_dev, N * sizeof(int));
+//CHECK-NEXT:    cudaMemset(_d_in_dev, 0, N * sizeof(int));
+//CHECK-NEXT:    cudaMalloc(&in_dev, N * sizeof(int));
+//CHECK-NEXT:    cudaMemcpy(in_dev, in, N * sizeof(int), cudaMemcpyHostToDevice);
+//CHECK-NEXT:    int *_d_out_dev = nullptr;
+//CHECK-NEXT:    int *out_dev = nullptr;
+//CHECK-NEXT:    cudaMalloc(&_d_out_dev, N * sizeof(int));
+//CHECK-NEXT:    cudaMemset(_d_out_dev, 0, N * sizeof(int));
+//CHECK-NEXT:    cudaMalloc(&out_dev, N * sizeof(int));
+//CHECK-NEXT:    cudaMemcpy(out_dev, out, N * sizeof(int), cudaMemcpyHostToDevice);
+//CHECK-NEXT:    add_kernel_4<<<1, 5>>>(out_dev, in_dev, N);
+//CHECK-NEXT:    cudaMemcpy(out, out_dev, N * sizeof(int), cudaMemcpyDeviceToHost);
+//CHECK-NEXT:    {
+//CHECK-NEXT:        unsigned long _r6 = 0UL;
+//CHECK-NEXT:        cudaMemcpyKind _r7 = static_cast<cudaMemcpyKind>(0U);
+//CHECK-NEXT:        clad::custom_derivatives::cudaMemcpy_pullback(out, out_dev, N * sizeof(int), cudaMemcpyDeviceToHost, _d_out, _d_out_dev, &_r6, &_r7);
+//CHECK-NEXT:        _d_N += _r6 * sizeof(int);
+//CHECK-NEXT:    }
+//CHECK-NEXT:    {
+//CHECK-NEXT:        int _r4 = 0;
+//CHECK-NEXT:        int *_r5 = nullptr;
+//CHECK-NEXT:        cudaMalloc(&_r5, 4);
+//CHECK-NEXT:        cudaMemset(_r5, 0, 4);
+//CHECK-NEXT:        add_kernel_4_pullback<<<1, 5>>>(out_dev, in_dev, N, _d_out_dev, _d_in_dev, _r5);
+//CHECK-NEXT:        cudaMemcpy(&_r4, _r5, 4, cudaMemcpyDeviceToHost);
+//CHECK-NEXT:        cudaFree(_r5);
+//CHECK-NEXT:        _d_N += _r4;
+//CHECK-NEXT:    }
+//CHECK-NEXT:    {
+//CHECK-NEXT:        unsigned long _r2 = 0UL;
+//CHECK-NEXT:        cudaMemcpyKind _r3 = static_cast<cudaMemcpyKind>(0U);
+//CHECK-NEXT:        clad::custom_derivatives::cudaMemcpy_pullback(out_dev, out, N * sizeof(int), cudaMemcpyHostToDevice, _d_out_dev, _d_out, &_r2, &_r3);
+//CHECK-NEXT:        _d_N += _r2 * sizeof(int);
+//CHECK-NEXT:    }
+//CHECK-NEXT:    {
+//CHECK-NEXT:        unsigned long _r0 = 0UL;
+//CHECK-NEXT:        cudaMemcpyKind _r1 = static_cast<cudaMemcpyKind>(0U);
+//CHECK-NEXT:        clad::custom_derivatives::cudaMemcpy_pullback(in_dev, in, N * sizeof(int), cudaMemcpyHostToDevice, _d_in_dev, _d_in, &_r0, &_r1);
+//CHECK-NEXT:        _d_N += _r0 * sizeof(int);
+//CHECK-NEXT:    }
+//CHECK-NEXT:    cudaFree(in_dev);
+//CHECK-NEXT:    cudaFree(_d_in_dev);
+//CHECK-NEXT:    cudaFree(out_dev);
+//CHECK-NEXT:    cudaFree(_d_out_dev);
+//CHECK-NEXT:}
+
+// CHECK: __attribute__((device)) void device_fn_pullback_1(const double in, double val, double _d_y, double *_d_in, double *_d_val) {
+//CHECK-NEXT:    {
+//CHECK-NEXT:                *_d_in += _d_y;
+//CHECK-NEXT:                *_d_val += _d_y;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
+// CHECK: __attribute__((device)) void device_fn_2_pullback_1(const double *in, double val, double _d_y, double *_d_val) {
+//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
+//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
+//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
+//CHECK-NEXT:    *_d_val += _d_y;
+//CHECK-NEXT:}
+
+// CHECK: __attribute__((device)) void device_fn_2_pullback_0(const double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
+//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
+//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        atomicAdd(&_d_in[index0], _d_y);
+//CHECK-NEXT:        *_d_val += _d_y;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
+// CHECK: __attribute__((device)) void device_fn_3_pullback_0_1(double *in, double *val, double _d_y, double *_d_in, double *_d_val) {
+//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
+//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
+//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        atomicAdd(&_d_in[index0], _d_y);
+//CHECK-NEXT:        atomicAdd(_d_val, _d_y);
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
+// CHECK: __attribute__((device)) void device_with_device_call_pullback_0(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+//CHECK-NEXT:    {
+//CHECK-NEXT:        double _r0 = 0.;
+//CHECK-NEXT:        device_fn_4_pullback_0_1(in, val, _d_y, _d_in, &_r0);
+//CHECK-NEXT:        *_d_val += _r0;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
+// CHECK: __attribute__((device)) void device_fn_4_pullback_0_1(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
 //CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
 //CHECK-NEXT:    unsigned int _t0 = blockDim.x;
 //CHECK-NEXT:    int _d_index = 0;

--- a/test/FirstDerivative/CallArguments.C
+++ b/test/FirstDerivative/CallArguments.C
@@ -104,7 +104,9 @@ float f_const_helper(const float x) {
   return x * x;
 }
 
-// CHECK: clad::ValueAndPushforward<float, float> f_const_helper_pushforward(const float x, const float _d_x);
+// CHECK: clad::ValueAndPushforward<float, float> f_const_helper_pushforward(const float x, const float _d_x) {
+// CHECK-NEXT:     return {x * x, _d_x * x + x * _d_x};
+// CHECK-NEXT: }
 
 float f_const_args_func_7(const float x, const float y) {
   return f_const_helper(x) + f_const_helper(y) - y;
@@ -145,8 +147,9 @@ float f_literal_args_func(float x, float y, float *z) {
 // CHECK-NEXT: float _d_x = 1;
 // CHECK-NEXT: float _d_y = 0;
 // CHECK-NEXT: printf("hello world ");
-// CHECK-NEXT: float _t0 = f_literal_helper(0.5, 'a', z, nullptr);
-// CHECK-NEXT: return _d_x * _t0 + x * 0.F;
+// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t0 = f_literal_helper_pushforward(0.5, 'a', z, nullptr, 0., 0, nullptr, nullptr);
+// CHECK-NEXT: float &_t1 = _t0.value;
+// CHECK-NEXT: return _d_x * _t1 + x * _t0.pushforward;
 // CHECK-NEXT: }
 
 inline unsigned int getBin(double low, double high, double val, unsigned int numBins) {
@@ -159,7 +162,15 @@ float f_call_inline_fxn(float *params, float const *obs, float const *xlArr) {
    return t116 * params[0];
 }
 
-// CHECK: inline clad::ValueAndPushforward<unsigned int, unsigned int> getBin_pushforward(double low, double high, double val, unsigned int numBins, double _d_low, double _d_high, double _d_val, unsigned int _d_numBins);
+// CHECK: inline clad::ValueAndPushforward<unsigned int, unsigned int> getBin_pushforward(double low, double high, double val, unsigned int numBins, double _d_low, double _d_high, double _d_val, unsigned int _d_numBins) {
+// CHECK-NEXT:     double _t0 = (high - low);
+// CHECK-NEXT:     double _d_binWidth = ((_d_high - _d_low) * numBins - _t0 * _d_numBins) / (numBins * numBins);
+// CHECK-NEXT:     double binWidth = _t0 / numBins;
+// CHECK-NEXT:     double _t1 = (val - low);
+// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<double, double> _t2 = clad::custom_derivatives::std::abs_pushforward(_t1 / binWidth, ((_d_val - _d_low) * binWidth - _t1 * _d_binWidth) / (binWidth * binWidth));
+// CHECK-NEXT:     bool _t3 = val >= high;
+// CHECK-NEXT:     return {(unsigned int)(_t3 ? numBins - 1 : _t2.value), (unsigned int)(_t3 ? _d_numBins - 0 : _t2.pushforward)};
+// CHECK-NEXT: }
 
 // CHECK: float f_call_inline_fxn_darg0_0(float *params, const float *obs, const float *xlArr) {
 // CHECK-NEXT:     clad::ValueAndPushforward<unsigned int, unsigned int> _t0 = getBin_pushforward(0., 1., params[0], 1, 0., 0., 1.F, 0);
@@ -209,20 +220,6 @@ int main () { // expected-no-diagnostics
   float params = 1.0, obs = 5.0, xlArr = 7.0;
   printf("f10_darg0_0=%.2f\n", f10.execute(&params, &obs, &xlArr));
   //CHECK-EXEC: f10_darg0_0=7.00
-
-// CHECK: clad::ValueAndPushforward<float, float> f_const_helper_pushforward(const float x, const float _d_x) {
-// CHECK-NEXT:     return {x * x, _d_x * x + x * _d_x};
-// CHECK-NEXT: }
-
-// CHECK: inline clad::ValueAndPushforward<unsigned int, unsigned int> getBin_pushforward(double low, double high, double val, unsigned int numBins, double _d_low, double _d_high, double _d_val, unsigned int _d_numBins) {
-// CHECK-NEXT:     double _t0 = (high - low);
-// CHECK-NEXT:     double _d_binWidth = ((_d_high - _d_low) * numBins - _t0 * _d_numBins) / (numBins * numBins);
-// CHECK-NEXT:     double binWidth = _t0 / numBins;
-// CHECK-NEXT:     double _t1 = (val - low);
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<double, double> _t2 = clad::custom_derivatives::std::abs_pushforward(_t1 / binWidth, ((_d_val - _d_low) * binWidth - _t1 * _d_binWidth) / (binWidth * binWidth));
-// CHECK-NEXT:     bool _t3 = val >= high;
-// CHECK-NEXT:     return {(unsigned int)(_t3 ? numBins - 1 : _t2.value), (unsigned int)(_t3 ? _d_numBins - 0 : _t2.pushforward)};
-// CHECK-NEXT: }
 
   return 0;
 }

--- a/test/FirstDerivative/FunctionCalls.C
+++ b/test/FirstDerivative/FunctionCalls.C
@@ -123,7 +123,10 @@ double test_7(double i, double j) {
   return res;
 }
 
-// CHECK: void increment_pushforward(int &i, int &_d_i);
+// CHECK: void increment_pushforward(int &i, int &_d_i) {
+// CHECK-NEXT: ++i;
+// CHECK-NEXT: }
+
 
 // CHECK: double test_7_darg0(double i, double j) {
 // CHECK-NEXT: double _d_i = 1;
@@ -150,7 +153,9 @@ double test_8(double x) {
   return func_with_enum(x, e);
 }
 
-// CHECK: clad::ValueAndPushforward<double, double> func_with_enum_pushforward(double x, E e, double _d_x);
+// CHECK: clad::ValueAndPushforward<double, double> func_with_enum_pushforward(double x, E e, double _d_x) {
+// CHECK-NEXT: return {x * x, _d_x * x + x * _d_x};
+// CHECK-NEXT: }
 
 // CHECK: double test_8_darg0(double x) {
 // CHECK-NEXT: double _d_x = 1;
@@ -213,13 +218,6 @@ int main () {
   clad::differentiate(test_10);
   return 0;
 
-// CHECK: void increment_pushforward(int &i, int &_d_i) {
-// CHECK-NEXT: ++i;
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<double, double> func_with_enum_pushforward(double x, E e, double _d_x) {
-// CHECK-NEXT: return {x * x, _d_x * x + x * _d_x};
-// CHECK-NEXT: }
 
 // CHECK: static clad::ValueAndPushforward<double, double> static_method_pushforward(double x, double _d_x) {
 // CHECK-NEXT: return {x, _d_x};

--- a/test/FirstDerivative/FunctionCallsWithResults.C
+++ b/test/FirstDerivative/FunctionCallsWithResults.C
@@ -88,7 +88,9 @@ double sum_of_squares(double u, double v) {
   return u*u + v*v;
 }
 
-// CHECK: clad::ValueAndPushforward<double, double> sum_of_squares_pushforward(double u, double v, double _d_u, double _d_v);
+// CHECK: clad::ValueAndPushforward<double, double> sum_of_squares_pushforward(double u, double v, double _d_u, double _d_v) {
+// CHECK-NEXT:     return {u * u + v * v, _d_u * u + u * _d_u + _d_v * v + v * _d_v};
+// CHECK-NEXT: }
 
 double fn1(double i, double j) {
   double res = sum_of_squares(i, j);
@@ -108,13 +110,23 @@ double fn1(double i, double j) {
 // CHECK-NEXT:     return _d_res;
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<double, double> fn1_pushforward(double i, double j, double _d_i, double _d_j);
+// CHECK: clad::ValueAndPushforward<double, double> fn1_pushforward(double i, double j, double _d_i, double _d_j) {
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = sum_of_squares_pushforward(i, j, _d_i, _d_j);
+// CHECK-NEXT:     double _d_res = _t0.pushforward;
+// CHECK-NEXT:     double res = _t0.value;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = sum_of_squares_pushforward(j, i, _d_j, _d_i);
+// CHECK-NEXT:     _d_res += _t1.pushforward;
+// CHECK-NEXT:     res += _t1.value;
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
 
 double sum_of_pairwise_product(double u, double v, double w) {
   return u*v + v*w + w*u;
 }
 
-// CHECK: clad::ValueAndPushforward<double, double> sum_of_pairwise_product_pushforward(double u, double v, double w, double _d_u, double _d_v, double _d_w);
+// CHECK: clad::ValueAndPushforward<double, double> sum_of_pairwise_product_pushforward(double u, double v, double w, double _d_u, double _d_v, double _d_w) {
+// CHECK-NEXT:     return {u * v + v * w + w * u, _d_u * v + u * _d_v + _d_v * w + v * _d_w + _d_w * u + w * _d_u};
+// CHECK-NEXT: }
 
 double fn2(double i, double j) {
   double res = fn1(i, j);
@@ -138,7 +150,10 @@ void square_inplace(double& u) {
   u = u*u;
 }
 
-// CHECK: void square_inplace_pushforward(double &u, double &_d_u);
+// CHECK: void square_inplace_pushforward(double &u, double &_d_u) {
+// CHECK-NEXT:     _d_u = _d_u * u + u * _d_u;
+// CHECK-NEXT:     u = u * u;
+// CHECK-NEXT: }
 
 double fn3(double i, double j) {
   square_inplace(i);
@@ -182,7 +197,13 @@ double fn5(double i, double j) {
   return fn5(0, i);
 }
 
-// CHECK: clad::ValueAndPushforward<double, double> fn5_pushforward(double i, double j, double _d_i, double _d_j);
+// CHECK: clad::ValueAndPushforward<double, double> fn5_pushforward(double i, double j, double _d_i, double _d_j) {
+// CHECK-NEXT:     if (i < 2) {
+// CHECK-NEXT:         return {j, _d_j};
+// CHECK-NEXT:     }
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn5_pushforward(0, i, 0, _d_i);
+// CHECK-NEXT:     return {_t0.value, _t0.pushforward};
+// CHECK-NEXT: }
 
 // CHECK: double fn5_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
@@ -200,7 +221,12 @@ double fn6(double i, double j, double k) {
   return i+j+k + fn6(i-1, j-1, k-1);
 }
 
-// CHECK: clad::ValueAndPushforward<double, double> fn6_pushforward(double i, double j, double k, double _d_i, double _d_j, double _d_k);
+// CHECK: clad::ValueAndPushforward<double, double> fn6_pushforward(double i, double j, double k, double _d_i, double _d_j, double _d_k) {
+// CHECK-NEXT:     if (i < 0.5)
+// CHECK-NEXT:         return {(double)0, (double)0};
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn6_pushforward(i - 1, j - 1, k - 1, _d_i - 0, _d_j - 0, _d_k - 0);
+// CHECK-NEXT:     return {i + j + k + _t0.value, _d_i + _d_j + _d_k + _t0.pushforward};
+// CHECK-NEXT: }
 
 // CHECK: double fn6_darg0(double i, double j, double k) {
 // CHECK-NEXT:     double _d_i = 1;
@@ -216,7 +242,9 @@ double helperFn(double&& i, double&& j) {
   return i+j;
 }
 
-// CHECK: clad::ValueAndPushforward<double, double> helperFn_pushforward(double &&i, double &&j, double &&_d_i, double &&_d_j);
+// CHECK: clad::ValueAndPushforward<double, double> helperFn_pushforward(double &&i, double &&j, double &&_d_i, double &&_d_j) {
+// CHECK-NEXT:     return {i + j, _d_i + _d_j};
+// CHECK-NEXT: }
 
 double fn7(double i, double j) {
   return helperFn(helperFn(7*i, 9*j), i+j);
@@ -235,7 +263,15 @@ void modifyArr(double* arr, int n, double val) {
     arr[i] = val;
 }
 
-// CHECK: void modifyArr_pushforward(double *arr, int n, double val, double *_d_arr, int _d_n, double _d_val);
+// CHECK: void modifyArr_pushforward(double *arr, int n, double val, double *_d_arr, int _d_n, double _d_val) {
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _d_i = 0;
+// CHECK-NEXT:         for (int i = 0; i < n; ++i) {
+// CHECK-NEXT:             _d_arr[i] = _d_val;
+// CHECK-NEXT:             arr[i] = val;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 double sum(double* arr, int n) {
   double val = 0;
@@ -244,14 +280,30 @@ double sum(double* arr, int n) {
   return val;
 }
 
-// CHECK: clad::ValueAndPushforward<double, double> sum_pushforward(double *arr, int n, double *_d_arr, int _d_n);
+// CHECK: clad::ValueAndPushforward<double, double> check_and_return_pushforward(double x, char c, double _d_x, char _d_c) {
+// CHECK-NEXT:   if (c == 'a')
+// CHECK-NEXT:     return {x, _d_x};
+// CHECK-NEXT:   return {(double)1, (double)0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<double, double> sum_pushforward(double *arr, int n, double *_d_arr, int _d_n) {
+// CHECK-NEXT:     double _d_val = 0;
+// CHECK-NEXT:     double val = 0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _d_i = 0;
+// CHECK-NEXT:         for (int i = 0; i < n; ++i) {
+// CHECK-NEXT:             _d_val += _d_arr[i];
+// CHECK-NEXT:             val += arr[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {val, _d_val};
+// CHECK-NEXT: }
 
 double check_and_return(double x, char c) {
   if (c == 'a')
     return x;
   return 1;
 }
-// CHECK: clad::ValueAndPushforward<double, double> check_and_return_pushforward(double x, char c, double _d_x, char _d_c);
 
 double fn8(double i, double j) {
   double arr[5] = {};
@@ -274,7 +326,9 @@ double fn8(double i, double j) {
 
 double g (double x) { return x; }
 
-// CHECK: clad::ValueAndPushforward<double, double> g_pushforward(double x, double _d_x);
+// CHECK: clad::ValueAndPushforward<double, double> g_pushforward(double x, double _d_x) {
+// CHECK-NEXT:     return {x, _d_x};
+// CHECK-NEXT: }
 
 double fn9 (double i, double j) {
   const int k = 1;
@@ -354,79 +408,4 @@ int main () {
   TEST(fn9, 3, 5);    // CHECK-EXEC: {5.00}
   TEST(fn10, 3);      // CHECK-EXEC: {1.00}
   return 0;
-
-// CHECK: clad::ValueAndPushforward<double, double> sum_of_squares_pushforward(double u, double v, double _d_u, double _d_v) {
-// CHECK-NEXT:     return {u * u + v * v, _d_u * u + u * _d_u + _d_v * v + v * _d_v};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<double, double> fn1_pushforward(double i, double j, double _d_i, double _d_j) {
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = sum_of_squares_pushforward(i, j, _d_i, _d_j);
-// CHECK-NEXT:     double _d_res = _t0.pushforward;
-// CHECK-NEXT:     double res = _t0.value;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = sum_of_squares_pushforward(j, i, _d_j, _d_i);
-// CHECK-NEXT:     _d_res += _t1.pushforward;
-// CHECK-NEXT:     res += _t1.value;
-// CHECK-NEXT:     return {res, _d_res};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<double, double> sum_of_pairwise_product_pushforward(double u, double v, double w, double _d_u, double _d_v, double _d_w) {
-// CHECK-NEXT:     return {u * v + v * w + w * u, _d_u * v + u * _d_v + _d_v * w + v * _d_w + _d_w * u + w * _d_u};
-// CHECK-NEXT: }
-
-// CHECK: void square_inplace_pushforward(double &u, double &_d_u) {
-// CHECK-NEXT:     _d_u = _d_u * u + u * _d_u;
-// CHECK-NEXT:     u = u * u;
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<double, double> fn5_pushforward(double i, double j, double _d_i, double _d_j) {
-// CHECK-NEXT:     if (i < 2) {
-// CHECK-NEXT:         return {j, _d_j};
-// CHECK-NEXT:     }
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn5_pushforward(0, i, 0, _d_i);
-// CHECK-NEXT:     return {_t0.value, _t0.pushforward};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<double, double> fn6_pushforward(double i, double j, double k, double _d_i, double _d_j, double _d_k) {
-// CHECK-NEXT:     if (i < 0.5)
-// CHECK-NEXT:         return {(double)0, (double)0};
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = fn6_pushforward(i - 1, j - 1, k - 1, _d_i - 0, _d_j - 0, _d_k - 0);
-// CHECK-NEXT:     return {i + j + k + _t0.value, _d_i + _d_j + _d_k + _t0.pushforward};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<double, double> helperFn_pushforward(double &&i, double &&j, double &&_d_i, double &&_d_j) {
-// CHECK-NEXT:     return {i + j, _d_i + _d_j};
-// CHECK-NEXT: }
-
-// CHECK: void modifyArr_pushforward(double *arr, int n, double val, double *_d_arr, int _d_n, double _d_val) {
-// CHECK-NEXT:     {
-// CHECK-NEXT:         int _d_i = 0;
-// CHECK-NEXT:         for (int i = 0; i < n; ++i) {
-// CHECK-NEXT:             _d_arr[i] = _d_val;
-// CHECK-NEXT:             arr[i] = val;
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<double, double> sum_pushforward(double *arr, int n, double *_d_arr, int _d_n) {
-// CHECK-NEXT:     double _d_val = 0;
-// CHECK-NEXT:     double val = 0;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         int _d_i = 0;
-// CHECK-NEXT:         for (int i = 0; i < n; ++i) {
-// CHECK-NEXT:             _d_val += _d_arr[i];
-// CHECK-NEXT:             val += arr[i];
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return {val, _d_val};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<double, double> check_and_return_pushforward(double x, char c, double _d_x, char _d_c) {
-// CHECK-NEXT:   if (c == 'a')
-// CHECK-NEXT:     return {x, _d_x};
-// CHECK-NEXT:   return {(double)1, (double)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<double, double> g_pushforward(double x, double _d_x) {
-// CHECK-NEXT:     return {x, _d_x};
-// CHECK-NEXT: }
 }

--- a/test/FirstDerivative/FunctionsInNamespaces.C
+++ b/test/FirstDerivative/FunctionsInNamespaces.C
@@ -22,6 +22,9 @@ namespace function_namespace10 {
     int func4(int x, int y) {
       return x*x + y;
     }
+    // CHECK: clad::ValueAndPushforward<int, int> func4_pushforward(int x, int y, int _d_x, int _d_y) {
+    // CHECK-NEXT:     return {x * x + y, _d_x * x + x * _d_x + _d_y};
+    // CHECK-NEXT: }
   }
 }
 
@@ -43,7 +46,10 @@ int test_1(int x, int y) {
   return function_namespace2::func3(x, y);
 }
 
-// CHECK: clad::ValueAndPushforward<int, int> func3_pushforward(int x, int y, int _d_x, int _d_y);
+// CHECK: clad::ValueAndPushforward<int, int> func3_pushforward(int x, int y, int _d_x, int _d_y) {
+// CHECK-NEXT:     clad::ValueAndPushforward<int, int> _t0 = function_namespace10::function_namespace11::func4_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     return {_t0.value, _t0.pushforward};
+// CHECK-NEXT: }
 
 // CHECK: int test_1_darg1(int x, int y) {
 // CHECK-NEXT:     int _d_x = 0;
@@ -59,18 +65,30 @@ namespace C {
     i = j;
     return 1;
   }
+  // CHECK: clad::ValueAndPushforward<double, double> someFn_1_pushforward(double &i, double j, double k, double &_d_i, double _d_j, double _d_k) {
+  // CHECK-NEXT:     _d_i = _d_j;
+  // CHECK-NEXT:     i = j;
+  // CHECK-NEXT:     return {(double)1, (double)0};
+  // CHECK-NEXT: }
 
   double someFn_1(double& i, double j) {
     someFn_1(i, j, j);
     return 2;
   }
+  // CHECK: clad::ValueAndPushforward<double, double> someFn_1_pushforward(double &i, double j, double &_d_i, double _d_j) {
+  // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = A::B::C::someFn_1_pushforward(i, j, j, _d_i, _d_j, _d_j);
+  // CHECK-NEXT:     return {(double)2, (double)0};
+  // CHECK-NEXT: }
 
   double someFn(double& i, double& j) {
     someFn_1(i, j);
     return 3;
   }
 
-  // CHECK: clad::ValueAndPushforward<double, double> someFn_pushforward(double &i, double &j, double &_d_i, double &_d_j);
+  // CHECK: clad::ValueAndPushforward<double, double> someFn_pushforward(double &i, double &j, double &_d_i, double &_d_j) {
+  // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = A::B::C::someFn_1_pushforward(i, j, _d_i, _d_j);
+  // CHECK-NEXT:     return {(double)3, (double)0};
+  // CHECK-NEXT: }
 } // namespace C
 } // namespace B
 } // namespace A
@@ -93,38 +111,6 @@ int main () {
 
   TEST_DIFFERENTIATE(test_1, 3, 5);   // CHECK-EXEC: {1}
   TEST_DIFFERENTIATE(fn1, 3, 5);      // CHECK-EXEC: {2.00}
-
-
-  // CHECK: clad::ValueAndPushforward<int, int> func4_pushforward(int x, int y, int _d_x, int _d_y);
-
-  // CHECK: clad::ValueAndPushforward<int, int> func3_pushforward(int x, int y, int _d_x, int _d_y) {
-  // CHECK-NEXT:     clad::ValueAndPushforward<int, int> _t0 = function_namespace10::function_namespace11::func4_pushforward(x, y, _d_x, _d_y);
-  // CHECK-NEXT:     return {_t0.value, _t0.pushforward};
-  // CHECK-NEXT: }
-
-  // CHECK: clad::ValueAndPushforward<double, double> someFn_1_pushforward(double &i, double j, double &_d_i, double _d_j);
-
-  // CHECK: clad::ValueAndPushforward<double, double> someFn_pushforward(double &i, double &j, double &_d_i, double &_d_j) {
-  // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = A::B::C::someFn_1_pushforward(i, j, _d_i, _d_j);
-  // CHECK-NEXT:     return {(double)3, (double)0};
-  // CHECK-NEXT: }
-
-  // CHECK: clad::ValueAndPushforward<int, int> func4_pushforward(int x, int y, int _d_x, int _d_y) {
-  // CHECK-NEXT:     return {x * x + y, _d_x * x + x * _d_x + _d_y};
-  // CHECK-NEXT: }
-
-  // CHECK: clad::ValueAndPushforward<double, double> someFn_1_pushforward(double &i, double j, double k, double &_d_i, double _d_j, double _d_k);
-
-  // CHECK: clad::ValueAndPushforward<double, double> someFn_1_pushforward(double &i, double j, double &_d_i, double _d_j) {
-  // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = A::B::C::someFn_1_pushforward(i, j, j, _d_i, _d_j, _d_j);
-  // CHECK-NEXT:     return {(double)2, (double)0};
-  // CHECK-NEXT: }
-
-  // CHECK: clad::ValueAndPushforward<double, double> someFn_1_pushforward(double &i, double j, double k, double &_d_i, double _d_j, double _d_k) {
-  // CHECK-NEXT:     _d_i = _d_j;
-  // CHECK-NEXT:     i = j;
-  // CHECK-NEXT:     return {(double)1, (double)0};
-  // CHECK-NEXT: }
 
   return 0;
 }

--- a/test/FirstDerivative/Recursive.C
+++ b/test/FirstDerivative/Recursive.C
@@ -12,7 +12,14 @@ int f_dec(int arg) {
     return f_dec(arg-1);
 }
 
-// CHECK: clad::ValueAndPushforward<int, int> f_dec_pushforward(int arg, int _d_arg);
+// CHECK: clad::ValueAndPushforward<int, int> f_dec_pushforward(int arg, int _d_arg) {
+// CHECK-NEXT:     if (arg == 0)
+// CHECK-NEXT:         return {arg, _d_arg};
+// CHECK-NEXT:     else {
+// CHECK-NEXT:         clad::ValueAndPushforward<int, int> _t0 = f_dec_pushforward(arg - 1, _d_arg - 0);
+// CHECK-NEXT:         return {_t0.value, _t0.pushforward};
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 // CHECK: int f_dec_darg0(int arg) {
 // CHECK-NEXT:     int _d_arg = 1;
@@ -33,7 +40,15 @@ int f_pow(int arg, int p) {
     return arg * f_pow(arg, p - 1);
 }
 
-// CHECK: clad::ValueAndPushforward<int, int> f_pow_pushforward(int arg, int p, int _d_arg, int _d_p);
+// CHECK: clad::ValueAndPushforward<int, int> f_pow_pushforward(int arg, int p, int _d_arg, int _d_p) {
+// CHECK-NEXT:     if (p == 0)
+// CHECK-NEXT:         return {1, 0};
+// CHECK-NEXT:     else {
+// CHECK-NEXT:         clad::ValueAndPushforward<int, int> _t0 = f_pow_pushforward(arg, p - 1, _d_arg, _d_p - 0);
+// CHECK-NEXT:         int &_t1 = _t0.value;
+// CHECK-NEXT:         return {arg * _t1, _d_arg * _t1 + arg * _t0.pushforward};
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 // CHECK: int f_pow_darg0(int arg, int p) {
 // CHECK-NEXT:     int _d_arg = 1;
@@ -54,23 +69,4 @@ int main() {
   printf("Result is = %d\n", f_dec_darg0(2)); // CHECK-EXEC: Result is = 1
   clad::differentiate(f_pow, 0);
   printf("Result is = %d\n", f_pow_darg0(10, 2)); //CHECK-EXEC: Result is = 20
-
-// CHECK: clad::ValueAndPushforward<int, int> f_dec_pushforward(int arg, int _d_arg) {
-// CHECK-NEXT:     if (arg == 0)
-// CHECK-NEXT:         return {arg, _d_arg};
-// CHECK-NEXT:     else {
-// CHECK-NEXT:         clad::ValueAndPushforward<int, int> _t0 = f_dec_pushforward(arg - 1, _d_arg - 0);
-// CHECK-NEXT:         return {_t0.value, _t0.pushforward};
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<int, int> f_pow_pushforward(int arg, int p, int _d_arg, int _d_p) {
-// CHECK-NEXT:     if (p == 0)
-// CHECK-NEXT:         return {1, 0};
-// CHECK-NEXT:     else {
-// CHECK-NEXT:         clad::ValueAndPushforward<int, int> _t0 = f_pow_pushforward(arg, p - 1, _d_arg, _d_p - 0);
-// CHECK-NEXT:         int &_t1 = _t0.value;
-// CHECK-NEXT:         return {arg * _t1, _d_arg * _t1 + arg * _t0.pushforward};
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
 }

--- a/test/ForwardMode/Pointer.C
+++ b/test/ForwardMode/Pointer.C
@@ -177,12 +177,14 @@ void* cling_runtime_internal_throwIfInvalidPointer(void *Sema, void *Expr, const
   return const_cast<void*>(Arg);
 }
 
+// CHECK: clad::ValueAndPushforward<void *, void *> cling_runtime_internal_throwIfInvalidPointer_pushforward(void *Sema, void *Expr, const void *Arg, void *_d_Sema, void *_d_Expr, const void *_d_Arg) {
+// CHECK-NEXT:     return {const_cast<void *>(Arg), const_cast<void *>(_d_Arg)};
+// CHECK-NEXT: }
+
 double fn8(double* params) {
   double arr[] = {3.0};
   return params[0]*params[0] + *(double*)(cling_runtime_internal_throwIfInvalidPointer((void*)0UL, (void*)0UL, arr));
 }
-
-// CHECK: clad::ValueAndPushforward<void *, void *> cling_runtime_internal_throwIfInvalidPointer_pushforward(void *Sema, void *Expr, const void *Arg, void *_d_Sema, void *_d_Expr, const void *_d_Arg);
 
 // CHECK: double fn8_darg0_0(double *params) {
 // CHECK-NEXT:     double _d_arr[1] = {0.};
@@ -244,7 +246,3 @@ int main() {
   d_param = fn10_dx.execute(params, constants);
   printf("{%.2f}\n", d_param); // CHECK-EXEC: {5.00}
 }
-
-// CHECK: clad::ValueAndPushforward<void *, void *> cling_runtime_internal_throwIfInvalidPointer_pushforward(void *Sema, void *Expr, const void *Arg, void *_d_Sema, void *_d_Expr, const void *_d_Arg) {
-// CHECK-NEXT:     return {const_cast<void *>(Arg), const_cast<void *>(_d_Arg)};
-// CHECK-NEXT: }

--- a/test/ForwardMode/STLCustomDerivatives.C
+++ b/test/ForwardMode/STLCustomDerivatives.C
@@ -389,6 +389,11 @@ double fnTuple1(double x, double y) {
     return v;
 } // = 2x + 2y
 
+//CHECK:      clad::ValueAndPushforward<{{.*}}> pack_pushforward({{.*}}) {
+//CHECK-NEXT:          clad::ValueAndPushforward<tuple<double, double, double>, tuple<double, double, double> > _t0 = clad::custom_derivatives::std::make_tuple_pushforward(x, 2 * x, 3 * x, _d_x, 0 * x + 2 * _d_x, 0 * x + 3 * _d_x);
+//CHECK-NEXT:          return {_t0.value, _t0.pushforward};
+//CHECK-NEXT:      }
+
 //CHECK:      double fnTuple1_darg0(double x, double y) {
 //CHECK-NEXT:          double _d_x = 1;
 //CHECK-NEXT:          double _d_y = 0;
@@ -398,10 +403,6 @@ double fnTuple1(double x, double y) {
 //CHECK-NEXT:          clad::ValueAndPushforward<{{.*}}> _t1 = pack_pushforward(x + y, _d_x + _d_y);
 //CHECK-NEXT:          clad::ValueAndPushforward<{{.*}}> _t2 = clad::custom_derivatives::class_functions::operator_equal_pushforward(&_t0.value, static_cast<std::tuple<double, double, double> &&>(_t1.value), &_t0.pushforward, static_cast<std::tuple<double, double, double> &&>(_t1.pushforward));
 //CHECK-NEXT:          return _d_v;
-//CHECK-NEXT:      }
-//CHECK:      clad::ValueAndPushforward<{{.*}}> pack_pushforward({{.*}}) {
-//CHECK-NEXT:          clad::ValueAndPushforward<tuple<double, double, double>, tuple<double, double, double> > _t0 = clad::custom_derivatives::std::make_tuple_pushforward(x, 2 * x, 3 * x, _d_x, 0 * x + 2 * _d_x, 0 * x + 3 * _d_x);
-//CHECK-NEXT:          return {_t0.value, _t0.pushforward};
 //CHECK-NEXT:      }
 
 int main() {

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -551,7 +551,7 @@ complexD fn9(double i, complexD c) {
 // CHECK-NEXT:     return _d_r;
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<complex<double> &, complex<double> &> operator_plus_equal_pushforward(const complex<double> &__z, std::complex<double> *_d_this, const complex<double> &_d___z);
+// CHECK: clad::ValueAndPushforward<complex<double> &, complex<double> &> operator_plus_equal_pushforward(const complex<double> &__[[PARAM:.*]], std::complex<double> *_d_this, const complex<double> &_d___[[PARAM]]){{.*}};
 
 std::complex<double> fn10(double i, double j) {
   std::complex<double> c1, c2;

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -440,11 +440,22 @@ double fn6(TensorD5 t, double i) {
   res += sum(t);
   return res;
 }
+// CHECK: clad::ValueAndPushforward<double, double> sum_pushforward(Tensor<double, 5U> &t, Tensor<double, 5U> &_d_t) {
+// CHECK-NEXT:     double _d_res = 0;
+// CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _d_i = 0;
+// CHECK-NEXT:         for (int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_res += _d_t.data[i];
+// CHECK-NEXT:             res += t.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
 // CHECK: clad::ValueAndPushforward<double, double> sum_pushforward(Tensor<double, 5> *_d_this);
 
 // CHECK: void updateTo_pushforward(double val, Tensor<double, 5> *_d_this, double _d_val);
-
-// CHECK: clad::ValueAndPushforward<double, double> sum_pushforward(Tensor<double, 5U> &t, Tensor<double, 5U> &_d_t);
 
 // CHECK: double fn6_darg1(TensorD5 t, double i) {
 // CHECK-NEXT:     TensorD5 _d_t;
@@ -540,6 +551,8 @@ complexD fn9(double i, complexD c) {
 // CHECK-NEXT:     return _d_r;
 // CHECK-NEXT: }
 
+// CHECK: clad::ValueAndPushforward<complex<double> &, complex<double> &> operator_plus_equal_pushforward(const complex<double> &__z, std::complex<double> *_d_this, const complex<double> &_d___z);
+
 std::complex<double> fn10(double i, double j) {
   std::complex<double> c1, c2;
   c1.real(2 * i);
@@ -567,6 +580,105 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:     return _t3.pushforward;
 // CHECK-NEXT: }
 
+// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_plus_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5U> _d_res;
+// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_res.data[i] = _d_a.data[i] + _d_b.data[i];
+// CHECK-NEXT:             res.data[i] = a.data[i] + b.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_minus_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5U> _d_res;
+// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_res.data[i] = _d_a.data[i] - _d_b.data[i];
+// CHECK-NEXT:             res.data[i] = a.data[i] - b.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
+// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_star_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5U> _d_res;
+// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             const double _t0 = a.data[i];
+// CHECK-NEXT:             const double _t1 = b.data[i];
+// CHECK-NEXT:             _d_res.data[i] = _d_a.data[i] * _t1 + _t0 * _d_b.data[i];
+// CHECK-NEXT:             res.data[i] = _t0 * _t1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_minus_pushforward(const Tensor<double, 5U> &t, const Tensor<double, 5U> &_d_t) {
+// CHECK-NEXT:     Tensor<double, 5U> _d_res;
+// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_res.data[i] = -_d_t.data[i];
+// CHECK-NEXT:             res.data[i] = -t.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_slash_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5U> _d_res;
+// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             const double _t0 = a.data[i];
+// CHECK-NEXT:             const double _t1 = b.data[i];
+// CHECK-NEXT:             _d_res.data[i] = (_d_a.data[i] * _t1 - _t0 * _d_b.data[i]) / (_t1 * _t1);
+// CHECK-NEXT:             res.data[i] = _t0 / _t1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_caret_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5U> _d_res;
+// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             {{(clad::)?}}ValueAndPushforward<double, double> _t0 = clad::custom_derivatives::std::pow_pushforward(a.data[i], b.data[i], _d_a.data[i], _d_b.data[i]);
+// CHECK-NEXT:             _d_res.data[i] = _t0.pushforward;
+// CHECK-NEXT:             res.data[i] = _t0.value;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {res, _d_res};
+// CHECK-NEXT: }
+
+// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_equal_pushforward(const Tensor<double, 5> &t, Tensor<double, 5> *_d_this, const Tensor<double, 5> &_d_t);
+
+// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_plus_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_plus_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
+// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
+// CHECK-NEXT: }
+
+// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_minus_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+
+// CHECK: void operator_call_pushforward(double val, Tensor<double, 5> *_d_this, double _d_val);
+// CHECK-NEXT: clad::ValueAndPushforward<double &, double &> operator_subscript_pushforward(std::size_t idx, Tensor<double, 5> *_d_this, std::size_t _d_idx);
+// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_plus_plus_pushforward(Tensor<double, 5> *_d_this);
+// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_minus_minus_pushforward(Tensor<double, 5> *_d_this);
+// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5>, Tensor<double, 5> > operator_plus_plus_pushforward(int param, Tensor<double, 5> *_d_this, int _d_param);
+
 TensorD5 fn11(double i, double j) {
   TensorD5 a, b;
   a(7*i);
@@ -588,34 +700,6 @@ TensorD5 fn11(double i, double j) {
   res2++;
   return res1;
 }
-
-// CHECK: void operator_call_pushforward(double val, Tensor<double, 5> *_d_this, double _d_val);
-
-// CHECK: clad::ValueAndPushforward<double &, double &> operator_subscript_pushforward(std::size_t idx, Tensor<double, 5> *_d_this, std::size_t _d_idx);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_plus_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_star_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_minus_pushforward(const Tensor<double, 5U> &t, const Tensor<double, 5U> &_d_t);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_minus_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_slash_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_equal_pushforward(const Tensor<double, 5> &t, Tensor<double, 5> *_d_this, const Tensor<double, 5> &_d_t);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_caret_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_plus_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_minus_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_plus_plus_pushforward(Tensor<double, 5> *_d_this);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_minus_minus_pushforward(Tensor<double, 5> *_d_this);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5>, Tensor<double, 5> > operator_plus_plus_pushforward(int param, Tensor<double, 5> *_d_this, int _d_param);
 
 // CHECK: TensorD5 fn11_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
@@ -680,11 +764,23 @@ TensorD5 fn12(double i, double j) {
   return res1;
 }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_star_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_star_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_star_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
+// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
+// CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_slash_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_slash_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_slash_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
+// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
+// CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_caret_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_caret_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_slash_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
+// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
+// CHECK-NEXT: }
 
 // CHECK: TensorD5 fn12_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
@@ -747,51 +843,116 @@ TensorD5 fn13(double i, double j) {
   return a + b;
 }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     double _d_lsum, _d_rsum;
+// CHECK-NEXT:     double lsum, rsum;
+// CHECK-NEXT:     _d_lsum = _d_rsum = 0;
+// CHECK-NEXT:     lsum = rsum = 0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_lsum += _d_lhs.data[i];
+// CHECK-NEXT:             lsum += lhs.data[i];
+// CHECK-NEXT:             _d_rsum += _d_lhs.data[i];
+// CHECK-NEXT:             rsum += lhs.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     double _d_lsum, _d_rsum;
+// CHECK-NEXT:     double lsum, rsum;
+// CHECK-NEXT:     _d_lsum = _d_rsum = 0;
+// CHECK-NEXT:     lsum = rsum = 0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_lsum += _d_lhs.data[i];
+// CHECK-NEXT:             lsum += lhs.data[i];
+// CHECK-NEXT:             _d_rsum += _d_lhs.data[i];
+// CHECK-NEXT:             rsum += lhs.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_equal_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_equal_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_exclaim_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_exclaim_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
 
-// CHECK: void operator_comma_pushforward(const Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, const Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
+// CHECK: void operator_comma_pushforward(const Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, const Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT: }
 
-// CHECK: void operator_exclaim_pushforward(const Tensor<double, 5U> &lhs, const Tensor<double, 5U> &_d_lhs);
+// CHECK: void operator_exclaim_pushforward(const Tensor<double, 5U> &lhs, const Tensor<double, 5U> &_d_lhs) {
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_percent_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     return {a, _d_a};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_percent_equal_pushforward(Tensor<double, 5U> &a, const Tensor<double, 5U> &b, Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK-NEXT:     return {(Tensor<double, 5U> &)a, (Tensor<double, 5U> &)_d_a};
+// CHECK-NEXT: }
+
+// CHECK: void operator_tilde_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &_d_a) {
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_less_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_greater_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_AmpAmp_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_pipe_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_less_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_greater_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_amp_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_amp_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK-NEXT:     return {(bool)1, (bool)0};
+// CHECK-NEXT: }
 
 // CHECK: clad::ValueAndPushforward<Tensor<double, 5> *, Tensor<double, 5> *> operator_amp_pushforward(Tensor<double, 5> *_d_this);
 
 // CHECK: clad::ValueAndPushforward<Tensor<double, 5> *, Tensor<double, 5> *> operator_arrow_pushforward(Tensor<double, 5> *_d_this);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_percent_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b);
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_percent_equal_pushforward(Tensor<double, 5U> &a, const Tensor<double, 5U> &b, Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b);
-
-// CHECK: void operator_tilde_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &_d_a);
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_less_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_greater_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_AmpAmp_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_pipe_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_less_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_greater_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_amp_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_amp_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs);
 
 // CHECK: TensorD5 fn13_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
@@ -1036,19 +1197,6 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<double, double> sum_pushforward(Tensor<double, 5U> &t, Tensor<double, 5U> &_d_t) {
-// CHECK-NEXT:     double _d_res = 0;
-// CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         int _d_i = 0;
-// CHECK-NEXT:         for (int i = 0; i < 5U; ++i) {
-// CHECK-NEXT:             _d_res += _d_t.data[i];
-// CHECK-NEXT:             res += t.data[i];
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return {res, _d_res};
-// CHECK-NEXT: }
-
 // CHECK: void real_pushforward({{.*}} [[__val:.*]], std{{(::__1)?}}::complex<double> *_d_this, {{.*}} [[_d___val:[a-zA-Z_]*]]){{.*}} {
 // CHECK-NEXT:     {{(__real)?}} _d_this->[[_M_value:.*]] = [[_d___val]];
 // CHECK-NEXT:     {{(__real)?}} this->[[_M_value]] = [[__val]];
@@ -1067,6 +1215,17 @@ int main() {
 // CHECK-NEXT:     return {{[{](__imag )?}}this->[[_M_value:[a-zA-Z_]+]],{{( __imag)?}} _d_this->[[_M_value:[a-zA-Z_]+]]};
 // CHECK-NEXT: }
 
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_equal_pushforward(const Tensor<double, 5> &t, Tensor<double, 5> *_d_this, const Tensor<double, 5> &_d_t) {
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_this->data[i] = _d_t.data[i];
+// CHECK-NEXT:             this->data[i] = t.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {(Tensor<double, 5> &)*this, (Tensor<double, 5> &)*_d_this};
+// CHECK-NEXT: }
+
 // CHECK: void operator_call_pushforward(double val, Tensor<double, 5> *_d_this, double _d_val) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         unsigned int _d_i = 0;
@@ -1079,112 +1238,6 @@ int main() {
 
 // CHECK: clad::ValueAndPushforward<double &, double &> operator_subscript_pushforward(std::size_t idx, Tensor<double, 5> *_d_this, std::size_t _d_idx) {
 // CHECK-NEXT:     return {(double &)this->data[idx], (double &)_d_this->data[idx]};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_plus_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     Tensor<double, 5U> _d_res;
-// CHECK-NEXT:     Tensor<double, 5U> res;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         unsigned int _d_i = 0;
-// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
-// CHECK-NEXT:             _d_res.data[i] = _d_a.data[i] + _d_b.data[i];
-// CHECK-NEXT:             res.data[i] = a.data[i] + b.data[i];
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return {res, _d_res};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_star_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     Tensor<double, 5U> _d_res;
-// CHECK-NEXT:     Tensor<double, 5U> res;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         unsigned int _d_i = 0;
-// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
-// CHECK-NEXT:             const double _t0 = a.data[i];
-// CHECK-NEXT:             const double _t1 = b.data[i];
-// CHECK-NEXT:             _d_res.data[i] = _d_a.data[i] * _t1 + _t0 * _d_b.data[i];
-// CHECK-NEXT:             res.data[i] = _t0 * _t1;
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return {res, _d_res};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_minus_pushforward(const Tensor<double, 5U> &t, const Tensor<double, 5U> &_d_t) {
-// CHECK-NEXT:     Tensor<double, 5U> _d_res;
-// CHECK-NEXT:     Tensor<double, 5U> res;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         unsigned int _d_i = 0;
-// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
-// CHECK-NEXT:             _d_res.data[i] = -_d_t.data[i];
-// CHECK-NEXT:             res.data[i] = -t.data[i];
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return {res, _d_res};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_minus_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     Tensor<double, 5U> _d_res;
-// CHECK-NEXT:     Tensor<double, 5U> res;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         unsigned int _d_i = 0;
-// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
-// CHECK-NEXT:             _d_res.data[i] = _d_a.data[i] - _d_b.data[i];
-// CHECK-NEXT:             res.data[i] = a.data[i] - b.data[i];
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return {res, _d_res};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_slash_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     Tensor<double, 5U> _d_res;
-// CHECK-NEXT:     Tensor<double, 5U> res;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         unsigned int _d_i = 0;
-// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
-// CHECK-NEXT:             const double _t0 = a.data[i];
-// CHECK-NEXT:             const double _t1 = b.data[i];
-// CHECK-NEXT:             _d_res.data[i] = (_d_a.data[i] * _t1 - _t0 * _d_b.data[i]) / (_t1 * _t1);
-// CHECK-NEXT:             res.data[i] = _t0 / _t1;
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return {res, _d_res};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_equal_pushforward(const Tensor<double, 5> &t, Tensor<double, 5> *_d_this, const Tensor<double, 5> &_d_t) {
-// CHECK-NEXT:     {
-// CHECK-NEXT:         unsigned int _d_i = 0;
-// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
-// CHECK-NEXT:             _d_this->data[i] = _d_t.data[i];
-// CHECK-NEXT:             this->data[i] = t.data[i];
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return {(Tensor<double, 5> &)*this, (Tensor<double, 5> &)*_d_this};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_caret_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     Tensor<double, 5U> _d_res;
-// CHECK-NEXT:     Tensor<double, 5U> res;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         unsigned int _d_i = 0;
-// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
-// CHECK-NEXT:             {{(clad::)?}}ValueAndPushforward<double, double> _t0 = clad::custom_derivatives::std::pow_pushforward(a.data[i], b.data[i], _d_a.data[i], _d_b.data[i]);
-// CHECK-NEXT:             _d_res.data[i] = _t0.pushforward;
-// CHECK-NEXT:             res.data[i] = _t0.value;
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return {res, _d_res};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_plus_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_plus_pushforward(lhs, rhs, _d_lhs, _d_rhs);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
-// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_minus_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_minus_pushforward(lhs, rhs, _d_lhs, _d_rhs);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
-// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_plus_plus_pushforward(Tensor<double, 5> *_d_this) {
@@ -1222,136 +1275,11 @@ int main() {
 // CHECK-NEXT:     return {temp, _d_temp};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_star_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_star_pushforward(lhs, rhs, _d_lhs, _d_rhs);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
-// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_slash_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_slash_pushforward(lhs, rhs, _d_lhs, _d_rhs);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
-// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_caret_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_slash_pushforward(lhs, rhs, _d_lhs, _d_rhs);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
-// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     double _d_lsum, _d_rsum;
-// CHECK-NEXT:     double lsum, rsum;
-// CHECK-NEXT:     _d_lsum = _d_rsum = 0;
-// CHECK-NEXT:     lsum = rsum = 0;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         unsigned int _d_i = 0;
-// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
-// CHECK-NEXT:             _d_lsum += _d_lhs.data[i];
-// CHECK-NEXT:             lsum += lhs.data[i];
-// CHECK-NEXT:             _d_rsum += _d_lhs.data[i];
-// CHECK-NEXT:             rsum += lhs.data[i];
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     double _d_lsum, _d_rsum;
-// CHECK-NEXT:     double lsum, rsum;
-// CHECK-NEXT:     _d_lsum = _d_rsum = 0;
-// CHECK-NEXT:     lsum = rsum = 0;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         unsigned int _d_i = 0;
-// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
-// CHECK-NEXT:             _d_lsum += _d_lhs.data[i];
-// CHECK-NEXT:             lsum += lhs.data[i];
-// CHECK-NEXT:             _d_rsum += _d_lhs.data[i];
-// CHECK-NEXT:             rsum += lhs.data[i];
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_equal_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_exclaim_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: void operator_comma_pushforward(const Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, const Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT: }
-
-// CHECK: void operator_exclaim_pushforward(const Tensor<double, 5U> &lhs, const Tensor<double, 5U> &_d_lhs) {
-// CHECK-NEXT: }
-
 // CHECK: clad::ValueAndPushforward<Tensor<double, 5> *, Tensor<double, 5> *> operator_amp_pushforward(Tensor<double, 5> *_d_this) {
 // CHECK-NEXT:     return {this, _d_this};
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndPushforward<Tensor<double, 5> *, Tensor<double, 5> *> operator_arrow_pushforward(Tensor<double, 5> *_d_this) {
 // CHECK-NEXT:     return {this, _d_this};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_percent_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     return {a, _d_a};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_percent_equal_pushforward(Tensor<double, 5U> &a, const Tensor<double, 5U> &b, Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     return {(Tensor<double, 5U> &)a, (Tensor<double, 5U> &)_d_a};
-// CHECK-NEXT: }
-
-// CHECK: void operator_tilde_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &_d_a) {
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_less_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_greater_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_AmpAmp_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_pipe_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_less_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_greater_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_amp_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_amp_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 }

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -263,7 +263,16 @@ int main() {
   FunctorAsArg_grad.execute(E_temp, 7, 9, &dE_temp, &di, &dj);
   printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 27.00 21.00
 
-  // CHECK: void FunctorAsArg_pullback(Experiment fn, double i, double j, double _d_y, Experiment *_d_fn, double *_d_i, double *_d_j);
+  // CHECK: void FunctorAsArg_pullback(Experiment fn, double i, double j, double _d_y, Experiment *_d_fn, double *_d_i, double *_d_j) {
+  // CHECK-NEXT:     Experiment _t0 = fn;
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         double _r0 = 0.;
+  // CHECK-NEXT:         double _r1 = 0.;
+  // CHECK-NEXT:         _t0.operator_call_pullback(i, j, _d_y, &(*_d_fn), &_r0, &_r1);
+  // CHECK-NEXT:         *_d_i += _r0;
+  // CHECK-NEXT:         *_d_j += _r1;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
   // CHECK: void FunctorAsArgWrapper_grad(double i, double j, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     Experiment E(3, 5);
@@ -289,14 +298,3 @@ int main() {
   FunctorAsArgWrapper_grad.execute(7, 9, &di, &dj);
   printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 27.00 21.00
 }
-
-// CHECK: void FunctorAsArg_pullback(Experiment fn, double i, double j, double _d_y, Experiment *_d_fn, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     Experiment _t0 = fn;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         double _r1 = 0.;
-// CHECK-NEXT:         _t0.operator_call_pullback(i, j, _d_y, &(*_d_fn), &_r0, &_r1);
-// CHECK-NEXT:         *_d_i += _r0;
-// CHECK-NEXT:         *_d_j += _r1;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -321,7 +321,12 @@ double f_sum(double *p, int n) {
 // CHECK-NEXT: }
 
 double sq(double x) { return x * x; }
-//CHECK:   void sq_pullback(double x, double _d_y, double *_d_x);
+//CHECK:   void sq_pullback(double x, double _d_y, double *_d_x) {
+//CHECK-NEXT:       {
+//CHECK-NEXT:           *_d_x += _d_y * x;
+//CHECK-NEXT:           *_d_x += x * _d_y;
+//CHECK-NEXT:       }
+//CHECK-NEXT:   }
 
 double f_sum_squares(double *p, int n) {
   double s = 0;
@@ -3351,10 +3356,3 @@ int main() {
   TEST_2(fn40, 2, 3); // CHECK-EXEC: {14.00, 0.00}
   TEST_2(fn41, 2, 3); // CHECK-EXEC: {1.00, 0.00}
 }
-
-//CHECK:   void sq_pullback(double x, double _d_y, double *_d_x) {
-//CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += _d_y * x;
-//CHECK-NEXT:           *_d_x += x * _d_y;
-//CHECK-NEXT:       }
-//CHECK-NEXT:   }

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -472,7 +472,17 @@ double* ptrValFn (double* x, int n) {
   return x;
 }
 
-// CHECK: void ptrValFn_pullback(double *x, int n, double *_d_x, int *_d_n);
+// CHECK: void ptrValFn_pullback(double *x, int n, double *_d_x, int *_d_n) {
+// CHECK-NEXT:     double *_t0 = x;
+// CHECK-NEXT:     double *_t1 = _d_x;
+// CHECK-NEXT:     _d_x += n;
+// CHECK-NEXT:     x += n;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         x = _t0;
+// CHECK-NEXT:         _d_x = _t1;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
 // CHECK: clad::ValueAndAdjoint<double *, double *> ptrValFn_forw(double *x, int n, double *_d_x, int _d_n);
 
 double nestedPtrFn (double x, double y) {
@@ -516,6 +526,14 @@ double listInitPtrFn (double x, double y) {
 // CHECK-NEXT:          *_d_y += _r_d0;
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
+
+// CHECK: clad::ValueAndAdjoint<double *, double *> ptrValFn_forw(double *x, int n, double *_d_x, int _d_n) {
+// CHECK-NEXT:     double *_t0 = x;
+// CHECK-NEXT:     double *_t1 = _d_x;
+// CHECK-NEXT:     _d_x += n;
+// CHECK-NEXT:     x += n;
+// CHECK-NEXT:     return {x, _d_x};
+// CHECK-NEXT: }
 
 #define NON_MEM_FN_TEST(var)\
 res[0]=0;\
@@ -635,22 +653,3 @@ int main() {
   d_listInitPtrFn.execute(5, 7, &d_i, &d_j);
   printf("%.2f %.2f\n", d_i, d_j); // CHECK-EXEC: 1.00 1.00
 }
-
-// CHECK: void ptrValFn_pullback(double *x, int n, double *_d_x, int *_d_n) {
-// CHECK-NEXT:     double *_t0 = x;
-// CHECK-NEXT:     double *_t1 = _d_x;
-// CHECK-NEXT:     _d_x += n;
-// CHECK-NEXT:     x += n;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         x = _t0;
-// CHECK-NEXT:         _d_x = _t1;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndAdjoint<double *, double *> ptrValFn_forw(double *x, int n, double *_d_x, int _d_n) {
-// CHECK-NEXT:     double *_t0 = x;
-// CHECK-NEXT:     double *_t1 = _d_x;
-// CHECK-NEXT:     _d_x += n;
-// CHECK-NEXT:     x += n;
-// CHECK-NEXT:     return {x, _d_x};
-// CHECK-NEXT: }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -52,7 +52,34 @@ double sum(Tangent& t) {
     return res;
 }
 
-// CHECK: void sum_pullback(Tangent &t, double _d_y, Tangent *_d_t);
+// CHECK: void sum_pullback(Tangent &t, double _d_y, Tangent *_d_t) {
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
+// CHECK-NEXT:     for (i = 0; ; ++i) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (!(i < 5))
+// CHECK-NEXT:                 break;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         clad::push(_t1, res);
+// CHECK-NEXT:         res += t.data[i];
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_res += _d_y;
+// CHECK-NEXT:     for (;; _t0--) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (!_t0)
+// CHECK-NEXT:                 break;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         --i;
+// CHECK-NEXT:         res = clad::pop(_t1);
+// CHECK-NEXT:         double _r_d0 = _d_res;
+// CHECK-NEXT:         (*_d_t).data[i] += _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 double sum(double *data) {
     double res = 0;
@@ -61,7 +88,34 @@ double sum(double *data) {
     return res;
 }
 
-// CHECK: void sum_pullback(double *data, double _d_y, double *_d_data);
+// CHECK: void sum_pullback(double *data, double _d_y, double *_d_data) {
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
+// CHECK-NEXT:     for (i = 0; ; ++i) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (!(i < 5))
+// CHECK-NEXT:                 break;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         clad::push(_t1, res);
+// CHECK-NEXT:         res += data[i];
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_res += _d_y;
+// CHECK-NEXT:     for (;; _t0--) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (!_t0)
+// CHECK-NEXT:                 break;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         --i;
+// CHECK-NEXT:         res = clad::pop(_t1);
+// CHECK-NEXT:         double _r_d0 = _d_res;
+// CHECK-NEXT:         _d_data[i] += _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 double fn2(Tangent t, double i) {
     double res = sum(t);
@@ -363,7 +417,12 @@ double operator+(const double& x, const Tangent& t) {
   return x + t.data[0];
 }
 
-// CHECK: void operator_plus_pullback(const double &x, const Tangent &t, double _d_y, double *_d_x, Tangent *_d_t);
+// CHECK: void operator_plus_pullback(const double &x, const Tangent &t, double _d_y, double *_d_x, Tangent *_d_t) {
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += _d_y;
+// CHECK-NEXT:         (*_d_t).data[0] += _d_y;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 double fn11(double x, double y) {
   Tangent t;
@@ -696,7 +755,12 @@ void fn20(MyStruct s) {
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 
-// CHECK: void operator_plus_pullback(const double &val, const SimpleFunctions1 &a, double _d_y, double *_d_val, SimpleFunctions1 *_d_a);
+// CHECK:  void operator_plus_pullback(const double &val, const SimpleFunctions1 &a, double _d_y, double *_d_val, SimpleFunctions1 *_d_a) {
+// CHECK-NEXT:      {
+// CHECK-NEXT:          (*_d_a).x += _d_y;
+// CHECK-NEXT:          *_d_val += _d_y;
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
 
 double fn21(double i, double j) {
     return 2 + SimpleFunctions1(i);
@@ -839,64 +903,6 @@ int main() {
     TEST_GRADIENT(fn22, /*numOfDerivativeArgs=*/2, 3, 2, &d_i, &d_j);    // CHECK-EXEC: {8.00, 0.00}
 }
 
-// CHECK: void sum_pullback(Tangent &t, double _d_y, Tangent *_d_t) {
-// CHECK-NEXT:     int _d_i = 0;
-// CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     double _d_res = 0.;
-// CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 5))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, res);
-// CHECK-NEXT:         res += t.data[i];
-// CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += _d_y;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
-// CHECK-NEXT:         --i;
-// CHECK-NEXT:         res = clad::pop(_t1);
-// CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         (*_d_t).data[i] += _r_d0;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-// CHECK: void sum_pullback(double *data, double _d_y, double *_d_data) {
-// CHECK-NEXT:     int _d_i = 0;
-// CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     double _d_res = 0.;
-// CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 5))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, res);
-// CHECK-NEXT:         res += data[i];
-// CHECK-NEXT:     }
-// CHECK-NEXT:     _d_res += _d_y;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
-// CHECK-NEXT:         --i;
-// CHECK-NEXT:         res = clad::pop(_t1);
-// CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         _d_data[i] += _r_d0;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
 // CHECK: void someMemFn2_pullback(double i, double j, double _d_y, Tangent *_d_this, double *_d_i, double *_d_j) const {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         (*_d_this).data[0] += _d_y * i;
@@ -950,13 +956,6 @@ int main() {
 // CHECK-NEXT:         double _r_d0 = (*_d_this).data[i];
 // CHECK-NEXT:         (*_d_this).data[i] = 0.;
 // CHECK-NEXT:         *_d_d += _r_d0;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-// CHECK: void operator_plus_pullback(const double &x, const Tangent &t, double _d_y, double *_d_x, Tangent *_d_t) {
-// CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_x += _d_y;
-// CHECK-NEXT:         (*_d_t).data[0] += _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -1035,14 +1034,3 @@ int main() {
 // CHECK-NEXT:        (*_d_rhs).y += this->y * _r1;
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
-
-// CHECK:  void operator_plus_pullback(const double &val, const SimpleFunctions1 &a, double _d_y, double *_d_val, SimpleFunctions1 *_d_a) {
-// CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_a).x += _d_y;
-// CHECK-NEXT:          *_d_val += _d_y;
-// CHECK-NEXT:      }
-// CHECK-NEXT:  }
-
-// CHECK:  void operator_call_pullback(double u, double _d_y, Identity *_d_this, double *_d_u) {
-// CHECK-NEXT:      *_d_u += _d_y;
-// CHECK-NEXT:  }

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -210,7 +210,13 @@
 //-----------------------------------------------------------------------------/
 // RUN: %cladclang %S/../../demos/GradientDescent.cpp -I%S/../../include -oGradientDescent.out | FileCheck -check-prefix CHECK_GRADIENT_DESCENT %s
 
-//CHECK_GRADIENT_DESCENT: void f_pullback(double theta_0, double theta_1, double x, double _d_y, double *_d_theta_0, double *_d_theta_1, double *_d_x);
+//CHECK_GRADIENT_DESCENT: void f_pullback(double theta_0, double theta_1, double x, double _d_y, double *_d_theta_0, double *_d_theta_1, double *_d_x) {
+//CHECK_GRADIENT_DESCENT-NEXT:     {
+//CHECK_GRADIENT_DESCENT-NEXT:         *_d_theta_0 += _d_y;
+//CHECK_GRADIENT_DESCENT-NEXT:         *_d_theta_1 += _d_y * x;
+//CHECK_GRADIENT_DESCENT-NEXT:         *_d_x += theta_1 * _d_y;
+//CHECK_GRADIENT_DESCENT-NEXT:     }
+//CHECK_GRADIENT_DESCENT-NEXT: }
 
 //CHECK_GRADIENT_DESCENT-NEXT: void cost_grad(double theta_0, double theta_1, double x, double y, double *_d_theta_0, double *_d_theta_1, double *_d_x, double *_d_y) {
 //CHECK_GRADIENT_DESCENT-NEXT:     double _d_f_x = 0.;
@@ -229,14 +235,6 @@
 //CHECK_GRADIENT_DESCENT-NEXT:         *_d_theta_0 += _r0;
 //CHECK_GRADIENT_DESCENT-NEXT:         *_d_theta_1 += _r1;
 //CHECK_GRADIENT_DESCENT-NEXT:         *_d_x += _r2;
-//CHECK_GRADIENT_DESCENT-NEXT:     }
-//CHECK_GRADIENT_DESCENT-NEXT: }
-
-//CHECK_GRADIENT_DESCENT: void f_pullback(double theta_0, double theta_1, double x, double _d_y, double *_d_theta_0, double *_d_theta_1, double *_d_x) {
-//CHECK_GRADIENT_DESCENT-NEXT:     {
-//CHECK_GRADIENT_DESCENT-NEXT:         *_d_theta_0 += _d_y;
-//CHECK_GRADIENT_DESCENT-NEXT:         *_d_theta_1 += _d_y * x;
-//CHECK_GRADIENT_DESCENT-NEXT:         *_d_x += theta_1 * _d_y;
 //CHECK_GRADIENT_DESCENT-NEXT:     }
 //CHECK_GRADIENT_DESCENT-NEXT: }
 

--- a/test/Misc/TimingsReport.C
+++ b/test/Misc/TimingsReport.C
@@ -5,14 +5,14 @@
 #include "clad/Differentiator/Differentiator.h"
 // CHECK: Timers for Clad Funcs
 // CHECK_STATS: *** INFORMATION ABOUT THE DIFF REQUESTS
-// CHECK_STATS-NEXT: <double test1(double x, double y)>[name=test1, order=1, mode=forward, args='"x"']: #0 (source), (done)
-// CHECK_STATS-NEXT: <double test2(double a, double b)>[name=test2, order=1, mode=reverse, args='']: #1 (source), (done)
-// CHECK_STATS-NEXT: <double nested1(double c)>[name=nested1, order=1, mode=pushforward, args='']: #2, (done)
-// CHECK_STATS-NEXT: <double nested2(double z)>[name=nested2, order=1, mode=pullback, args='']: #3, (done)
-// CHECK_STATS-NEXT: 0 -> 2
-// CHECK_STATS-NEXT: 1 -> 3
+// CHECK_STATS-NEXT: <double nested1(double c)>[name=nested1, order=1, mode=pushforward, args='c']: #0 (source), (done)
+// CHECK_STATS-NEXT: <double test1(double x, double y)>[name=test1, order=1, mode=forward, args='"x"']: #1 (source), (done)
+// CHECK_STATS-NEXT: <double nested2(double z)>[name=nested2, order=1, mode=pullback, args='z']: #2 (source), (done)
+// CHECK_STATS-NEXT: <double test2(double a, double b)>[name=test2, order=1, mode=reverse, args='']: #3 (source), (done)
+// CHECK_STATS-NEXT: <double addArrImpl(double *arr)>[name=addArrImpl, order=1, mode=pullback, args='arr']: #4 (source), (done)
+// CHECK_STATS-NEXT: <double addArr(double *arr)>[name=addArr, order=1, mode=reverse, args='"arr[0:1]"']: #5 (source), (done)
 
-// CHECK_STATS_TBR: <double test1(double x, double y)>[name=test1, order=1, mode=forward, args='"x"', tbr]: #0 (source), (done)
+// CHECK_STATS_TBR: <double test1(double x, double y)>[name=test1, order=1, mode=forward, args='"x"', tbr]: #1 (source), (done)
 
 double nested1(double c){
   return c*3*c;
@@ -30,6 +30,14 @@ double test2(double a, double b) {
   return 3*a*a + b * nested2(a) + a * b;
 }
 
+double addArrImpl(double *arr) {
+  return arr[0] + arr[1] + arr[2] + arr[3];
+}
+
+double addArr(double *arr) {
+  return addArrImpl(arr);
+}
+
 int main() {
   auto d_fn_1 = clad::differentiate(test1, "x");
   double dp = -1, dq = -1;
@@ -37,5 +45,6 @@ int main() {
   f_grad.execute(3, 4, &dp, &dq);
   printf("Result is = %f\n", d_fn_1.execute(3,4));
   printf("Result is = %f %f\n", dp, dq);
+  clad::gradient(addArr, "arr[0:1]");
   return 0;
 }

--- a/test/NestedCalls/NestedCalls.C
+++ b/test/NestedCalls/NestedCalls.C
@@ -12,12 +12,22 @@ double sq(double x) { return x * x; }
 
 double one(double x) { return sq(std::sin(x)) + sq(std::cos(x)); }
 
-// CHECK: clad::ValueAndPushforward<double, double> one_pushforward(double x, double _d_x);
-
 double f(double x, double y) {
   double t = one(x);
   return t * y;
 }
+//CHECK:   clad::ValueAndPushforward<double, double> sq_pushforward(double x, double _d_x) {
+//CHECK-NEXT:    return {x * x, _d_x * x + x * _d_x};
+//CHECK-NEXT:}
+
+//CHECK:   clad::ValueAndPushforward<double, double> one_pushforward(double x, double _d_x) {
+//CHECK-NEXT:    ValueAndPushforward<double, double> _t0 = clad::custom_derivatives::std::sin_pushforward(x, _d_x);
+//CHECK-NEXT:    clad::ValueAndPushforward<double, double> _t1 = sq_pushforward(_t0.value, _t0.pushforward);
+//CHECK-NEXT:    ValueAndPushforward<double, double> _t2 = clad::custom_derivatives::std::cos_pushforward(x, _d_x);
+//CHECK-NEXT:    clad::ValueAndPushforward<double, double> _t3 = sq_pushforward(_t2.value, _t2.pushforward);
+//CHECK-NEXT:    return {_t1.value + _t3.value, _t1.pushforward + _t3.pushforward};
+//CHECK-NEXT:}
+
 // CHECK: double f_darg0(double x, double y) {
 // CHECK-NEXT:     double _d_x = 1;
 // CHECK-NEXT:     double _d_y = 0;
@@ -27,21 +37,19 @@ double f(double x, double y) {
 // CHECK-NEXT:     return _d_t * y + t * _d_y;
 // CHECK-NEXT: }
 
-//CHECK:   void one_pullback(double x, double _d_y, double *_d_x);
-
 //CHECK:   void f_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _d_t = 0.;
-//CHECK-NEXT:       double t = one(x);
-//CHECK-NEXT:       {
-//CHECK-NEXT:           _d_t += 1 * y;
-//CHECK-NEXT:           *_d_y += t * 1;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 0.;
-//CHECK-NEXT:           one_pullback(x, _d_t, &_r0);
-//CHECK-NEXT:           *_d_x += _r0;
-//CHECK-NEXT:       }
-//CHECK-NEXT:   }
+//CHECK-NEXT:    double _d_t = 0.;
+//CHECK-NEXT:    double t = one(x);
+//CHECK-NEXT:    {
+//CHECK-NEXT:        _d_t += 1 * y;
+//CHECK-NEXT:        *_d_y += t * 1;
+//CHECK-NEXT:    }
+//CHECK-NEXT:    {
+//CHECK-NEXT:        double _r0 = 0.;
+//CHECK-NEXT:        _r0 += _d_t * one_pushforward(x, 1.).pushforward;
+//CHECK-NEXT:        *_d_x += _r0;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
 
 int main () { // expected-no-diagnostics
   auto df = clad::differentiate(f, 0);
@@ -53,42 +61,4 @@ int main () { // expected-no-diagnostics
   gradf.execute(2, 3, &result[0], &result[1]);
   printf("{%.2f, %.2f}\n", result[0], result[1]); // CHECK-EXEC: {0.00, 1.00}
   return 0;
-
-// CHECK: clad::ValueAndPushforward<double, double> sq_pushforward(double x, double _d_x);
-
-// CHECK: clad::ValueAndPushforward<double, double> one_pushforward(double x, double _d_x) {
-// CHECK-NEXT:     ValueAndPushforward<double, double> _t0 = clad::custom_derivatives::std::sin_pushforward(x, _d_x);
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = sq_pushforward(_t0.value, _t0.pushforward);
-// CHECK-NEXT:     ValueAndPushforward<double, double> _t2 = clad::custom_derivatives::std::cos_pushforward(x, _d_x);
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t3 = sq_pushforward(_t2.value, _t2.pushforward);
-// CHECK-NEXT:     return {_t1.value + _t3.value, _t1.pushforward + _t3.pushforward};
-// CHECK-NEXT: }
-
-//CHECK:   void sq_pullback(double x, double _d_y, double *_d_x);
-
-//CHECK:   void one_pullback(double x, double _d_y, double *_d_x) {
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r0 = 0.;
-//CHECK-NEXT:           sq_pullback(std::sin(x), _d_y, &_r0);
-//CHECK-NEXT:           double _r1 = 0.;
-//CHECK-NEXT:           _r1 += _r0 * clad::custom_derivatives::std::sin_pushforward(x, 1.).pushforward;
-//CHECK-NEXT:           *_d_x += _r1;
-//CHECK-NEXT:           double _r2 = 0.;
-//CHECK-NEXT:           sq_pullback(std::cos(x), _d_y, &_r2);
-//CHECK-NEXT:           double _r3 = 0.;
-//CHECK-NEXT:           _r3 += _r2 * clad::custom_derivatives::std::cos_pushforward(x, 1.).pushforward;
-//CHECK-NEXT:           *_d_x += _r3;
-//CHECK-NEXT:       }
-//CHECK-NEXT:   }
-
-// CHECK: clad::ValueAndPushforward<double, double> sq_pushforward(double x, double _d_x) {
-// CHECK-NEXT:     return {x * x, _d_x * x + x * _d_x};
-// CHECK-NEXT: }
-
-//CHECK:   void sq_pullback(double x, double _d_y, double *_d_x) {
-//CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += _d_y * x;
-//CHECK-NEXT:           *_d_x += x * _d_y;
-//CHECK-NEXT:       }
-//CHECK-NEXT:   }
 }


### PR DESCRIPTION
This patch creates a DiffRequest graph statically and we can plan accordingly the sequence of differentiation steps. The key advantage is that we can remove the recursive calls to ProcessDiffRequest. Recursive diff requests are not good because Clang is not designed to build functions while building other functions.

This patch does not solve all nested requests just yet but lays the foundation of infrastructure that will help removing the remaining parts in an upcoming pull request.

Fixes #1009.