### PR TITLE
Don't account for output parameter in indepVarCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ int main() {
 
 ### Jacobian mode - `clad::jacobian`
 
-Clad can produce the jacobian of a function using its reverse mode. It returns the jacobian matrix as a `clad::matrix` for every pointer/array parameter.
+Clad can produce the jacobian of a function using its *vectorized forward mode*. It returns the jacobian matrix as a `clad::matrix` for every pointer/array parameter.
 
 `clad::jacobian(f, /*optional*/ ARGS)` takes 1 or 2 arguments:
 1. `f` is a pointer to a function or a method to be differentiated
@@ -143,14 +143,14 @@ Clad can produce the jacobian of a function using its reverse mode. It returns t
     * a string literal with comma-separated names of independent variables (e.g. `"x"` or `"y"` or `"x, y"` or `"y, x"`)
 
 The generated function has `void` return type and same input arguments. For every pointer/array parameter `arr`, the function has an additional argument `_d_vector_arr`. Its
-type is `clad::matrix<T>`, where `T` is the pointee type of `arr`. These variables store their derivatives w.r.t. all inputs.
+type is `clad::matrix<T>`, where `T` is the pointee type of `arr`. These variables store their derivatives w.r.t. all inputs. Output parameters are supposed to have `_clad_out_` prefix.
 *The caller is responsible for allocating the matrices*. Example:
 
 ```cpp
 #include "clad/Differentiator/Differentiator.h"
 #include <iostream>
 
-void h(double a, double b, double output[]) {
+void h(double a, double b, double _clad_out_output[]) {
     output[0] = a * a * a;
     output[1] = a * a * a + b * b * b;
     output[2] = 2 * (a + b);
@@ -180,7 +180,7 @@ Or in the case of multiple array parameters:
 #include "clad/Differentiator/Differentiator.h"
 #include <iostream>
 
-void h(double a, double b, double arr[], double* ptr) {
+void h(double a, double b, double _clad_out_arr[], double* _clad_out_ptr) {
     arr[0] = a * a * a;
     ptr[0] = arr[0] + b * b * b;
     arr[1] = 2 * (a + b);

--- a/test/Jacobian/FunctionCalls.C
+++ b/test/Jacobian/FunctionCalls.C
@@ -9,22 +9,22 @@
 double outputs[4];
 clad::matrix<double> results(2, 2);
 
-void fn1(double i, double j, double* output) {
-  output[0] = std::pow(i, j);
-  output[1] = std::pow(j, i);
+void fn1(double i, double j, double* _clad_out_output) {
+  _clad_out_output[0] = std::pow(i, j);
+  _clad_out_output[1] = std::pow(j, i);
 }
 
-// CHECK: void fn1_jac(double i, double j, double *output, clad::matrix<double> *_d_vector_output) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{2U|2UL|2ULL}};
+// CHECK: void fn1_jac(double i, double j, double *_clad_out_output, clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-// CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     {{.*}} _t0 = clad::custom_derivatives::std::pow_pushforward(i, j, _d_vector_i, _d_vector_j);
-// CHECK-NEXT:     (*_d_vector_output)[0] = _t0.pushforward;
-// CHECK-NEXT:     output[0] = _t0.value;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = _t0.pushforward;
+// CHECK-NEXT:     _clad_out_output[0] = _t0.value;
 // CHECK-NEXT:     {{.*}} _t1 = clad::custom_derivatives::std::pow_pushforward(j, i, _d_vector_j, _d_vector_i);
-// CHECK-NEXT:     (*_d_vector_output)[1] = _t1.pushforward;
-// CHECK-NEXT:     output[1] = _t1.value;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = _t1.pushforward;
+// CHECK-NEXT:     _clad_out_output[1] = _t1.value;
 // CHECK-NEXT: }
 
 double add(double a, double b) { return a + b ;}
@@ -34,27 +34,27 @@ double add(double a, double b) { return a + b ;}
 // CHECK-NEXT:     return {a + b, _d_a + _d_b};
 // CHECK-NEXT: }
 
-void fn2(double a, double b, double* res){ 
-    res[0] = a*10 + b*b*9;
-    res[0] = add(res[0], 10);
-    res[1] = a*a*9 + b*b*10;
+void fn2(double a, double b, double* _clad_out_res){ 
+    _clad_out_res[0] = a*10 + b*b*9;
+    _clad_out_res[0] = add(_clad_out_res[0], 10);
+    _clad_out_res[1] = a*a*9 + b*b*10;
 }
 
-// CHECK: void fn2_jac(double a, double b, double *res, clad::matrix<double> *_d_vector_res) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_res->rows() + 2UL;
-// CHECK-NEXT:     clad::array<double> _d_vector_a = clad::one_hot_vector(indepVarCount, 0UL);
-// CHECK-NEXT:     clad::array<double> _d_vector_b = clad::one_hot_vector(indepVarCount, 1UL);
-// CHECK-NEXT:     *_d_vector_res = clad::identity_matrix(_d_vector_res->rows(), indepVarCount, 2UL);
+// CHECK: void fn2_jac(double a, double b, double *_clad_out_res, clad::matrix<double> *_d_vector__clad_out_res) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
+// CHECK-NEXT:     clad::array<double> _d_vector_a = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:     clad::array<double> _d_vector_b = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out_res = clad::identity_matrix(_d_vector__clad_out_res->rows(), indepVarCount, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     double _t0 = b * b;
-// CHECK-NEXT:     (*_d_vector_res)[0] = _d_vector_a * 10 + a * (clad::zero_vector(indepVarCount)) + (_d_vector_b * b + b * _d_vector_b) * 9 + _t0 * (clad::zero_vector(indepVarCount));
-// CHECK-NEXT:     res[0] = a * 10 + _t0 * 9;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, clad::array<double> > _t1 = add_vector_pushforward(res[0], 10, (*_d_vector_res)[0], clad::zero_vector(indepVarCount));
-// CHECK-NEXT:     (*_d_vector_res)[0] = _t1.pushforward;
-// CHECK-NEXT:     res[0] = _t1.value;
+// CHECK-NEXT:     (*_d_vector__clad_out_res)[0] = _d_vector_a * 10 + a * (clad::zero_vector(indepVarCount)) + (_d_vector_b * b + b * _d_vector_b) * 9 + _t0 * (clad::zero_vector(indepVarCount));
+// CHECK-NEXT:     _clad_out_res[0] = a * 10 + _t0 * 9;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, clad::array<double> > _t1 = add_vector_pushforward(_clad_out_res[0], 10, (*_d_vector__clad_out_res)[0], clad::zero_vector(indepVarCount));
+// CHECK-NEXT:     (*_d_vector__clad_out_res)[0] = _t1.pushforward;
+// CHECK-NEXT:     _clad_out_res[0] = _t1.value;
 // CHECK-NEXT:     double _t2 = a * a;
 // CHECK-NEXT:     double _t3 = b * b;
-// CHECK-NEXT:     (*_d_vector_res)[1] = (_d_vector_a * a + a * _d_vector_a) * 9 + _t2 * (clad::zero_vector(indepVarCount)) + (_d_vector_b * b + b * _d_vector_b) * 10 + _t3 * (clad::zero_vector(indepVarCount));
-// CHECK-NEXT:     res[1] = _t2 * 9 + _t3 * 10;
+// CHECK-NEXT:     (*_d_vector__clad_out_res)[1] = (_d_vector_a * a + a * _d_vector_a) * 9 + _t2 * (clad::zero_vector(indepVarCount)) + (_d_vector_b * b + b * _d_vector_b) * 10 + _t3 * (clad::zero_vector(indepVarCount));
+// CHECK-NEXT:     _clad_out_res[1] = _t2 * 9 + _t3 * 10;
 // CHECK-NEXT: }
 
 #define INIT(F) auto d_##F = clad::jacobian(F);

--- a/test/Jacobian/Functors.C
+++ b/test/Jacobian/Functors.C
@@ -8,29 +8,29 @@
 struct Experiment {
   mutable double x, y;
   Experiment(double p_x, double p_y) : x(p_x), y(p_y) {}
-  void operator()(double i, double j, double *output) {
-    output[0] = x*i*i*j;
-    output[1] = y*i*j*j;
+  void operator()(double i, double j, double *_clad_out_output) {
+    _clad_out_output[0] = x*i*i*j;
+    _clad_out_output[1] = y*i*j*j;
   }
   void setX(double val) {
     x = val;
   }
 
-  // CHECK: void operator_call_jac(double i, double j, double *output, clad::matrix<double> *_d_vector_output) {
-  // CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{2U|2UL|2ULL}};
+  // CHECK: void operator_call_jac(double i, double j, double *_clad_out_output, clad::matrix<double> *_d_vector__clad_out_output) {
+  // CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
   // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
   // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-  // CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
+  // CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
   // CHECK-NEXT:     double &_t0 = this->x;
   // CHECK-NEXT:     double _t1 = _t0 * i;
   // CHECK-NEXT:     double _t2 = _t1 * i;
-  // CHECK-NEXT:     (*_d_vector_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
-  // CHECK-NEXT:     output[0] = _t2 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[0] = _t2 * j;
   // CHECK-NEXT:     double &_t3 = this->y;
   // CHECK-NEXT:     double _t4 = _t3 * i;
   // CHECK-NEXT:     double _t5 = _t4 * j;
-  // CHECK-NEXT:     (*_d_vector_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
-  // CHECK-NEXT:     output[1] = _t5 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[1] = _t5 * j;
   // CHECK-NEXT: }
 
 };
@@ -38,29 +38,29 @@ struct Experiment {
 struct ExperimentConst {
   mutable double x, y;
   ExperimentConst(double p_x, double p_y) : x(p_x), y(p_y) {}
-  void operator()(double i, double j, double *output) const {
-    output[0] = x*i*i*j;
-    output[1] = y*i*j*j;
+  void operator()(double i, double j, double *_clad_out_output) const {
+    _clad_out_output[0] = x*i*i*j;
+    _clad_out_output[1] = y*i*j*j;
   }
   void setX(double val) const {
     x = val;
   }
 
-  // CHECK: void operator_call_jac(double i, double j, double *output, clad::matrix<double> *_d_vector_output) const {
-  // CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{2U|2UL|2ULL}};
+  // CHECK: void operator_call_jac(double i, double j, double *_clad_out_output, clad::matrix<double> *_d_vector__clad_out_output) const {
+  // CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
   // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
   // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-  // CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
+  // CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
   // CHECK-NEXT:     double &_t0 = this->x;
   // CHECK-NEXT:     double _t1 = _t0 * i;
   // CHECK-NEXT:     double _t2 = _t1 * i;
-  // CHECK-NEXT:     (*_d_vector_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
-  // CHECK-NEXT:     output[0] = _t2 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[0] = _t2 * j;
   // CHECK-NEXT:     double &_t3 = this->y;
   // CHECK-NEXT:     double _t4 = _t3 * i;
   // CHECK-NEXT:     double _t5 = _t4 * j;
-  // CHECK-NEXT:     (*_d_vector_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
-  // CHECK-NEXT:     output[1] = _t5 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[1] = _t5 * j;
   // CHECK-NEXT: }
 
 };
@@ -68,29 +68,29 @@ struct ExperimentConst {
 struct ExperimentVolatile {
   mutable double x, y;
   ExperimentVolatile(double p_x, double p_y) : x(p_x), y(p_y) {}
-  void operator()(double i, double j, double *output) volatile {
-    output[0] = x*i*i*j;
-    output[1] = y*i*j*j;
+  void operator()(double i, double j, double *_clad_out_output) volatile {
+    _clad_out_output[0] = x*i*i*j;
+    _clad_out_output[1] = y*i*j*j;
   }
   void setX(double val) volatile {
     x = val;
   }
 
-  // CHECK: void operator_call_jac(double i, double j, double *output, clad::matrix<double> *_d_vector_output) volatile {
-  // CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{2U|2UL|2ULL}};
+  // CHECK: void operator_call_jac(double i, double j, double *_clad_out_output, clad::matrix<double> *_d_vector__clad_out_output) volatile {
+  // CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
   // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
   // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-  // CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
+  // CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
   // CHECK-NEXT:     volatile double &_t0 = this->x;
   // CHECK-NEXT:     double _t1 = _t0 * i;
   // CHECK-NEXT:     double _t2 = _t1 * i;
-  // CHECK-NEXT:     (*_d_vector_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
-  // CHECK-NEXT:     output[0] = _t2 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[0] = _t2 * j;
   // CHECK-NEXT:     volatile double &_t3 = this->y;
   // CHECK-NEXT:     double _t4 = _t3 * i;
   // CHECK-NEXT:     double _t5 = _t4 * j;
-  // CHECK-NEXT:     (*_d_vector_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
-  // CHECK-NEXT:     output[1] = _t5 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[1] = _t5 * j;
   // CHECK-NEXT: }
 
 };
@@ -98,29 +98,29 @@ struct ExperimentVolatile {
 struct ExperimentConstVolatile {
   mutable double x, y;
   ExperimentConstVolatile(double p_x, double p_y) : x(p_x), y(p_y) {}
-  void operator()(double i, double j, double *output) const volatile {
-    output[0] = x*i*i*j;
-    output[1] = y*i*j*j;
+  void operator()(double i, double j, double *_clad_out_output) const volatile {
+    _clad_out_output[0] = x*i*i*j;
+    _clad_out_output[1] = y*i*j*j;
   }
   void setX(double val) const volatile {
     x = val;
   }
 
-  // CHECK: void operator_call_jac(double i, double j, double *output, clad::matrix<double> *_d_vector_output) const volatile {
-  // CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{2U|2UL|2ULL}};
+  // CHECK: void operator_call_jac(double i, double j, double *_clad_out_output, clad::matrix<double> *_d_vector__clad_out_output) const volatile {
+  // CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
   // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
   // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-  // CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
+  // CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
   // CHECK-NEXT:     volatile double &_t0 = this->x;
   // CHECK-NEXT:     double _t1 = _t0 * i;
   // CHECK-NEXT:     double _t2 = _t1 * i;
-  // CHECK-NEXT:     (*_d_vector_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
-  // CHECK-NEXT:     output[0] = _t2 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[0] = _t2 * j;
   // CHECK-NEXT:     volatile double &_t3 = this->y;
   // CHECK-NEXT:     double _t4 = _t3 * i;
   // CHECK-NEXT:     double _t5 = _t4 * j;
-  // CHECK-NEXT:     (*_d_vector_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
-  // CHECK-NEXT:     output[1] = _t5 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[1] = _t5 * j;
   // CHECK-NEXT: }
 
 };
@@ -130,49 +130,49 @@ namespace outer {
     struct ExperimentNNS {
       mutable double x, y;
       ExperimentNNS(double p_x, double p_y) : x(p_x), y(p_y) {}
-      void operator()(double i, double j, double *output) {
-        output[0] = x*i*i*j;
-        output[1] = y*i*j*j;
+      void operator()(double i, double j, double *_clad_out_output) {
+        _clad_out_output[0] = x*i*i*j;
+        _clad_out_output[1] = y*i*j*j;
       }
       void setX(double val) {
         x = val;
       }
       
-  // CHECK: void operator_call_jac(double i, double j, double *output, clad::matrix<double> *_d_vector_output) {
-  // CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{2U|2UL|2ULL}};
+  // CHECK: void operator_call_jac(double i, double j, double *_clad_out_output, clad::matrix<double> *_d_vector__clad_out_output) {
+  // CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
   // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
   // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-  // CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
+  // CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
   // CHECK-NEXT:     double &_t0 = this->x;
   // CHECK-NEXT:     double _t1 = _t0 * i;
   // CHECK-NEXT:     double _t2 = _t1 * i;
-  // CHECK-NEXT:     (*_d_vector_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
-  // CHECK-NEXT:     output[0] = _t2 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[0] = _t2 * j;
   // CHECK-NEXT:     double &_t3 = this->y;
   // CHECK-NEXT:     double _t4 = _t3 * i;
   // CHECK-NEXT:     double _t5 = _t4 * j;
-  // CHECK-NEXT:     (*_d_vector_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
-  // CHECK-NEXT:     output[1] = _t5 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[1] = _t5 * j;
   // CHECK-NEXT: }
 
     };
 
-    auto lambdaNNS = [](double i, double j, double *output) {
-      output[0] = i*i*j;
-      output[1] = i*j*j;
+    auto lambdaNNS = [](double i, double j, double *_clad_out_output) {
+      _clad_out_output[0] = i*i*j;
+      _clad_out_output[1] = i*j*j;
     };
 
-  // CHECK: inline void operator_call_jac(double i, double j, double *output, clad::matrix<double> *_d_vector_output) const {
-  // CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{2U|2UL|2ULL}};
+  // CHECK: inline void operator_call_jac(double i, double j, double *_clad_out_output, clad::matrix<double> *_d_vector__clad_out_output) const {
+  // CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
   // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
   // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-  // CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
+  // CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
   // CHECK-NEXT:     double _t0 = i * i;
-  // CHECK-NEXT:     (*_d_vector_output)[0] = (_d_vector_i * i + i * _d_vector_i) * j + _t0 * _d_vector_j;
-  // CHECK-NEXT:     output[0] = _t0 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = (_d_vector_i * i + i * _d_vector_i) * j + _t0 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[0] = _t0 * j;
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     (*_d_vector_output)[1] = (_d_vector_i * j + i * _d_vector_j) * j + _t1 * _d_vector_j;
-  // CHECK-NEXT:     output[1] = _t1 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (_d_vector_i * j + i * _d_vector_j) * j + _t1 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[1] = _t1 * j;
   // CHECK-NEXT: }
 
   }
@@ -183,19 +183,19 @@ namespace outer {
   auto d_##E##Ref = clad::jacobian(E);
 
 #define TEST(E)                                                                \
-  output[0] = output[1] = 0;                                                   \
-  d_##E.execute(7, 9, output, &result);                                        \
+  _clad_out_output[0] = _clad_out_output[1] = 0;                                                   \
+  d_##E.execute(7, 9, _clad_out_output, &result);                                        \
   printf("{%.2f, %.2f, %.2f, %.2f}, ", result[0][0], result[0][1],             \
                                        result[1][0], result[1][1]);            \
-  output[0] = output[1] = 0;                                                   \
-  d_##E##Ref.execute(7, 9, output, &result);                                   \
+  _clad_out_output[0] = _clad_out_output[1] = 0;                                                   \
+  d_##E##Ref.execute(7, 9, _clad_out_output, &result);                                   \
   printf("{%.2f, %.2f, %.2f, %.2f}, ", result[0][0], result[0][1],             \
                                        result[1][0], result[1][1]);
 
 double x = 3;
 double y = 5;
 int main() {
-  double output[2];
+  double _clad_out_output[2];
   clad::matrix<double> result(2, 2);
   Experiment E(3, 5);
   auto E_Again = E;
@@ -204,42 +204,42 @@ int main() {
   const volatile ExperimentConstVolatile E_ConstVolatile(3, 5);
   outer::inner::ExperimentNNS E_NNS(3, 5);
   auto E_NNS_Again = E_NNS;
-  auto lambda = [](double i, double j, double *output) {
-    output[0] = i*i*j;
-    output[1] = i*j*j;
+  auto lambda = [](double i, double j, double *_clad_out_output) {
+    _clad_out_output[0] = i*i*j;
+    _clad_out_output[1] = i*j*j;
   };
 
-  // CHECK-NEXT: inline void operator_call_jac(double i, double j, double *output, clad::matrix<double> *_d_vector_output) const {
-  // CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{2U|2UL|2ULL}};
+  // CHECK-NEXT: inline void operator_call_jac(double i, double j, double *_clad_out_output, clad::matrix<double> *_d_vector__clad_out_output) const {
+  // CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
   // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
   // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-  // CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
+  // CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
   // CHECK-NEXT:     double _t0 = i * i;
-  // CHECK-NEXT:     (*_d_vector_output)[0] = (_d_vector_i * i + i * _d_vector_i) * j + _t0 * _d_vector_j;
-  // CHECK-NEXT:     output[0] = _t0 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = (_d_vector_i * i + i * _d_vector_i) * j + _t0 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[0] = _t0 * j;
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     (*_d_vector_output)[1] = (_d_vector_i * j + i * _d_vector_j) * j + _t1 * _d_vector_j;
-  // CHECK-NEXT:     output[1] = _t1 * j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (_d_vector_i * j + i * _d_vector_j) * j + _t1 * _d_vector_j;
+  // CHECK-NEXT:     _clad_out_output[1] = _t1 * j;
   // CHECK-NEXT: }
 
-  auto lambdaWithCapture = [&](double i, double jj, double *output) {
-    output[0] = x*i*i*jj;
-    output[1] = y*i*jj*jj;
+  auto lambdaWithCapture = [&](double i, double jj, double *_clad_out_output) {
+    _clad_out_output[0] = x*i*i*jj;
+    _clad_out_output[1] = y*i*jj*jj;
   };
 
-// CHECK: inline void operator_call_jac(double i, double jj, double *output, clad::matrix<double> *_d_vector_output) const {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{2U|2UL|2ULL}};
+// CHECK: inline void operator_call_jac(double i, double jj, double *_clad_out_output, clad::matrix<double> *_d_vector__clad_out_output) const {
+// CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_jj = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-// CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     double _t0 = x * i;
 // CHECK-NEXT:     double _t1 = _t0 * i;
-// CHECK-NEXT:     (*_d_vector_output)[0] = ((0. * i + x * _d_vector_i) * i + _t0 * _d_vector_i) * jj + _t1 * _d_vector_jj;
-// CHECK-NEXT:     output[0] = _t1 * jj;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0. * i + x * _d_vector_i) * i + _t0 * _d_vector_i) * jj + _t1 * _d_vector_jj;
+// CHECK-NEXT:     _clad_out_output[0] = _t1 * jj;
 // CHECK-NEXT:     double _t2 = y * i;
 // CHECK-NEXT:     double _t3 = _t2 * jj;
-// CHECK-NEXT:     (*_d_vector_output)[1] = ((0. * i + y * _d_vector_i) * jj + _t2 * _d_vector_jj) * jj + _t3 * _d_vector_jj;
-// CHECK-NEXT:     output[1] = _t3 * jj;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((0. * i + y * _d_vector_i) * jj + _t2 * _d_vector_jj) * jj + _t3 * _d_vector_jj;
+// CHECK-NEXT:     _clad_out_output[1] = _t3 * jj;
 // CHECK-NEXT: }
 
   auto lambdaNNS = outer::inner::lambdaNNS;

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -6,58 +6,58 @@
 #include "clad/Differentiator/Differentiator.h"
 #include <cmath>
 
-void f_1(double a, double b, double c, double output[]) {
-  output[0] = a * a * a;
-  output[1] = a * a * a + b * b * b;
-  output[2] = c * c * 10 - a * a;
+void f_1(double a, double b, double c, double _clad_out_output[]) {
+  _clad_out_output[0] = a * a * a;
+  _clad_out_output[1] = a * a * a + b * b * b;
+  _clad_out_output[2] = c * c * 10 - a * a;
 }
 
-// CHECK: void f_1_jac(double a, double b, double c, double output[], clad::matrix<double> *_d_vector_output) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{3U|3UL|3ULL}};
+// CHECK: void f_1_jac(double a, double b, double c, double _clad_out_output[], clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{3U|3UL|3ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_a = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_b = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_c = clad::one_hot_vector(indepVarCount, {{2U|2UL|2ULL}});
-// CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{3U|3UL|3ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{3U|3UL|3ULL}});
 // CHECK-NEXT:     double _t0 = a * a;
-// CHECK-NEXT:     (*_d_vector_output)[0] = (_d_vector_a * a + a * _d_vector_a) * a + _t0 * _d_vector_a;
-// CHECK-NEXT:     output[0] = _t0 * a;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = (_d_vector_a * a + a * _d_vector_a) * a + _t0 * _d_vector_a;
+// CHECK-NEXT:     _clad_out_output[0] = _t0 * a;
 // CHECK-NEXT:     double _t1 = a * a;
 // CHECK-NEXT:     double _t2 = b * b;
-// CHECK-NEXT:     (*_d_vector_output)[1] = (_d_vector_a * a + a * _d_vector_a) * a + _t1 * _d_vector_a + (_d_vector_b * b + b * _d_vector_b) * b + _t2 * _d_vector_b;
-// CHECK-NEXT:     output[1] = _t1 * a + _t2 * b;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (_d_vector_a * a + a * _d_vector_a) * a + _t1 * _d_vector_a + (_d_vector_b * b + b * _d_vector_b) * b + _t2 * _d_vector_b;
+// CHECK-NEXT:     _clad_out_output[1] = _t1 * a + _t2 * b;
 // CHECK-NEXT:     double _t3 = c * c;
-// CHECK-NEXT:     (*_d_vector_output)[2] = (_d_vector_c * c + c * _d_vector_c) * 10 + _t3 * (clad::zero_vector(indepVarCount)) - (_d_vector_a * a + a * _d_vector_a);
-// CHECK-NEXT:     output[2] = _t3 * 10 - a * a;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[2] = (_d_vector_c * c + c * _d_vector_c) * 10 + _t3 * (clad::zero_vector(indepVarCount)) - (_d_vector_a * a + a * _d_vector_a);
+// CHECK-NEXT:     _clad_out_output[2] = _t3 * 10 - a * a;
 // CHECK-NEXT: }
 
-void f_3(double x, double y, double z, double *_result) {
+void f_3(double x, double y, double z, double *_clad_out__result) {
   double constant = 42;
 
-  _result[0] = sin(x) * constant;
-  _result[1] = sin(y) * constant;
-  _result[2] = sin(z) * constant;
+  _clad_out__result[0] = sin(x) * constant;
+  _clad_out__result[1] = sin(y) * constant;
+  _clad_out__result[2] = sin(z) * constant;
 }
 
-// CHECK: void f_3_jac(double x, double y, double z, double *_result, clad::matrix<double> *_d_vector__result) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector__result->rows() + {{3U|3UL|3ULL}};
+// CHECK: void f_3_jac(double x, double y, double z, double *_clad_out__result, clad::matrix<double> *_d_vector__clad_out__result) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{3U|3UL|3ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_z = clad::one_hot_vector(indepVarCount, {{2U|2UL|2ULL}});
-// CHECK-NEXT:     *_d_vector__result = clad::identity_matrix(_d_vector__result->rows(), indepVarCount, {{3U|3UL|3ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out__result = clad::identity_matrix(_d_vector__clad_out__result->rows(), indepVarCount, {{3U|3UL|3ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_constant(clad::zero_vector(indepVarCount)); 
 // CHECK-NEXT:     double constant = 42;
 // CHECK-NEXT:     {{.*}} _t0 = clad::custom_derivatives::sin_pushforward(x, _d_vector_x);
 // CHECK-NEXT:     double &_t1 = _t0.value;
-// CHECK-NEXT:     (*_d_vector__result)[0] = _t0.pushforward * constant + _t1 * _d_vector_constant;
-// CHECK-NEXT:     _result[0] = _t1 * constant;
+// CHECK-NEXT:     (*_d_vector__clad_out__result)[0] = _t0.pushforward * constant + _t1 * _d_vector_constant;
+// CHECK-NEXT:     _clad_out__result[0] = _t1 * constant;
 // CHECK-NEXT:     {{.*}} _t2 = clad::custom_derivatives::sin_pushforward(y, _d_vector_y);
 // CHECK-NEXT:     double &_t3 = _t2.value;
-// CHECK-NEXT:     (*_d_vector__result)[1] = _t2.pushforward * constant + _t3 * _d_vector_constant;
-// CHECK-NEXT:     _result[1] = _t3 * constant;
+// CHECK-NEXT:     (*_d_vector__clad_out__result)[1] = _t2.pushforward * constant + _t3 * _d_vector_constant;
+// CHECK-NEXT:     _clad_out__result[1] = _t3 * constant;
 // CHECK-NEXT:     {{.*}} _t4 = clad::custom_derivatives::sin_pushforward(z, _d_vector_z);
 // CHECK-NEXT:     double &_t5 = _t4.value;
-// CHECK-NEXT:     (*_d_vector__result)[2] = _t4.pushforward * constant + _t5 * _d_vector_constant;
-// CHECK-NEXT:     _result[2] = _t5 * constant;
+// CHECK-NEXT:     (*_d_vector__clad_out__result)[2] = _t4.pushforward * constant + _t5 * _d_vector_constant;
+// CHECK-NEXT:     _clad_out__result[2] = _t5 * constant;
 // CHECK-NEXT: }
 
 double multiply(double x, double y) { return x * y; }
@@ -67,89 +67,89 @@ double multiply(double x, double y) { return x * y; }
 // CHECK-NEXT:     return {x * y, _d_x * y + x * _d_y};
 // CHECK-NEXT: }
 
-void f_4(double x, double y, double z, double *_result) {
+void f_4(double x, double y, double z, double *_clad_out__result) {
   double constant = 42;
 
-  _result[0] = multiply(x, y) * constant;
-  _result[1] = multiply(y, z) * constant;
-  _result[2] = multiply(z, x) * constant;
+  _clad_out__result[0] = multiply(x, y) * constant;
+  _clad_out__result[1] = multiply(y, z) * constant;
+  _clad_out__result[2] = multiply(z, x) * constant;
 }
 
-// CHECK: void f_4_jac(double x, double y, double z, double *_result, clad::matrix<double> *_d_vector__result) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector__result->rows() + {{3U|3UL|3ULL}};
+// CHECK: void f_4_jac(double x, double y, double z, double *_clad_out__result, clad::matrix<double> *_d_vector__clad_out__result) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{3U|3UL|3ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_z = clad::one_hot_vector(indepVarCount, {{2U|2UL|2ULL}});
-// CHECK-NEXT:     *_d_vector__result = clad::identity_matrix(_d_vector__result->rows(), indepVarCount, {{3U|3UL|3ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out__result = clad::identity_matrix(_d_vector__clad_out__result->rows(), indepVarCount, {{3U|3UL|3ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_constant(clad::zero_vector(indepVarCount)); 
 // CHECK-NEXT:     double constant = 42;
 // CHECK-NEXT:     clad::ValueAndPushforward<double, clad::array<double> > _t0 = multiply_vector_pushforward(x, y, _d_vector_x, _d_vector_y);
 // CHECK-NEXT:     double &_t1 = _t0.value;
-// CHECK-NEXT:     (*_d_vector__result)[0] = _t0.pushforward * constant + _t1 * _d_vector_constant;
-// CHECK-NEXT:     _result[0] = _t1 * constant;
+// CHECK-NEXT:     (*_d_vector__clad_out__result)[0] = _t0.pushforward * constant + _t1 * _d_vector_constant;
+// CHECK-NEXT:     _clad_out__result[0] = _t1 * constant;
 // CHECK-NEXT:     clad::ValueAndPushforward<double, clad::array<double> > _t2 = multiply_vector_pushforward(y, z, _d_vector_y, _d_vector_z);
 // CHECK-NEXT:     double &_t3 = _t2.value;
-// CHECK-NEXT:     (*_d_vector__result)[1] = _t2.pushforward * constant + _t3 * _d_vector_constant;
-// CHECK-NEXT:     _result[1] = _t3 * constant;
+// CHECK-NEXT:     (*_d_vector__clad_out__result)[1] = _t2.pushforward * constant + _t3 * _d_vector_constant;
+// CHECK-NEXT:     _clad_out__result[1] = _t3 * constant;
 // CHECK-NEXT:     clad::ValueAndPushforward<double, clad::array<double> > _t4 = multiply_vector_pushforward(z, x, _d_vector_z, _d_vector_x);
 // CHECK-NEXT:     double &_t5 = _t4.value;
-// CHECK-NEXT:     (*_d_vector__result)[2] = _t4.pushforward * constant + _t5 * _d_vector_constant;
-// CHECK-NEXT:     _result[2] = _t5 * constant;
+// CHECK-NEXT:     (*_d_vector__clad_out__result)[2] = _t4.pushforward * constant + _t5 * _d_vector_constant;
+// CHECK-NEXT:     _clad_out__result[2] = _t5 * constant;
 // CHECK-NEXT: }
 
-// CHECK: void f_1_jac_0(double a, double b, double c, double output[], clad::matrix<double> *_d_vector_output) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{3U|3UL|3ULL}};
+// CHECK: void f_1_jac_0(double a, double b, double c, double _clad_out_output[], clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{3U|3UL|3ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_a = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_b = clad::zero_vector(indepVarCount);
 // CHECK-NEXT:     clad::array<double> _d_vector_c = clad::zero_vector(indepVarCount);
 // CHECK-NEXT:     double _t0 = a * a;
-// CHECK-NEXT:     (*_d_vector_output)[0] = (_d_vector_a * a + a * _d_vector_a) * a + _t0 * _d_vector_a;
-// CHECK-NEXT:     output[0] = _t0 * a;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = (_d_vector_a * a + a * _d_vector_a) * a + _t0 * _d_vector_a;
+// CHECK-NEXT:     _clad_out_output[0] = _t0 * a;
 // CHECK-NEXT:     double _t1 = a * a;
 // CHECK-NEXT:     double _t2 = b * b;
-// CHECK-NEXT:     (*_d_vector_output)[1] = (_d_vector_a * a + a * _d_vector_a) * a + _t1 * _d_vector_a + (_d_vector_b * b + b * _d_vector_b) * b + _t2 * _d_vector_b;
-// CHECK-NEXT:     output[1] = _t1 * a + _t2 * b;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (_d_vector_a * a + a * _d_vector_a) * a + _t1 * _d_vector_a + (_d_vector_b * b + b * _d_vector_b) * b + _t2 * _d_vector_b;
+// CHECK-NEXT:     _clad_out_output[1] = _t1 * a + _t2 * b;
 // CHECK-NEXT:     double _t3 = c * c;
-// CHECK-NEXT:     (*_d_vector_output)[2] = (_d_vector_c * c + c * _d_vector_c) * 10 + _t3 * (clad::zero_vector(indepVarCount)) - (_d_vector_a * a + a * _d_vector_a);
-// CHECK-NEXT:     output[2] = _t3 * 10 - a * a;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[2] = (_d_vector_c * c + c * _d_vector_c) * 10 + _t3 * (clad::zero_vector(indepVarCount)) - (_d_vector_a * a + a * _d_vector_a);
+// CHECK-NEXT:     _clad_out_output[2] = _t3 * 10 - a * a;
 // CHECK-NEXT: }
 
-void f_5(float a, double output[]){
-  output[1]=a;
-  output[0]=a*a;  
+void f_5(float a, double _clad_out_output[]){
+  _clad_out_output[1]=a;
+  _clad_out_output[0]=a*a;  
 }
 
-// CHECK: void f_5_jac(float a, double output[], clad::matrix<double> *_d_vector_output) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{1U|1UL|1ULL}};
+// CHECK: void f_5_jac(float a, double _clad_out_output[], clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{1U|1UL|1ULL}};
 // CHECK-NEXT:     clad::array<float> _d_vector_a = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
-// CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{1U|1UL|1ULL}});
-// CHECK-NEXT:     (*_d_vector_output)[1] = _d_vector_a;
-// CHECK-NEXT:     output[1] = a;
-// CHECK-NEXT:     (*_d_vector_output)[0] = _d_vector_a * a + a * _d_vector_a;
-// CHECK-NEXT:     output[0] = a * a;
+// CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{1U|1UL|1ULL}});
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = _d_vector_a;
+// CHECK-NEXT:     _clad_out_output[1] = a;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = _d_vector_a * a + a * _d_vector_a;
+// CHECK-NEXT:     _clad_out_output[0] = a * a;
 // CHECK-NEXT: }
 
-void f_6(double a[3], double b, double output[]) {
-    output[0] = a[0] * a[0] * a[0];
-    output[1] = a[0] * a[0] * a[0] + b * b * b;
-    output[2] = 2 * (a[0] + b);
+void f_6(double a[2], double b, double _clad_out_output[]) {
+    _clad_out_output[0] = a[0] * a[0] * a[0];
+    _clad_out_output[1] = a[0] * a[0] * a[0] + b * b * b;
+    _clad_out_output[2] = 2 * (a[0] + b);
 }
 
-// CHECK: void f_6_jac(double a[3], double b, double output[], clad::matrix<double> *_d_vector_a, clad::matrix<double> *_d_vector_output) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_a->rows() + _d_vector_output->rows() + {{1U|1UL|1ULL}};
+// CHECK: void f_6_jac(double a[2], double b, double _clad_out_output[], clad::matrix<double> *_d_vector_a, clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_a->rows() + {{1U|1UL|1ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_b = clad::one_hot_vector(indepVarCount, _d_vector_a->rows());
 // CHECK-NEXT:     *_d_vector_a = clad::identity_matrix(_d_vector_a->rows(), indepVarCount, {{0U|0UL|0ULL}});
-// CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, _d_vector_a->rows() + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, _d_vector_a->rows() + {{1U|1UL|1ULL}});
 // CHECK-NEXT:     double _t0 = a[0] * a[0];
-// CHECK-NEXT:     (*_d_vector_output)[0] = (((*_d_vector_a)[0]) * a[0] + a[0] * ((*_d_vector_a)[0])) * a[0] + _t0 * ((*_d_vector_a)[0]);
-// CHECK-NEXT:     output[0] = _t0 * a[0];
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = (((*_d_vector_a)[0]) * a[0] + a[0] * ((*_d_vector_a)[0])) * a[0] + _t0 * ((*_d_vector_a)[0]);
+// CHECK-NEXT:     _clad_out_output[0] = _t0 * a[0];
 // CHECK-NEXT:     double _t1 = a[0] * a[0];
 // CHECK-NEXT:     double _t2 = b * b;
-// CHECK-NEXT:     (*_d_vector_output)[1] = (((*_d_vector_a)[0]) * a[0] + a[0] * ((*_d_vector_a)[0])) * a[0] + _t1 * ((*_d_vector_a)[0]) + (_d_vector_b * b + b * _d_vector_b) * b + _t2 * _d_vector_b;
-// CHECK-NEXT:     output[1] = _t1 * a[0] + _t2 * b;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (((*_d_vector_a)[0]) * a[0] + a[0] * ((*_d_vector_a)[0])) * a[0] + _t1 * ((*_d_vector_a)[0]) + (_d_vector_b * b + b * _d_vector_b) * b + _t2 * _d_vector_b;
+// CHECK-NEXT:     _clad_out_output[1] = _t1 * a[0] + _t2 * b;
 // CHECK-NEXT:     double _t3 = (a[0] + b);
-// CHECK-NEXT:     (*_d_vector_output)[2] = (clad::zero_vector(indepVarCount)) * _t3 + 2 * ((*_d_vector_a)[0] + _d_vector_b);
-// CHECK-NEXT:     output[2] = 2 * _t3;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[2] = (clad::zero_vector(indepVarCount)) * _t3 + 2 * ((*_d_vector_a)[0] + _d_vector_b);
+// CHECK-NEXT:     _clad_out_output[2] = 2 * _t3;
 // CHECK-NEXT: }
 
 void f_7(double a, double& b, double&c) {
@@ -168,62 +168,82 @@ void f_7(double a, double& b, double&c) {
 // CHECK-NEXT:     c = -5 * b;
 // CHECK-NEXT: }
 
-void f_8(double a, double b, double output[]) {
+void f_8(double a, double b, double _clad_out_output[]) {
   double a3 = a * a * a;
-  output[0] = a3;
-  output[1] = a3 + b * b * b;
-  output[2] = 2 * (a + b);
+  _clad_out_output[0] = a3;
+  _clad_out_output[1] = a3 + b * b * b;
+  _clad_out_output[2] = 2 * (a + b);
 }
 
-// CHECK: void f_8_jac(double a, double b, double output[], clad::matrix<double> *_d_vector_output) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + 2UL;
-// CHECK-NEXT:     clad::array<double> _d_vector_a = clad::one_hot_vector(indepVarCount, 0UL);
-// CHECK-NEXT:     clad::array<double> _d_vector_b = clad::one_hot_vector(indepVarCount, 1UL);
-// CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, 2UL);
+// CHECK: void f_8_jac(double a, double b, double _clad_out_output[], clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
+// CHECK-NEXT:     clad::array<double> _d_vector_a = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:     clad::array<double> _d_vector_b = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, 2UL);
 // CHECK-NEXT:     double _t0 = a * a;
 // CHECK-NEXT:     clad::array<double> _d_vector_a3((_d_vector_a * a + a * _d_vector_a) * a + _t0 * _d_vector_a);
 // CHECK-NEXT:     double a3 = _t0 * a;
-// CHECK-NEXT:     (*_d_vector_output)[0] = _d_vector_a3;
-// CHECK-NEXT:     output[0] = a3;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = _d_vector_a3;
+// CHECK-NEXT:     _clad_out_output[0] = a3;
 // CHECK-NEXT:     double _t1 = b * b;
-// CHECK-NEXT:     (*_d_vector_output)[1] = _d_vector_a3 + (_d_vector_b * b + b * _d_vector_b) * b + _t1 * _d_vector_b;
-// CHECK-NEXT:     output[1] = a3 + _t1 * b;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = _d_vector_a3 + (_d_vector_b * b + b * _d_vector_b) * b + _t1 * _d_vector_b;
+// CHECK-NEXT:     _clad_out_output[1] = a3 + _t1 * b;
 // CHECK-NEXT:     double _t2 = (a + b);
-// CHECK-NEXT:     (*_d_vector_output)[2] = (clad::zero_vector(indepVarCount)) * _t2 + 2 * (_d_vector_a + _d_vector_b);
-// CHECK-NEXT:     output[2] = 2 * _t2;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[2] = (clad::zero_vector(indepVarCount)) * _t2 + 2 * (_d_vector_a + _d_vector_b);
+// CHECK-NEXT:     _clad_out_output[2] = 2 * _t2;
 // CHECK-NEXT: }
 
-void f_9(float a, double output[]){
-  output[0]=a*a;  
-  output[1]=output[0]*3;
+void f_9(float a, double _clad_out_output[]){
+  _clad_out_output[0]= a * a;  
+  _clad_out_output[1] = _clad_out_output[0] * 3;
 }
 
-// CHECK: void f_9_jac(float a, double output[], clad::matrix<double> *_d_vector_output) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + 1UL;
-// CHECK-NEXT:     clad::array<float> _d_vector_a = clad::one_hot_vector(indepVarCount, 0UL);
-// CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, 1UL);
-// CHECK-NEXT:     (*_d_vector_output)[0] = _d_vector_a * a + a * _d_vector_a;
-// CHECK-NEXT:     output[0] = a * a;
-// CHECK-NEXT:     (*_d_vector_output)[1] = ((*_d_vector_output)[0]) * 3 + output[0] * (clad::zero_vector(indepVarCount));
-// CHECK-NEXT:     output[1] = output[0] * 3;
+// CHECK: void f_9_jac(float a, double _clad_out_output[], clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{1U|1UL|1ULL}};
+// CHECK-NEXT:     clad::array<float> _d_vector_a = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount,  {{1U|1UL|1ULL}});
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = _d_vector_a * a + a * _d_vector_a;
+// CHECK-NEXT:     _clad_out_output[0] = a * a;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((*_d_vector__clad_out_output)[0]) * 3 + _clad_out_output[0] * (clad::zero_vector(indepVarCount));
+// CHECK-NEXT:     _clad_out_output[1] = _clad_out_output[0] * 3;
 // CHECK-NEXT: }
 
-void f_10(float a, double output[]){
-  output[0]=a*a;  
-  output[1]=output[0];
+void f_10(float a, double _clad_out_output[]){
+  _clad_out_output[0]= a * a;  
+  _clad_out_output[1] = _clad_out_output[0];
 }
 
-// CHECK: void f_10_jac(float a, double output[], clad::matrix<double> *_d_vector_output) {
-// CHECK-NEXT:    unsigned long indepVarCount = _d_vector_output->rows() + 1UL;
+// CHECK: void f_10_jac(float a, double _clad_out_output[], clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:    unsigned long indepVarCount = 1UL;
 // CHECK-NEXT:    clad::array<float> _d_vector_a = clad::one_hot_vector(indepVarCount, 0UL);
-// CHECK-NEXT:    *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, 1UL);
-// CHECK-NEXT:    (*_d_vector_output)[0] = _d_vector_a * a + a * _d_vector_a;
-// CHECK-NEXT:    output[0] = a * a;
-// CHECK-NEXT:   (*_d_vector_output)[1] = (*_d_vector_output)[0];
-// CHECK-NEXT:    output[1] = output[0];
+// CHECK-NEXT:    *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, 1UL);
+// CHECK-NEXT:    (*_d_vector__clad_out_output)[0] = _d_vector_a * a + a * _d_vector_a;
+// CHECK-NEXT:    _clad_out_output[0] = a * a;
+// CHECK-NEXT:   (*_d_vector__clad_out_output)[1] = (*_d_vector__clad_out_output)[0];
+// CHECK-NEXT:    _clad_out_output[1] = _clad_out_output[0];
 // CHECK-NEXT:}
 
-#define TEST(F, ...) { \
+void f_11(double a[2], double b[1], double _clad_out_output[]) {
+    _clad_out_output[0] = a[0] * a[1];
+    _clad_out_output[1] = a[0] * a[0] + b[0];
+    _clad_out_output[2] = 2 * (a[0] + b[0]);
+}
+
+// CHECK: void f_11_jac(double a[2], double b[1], double _clad_out_output[], clad::matrix<double> *_d_vector_a, clad::matrix<double> *_d_vector_b, clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:    unsigned long indepVarCount = _d_vector_a->rows() + _d_vector_b->rows();
+// CHECK-NEXT:    *_d_vector_a = clad::identity_matrix(_d_vector_a->rows(), indepVarCount, 0UL);
+// CHECK-NEXT:    *_d_vector_b = clad::identity_matrix(_d_vector_b->rows(), indepVarCount, _d_vector_a->rows());
+// CHECK-NEXT:    *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, _d_vector_a->rows() + _d_vector_b->rows());
+// CHECK-NEXT:    (*_d_vector__clad_out_output)[0] = ((*_d_vector_a)[0]) * a[1] + a[0] * ((*_d_vector_a)[1]);
+// CHECK-NEXT:    _clad_out_output[0] = a[0] * a[1];
+// CHECK-NEXT:    (*_d_vector__clad_out_output)[1] = ((*_d_vector_a)[0]) * a[0] + a[0] * ((*_d_vector_a)[0]) + (*_d_vector_b)[0];
+// CHECK-NEXT:    _clad_out_output[1] = a[0] * a[0] + b[0];
+// CHECK-NEXT:    double _t0 = (a[0] + b[0]);
+// CHECK-NEXT:    (*_d_vector__clad_out_output)[2] = (clad::zero_vector(indepVarCount)) * _t0 + 2 * ((*_d_vector_a)[0] + (*_d_vector_b)[0]);
+// CHECK-NEXT:    _clad_out_output[2] = 2 * _t0;
+// CHECK-NEXT:}
+
+#define TEST9(F, ...) { \
   outputarr[0] = 0; outputarr[1] = 1; outputarr[2] = 0;\
   auto j = clad::jacobian(F);\
   j.execute(__VA_ARGS__, &result);\
@@ -231,6 +251,16 @@ void f_10(float a, double output[]){
   result[0][0], result[0][1], result[0][2],\
   result[1][0], result[1][1], result[1][2],\
   result[2][0], result[2][1], result[2][2]);\
+}
+
+#define TEST6(F, ...) { \
+  outputarr6[0] = 0; outputarr6[1] = 1; outputarr6[2] = 0;\
+  auto j = clad::jacobian(F);\
+  j.execute(__VA_ARGS__, &result);\
+  printf("Result is = {%.2f, %.2f, %.2f, %.2f, %.2f, %.2f}\n",\
+  result[0][0], result[0][1],\
+  result[1][0], result[1][1],\
+  result[2][0], result[2][1]);\
 }
 
 #define TEST_F_1_SINGLE_PARAM(x, y, z) { \
@@ -245,18 +275,19 @@ void f_10(float a, double output[]){
 int main() {
   clad::matrix<double> result (3, 3);
   double outputarr[9];
-  TEST(f_1, 1, 2, 3, outputarr); // CHECK-EXEC: Result is = {3.00, 0.00, 0.00, 3.00, 12.00, 0.00, -2.00, 0.00, 60.00}
-  TEST(f_3, 1, 2, 3, outputarr); // CHECK-EXEC: Result is = {22.69, 0.00, 0.00, 0.00, -17.48, 0.00, 0.00, 0.00, -41.58}
-  TEST(f_4, 1, 2, 3, outputarr); // CHECK-EXEC: Result is = {84.00, 42.00, 0.00, 0.00, 126.00, 84.00, 126.00, 0.00, 42.00}
+  double outputarr6[6];
+  TEST9(f_1, 1, 2, 3, outputarr); // CHECK-EXEC: Result is = {3.00, 0.00, 0.00, 3.00, 12.00, 0.00, -2.00, 0.00, 60.00}
+  TEST9(f_3, 1, 2, 3, outputarr); // CHECK-EXEC: Result is = {22.69, 0.00, 0.00, 0.00, -17.48, 0.00, 0.00, 0.00, -41.58}
+  TEST9(f_4, 1, 2, 3, outputarr); // CHECK-EXEC: Result is = {84.00, 42.00, 0.00, 0.00, 126.00, 84.00, 126.00, 0.00, 42.00}
   TEST_F_1_SINGLE_PARAM(1, 2, 3); // CHECK-EXEC: Result is = {3.00, 3.00, -2.00}
 
   auto df5 = clad::jacobian(f_5);
   df5.execute(3, outputarr, &result);
   printf("Result is = {%.2f, %.2f}\n", result[0][0], result[1][0]); // CHECK-EXEC: Result is = {6.00, 1.00}
   
-  double a[] = {3, 1};
-  clad::matrix<double> da (2, 5);
-  TEST(f_6, a, 2, outputarr, &da); // CHECK-EXEC: Result is = {27.00, 0.00, 0.00, 27.00, 0.00, 12.00, 2.00, 0.00, 2.00}
+  double a6[] = {3, 1};
+  clad::matrix<double> da (2, 1);
+  TEST9(f_6, a6, 2, outputarr, &da); // CHECK-EXEC: Result is = {27.00, 0.00, 0.00, 27.00, 0.00, 12.00, 2.00, 0.00, 2.00}
 
   auto df7 = clad::jacobian(f_7);
   clad::array<double> db, dc;
@@ -264,7 +295,7 @@ int main() {
   df7.execute(a7, b, c, &db, &dc);
   printf("Result is = {%.2f, %.2f}\n", db[0], dc[0]); // CHECK-EXEC: Result is = {3.00, -15.00}
 
-  TEST(f_8, 4, -3, outputarr); // CHECK-EXEC: Result is = {48.00, 0.00, 0.00, 48.00, 27.00, 0.00, 2.00, 2.00, 0.00} 
+  TEST6(f_8, 4, -3, outputarr6); // CHECK-EXEC: Result is = {48.00, 0.00, 48.00, 27.00, 2.00, 2.00} 
 
   auto df9 = clad::jacobian(f_9);
   df9.execute(3, outputarr, &result);
@@ -273,4 +304,10 @@ int main() {
   auto df10 = clad::jacobian(f_10);
   df10.execute(3, outputarr, &result);
   printf("Result is = {%.2f, %.2f}\n", result[0][0], result[1][0]); // CHECK-EXEC: Result is = {6.00, 6.00}
+                                                                
+  double a11[] = {3, 1};
+  double b11[] = {1};
+  clad::matrix<double> da11 (3, 3);
+  clad::matrix<double> db11 (1, 1);
+  TEST9(f_11, a11, b11, outputarr, &da11, &db11); // CHECK-EXEC: Result is = {1.00, 3.00, 0.00, 6.00, 0.00, 0.00, 2.00, 0.00, 0.00}
 }

--- a/test/Jacobian/Pointers.C
+++ b/test/Jacobian/Pointers.C
@@ -1,28 +1,28 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oPointers.out 2>&1 | %filecheck %s
-// RUN: ./Pointers.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oPointers.out
-// RUN: ./Pointers.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oPointers._clad_out_out 2>&1 | %filecheck %s
+// RUN: ./Pointers._clad_out_out | %filecheck_exec %s
+// RUN: %cladclang %s -I%S/../../include -oPointers._clad_out_out
+// RUN: ./Pointers._clad_out_out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
 
-void nonMemFn(double i, double j, double* out) {
-  out[0] = i;
-  out[1] = j;
+void nonMemFn(double i, double j, double* _clad_out_out) {
+  _clad_out_out[0] = i;
+  _clad_out_out[1] = j;
 }
 
-// CHECK: void nonMemFn_jac(double i, double j, double *out, clad::matrix<double> *_d_vector_out) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_out->rows() + {{2U|2UL|2ULL}};
+// CHECK: void nonMemFn_jac(double i, double j, double *_clad_out_out, clad::matrix<double> *_d_vector__clad_out_out) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-// CHECK-NEXT:     *_d_vector_out = clad::identity_matrix(_d_vector_out->rows(), indepVarCount, {{2U|2UL|2ULL}});
-// CHECK-NEXT:     (*_d_vector_out)[0] = _d_vector_i;
-// CHECK-NEXT:     out[0] = i;
-// CHECK-NEXT:     (*_d_vector_out)[1] = _d_vector_j;
-// CHECK-NEXT:     out[1] = j;
+// CHECK-NEXT:     *_d_vector__clad_out_out = clad::identity_matrix(_d_vector__clad_out_out->rows(), indepVarCount, {{2U|2UL|2ULL}});
+// CHECK-NEXT:     (*_d_vector__clad_out_out)[0] = _d_vector_i;
+// CHECK-NEXT:     _clad_out_out[0] = i;
+// CHECK-NEXT:     (*_d_vector__clad_out_out)[1] = _d_vector_j;
+// CHECK-NEXT:     _clad_out_out[1] = j;
 // CHECK-NEXT: }
 
 #define NON_MEM_FN_TEST(var)\
-var.execute(5, 7, out, &res);\
+var.execute(5, 7, _clad_out_out, &res);\
 printf("{%.2f %.2f %.2f %.2f}\n", res[0][0], res[0][1],\
                                   res[1][0], res[1][1]);
 
@@ -31,7 +31,7 @@ int main() {
   auto nonMemFnPtrToPtr = &nonMemFnPtr;
 
   clad::matrix<double> res(2, 2);
-  double out[2];
+  double _clad_out_out[2];
   auto d_nonMemFn = clad::jacobian(nonMemFn);
   auto d_nonMemFnPar = clad::jacobian((nonMemFn));
   auto d_nonMemFnPtr = clad::jacobian(nonMemFnPtr);

--- a/test/Jacobian/TemplateFunctors.C
+++ b/test/Jacobian/TemplateFunctors.C
@@ -8,63 +8,63 @@
 template <typename T> struct Experiment {
   mutable T x, y;
   Experiment(T p_x, T p_y) : x(p_x), y(p_y) {}
-  void operator()(T i, T j, T *output) {
-    output[0] = x*y*i*j;
-    output[1] = 2*x*y*i*j;
+  void operator()(T i, T j, T *_clad_out_output) {
+    _clad_out_output[0] = x*y*i*j;
+    _clad_out_output[1] = 2*x*y*i*j;
   }
   void setX(T val) { x = val; }
 };
 
-// CHECK: void operator_call_jac(double i, double j, double *output, clad::matrix<double> *_d_vector_output) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{2U|2UL|2ULL}};
+// CHECK: void operator_call_jac(double i, double j, double *_clad_out_output, clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-// CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     double &_t0 = this->x;
 // CHECK-NEXT:     double &_t1 = this->y;
 // CHECK-NEXT:     double _t2 = _t0 * _t1;
 // CHECK-NEXT:     double _t3 = _t2 * i;
-// CHECK-NEXT:     (*_d_vector_output)[0] = ((0 * _t1 + _t0 * 0) * i + _t2 * _d_vector_i) * j + _t3 * _d_vector_j;
-// CHECK-NEXT:     output[0] = _t3 * j;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0 * _t1 + _t0 * 0) * i + _t2 * _d_vector_i) * j + _t3 * _d_vector_j;
+// CHECK-NEXT:     _clad_out_output[0] = _t3 * j;
 // CHECK-NEXT:     double &_t4 = this->x;
 // CHECK-NEXT:     double _t5 = 2 * _t4;
 // CHECK-NEXT:     double &_t6 = this->y;
 // CHECK-NEXT:     double _t7 = _t5 * _t6;
 // CHECK-NEXT:     double _t8 = _t7 * i;
-// CHECK-NEXT:     (*_d_vector_output)[1] = ((((clad::zero_vector(indepVarCount)) * _t4 + 2 * 0) * _t6 + _t5 * 0) * i + _t7 * _d_vector_i) * j + _t8 * _d_vector_j;
-// CHECK-NEXT:     output[1] = _t8 * j;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((((clad::zero_vector(indepVarCount)) * _t4 + 2 * 0) * _t6 + _t5 * 0) * i + _t7 * _d_vector_i) * j + _t8 * _d_vector_j;
+// CHECK-NEXT:     _clad_out_output[1] = _t8 * j;
 // CHECK-NEXT: }
 
 template <> struct Experiment<long double> {
   mutable long double x, y;
   Experiment(long double p_x, long double p_y) : x(p_x), y(p_y) {}
-  void operator()(long double i, long double j, long double *output) {
-    output[0] = x*y*i*i*j;
-    output[1] = 2*x*y*i*i*j;
+  void operator()(long double i, long double j, long double *_clad_out_output) {
+    _clad_out_output[0] = x*y*i*i*j;
+    _clad_out_output[1] = 2*x*y*i*i*j;
   }
   void setX(long double val) { x = val; }
 };
 
-// CHECK: void operator_call_jac(long double i, long double j, long double *output, clad::matrix<long double> *_d_vector_output) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{2U|2UL|2ULL}};
+// CHECK: void operator_call_jac(long double i, long double j, long double *_clad_out_output, clad::matrix<long double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
 // CHECK-NEXT:     clad::array<long double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<long double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-// CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     long double &_t0 = this->x;
 // CHECK-NEXT:     long double &_t1 = this->y;
 // CHECK-NEXT:     long double _t2 = _t0 * _t1;
 // CHECK-NEXT:     long double _t3 = _t2 * i;
 // CHECK-NEXT:     long double _t4 = _t3 * i;
-// CHECK-NEXT:     (*_d_vector_output)[0] = (((0 * _t1 + _t0 * 0) * i + _t2 * _d_vector_i) * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j;
-// CHECK-NEXT:     output[0] = _t4 * j;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = (((0 * _t1 + _t0 * 0) * i + _t2 * _d_vector_i) * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j;
+// CHECK-NEXT:     _clad_out_output[0] = _t4 * j;
 // CHECK-NEXT:     long double &_t5 = this->x;
 // CHECK-NEXT:     long double _t6 = 2 * _t5;
 // CHECK-NEXT:     long double &_t7 = this->y;
 // CHECK-NEXT:     long double _t8 = _t6 * _t7;
 // CHECK-NEXT:     long double _t9 = _t8 * i;
 // CHECK-NEXT:     long double _t10 = _t9 * i;
-// CHECK-NEXT:     (*_d_vector_output)[1] = (((((clad::zero_vector(indepVarCount)) * _t5 + 2 * 0) * _t7 + _t6 * 0) * i + _t8 * _d_vector_i) * i + _t9 * _d_vector_i) * j + _t10 * _d_vector_j;
-// CHECK-NEXT:     output[1] = _t10 * j;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (((((clad::zero_vector(indepVarCount)) * _t5 + 2 * 0) * _t7 + _t6 * 0) * i + _t8 * _d_vector_i) * i + _t9 * _d_vector_i) * j + _t10 * _d_vector_j;
+// CHECK-NEXT:     _clad_out_output[1] = _t10 * j;
 // CHECK-NEXT: }
 
 #define INIT(E)                                                                \
@@ -72,12 +72,12 @@ template <> struct Experiment<long double> {
   auto d_##E##Ref = clad::jacobian(E);
 
 #define TEST_DOUBLE(E, ...)                                                    \
-  output[0] = output[1] = 0;                                                   \
-  d_##E.execute(__VA_ARGS__, output, &result);                                 \
+  _clad_out_output[0] = _clad_out_output[1] = 0;                                                   \
+  d_##E.execute(__VA_ARGS__, _clad_out_output, &result);                                 \
   printf("{%.2f, %.2f, %.2f, %.2f} ", result[0][0], result[0][1],              \
                                       result[1][0], result[1][1]);             \
-  output[0] = output[1] = 0;                                                   \
-  d_##E##Ref.execute(__VA_ARGS__, output, &result);                            \
+  _clad_out_output[0] = _clad_out_output[1] = 0;                                                   \
+  d_##E##Ref.execute(__VA_ARGS__, _clad_out_output, &result);                            \
   printf("{%.2f, %.2f, %.2f, %.2f} ", result[0][0], result[0][1],              \
                                       result[1][0], result[1][1]);             
 
@@ -92,7 +92,7 @@ template <> struct Experiment<long double> {
                                       result_ld[1][0], result_ld[1][1]);             
 
 int main() {
-  double output[2];
+  double _clad_out_output[2];
   clad::matrix<double> result(2, 2);
   long double output_ld[2];
   clad::matrix<long double> result_ld(2, 2);

--- a/test/Jacobian/constexprTest.C
+++ b/test/Jacobian/constexprTest.C
@@ -11,48 +11,48 @@
   double result1[3] = {0};
   clad::matrix<double> jacobian(3, 2);
 
-constexpr void fn_mul(double i, double j, double *res) {
-   res[0] = i*i;
-   res[1] = j*j;
-   res[2] = i*j;
+constexpr void fn_mul(double i, double j, double *_clad_out_res) {
+   _clad_out_res[0] = i*i;
+   _clad_out_res[1] = j*j;
+   _clad_out_res[2] = i*j;
 }
 
-// CHECK: constexpr void fn_mul_jac(double i, double j, double *res, clad::matrix<double> *_d_vector_res) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_res->rows() + {{2U|2UL|2ULL}};
+// CHECK: constexpr void fn_mul_jac(double i, double j, double *_clad_out_res, clad::matrix<double> *_d_vector__clad_out_res) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-// CHECK-NEXT:     *_d_vector_res = clad::identity_matrix(_d_vector_res->rows(), indepVarCount, {{2U|2UL|2ULL}});
-// CHECK-NEXT:     (*_d_vector_res)[0] = _d_vector_i * i + i * _d_vector_i;
-// CHECK-NEXT:     res[0] = i * i;
-// CHECK-NEXT:     (*_d_vector_res)[1] = _d_vector_j * j + j * _d_vector_j;
-// CHECK-NEXT:     res[1] = j * j;
-// CHECK-NEXT:     (*_d_vector_res)[2] = _d_vector_i * j + i * _d_vector_j;
-// CHECK-NEXT:     res[2] = i * j;
+// CHECK-NEXT:     *_d_vector__clad_out_res = clad::identity_matrix(_d_vector__clad_out_res->rows(), indepVarCount, {{2U|2UL|2ULL}});
+// CHECK-NEXT:     (*_d_vector__clad_out_res)[0] = _d_vector_i * i + i * _d_vector_i;
+// CHECK-NEXT:     _clad_out_res[0] = i * i;
+// CHECK-NEXT:     (*_d_vector__clad_out_res)[1] = _d_vector_j * j + j * _d_vector_j;
+// CHECK-NEXT:     _clad_out_res[1] = j * j;
+// CHECK-NEXT:     (*_d_vector__clad_out_res)[2] = _d_vector_i * j + i * _d_vector_j;
+// CHECK-NEXT:     _clad_out_res[2] = i * j;
 // CHECK-NEXT: }
 
 
-constexpr void f_1(double x, double y, double z, double output[]) {
-  output[0] = x * x * x;
-  output[1] = x * y * x + y * x * x;
-  output[2] = z * x * 10 - y * z;
+constexpr void f_1(double x, double y, double z, double _clad_out_output[]) {
+  _clad_out_output[0] = x * x * x;
+  _clad_out_output[1] = x * y * x + y * x * x;
+  _clad_out_output[2] = z * x * 10 - y * z;
 }
 
-// CHECK: constexpr void f_1_jac(double x, double y, double z, double output[], clad::matrix<double> *_d_vector_output) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{3U|3UL|3ULL}};
+// CHECK: constexpr void f_1_jac(double x, double y, double z, double _clad_out_output[], clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{3U|3UL|3ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_z = clad::one_hot_vector(indepVarCount, {{2U|2UL|2ULL}});
-// CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{3U|3UL|3ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{3U|3UL|3ULL}});
 // CHECK-NEXT:     double _t0 = x * x;
-// CHECK-NEXT:     (*_d_vector_output)[0] = (_d_vector_x * x + x * _d_vector_x) * x + _t0 * _d_vector_x;
-// CHECK-NEXT:     output[0] = _t0 * x;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = (_d_vector_x * x + x * _d_vector_x) * x + _t0 * _d_vector_x;
+// CHECK-NEXT:     _clad_out_output[0] = _t0 * x;
 // CHECK-NEXT:     double _t1 = x * y;
 // CHECK-NEXT:     double _t2 = y * x;
-// CHECK-NEXT:     (*_d_vector_output)[1] = (_d_vector_x * y + x * _d_vector_y) * x + _t1 * _d_vector_x + (_d_vector_y * x + y * _d_vector_x) * x + _t2 * _d_vector_x;
-// CHECK-NEXT:     output[1] = _t1 * x + _t2 * x;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (_d_vector_x * y + x * _d_vector_y) * x + _t1 * _d_vector_x + (_d_vector_y * x + y * _d_vector_x) * x + _t2 * _d_vector_x;
+// CHECK-NEXT:     _clad_out_output[1] = _t1 * x + _t2 * x;
 // CHECK-NEXT:     double _t3 = z * x;
-// CHECK-NEXT:     (*_d_vector_output)[2] = (_d_vector_z * x + z * _d_vector_x) * 10 + _t3 * (clad::zero_vector(indepVarCount)) - (_d_vector_y * z + y * _d_vector_z); 
-// CHECK-NEXT:     output[2] = _t3 * 10 - y * z;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[2] = (_d_vector_z * x + z * _d_vector_x) * 10 + _t3 * (clad::zero_vector(indepVarCount)) - (_d_vector_y * z + y * _d_vector_z); 
+// CHECK-NEXT:     _clad_out_output[2] = _t3 * 10 - y * z;
 // CHECK-NEXT: }
 
 int main() {

--- a/test/Jacobian/testUtility.C
+++ b/test/Jacobian/testUtility.C
@@ -7,53 +7,53 @@
 
 #include "../TestUtils.h"
 
-  double output[3] = {0};
+  double _clad_out_output[3] = {0};
   double output1[3] = {0};
   clad::matrix<double> jacobian(3, 3);
 
-void fn_mul(double i, double j, double *res) {
-   res[0] = i*i;
-   res[1] = j*j;
-   res[2] = i*j;
+void fn_mul(double i, double j, double *_clad_out_res) {
+   _clad_out_res[0] = i*i;
+   _clad_out_res[1] = j*j;
+   _clad_out_res[2] = i*j;
 }
 
-// CHECK: void fn_mul_jac(double i, double j, double *res, clad::matrix<double> *_d_vector_res) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_res->rows() + {{2U|2UL|2ULL}};
+// CHECK: void fn_mul_jac(double i, double j, double *_clad_out_res, clad::matrix<double> *_d_vector__clad_out_res) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{2U|2UL|2ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
-// CHECK-NEXT:     *_d_vector_res = clad::identity_matrix(_d_vector_res->rows(), indepVarCount, {{2U|2UL|2ULL}});
-// CHECK-NEXT:     (*_d_vector_res)[0] = _d_vector_i * i + i * _d_vector_i;
-// CHECK-NEXT:     res[0] = i * i;
-// CHECK-NEXT:     (*_d_vector_res)[1] = _d_vector_j * j + j * _d_vector_j;
-// CHECK-NEXT:     res[1] = j * j;
-// CHECK-NEXT:     (*_d_vector_res)[2] = _d_vector_i * j + i * _d_vector_j;
-// CHECK-NEXT:     res[2] = i * j;
+// CHECK-NEXT:     *_d_vector__clad_out_res = clad::identity_matrix(_d_vector__clad_out_res->rows(), indepVarCount, {{2U|2UL|2ULL}});
+// CHECK-NEXT:     (*_d_vector__clad_out_res)[0] = _d_vector_i * i + i * _d_vector_i;
+// CHECK-NEXT:     _clad_out_res[0] = i * i;
+// CHECK-NEXT:     (*_d_vector__clad_out_res)[1] = _d_vector_j * j + j * _d_vector_j;
+// CHECK-NEXT:     _clad_out_res[1] = j * j;
+// CHECK-NEXT:     (*_d_vector__clad_out_res)[2] = _d_vector_i * j + i * _d_vector_j;
+// CHECK-NEXT:     _clad_out_res[2] = i * j;
 // CHECK-NEXT: }
 
 
 
-void f_1(double x, double y, double z, double output[]) {
-  output[0] = x * x * x;
-  output[1] = x * y * x + y * x * x;
-  output[2] = z * x * 10 - y * z;
+void f_1(double x, double y, double z, double _clad_out_output[]) {
+  _clad_out_output[0] = x * x * x;
+  _clad_out_output[1] = x * y * x + y * x * x;
+  _clad_out_output[2] = z * x * 10 - y * z;
 }
 
-// CHECK: void f_1_jac(double x, double y, double z, double output[], clad::matrix<double> *_d_vector_output) {
-// CHECK-NEXT:     unsigned long indepVarCount = _d_vector_output->rows() + {{3U|3UL|3ULL}};
+// CHECK: void f_1_jac(double x, double y, double z, double _clad_out_output[], clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:     unsigned long indepVarCount = {{3U|3UL|3ULL}};
 // CHECK-NEXT:     clad::array<double> _d_vector_x = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_y = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_z = clad::one_hot_vector(indepVarCount, {{2U|2UL|2ULL}});
-// CHECK-NEXT:     *_d_vector_output = clad::identity_matrix(_d_vector_output->rows(), indepVarCount, {{3U|3UL|3ULL}});
+// CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{3U|3UL|3ULL}});
 // CHECK-NEXT:     double _t0 = x * x;
-// CHECK-NEXT:     (*_d_vector_output)[0] = (_d_vector_x * x + x * _d_vector_x) * x + _t0 * _d_vector_x;
-// CHECK-NEXT:     output[0] = _t0 * x;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = (_d_vector_x * x + x * _d_vector_x) * x + _t0 * _d_vector_x;
+// CHECK-NEXT:     _clad_out_output[0] = _t0 * x;
 // CHECK-NEXT:     double _t1 = x * y;
 // CHECK-NEXT:     double _t2 = y * x;
-// CHECK-NEXT:     (*_d_vector_output)[1] = (_d_vector_x * y + x * _d_vector_y) * x + _t1 * _d_vector_x + (_d_vector_y * x + y * _d_vector_x) * x + _t2 * _d_vector_x;
-// CHECK-NEXT:     output[1] = _t1 * x + _t2 * x;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (_d_vector_x * y + x * _d_vector_y) * x + _t1 * _d_vector_x + (_d_vector_y * x + y * _d_vector_x) * x + _t2 * _d_vector_x;
+// CHECK-NEXT:     _clad_out_output[1] = _t1 * x + _t2 * x;
 // CHECK-NEXT:     double _t3 = z * x;
-// CHECK-NEXT:     (*_d_vector_output)[2] = (_d_vector_z * x + z * _d_vector_x) * 10 + _t3 * (clad::zero_vector(indepVarCount)) - (_d_vector_y * z + y * _d_vector_z); 
-// CHECK-NEXT:     output[2] = _t3 * 10 - y * z;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[2] = (_d_vector_z * x + z * _d_vector_x) * 10 + _t3 * (clad::zero_vector(indepVarCount)) - (_d_vector_y * z + y * _d_vector_z); 
+// CHECK-NEXT:     _clad_out_output[2] = _t3 * 10 - y * z;
 // CHECK-NEXT: }
 
 
@@ -61,7 +61,7 @@ int main(){
     INIT_JACOBIAN(fn_mul);
     INIT_JACOBIAN(f_1);
 
-    TEST_JACOBIAN(fn_mul, 2, 6, 3, 1, output, &jacobian); // CHECK-EXEC: {6.00, 0.00, 0.00, 2.00, 1.00, 3.00}
+    TEST_JACOBIAN(fn_mul, 2, 6, 3, 1, _clad_out_output, &jacobian); // CHECK-EXEC: {6.00, 0.00, 0.00, 2.00, 1.00, 3.00}
     TEST_JACOBIAN(f_1, 3, 9, 4, 5, 6, output1, &jacobian); // CHECK-EXEC: {48.00, 0.00, 0.00, 80.00, 32.00, 0.00, 60.00, -6.00, 35.00}
 
 }


### PR DESCRIPTION
Before this PR, we would assume that ouput parameters are inputs as well and hence create larger `one_hot_vector` arrays and `identity_matrix` matricies than needed. In this PR we assume all parameters with `_clad_out_` prefix are the output parameters. For example, the function

```cpp
void f_10(float a, double _clad_out_output[]){
  _clad_out_output[0]= a * a;  
  _clad_out_output[1] = _clad_out_output[0];
}
```
produced
```cpp
void f_10_jac(float a, double _clad_out_output[], clad::matrix<double> *_d_vector__clad_out_output) {
    unsigned long indepVarCount = _d_vector__clad_out_output->rows() + 1UL;
                                                ...
```
and after

```cpp
void f_10_jac(float a, double _clad_out_output[], clad::matrix<double> *_d_vector__clad_out_output) {
    unsigned long indepVarCount = 1UL;
                                                ...
```