### PR TITLE
No need to provide the constructed object to a constructor pullback

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -1633,11 +1633,10 @@ using std::sqrt_pushforward;
 
 namespace class_functions {
 template <typename T, typename U>
-void constructor_pullback(ValueAndPushforward<T, U>* lhs,
-                          ValueAndPushforward<T, U> rhs,
-                          ValueAndPushforward<T, U>* d_lhs,
+void constructor_pullback(ValueAndPushforward<T, U> rhs,
+                          ValueAndPushforward<T, U>* d_this,
                           ValueAndPushforward<T, U>* d_rhs) {
-  d_rhs->pushforward += d_lhs->pushforward;
+  d_rhs->pushforward += d_this->pushforward;
 }
 } // namespace class_functions
 } // namespace custom_derivatives

--- a/include/clad/Differentiator/KokkosBuiltins.h
+++ b/include/clad/Differentiator/KokkosBuiltins.h
@@ -6,6 +6,8 @@
 #define CLAD_DIFFERENTIATOR_KOKKOSBUILTINS_H
 
 #include <Kokkos_Core.hpp>
+#include <cstddef>
+#include <string>
 #include <type_traits>
 #include "clad/Differentiator/Differentiator.h"
 
@@ -49,13 +51,12 @@ constructor_reverse_forw(
               "_diff_" + name, idx0, idx1, idx2, idx3, idx4, idx5, idx6, idx7)};
 }
 template <class DataType, class... ViewParams>
