### PR TITLE
Remove short int suffix in constant creation

### DIFF
--- a/lib/Differentiator/ConstantFolder.cpp
+++ b/lib/Differentiator/ConstantFolder.cpp
@@ -162,6 +162,9 @@ namespace clad {
     } else if (QT->isIntegralType(C)) {
       if (QT->isAnyCharacterType())
         QT = C.IntTy;
+      if (auto* BT = dyn_cast<BuiltinType>(QT.getTypePtr()))
+        if (BT->getKind() == BuiltinType::Short)
+          QT = C.IntTy;
       llvm::APInt APVal(C.getIntWidth(QT), val,
                          QT->isSignedIntegerOrEnumerationType());
       Result = clad::synthesizeLiteral(QT, C, APVal);

--- a/lib/Differentiator/ConstantFolder.cpp
+++ b/lib/Differentiator/ConstantFolder.cpp
@@ -162,7 +162,7 @@ namespace clad {
     } else if (QT->isIntegralType(C)) {
       if (QT->isAnyCharacterType())
         QT = C.IntTy;
-      if (auto* BT = dyn_cast<BuiltinType>(QT.getTypePtr()))
+      if (const auto* BT = dyn_cast<BuiltinType>(QT.getTypePtr()))
         if (BT->getKind() == BuiltinType::Short)
           QT = C.IntTy;
       llvm::APInt APVal(C.getIntWidth(QT), val,

--- a/test/FirstDerivative/BasicArithmeticAddSub.C
+++ b/test/FirstDerivative/BasicArithmeticAddSub.C
@@ -6,13 +6,13 @@
 extern "C" int printf(const char* fmt, ...);
 
 int a_1(int x) {
-  short int y = 4;
+  int y = 4;
   return y + y; // == 0
 }
 // CHECK: int a_1_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: short _d_y = 0;
-// CHECK-NEXT: short y = 4;
+// CHECK-NEXT: int _d_y = 0;
+// CHECK-NEXT: int y = 4;
 // CHECK-NEXT: return _d_y + _d_y;
 // CHECK-NEXT: }
 

--- a/test/FirstDerivative/BasicArithmeticAddSub.C
+++ b/test/FirstDerivative/BasicArithmeticAddSub.C
@@ -6,13 +6,13 @@
 extern "C" int printf(const char* fmt, ...);
 
 int a_1(int x) {
-  int y = 4;
+  short int y = 4;
   return y + y; // == 0
 }
 // CHECK: int a_1_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: int _d_y = 0;
-// CHECK-NEXT: int y = 4;
+// CHECK-NEXT: short _d_y = 0;
+// CHECK-NEXT: short y = 4;
 // CHECK-NEXT: return _d_y + _d_y;
 // CHECK-NEXT: }
 

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -900,6 +900,17 @@ double f24(double x, double y) {
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
+short int f25(short int x, short int y) {
+  return x * y;
+}
+
+// CHECK: void f25_grad_0(short x, short y, short *_d_x) {
+//CHECK-NEXT:    short _d_y = 0;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        *_d_x += 1 * y;
+//CHECK-NEXT:        _d_y += x * 1;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
 
 #define TEST(F, x, y)                                                          \
   {                                                                            \
@@ -983,4 +994,10 @@ int main() {
   printf("%.2f\n", const_test_input_result); // CHECK-EXEC: 1.00
 
   TEST(f24, 7, 5); // CHECK-EXEC: {1.00, 1.00}
+
+  auto f25_grad = clad::gradient(f25, "x");
+  short int x = 3, y = 4;
+  short int grad_x = 0, grad_y = 0;
+  f25_grad.execute(x, y, &grad_x, &grad_y);
+  printf("{%d, %d}\n", grad_x, grad_y); // CHECK-EXEC: {4, 0}
 }


### PR DESCRIPTION
Previously:
```
short _d_y = 0i16; // doesn't compile
```
Now:
```
short _d_y = 0; 
```