### PR TITLE
Fix crashing for differentiating static member functions

### DIFF
--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -240,8 +240,9 @@ namespace clad {
     // lvalue. However, due to an inconsistency of the expression classfication
     // in clang we need to change it to an r-value to avoid an assertion when
     // building a unary op. See llvm/llvm-project#53958.
-    if (isa<CXXMethodDecl>(DRE->getDecl()))
-      DRE->setValueKind(CLAD_COMPAT_ExprValueKind_R_or_PR_Value);
+    if (const auto* MD = dyn_cast<CXXMethodDecl>(DRE->getDecl()))
+      if (MD->isInstance())
+        DRE->setValueKind(CLAD_COMPAT_ExprValueKind_R_or_PR_Value);
 
     if (derivedFnArgIdx != -1) {
       // Add the "&" operator

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -717,8 +717,9 @@ namespace clad {
                                        llvm::MutableArrayRef<Expr*> argExprs,
                                        bool useRefQualifiedThisObj /*=false*/) {
     Expr* call = nullptr;
-    if (auto derMethod = dyn_cast<CXXMethodDecl>(FD)) {
-      call = BuildCallExprToMemFn(derMethod, argExprs, useRefQualifiedThisObj);
+    if (auto* MD = dyn_cast<CXXMethodDecl>(FD)) {
+      if (MD->isInstance())
+        call = BuildCallExprToMemFn(MD, argExprs, useRefQualifiedThisObj);
     } else {
       Expr* exprFunc = BuildDeclRef(FD);
       call = m_Sema


### PR DESCRIPTION
Trying to differentiate static member function failed with an out of bounds error, which this PR fixes.

Fixes #1270 
