### PR TITLE
Consider calls with const reference params non-differentiable

### DIFF
--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -339,8 +339,10 @@ namespace clad {
 
     bool HasAnyReferenceOrPointerArgument(const clang::FunctionDecl* FD) {
       for (auto PVD : FD->parameters()) {
-        if (PVD->getType()->isReferenceType() ||
-            isArrayOrPointerType(PVD->getType()))
+        QualType paramTy = PVD->getType();
+        bool isConstTy = paramTy.getNonReferenceType().isConstQualified();
+        if ((paramTy->isReferenceType() || isArrayOrPointerType(paramTy)) &&
+            !isConstTy)
           return true;
       }
       return false;

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1518,7 +1518,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // derived function. In the case of member functions, `implicit`
     // this object is always passed by reference.
     if (!nonDiff && !dfdx() && !utils::HasAnyReferenceOrPointerArgument(FD) &&
-        (!baseOriginalE || baseOriginalE->getType().isConstQualified()))
+        (!baseOriginalE || MD->isConst()))
       nonDiff = true;
 
     // If all arguments are constant literals, then this does not contribute to


### PR DESCRIPTION
Currently, we consider a function non-differentiable if it doesn't have any pointer/reference params and dfdx. This PR lowers the requirement to non-const pointer/reference params.