### PR TITLE
Don't call operators with method calls

### DIFF
--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -13,12 +13,12 @@
 
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
+#include "clang/AST/Type.h"
+#include "clang/Basic/OperatorKinds.h"
 #include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/Sema.h"
-#include <clang/AST/Type.h>
-#include <clang/Basic/OperatorKinds.h>
-#include <llvm/ADT/ArrayRef.h>
-#include <llvm/ADT/StringRef.h>
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
 
 #include <array>
 #include <stack>

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -16,6 +16,8 @@
 #include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/Sema.h"
 #include <clang/AST/Type.h>
+#include <clang/Basic/OperatorKinds.h>
+#include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/StringRef.h>
 
 #include <array>
@@ -266,6 +268,16 @@ namespace clad {
     /// either LHS or RHS is null.
     clang::Expr* BuildOp(clang::BinaryOperatorKind OpCode, clang::Expr* L,
                          clang::Expr* R, clang::SourceLocation OpLoc = noLoc);
+
+    /// A shorthand to simplify syntax for creation of CXXOperatorCallExpr.
+    /// We need it because Clang doesn't have a common ActOn- function to
+    /// generate operator calls based on the operator kind. \param[in] OOK The
+    /// kind of the operator. \param[in] ArgExprs The arguments of the operator.
+    /// \param[in] OpLoc The source location, if necessary.
+    /// \returns An expression of the built operator.
+    clang::Expr* BuildOperatorCall(clang::OverloadedOperatorKind OOK,
+                                   llvm::MutableArrayRef<clang::Expr*> ArgExprs,
+                                   clang::SourceLocation OpLoc = noLoc);
     /// Function to resolve Unary Minus. If the leftmost operand
     /// has a Unary Minus then adds parens before adding the unary minus.
     /// \param[in] E Expression fed to the recursive call.

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -715,6 +715,9 @@ namespace clad {
           return false;
         return true;
       }
+      // FIXME: This is a temporary measure until we add support for
+      // `this` in varied analysis.
+      bool VisitCXXThisExpr(const clang::CXXThisExpr* TE) { return false; }
     } analyzer(*this);
     return analyzer.isVariedE(E);
   }

--- a/test/Gradient/Lambdas.C
+++ b/test/Gradient/Lambdas.C
@@ -39,7 +39,7 @@ double f2(double i, double j) {
 // CHECK-NEXT:                 return t + k;
 // CHECK-NEXT:             }{{;?}}
 // CHECK:        double _d_x = 0.;
-// CHECK-NEXT:             double x = _f.operator()(i + j, i);
+// CHECK-NEXT:             double x = _f(i + j, i);
 // CHECK-NEXT:             _d_x += 1;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 double _r0 = 0.;

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -614,8 +614,8 @@ double fn10(double x, double y) {
 // CHECK-NEXT:      S _d_s = {0., false};
 // CHECK-NEXT:      S s = {x, false};
 // CHECK-NEXT:      S _t0 = s;
-// CHECK-NEXT:      S _t1 = s.operator-(4 * x);
-// CHECK-NEXT:      S _t2 = (s - 4 * x).operator-(y);
+// CHECK-NEXT:      S _t1 = (_t0 - 4 * x);
+// CHECK-NEXT:      S _t2 = (_t1 - y);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          S _r0 = {0., false};
 // CHECK-NEXT:          _t2.getVal_pullback(1, &_r0);

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -608,7 +608,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:    SimpleFunctions1 _d_obj2(obj2);
 // CHECK-NEXT:    clad::zero_init(_d_obj2);
 // CHECK-NEXT:    SimpleFunctions1 _t0 = obj1;
-// CHECK-NEXT:    SimpleFunctions1 _t1 = obj1.operator+(obj2);
+// CHECK-NEXT:    SimpleFunctions1 _t1 = (_t0 + obj2);
 // CHECK-NEXT:    {
 // CHECK-NEXT:        double _r4 = 0.;
 // CHECK-NEXT:        double _r5 = 0.;
@@ -685,7 +685,7 @@ double fn19(double i, double j) {
 // CHECK-NEXT:      SimpleFunctions1 _d_sf2(sf2);
 // CHECK-NEXT:      clad::zero_init(_d_sf2);
 // CHECK-NEXT:      SimpleFunctions1 _t0 = sf1;
-// CHECK-NEXT:      SimpleFunctions1 _t1 = sf1.operator*(sf2);
+// CHECK-NEXT:      SimpleFunctions1 _t1 = (_t0 * sf2);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r2 = 0.;
 // CHECK-NEXT:          double _r3 = 0.;
@@ -753,7 +753,7 @@ double fn22(double x, double y) {
 // CHECK-NEXT:      Identity di{};
 // CHECK-NEXT:      Identity _t0 = di;
 // CHECK-NEXT:      double _d_val = 0.;
-// CHECK-NEXT:      double val = di.operator()(x);
+// CHECK-NEXT:      double val = _t0(x);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          _d_val += 1 * val;
 // CHECK-NEXT:          _d_val += val * 1;
@@ -927,13 +927,13 @@ double fn27(double x, double y) {
 // CHECK-NEXT:      Vector3 v(x, x, y);
 // CHECK-NEXT:      Vector3 _d_v(v);
 // CHECK-NEXT:      clad::zero_init(_d_v);
-// CHECK-NEXT:      Vector3 w = operator*(2, v);
+// CHECK-NEXT:      Vector3 w = 2 * v;
 // CHECK-NEXT:      Vector3 _d_w(w);
 // CHECK-NEXT:      clad::zero_init(_d_w);
 // CHECK-NEXT:      _d_w.x += 1;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          Vector3 _r0 = {};
-// CHECK-NEXT:          Vector3::constructor_pullback(operator*(2, v), &_d_w, &_r0);
+// CHECK-NEXT:          Vector3::constructor_pullback(2 * v, &_d_w, &_r0);
 // CHECK-NEXT:          double _r1 = 0.;
 // CHECK-NEXT:          operator_star_pullback(2, v, _r0, &_r1, &_d_v);
 // CHECK-NEXT:      }

--- a/test/ValidCodeGen/ValidCodeGen.C
+++ b/test/ValidCodeGen/ValidCodeGen.C
@@ -70,7 +70,7 @@ int main() {
 //CHECK-NEXT:         TN::Test2<double> t;
 //CHECK-NEXT:         TN::Test2<double> _t0 = t;
 //CHECK-NEXT:         double _d_q = 0.;
-//CHECK-NEXT:         double q = t.operator[](x);
+//CHECK-NEXT:         double q = _t0[x];
 //CHECK-NEXT:         _d_q += 1;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r0 = 0.;


### PR DESCRIPTION
Currently, we turn ``CXXOperatorCallExpr`` into ``CXXMethodCallExpr`` for member operators and ``CallExpr`` otherwise. This PR changes those to actual ``CXXOperatorCallExpr``. Sadly, there is no common ``Sema::ActOn...`` function to build them, so different ones have to be used. The good thing is that all operators except for 3 (call, subscript, arrow) are considered either unary or binary, so we can use ``VisitorBase::BuildOp``.