-void constructor_pullback(::Kokkos::View<DataType, ViewParams...>* v,
-                          const ::std::string& name, const size_t& idx0,
+void constructor_pullback(const ::std::string& name, const size_t& idx0,
                           const size_t& idx1, const size_t& idx2,
                           const size_t& idx3, const size_t& idx4,
                           const size_t& idx5, const size_t& idx6,
                           const size_t& idx7,
-                          ::Kokkos::View<DataType, ViewParams...>* d_v,
+                          ::Kokkos::View<DataType, ViewParams...>* d_this,
                           const ::std::string* /*d_name*/,
                           const size_t& /*d_idx0*/, const size_t* /*d_idx1*/,
                           const size_t* /*d_idx2*/, const size_t* /*d_idx3*/,

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -703,7 +703,7 @@ namespace clad {
     struct ConstructorPullbackCallInfo {
       clang::CallExpr* pullbackCE = nullptr;
       size_t thisAdjointArgIdx = std::numeric_limits<size_t>::max();
-      void updateThisParmArgs(clang::Expr* thisE, clang::Expr* dThisE) const;
+      void updateDThisParm(clang::Expr* dThisE) const;
       ConstructorPullbackCallInfo() = default;
       ConstructorPullbackCallInfo(clang::CallExpr* pPullbackCE,
                                   size_t pThisAdjointArgIdx)

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -454,37 +454,36 @@ void at_pullback(::std::vector<T>* vec,
 }
 
 template <typename T, typename S, typename U>
-void constructor_pullback(::std::vector<T>* v, S count, U val,
+void constructor_pullback(S count, U val,
                           typename ::std::vector<T>::allocator_type alloc,
-                          ::std::vector<T>* d_v, S* d_count, U* d_val,
+                          ::std::vector<T>* d_this, S* d_count, U* d_val,
                           typename ::std::vector<T>::allocator_type* d_alloc) {
   for (unsigned i = 0; i < count; ++i)
-    *d_val += (*d_v)[i];
-  d_v->clear();
+    *d_val += (*d_this)[i];
+  d_this->clear();
 }
 
 // A specialization for std::initializer_list (which is replaced with
 // clad::array).
 template <typename T>
 void constructor_pullback(
-    ::std::vector<T>* v, clad::array<T> init,
-    const typename ::std::vector<T>::allocator_type& alloc,
-    ::std::vector<T>* d_v, clad::array<T>* d_init,
+    clad::array<T> init, const typename ::std::vector<T>::allocator_type& alloc,
+    ::std::vector<T>* d_this, clad::array<T>* d_init,
     const typename ::std::vector<T>::allocator_type* d_alloc) {
   for (unsigned i = 0; i < init.size(); ++i) {
-    (*d_init)[i] += (*d_v)[i];
-    (*d_v)[i] = 0;
+    (*d_init)[i] += (*d_this)[i];
+    (*d_this)[i] = 0;
   }
 }
 
 // A specialization for std::initializer_list (which is replaced with
 // clad::array).
 template <typename T>
-void constructor_pullback(::std::vector<T>* v, clad::array<T> init,
-                          ::std::vector<T>* d_v, clad::array<T>* d_init) {
+void constructor_pullback(clad::array<T> init, ::std::vector<T>* d_this,
+                          clad::array<T>* d_init) {
   for (unsigned i = 0; i < init.size(); ++i) {
-    (*d_init)[i] += (*d_v)[i];
-    (*d_v)[i] = 0;
+    (*d_init)[i] += (*d_this)[i];
+    (*d_this)[i] = 0;
   }
 }
 
@@ -600,10 +599,11 @@ template <typename T, ::std::size_t N, typename U>
 void size_pullback(::std::array<T, N>* /*a*/, U /*d_y*/,
                    ::std::array<T, N>* /*d_a*/) noexcept {}
 template <typename T, ::std::size_t N>
-void constructor_pullback(::std::array<T, N>* a, const ::std::array<T, N>& arr,
-                          ::std::array<T, N>* d_a, ::std::array<T, N>* d_arr) {
+void constructor_pullback(const ::std::array<T, N>& arr,
+                          ::std::array<T, N>* d_this,
+                          ::std::array<T, N>* d_arr) {
   for (size_t i = 0; i < N; ++i)
-    (*d_arr)[i] += (*d_a)[i];
+    (*d_arr)[i] += (*d_this)[i];
 }
 
 // tuple forward mode

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -510,7 +510,7 @@ namespace class_functions {
         return {SafeTestClass(), SafeTestClass()};
     }
 
-    void constructor_pullback(SafeTestClass *c, double x, double* y, SafeTestClass *d_c, double* d_x, double* d_y) {
+    void constructor_pullback(double x, double* y, SafeTestClass *d_this, double* d_x, double* d_y) {
         *d_x += *d_y;
         *d_y = 0;
     }
@@ -537,7 +537,7 @@ double fn6(double u, double v) {
 // CHECK-NEXT:      SafeTestClass s3(_t2.value);
 // CHECK-NEXT:      SafeTestClass _d_s3 = _t2.adjoint;
 // CHECK-NEXT:      *_d_v += 1;
-// CHECK-NEXT:      {{.*}}constructor_pullback(&s2, u, &v, &_d_s2, &*_d_u, &*_d_v);
+// CHECK-NEXT:      {{.*}}constructor_pullback(u, &v, &_d_s2, &*_d_u, &*_d_v);
 // CHECK-NEXT:  }
 
 

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -1,4 +1,3 @@
-// XFAIL: asserts
 // RUN: %cladclang -std=c++14 -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oSTLCustomDerivatives.out 2>&1 | %filecheck %s
 // RUN: ./STLCustomDerivatives.out | %filecheck_exec %s
 // RUN: %cladclang -std=c++14 %s -I%S/../../include -oSTLCustomDerivativesWithTBR.out
@@ -516,7 +515,7 @@ int main() {
 // CHECK-NEXT:             {{.*}} _r2 = {{0U|0UL}};
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t4, 2, 1, &_d_vec, &_r2);
 // CHECK-NEXT:         }
-// CHECK-NEXT:         {{.*}}constructor_pullback(&vec, count, u, allocator, &_d_vec, &_d_count, &*_d_u, &_d_allocator);
+// CHECK-NEXT:         {{.*}}constructor_pullback(count, u, allocator, &_d_vec, &_d_count, &*_d_u, &_d_allocator);
 // CHECK-NEXT:        *_d_u += _d_res;
 // CHECK-NEXT:     }
 
@@ -645,7 +644,7 @@ int main() {
 // CHECK-NEXT:             {{.*}}size_type _r6 = {{0U|0UL}};
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t21, 1, 1, &_d_b, &_r6);
 // CHECK-NEXT:         }
-// CHECK-NEXT:         {{.*}}constructor_pullback(&b, _b0, &_d_b, &_d__b);
+// CHECK-NEXT:         {{.*}}constructor_pullback(_b0, &_d_b, &_d__b);
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t13.value = _t14;
 // CHECK-NEXT:             double _r_d4 = _t13.adjoint;
@@ -927,7 +926,7 @@ int main() {
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          clad::array<double> _r0 = {{2U|2UL|2ULL}};
-// CHECK-NEXT:          {{.*}}::class_functions::constructor_pullback(&ls, {{.*u, v.*}}, alloc, &_d_ls, &_r0, &_d_alloc);
+// CHECK-NEXT:          {{.*}}::class_functions::constructor_pullback({{.*u, v.*}}, alloc, &_d_ls, &_r0, &_d_alloc);
 // CHECK-NEXT:          *_d_u += _r0[0];
 // CHECK-NEXT:          *_d_v += _r0[1];
 // CHECK-NEXT:      }
@@ -1003,7 +1002,7 @@ int main() {
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              clad::array<double> _r0 = {{2U|2UL|2ULL}};
-// CHECK-NEXT:              {{.*}}::class_functions::constructor_pullback(&ls, {u, v}, alloc, &_d_ls, &_r0, &_d_alloc);
+// CHECK-NEXT:              {{.*}}::class_functions::constructor_pullback({u, v}, alloc, &_d_ls, &_r0, &_d_alloc);
 // CHECK-NEXT:              *_d_u += _r0[0];
 // CHECK-NEXT:              *_d_v += _r0[1];
 // CHECK-NEXT:              _d_ls = clad::pop(_t1);
@@ -1083,7 +1082,7 @@ int main() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}}value_type _r0 = 0.;
-// CHECK-NEXT:             clad::custom_derivatives::class_functions::constructor_pullback(&vec, i, v + u, alloc, &_d_vec, &_d_i, &_r0, &_d_alloc);
+// CHECK-NEXT:             clad::custom_derivatives::class_functions::constructor_pullback(i, v + u, alloc, &_d_vec, &_d_i, &_r0, &_d_alloc);
 // CHECK-NEXT:             *_d_v += _r0;
 // CHECK-NEXT:             *_d_u += _r0;
 // CHECK-NEXT:             _d_vec = clad::pop(_t1);
@@ -1161,7 +1160,7 @@ int main() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::array<double> _r0 = {{2U|2UL|2ULL}};
-// CHECK:                  clad::custom_derivatives::class_functions::constructor_pullback(&ls, {u, v},{{.*}} &_d_ls, &_r0{{.*}});
+// CHECK:                  clad::custom_derivatives::class_functions::constructor_pullback({u, v},{{.*}} &_d_ls, &_r0{{.*}});
 // CHECK-NEXT:             *_d_u += _r0[0];
 // CHECK-NEXT:             *_d_v += _r0[1];
 // CHECK-NEXT:             _d_ls = clad::pop(_t1);

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -597,16 +597,16 @@ public:
 namespace clad {
 namespace custom_derivatives {
 namespace class_functions {
-void constructor_pullback(SimpleFunctions1* f, double x, SimpleFunctions1* d_f, double* d_x) {
-  *d_x += d_f->x;
+void constructor_pullback(double x, SimpleFunctions1* d_this, double* d_x) {
+  *d_x += d_this->x;
 }
-void constructor_pullback(SimpleFunctions1* f, double x, double y, SimpleFunctions1* d_f, double* d_x, double* d_y) {
-  *d_x += d_f->x;
-  *d_y += d_f->y;
+void constructor_pullback(double x, double y, SimpleFunctions1* d_this, double* d_x, double* d_y) {
+  *d_x += d_this->x;
+  *d_y += d_this->y;
 }
-void constructor_pullback(SimpleFunctions1* f, const SimpleFunctions1& other, SimpleFunctions1* d_f, SimpleFunctions1* d_other) {
-  d_other->x += d_f->x;
-  d_other->y += d_f->y;
+void constructor_pullback(const SimpleFunctions1& other, SimpleFunctions1* d_this, SimpleFunctions1* d_other) {
+  d_other->x += d_this->x;
+  d_other->y += d_this->y;
 }
 }}}
 
@@ -645,12 +645,12 @@ double fn16(double i, double j) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        double _r2 = 0.;
 // CHECK-NEXT:        double _r3 = 0.;
-// CHECK-NEXT:        clad::custom_derivatives::class_functions::constructor_pullback(&obj2, 3, 5, &_d_obj2, &_r2, &_r3);
+// CHECK-NEXT:        clad::custom_derivatives::class_functions::constructor_pullback(3, 5, &_d_obj2, &_r2, &_r3);
 // CHECK-NEXT:    }
 // CHECK-NEXT:    {
 // CHECK-NEXT:        double _r0 = 0.;
 // CHECK-NEXT:        double _r1 = 0.;
-// CHECK-NEXT:        clad::custom_derivatives::class_functions::constructor_pullback(&obj1, 2, 3, &_d_obj1, &_r0, &_r1);
+// CHECK-NEXT:        clad::custom_derivatives::class_functions::constructor_pullback(2, 3, &_d_obj1, &_r0, &_r1);
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 
@@ -676,7 +676,7 @@ double fn17(double i, double j) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        double _r0 = 0.;
 // CHECK-NEXT:        double _r1 = 0.;
-// CHECK-NEXT:        clad::custom_derivatives::class_functions::constructor_pullback(&sf, 3, 5, &_d_sf, &_r0, &_r1);
+// CHECK-NEXT:        clad::custom_derivatives::class_functions::constructor_pullback(3, 5, &_d_sf, &_r0, &_r1);
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 
@@ -700,7 +700,7 @@ double fn18(double i, double j) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
 // CHECK-NEXT:          double _r1 = 0.;
-// CHECK-NEXT:          clad::custom_derivatives::class_functions::constructor_pullback(&sf, 3 * i, 5 * j, &_d_sf, &_r0, &_r1);
+// CHECK-NEXT:          clad::custom_derivatives::class_functions::constructor_pullback(3 * i, 5 * j, &_d_sf, &_r0, &_r1);
 // CHECK-NEXT:          *_d_i += 3 * _r0;
 // CHECK-NEXT:          *_d_j += 5 * _r1;
 // CHECK-NEXT:      }
@@ -732,11 +732,11 @@ double fn19(double i, double j) {
 // CHECK-NEXT:          *_d_j += _r3;
 // CHECK-NEXT:          _t0.operator_star_pullback(sf2, _r4, &_d_sf1, &_d_sf2);
 // CHECK-NEXT:      }
-// CHECK-NEXT:      clad::custom_derivatives::class_functions::constructor_pullback(&sf2, i, j, &_d_sf2, &*_d_i, &*_d_j);
+// CHECK-NEXT:      clad::custom_derivatives::class_functions::constructor_pullback(i, j, &_d_sf2, &*_d_i, &*_d_j);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
 // CHECK-NEXT:          double _r1 = 0.;
-// CHECK-NEXT:          clad::custom_derivatives::class_functions::constructor_pullback(&sf1, 3, 5, &_d_sf1, &_r0, &_r1);
+// CHECK-NEXT:          clad::custom_derivatives::class_functions::constructor_pullback(3, 5, &_d_sf1, &_r0, &_r1);
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
@@ -771,7 +771,7 @@ double fn21(double i, double j) {
 // CHECK-NEXT:          double _r0 = 0.;
 // CHECK-NEXT:          SimpleFunctions1 _r1 = {};
 // CHECK-NEXT:          operator_plus_pullback(2, SimpleFunctions1(i), 1, &_r0, &_r1);
-// CHECK-NEXT:          clad::custom_derivatives::class_functions::constructor_pullback(nullptr, i, &_r1, &*_d_i);
+// CHECK-NEXT:          clad::custom_derivatives::class_functions::constructor_pullback(i, &_r1, &*_d_i);
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
@@ -990,11 +990,11 @@ int main() {
 // CHECK-NEXT:    SimpleFunctions1 res(this->x + other.x, this->y + other.y);
 // CHECK-NEXT:    SimpleFunctions1 _d_res(res);
 // CHECK-NEXT:    clad::zero_init(_d_res);
-// CHECK-NEXT:    clad::custom_derivatives::class_functions::constructor_pullback(nullptr, res, &_d_y, &_d_res); 
+// CHECK-NEXT:    clad::custom_derivatives::class_functions::constructor_pullback(res, &_d_y, &_d_res); 
 // CHECK-NEXT:    {
 // CHECK-NEXT:        double _r0 = 0.;
 // CHECK-NEXT:        double _r1 = 0.;
-// CHECK-NEXT:        clad::custom_derivatives::class_functions::constructor_pullback(&res, this->x + other.x, this->y + other.y, &_d_res, &_r0, &_r1);
+// CHECK-NEXT:        clad::custom_derivatives::class_functions::constructor_pullback(this->x + other.x, this->y + other.y, &_d_res, &_r0, &_r1);
 // CHECK-NEXT:        (*_d_this).x += _r0;
 // CHECK-NEXT:        (*_d_other).x += _r0;
 // CHECK-NEXT:        (*_d_this).y += _r1;
@@ -1027,7 +1027,7 @@ int main() {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        double _r0 = 0.;
 // CHECK-NEXT:        double _r1 = 0.;
-// CHECK-NEXT:        clad::custom_derivatives::class_functions::constructor_pullback(nullptr, this->x * rhs.x, this->y * rhs.y, &_d_y, &_r0, &_r1);
+// CHECK-NEXT:        clad::custom_derivatives::class_functions::constructor_pullback(this->x * rhs.x, this->y * rhs.y, &_d_y, &_r0, &_r1);
 // CHECK-NEXT:        (*_d_this).x += _r0 * rhs.x;
 // CHECK-NEXT:        (*_d_rhs).x += this->x * _r0;
 // CHECK-NEXT:        (*_d_this).y += _r1 * rhs.y;

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -196,7 +196,7 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r3 = {0.F, 0.F};
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(&_t10, {{.*}}cos_pushforward(x, _d_x0), &_d__t1, &_r3);
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback({{.*}}cos_pushforward(x, _d_x0), &_d__t1, &_r3);
 // CHECK-NEXT:         float _r4 = 0.F;
 // CHECK-NEXT:         float _r5 = 0.F;
 // CHECK-NEXT:         cos_pushforward_pullback(x, _d_x0, _r3, &_r4, &_r5);
@@ -205,7 +205,7 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r0 = {0.F, 0.F};
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(&_t00, {{.*}}sin_pushforward(x, _d_x0), &_d__t0, &_r0);
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback({{.*}}sin_pushforward(x, _d_x0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         sin_pushforward_pullback(x, _d_x0, _r0, &_r1, &_r2);
@@ -230,7 +230,7 @@ int main() {
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r0 = {0.F, 0.F};
-// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}exp_pushforward(x, _d_x0), &_d__t0, &_r0);
+// CHECK-NEXT:         {{.*}}constructor_pullback({{.*}}exp_pushforward(x, _d_x0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         exp_pushforward_pullback(x, _d_x0, _r0, &_r1, &_r2);
@@ -255,7 +255,7 @@ int main() {
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}}ValueAndPushforward<float, float> _r0 = {0.F, 0.F};
-// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}log_pushforward(x, _d_x0), &_d__t0, &_r0);
+// CHECK-NEXT:         {{.*}}constructor_pullback({{.*}}log_pushforward(x, _d_x0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         log_pushforward_pullback(x, _d_x0, _r0, &_r1, &_r2);
@@ -280,7 +280,7 @@ int main() {
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = {0.F, 0.F};
-// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}pow_pushforward(x, 4.F, _d_x0, 0.F), &_d__t0, &_r0);
+// CHECK-NEXT:         {{.*}}constructor_pullback({{.*}}pow_pushforward(x, 4.F, _d_x0, 0.F), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
@@ -305,7 +305,7 @@ int main() {
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = {0.F, 0.F};
-// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}pow_pushforward(2.F, x, 0.F, _d_x0), &_d__t0, &_r0);
+// CHECK-NEXT:         {{.*}}constructor_pullback({{.*}}pow_pushforward(2.F, x, 0.F, _d_x0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
@@ -333,7 +333,7 @@ int main() {
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = {0.F, 0.F};
-// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}pow_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
+// CHECK-NEXT:         {{.*}}constructor_pullback({{.*}}pow_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
@@ -363,7 +363,7 @@ int main() {
 // CHECK-NEXT:     _d__t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = {0.F, 0.F};
-// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, {{.*}}pow_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
+// CHECK-NEXT:         {{.*}}constructor_pullback({{.*}}pow_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -54,7 +54,7 @@ double f2(double x, double y){
 // CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}}ValueAndPushforward<double, double> _r0 = {0., 0.};
-// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, f_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
+// CHECK-NEXT:         {{.*}}constructor_pullback(f_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
 // CHECK-NEXT:         double _r1 = 0.;
 // CHECK-NEXT:         double _r2 = 0.;
 // CHECK-NEXT:         double _r3 = 0.;
@@ -92,7 +92,7 @@ double f2(double x, double y){
 // CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}}ValueAndPushforward<double, double> _r0 = {0., 0.};
-// CHECK-NEXT:         {{.*}}constructor_pullback(&_t00, f_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
+// CHECK-NEXT:         {{.*}}constructor_pullback(f_pushforward(x, y, _d_x0, _d_y0), &_d__t0, &_r0);
 // CHECK-NEXT:         double _r1 = 0.;
 // CHECK-NEXT:         double _r2 = 0.;
 // CHECK-NEXT:         double _r3 = 0.;


### PR DESCRIPTION
Constructor pullbacks do not require the original constructed object, only its derivative ``_d_this``. This is similar to how regular function pullbacks do not require the original return value, only the pullback ``_d_y`` argument. Currently, the first argument of constructor pullbacks is never used and, in some cases, is even set to ``nullptr``.