### PR TITLE
Use move semantics to push objects on tapes

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -73,7 +73,7 @@ CUDA_HOST_DEVICE T push(tape<T>& to, ArgsT... val) {
   /// Remove the last value from the tape, return it.
   template <typename T>
   CUDA_HOST_DEVICE T pop(tape<T>& to) {
-    T val = to.back();
+    T val = std::move(to.back());
     to.pop_back();
     return val;
   }

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -251,7 +251,8 @@ namespace clad {
     clang::Expr* GlobalStoreAndRef(clang::Expr* E,
                                    llvm::StringRef prefix = "_t",
                                    bool force = false);
-    StmtDiff StoreAndRestore(clang::Expr* E, llvm::StringRef prefix = "_t");
+    StmtDiff StoreAndRestore(clang::Expr* E, llvm::StringRef prefix = "_t",
+                             bool moveToTape = false);
 
     //// A type returned by DelayedGlobalStoreAndRef
     /// .Result is a reference to the created (yet uninitialized) global
@@ -314,7 +315,8 @@ namespace clad {
     /// \returns A struct containg necessary call expressions for the built
     /// tape
     CladTapeResult MakeCladTapeFor(clang::Expr* E,
-                                   llvm::StringRef prefix = "_t");
+                                   llvm::StringRef prefix = "_t",
+                                   clang::QualType type = {});
 
     /// A function to get the multi-argument "central_difference"
     /// call expression for the given arguments.

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -317,7 +317,7 @@ double func6(double seed) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, arr) , arr = {seed, seed * i, seed + i};
+//CHECK-NEXT:         clad::push(_t1, std::move(arr)) , arr = {seed, seed * i, seed + i};
 //CHECK-NEXT:         clad::push(_t2, sum);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
@@ -377,7 +377,7 @@ double func7(double *params) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, paramsPrime) , paramsPrime = {params[0]};
+// CHECK-NEXT:         clad::push(_t1, std::move(paramsPrime)) , paramsPrime = {params[0]};
 // CHECK-NEXT:         clad::push(_t2, out);
 // CHECK-NEXT:         out = out + inv_square(paramsPrime);
 // CHECK-NEXT:     }

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -1773,7 +1773,7 @@ double fn21(double x) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, arr) , arr = {1, x, 2};
+// CHECK-NEXT:         clad::push(_t1, std::move(arr)) , arr = {1, x, 2};
 // CHECK-NEXT:         clad::push(_t2, res);
 // CHECK-NEXT:         res += arr[0] + arr[1];
 // CHECK-NEXT:     }
@@ -1825,7 +1825,7 @@ double fn22(double param) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, arr) , arr = {1.};
+// CHECK-NEXT:         clad::push(_t1, std::move(arr)) , arr = {1.};
 // CHECK-NEXT:         clad::push(_t2, out);
 // CHECK-NEXT:         clad::push(_t3, arr[0]);
 // CHECK-NEXT:         out += clad::back(_t3) * param;

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -927,7 +927,7 @@ int main() {
 // CHECK-NEXT:                  break;
 // CHECK-NEXT:          }
 // CHECK-NEXT:          _t0++;
-// CHECK-NEXT:          clad::push(_t1, ls) , ls = {u, v}, alloc;
+// CHECK-NEXT:          clad::push(_t1, std::move(ls)) , ls = {u, v}, alloc;
 // CHECK-NEXT:          _d_ls = ls;
 // CHECK-NEXT:          clad::zero_init(_d_ls);
 // CHECK-NEXT:          clad::push(_t2, ls);


### PR DESCRIPTION
This PR introduces move semantics to ``clad::pop`` and, where possible, ``clad::push``. The latter is done when local variables inside loops get promoted to the function scope, e.g.
```
while (cond) {
   some_type x = init;
   ...
}
```
In the reverse mode, it becomes
```
some_type x;
while (cond) {
   clad::push(_tape, x), x = init; // the value will be usefull in the reverse pass, we need to store it
   ...
}
```
In such cases, the PR introduces ``std::move``:
```
some_type x;
while (cond) {
   clad::push(_tape, std::move(x)), x = init; // the value is stored right before it's overwritten so we can move it
   ...
}
```
This is useful for 2 reasons:
1) Moving objects is move efficient than copying.
2) This way, we can expect the underlying data (e.g. of stl containers) to stay at the same memory location in the reverse pass.

This PR is opened to make #1247 smaller.