### PR TITLE
Do not dereference _d_this by default

### DIFF
--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -144,9 +144,7 @@ ReverseModeForwPassVisitor::BuildParams(DiffParams& diffParams) {
         m_Sema.PushOnScopeChains(thisDerivativePVD, getCurrentScope(),
                                  /*AddToContext=*/false);
 
-      Expr* deref =
-          BuildOp(UnaryOperatorKind::UO_Deref, BuildDeclRef(thisDerivativePVD));
-      m_ThisExprDerivative = utils::BuildParenExpr(m_Sema, deref);
+      m_ThisExprDerivative = BuildDeclRef(thisDerivativePVD);
       ++dParamTypesIdx;
     }
   }
@@ -246,7 +244,8 @@ ReverseModeForwPassVisitor::VisitUnaryOperator(const UnaryOperator* UnOp) {
       if (MD->isInstance()) {
         diff = Visit(UnOp->getSubExpr());
         Expr* cloneE = BuildOp(UnaryOperatorKind::UO_Deref, diff.getExpr());
-        Expr* derivedE = diff.getExpr_dx();
+        Expr* derivedE =
+            BuildOp(UnaryOperatorKind::UO_Deref, diff.getExpr_dx());
         return {cloneE, derivedE};
       }
     }

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -15,7 +15,7 @@ struct Experiment {
 
   // CHECK: void operator_call_grad(double i, double j, Experiment *_d_this, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
+  // CHECK-NEXT:         _d_this->x += 1 * j * i;
   // CHECK-NEXT:         *_d_i += this->x * 1 * j;
   // CHECK-NEXT:         *_d_j += this->x * i * 1;
   // CHECK-NEXT:     }
@@ -31,7 +31,7 @@ struct ExperimentConst {
   ExperimentConst& operator=(const ExperimentConst& E) = default;
   // CHECK: void operator_call_grad(double i, double j, ExperimentConst *_d_this, double *_d_i, double *_d_j) const {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
+  // CHECK-NEXT:         _d_this->x += 1 * j * i;
   // CHECK-NEXT:         *_d_i += this->x * 1 * j;
   // CHECK-NEXT:         *_d_j += this->x * i * 1;
   // CHECK-NEXT:     }
@@ -54,7 +54,7 @@ struct ExperimentVolatile {
   // CHECK: void operator_call_grad(double i, double j, volatile ExperimentVolatile *_d_this, double *_d_i, double *_d_j) volatile {
   // CHECK-NEXT:     double _t0 = this->x * i;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
+  // CHECK-NEXT:         _d_this->x += 1 * j * i;
   // CHECK-NEXT:         *_d_i += this->x * 1 * j;
   // CHECK-NEXT:         *_d_j += _t0 * 1;
   // CHECK-NEXT:     }
@@ -77,7 +77,7 @@ struct ExperimentConstVolatile {
   // CHECK: void operator_call_grad(double i, double j, volatile ExperimentConstVolatile *_d_this, double *_d_i, double *_d_j) const volatile {
   // CHECK-NEXT:     double _t0 = this->x * i;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
+  // CHECK-NEXT:         _d_this->x += 1 * j * i;
   // CHECK-NEXT:         *_d_i += this->x * 1 * j;
   // CHECK-NEXT:         *_d_j += _t0 * 1;
   // CHECK-NEXT:     }
@@ -96,7 +96,7 @@ struct ExperimentNNS {
 
   // CHECK: void operator_call_grad(double i, double j, outer::inner::ExperimentNNS *_d_this, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * j * i;
+  // CHECK-NEXT:         _d_this->x += 1 * j * i;
   // CHECK-NEXT:         *_d_i += this->x * 1 * j;
   // CHECK-NEXT:         *_d_j += this->x * i * 1;
   // CHECK-NEXT:     }
@@ -296,11 +296,11 @@ int main() {
 
 // CHECK: static inline constexpr void constructor_pullback(const Experiment &arg, Experiment *_d_this, Experiment *_d_arg) noexcept {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_arg).y += (*_d_this).y;
-// CHECK-NEXT:         (*_d_this).y = 0.;
+// CHECK-NEXT:         (*_d_arg).y += _d_this->y;
+// CHECK-NEXT:         _d_this->y = 0.;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_arg).x += (*_d_this).x;
-// CHECK-NEXT:         (*_d_this).x = 0.;
+// CHECK-NEXT:         (*_d_arg).x += _d_this->x;
+// CHECK-NEXT:         _d_this->x = 0.;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -355,9 +355,9 @@ struct S {
 
   //CHECK:   void S::f_grad(double x, double y, S *_d_this, double *_d_x, double *_d_y) {
   //CHECK-NEXT:       {
-  //CHECK-NEXT:           (*_d_this).c1 += 1 * x;
+  //CHECK-NEXT:           _d_this->c1 += 1 * x;
   //CHECK-NEXT:           *_d_x += this->c1 * 1;
-  //CHECK-NEXT:           (*_d_this).c2 += 1 * y;
+  //CHECK-NEXT:           _d_this->c2 += 1 * y;
   //CHECK-NEXT:           *_d_y += this->c2 * 1;
   //CHECK-NEXT:       }
   //CHECK-NEXT:   }

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -23,8 +23,8 @@ public:
 
   // CHECK: void SimpleFunctions::mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -35,8 +35,8 @@ public:
 
   // CHECK: void SimpleFunctions::const_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -50,8 +50,8 @@ public:
   // CHECK: void SimpleFunctions::volatile_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += _t0 * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -65,8 +65,8 @@ public:
   // CHECK: void SimpleFunctions::const_volatile_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += _t0 * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -77,8 +77,8 @@ public:
 
   // CHECK: void SimpleFunctions::lval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) & {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -91,8 +91,8 @@ public:
 
   // CHECK: void SimpleFunctions::const_lval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const & {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -106,8 +106,8 @@ public:
   // CHECK: void SimpleFunctions::volatile_lval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += _t0 * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -121,8 +121,8 @@ public:
   // CHECK: void SimpleFunctions::const_volatile_lval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += _t0 * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -133,8 +133,8 @@ public:
 
   // CHECK: void SimpleFunctions::rval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) && {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -147,8 +147,8 @@ public:
 
   // CHECK: void SimpleFunctions::const_rval_ref_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const && {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -162,8 +162,8 @@ public:
   // CHECK: void SimpleFunctions::volatile_rval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += _t0 * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -177,8 +177,8 @@ public:
   // CHECK: void SimpleFunctions::const_volatile_rval_ref_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += _t0 * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -191,8 +191,8 @@ public:
 
   // CHECK: void SimpleFunctions::noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) noexcept {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -205,8 +205,8 @@ public:
 
   // CHECK: void SimpleFunctions::const_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const noexcept {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -220,8 +220,8 @@ public:
   // CHECK: void SimpleFunctions::volatile_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile noexcept {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += _t0 * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -235,8 +235,8 @@ public:
   // CHECK: void SimpleFunctions::const_volatile_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile noexcept {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += _t0 * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -249,8 +249,8 @@ public:
 
   // CHECK: void SimpleFunctions::lval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) & noexcept {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -263,8 +263,8 @@ public:
 
   // CHECK: void SimpleFunctions::const_lval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const & noexcept {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -278,8 +278,8 @@ public:
   // CHECK: void SimpleFunctions::volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile & noexcept {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += _t0 * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -293,8 +293,8 @@ public:
   // CHECK: void SimpleFunctions::const_volatile_lval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile & noexcept {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += _t0 * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -307,8 +307,8 @@ public:
 
   // CHECK: void SimpleFunctions::rval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) && noexcept {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -321,8 +321,8 @@ public:
 
   // CHECK: void SimpleFunctions::const_rval_ref_noexcept_mem_fn_grad(double i, double j, SimpleFunctions *_d_this, double *_d_i, double *_d_j) const && noexcept {
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -336,8 +336,8 @@ public:
   // CHECK: void SimpleFunctions::volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) volatile && noexcept {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += _t0 * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -351,8 +351,8 @@ public:
   // CHECK: void SimpleFunctions::const_volatile_rval_ref_noexcept_mem_fn_grad(double i, double j, volatile SimpleFunctions *_d_this, double *_d_i, double *_d_j) const volatile && noexcept {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += _t0 * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         *_d_j += i * 1;
@@ -364,8 +364,8 @@ public:
   // CHECK: void partial_mem_fn_grad_0(double i, double j, SimpleFunctions *_d_this, double *_d_i) {
   // CHECK-NEXT:     double _d_j = 0.;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         (*_d_this).x += 1 * i;
-  // CHECK-NEXT:         (*_d_this).y += 1 * i;
+  // CHECK-NEXT:         _d_this->x += 1 * i;
+  // CHECK-NEXT:         _d_this->y += 1 * i;
   // CHECK-NEXT:         *_d_i += (this->x + this->y) * 1;
   // CHECK-NEXT:         *_d_i += 1 * j;
   // CHECK-NEXT:         _d_j += i * 1;
@@ -604,8 +604,8 @@ int main() {
   // CHECK-NEXT:       double _d_j = 0.;
   // CHECK-NEXT:       double _t0 = (this->x + this->y);
   // CHECK-NEXT:       {
-  // CHECK-NEXT:           (*_d_this).x += 1 * i;
-  // CHECK-NEXT:           (*_d_this).y += 1 * i;
+  // CHECK-NEXT:           _d_this->x += 1 * i;
+  // CHECK-NEXT:           _d_this->y += 1 * i;
   // CHECK-NEXT:           *_d_i += _t0 * 1;
   // CHECK-NEXT:           *_d_i += 1 * j;
   // CHECK-NEXT:           _d_j += i * 1;
@@ -618,8 +618,8 @@ int main() {
   // CHECK-NEXT:       double _d_i = 0.;
   // CHECK-NEXT:       double _t0 = (this->x + this->y);
   // CHECK-NEXT:       {
-  // CHECK-NEXT:           (*_d_this).x += 1 * i;
-  // CHECK-NEXT:           (*_d_this).y += 1 * i;
+  // CHECK-NEXT:           _d_this->x += 1 * i;
+  // CHECK-NEXT:           _d_this->y += 1 * i;
   // CHECK-NEXT:           _d_i += _t0 * 1;
   // CHECK-NEXT:           _d_i += 1 * j;
   // CHECK-NEXT:           *_d_j += i * 1;
@@ -654,17 +654,17 @@ int main() {
 // CHECK-NEXT:     this->x = +i;
 // CHECK-NEXT:     double _t1 = this->x;
 // CHECK-NEXT:     this->x = -i;
-// CHECK-NEXT:     (*_d_this).x += _d_y;
+// CHECK-NEXT:     _d_this->x += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t1;
-// CHECK-NEXT:         double _r_d1 = (*_d_this).x;
-// CHECK-NEXT:         (*_d_this).x = 0.;
+// CHECK-NEXT:         double _r_d1 = _d_this->x;
+// CHECK-NEXT:         _d_this->x = 0.;
 // CHECK-NEXT:         *_d_i += -_r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t0;
-// CHECK-NEXT:         double _r_d0 = (*_d_this).x;
-// CHECK-NEXT:         (*_d_this).x = 0.;
+// CHECK-NEXT:         double _r_d0 = _d_this->x;
+// CHECK-NEXT:         _d_this->x = 0.;
 // CHECK-NEXT:         *_d_i += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -674,7 +674,7 @@ int main() {
 // CHECK-NEXT:     this->x = +i;
 // CHECK-NEXT:     double _t1 = this->x;
 // CHECK-NEXT:     this->x = -i;
-// CHECK-NEXT:     return {this->x, (*_d_this).x};
+// CHECK-NEXT:     return {this->x, _d_this->x};
 // CHECK-NEXT: }
 
 // CHECK: void operator_plus_equal_pullback(double value, SimpleFunctions _d_y, SimpleFunctions *_d_this, double *_d_value) {
@@ -682,7 +682,7 @@ int main() {
 // CHECK-NEXT:     this->x += value;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t0;
-// CHECK-NEXT:         double _r_d0 = (*_d_this).x;
+// CHECK-NEXT:         double _r_d0 = _d_this->x;
 // CHECK-NEXT:         *_d_value += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -690,7 +690,7 @@ int main() {
 // CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_equal_forw(double value, SimpleFunctions *_d_this, double _d_value) {
 // CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x += value;
-// CHECK-NEXT:     return {*this, (*_d_this)};
+// CHECK-NEXT:     return {*this, *_d_this};
 // CHECK-NEXT: }
 
 // CHECK: void operator_plus_plus_pullback(SimpleFunctions _d_y, SimpleFunctions *_d_this) {
@@ -698,14 +698,14 @@ int main() {
 // CHECK-NEXT:     this->x += 1.;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t0;
-// CHECK-NEXT:         double _r_d0 = (*_d_this).x;
+// CHECK-NEXT:         double _r_d0 = _d_this->x;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_plus_forw(SimpleFunctions *_d_this) {
 // CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x += 1.;
-// CHECK-NEXT:     return {*this, (*_d_this)};
+// CHECK-NEXT:     return {*this, *_d_this};
 // CHECK-NEXT: }
 
 // CHECK: static void constructor_pullback(double &x, SafeTestClass *_d_this, double *_d_x) {
@@ -713,12 +713,12 @@ int main() {
 
 // CHECK: static void constructor_pullback(double p_x, double p_y, SimpleFunctions *_d_this, double *_d_p_x, double *_d_p_y) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_p_y += (*_d_this).y;
-// CHECK-NEXT:         (*_d_this).y = 0.;
+// CHECK-NEXT:         *_d_p_y += _d_this->y;
+// CHECK-NEXT:         _d_this->y = 0.;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_p_x += (*_d_this).x;
-// CHECK-NEXT:         (*_d_this).x = 0.;
+// CHECK-NEXT:         *_d_p_x += _d_this->x;
+// CHECK-NEXT:         _d_this->x = 0.;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 }

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -185,7 +185,7 @@ int main() {
     
     // CHECK: void mem_fn_1_pullback(double i, double j, double _d_y, SimpleFunctions1 *_d_this, double *_d_i, double *_d_j) {
     // CHECK-NEXT:     {
-    // CHECK-NEXT:         (*_d_this).x += _d_y * i;
+    // CHECK-NEXT:         _d_this->x += _d_y * i;
     // CHECK-NEXT:         *_d_i += (this->x + this->y) * _d_y;
     // CHECK-NEXT:         *_d_i += _d_y * j * j;
     // CHECK-NEXT:         *_d_j += i * _d_y * j;

--- a/test/Gradient/TemplateFunctors.C
+++ b/test/Gradient/TemplateFunctors.C
@@ -15,10 +15,10 @@ template <typename T> struct Experiment {
 
 // CHECK: void operator_call_grad(double i, double j, Experiment<double> *_d_this, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_this).x += 1 * i * i;
+// CHECK-NEXT:         _d_this->x += 1 * i * i;
 // CHECK-NEXT:         *_d_i += this->x * 1 * i;
 // CHECK-NEXT:         *_d_i += this->x * i * 1;
-// CHECK-NEXT:         (*_d_this).y += 1 * j;
+// CHECK-NEXT:         _d_this->y += 1 * j;
 // CHECK-NEXT:         *_d_j += this->y * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -35,11 +35,11 @@ template <> struct Experiment<long double> {
 
 // CHECK: void operator_call_grad(long double i, long double j, Experiment<long double>  *_d_this, long double  *_d_i, long double  *_d_j) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_this).x += 1 * j * i * i;
+// CHECK-NEXT:         _d_this->x += 1 * j * i * i;
 // CHECK-NEXT:         *_d_i += this->x * 1 * j * i;
 // CHECK-NEXT:         *_d_i += this->x * i * 1 * j;
 // CHECK-NEXT:         *_d_j += this->x * i * i * 1;
-// CHECK-NEXT:         (*_d_this).y += 1 * i * j;
+// CHECK-NEXT:         _d_this->y += 1 * i * j;
 // CHECK-NEXT:         *_d_j += this->y * 1 * i;
 // CHECK-NEXT:         *_d_i += this->y * j * 1;
 // CHECK-NEXT:     }
@@ -56,10 +56,10 @@ template <typename T> struct ExperimentConstVolatile {
 // CHECK: void operator_call_grad(double i, double j, volatile ExperimentConstVolatile<double> *_d_this, double *_d_i, double *_d_j) const volatile {
 // CHECK-NEXT:     double _t0 = this->x * i;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_this).x += 1 * i * i;
+// CHECK-NEXT:         _d_this->x += 1 * i * i;
 // CHECK-NEXT:         *_d_i += this->x * 1 * i;
 // CHECK-NEXT:         *_d_i += _t0 * 1;
-// CHECK-NEXT:         (*_d_this).y += 1 * j;
+// CHECK-NEXT:         _d_this->y += 1 * j;
 // CHECK-NEXT:         *_d_j += this->y * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -78,11 +78,11 @@ template <> struct ExperimentConstVolatile<long double> {
 // CHECK-NEXT:     double _t0 = this->x * i;
 // CHECK-NEXT:     double _t1 = this->y * j;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_this).x += 1 * j * i * i;
+// CHECK-NEXT:         _d_this->x += 1 * j * i * i;
 // CHECK-NEXT:         *_d_i += this->x * 1 * j * i;
 // CHECK-NEXT:         *_d_i += _t0 * 1 * j;
 // CHECK-NEXT:         *_d_j += _t0 * i * 1;
-// CHECK-NEXT:         (*_d_this).y += 1 * i * j;
+// CHECK-NEXT:         _d_this->y += 1 * i * j;
 // CHECK-NEXT:         *_d_j += this->y * 1 * i;
 // CHECK-NEXT:         *_d_i += _t1 * 1;
 // CHECK-NEXT:     }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -205,13 +205,13 @@ double fn4(double i, double j) {
 
 // CHECK: void someMemFn_grad(double i, double j, Tangent *_d_this, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_this).data[0] += 1 * i;
+// CHECK-NEXT:         _d_this->data[0] += 1 * i;
 // CHECK-NEXT:         *_d_i += this->data[0] * 1;
-// CHECK-NEXT:         (*_d_this).data[1] += 1 * j;
+// CHECK-NEXT:         _d_this->data[1] += 1 * j;
 // CHECK-NEXT:         *_d_j += this->data[1] * 1;
-// CHECK-NEXT:         (*_d_this).data[2] += 3 * 1;
-// CHECK-NEXT:         (*_d_this).data[3] += 1 * this->data[4];
-// CHECK-NEXT:         (*_d_this).data[4] += this->data[3] * 1;
+// CHECK-NEXT:         _d_this->data[2] += 3 * 1;
+// CHECK-NEXT:         _d_this->data[3] += 1 * this->data[4];
+// CHECK-NEXT:         _d_this->data[4] += this->data[3] * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -999,9 +999,9 @@ int main() {
 
 // CHECK: void someMemFn2_pullback(double i, double j, double _d_y, Tangent *_d_this, double *_d_i, double *_d_j) const {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_this).data[0] += _d_y * i;
+// CHECK-NEXT:         _d_this->data[0] += _d_y * i;
 // CHECK-NEXT:         *_d_i += this->data[0] * _d_y;
-// CHECK-NEXT:         (*_d_this).data[1] += _d_y * j * i;
+// CHECK-NEXT:         _d_this->data[1] += _d_y * j * i;
 // CHECK-NEXT:         *_d_i += this->data[1] * _d_y * j;
 // CHECK-NEXT:         *_d_j += this->data[1] * i * _d_y;
 // CHECK-NEXT:     }
@@ -1012,18 +1012,18 @@ int main() {
 // CHECK-NEXT:     {{(__real)?}} this->[[_M_value:.*]] = [[__val]];
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{(__real)?}} this->[[_M_value:.*]] = _t0;
-// CHECK-NEXT:         double _r_d0 ={{( __real)?}} (*_d_this).[[_M_value]];
-// CHECK-NEXT:         {{(__real)?}} (*_d_this).[[_M_value]] = 0.;
+// CHECK-NEXT:         double _r_d0 ={{( __real)?}} _d_this->[[_M_value]];
+// CHECK-NEXT:         {{(__real)?}} _d_this->[[_M_value]] = 0.;
 // CHECK-NEXT:         *[[_d___val]] += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: constexpr void real_pullback(double _d_y, std{{(::__1)?}}::complex<double> *_d_this){{.*}} {
-// CHECK-NEXT:     {{(__real)?}} (*_d_this).{{.*}} += _d_y;
+// CHECK-NEXT:     {{(__real)?}} _d_this->{{.*}} += _d_y;
 // CHECK-NEXT: }
 
 // CHECK: constexpr void imag_pullback(double _d_y, std{{(::__1)?}}::complex<double> *_d_this){{.*}} {
-// CHECK-NEXT:     {{(__imag)?}} (*_d_this).{{.*}} += _d_y;
+// CHECK-NEXT:     {{(__imag)?}} _d_this->{{.*}} += _d_y;
 // CHECK-NEXT: }
 
 // CHECK: void updateTo_pullback(double d, Tangent *_d_this, double *_d_d) {
@@ -1047,8 +1047,8 @@ int main() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         this->data[i] = clad::pop(_t1);
-// CHECK-NEXT:         double _r_d0 = (*_d_this).data[i];
-// CHECK-NEXT:         (*_d_this).data[i] = 0.;
+// CHECK-NEXT:         double _r_d0 = _d_this->data[i];
+// CHECK-NEXT:         _d_this->data[i] = 0.;
 // CHECK-NEXT:         *_d_d += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -1060,14 +1060,14 @@ int main() {
 // CHECK-NEXT:    this->b = arg.b;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        this->b = _t1;
-// CHECK-NEXT:        double _r_d1 = (*_d_this).b;
-// CHECK-NEXT:        (*_d_this).b = 0.;
+// CHECK-NEXT:        double _r_d1 = _d_this->b;
+// CHECK-NEXT:        _d_this->b = 0.;
 // CHECK-NEXT:        (*_d_arg).b += _r_d1;
 // CHECK-NEXT:    }
 // CHECK-NEXT:    {
 // CHECK-NEXT:        this->a = _t0;
-// CHECK-NEXT:        double _r_d0 = (*_d_this).a;
-// CHECK-NEXT:        (*_d_this).a = 0.;
+// CHECK-NEXT:        double _r_d0 = _d_this->a;
+// CHECK-NEXT:        _d_this->a = 0.;
 // CHECK-NEXT:        (*_d_arg).a += _r_d0;
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -1077,7 +1077,7 @@ int main() {
 // CHECK-NEXT:    this->a = arg.a;
 // CHECK-NEXT:    double _t1 = this->b;
 // CHECK-NEXT:    this->b = arg.b;
-// CHECK-NEXT:    return {*this, (*_d_this)};
+// CHECK-NEXT:    return {*this, *_d_this};
 // CHECK-NEXT:}
 
 // CHECK: static inline constexpr void constructor_pullback(SimpleFunctions1 &&arg, SimpleFunctions1 *_d_this, SimpleFunctions1 *_d_arg) noexcept;
@@ -1091,17 +1091,17 @@ int main() {
 // CHECK-NEXT:        double _r0 = 0.;
 // CHECK-NEXT:        double _r1 = 0.;
 // CHECK-NEXT:        SimpleFunctions1::constructor_pullback(this->x + other.x, this->y + other.y, &_d_res, &_r0, &_r1);
-// CHECK-NEXT:        (*_d_this).x += _r0;
+// CHECK-NEXT:        _d_this->x += _r0;
 // CHECK-NEXT:        (*_d_other).x += _r0;
-// CHECK-NEXT:        (*_d_this).y += _r1;
+// CHECK-NEXT:        _d_this->y += _r1;
 // CHECK-NEXT:        (*_d_other).y += _r1;
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 
 // CHECK: void mem_fn_1_pullback(double i, double j, double _d_y, SimpleFunctions1 *_d_this, double *_d_i, double *_d_j) {
 // CHECK-NEXT:    {
-// CHECK-NEXT:        (*_d_this).x += _d_y * i;
-// CHECK-NEXT:        (*_d_this).y += _d_y * i;
+// CHECK-NEXT:        _d_this->x += _d_y * i;
+// CHECK-NEXT:        _d_this->y += _d_y * i;
 // CHECK-NEXT:        *_d_i += (this->x + this->y) * _d_y;
 // CHECK-NEXT:        *_d_i += _d_y * j * j;
 // CHECK-NEXT:        *_d_j += i * _d_y * j;
@@ -1111,8 +1111,8 @@ int main() {
 
 // CHECK: void mem_fn_pullback(double i, double j, double _d_y, SimpleFunctions1 *_d_this, double *_d_i, double *_d_j) {
 // CHECK-NEXT:    {
-// CHECK-NEXT:        (*_d_this).x += _d_y * i;
-// CHECK-NEXT:        (*_d_this).y += _d_y * i;
+// CHECK-NEXT:        _d_this->x += _d_y * i;
+// CHECK-NEXT:        _d_this->y += _d_y * i;
 // CHECK-NEXT:        *_d_i += (this->x + this->y) * _d_y;
 // CHECK-NEXT:        *_d_i += _d_y * j;
 // CHECK-NEXT:        *_d_j += i * _d_y;
@@ -1124,37 +1124,37 @@ int main() {
 // CHECK-NEXT:        double _r0 = 0.;
 // CHECK-NEXT:        double _r1 = 0.;
 // CHECK-NEXT:        SimpleFunctions1::constructor_pullback(this->x * rhs.x, this->y * rhs.y, &_d_y, &_r0, &_r1);
-// CHECK-NEXT:        (*_d_this).x += _r0 * rhs.x;
+// CHECK-NEXT:        _d_this->x += _r0 * rhs.x;
 // CHECK-NEXT:        (*_d_rhs).x += this->x * _r0;
-// CHECK-NEXT:        (*_d_this).y += _r1 * rhs.y;
+// CHECK-NEXT:        _d_this->y += _r1 * rhs.y;
 // CHECK-NEXT:        (*_d_rhs).y += this->y * _r1;
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 
 // CHECK:  static void constructor_pullback(double px, SimpleFunctions1 *_d_this, double *_d_px) {
 // CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_this).y = 0.;
+// CHECK-NEXT:          _d_this->y = 0.;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
-// CHECK-NEXT:          *_d_px += (*_d_this).x;
-// CHECK-NEXT:          (*_d_this).x = 0.;
+// CHECK-NEXT:          *_d_px += _d_this->x;
+// CHECK-NEXT:          _d_this->x = 0.;
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
 // CHECK:  static inline constexpr void constructor_pullback(const B &arg, B *_d_this, B *_d_arg) noexcept {
 // CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_arg).data += (*_d_this).data;
-// CHECK-NEXT:          (*_d_this).data = 0.;
+// CHECK-NEXT:          (*_d_arg).data += _d_this->data;
+// CHECK-NEXT:          _d_this->data = 0.;
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
 // CHECK:  static inline constexpr void constructor_pullback(SimpleFunctions1 &&arg, SimpleFunctions1 *_d_this, SimpleFunctions1 *_d_arg) noexcept {
 // CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_arg).y += (*_d_this).y;
-// CHECK-NEXT:          (*_d_this).y = 0.;
+// CHECK-NEXT:          (*_d_arg).y += _d_this->y;
+// CHECK-NEXT:          _d_this->y = 0.;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_arg).x += (*_d_this).x;
-// CHECK-NEXT:          (*_d_this).x = 0.;
+// CHECK-NEXT:          (*_d_arg).x += _d_this->x;
+// CHECK-NEXT:          _d_this->x = 0.;
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }


### PR DESCRIPTION
In the reverse mode, we still consider the adjoint of `this` to be `(*_d_this)`. We have had this inconsistency since the time we didn't support pointers to avoid using them. Now, we can support pointers perfectly fine and there is no reason to introduce type inconsistency between the clone and the adjoint.