### PR TITLE
Specialize zero_init for std::pair.

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <iterator>
 #include <type_traits>
+#include <utility>
 
 namespace clad {
 
@@ -126,6 +127,12 @@ CUDA_HOST_DEVICE T push(tape<T>& to, ArgsT... val) {
   void zero_impl(T& t) {
     for (auto& x : t)
       zero_init(x);
+  }
+
+  // std::pair<T1, T2> is almost trivially copyable. Specialize it.
+  template <class T1, class T2> void zero_init(std::pair<T1, T2>& p) {
+    zero_init(p.first);
+    zero_init(p.second);
   }
 
   template <class T> void zero_init(T& t) { zero_impl(t); }


### PR DESCRIPTION
The type std::pair is special as it is almost trivially copiable. Specialize it to avoid warnings with clang 20.