### PR TITLE
Harmonize derivative type generation over all modes

### DIFF
--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -111,8 +111,6 @@ public:
   static DeclDiff<clang::StaticAssertDecl>
   DifferentiateStaticAssertDecl(const clang::StaticAssertDecl* SAD);
 
-  virtual clang::QualType
-  GetPushForwardDerivativeType(clang::QualType ParamType);
   virtual std::string GetPushForwardFunctionSuffix();
   virtual DiffMode GetPushForwardMode();
 
@@ -145,9 +143,6 @@ protected:
       llvm::SmallVectorImpl<clang::Expr*>& derivedArgs);
 
 private:
-  /// Computes the return type of the derivative in `m_DiffReq->Function`.
-  clang::QualType ComputeDerivativeFunctionType();
-
   /// Prepares the derivative function parameters.
   void
   SetupDerivativeParameters(llvm::SmallVectorImpl<clang::ParmVarDecl*>& params);

--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -39,8 +39,6 @@ public:
 
   virtual void ExecuteInsidePushforwardFunctionBlock() {}
 
-  static bool IsDifferentiableType(clang::QualType T);
-
   virtual StmtDiff
   VisitArraySubscriptExpr(const clang::ArraySubscriptExpr* ASE);
   StmtDiff VisitBinaryOperator(const clang::BinaryOperator* BinOp);

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -226,6 +226,8 @@ namespace clad {
     /// Returns the same type as GetValueType but without const qualifier.
     clang::QualType GetNonConstValueType(clang::QualType T);
 
+    clang::QualType getNonConstType(clang::QualType T, clang::Sema& S);
+
     /// Builds and returns the init expression to initialise `clad::array` and
     /// `clad::array_ref` from a constant array.
     ///

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -348,6 +348,8 @@ namespace clad {
     bool isLinearConstructor(const clang::CXXConstructorDecl* CD,
                              const clang::ASTContext& C);
 
+    bool IsDifferentiableType(clang::QualType T);
+
     } // namespace utils
     } // namespace clad
 

--- a/include/clad/Differentiator/HessianModeVisitor.h
+++ b/include/clad/Differentiator/HessianModeVisitor.h
@@ -31,8 +31,7 @@ namespace clad {
     Merge(std::vector<clang::FunctionDecl*> secDerivFuncs,
           llvm::SmallVector<size_t, 16> IndependentArgsSize,
           size_t TotalIndependentArgsSize, const std::string& hessianFuncName,
-          clang::DeclContext* FD, clang::QualType hessianFuncType,
-          llvm::SmallVector<clang::QualType, 16> paramTypes);
+          clang::DeclContext* FD, clang::QualType hessianFuncType);
 
   public:
     HessianModeVisitor(DerivativeBuilder& builder, const DiffRequest& request);

