### PR TITLE
Correctly handle memory taken by objects in loops

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1939,7 +1939,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       if (!utils::isNonConstReferenceType(returnType) &&
           !returnType->isPointerType())
         return StmtDiff{customForwardPassCE};
-      auto* callRes = StoreAndRef(customForwardPassCE);
+      Expr* callRes = nullptr;
+      if (isInsideLoop)
+        callRes = GlobalStoreAndRef(customForwardPassCE, /*prefix=*/"_t",
+                                    /*force=*/true);
+      else
+        callRes = StoreAndRef(customForwardPassCE);
       auto* resValue =
           utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");
       auto* resAdjoint =

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -927,19 +927,20 @@ int main() {
 // CHECK-NEXT:                  break;
 // CHECK-NEXT:          }
 // CHECK-NEXT:          _t0++;
-// CHECK-NEXT:          clad::push(_t1, std::move(ls)) , ls = {u, v}, alloc;
+// CHECK-NEXT:          clad::push(_t1, std::move(_d_ls));
+// CHECK-NEXT:          clad::push(_t2, std::move(ls)) , ls = {u, v}, alloc;
 // CHECK-NEXT:          _d_ls = ls;
 // CHECK-NEXT:          clad::zero_init(_d_ls);
-// CHECK-NEXT:          clad::push(_t2, ls);
-// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t3 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}});
-// CHECK-NEXT:          clad::push(_t4, _t3.value);
-// CHECK-NEXT:          clad::push(_t5, ls);
-// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t6 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}});
-// CHECK-NEXT:          _t3.value += _t6.value;
-// CHECK-NEXT:          clad::push(_t7, u);
-// CHECK-NEXT:          clad::push(_t8, ls);
-// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t9 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}});
-// CHECK-NEXT:          u = _t9.value;
+// CHECK-NEXT:          clad::push(_t3, ls);
+// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t4 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}});
+// CHECK-NEXT:          clad::push(_t5, _t3.value);
+// CHECK-NEXT:          clad::push(_t6, ls);
+// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t7 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}});
+// CHECK-NEXT:          _t4.value += _t7.value;
+// CHECK-NEXT:          clad::push(_t8, u);
+// CHECK-NEXT:          clad::push(_t9, ls);
+// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t10 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}});
+// CHECK-NEXT:          u = _t10.value;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      *_d_u += 1;
 // CHECK-NEXT:      for (;; _t0--) {
@@ -949,30 +950,27 @@ int main() {
 // CHECK-NEXT:          }
 // CHECK-NEXT:          --i;
 // CHECK-NEXT:          {
-// CHECK-NEXT:              u = clad::pop(_t7);
+// CHECK-NEXT:              u = clad::pop(_t8);
 // CHECK-NEXT:              double _r_d1 = *_d_u;
 // CHECK-NEXT:              *_d_u = 0.;
 // CHECK-NEXT:              {{.*}}size_type _r3 = 0{{.*}};
-// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t8), 1, _r_d1, &_d_ls, &_r3);
-// CHECK-NEXT:              clad::pop(_t8);
+// CHECK-NEXT:              clad::pop(_t9);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              _t3.value = clad::pop(_t4);
-// CHECK-NEXT:              double _r_d0 = _t3.adjoint;
+// CHECK-NEXT:              _t4.value = clad::pop(_t5);
+// CHECK-NEXT:              double _r_d0 = _t4.adjoint;
 // CHECK-NEXT:              {{.*}}size_type _r2 = 0{{.*}};
-// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t5), 0, _r_d0, &_d_ls, &_r2);
-// CHECK-NEXT:              clad::pop(_t5);
+// CHECK-NEXT:              clad::pop(_t6);
 // CHECK-NEXT:              {{.*}}size_type _r1 = 0{{.*}};
-// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t2), 1, 0., &_d_ls, &_r1);
-// CHECK-NEXT:              clad::pop(_t2);
+// CHECK-NEXT:              clad::pop(_t3);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              clad::array<double> _r0 = {{2U|2UL|2ULL}};
 // CHECK-NEXT:              {{.*}}::class_functions::constructor_pullback(&ls, {u, v}, alloc, &_d_ls, &_r0, &_d_alloc);
 // CHECK-NEXT:              *_d_u += _r0[0];
 // CHECK-NEXT:              *_d_v += _r0[1];
-// CHECK-NEXT:              clad::zero_init(_d_ls);
-// CHECK-NEXT:              ls = clad::pop(_t1);
+// CHECK-NEXT:              _d_ls = clad::pop(_t1);
+// CHECK-NEXT:              ls = clad::pop(_t2);
 // CHECK-NEXT:          }
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -534,6 +534,7 @@ int main() {
 // CHECK-NEXT:        clad::tape<std::array<double, 3> > _t2 = {};
 // CHECK-NEXT:        clad::tape<double> _t3 = {};
 // CHECK-NEXT:        clad::tape<std::array<double, 3> > _t4 = {};
+// CHECK-NEXT:        clad::tape<clad::ValueAndAdjoint<double &, double &> > _t5 = {};
 // CHECK-NEXT:        std::array<double, 3> _d_a = {{.*}};
 // CHECK-NEXT:        std::array<double, 3> a;
 // CHECK-NEXT:        std::array<double, 3> _t0 = a;
@@ -552,8 +553,8 @@ int main() {
 // CHECK-NEXT:            _t1++;
 // CHECK-NEXT:            clad::push(_t3, res);
 // CHECK-NEXT:            clad::push(_t4, a);
-// CHECK-NEXT:            clad::ValueAndAdjoint<double &, double &> _t5 = {{.*}}at_reverse_forw(&a, i, &_d_a, {{0U|0UL|0}});
-// CHECK-NEXT:            res += _t5.value;
+// CHECK-NEXT:            clad::push(_t5, {{.*}}at_reverse_forw(&a, i, &_d_a, {{0U|0UL|0}}));
+// CHECK-NEXT:            res += clad::back(_t5).value;
 // CHECK-NEXT:        }
 // CHECK-NEXT:        _d_res += 1;
 // CHECK-NEXT:        for (;; _t1--) {
@@ -573,6 +574,7 @@ int main() {
 // CHECK-NEXT:                {{.*}}at_pullback(&clad::back(_t4), i, _r_d0, &_d_a, &_r0);
 // CHECK-NEXT:                _d_i += _r0;
 // CHECK-NEXT:                clad::pop(_t4);
+// CHECK-NEXT:                clad::pop(_t5);
 // CHECK-NEXT:            }
 // CHECK-NEXT:        }
 // CHECK-NEXT:        {{.*}}fill_pullback(&_t0, x, &_d_a, &*_d_x);
@@ -718,6 +720,7 @@ int main() {
 // CHECK-NEXT:          {{.*}}tape<{{.*}}vector<double> > _t3 = {};
 // CHECK-NEXT:          {{.*}}tape<double> _t4 = {};
 // CHECK-NEXT:          {{.*}}tape<{{.*}}vector<double> > _t5 = {};
+// CHECK-NEXT:          clad::tape<clad::ValueAndAdjoint<double &, double &> > _t6 = {};
 // CHECK-NEXT:          {{.*}}vector<double> v;
 // CHECK-NEXT:          {{.*}}vector<double> _d_v = {};
 // CHECK-NEXT:          clad::zero_init(_d_v);
@@ -745,8 +748,8 @@ int main() {
 // CHECK-NEXT:              _t2++;
 // CHECK-NEXT:              {{.*}}push(_t4, res);
 // CHECK-NEXT:              {{.*}}push(_t5, v);
-// CHECK-NEXT:              {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}at_reverse_forw(&v, i0, &_d_v, {{0U|0UL|0}});
-// CHECK-NEXT:              res += _t6.value;
+// CHECK-NEXT:              clad::push(_t6, {{.*}}at_reverse_forw(&v, i0, &_d_v, {{0U|0UL|0}}));
+// CHECK-NEXT:              res += clad::back(_t6).value;
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {{.*}}vector<double> _t7 = v;
 // CHECK-NEXT:          v.assign(3, 0);
@@ -793,6 +796,7 @@ int main() {
 // CHECK-NEXT:                  {{.*}}at_pullback(&{{.*}}back(_t5), i0, _r_d0, &_d_v, &_r0);
 // CHECK-NEXT:                  _d_i0 += _r0;
 // CHECK-NEXT:                  {{.*}}pop(_t5);
+// CHECK-NEXT:                  {{.*}}pop(_t6);
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
 // CHECK-NEXT:          for (;; _t0--) {
@@ -910,13 +914,17 @@ int main() {
 // CHECK-NEXT:      int _d_i = 0;
 // CHECK-NEXT:      int i = 0;
 // CHECK-NEXT:      clad::tape<std::vector<double> > _t1 = {};
+// CHECK-NEXT:      clad::tape<std::vector<double> > _t2 = {};
 // CHECK-NEXT:      std::vector<double> ls = {};
 // CHECK-NEXT:      std::vector<double> _d_ls{};
-// CHECK-NEXT:      clad::tape<std::vector<double> > _t2 = {};
-// CHECK-NEXT:      clad::tape<double> _t4 = {};
-// CHECK-NEXT:      clad::tape<std::vector<double> > _t5 = {};
-// CHECK-NEXT:      clad::tape<double> _t7 = {};
-// CHECK-NEXT:      clad::tape<std::vector<double> > _t8 = {};
+// CHECK-NEXT:      clad::tape<std::vector<double> > _t3 = {};
+// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t4 = {};
+// CHECK-NEXT:      clad::tape<double> _t5 = {};
+// CHECK-NEXT:      clad::tape<std::vector<double> > _t6 = {};
+// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t7 = {};
+// CHECK-NEXT:      clad::tape<double> _t8 = {};
+// CHECK-NEXT:      clad::tape<std::vector<double> > _t9 = {};
+// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t10 = {};
 // CHECK-NEXT:      {{.*}}allocator_type alloc;
 // CHECK-NEXT:      {{.*}}allocator_type _d_alloc = {};
 // CHECK-NEXT:      clad::zero_init(_d_alloc);
@@ -932,15 +940,15 @@ int main() {
 // CHECK-NEXT:          _d_ls = ls;
 // CHECK-NEXT:          clad::zero_init(_d_ls);
 // CHECK-NEXT:          clad::push(_t3, ls);
-// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t4 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}});
-// CHECK-NEXT:          clad::push(_t5, _t3.value);
+// CHECK-NEXT:          clad::push(_t4, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
+// CHECK-NEXT:          clad::push(_t5, clad::back(_t4).value); 
 // CHECK-NEXT:          clad::push(_t6, ls);
-// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t7 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}});
-// CHECK-NEXT:          _t4.value += _t7.value;
+// CHECK-NEXT:          clad::push(_t7, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}}));
+// CHECK-NEXT:          clad::back(_t4).value += clad::back(_t7).value;
 // CHECK-NEXT:          clad::push(_t8, u);
 // CHECK-NEXT:          clad::push(_t9, ls);
-// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t10 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}});
-// CHECK-NEXT:          u = _t10.value;
+// CHECK-NEXT:          clad::push(_t10, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
+// CHECK-NEXT:          u = clad::back(_t10).value;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      *_d_u += 1;
 // CHECK-NEXT:      for (;; _t0--) {
@@ -954,15 +962,21 @@ int main() {
 // CHECK-NEXT:              double _r_d1 = *_d_u;
 // CHECK-NEXT:              *_d_u = 0.;
 // CHECK-NEXT:              {{.*}}size_type _r3 = 0{{.*}};
+// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t9), 1, _r_d1, &_d_ls, &_r3);
 // CHECK-NEXT:              clad::pop(_t9);
+// CHECK-NEXT:              clad::pop(_t10);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              _t4.value = clad::pop(_t5);
-// CHECK-NEXT:              double _r_d0 = _t4.adjoint;
+// CHECK-NEXT:              clad::back(_t4).value = clad::pop(_t5);
+// CHECK-NEXT:              double _r_d0 = clad::back(_t4).adjoint;
 // CHECK-NEXT:              {{.*}}size_type _r2 = 0{{.*}};
+// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t6), 0, _r_d0, &_d_ls, &_r2);
 // CHECK-NEXT:              clad::pop(_t6);
+// CHECK-NEXT:              clad::pop(_t7);
 // CHECK-NEXT:              {{.*}}size_type _r1 = 0{{.*}};
+// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t3), 1, 0., &_d_ls, &_r1);
 // CHECK-NEXT:              clad::pop(_t3);
+// CHECK-NEXT:              clad::pop(_t4);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              clad::array<double> _r0 = {{2U|2UL|2ULL}};

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -208,6 +208,16 @@ double fn24(double d, double e) {
   return *up;
 }
 
+double fn25(double u, double v) {
+    std::vector<double>::allocator_type alloc;
+    double prod = 1;
+    for (int i = 3; i >= 1; --i) {
+        std::vector<double> vec(i, v + u, alloc);
+        prod *= vec[i - 1];
+    }
+    return prod;
+}
+
 int main() {
     double d_i, d_j;
     INIT_GRADIENT(fn10);
@@ -225,6 +235,7 @@ int main() {
     INIT_GRADIENT(fn22);
     INIT_GRADIENT(fn23);
     INIT_GRADIENT(fn24);
+    INIT_GRADIENT(fn25);
 
     TEST_GRADIENT(fn10, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {1.00, 1.00}
     TEST_GRADIENT(fn11, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {2.00, 1.00}
@@ -241,6 +252,7 @@ int main() {
     TEST_GRADIENT(fn22, /*numOfDerivativeArgs=*/2, 3, 4, &d_i, &d_j);  // CHECK-EXEC: {-2.00, 1.00}
     TEST_GRADIENT(fn23, /*numOfDerivativeArgs=*/2, 1, 1, &d_i, &d_j);  // CHECK-EXEC: {1.00, 3.00}
     TEST_GRADIENT(fn24, /*NumOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {1.00, 5.00}
+    TEST_GRADIENT(fn25, /*NumOfDerivativeArgs=*/2, 3, 1, &d_i, &d_j);  // CHECK-EXEC: {48.00, 48.00}
 }
 
 // CHECK: void fn10_grad(double u, double v, double *_d_u, double *_d_v) {
@@ -1007,4 +1019,64 @@ int main() {
 // CHECK-NEXT:         {{.*}}class_functions::operator_star_pullback(&up, 0., &_d_up);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_d += *_d_p;
+// CHECK-NEXT: }
+
+// CHECK-NEXT: void fn25_grad(double u, double v, double *_d_u, double *_d_v) {
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     clad::tape<std::vector<double> > _t1 = {};
+// CHECK-NEXT:     clad::tape<std::vector<double> > _t2 = {};
+// CHECK-NEXT:     std::vector<double> vec = {};
+// CHECK-NEXT:     std::vector<double> _d_vec{};
+// CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     clad::tape<std::vector<double> > _t4 = {};
+// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t5 = {};
+// CHECK-NEXT:     {{.*}}allocator_type alloc;
+// CHECK-NEXT:     {{.*}}allocator_type _d_alloc = {};
+// CHECK-NEXT:     clad::zero_init(_d_alloc);
+// CHECK-NEXT:     double _d_prod = 0.;
+// CHECK-NEXT:     double prod = 1;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
+// CHECK-NEXT:     for (i = 3; ; --i) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (!(i >= 1))
+// CHECK-NEXT:                 break;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         clad::push(_t1, std::move(_d_vec));
+// CHECK-NEXT:         clad::push(_t2, std::move(vec)) , vec = i, v + u, alloc;
+// CHECK-NEXT:         _d_vec = vec;
+// CHECK-NEXT:         clad::zero_init(_d_vec);
+// CHECK-NEXT:         clad::push(_t3, prod);
+// CHECK-NEXT:         clad::push(_t4, vec);
+// CHECK-NEXT:         clad::push(_t5, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&vec, i - 1, &_d_vec, {{0U|0UL|0}}));
+// CHECK-NEXT:         prod *= clad::back(_t5).value;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_prod += 1;
+// CHECK-NEXT:     for (;; _t0--) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (!_t0)
+// CHECK-NEXT:                 break;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         ++i;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             prod = clad::pop(_t3);
+// CHECK-NEXT:             double _r_d0 = _d_prod;
+// CHECK-NEXT:             _d_prod = 0.;
+// CHECK-NEXT:             _d_prod += _r_d0 * clad::back(_t5).value;
+// CHECK-NEXT:             {{.*}}size_type _r1 = 0{{.*}};
+// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t4), i - 1, prod * _r_d0, &_d_vec, &_r1);
+// CHECK-NEXT:             _d_i += _r1;
+// CHECK-NEXT:             clad::pop(_t4);
+// CHECK-NEXT:             clad::pop(_t5);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             {{.*}}value_type _r0 = 0.;
+// CHECK-NEXT:             clad::custom_derivatives::class_functions::constructor_pullback(&vec, i, v + u, alloc, &_d_vec, &_d_i, &_r0, &_d_alloc);
+// CHECK-NEXT:             *_d_v += _r0;
+// CHECK-NEXT:             *_d_u += _r0;
+// CHECK-NEXT:             _d_vec = clad::pop(_t1);
+// CHECK-NEXT:             vec = clad::pop(_t2);
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
 // CHECK-NEXT: }


### PR DESCRIPTION
This PR addresses 2 issues:
1) Currently, object adjoints copy the structure of the original variables (e.g. ``std::vector<...> _d_x(x);``). However, if this happens in a loop, the structure of the adjoint ``_d_x`` might change every iteration. In the reverse pass, we will be left with whatever adjoint was left after the last iteration. This could lead to errors if, for example, the corresponding array had more elements on some previous iteration.
2) When calling ``_reverse_forward`` functions, we store the result as a reference. The problem is that the result is stored as a local variable in the forward pass and cannot be used in the reverse mode. This was left unnoticed because the memory location of the local reference was not overwritten. However, when dealing with a local variable inside a loop, it's guaranteed to be overwritten on next iterations. The solution is to store the references on a tape.
This PR also introduces a test for both issues. In theory, these issues could be considered and tested separately but each one breaks other tests when being introduced on its own. This happens because those tests are currently bugged but work under specific conditions.