### PR TITLE
Reduce tape usage for objects

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1796,7 +1796,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             } else {
               Expr* baseDiffStore =
                   GlobalStoreAndRef(baseDiff.getExpr(), "_t", /*force=*/true);
-              baseDiff.updateStmt(baseDiffStore);
+              Expr* assign =
+                  BuildOp(BO_Assign, baseDiff.getExpr(), baseDiffStore);
+              PreCallStmts.push_back(assign);
             }
           }
           Expr* baseDerivative = baseDiff.getExpr_dx();

--- a/lib/Differentiator/TBRAnalyzer.cpp
+++ b/lib/Differentiator/TBRAnalyzer.cpp
@@ -332,8 +332,11 @@ void TBRAnalyzer::Analyze(const FunctionDecl* FD) {
   const auto* MD = dyn_cast<CXXMethodDecl>(FD);
   if (MD && !MD->isStatic()) {
     const Type* recordType = MD->getParent()->getTypeForDecl();
-    getCurBlockVarsData()[nullptr] =
-        VarData(QualType::getFromOpaquePtr(recordType), m_Context);
+    VarData& thisData = getCurBlockVarsData()[nullptr];
+    thisData = VarData(QualType::getFromOpaquePtr(recordType), m_Context);
+    // We have to set all pointer/reference parameters to tbr
+    // since method pullbacks aren't supposed to change objects.
+    setIsRequired(thisData);
   }
   auto paramsRef = FD->parameters();
   for (std::size_t i = 0; i < FD->getNumParams(); ++i)

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -233,7 +233,8 @@ int main() {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r2 = 0.;
   // CHECK-NEXT:         double _r3 = 0.;
-  // CHECK-NEXT:         _t0.operator_call_pullback(i, j, 1, &_d_E, &_r2, &_r3);
+  // CHECK-NEXT:         E = _t0;
+  // CHECK-NEXT:         E.operator_call_pullback(i, j, 1, &_d_E, &_r2, &_r3);
   // CHECK-NEXT:         *_d_i += _r2;
   // CHECK-NEXT:         *_d_j += _r3;
   // CHECK-NEXT:     }
@@ -250,7 +251,8 @@ int main() {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0.;
   // CHECK-NEXT:         double _r1 = 0.;
-  // CHECK-NEXT:         _t0.operator_call_pullback(i, j, 1, &(*_d_fn), &_r0, &_r1);
+  // CHECK-NEXT:         fn = _t0;
+  // CHECK-NEXT:         fn.operator_call_pullback(i, j, 1, &(*_d_fn), &_r0, &_r1);
   // CHECK-NEXT:         *_d_i += _r0;
   // CHECK-NEXT:         *_d_j += _r1;
   // CHECK-NEXT:     }
@@ -268,7 +270,8 @@ int main() {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0.;
   // CHECK-NEXT:         double _r1 = 0.;
-  // CHECK-NEXT:         _t0.operator_call_pullback(i, j, _d_y, &(*_d_fn), &_r0, &_r1);
+  // CHECK-NEXT:         fn = _t0;
+  // CHECK-NEXT:         fn.operator_call_pullback(i, j, _d_y, &(*_d_fn), &_r0, &_r1);
   // CHECK-NEXT:         *_d_i += _r0;
   // CHECK-NEXT:         *_d_j += _r1;
   // CHECK-NEXT:     }

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -445,10 +445,11 @@ double fn2(SimpleFunctions& sf, double i) {
 
 // CHECK: void fn2_grad(SimpleFunctions &sf, double i, SimpleFunctions *_d_sf, double *_d_i) {
 // CHECK-NEXT:     SimpleFunctions _t0 = sf;
-// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = _t0.ref_mem_fn_forw(i, &(*_d_sf), 0.);
+// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = sf.ref_mem_fn_forw(i, &(*_d_sf), 0.);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         _t0.ref_mem_fn_pullback(i, 1, &(*_d_sf), &_r0);
+// CHECK-NEXT:         sf = _t0;
+// CHECK-NEXT:         sf.ref_mem_fn_pullback(i, 1, &(*_d_sf), &_r0);
 // CHECK-NEXT:         *_d_i += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -469,11 +470,12 @@ double fn5(SimpleFunctions& v, double value) {
 
 // CHECK: void fn5_grad(SimpleFunctions &v, double value, SimpleFunctions *_d_v, double *_d_value) {
 // CHECK-NEXT:     SimpleFunctions _t0 = v;
-// CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = _t0.operator_plus_equal_forw(value, &(*_d_v), 0.);
+// CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = v.operator_plus_equal_forw(value, &(*_d_v), 0.);
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         _t0.operator_plus_equal_pullback(value, {}, &(*_d_v), &_r0);
+// CHECK-NEXT:         v = _t0;
+// CHECK-NEXT:         v.operator_plus_equal_pullback(value, {}, &(*_d_v), &_r0);
 // CHECK-NEXT:         *_d_value += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -489,9 +491,12 @@ double fn4(SimpleFunctions& v) {
 
 // CHECK: void fn4_grad(SimpleFunctions &v, SimpleFunctions *_d_v) {
 // CHECK-NEXT:     SimpleFunctions _t0 = v;
-// CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = _t0.operator_plus_plus_forw(&(*_d_v));
+// CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = v.operator_plus_plus_forw(&(*_d_v));
 // CHECK-NEXT:     (*_d_v).x += 1;
-// CHECK-NEXT:     _t0.operator_plus_plus_pullback({}, &(*_d_v));
+// CHECK-NEXT:     {
+// CHECK-NEXT:         v = _t0;
+// CHECK-NEXT:         v.operator_plus_plus_pullback({}, &(*_d_v));
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 class SafeTestClass {
@@ -623,6 +628,56 @@ double fn10(double x, double y) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:      *_d_x += _d_s.val;
 // CHECK-NEXT:  }
+
+class A {
+public:
+  void increment() { data++; }
+  void setData(double u) { data = u; }
+  double data = 0;
+};
+
+// CHECK:  void setData_pullback(double u, A *_d_this, double *_d_u);
+// CHECK:  void increment_pullback(A *_d_this);
+
+double fn11(double u, double v) {
+  double res = 0;
+  A a;
+  a.setData(u);
+  res += a.data * v;
+  a.increment();
+  return res;
+}
+
+// CHECK:  void fn11_grad(double u, double v, double *_d_u, double *_d_v) {
+// CHECK-NEXT:      double _d_res = 0.;
+// CHECK-NEXT:      double res = 0;
+// CHECK-NEXT:      A _d_a = {0.};
+// CHECK-NEXT:      A a;
+// CHECK-NEXT:      A _t0 = a;
+// CHECK-NEXT:      a.setData(u);
+// CHECK-NEXT:      double _t1 = res;
+// CHECK-NEXT:      res += a.data * v;
+// CHECK-NEXT:      A _t2 = a;
+// CHECK-NEXT:      a.increment();
+// CHECK-NEXT:      _d_res += 1;
+// CHECK-NEXT:      {
+// CHECK-NEXT:          a = _t2;
+// CHECK-NEXT:          a.increment_pullback(&_d_a);
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          res = _t1;
+// CHECK-NEXT:          double _r_d0 = _d_res;
+// CHECK-NEXT:          _d_a.data += _r_d0 * v;
+// CHECK-NEXT:          *_d_v += a.data * _r_d0;
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          double _r0 = 0.;
+// CHECK-NEXT:          a = _t0;
+// CHECK-NEXT:          a.setData_pullback(u, &_d_a, &_r0);
+// CHECK-NEXT:          *_d_u += _r0;
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
+
 int main() {
   auto d_mem_fn = clad::gradient(&SimpleFunctions::mem_fn);
   auto d_const_mem_fn = clad::gradient(&SimpleFunctions::const_mem_fn);
@@ -702,6 +757,12 @@ int main() {
   d_fn10.execute(3, -5, &dx, &dy);
   printf("%.2f", dx); //CHECK-EXEC: -3.00
   printf("%.2f", dy); //CHECK-EXEC: -1.00
+
+  dx = 0, dy = 0;
+  auto d_fn11 = clad::gradient(fn11);
+  d_fn11.execute(3, 5, &dx, &dy);
+  printf("%.2f", dx); //CHECK-EXEC: 5.00
+  printf("%.2f", dy); //CHECK-EXEC: 3.00
   
   auto d_const_volatile_lval_ref_mem_fn_i = clad::gradient(&SimpleFunctions::const_volatile_lval_ref_mem_fn, "i");
 
@@ -746,7 +807,8 @@ int main() {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r0 = 0.;
 // CHECK-NEXT:             double _r1 = 0.;
-// CHECK-NEXT:             _t0.mem_fn_pullback(i, j, 1, &_d_sf, &_r0, &_r1);
+// CHECK-NEXT:             sf = _t0;
+// CHECK-NEXT:             sf.mem_fn_pullback(i, j, 1, &_d_sf, &_r0, &_r1);
 // CHECK-NEXT:             *_d_i += _r0;
 // CHECK-NEXT:             *_d_j += _r1;
 // CHECK-NEXT:         }
@@ -822,6 +884,22 @@ int main() {
 // CHECK-NEXT:          *_d_x += -_d_y.val;
 // CHECK-NEXT:          _d_this->cond += _d_y.cond;
 // CHECK-NEXT:      }
+// CHECK-NEXT:  }
+
+// CHECK:  void setData_pullback(double u, A *_d_this, double *_d_u) {
+// CHECK-NEXT:      double _t0 = this->data;
+// CHECK-NEXT:      this->data = u;
+// CHECK-NEXT:      {
+// CHECK-NEXT:          this->data = _t0;
+// CHECK-NEXT:          double _r_d0 = _d_this->data;
+// CHECK-NEXT:          _d_this->data = 0.;
+// CHECK-NEXT:          *_d_u += _r_d0;
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
+
+// CHECK:  void increment_pullback(A *_d_this) {
+// CHECK-NEXT:      this->data++;
+// CHECK-NEXT:      this->data--;
 // CHECK-NEXT:  }
 
 // CHECK: static void constructor_pullback(double p_x, double p_y, SimpleFunctions *_d_this, double *_d_p_x, double *_d_p_y) {

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -598,8 +598,7 @@ double fn9(double x, double y) {
 // CHECK:  void fn9_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      S *_d_s = new S();
 // CHECK-NEXT:      S *s = new S({x, false});
-// CHECK-NEXT:      S *_t0 = s;
-// CHECK-NEXT:      _t0->getVal_pullback(1, _d_s);
+// CHECK-NEXT:      s->getVal_pullback(1, _d_s);
 // CHECK-NEXT:      *_d_x += *_d_s.val;
 // CHECK-NEXT:  }
 
@@ -613,16 +612,13 @@ double fn10(double x, double y) {
 // CHECK:  void fn10_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      S _d_s = {0., false};
 // CHECK-NEXT:      S s = {x, false};
-// CHECK-NEXT:      S _t0 = s;
-// CHECK-NEXT:      S _t1 = (_t0 - 4 * x);
-// CHECK-NEXT:      S _t2 = (_t1 - y);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          S _r0 = {0., false};
-// CHECK-NEXT:          _t2.getVal_pullback(1, &_r0);
+// CHECK-NEXT:          ((s - 4 * x) - y).getVal_pullback(1, &_r0);
 // CHECK-NEXT:          S _r1 = {0., false};
-// CHECK-NEXT:          _t1.operator_minus_pullback(y, _r0, &_r1, &*_d_y);
+// CHECK-NEXT:          (s - 4 * x).operator_minus_pullback(y, _r0, &_r1, &*_d_y);
 // CHECK-NEXT:          double _r2 = 0.;
-// CHECK-NEXT:          _t0.operator_minus_pullback(4 * x, _r1, &_d_s, &_r2);
+// CHECK-NEXT:          s.operator_minus_pullback(4 * x, _r1, &_d_s, &_r2);
 // CHECK-NEXT:          *_d_x += 4 * _r2;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      *_d_x += _d_s.val;

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -152,7 +152,8 @@ int main() {
     // CHECK-NEXT:     {
     // CHECK-NEXT:         double _r2 = 0.;
     // CHECK-NEXT:         double _r3 = 0.;
-    // CHECK-NEXT:         _t0.mem_fn_1_pullback(i, j, 1, &_d_obj, &_r2, &_r3);
+    // CHECK-NEXT:         obj = _t0;
+    // CHECK-NEXT:         obj.mem_fn_1_pullback(i, j, 1, &_d_obj, &_r2, &_r3);
     // CHECK-NEXT:         *_d_i += _r2;
     // CHECK-NEXT:         *_d_j += _r3;
     // CHECK-NEXT:         *_d_i += 1 * j;

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -623,18 +623,15 @@ int main() {
 // CHECK-NEXT:         const std::array<double, 3> b = _b0;
 // CHECK-NEXT:         std::array<double, 2> _t17 = a;
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t18 = {{.*}}back_reverse_forw(&a, &_d_a);
-// CHECK-NEXT:         std::array<double, 3> _t19 = b;
 // CHECK-NEXT:         {{.*}}value_type _t16 = b.front();
-// CHECK-NEXT:         std::array<double, 3> _t20 = b;
 // CHECK-NEXT:         {{.*}}value_type _t15 = b.at(2);
-// CHECK-NEXT:         std::array<double, 3> _t21 = b;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}}back_pullback(&_t17, 1 * _t15 * _t16, &_d_a);
-// CHECK-NEXT:             {{.*}}front_pullback(&_t19, _t18.value * 1 * _t15, &_d_b);
+// CHECK-NEXT:             {{.*}}front_pullback(&b, _t18.value * 1 * _t15, &_d_b);
 // CHECK-NEXT:             {{.*}}size_type _r5 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}at_pullback(&_t20, 2, _t18.value * _t16 * 1, &_d_b, &_r5);
+// CHECK-NEXT:             {{.*}}at_pullback(&b, 2, _t18.value * _t16 * 1, &_d_b, &_r5);
 // CHECK-NEXT:             {{.*}}size_type _r6 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t21, 1, 1, &_d_b, &_r6);
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&b, 1, 1, &_d_b, &_r6);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {{.*}}constructor_pullback(_b0, &_d_b, &_d__b);
 // CHECK-NEXT:         {
@@ -824,34 +821,31 @@ int main() {
 // CHECK-NEXT:          clad::zero_init(_d_v);
 // CHECK-NEXT:          {{.*}}vector<double> _t0 = v;
 // CHECK-NEXT:          v.reserve(10);
-// CHECK-NEXT:          {{.*}}vector<double> _t2 = v;
 // CHECK-NEXT:          double _t1 = v.capacity();
 // CHECK-NEXT:          double _d_res = 0.;
 // CHECK-NEXT:          double res = x * _t1;
-// CHECK-NEXT:          {{.*}}vector<double> _t3 = v;
+// CHECK-NEXT:          {{.*}}vector<double> _t2 = v;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&v, x, &_d_v, *_d_x);
-// CHECK-NEXT:          {{.*}}vector<double> _t4 = v;
+// CHECK-NEXT:          {{.*}}vector<double> _t3 = v;
 // CHECK-NEXT:          v.shrink_to_fit();
-// CHECK-NEXT:          double _t5 = res;
-// CHECK-NEXT:          {{.*}}vector<double> _t7 = v;
-// CHECK-NEXT:          double _t6 = v.capacity();
-// CHECK-NEXT:          {{.*}}vector<double> _t9 = v;
-// CHECK-NEXT:          double _t8 = v.size();
-// CHECK-NEXT:          res += y * _t6 + x * _t8;
+// CHECK-NEXT:          double _t4 = res;
+// CHECK-NEXT:          double _t5 = v.capacity();
+// CHECK-NEXT:          double _t6 = v.size();
+// CHECK-NEXT:          res += y * _t5 + x * _t6;
 // CHECK-NEXT:          _d_res += 1;
 // CHECK-NEXT:          {
-// CHECK-NEXT:              res = _t5;
+// CHECK-NEXT:              res = _t4;
 // CHECK-NEXT:              double _r_d0 = _d_res;
-// CHECK-NEXT:              *_d_y += _r_d0 * _t6;
-// CHECK-NEXT:              {{.*}}capacity_pullback(&_t7, y * _r_d0, &_d_v);
-// CHECK-NEXT:              *_d_x += _r_d0 * _t8;
-// CHECK-NEXT:              {{.*}}size_pullback(&_t9, x * _r_d0, &_d_v);
+// CHECK-NEXT:              *_d_y += _r_d0 * _t5;
+// CHECK-NEXT:              {{.*}}capacity_pullback(&v, y * _r_d0, &_d_v);
+// CHECK-NEXT:              *_d_x += _r_d0 * _t6;
+// CHECK-NEXT:              {{.*}}size_pullback(&v, x * _r_d0, &_d_v);
 // CHECK-NEXT:          }
-// CHECK-NEXT:          {{.*}}shrink_to_fit_pullback(&_t4, &_d_v);
-// CHECK-NEXT:          {{.*}}push_back_pullback(&_t3, x, &_d_v, &*_d_x);
+// CHECK-NEXT:          {{.*}}shrink_to_fit_pullback(&_t3, &_d_v);
+// CHECK-NEXT:          {{.*}}push_back_pullback(&_t2, x, &_d_v, &*_d_x);
 // CHECK-NEXT:          {
 // CHECK-NEXT:              *_d_x += _d_res * _t1;
-// CHECK-NEXT:              {{.*}}capacity_pullback(&_t2, x * _d_res, &_d_v);
+// CHECK-NEXT:              {{.*}}capacity_pullback(&v, x * _d_res, &_d_v);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r0 = {{0U|0UL|0}};

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -279,12 +279,20 @@ int main() {
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
 // CHECK-NEXT:         size_type _r0 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t2, 0, 1, &_d_vec, &_r0);
+// CHECK-NEXT:         vec = _t2;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r0);
 // CHECK-NEXT:         size_type _r1 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t4, 1, 1, &_d_vec, &_r1);
+// CHECK-NEXT:         vec = _t4;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r1);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {{.*}}class_functions::push_back_pullback(&_t1, v, &_d_vec, &*_d_v);
-// CHECK-NEXT:     {{.*}}class_functions::push_back_pullback(&_t0, u, &_d_vec, &*_d_u);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         vec = _t1;
+// CHECK-NEXT:         {{.*}}class_functions::push_back_pullback(&vec, v, &_d_vec, &*_d_v);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         vec = _t0;
+// CHECK-NEXT:         {{.*}}class_functions::push_back_pullback(&vec, u, &_d_vec, &*_d_u);
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK-NEXT: void fn11_grad(double u, double v, double *_d_u, double *_d_v) {
@@ -307,9 +315,11 @@ int main() {
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t8 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t5, 0, 1, &_d_vec, &_r1);
+// CHECK-NEXT:         vec = _t5;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r1);
 // CHECK-NEXT:         {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t7, 1, 1, &_d_vec, &_r2);
+// CHECK-NEXT:         vec = _t7;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r2);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         ref = _t4;
@@ -318,10 +328,17 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t2, 0, 0., &_d_vec, &_r0);
+// CHECK-NEXT:         vec = _t2;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 0., &_d_vec, &_r0);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     clad::custom_derivatives::class_functions::push_back_pullback(&_t1, v, &_d_vec, &*_d_v);
-// CHECK-NEXT:     clad::custom_derivatives::class_functions::push_back_pullback(&_t0, u, &_d_vec, &*_d_u);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         vec = _t1;
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::push_back_pullback(&vec, v, &_d_vec, &*_d_v);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         vec = _t0;
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::push_back_pullback(&vec, u, &_d_vec, &*_d_u);
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: void fn12_grad(double u, double v, double *_d_u, double *_d_v) {
@@ -409,9 +426,11 @@ int main() {
 // CHECK-NEXT:         res = _t25;
 // CHECK-NEXT:         double _r_d6 = _d_res;
 // CHECK-NEXT:         {{.*}} _r10 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t26, 0, _r_d6, &_d_vec, &_r10);
+// CHECK-NEXT:         vec = _t26;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, _r_d6, &_d_vec, &_r10);
 // CHECK-NEXT:         {{.*}} _r11 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t28, 1, _r_d6, &_d_vec, &_r11);
+// CHECK-NEXT:         vec = _t28;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, _r_d6, &_d_vec, &_r11);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
@@ -428,28 +447,37 @@ int main() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r9 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&_t21, 1, 0., &_d_vec, &_r9);
+// CHECK-NEXT:             vec = _t21;
+// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 0., &_d_vec, &_r9);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r8 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&_t19, 0, 0., &_d_vec, &_r8);
+// CHECK-NEXT:             vec = _t19;
+// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 0., &_d_vec, &_r8);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r7 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&_t18, 2, &_d_vec, &_r7);
+// CHECK-NEXT:         vec = _t18;
+// CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&vec, 2, &_d_vec, &_r7);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     clad::custom_derivatives::class_functions::clear_pullback(&_t17, &_d_vec);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         vec = _t17;
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::clear_pullback(&vec, &_d_vec);
+// CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t10;
 // CHECK-NEXT:         double _r_d3 = _d_res;
 // CHECK-NEXT:         _d_res = 0.;
 // CHECK-NEXT:         {{.*}} _r4 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t11, 0, _r_d3, &_d_vec, &_r4);
+// CHECK-NEXT:         vec = _t11;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, _r_d3, &_d_vec, &_r4);
 // CHECK-NEXT:         {{.*}} _r5 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t13, 1, _r_d3, &_d_vec, &_r5);
+// CHECK-NEXT:         vec = _t13;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, _r_d3, &_d_vec, &_r5);
 // CHECK-NEXT:         {{.*}} _r6 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&_t15, 2, _r_d3, &_d_vec, &_r6);
+// CHECK-NEXT:         vec = _t15;
+// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 2, _r_d3, &_d_vec, &_r6);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
@@ -473,20 +501,24 @@ int main() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r3 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&_t5, 2, 0., &_d_vec, &_r3);
+// CHECK-NEXT:             vec = _t5;
+// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 2, 0., &_d_vec, &_r3);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&_t3, 1, 0., &_d_vec, &_r2);
+// CHECK-NEXT:             vec = _t3;
+// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 0., &_d_vec, &_r2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&_t1, 0, 0., &_d_vec, &_r1);
+// CHECK-NEXT:             vec = _t1;
+// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 0., &_d_vec, &_r1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&_t0, 3, &_d_vec, &_r0);
+// CHECK-NEXT:         vec = _t0;
+// CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&vec, 3, &_d_vec, &_r0);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -509,11 +541,14 @@ int main() {
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
 // CHECK-NEXT:             {{.*}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t0, 0, 1, &_d_vec, &_r0);
+// CHECK-NEXT:             vec = _t0;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r0);
 // CHECK-NEXT:             {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t2, 1, 1, &_d_vec, &_r1);
+// CHECK-NEXT:             vec = _t2;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r1);
 // CHECK-NEXT:             {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t4, 2, 1, &_d_vec, &_r2);
+// CHECK-NEXT:             vec = _t4;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&vec, 2, 1, &_d_vec, &_r2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {{.*}}constructor_pullback(count, u, allocator, &_d_vec, &_d_count, &*_d_u, &_d_allocator);
 // CHECK-NEXT:        *_d_u += _d_res;
@@ -535,7 +570,8 @@ int main() {
 // CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t6 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&_t5, 1, 1, &_d_a, &_r1);
+// CHECK-NEXT:              a = _t5;
+// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 1, 1, &_d_a, &_r1);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              _t3.value = _t4;
@@ -544,10 +580,17 @@ int main() {
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
 // CHECK-NEXT:              {{.*}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&_t2, 1, 0., &_d_a, &_r0);
+// CHECK-NEXT:              a = _t2;
+// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 1, 0., &_d_a, &_r0);
 // CHECK-NEXT:          }
-// CHECK-NEXT:          {{.*}}push_back_pullback(&_t1, x, &_d_a, &*_d_x);
-// CHECK-NEXT:          {{.*}}push_back_pullback(&_t0, x, &_d_a, &*_d_x);
+// CHECK-NEXT:          {
+// CHECK-NEXT:              a = _t1;
+// CHECK-NEXT:              {{.*}}push_back_pullback(&a, x, &_d_a, &*_d_x);
+// CHECK-NEXT:          }
+// CHECK-NEXT:          {
+// CHECK-NEXT:              a = _t0;
+// CHECK-NEXT:              {{.*}}push_back_pullback(&a, x, &_d_a, &*_d_x);
+// CHECK-NEXT:          }
 // CHECK-NEXT:      }
 
 // CHECK:          void fn15_grad(double x, double y, double *_d_x, double *_d_y) {
@@ -585,13 +628,17 @@ int main() {
 // CHECK-NEXT:                res = clad::pop(_t2);
 // CHECK-NEXT:                double _r_d0 = _d_res;
 // CHECK-NEXT:                size_t _r0 = {{0U|0UL}};
-// CHECK-NEXT:                {{.*}}at_pullback(&clad::back(_t3), i, _r_d0, &_d_a, &_r0);
+// CHECK-NEXT:                a = clad::back(_t3);
+// CHECK-NEXT:                {{.*}}at_pullback(&a, i, _r_d0, &_d_a, &_r0);
 // CHECK-NEXT:                _d_i += _r0;
 // CHECK-NEXT:                clad::pop(_t3);
 // CHECK-NEXT:                clad::pop(_t4);
 // CHECK-NEXT:            }
 // CHECK-NEXT:        }
-// CHECK-NEXT:        {{.*}}fill_pullback(&_t0, x, &_d_a, &*_d_x);
+// CHECK-NEXT:        {
+// CHECK-NEXT:            a = _t0;
+// CHECK-NEXT:            {{.*}}fill_pullback(&a, x, &_d_a, &*_d_x);
+// CHECK-NEXT:        }
 // CHECK-NEXT: }
 
 // CHECK:     void fn16_grad(double x, double y, double *_d_x, double *_d_y) {
@@ -626,7 +673,8 @@ int main() {
 // CHECK-NEXT:         {{.*}}value_type _t16 = b.front();
 // CHECK-NEXT:         {{.*}}value_type _t15 = b.at(2);
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}}back_pullback(&_t17, 1 * _t15 * _t16, &_d_a);
+// CHECK-NEXT:             a = _t17;
+// CHECK-NEXT:             {{.*}}back_pullback(&a, 1 * _t15 * _t16, &_d_a);
 // CHECK-NEXT:             {{.*}}front_pullback(&b, _t18.value * 1 * _t15, &_d_b);
 // CHECK-NEXT:             {{.*}}size_type _r5 = {{0U|0UL}};
 // CHECK-NEXT:             {{.*}}at_pullback(&b, 2, _t18.value * _t16 * 1, &_d_b, &_r5);
@@ -641,14 +689,16 @@ int main() {
 // CHECK-NEXT:             *_d_x += _r_d4 * x;
 // CHECK-NEXT:             *_d_x += x * _r_d4;
 // CHECK-NEXT:             {{.*}}size_type _r4 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t12, 2, 0., &_d__b, &_r4);
+// CHECK-NEXT:             _b0 = _t12;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_b0, 2, 0., &_d__b, &_r4);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t10.value = _t11;
 // CHECK-NEXT:             double _r_d3 = _t10.adjoint;
 // CHECK-NEXT:             _t10.adjoint = 0.;
 // CHECK-NEXT:             {{.*}}size_type _r3 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t9, 1, 0., &_d__b, &_r3);
+// CHECK-NEXT:             _b0 = _t9;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_b0, 1, 0., &_d__b, &_r3);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t7.value = _t8;
@@ -656,7 +706,8 @@ int main() {
 // CHECK-NEXT:             _t7.adjoint = 0.;
 // CHECK-NEXT:             *_d_x += _r_d2;
 // CHECK-NEXT:             {{.*}}size_type _r2 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t6, 0, 0., &_d__b, &_r2);
+// CHECK-NEXT:             _b0 = _t6;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_b0, 0, 0., &_d__b, &_r2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t4.value = _t5;
@@ -664,14 +715,16 @@ int main() {
 // CHECK-NEXT:             _t4.adjoint = 0.;
 // CHECK-NEXT:             *_d_y += _r_d1;
 // CHECK-NEXT:             {{.*}}size_type _r1 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t3, 1, 0., &_d_a, &_r1);
+// CHECK-NEXT:             a = _t3;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 1, 0., &_d_a, &_r1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t1.value = _t2;
 // CHECK-NEXT:             double _r_d0 = _t1.adjoint;
 // CHECK-NEXT:             _t1.adjoint = 0.;
 // CHECK-NEXT:             {{.*}}size_type _r0 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t0, 0, 0., &_d_a, &_r0);
+// CHECK-NEXT:             a = _t0;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 0, 0., &_d_a, &_r0);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 
@@ -686,13 +739,16 @@ int main() {
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t4 = {{.*}}operator_subscript_reverse_forw(&a, 3, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}}size_type _r1 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t1, 49, 1, &_d_a, &_r1);
+// CHECK-NEXT:             a = _t1;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 49, 1, &_d_a, &_r1);
 // CHECK-NEXT:             {{.*}}size_type _r2 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t3, 3, 1, &_d_a, &_r2);
+// CHECK-NEXT:             a = _t3;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 3, 1, &_d_a, &_r2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r0 = 0.;
-// CHECK-NEXT:             {{.*}}fill_pullback(&_t0, y + x + x, &_d_a, &_r0);
+// CHECK-NEXT:             a = _t0;
+// CHECK-NEXT:             {{.*}}fill_pullback(&a, y + x + x, &_d_a, &_r0);
 // CHECK-NEXT:             *_d_y += _r0;
 // CHECK-NEXT:             *_d_x += _r0;
 // CHECK-NEXT:             *_d_x += _r0;
@@ -710,7 +766,8 @@ int main() {
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t4 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}}size_type _r1 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t3, 1, 1, &_d_a, &_r1);
+// CHECK-NEXT:             a = _t3;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 1, 1, &_d_a, &_r1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t1.value = _t2;
@@ -718,7 +775,8 @@ int main() {
 // CHECK-NEXT:             _t1.adjoint = 0.;
 // CHECK-NEXT:             *_d_x += 2 * _r_d0;
 // CHECK-NEXT:             {{.*}}size_type _r0 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_t0, 1, 0., &_d_a, &_r0);
+// CHECK-NEXT:             a = _t0;
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 1, 0., &_d_a, &_r0);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 
@@ -771,20 +829,25 @@ int main() {
 // CHECK-NEXT:          {
 // CHECK-NEXT:              _d_res += 1;
 // CHECK-NEXT:              {{.*}}size_type _r4 = {{0U|0UL|0}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&_t8, 0, 1, &_d_v, &_r4);
+// CHECK-NEXT:              v = _t8;
+// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&v, 0, 1, &_d_v, &_r4);
 // CHECK-NEXT:              {{.*}}size_type _r5 = {{0U|0UL|0}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&_t10, 1, 1, &_d_v, &_r5);
+// CHECK-NEXT:              v = _t10;
+// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&v, 1, 1, &_d_v, &_r5);
 // CHECK-NEXT:              {{.*}}size_type _r6 = {{0U|0UL|0}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&_t12, 2, 1, &_d_v, &_r6);
+// CHECK-NEXT:              v = _t12;
+// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&v, 2, 1, &_d_v, &_r6);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r3 = {{0U|0UL|0}};
-// CHECK-NEXT:              {{.*}}assign_pullback(&_t7, 2, y, &_d_v, &_r3, &*_d_y);
+// CHECK-NEXT:              v = _t7;
+// CHECK-NEXT:              {{.*}}assign_pullback(&v, 2, y, &_d_v, &_r3, &*_d_y);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r1 = {{0U|0UL|0}};
 // CHECK-NEXT:              {{.*}}value_type _r2 = 0.;
-// CHECK-NEXT:              {{.*}}assign_pullback(&_t6, 3, 0, &_d_v, &_r1, &_r2);
+// CHECK-NEXT:              v = _t6;
+// CHECK-NEXT:              {{.*}}assign_pullback(&v, 3, 0, &_d_v, &_r1, &_r2);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          for (;; _t2--) {
 // CHECK-NEXT:              {
@@ -796,7 +859,8 @@ int main() {
 // CHECK-NEXT:                  res = {{.*}}pop(_t3);
 // CHECK-NEXT:                  double _r_d0 = _d_res;
 // CHECK-NEXT:                  size_t _r0 = {{0U|0UL|0}};
-// CHECK-NEXT:                  {{.*}}at_pullback(&{{.*}}back(_t4), i0, _r_d0, &_d_v, &_r0);
+// CHECK-NEXT:                  v = {{.*}}back(_t4);
+// CHECK-NEXT:                  {{.*}}at_pullback(&v, i0, _r_d0, &_d_v, &_r0);
 // CHECK-NEXT:                  _d_i0 += _r0;
 // CHECK-NEXT:                  {{.*}}pop(_t4);
 // CHECK-NEXT:                  {{.*}}pop(_t5);
@@ -809,7 +873,8 @@ int main() {
 // CHECK-NEXT:              }
 // CHECK-NEXT:              --i;
 // CHECK-NEXT:              {
-// CHECK-NEXT:                  {{.*}}push_back_pullback(&{{.*}}back(_t1), x, &_d_v, &*_d_x);
+// CHECK-NEXT:                  v = {{.*}}back(_t1);
+// CHECK-NEXT:                  {{.*}}push_back_pullback(&v, x, &_d_v, &*_d_x);
 // CHECK-NEXT:                  {{.*}}pop(_t1);
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -841,15 +906,22 @@ int main() {
 // CHECK-NEXT:              *_d_x += _r_d0 * _t6;
 // CHECK-NEXT:              {{.*}}size_pullback(&v, x * _r_d0, &_d_v);
 // CHECK-NEXT:          }
-// CHECK-NEXT:          {{.*}}shrink_to_fit_pullback(&_t3, &_d_v);
-// CHECK-NEXT:          {{.*}}push_back_pullback(&_t2, x, &_d_v, &*_d_x);
+// CHECK-NEXT:          {
+// CHECK-NEXT:              v = _t3;
+// CHECK-NEXT:              {{.*}}shrink_to_fit_pullback(&v, &_d_v);
+// CHECK-NEXT:          }
+// CHECK-NEXT:          {
+// CHECK-NEXT:              v = _t2;
+// CHECK-NEXT:              {{.*}}push_back_pullback(&v, x, &_d_v, &*_d_x);
+// CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              *_d_x += _d_res * _t1;
 // CHECK-NEXT:              {{.*}}capacity_pullback(&v, x * _d_res, &_d_v);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r0 = {{0U|0UL|0}};
-// CHECK-NEXT:              {{.*}}reserve_pullback(&_t0, 10, &_d_v, &_r0);
+// CHECK-NEXT:              v = _t0;
+// CHECK-NEXT:              {{.*}}reserve_pullback(&v, 10, &_d_v, &_r0);
 // CHECK-NEXT:          }
 // CHECK-NEXT:      }
 
@@ -867,7 +939,8 @@ int main() {
 // CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r2 = 0{{.*}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&_t4, 0, 1, &_d_a, &_r2);
+// CHECK-NEXT:              a = _t4;
+// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 0, 1, &_d_a, &_r2);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              _t2.value = _t3;
@@ -876,11 +949,13 @@ int main() {
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
 // CHECK-NEXT:              {{.*}}size_type _r1 = 0{{.*}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&_t1, 0, 0{{.*}}, &_d_a, &_r1);
+// CHECK-NEXT:              a = _t1;
+// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 0, 0{{.*}}, &_d_a, &_r1);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}value_type _r0 = 0.;
-// CHECK-NEXT:              {{.*}}push_back_pullback(&_t0, 0{{.*}}, &_d_a, &_r0);
+// CHECK-NEXT:              a = _t0;
+// CHECK-NEXT:              {{.*}}push_back_pullback(&a, 0{{.*}}, &_d_a, &_r0);
 // CHECK-NEXT:          }
 // CHECK-NEXT:      }
 
@@ -898,9 +973,11 @@ int main() {
 // CHECK-NEXT:      {{.*}}value_type _t2 = _t4.value;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          {{.*}}size_type _r1 = 0{{.*}};
-// CHECK-NEXT:          clad::custom_derivatives::class_functions::operator_subscript_pullback(&_t0, 1, 1, &_d_ls, &_r1);
+// CHECK-NEXT:          ls = _t0;
+// CHECK-NEXT:          clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, 1, &_d_ls, &_r1);
 // CHECK-NEXT:          {{.*}}size_type _r2 = 0{{.*}};
-// CHECK-NEXT:          clad::custom_derivatives::class_functions::operator_subscript_pullback(&_t3, 0, 2 * -1, &_d_ls, &_r2);
+// CHECK-NEXT:          ls = _t3;
+// CHECK-NEXT:          clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 0, 2 * -1, &_d_ls, &_r2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          clad::array<double> _r0 = {{2U|2UL|2ULL}};
@@ -962,7 +1039,8 @@ int main() {
 // CHECK-NEXT:              double _r_d1 = *_d_u;
 // CHECK-NEXT:              *_d_u = 0.;
 // CHECK-NEXT:              {{.*}}size_type _r3 = 0{{.*}};
-// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t9), 1, _r_d1, &_d_ls, &_r3);
+// CHECK-NEXT:              ls = clad::back(_t9);
+// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, _r_d1, &_d_ls, &_r3);
 // CHECK-NEXT:              clad::pop(_t9);
 // CHECK-NEXT:              clad::pop(_t10);
 // CHECK-NEXT:          }
@@ -970,11 +1048,13 @@ int main() {
 // CHECK-NEXT:              clad::back(_t4).value = clad::pop(_t5);
 // CHECK-NEXT:              double _r_d0 = clad::back(_t4).adjoint;
 // CHECK-NEXT:              {{.*}}size_type _r2 = 0{{.*}};
-// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t6), 0, _r_d0, &_d_ls, &_r2);
+// CHECK-NEXT:              ls = clad::back(_t6);
+// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 0, _r_d0, &_d_ls, &_r2);
 // CHECK-NEXT:              clad::pop(_t6);
 // CHECK-NEXT:              clad::pop(_t7);
 // CHECK-NEXT:              {{.*}}size_type _r1 = 0{{.*}};
-// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t3), 1, 0., &_d_ls, &_r1);
+// CHECK-NEXT:              ls = clad::back(_t3);
+// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, 0., &_d_ls, &_r1);
 // CHECK-NEXT:              clad::pop(_t3);
 // CHECK-NEXT:              clad::pop(_t4);
 // CHECK-NEXT:          }
@@ -1053,7 +1133,8 @@ int main() {
 // CHECK-NEXT:             _d_prod = 0.;
 // CHECK-NEXT:             _d_prod += _r_d0 * clad::back(_t5).value;
 // CHECK-NEXT:             {{.*}}size_type _r1 = 0{{.*}};
-// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t4), i - 1, prod * _r_d0, &_d_vec, &_r1);
+// CHECK-NEXT:             vec = clad::back(_t4);
+// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&vec, i - 1, prod * _r_d0, &_d_vec, &_r1);
 // CHECK-NEXT:             _d_i += _r1;
 // CHECK-NEXT:             clad::pop(_t4);
 // CHECK-NEXT:             clad::pop(_t5);
@@ -1120,7 +1201,8 @@ int main() {
 // CHECK-NEXT:             double _r_d1 = *_d_u;
 // CHECK-NEXT:             *_d_u = 0.;
 // CHECK-NEXT:             {{.*}}size_type _r{{3|4}} = {{0U|0UL|0ULL}};
-// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t9), 1, _r_d1, &_d_ls, &_r{{3|4}});
+// CHECK-NEXT:             ls = clad::back(_t9);
+// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, _r_d1, &_d_ls, &_r{{3|4}});
 // CHECK-NEXT:             clad::pop(_t9);
 // CHECK-NEXT:             clad::pop(_t10);
 // CHECK-NEXT:         }
@@ -1128,11 +1210,13 @@ int main() {
 // CHECK-NEXT:             clad::back(_t4).value = clad::pop(_t5);
 // CHECK-NEXT:             double _r_d0 = clad::back(_t4).adjoint;
 // CHECK-NEXT:             {{.*}}size_type _r{{2|3}} = {{0U|0UL|0ULL}};
-// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t6), 0, _r_d0, &_d_ls, &_r{{2|3}});
+// CHECK-NEXT:             ls = clad::back(_t6);
+// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 0, _r_d0, &_d_ls, &_r{{2|3}});
 // CHECK-NEXT:             clad::pop(_t6);
 // CHECK-NEXT:             clad::pop(_t7);
 // CHECK-NEXT:             {{.*}}size_type _r{{1|2}} = {{0U|0UL|0ULL}};
-// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&clad::back(_t3), 1, 0., &_d_ls, &_r{{1|2}});
+// CHECK-NEXT:             ls = clad::back(_t3);
+// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, 0., &_d_ls, &_r{{1|2}});
 // CHECK-NEXT:             clad::pop(_t3);
 // CHECK-NEXT:             clad::pop(_t4);
 // CHECK-NEXT:         }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -267,7 +267,8 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         _t0.real_pullback(5 * i, &(*_d_c), &_r0);
+// CHECK-NEXT:         c = _t0;
+// CHECK-NEXT:         c.real_pullback(5 * i, &(*_d_c), &_r0);
 // CHECK-NEXT:         *_d_i += 5 * _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -288,7 +289,8 @@ double fn7(dcomplex c1, dcomplex c2) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         _t1.real_pullback(c2.imag() + 5 * _t0, &(*_d_c1), &_r0);
+// CHECK-NEXT:         c1 = _t1;
+// CHECK-NEXT:         c1.real_pullback(c2.imag() + 5 * _t0, &(*_d_c1), &_r0);
 // CHECK-NEXT:         c2.imag_pullback(_r0, &(*_d_c2));
 // CHECK-NEXT:         c2.real_pullback(5 * _r0, &(*_d_c2));
 // CHECK-NEXT:     }
@@ -311,7 +313,8 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         _t0.updateTo_pullback(c.real(), &(*_d_t), &_r0);
+// CHECK-NEXT:         t = _t0;
+// CHECK-NEXT:         t.updateTo_pullback(c.real(), &(*_d_t), &_r0);
 // CHECK-NEXT:         c.real_pullback(_r0, &(*_d_c));
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -434,10 +437,11 @@ MyStruct fn12(MyStruct s) {  // expected-warning {{clad::gradient only supports 
 
 // CHECK: void fn12_grad(MyStruct s, MyStruct *_d_s) {
 // CHECK-NEXT:     MyStruct _t0 = s;
-// CHECK-NEXT:     clad::ValueAndAdjoint<MyStruct &, MyStruct &> _t1 = _t0.operator_equal_forw({2 * s.a, 2 * s.b + 2}, &(*_d_s), {0., 0.});
+// CHECK-NEXT:     clad::ValueAndAdjoint<MyStruct &, MyStruct &> _t1 = s.operator_equal_forw({2 * s.a, 2 * s.b + 2}, &(*_d_s), {0., 0.});
 // CHECK-NEXT:    {
 // CHECK-NEXT:        MyStruct _r0 = {0., 0.};
-// CHECK-NEXT:        _t0.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, {0., 0.}, &(*_d_s), &_r0);
+// CHECK-NEXT:        s = _t0;
+// CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, {0., 0.}, &(*_d_s), &_r0);
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;
 // CHECK-NEXT:    }
@@ -618,7 +622,8 @@ double fn17(double i, double j) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        double _r2 = 0.;
 // CHECK-NEXT:        double _r3 = 0.;
-// CHECK-NEXT:        _t0.mem_fn_pullback(i, j, 1, &_d_sf, &_r2, &_r3);
+// CHECK-NEXT:        sf = _t0;
+// CHECK-NEXT:        sf.mem_fn_pullback(i, j, 1, &_d_sf, &_r2, &_r3);
 // CHECK-NEXT:        *_d_i += _r2;
 // CHECK-NEXT:        *_d_j += _r3;
 // CHECK-NEXT:    }
@@ -639,7 +644,8 @@ double fn18(double i, double j) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r2 = 0.;
 // CHECK-NEXT:          double _r3 = 0.;
-// CHECK-NEXT:          _t0.mem_fn_pullback(i, j, 1, &_d_sf, &_r2, &_r3);
+// CHECK-NEXT:          sf = _t0;
+// CHECK-NEXT:          sf.mem_fn_pullback(i, j, 1, &_d_sf, &_r2, &_r3);
 // CHECK-NEXT:          *_d_i += _r2;
 // CHECK-NEXT:          *_d_j += _r3;
 // CHECK-NEXT:      }
@@ -685,10 +691,11 @@ void fn20(MyStruct s) {
 
 // CHECK: void fn20_grad(MyStruct s, MyStruct *_d_s) {
 // CHECK-NEXT:     MyStruct _t0 = s;
-// CHECK-NEXT:     clad::ValueAndAdjoint<MyStruct &, MyStruct &> _t1 = _t0.operator_equal_forw({2 * s.a, 2 * s.b + 2}, &(*_d_s), {0., 0.});
+// CHECK-NEXT:     clad::ValueAndAdjoint<MyStruct &, MyStruct &> _t1 = s.operator_equal_forw({2 * s.a, 2 * s.b + 2}, &(*_d_s), {0., 0.});
 // CHECK-NEXT:    {
 // CHECK-NEXT:        MyStruct _r0 = {0., 0.};
-// CHECK-NEXT:        _t0.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, {0., 0.}, &(*_d_s), &_r0);
+// CHECK-NEXT:        s = _t0;
+// CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, {0., 0.}, &(*_d_s), &_r0);
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;
 // CHECK-NEXT:    }
@@ -734,14 +741,15 @@ double fn22(double x, double y) {
 // CHECK-NEXT:      Identity di{};
 // CHECK-NEXT:      Identity _t0 = di;
 // CHECK-NEXT:      double _d_val = 0.;
-// CHECK-NEXT:      double val = _t0(x);
+// CHECK-NEXT:      double val = di(x);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          _d_val += 1 * val;
 // CHECK-NEXT:          _d_val += val * 1;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
-// CHECK-NEXT:          _t0.operator_call_pullback(x, _d_val, &_d_di, &_r0);
+// CHECK-NEXT:          di = _t0;
+// CHECK-NEXT:          di.operator_call_pullback(x, _d_val, &_d_di, &_r0);
 // CHECK-NEXT:          *_d_x += _r0;
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
@@ -938,14 +946,15 @@ double fn28(double x, double y) {
 // CHECK-NEXT:      Vector3 _d_v(v);
 // CHECK-NEXT:      clad::zero_init(_d_v);
 // CHECK-NEXT:      Vector3 _t0 = v;
-// CHECK-NEXT:      Vector3 w = - _t0;
+// CHECK-NEXT:      Vector3 w = - v;
 // CHECK-NEXT:      Vector3 _d_w(w);
 // CHECK-NEXT:      clad::zero_init(_d_w);
 // CHECK-NEXT:      _d_w.x += 1;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          Vector3 _r0 = {};
-// CHECK-NEXT:          Vector3::constructor_pullback(- _t0, &_d_w, &_r0);
-// CHECK-NEXT:          _t0.operator_minus_pullback(_r0, &_d_v);
+// CHECK-NEXT:          Vector3::constructor_pullback(- v, &_d_w, &_r0);
+// CHECK-NEXT:          v = _t0;
+// CHECK-NEXT:          v.operator_minus_pullback(_r0, &_d_v);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      Vector3::constructor_pullback(x, x, y, &_d_v, &*_d_x, &*_d_x, &*_d_y);
 // CHECK-NEXT:  }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -222,11 +222,10 @@ double fn5(const Tangent& t, double i) {
 // CHECK: void someMemFn2_pullback(double i, double j, double _d_y, Tangent *_d_this, double *_d_i, double *_d_j) const;
 
 // CHECK: void fn5_grad(const Tangent &t, double i, Tangent *_d_t, double *_d_i) {
-// CHECK-NEXT:     Tangent _t0 = t;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         double _r1 = 0.;
-// CHECK-NEXT:         _t0.someMemFn2_pullback(i, i, 1, &(*_d_t), &_r0, &_r1);
+// CHECK-NEXT:         t.someMemFn2_pullback(i, i, 1, &(*_d_t), &_r0, &_r1);
 // CHECK-NEXT:         *_d_i += _r0;
 // CHECK-NEXT:         *_d_i += _r1;
 // CHECK-NEXT:     }
@@ -249,24 +248,21 @@ double fn6(dcomplex c, double i) {
 // CHECK: void fn6_grad(dcomplex c, double i, dcomplex *_d_c, double *_d_i) {
 // CHECK-NEXT:     dcomplex _t0 = c;
 // CHECK-NEXT:     c.real(5 * i);
-// CHECK-NEXT:     dcomplex _t1 = c;
-// CHECK-NEXT:     dcomplex _t3 = c;
-// CHECK-NEXT:     double _t2 = c.imag();
+// CHECK-NEXT:     double _t1 = c.imag();
 // CHECK-NEXT:     double _d_res = 0.;
-// CHECK-NEXT:     double res = c.real() + 3 * _t2 + 6 * i;
-// CHECK-NEXT:     double _t4 = res;
-// CHECK-NEXT:     dcomplex _t6 = c;
-// CHECK-NEXT:     double _t5 = c.real();
-// CHECK-NEXT:     res += 4 * _t5;
+// CHECK-NEXT:     double res = c.real() + 3 * _t1 + 6 * i;
+// CHECK-NEXT:     double _t2 = res;
+// CHECK-NEXT:     double _t3 = c.real();
+// CHECK-NEXT:     res += 4 * _t3;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         res = _t4;
+// CHECK-NEXT:         res = _t2;
 // CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         _t6.real_pullback(4 * _r_d0, &(*_d_c));
+// CHECK-NEXT:         c.real_pullback(4 * _r_d0, &(*_d_c));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _t1.real_pullback(_d_res, &(*_d_c));
-// CHECK-NEXT:         _t3.imag_pullback(3 * _d_res, &(*_d_c));
+// CHECK-NEXT:         c.real_pullback(_d_res, &(*_d_c));
+// CHECK-NEXT:         c.imag_pullback(3 * _d_res, &(*_d_c));
 // CHECK-NEXT:         *_d_i += 6 * _d_res;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -282,23 +278,19 @@ double fn7(dcomplex c1, dcomplex c2) {
 }
 
 // CHECK: void fn7_grad(dcomplex c1, dcomplex c2, dcomplex *_d_c1, dcomplex *_d_c2) {
-// CHECK-NEXT:     dcomplex _t0 = c2;
-// CHECK-NEXT:     dcomplex _t2 = c2;
-// CHECK-NEXT:     double _t1 = c2.real();
-// CHECK-NEXT:     dcomplex _t3 = c1;
-// CHECK-NEXT:     c1.real(c2.imag() + 5 * _t1);
-// CHECK-NEXT:     dcomplex _t4 = c1;
-// CHECK-NEXT:     dcomplex _t6 = c1;
-// CHECK-NEXT:     double _t5 = c1.imag();
+// CHECK-NEXT:     double _t0 = c2.real();
+// CHECK-NEXT:     dcomplex _t1 = c1;
+// CHECK-NEXT:     c1.real(c2.imag() + 5 * _t0);
+// CHECK-NEXT:     double _t2 = c1.imag();
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _t4.real_pullback(1, &(*_d_c1));
-// CHECK-NEXT:         _t6.imag_pullback(3 * 1, &(*_d_c1));
+// CHECK-NEXT:         c1.real_pullback(1, &(*_d_c1));
+// CHECK-NEXT:         c1.imag_pullback(3 * 1, &(*_d_c1));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         _t3.real_pullback(c2.imag() + 5 * _t1, &(*_d_c1), &_r0);
-// CHECK-NEXT:         _t0.imag_pullback(_r0, &(*_d_c2));
-// CHECK-NEXT:         _t2.real_pullback(5 * _r0, &(*_d_c2));
+// CHECK-NEXT:         _t1.real_pullback(c2.imag() + 5 * _t0, &(*_d_c1), &_r0);
+// CHECK-NEXT:         c2.imag_pullback(_r0, &(*_d_c2));
+// CHECK-NEXT:         c2.real_pullback(5 * _r0, &(*_d_c2));
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -310,18 +302,17 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK: void updateTo_pullback(double d, Tangent *_d_this, double *_d_d);
 
 // CHECK: void fn8_grad(Tangent t, dcomplex c, Tangent *_d_t, dcomplex *_d_c) {
-// CHECK-NEXT:     dcomplex _t0 = c;
-// CHECK-NEXT:     Tangent _t1 = t;
+// CHECK-NEXT:     Tangent _t0 = t;
 // CHECK-NEXT:     t.updateTo(c.real());
-// CHECK-NEXT:     Tangent _t2 = t;
+// CHECK-NEXT:     Tangent _t1 = t;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         t = _t2;
-// CHECK-NEXT:         sum_pullback(_t2, 1, &(*_d_t));
+// CHECK-NEXT:         t = _t1;
+// CHECK-NEXT:         sum_pullback(_t1, 1, &(*_d_t));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         _t1.updateTo_pullback(c.real(), &(*_d_t), &_r0);
-// CHECK-NEXT:         _t0.real_pullback(_r0, &(*_d_c));
+// CHECK-NEXT:         _t0.updateTo_pullback(c.real(), &(*_d_t), &_r0);
+// CHECK-NEXT:         c.real_pullback(_r0, &(*_d_c));
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -338,9 +329,7 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<dcomplex> _t2 = {};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<dcomplex> _t4 = {};
+// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
@@ -351,19 +340,17 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
-// CHECK-NEXT:         clad::push(_t2, c);
-// CHECK-NEXT:         clad::push(_t4, c);
-// CHECK-NEXT:         res += c.real() + 2 * clad::push(_t3, c.imag());
+// CHECK-NEXT:         res += c.real() + 2 * clad::push(_t2, c.imag());
 // CHECK-NEXT:     }
-// CHECK-NEXT:     double _t5 = res;
-// CHECK-NEXT:     Tangent _t6 = t;
+// CHECK-NEXT:     double _t3 = res;
+// CHECK-NEXT:     Tangent _t4 = t;
 // CHECK-NEXT:     res += sum(t);
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         res = _t5;
+// CHECK-NEXT:         res = _t3;
 // CHECK-NEXT:         double _r_d1 = _d_res;
-// CHECK-NEXT:         t = _t6;
-// CHECK-NEXT:         sum_pullback(_t6, _r_d1, &(*_d_t));
+// CHECK-NEXT:         t = _t4;
+// CHECK-NEXT:         sum_pullback(_t4, _r_d1, &(*_d_t));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     for (;; _t0--) {
 // CHECK-NEXT:         {
@@ -374,10 +361,8 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t1);
 // CHECK-NEXT:             double _r_d0 = _d_res;
-// CHECK-NEXT:             clad::back(_t2).real_pullback(_r_d0, &(*_d_c));
-// CHECK-NEXT:             clad::pop(_t2);
-// CHECK-NEXT:             clad::back(_t4).imag_pullback(2 * _r_d0, &(*_d_c));
-// CHECK-NEXT:             clad::pop(_t4);
+// CHECK-NEXT:             c.real_pullback(_r_d0, &(*_d_c));
+// CHECK-NEXT:             c.imag_pullback(2 * _r_d0, &(*_d_c));
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -581,7 +566,7 @@ public:
     SimpleFunctions1 res(x + other.x, y + other.y);
     return res;
   }
-  SimpleFunctions1 operator*(const SimpleFunctions1& rhs) {
+  SimpleFunctions1 operator*(const SimpleFunctions1& rhs) const {
     return {this->x * rhs.x, this->y * rhs.y};
   }
 };
@@ -607,16 +592,14 @@ double fn16(double i, double j) {
 // CHECK-NEXT:    SimpleFunctions1 obj2(3, 5);
 // CHECK-NEXT:    SimpleFunctions1 _d_obj2(obj2);
 // CHECK-NEXT:    clad::zero_init(_d_obj2);
-// CHECK-NEXT:    SimpleFunctions1 _t0 = obj1;
-// CHECK-NEXT:    SimpleFunctions1 _t1 = (_t0 + obj2);
 // CHECK-NEXT:    {
 // CHECK-NEXT:        double _r4 = 0.;
 // CHECK-NEXT:        double _r5 = 0.;
 // CHECK-NEXT:        SimpleFunctions1 _r6 = {};
-// CHECK-NEXT:        _t1.mem_fn_1_pullback(i, j, 1, &_r6, &_r4, &_r5);
+// CHECK-NEXT:        (obj1 + obj2).mem_fn_1_pullback(i, j, 1, &_r6, &_r4, &_r5);
 // CHECK-NEXT:        *_d_i += _r4;
 // CHECK-NEXT:        *_d_j += _r5;
-// CHECK-NEXT:        _t0.operator_plus_pullback(obj2, _r6, &_d_obj1, &_d_obj2);
+// CHECK-NEXT:        obj1.operator_plus_pullback(obj2, _r6, &_d_obj1, &_d_obj2);
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 
@@ -669,7 +652,7 @@ double fn18(double i, double j) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
-// CHECK:  void operator_star_pullback(const SimpleFunctions1 &rhs, SimpleFunctions1 _d_y, SimpleFunctions1 *_d_this, SimpleFunctions1 *_d_rhs);
+// CHECK:  void operator_star_pullback(const SimpleFunctions1 &rhs, SimpleFunctions1 _d_y, SimpleFunctions1 *_d_this, SimpleFunctions1 *_d_rhs) const;
 
 double fn19(double i, double j) {
     SimpleFunctions1 sf1(3, 5);
@@ -684,16 +667,14 @@ double fn19(double i, double j) {
 // CHECK-NEXT:      SimpleFunctions1 sf2(i, j);
 // CHECK-NEXT:      SimpleFunctions1 _d_sf2(sf2);
 // CHECK-NEXT:      clad::zero_init(_d_sf2);
-// CHECK-NEXT:      SimpleFunctions1 _t0 = sf1;
-// CHECK-NEXT:      SimpleFunctions1 _t1 = (_t0 * sf2);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r2 = 0.;
 // CHECK-NEXT:          double _r3 = 0.;
 // CHECK-NEXT:          SimpleFunctions1 _r4 = {};
-// CHECK-NEXT:          _t1.mem_fn_pullback(i, j, 1, &_r4, &_r2, &_r3);
+// CHECK-NEXT:          (sf1 * sf2).mem_fn_pullback(i, j, 1, &_r4, &_r2, &_r3);
 // CHECK-NEXT:          *_d_i += _r2;
 // CHECK-NEXT:          *_d_j += _r3;
-// CHECK-NEXT:          _t0.operator_star_pullback(sf2, _r4, &_d_sf1, &_d_sf2);
+// CHECK-NEXT:          sf1.operator_star_pullback(sf2, _r4, &_d_sf1, &_d_sf2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      SimpleFunctions1::constructor_pullback(i, j, &_d_sf2, &*_d_i, &*_d_j);
 // CHECK-NEXT:  }
@@ -1206,7 +1187,7 @@ int main() {
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 
-// CHECK: void operator_star_pullback(const SimpleFunctions1 &rhs, SimpleFunctions1 _d_y, SimpleFunctions1 *_d_this, SimpleFunctions1 *_d_rhs) {
+// CHECK: void operator_star_pullback(const SimpleFunctions1 &rhs, SimpleFunctions1 _d_y, SimpleFunctions1 *_d_this, SimpleFunctions1 *_d_rhs) const {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        double _r0 = 0.;
 // CHECK-NEXT:        double _r1 = 0.;

--- a/test/ValidCodeGen/ValidCodeGen.C
+++ b/test/ValidCodeGen/ValidCodeGen.C
@@ -70,11 +70,12 @@ int main() {
 //CHECK-NEXT:         TN::Test2<double> t;
 //CHECK-NEXT:         TN::Test2<double> _t0 = t;
 //CHECK-NEXT:         double _d_q = 0.;
-//CHECK-NEXT:         double q = _t0[x];
+//CHECK-NEXT:         double q = t[x];
 //CHECK-NEXT:         _d_q += 1;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r0 = 0.;
-//CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&_t0, x, _d_q, &_d_t, &_r0);
+//CHECK-NEXT:             t = _t0;
+//CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&t, x, _d_q, &_d_t, &_r0);
 //CHECK-NEXT:             *_d_x += _r0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }


### PR DESCRIPTION
We switched from the `store per use` to `store per change` system in reverse mode a while ago, i.e.
instead of
```
_t0 = x;
f(x);  // x passed by reference
...
f_pullback(_t0); // we use a different _t variable for every use
```
we do
```
_t0 = x;
f(x); // x passed by reference
...
x = _t0; // this way, we can reuse x many times per one change
f_pullback(x);
```
However, we haven't completed it for objects. Other parts of Clad expect original objects to be set to correct values, this inconsistency sometimes results in bugs like #1276. This PR implements the `store per change` system for method call bases.
Another big advantage of this approach is decreased tape usage, as we don't have to store bases of const methods of ones represented with temporary expressions. Also, in the future, we can extend TBR analysis and make it go into called functions so that we can remove even more stores.

Fixes #1276.