### PR TITLE
Take const base in custom pullbacks of const methods

### DIFF
--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -409,14 +409,14 @@ void push_back_reverse_forw(::std::vector<T>* v, U val, ::std::vector<T>* d_v,
 }
 
 template <typename T, typename U, typename pU>
-void push_back_pullback(::std::vector<T>* v, U val, ::std::vector<T>* d_v,
+void push_back_pullback(const ::std::vector<T>* v, U val, ::std::vector<T>* d_v,
                         pU* d_val) {
   *d_val += d_v->back();
   d_v->pop_back();
 }
 
 template <typename T, typename U>
-void push_back_pullback(::std::vector<T>* v, U val, ::std::vector<T>* d_v,
+void push_back_pullback(const ::std::vector<T>* v, U val, ::std::vector<T>* d_v,
                         U* d_val) {
   *d_val += d_v->back();
   d_v->pop_back();
@@ -430,7 +430,7 @@ clad::ValueAndAdjoint<T&, T&> operator_subscript_reverse_forw(
 }
 
 template <typename T, typename P>
-void operator_subscript_pullback(::std::vector<T>* vec,
+void operator_subscript_pullback(const ::std::vector<T>* vec,
                                  typename ::std::vector<T>::size_type idx,
                                  P d_y, ::std::vector<T>* d_vec,
                                  typename ::std::vector<T>::size_type* d_idx) {
@@ -446,7 +446,7 @@ at_reverse_forw(::std::vector<T>* vec, typename ::std::vector<T>::size_type idx,
 }
 
 template <typename T, typename P>
-void at_pullback(::std::vector<T>* vec,
+void at_pullback(const ::std::vector<T>* vec,
                  typename ::std::vector<T>::size_type idx, P d_y,
                  ::std::vector<T>* d_vec,
                  typename ::std::vector<T>::size_type* d_idx) {
@@ -488,7 +488,7 @@ void constructor_pullback(clad::array<T> init, ::std::vector<T>* d_this,
 }
 
 template <typename T, typename U, typename dU>
-void assign_pullback(::std::vector<T>* v,
+void assign_pullback(const ::std::vector<T>* v,
                      typename ::std::vector<T>::size_type n, U /*val*/,
                      ::std::vector<T>* d_v,
                      typename ::std::vector<T>::size_type* /*d_n*/, dU* d_val) {
@@ -499,29 +499,29 @@ void assign_pullback(::std::vector<T>* v,
 }
 
 template <typename T>
-void reserve_pullback(::std::vector<T>* v,
+void reserve_pullback(const ::std::vector<T>* v,
                       typename ::std::vector<T>::size_type n,
                       ::std::vector<T>* d_v,
                       typename ::std::vector<T>::size_type* /*d_n*/) noexcept {}
 
 template <typename T>
-void shrink_to_fit_pullback(::std::vector<T>* /*v*/,
+void shrink_to_fit_pullback(const ::std::vector<T>* /*v*/,
                             ::std::vector<T>* /*d_v*/) noexcept {}
 
 template <typename T>
-void size_pullback(::std::vector<T>* /*v*/,
+void size_pullback(const ::std::vector<T>* /*v*/,
                    ::std::vector<T>* /*d_v*/) noexcept {}
 
 template <typename T>
-void capacity_pullback(::std::vector<T>* /*v*/,
+void capacity_pullback(const ::std::vector<T>* /*v*/,
                        ::std::vector<T>* /*d_v*/) noexcept {}
 
 template <typename T, typename U>
-void size_pullback(::std::vector<T>* /*v*/, U /*d_y*/,
+void size_pullback(const ::std::vector<T>* /*v*/, U /*d_y*/,
                    ::std::vector<T>* /*d_v*/) noexcept {}
 
 template <typename T, typename U>
-void capacity_pullback(::std::vector<T>* /*v*/, U /*d_y*/,
+void capacity_pullback(const ::std::vector<T>* /*v*/, U /*d_y*/,
                        ::std::vector<T>* /*d_v*/) noexcept {}
 
 // array reverse mode
@@ -534,8 +534,9 @@ clad::ValueAndAdjoint<T&, T&> operator_subscript_reverse_forw(
 }
 template <typename T, ::std::size_t N, typename P>
 void operator_subscript_pullback(
-    ::std::array<T, N>* arr, typename ::std::array<T, N>::size_type idx, P d_y,
-    ::std::array<T, N>* d_arr, typename ::std::array<T, N>::size_type* d_idx) {
+    const ::std::array<T, N>* arr, typename ::std::array<T, N>::size_type idx,
+    P d_y, ::std::array<T, N>* d_arr,
+    typename ::std::array<T, N>::size_type* d_idx) {
   (*d_arr)[idx] += d_y;
 }
 template <typename T, ::std::size_t N>
@@ -545,7 +546,7 @@ clad::ValueAndAdjoint<T&, T&> at_reverse_forw(
   return {(*arr)[idx], (*d_arr)[idx]};
 }
 template <typename T, ::std::size_t N, typename P>
-void at_pullback(::std::array<T, N>* arr,
+void at_pullback(const ::std::array<T, N>* arr,
                  typename ::std::array<T, N>::size_type idx, P d_y,
                  ::std::array<T, N>* d_arr,
                  typename ::std::array<T, N>::size_type* d_idx) {
@@ -560,7 +561,7 @@ void fill_reverse_forw(::std::array<T, N>* a,
   d_a->fill(0);
 }
 template <typename T, ::std::size_t N>
-void fill_pullback(::std::array<T, N>* arr,
+void fill_pullback(const ::std::array<T, N>* arr,
                    const typename ::std::array<T, N>::value_type& u,
                    ::std::array<T, N>* d_arr,
                    typename ::std::array<T, N>::value_type* d_u) {
@@ -576,7 +577,7 @@ back_reverse_forw(::std::array<T, N>* arr, ::std::array<T, N>* d_arr) noexcept {
   return {arr->back(), d_arr->back()};
 }
 template <typename T, ::std::size_t N>
-void back_pullback(::std::array<T, N>* arr,
+void back_pullback(const ::std::array<T, N>* arr,
                    typename ::std::array<T, N>::value_type d_u,
                    ::std::array<T, N>* d_arr) noexcept {
   (*d_arr)[d_arr->size() - 1] += d_u;
@@ -588,15 +589,16 @@ front_reverse_forw(::std::array<T, N>* arr,
   return {arr->front(), d_arr->front()};
 }
 template <typename T, ::std::size_t N>
-void front_pullback(::std::array<T, N>* arr,
+void front_pullback(const ::std::array<T, N>* arr,
                     typename ::std::array<T, N>::value_type d_u,
                     ::std::array<T, N>* d_arr) {
   (*d_arr)[0] += d_u;
 }
 template <typename T, ::std::size_t N>
-void size_pullback(::std::array<T, N>* a, ::std::array<T, N>* d_a) noexcept {}
+void size_pullback(const ::std::array<T, N>* a,
+                   ::std::array<T, N>* d_a) noexcept {}
 template <typename T, ::std::size_t N, typename U>
-void size_pullback(::std::array<T, N>* /*a*/, U /*d_y*/,
+void size_pullback(const ::std::array<T, N>* /*a*/, U /*d_y*/,
                    ::std::array<T, N>* /*d_a*/) noexcept {}
 template <typename T, ::std::size_t N>
 void constructor_pullback(const ::std::array<T, N>& arr,
@@ -634,7 +636,7 @@ operator_star_reverse_forw(::std::unique_ptr<T>* u, ::std::unique_ptr<T>* d_u) {
 }
 
 template <typename T, typename U>
-void operator_star_pullback(::std::unique_ptr<T>* u, U pullback,
+void operator_star_pullback(const ::std::unique_ptr<T>* u, U pullback,
                             ::std::unique_ptr<T>* d_u) {
   **d_u += pullback;
 }


### PR DESCRIPTION
We often provide custom STL pullbacks with non-const base arguments while the original method is const. This may lead overload mismatch and Clad attempting to differentiate these methods.
Here's a simple example:
```
retTy method(...) const {
...
```
should be differentiated as
```
retTy method_pullback(const classTy* a, ...) {
...
```
instead of
```
retTy method_pullback(classTy* a, ...) {
...
```