### PR TITLE
Improve differentiation of object-type decls in the reverse mode

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -700,34 +700,15 @@ namespace clad {
 
     void PopSwitchStmtInfo() { m_SwitchStmtsData.pop_back(); }
 
-    struct ConstructorPullbackCallInfo {
-      clang::CallExpr* pullbackCE = nullptr;
-      size_t thisAdjointArgIdx = std::numeric_limits<size_t>::max();
-      void updateDThisParm(clang::Expr* dThisE) const;
-      ConstructorPullbackCallInfo() = default;
-      ConstructorPullbackCallInfo(clang::CallExpr* pPullbackCE,
-                                  size_t pThisAdjointArgIdx)
-          : pullbackCE(pPullbackCE), thisAdjointArgIdx(pThisAdjointArgIdx) {}
-
-      bool empty() const { return !pullbackCE; }
-    };
-
-    void setConstructorPullbackCallInfo(clang::CallExpr* pullbackCE,
-                                        size_t thisAdjointArgIdx) {
-      m_ConstructorPullbackCallInfo = {pullbackCE, thisAdjointArgIdx};
-    }
-
-    ConstructorPullbackCallInfo getConstructorPullbackCallInfo() {
-      return m_ConstructorPullbackCallInfo;
-    }
-
-    void resetConstructorPullbackCallInfo() {
-      m_ConstructorPullbackCallInfo = ConstructorPullbackCallInfo{};
-    }
-
   private:
-    ConstructorPullbackCallInfo m_ConstructorPullbackCallInfo;
-    bool m_TrackConstructorPullbackInfo = false;
+    // FIXME: This variable is used to track
+    // whether we're currently visiting an init of a var decl.
+    // This is only necessary because we don't create constructors
+    // explicitly, instead we create a ParenListExpr and expect clang to
+    // build the constructor. However, this only works as var decl inits. In
+    // other cases, we have to use InitListExpr and change the constructor
+    // style. Remove this once we generate constructors explicitly.
+    bool m_TrackVarDeclConstructor = false;
   };
 } // end namespace clad
 

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -180,9 +180,7 @@ int main() {
     // CHECK-NEXT: }
 
     // CHECK: void fn_non_diff_var_grad(double i, double j, double *_d_i, double *_d_j) {
-    // CHECK-NEXT:     double _d_k = 0.;
     // CHECK-NEXT:     double k = i * i * j;
-    // CHECK-NEXT:     _d_k += 1;
     // CHECK-NEXT: }
     
     // CHECK: void mem_fn_1_pullback(double i, double j, double _d_y, SimpleFunctions1 *_d_this, double *_d_i, double *_d_j) {

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -777,6 +777,22 @@ double fn22(double x, double y) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
+struct StructNoDefConstr {
+  StructNoDefConstr(int){}
+};
+
+double fn23(double x){
+  StructNoDefConstr t{0};
+  return x;
+}
+
+// CHECK:  void fn23_grad(double x, double *_d_x) {
+// CHECK-NEXT:      StructNoDefConstr t(0);
+// CHECK-NEXT:      StructNoDefConstr _d_t(t);
+// CHECK-NEXT:      clad::zero_init(_d_t);
+// CHECK-NEXT:      *_d_x += 1;
+// CHECK-NEXT:  }
+
 void print(const Tangent& t) {
   for (int i = 0; i < 5; ++i) {
     printf("%.2f", t.data[i]);
@@ -873,6 +889,8 @@ int main() {
 
     INIT_GRADIENT(fn22);
     TEST_GRADIENT(fn22, /*numOfDerivativeArgs=*/2, 3, 2, &d_i, &d_j);    // CHECK-EXEC: {8.00, 0.00}
+
+    INIT_GRADIENT(fn23);
 }
 
 // CHECK: void someMemFn2_pullback(double i, double j, double _d_y, Tangent *_d_this, double *_d_i, double *_d_j) const {


### PR DESCRIPTION
This PR addresses two issues:
1) Constructor inits in ``RMV::DifferentiateVarDecl`` are differentiated at a point when ``_d_this`` argument is unknown. It is initialized with ``nullptr`` and is updated once the derivative is known. This goes against the regular logic of the reverse mode in Clad since the derivative is usually known before the visitation of the corresponding expr starts. Because of this,  ``ConstructorPullbackCallInfo`` was introduced to keep track of updating the derivative object. In this PR, the code in ``RMV::DifferentiateVarDecl`` is refactored so that the derivative is known before the differentiation of the constructor starts.
2) In ``RMV::DifferentiateVarDecl``, when an object adjoint is initialized with the original object (i.e. ``_d_x(x);``) to preserve the structure, the adjoint is first temporarily initialized with the default constructor. If the default constructor is deleted, an error is produced. Instead of the default constructor, we can use a placeholder ``*nullptr``. Fixes #800.