### PR TITLE
[ci] Remove redundant main.cpp and avoid specifying C++ standard.

### DIFF
--- a/unittests/Misc/CMakeLists.txt
+++ b/unittests/Misc/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_clad_unittest(MiscTests
-  main.cpp
   CallDeclOnly.cpp
   Defs.cpp
   DynamicGraph.cpp
@@ -9,4 +8,3 @@ add_clad_unittest(MiscTests
 ADD_CLAD_LIBRARY(Defs Defs.cpp)
 # Link the library to the test
 target_link_libraries(MiscTests PRIVATE Defs)
-set_property(TARGET MiscTests PROPERTY CXX_STANDARD 11)

--- a/unittests/Misc/main.cpp
+++ b/unittests/Misc/main.cpp
@@ -1,6 +1,0 @@
-#include <gtest/gtest.h>
-
-int main(int argc, char** argv) {
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
This should help us build with newer gtest versions which require C++ later than 11.