### PR TITLE
Add Windows arm job to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,11 @@ jobs:
             compiler: msvc
             clang-runtime: '20'
 
+          - name: win11-arm-msvc-runtime20
+            os: windows-11-arm
+            compiler: msvc
+            clang-runtime: '20'
+
           - name: ubu22-clang15-runtime16-debug
             os: ubuntu-22.04
             compiler: clang-15


### PR DESCRIPTION
According to https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/ Windows arm Github runners are now available for free for public repositories. Therefore I have added them to Clads ci. Hopefully they build first time like Windows x86, but won't know until the workflow runs. Just adding for llvm 20 for now.