### PR TITLE
Fixes #1283: Gradient: Fix missing struct initialization to structs declared inside a loop but not originally initialized

### DIFF
--- a/test/Misc/UninitStructInLoops.cpp
+++ b/test/Misc/UninitStructInLoops.cpp
@@ -1,0 +1,26 @@
+#include "clad/Differentiator/Differentiator.h"
+#include <stdio.h>
+
+typedef struct {
+    double val;
+} Struct;
+
+void fn1(double a) {
+    for (int i=0;i<1;i++){
+        Struct s;
+    }
+}
+
+void fn2 (int a) {
+    int i = 1;
+    while (i--) {
+        Struct s1 = {0};
+        Struct s2;
+    }
+}
+
+int main(){
+    auto grad = clad::gradient(fn1);
+    auto grad2 = clad::gradient(fn2);
+    return 0;
+}


### PR DESCRIPTION
Handles implicit constructors in uninitialized structs declared in loops.

The issue would occur due to clang assigning uninitialized structs an implicit constructor, making if (VD->getInit()) = True. However, implicit constructors can't be assigned as a RHS expression, resulting in: 
`clad::push(_t1, std::move(s)) , s = ;`

Changes made to ReverseModeVisitor::VisitDeclStmt:
1. **Added initExpr**, which would by default be decl->getInit().
`Expr* initExpr = decl->getInit();`

2. **Added an if statement**, to check if its an implicit constructor, if so, make it initExpr = {0.}
```
// Here, we check if the initiator is an implicit constructor.
// In the case of an uninitialized struct
// clang would provide an implicit default constructor
// which cant be used as an expression, resulting in an error:
// e.g.
// typedef struct { int a } Struct; 
// while (cond) {
//   Struct s;
// ...
// ->
// Struct s = {0.};
// while (cond) {
//  clad::push(_t1, std::move(s)) , s = ;     <--(error)
// ...
auto* constrExpr = dyn_cast<CXXConstructExpr>(VD->getInit());
if (constrExpr) {
  if (constrExpr->getConstructor()->isImplicit()) {
    Expr* zeroInit = 
        FloatingLiteral::Create(m_Context, llvm::APFloat(0.), true,
                                m_Context.DoubleTy, noLoc);
    initExpr = m_Sema.ActOnInitList(noLoc, { zeroInit }, noLoc).get();
  }
}
```

3. **Replaced `decl->getInit()` with initExpr**
`auto* assignment = BuildOp(BO_Assign, declRef, initExpr);`