--- a/include/clad/Differentiator/ReverseModeForwPassVisitor.h
+++ b/include/clad/Differentiator/ReverseModeForwPassVisitor.h
@@ -14,10 +14,10 @@ class ReverseModeForwPassVisitor : public ReverseModeVisitor {
 private:
   Stmts m_Globals;
 
-  llvm::SmallVector<clang::QualType, 8>
-  ComputeParamTypes(const DiffParams& diffParams);
-  clang::QualType ComputeReturnType();
   llvm::SmallVector<clang::ParmVarDecl*, 8> BuildParams(DiffParams& diffParams);
+  clang::QualType GetParameterDerivativeType(clang::QualType Type) override {
+    return Type;
+  }
 
 public:
   ReverseModeForwPassVisitor(DerivativeBuilder& builder,

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -74,10 +74,6 @@ namespace clad {
 
     unsigned outputArrayCursor = 0;
     unsigned numParams = 0;
-    // FIXME: Should we make this an object instead of a pointer?
-    // Downside of making it an object: We will need to include
-    // 'MultiplexExternalRMVSource.h' file
-    MultiplexExternalRMVSource* m_ExternalSource = nullptr;
     clang::Expr* m_Pullback = nullptr;
     const char* funcPostfix() const {
       if (m_DiffReq.Mode == DiffMode::jacobian)
@@ -474,7 +470,7 @@ namespace clad {
     /// type rules for local variables. We should remove this inconsistency.
     /// See the following issue for more details:
     /// https://github.com/vgvassilev/clad/issues/385
-    clang::QualType GetParameterDerivativeType(clang::QualType Type);
+    clang::QualType GetParameterDerivativeType(clang::QualType Type) override;
 
     /// Allows to easily create and manage a counter for counting the number of
     /// executed iterations of a loop.
@@ -661,9 +657,6 @@ namespace clad {
     /// multiple times.
     ///\paramp[in] source An external RMV source
     void AddExternalSource(ExternalRMVSource& source);
-
-    /// Computes and returns the derived function prototype.
-    clang::QualType ComputeDerivativeFunctionType();
 
     /// Builds and returns the sequence of derived function parameters.
     void BuildParams(llvm::SmallVectorImpl<clang::ParmVarDecl*>& params);

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -7,6 +7,7 @@
 #ifndef CLAD_REVERSE_MODE_VISITOR_H
 #define CLAD_REVERSE_MODE_VISITOR_H
 
+#include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/Compatibility.h"
 #include "clad/Differentiator/ParseDiffArgsTypes.h"
 #include "clad/Differentiator/ReverseModeVisitorDirectionKinds.h"
@@ -86,20 +87,6 @@ namespace clad {
       return "_grad";
     }
 
-    /// Removes the local const qualifiers from a QualType and returns a new
-    /// type.
-    static clang::QualType
-    getNonConstType(clang::QualType T, clang::ASTContext& C, clang::Sema& S) {
-      bool isLValueRefType = T->isLValueReferenceType();
-      T = T.getNonReferenceType();
-      clang::Qualifiers quals(T.getQualifiers());
-      quals.removeConst();
-      clang::QualType nonConstType =
-          S.BuildQualifiedType(T.getUnqualifiedType(), noLoc, quals);
-      if (isLValueRefType)
-        return C.getLValueReferenceType(nonConstType);
-      return nonConstType;
-    }
     // Function to Differentiate with Clad as Backend
     void DifferentiateWithClad();
 
@@ -198,7 +185,7 @@ namespace clad {
                              llvm::StringRef prefix = "_t",
                              bool forceDeclCreation = false) {
       assert(E && "cannot infer type from null expression");
-      return StoreAndRef(E, getNonConstType(E->getType(), m_Context, m_Sema), d,
+      return StoreAndRef(E, utils::getNonConstType(E->getType(), m_Sema), d,
                          prefix, forceDeclCreation);
     }
 

--- a/include/clad/Differentiator/VectorForwardModeVisitor.h
+++ b/include/clad/Differentiator/VectorForwardModeVisitor.h
@@ -79,7 +79,7 @@ public:
   DifferentiateVarDecl(const clang::VarDecl* VD) override;
 
   clang::QualType
-  GetPushForwardDerivativeType(clang::QualType ParamType) override;
+  GetParameterDerivativeType(clang::QualType ParamType) override;
   std::string GetPushForwardFunctionSuffix() override;
   DiffMode GetPushForwardMode() override;
 

--- a/include/clad/Differentiator/VectorPushForwardModeVisitor.h
+++ b/include/clad/Differentiator/VectorPushForwardModeVisitor.h
@@ -4,6 +4,8 @@
 #include "PushForwardModeVisitor.h"
 #include "VectorForwardModeVisitor.h"
 
+#include "clang/AST/Type.h"
+
 namespace clad {
 class VectorPushForwardModeVisitor : public VectorForwardModeVisitor {
 
@@ -14,6 +16,8 @@ public:
 
   void ExecuteInsidePushforwardFunctionBlock() override;
 
+  clang::QualType
+  GetParameterDerivativeType(clang::QualType ParamType) override;
   StmtDiff VisitReturnStmt(const clang::ReturnStmt* RS) override;
 };
 } // end namespace clad

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -29,6 +29,7 @@ class NestedNameSpecifier;
 } // namespace clang
 
 namespace clad {
+  class MultiplexExternalRMVSource;
   /// A class that represents the result of Visit of ForwardModeVisitor.
   /// Stmt() allows to access the original (cloned) Stmt and Stmt_dx() allows
   /// to access its derivative (if exists, otherwise null). If Visit produces
@@ -133,6 +134,11 @@ namespace clad {
     // FIXME: Fix this inconsistency, by making `this` pointer derivative
     // expression to be of object type in the reverse mode as well.
     clang::Expr* m_ThisExprDerivative = nullptr;
+
+    // FIXME: Should we make this an object instead of a pointer?
+    // Downside of making it an object: We will need to include
+    // 'MultiplexExternalRMVSource.h' file
+    MultiplexExternalRMVSource* m_ExternalSource = nullptr;
 
     /// A function used to wrap result of visiting E in a lambda. Returns a call
     /// to the built lambda. Func is a functor that will be invoked inside
@@ -614,6 +620,8 @@ namespace clad {
 
     clang::QualType DetermineCladArrayValueType(clang::QualType T);
 
+    clang::QualType GetDerivativeType();
+
     /// Returns clad::Identify template declaration.
     clang::TemplateDecl* GetCladConstructorPushforwardTag();
 
@@ -631,6 +639,11 @@ namespace clad {
     /// original derivative function internally. Used in gradient and jacobian
     /// modes.
     clang::FunctionDecl* CreateDerivativeOverload();
+
+    virtual clang::QualType
+    GetParameterDerivativeType(clang::QualType ParamType) {
+      return ParamType;
+    }
 
   public:
     /// Rebuild a sequence of nested namespaces ending with DC.

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -481,6 +481,19 @@ namespace clad {
       return newExpr;
     }
 
+    /// Removes the local const qualifiers from a QualType and returns a new
+    /// type.
+    clang::QualType getNonConstType(clang::QualType T, clang::Sema& S) {
+      bool isLValueRefType = T->isLValueReferenceType();
+      T = T.getNonReferenceType();
+      clang::Qualifiers quals(T.getQualifiers());
+      quals.removeConst();
+      clang::QualType nonConstType =
+          S.BuildQualifiedType(T.getUnqualifiedType(), noLoc, quals);
+      if (isLValueRefType)
+        return S.getASTContext().getLValueReferenceType(nonConstType);
+      return nonConstType;
+    }
     clang::Expr* BuildStaticCastToRValue(clang::Sema& semaRef, clang::Expr* E) {
       ASTContext& C = semaRef.getASTContext();
       QualType T = E->getType();

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -814,5 +814,20 @@ namespace clad {
         }
       return S.ActOnInitList(noLoc, {}, noLoc).get();
     }
+
+    bool IsDifferentiableType(QualType T) {
+      QualType origType = T;
+      // FIXME: arbitrary dimension array type as well.
+      while (utils::isArrayOrPointerType(T))
+        T = utils::GetValueType(T);
+      T = T.getNonReferenceType();
+      if (T->isEnumeralType())
+        return false;
+      if (T->isRealType() || T->isStructureOrClassType())
+        return true;
+      if (origType->isPointerType() && T->isVoidType())
+        return true;
+      return false;
+    }
   } // namespace utils
 } // namespace clad

--- a/lib/Differentiator/JacobianModeVisitor.cpp
+++ b/lib/Differentiator/JacobianModeVisitor.cpp
@@ -88,7 +88,7 @@ DerivativeAndOverload JacobianModeVisitor::DeriveJacobian() {
                                     /*cloneDefaultArg=*/false);
     params.push_back(newPVD);
 
-    if (!BaseForwardModeVisitor::IsDifferentiableType(PVD->getType()))
+    if (!utils::IsDifferentiableType(PVD->getType()))
       continue;
     auto derivedPVDName = "_d_vector_" + std::string(PVDII->getName());
     IdentifierInfo* derivedPVDII = CreateUniqueIdentifier(derivedPVDName);

--- a/lib/Differentiator/JacobianModeVisitor.cpp
+++ b/lib/Differentiator/JacobianModeVisitor.cpp
@@ -33,22 +33,7 @@ DerivativeAndOverload JacobianModeVisitor::DeriveJacobian() {
   SourceLocation loc{m_DiffReq->getLocation()};
   DeclarationNameInfo name(II, loc);
 
-  llvm::SmallVector<QualType, 8> paramTypes;
-
-  // Generate the function type for the derivative.
-  paramTypes.reserve(m_DiffReq->getNumParams() + args.size());
-  for (auto* PVD : m_DiffReq->parameters())
-    paramTypes.push_back(PVD->getType());
-  for (auto* PVD : m_DiffReq->parameters()) {
-    QualType paramTy = PVD->getType();
-    if (utils::isArrayOrPointerType(paramTy) || paramTy->isReferenceType())
-      paramTypes.push_back(getParamAdjointType(paramTy));
-  }
-  QualType vectorDiffFunctionType = m_Context.getFunctionType(
-      m_Context.VoidTy,
-      llvm::ArrayRef<QualType>(paramTypes.data(), paramTypes.size()),
-      // Cast to function pointer.
-      dyn_cast<FunctionProtoType>(m_DiffReq->getType())->getExtProtoInfo());
+  QualType vectorDiffFunctionType = GetDerivativeType();
 
   // Create the function declaration for the derivative.
   // FIXME: We should not use const_cast to get the decl context here.
@@ -96,7 +81,7 @@ DerivativeAndOverload JacobianModeVisitor::DeriveJacobian() {
     if (utils::isArrayOrPointerType(PVD->getType())) {
       ParmVarDecl* derivedPVD = utils::BuildParmVarDecl(
           m_Sema, m_Derivative, derivedPVDII,
-          getParamAdjointType(PVD->getType()), PVD->getStorageClass());
+          GetParameterDerivativeType(PVD->getType()), PVD->getStorageClass());
       derivedParams.push_back(derivedPVD);
       derivedExpr =
           BuildOp(UO_Deref, BuildDeclRef(derivedPVD), PVD->getBeginLoc());
@@ -110,14 +95,15 @@ DerivativeAndOverload JacobianModeVisitor::DeriveJacobian() {
     } else if (PVD->getType()->isReferenceType()) {
       ParmVarDecl* derivedPVD = utils::BuildParmVarDecl(
           m_Sema, m_Derivative, derivedPVDII,
-          getParamAdjointType(PVD->getType()), PVD->getStorageClass());
+          GetParameterDerivativeType(PVD->getType()), PVD->getStorageClass());
       derivedParams.push_back(derivedPVD);
       derivedExpr =
           BuildOp(UO_Deref, BuildDeclRef(derivedPVD), PVD->getBeginLoc());
       nonArrayIndVarCount += 1;
     } else {
       VarDecl* derivedPVD = BuildVarDecl(
-          GetPushForwardDerivativeType(PVD->getType()), derivedPVDII);
+          GetParameterDerivativeType(PVD->getType())->getPointeeType(),
+          derivedPVDII);
       adjointDecls.push_back(BuildDeclStmt(derivedPVD));
       derivedExpr = BuildDeclRef(derivedPVD);
       nonArrayIndVarCount += 1;
@@ -259,8 +245,9 @@ DerivativeAndOverload JacobianModeVisitor::DeriveJacobian() {
   return DerivativeAndOverload{vectorDiffFD, overloadFD};
 }
 
-QualType JacobianModeVisitor::getParamAdjointType(QualType T) {
-  QualType derivedTy = GetPushForwardDerivativeType(T);
+QualType JacobianModeVisitor::GetParameterDerivativeType(QualType T) {
+  QualType derivedTy =
+      this->VectorPushForwardModeVisitor::GetParameterDerivativeType(T);
   derivedTy = m_Context.getPointerType(derivedTy.getNonReferenceType());
   return derivedTy;
 }

--- a/lib/Differentiator/JacobianModeVisitor.h
+++ b/lib/Differentiator/JacobianModeVisitor.h
@@ -3,6 +3,8 @@
 
 #include "clad/Differentiator/VectorPushForwardModeVisitor.h"
 
+#include "clang/AST/Type.h"
+
 namespace clad {
 class JacobianModeVisitor : public VectorPushForwardModeVisitor {
 
@@ -11,7 +13,7 @@ public:
 
   DerivativeAndOverload DeriveJacobian();
 
-  clang::QualType getParamAdjointType(clang::QualType T);
+  clang::QualType GetParameterDerivativeType(clang::QualType T) override;
 
   StmtDiff VisitReturnStmt(const clang::ReturnStmt* RS) override;
 };

--- a/lib/Differentiator/VectorForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorForwardModeVisitor.cpp
@@ -2,10 +2,11 @@
 
 #include "ConstantFolder.h"
 #include "clad/Differentiator/CladUtils.h"
+#include "clad/Differentiator/ParseDiffArgsTypes.h"
 
+#include "clang/AST/Decl.h"
 #include "clang/AST/TemplateName.h"
 #include "clang/Sema/Lookup.h"
-#include <clang/AST/Decl.h>
 
 #include "llvm/Support/SaveAndRestore.h"
 
@@ -27,30 +28,13 @@ DiffMode VectorForwardModeVisitor::GetPushForwardMode() {
 }
 
 QualType
-VectorForwardModeVisitor::GetPushForwardDerivativeType(QualType ParamType) {
-  if (ParamType == m_Context.VoidTy)
-    return ParamType;
+VectorForwardModeVisitor::GetParameterDerivativeType(QualType ParamType) {
   QualType valueType = utils::GetNonConstValueType(ParamType);
-  QualType resType;
-  if (utils::isArrayOrPointerType(ParamType)) {
-    // If the parameter is a pointer or an array, then the derivative will be a
-    // reference to the matrix.
-    resType = GetCladMatrixOfType(valueType);
-    resType = m_Context.getLValueReferenceType(resType);
-  } else {
-    // If the parameter is not a pointer or an array, then the derivative will
-    // be a clad array.
-    resType = GetCladArrayOfType(valueType);
-
-    // Add const qualifier if the parameter is const.
-    if (ParamType.getNonReferenceType().isConstQualified())
-      resType.addConst();
-
-    // Add reference qualifier if the parameter is a reference.
-    if (ParamType->isReferenceType())
-      resType = m_Context.getLValueReferenceType(resType);
-  }
-  return resType;
+  if (utils::isArrayOrPointerType(ParamType))
+    // Generate array reference type for the derivative.
+    return GetCladArrayRefOfType(valueType);
+  // Generate pointer type for the derivative.
+  return m_Context.getPointerType(valueType);
 }
 
 void VectorForwardModeVisitor::SetIndependentVarsExpr(Expr* IndVarCountExpr) {
@@ -62,36 +46,7 @@ DerivativeAndOverload VectorForwardModeVisitor::DeriveVectorMode() {
   assert(m_DiffReq.Mode == DiffMode::vector_forward_mode);
 
   // Generate the function type for the derivative.
-  DiffParams args{};
-  for (const auto& dParam : m_DiffReq.DVI)
-    args.push_back(dParam.param);
-
-  llvm::SmallVector<clang::QualType, 8> paramTypes;
-  paramTypes.reserve(m_DiffReq->getNumParams() + args.size());
-  for (auto* PVD : m_DiffReq->parameters())
-    paramTypes.push_back(PVD->getType());
-  for (auto* PVD : m_DiffReq->parameters()) {
-    auto it = std::find(std::begin(args), std::end(args), PVD);
-    if (it == std::end(args))
-      continue; // This parameter is not in the diff list.
-
-    QualType valueType = utils::GetNonConstValueType(PVD->getType());
-    QualType dParamType;
-    if (utils::isArrayOrPointerType(PVD->getType())) {
-      // Generate array reference type for the derivative.
-      dParamType = GetCladArrayRefOfType(valueType);
-    } else {
-      // Generate pointer type for the derivative.
-      dParamType = m_Context.getPointerType(valueType);
-    }
-    paramTypes.push_back(dParamType);
-  }
-
-  QualType vectorDiffFunctionType = m_Context.getFunctionType(
-      m_Context.VoidTy,
-      llvm::ArrayRef<QualType>(paramTypes.data(), paramTypes.size()),
-      // Cast to function pointer.
-      dyn_cast<FunctionProtoType>(m_DiffReq->getType())->getExtProtoInfo());
+  QualType vectorDiffFunctionType = GetDerivativeType();
 
   // Create the function declaration for the derivative.
   std::string derivedFnName = m_DiffReq.ComputeDerivativeName();
@@ -126,6 +81,9 @@ DerivativeAndOverload VectorForwardModeVisitor::DeriveVectorMode() {
   m_Sema.PushDeclContext(getCurrentScope(), m_Derivative);
 
   // Set the parameters for the derivative.
+  DiffParams args{};
+  for (const auto& dParam : m_DiffReq.DVI)
+    args.push_back(dParam.param);
   auto params = BuildVectorModeParams(args);
   vectorDiffFD->setParams(
       clad_compat::makeArrayRef(params.data(), params.size()));

--- a/lib/Differentiator/VectorPushForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorPushForwardModeVisitor.cpp
@@ -47,6 +47,31 @@ void VectorPushForwardModeVisitor::ExecuteInsidePushforwardFunctionBlock() {
   BaseForwardModeVisitor::ExecuteInsidePushforwardFunctionBlock();
 }
 
+QualType
+VectorPushForwardModeVisitor::GetParameterDerivativeType(QualType ParamType) {
+  QualType valueType = utils::GetNonConstValueType(ParamType);
+  QualType resType;
+  if (utils::isArrayOrPointerType(ParamType)) {
+    // If the parameter is a pointer or an array, then the derivative will be a
+    // reference to the matrix.
+    resType = GetCladMatrixOfType(valueType);
+    resType = m_Context.getLValueReferenceType(resType);
+  } else {
+    // If the parameter is not a pointer or an array, then the derivative will
+    // be a clad array.
+    resType = GetCladArrayOfType(valueType);
+
+    // Add const qualifier if the parameter is const.
+    if (ParamType.getNonReferenceType().isConstQualified())
+      resType.addConst();
+
+    // Add reference qualifier if the parameter is a reference.
+    if (ParamType->isReferenceType())
+      resType = m_Context.getLValueReferenceType(resType);
+  }
+  return resType;
+}
+
 StmtDiff
 VectorPushForwardModeVisitor::VisitReturnStmt(const clang::ReturnStmt* RS) {
   // If there is no return value, we must not attempt to differentiate

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -1126,9 +1126,7 @@ namespace clad {
 
     if (const auto* MD = dyn_cast<CXXMethodDecl>(FD)) {
       const CXXRecordDecl* RD = MD->getParent();
-      if (MD->isInstance() &&
-          (!RD->isLambda() ||
-           m_DiffReq.Mode == DiffMode::experimental_pushforward) &&
+      if (MD->isInstance() && !RD->isLambda() &&
           m_DiffReq.Mode != DiffMode::jacobian) {
         QualType thisTy = GetParameterDerivativeType(MD->getThisType());
         FnTypes.push_back(thisTy);


### PR DESCRIPTION
Forward modes already have a common function ``GetPushForwardDerivativeType`` to build the derivative `QualType`. It utilizes a virtual function ``GetParameterDerivativeType`` to make the implementation consistent with the vectorized forward mode. This PR extends this approach to all modes. 
Note: function type is not the return type, it also accounts for the signature, e.g., `returnTy(parTy1, parTy2, ...)`.
There are 2 goals this PR is meant to achieve:
1) Avoid code repetition.
2) Create a common point to generate derivative QualType (derivative signature) so that it's easily available on higher levels (primarily, to perform custom derivative lookups).