### PR TITLE
Enable custom derivative lookups on the DiffPlanner stage

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -1357,7 +1357,7 @@ clamp_pushforward(const T& v, const T& lo, const T& hi, const T& d_v,
 
 template <typename T, typename U>
 CUDA_HOST_DEVICE void clamp_pullback(const T& v, const T& lo, const T& hi,
-                                     const U& d_y, T* d_v, T* d_lo, T* d_hi) {
+                                     U d_y, T* d_v, T* d_lo, T* d_hi) {
   if (v < lo)
     *d_lo += d_y;
   else if (hi < v)

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -11,6 +11,8 @@
 #include "clang/AST/Type.h"
 #include "llvm/ADT/StringRef.h"
 
+#include "DiffMode.h"
+
 #include <clang/AST/DeclCXX.h>
 #include <string>
 
@@ -318,6 +320,35 @@ namespace clad {
     ComputeMemExprPathType(clang::Sema& semaRef, clang::RecordDecl* RD,
                            llvm::ArrayRef<llvm::StringRef> fields);
 
+    /// Instantiate clad::class<TemplateArgs> type
+    ///
+    /// \param[in] CladClassDecl the decl of the class that is going to be used
+    /// in the creation of the type \param[in] TemplateArgs an array of template
+    /// arguments \returns The created type clad::class<TemplateArgs>
+    clang::QualType
+    InstantiateTemplate(clang::Sema& S, clang::TemplateDecl* CladClassDecl,
+                        llvm::ArrayRef<clang::QualType> TemplateArgs);
+    clang::QualType InstantiateTemplate(clang::Sema& S,
+                                        clang::TemplateDecl* CladClassDecl,
+                                        clang::TemplateArgumentListInfo& TLI);
+    /// Builds the QualType of the derivative to be generated.
+    ///
+    /// \param[in] moveBaseToParams If true, turns member functions into regular
+    /// functions by moving the base to the parameters.
+    clang::QualType
+    GetDerivativeType(clang::Sema& S, const clang::FunctionDecl* FD,
+                      DiffMode mode,
+                      llvm::ArrayRef<const clang::ValueDecl*> diffParams,
+                      bool moveBaseToParams = false,
+                      llvm::ArrayRef<clang::QualType> customParams = {});
+    /// Find declaration of clad::class templated type
+    ///
+    /// \param[in] className name of the class to be found
+    /// \returns The declaration of the class with the name ClassName
+    clang::TemplateDecl*
+    LookupTemplateDeclInCladNamespace(clang::Sema& S,
+                                      llvm::StringRef ClassName);
+
     bool hasNonDifferentiableAttribute(const clang::Decl* D);
 
     bool hasNonDifferentiableAttribute(const clang::Expr* E);
@@ -331,6 +362,18 @@ namespace clad {
     clang::Expr* getZeroInit(clang::QualType T, clang::Sema& S);
 
     bool ContainsFunctionCalls(const clang::Stmt* E);
+
+    /// Find namespace clad declaration.
+    clang::NamespaceDecl* GetCladNamespace(clang::Sema& S);
+    /// Create clad::array<T> type.
+    clang::QualType GetCladArrayOfType(clang::Sema& S, clang::QualType T);
+    /// Create clad::matrix<T> type.
+    clang::QualType GetCladMatrixOfType(clang::Sema& S, clang::QualType T);
+    /// Create clad::array_ref<T> type.
+    clang::QualType GetCladArrayRefOfType(clang::Sema& S, clang::QualType T);
+
+    clang::QualType GetParameterDerivativeType(clang::Sema& S, DiffMode Mode,
+                                               clang::QualType Type);
 
     void SetSwitchCaseSubStmt(clang::SwitchCase* SC, clang::Stmt* subStmt);
 

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -3,17 +3,17 @@
 #ifndef CLAD_UTILS_CLADUTILS_H
 #define CLAD_UTILS_CLADUTILS_H
 
-#include "clang/AST/ASTContext.h"
-#include "clang/AST/Decl.h"
-#include "clang/AST/DeclarationName.h"
-#include "clang/Basic/Diagnostic.h"
-#include "clang/Sema/Sema.h"
-#include "clang/AST/Type.h"
-#include "llvm/ADT/StringRef.h"
-
 #include "DiffMode.h"
 
-#include <clang/AST/DeclCXX.h>
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclarationName.h"
+#include "clang/AST/Type.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Sema/Sema.h"
+#include "llvm/ADT/StringRef.h"
+
 #include <string>
 
 namespace clang {

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -1,6 +1,7 @@
 #ifndef CLAD_DIFF_PLANNER_H
 #define CLAD_DIFF_PLANNER_H
 
+#include "clad/Differentiator/DerivedFnCollector.h"
 #include "clad/Differentiator/DiffMode.h"
 #include "clad/Differentiator/DynamicGraph.h"
 #include "clad/Differentiator/ParseDiffArgsTypes.h"
@@ -215,10 +216,12 @@ public:
 
     bool m_IsTraversingTopLevelDecl = true;
 
+    DerivedFnCollector& m_DFC;
+
   public:
     DiffCollector(clang::DeclGroupRef DGR, DiffInterval& Interval,
                   clad::DynamicGraph<DiffRequest>& requestGraph, clang::Sema& S,
-                  RequestOptions& opts);
+                  RequestOptions& opts, DerivedFnCollector& DFC);
     bool VisitCallExpr(clang::CallExpr* E);
     bool VisitDeclRefExpr(clang::DeclRefExpr* DRE);
     bool TraverseFunctionDeclOnce(const clang::FunctionDecl* FD) {
@@ -228,6 +231,12 @@ public:
       m_Traversed.insert(FD);
       return TraverseDecl(const_cast<clang::FunctionDecl*>(FD));
     }
+    /// Looks up if the user has defined a custom derivative for the given
+    /// derivative function. If found, it is automatically attached to the
+    /// request in derived function collector.
+    /// \param[in] request The request for the derivative to lookup.
+    /// \returns true if a custom derivative was found, false otherwise
+    bool LookupCustomDerivativeDecl(const DiffRequest& request);
 
   private:
     bool isInInterval(clang::SourceLocation Loc) const;

--- a/include/clad/Differentiator/ReverseModeForwPassVisitor.h
+++ b/include/clad/Differentiator/ReverseModeForwPassVisitor.h
@@ -16,9 +16,6 @@ private:
   Stmts m_Globals;
 
   llvm::SmallVector<clang::ParmVarDecl*, 8> BuildParams(DiffParams& diffParams);
-  clang::QualType GetParameterDerivativeType(clang::QualType Type) override {
-    return Type;
-  }
 
 public:
   ReverseModeForwPassVisitor(DerivativeBuilder& builder,

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -49,6 +49,10 @@ namespace clad {
     // a separate namespace, as well as add getters/setters function of
     // several private/protected members of the visitor classes.
     friend class ErrorEstimationHandler;
+    // FIXME: Should we make this an object instead of a pointer?
+    // Downside of making it an object: We will need to include
+    // 'MultiplexExternalRMVSource.h' file
+    MultiplexExternalRMVSource* m_ExternalSource = nullptr;
     llvm::SmallVector<const clang::ParmVarDecl*, 16> m_NonIndepParams;
     /// In addition to a sequence of forward-accumulated Stmts (m_Blocks), in
     /// the reverse mode we also accumulate Stmts for the reverse pass which
@@ -464,14 +468,6 @@ namespace clad {
            "attempt to differentiate unsupported operator, ignored.",
            args);
     }
-
-    /// Returns the type that should be used to represent the derivative of a
-    ///
-    /// FIXME: Parameter derivative type rules are different from the derivative
-    /// type rules for local variables. We should remove this inconsistency.
-    /// See the following issue for more details:
-    /// https://github.com/vgvassilev/clad/issues/385
-    clang::QualType GetParameterDerivativeType(clang::QualType Type) override;
 
     /// Allows to easily create and manage a counter for counting the number of
     /// executed iterations of a loop.

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -37,15 +37,19 @@ void clear_pushforward(::std::vector<T>* v, ::std::vector<T>* d_v) {
 }
 
 template <typename T>
-void resize_pushforward(::std::vector<T>* v, unsigned sz, ::std::vector<T>* d_v,
-                        unsigned d_sz) {
+void resize_pushforward(::std::vector<T>* v,
+                        typename ::std::vector<T>::size_type sz,
+                        ::std::vector<T>* d_v,
+                        typename ::std::vector<T>::size_type d_sz) {
   d_v->resize(sz, T());
   v->resize(sz);
 }
 
 template <typename T, typename U>
-void resize_pushforward(::std::vector<T>* v, unsigned sz, U val,
-                        ::std::vector<T>* d_v, unsigned d_sz, U d_val) {
+void resize_pushforward(::std::vector<T>* v,
+                        typename ::std::vector<T>::size_type sz, U val,
+                        ::std::vector<T>* d_v,
+                        typename ::std::vector<T>::size_type d_sz, U d_val) {
   d_v->resize(sz, d_val);
   v->resize(sz, val);
 }
@@ -136,30 +140,31 @@ constructor_pushforward(ConstructorPushforwardTag<::std::vector<T>>,
 }
 
 template <typename T>
+ValueAndPushforward<T&, T&> operator_subscript_pushforward(
+    ::std::vector<T>* v, typename ::std::vector<T>::size_type idx,
+    ::std::vector<T>* d_v, typename ::std::vector<T>::size_type d_idx) {
+  return {(*v)[idx], (*d_v)[idx]};
+}
+
+template <typename T>
+ValueAndPushforward<const T&, const T&> operator_subscript_pushforward(
+    const ::std::vector<T>* v, typename ::std::vector<T>::size_type idx,
+    const ::std::vector<T>* d_v, typename ::std::vector<T>::size_type d_idx) {
+  return {(*v)[idx], (*d_v)[idx]};
+}
+
+template <typename T>
 ValueAndPushforward<T&, T&>
-operator_subscript_pushforward(::std::vector<T>* v, unsigned idx,
-                               ::std::vector<T>* d_v, unsigned d_idx) {
+at_pushforward(::std::vector<T>* v, typename ::std::vector<T>::size_type idx,
+               ::std::vector<T>* d_v,
+               typename ::std::vector<T>::size_type d_idx) {
   return {(*v)[idx], (*d_v)[idx]};
 }
 
 template <typename T>
-ValueAndPushforward<const T&, const T&>
-operator_subscript_pushforward(const ::std::vector<T>* v, unsigned idx,
-                               const ::std::vector<T>* d_v, unsigned d_idx) {
-  return {(*v)[idx], (*d_v)[idx]};
-}
-
-template <typename T>
-ValueAndPushforward<T&, T&> at_pushforward(::std::vector<T>* v, unsigned idx,
-                                           ::std::vector<T>* d_v,
-                                           unsigned d_idx) {
-  return {(*v)[idx], (*d_v)[idx]};
-}
-
-template <typename T>
-ValueAndPushforward<const T&, const T&>
-at_pushforward(const ::std::vector<T>* v, unsigned idx,
-               const ::std::vector<T>* d_v, unsigned d_idx) {
+ValueAndPushforward<const T&, const T&> at_pushforward(
+    const ::std::vector<T>* v, typename ::std::vector<T>::size_type idx,
+    const ::std::vector<T>* d_v, typename ::std::vector<T>::size_type d_idx) {
   return {(*v)[idx], (*d_v)[idx]};
 }
 
@@ -415,23 +420,9 @@ void push_back_reverse_forw(::std::vector<T>* v, U val, ::std::vector<T>* d_v,
   d_v->push_back(0);
 }
 
-template <typename T, typename U>
-void push_back_reverse_forw(::std::vector<T>* v, U val, ::std::vector<T>* d_v,
-                            U /*d_val*/) {
-  v->push_back(val);
-  d_v->push_back(0);
-}
-
 template <typename T, typename U, typename pU>
-void push_back_pullback(const ::std::vector<T>* v, U val, ::std::vector<T>* d_v,
+void push_back_pullback(::std::vector<T>* v, U val, ::std::vector<T>* d_v,
                         pU* d_val) {
-  *d_val += d_v->back();
-  d_v->pop_back();
-}
-
-template <typename T, typename U>
-void push_back_pullback(const ::std::vector<T>* v, U val, ::std::vector<T>* d_v,
-                        U* d_val) {
   *d_val += d_v->back();
   d_v->pop_back();
 }
@@ -451,6 +442,14 @@ void operator_subscript_pullback(const ::std::vector<T>* vec,
   (*d_vec)[idx] += d_y;
 }
 
+template <typename T, typename P>
+void operator_subscript_pullback(::std::vector<T>* vec,
+                                 typename ::std::vector<T>::size_type idx,
+                                 P d_y, ::std::vector<T>* d_vec,
+                                 typename ::std::vector<T>::size_type* d_idx) {
+  (*d_vec)[idx] += d_y;
+}
+
 template <typename T>
 clad::ValueAndAdjoint<T&, T&>
 at_reverse_forw(::std::vector<T>* vec, typename ::std::vector<T>::size_type idx,
@@ -461,6 +460,14 @@ at_reverse_forw(::std::vector<T>* vec, typename ::std::vector<T>::size_type idx,
 
 template <typename T, typename P>
 void at_pullback(const ::std::vector<T>* vec,
+                 typename ::std::vector<T>::size_type idx, P d_y,
+                 ::std::vector<T>* d_vec,
+                 typename ::std::vector<T>::size_type* d_idx) {
+  (*d_vec)[idx] += d_y;
+}
+
+template <typename T, typename P>
+void at_pullback(::std::vector<T>* vec,
                  typename ::std::vector<T>::size_type idx, P d_y,
                  ::std::vector<T>* d_vec,
                  typename ::std::vector<T>::size_type* d_idx) {
@@ -502,7 +509,7 @@ void constructor_pullback(clad::array<T> init, ::std::vector<T>* d_this,
 }
 
 template <typename T, typename U, typename dU>
-void assign_pullback(const ::std::vector<T>* v,
+void assign_pullback(::std::vector<T>* v,
                      typename ::std::vector<T>::size_type n, U /*val*/,
                      ::std::vector<T>* d_v,
                      typename ::std::vector<T>::size_type* /*d_n*/, dU* d_val) {
@@ -513,18 +520,14 @@ void assign_pullback(const ::std::vector<T>* v,
 }
 
 template <typename T>
-void reserve_pullback(const ::std::vector<T>* v,
+void reserve_pullback(::std::vector<T>* v,
                       typename ::std::vector<T>::size_type n,
                       ::std::vector<T>* d_v,
                       typename ::std::vector<T>::size_type* /*d_n*/) noexcept {}
 
 template <typename T>
-void shrink_to_fit_pullback(const ::std::vector<T>* /*v*/,
+void shrink_to_fit_pullback(::std::vector<T>* /*v*/,
                             ::std::vector<T>* /*d_v*/) noexcept {}
-
-template <typename T>
-void size_pullback(const ::std::vector<T>* /*v*/,
-                   ::std::vector<T>* /*d_v*/) noexcept {}
 
 template <typename T>
 void capacity_pullback(const ::std::vector<T>* /*v*/,
@@ -553,6 +556,12 @@ void operator_subscript_pullback(
     typename ::std::array<T, N>::size_type* d_idx) {
   (*d_arr)[idx] += d_y;
 }
+template <typename T, ::std::size_t N, typename P>
+void operator_subscript_pullback(
+    ::std::array<T, N>* arr, typename ::std::array<T, N>::size_type idx, P d_y,
+    ::std::array<T, N>* d_arr, typename ::std::array<T, N>::size_type* d_idx) {
+  (*d_arr)[idx] += d_y;
+}
 template <typename T, ::std::size_t N>
 clad::ValueAndAdjoint<T&, T&> at_reverse_forw(
     ::std::array<T, N>* arr, typename ::std::array<T, N>::size_type idx,
@@ -561,6 +570,13 @@ clad::ValueAndAdjoint<T&, T&> at_reverse_forw(
 }
 template <typename T, ::std::size_t N, typename P>
 void at_pullback(const ::std::array<T, N>* arr,
+                 typename ::std::array<T, N>::size_type idx, P d_y,
+                 ::std::array<T, N>* d_arr,
+                 typename ::std::array<T, N>::size_type* d_idx) {
+  (*d_arr)[idx] += d_y;
+}
+template <typename T, ::std::size_t N, typename P>
+void at_pullback(::std::array<T, N>* arr,
                  typename ::std::array<T, N>::size_type idx, P d_y,
                  ::std::array<T, N>* d_arr,
                  typename ::std::array<T, N>::size_type* d_idx) {
@@ -575,7 +591,7 @@ void fill_reverse_forw(::std::array<T, N>* a,
   d_a->fill(0);
 }
 template <typename T, ::std::size_t N>
-void fill_pullback(const ::std::array<T, N>* arr,
+void fill_pullback(::std::array<T, N>* arr,
                    const typename ::std::array<T, N>::value_type& u,
                    ::std::array<T, N>* d_arr,
                    typename ::std::array<T, N>::value_type* d_u) {
@@ -597,6 +613,12 @@ void back_pullback(const ::std::array<T, N>* arr,
   (*d_arr)[d_arr->size() - 1] += d_u;
 }
 template <typename T, ::std::size_t N>
+void back_pullback(::std::array<T, N>* arr,
+                   typename ::std::array<T, N>::value_type d_u,
+                   ::std::array<T, N>* d_arr) noexcept {
+  (*d_arr)[d_arr->size() - 1] += d_u;
+}
+template <typename T, ::std::size_t N>
 clad::ValueAndAdjoint<T&, T&>
 front_reverse_forw(::std::array<T, N>* arr,
                    ::std::array<T, N>* d_arr) noexcept {
@@ -608,9 +630,6 @@ void front_pullback(const ::std::array<T, N>* arr,
                     ::std::array<T, N>* d_arr) {
   (*d_arr)[0] += d_u;
 }
-template <typename T, ::std::size_t N>
-void size_pullback(const ::std::array<T, N>* a,
-                   ::std::array<T, N>* d_a) noexcept {}
 template <typename T, ::std::size_t N, typename U>
 void size_pullback(const ::std::array<T, N>* /*a*/, U /*d_y*/,
                    ::std::array<T, N>* /*d_a*/) noexcept {}
@@ -625,13 +644,13 @@ void constructor_pullback(const ::std::array<T, N>& arr,
 // tuple forward mode
 
 template <typename... Args1, typename... Args2>
-clad::ValueAndPushforward<::std::tuple<Args1...>, ::std::tuple<Args1...>>
+clad::ValueAndPushforward<::std::tuple<Args1...>&, ::std::tuple<Args1...>&>
 operator_equal_pushforward(::std::tuple<Args1...>* tu,
                            ::std::tuple<Args2...>&& in,
                            ::std::tuple<Args1...>* d_tu,
                            ::std::tuple<Args2...>&& d_in) noexcept {
-  ::std::tuple<Args1...> t1 = (*tu = in);
-  ::std::tuple<Args1...> t2 = (*d_tu = d_in);
+  ::std::tuple<Args1...>& t1 = (*tu = in);
+  ::std::tuple<Args1...>& t2 = (*d_tu = d_in);
   return {t1, t2};
 }
 

--- a/include/clad/Differentiator/VectorForwardModeVisitor.h
+++ b/include/clad/Differentiator/VectorForwardModeVisitor.h
@@ -79,8 +79,6 @@ public:
   DeclDiff<clang::VarDecl>
   DifferentiateVarDecl(const clang::VarDecl* VD) override;
 
-  clang::QualType
-  GetParameterDerivativeType(clang::QualType ParamType) override;
   std::string GetPushForwardFunctionSuffix() override;
   DiffMode GetPushForwardMode() override;
 

--- a/include/clad/Differentiator/VectorPushForwardModeVisitor.h
+++ b/include/clad/Differentiator/VectorPushForwardModeVisitor.h
@@ -19,8 +19,6 @@ public:
 
   DerivativeAndOverload Derive() override;
 
-  clang::QualType
-  GetParameterDerivativeType(clang::QualType ParamType) override;
   StmtDiff VisitReturnStmt(const clang::ReturnStmt* RS) override;
 };
 } // end namespace clad

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -136,11 +136,6 @@ namespace clad {
     // expression to be of object type in the reverse mode as well.
     clang::Expr* m_ThisExprDerivative = nullptr;
 
-    // FIXME: Should we make this an object instead of a pointer?
-    // Downside of making it an object: We will need to include
-    // 'MultiplexExternalRMVSource.h' file
-    MultiplexExternalRMVSource* m_ExternalSource = nullptr;
-
     /// A function used to wrap result of visiting E in a lambda. Returns a call
     /// to the built lambda. Func is a functor that will be invoked inside
     /// lambda scope and block. Statements inside lambda are expected to be
@@ -444,24 +439,6 @@ namespace clad {
       llvm::SmallVector<clang::Expr*, 1> IS = {Idx};
       return BuildArraySubscript(Base, IS);
     }
-    /// Find namespace clad declaration.
-    clang::NamespaceDecl* GetCladNamespace();
-    /// Find declaration of clad::class templated type
-    ///
-    /// \param[in] className name of the class to be found
-    /// \returns The declaration of the class with the name ClassName
-    clang::TemplateDecl*
-    LookupTemplateDeclInCladNamespace(llvm::StringRef ClassName);
-    /// Instantiate clad::class<TemplateArgs> type
-    ///
-    /// \param[in] CladClassDecl the decl of the class that is going to be used
-    /// in the creation of the type \param[in] TemplateArgs an array of template
-    /// arguments \returns The created type clad::class<TemplateArgs>
-    clang::QualType
-    InstantiateTemplate(clang::TemplateDecl* CladClassDecl,
-                        llvm::ArrayRef<clang::QualType> TemplateArgs);
-    clang::QualType InstantiateTemplate(clang::TemplateDecl* CladClassDecl,
-                                        clang::TemplateArgumentListInfo& TLI);
     /// Find declaration of clad::tape templated type.
     clang::TemplateDecl* GetCladTapeDecl();
     /// Perform a lookup into clad namespace for an entity with given name.
@@ -562,20 +539,8 @@ namespace clad {
         llvm::ArrayRef<clang::TemplateArgument> templateArgs,
         clang::SourceLocation loc);
 
-    /// Find declaration of clad::array_ref templated type.
-    clang::TemplateDecl* GetCladArrayRefDecl();
-    /// Create clad::array_ref<T> type.
-    clang::QualType GetCladArrayRefOfType(clang::QualType T);
     /// Checks if the type is of clad::array<T> or clad::array_ref<T> type
     bool isCladArrayType(clang::QualType QT);
-    /// Find declaration of clad::array templated type.
-    clang::TemplateDecl* GetCladArrayDecl();
-    /// Create clad::array<T> type.
-    clang::QualType GetCladArrayOfType(clang::QualType T);
-    /// Find declaration of clad::matrix templated type.
-    clang::TemplateDecl* GetCladMatrixDecl();
-    /// Create clad::matrix<T> type.
-    clang::QualType GetCladMatrixOfType(clang::QualType T);
     /// Creates the expression clad::matrix<T>::identity(Args) for the given
     /// type and args.
     clang::Expr*
@@ -620,7 +585,8 @@ namespace clad {
 
     clang::QualType DetermineCladArrayValueType(clang::QualType T);
 
-    clang::QualType GetDerivativeType();
+    clang::QualType
+    GetDerivativeType(llvm::ArrayRef<clang::QualType> customParams = {});
 
     /// Returns clad::Identify template declaration.
     clang::TemplateDecl* GetCladConstructorPushforwardTag();
@@ -639,11 +605,6 @@ namespace clad {
     /// original derivative function internally. Used in gradient and jacobian
     /// modes.
     clang::FunctionDecl* CreateDerivativeOverload();
-
-    virtual clang::QualType
-    GetParameterDerivativeType(clang::QualType ParamType) {
-      return ParamType;
-    }
 
   public:
     /// Rebuild a sequence of nested namespaces ending with DC.

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -585,9 +585,6 @@ namespace clad {
 
     clang::QualType DetermineCladArrayValueType(clang::QualType T);
 
-    clang::QualType
-    GetDerivativeType(llvm::ArrayRef<clang::QualType> customParams = {});
-
     /// Returns clad::Identify template declaration.
     clang::TemplateDecl* GetCladConstructorPushforwardTag();
 
@@ -620,6 +617,13 @@ namespace clad {
     /// Initiates the differentiation process.
     /// Returns the derivative and its overload, if any.
     virtual DerivativeAndOverload Derive() = 0;
+
+    /// Builds the QualType of the derivative to be generated.
+    ///
+    /// \param[in] moveBaseToParams If true, turns member functions into regular
+    /// functions by moving the base to the parameters.
+    clang::QualType
+    GetDerivativeType(llvm::ArrayRef<clang::QualType> customParams = {});
 
     /// Computes effective derivative operands. It should be used when operands
     /// might be of pointer types.

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -287,9 +287,10 @@ void BaseForwardModeVisitor::SetupDerivativeParameters(
       continue;
 
     IdentifierInfo* II = &m_Context.Idents.get("_d_" + PVD->getNameAsString());
-    auto* dPVD = utils::BuildParmVarDecl(
-        m_Sema, m_Derivative, II, GetParameterDerivativeType(PVD->getType()),
-        PVD->getStorageClass());
+    QualType diffTy = utils::GetParameterDerivativeType(m_Sema, m_DiffReq.Mode,
+                                                        PVD->getType());
+    auto* dPVD = utils::BuildParmVarDecl(m_Sema, m_Derivative, II, diffTy,
+                                         PVD->getStorageClass());
     params.push_back(dPVD);
     m_Variables[PVD] = BuildDeclRef(dPVD);
   }

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -793,6 +793,19 @@ namespace clad {
       return true;
     }
 
+    NamespaceDecl* GetCladNamespace(Sema& S) {
+      static NamespaceDecl* Result = nullptr;
+      if (Result)
+        return Result;
+      DeclarationName CladName = &S.getASTContext().Idents.get("clad");
+      LookupResult CladR(S, CladName, noLoc, Sema::LookupNamespaceName,
+                         CLAD_COMPAT_Sema_ForVisibleRedeclaration);
+      S.LookupQualifiedName(CladR, S.getASTContext().getTranslationUnitDecl());
+      assert(!CladR.empty() && "cannot find clad namespace");
+      Result = cast<NamespaceDecl>(CladR.getFoundDecl());
+      return Result;
+    }
+
     Expr* getZeroInit(QualType T, Sema& S) {
       // FIXME: Consolidate other uses of synthesizeLiteral for creation 0 or 1.
       if (T->isVoidType() || isa<VariableArrayType>(T))
@@ -815,6 +828,66 @@ namespace clad {
       return S.ActOnInitList(noLoc, {}, noLoc).get();
     }
 
+    QualType InstantiateTemplate(Sema& S, TemplateDecl* CladClassDecl,
+                                 TemplateArgumentListInfo& TLI) {
+      // This will instantiate tape<T> type and return it.
+      QualType TT = S.CheckTemplateIdType(TemplateName(CladClassDecl),
+                                          GetValidSLoc(S), TLI);
+      // Get clad namespace and its identifier clad::.
+      CXXScopeSpec CSS;
+      CSS.Extend(S.getASTContext(), GetCladNamespace(S), GetValidSLoc(S),
+                 GetValidSLoc(S));
+      NestedNameSpecifier* NS = CSS.getScopeRep();
+
+      // Create elaborated type with namespace specifier,
+      // i.e. class<T> -> clad::class<T>
+      return S.getASTContext().getElaboratedType(
+          clad_compat::ElaboratedTypeKeyword_None, NS, TT);
+    }
+
+    TemplateDecl* LookupTemplateDeclInCladNamespace(Sema& S,
+                                                    llvm::StringRef ClassName) {
+      NamespaceDecl* CladNS = GetCladNamespace(S);
+      CXXScopeSpec CSS;
+      CSS.Extend(S.getASTContext(), CladNS, noLoc, noLoc);
+      DeclarationName TapeName = &S.getASTContext().Idents.get(ClassName);
+      LookupResult TapeR(S, TapeName, noLoc, Sema::LookupUsingDeclName,
+                         CLAD_COMPAT_Sema_ForVisibleRedeclaration);
+      S.LookupQualifiedName(TapeR, CladNS, CSS);
+      assert(!TapeR.empty() && isa<TemplateDecl>(TapeR.getFoundDecl()) &&
+             "cannot find clad::tape");
+      return cast<TemplateDecl>(TapeR.getFoundDecl());
+    }
+
+    QualType InstantiateTemplate(Sema& S, TemplateDecl* CladClassDecl,
+                                 ArrayRef<QualType> TemplateArgs) {
+      // Create a list of template arguments.
+      TemplateArgumentListInfo TLI{};
+      for (auto T : TemplateArgs) {
+        TemplateArgument TA = T;
+        TLI.addArgument(TemplateArgumentLoc(
+            TA, S.getASTContext().getTrivialTypeSourceInfo(T)));
+      }
+
+      return InstantiateTemplate(S, CladClassDecl, TLI);
+    }
+
+    QualType GetCladMatrixOfType(Sema& S, clang::QualType T) {
+      static TemplateDecl* matrixDecl = nullptr;
+      if (!matrixDecl)
+        matrixDecl =
+            utils::LookupTemplateDeclInCladNamespace(S,
+                                                     /*ClassName=*/"matrix");
+      return InstantiateTemplate(S, matrixDecl, {T});
+    }
+
+    QualType GetCladArrayOfType(Sema& S, clang::QualType T) {
+      static TemplateDecl* arrayDecl = nullptr;
+      if (!arrayDecl)
+        arrayDecl = LookupTemplateDeclInCladNamespace(S, /*ClassName=*/"array");
+      return utils::InstantiateTemplate(S, arrayDecl, {T});
+    }
+
     bool IsDifferentiableType(QualType T) {
       QualType origType = T;
       // FIXME: arbitrary dimension array type as well.
@@ -828,6 +901,156 @@ namespace clad {
       if (origType->isPointerType() && T->isVoidType())
         return true;
       return false;
+    }
+
+    QualType GetCladArrayRefOfType(Sema& S, QualType T) {
+      static TemplateDecl* arrayRefDecl = nullptr;
+      if (!arrayRefDecl)
+        arrayRefDecl = utils::LookupTemplateDeclInCladNamespace(
+            S, /*ClassName=*/"array_ref");
+      return utils::InstantiateTemplate(S, arrayRefDecl, {T});
+    }
+
+    QualType GetParameterDerivativeType(Sema& S, DiffMode Mode, QualType Type) {
+      ASTContext& C = S.getASTContext();
+      if (Mode == DiffMode::experimental_vector_pushforward ||
+          Mode == DiffMode::jacobian) {
+        QualType valueType = GetNonConstValueType(Type);
+        QualType resType;
+        if (isArrayOrPointerType(Type)) {
+          // If the parameter is a pointer or an array, then the derivative will
+          // be a reference to the matrix.
+          resType = GetCladMatrixOfType(S, valueType);
+          resType = C.getLValueReferenceType(resType);
+        } else {
+          // If the parameter is not a pointer or an array, then the derivative
+          // will be a clad array.
+          resType = GetCladArrayOfType(S, valueType);
+
+          // Add const qualifier if the parameter is const.
+          if (Type.getNonReferenceType().isConstQualified())
+            resType.addConst();
+
+          // Add reference qualifier if the parameter is a reference.
+          if (Type->isReferenceType())
+            resType = C.getLValueReferenceType(resType);
+        }
+        if (Mode == DiffMode::jacobian)
+          resType = C.getPointerType(resType.getNonReferenceType());
+        return resType;
+      }
+
+      if (Mode == DiffMode::reverse ||
+          Mode == DiffMode::experimental_pullback ||
+          Mode == DiffMode::error_estimation) {
+        QualType ValueType = GetNonConstValueType(Type);
+        QualType nonRefValueType = ValueType.getNonReferenceType();
+        return C.getPointerType(nonRefValueType);
+      }
+
+      if (Mode == DiffMode::vector_forward_mode) {
+        QualType valueType = GetNonConstValueType(Type);
+        if (isArrayOrPointerType(Type))
+          // Generate array reference type for the derivative.
+          return GetCladArrayRefOfType(S, valueType);
+        // Generate pointer type for the derivative.
+        return C.getPointerType(valueType);
+      }
+
+      return Type;
+    }
+
+    QualType
+    GetDerivativeType(Sema& S, const clang::FunctionDecl* FD, DiffMode mode,
+                      llvm::ArrayRef<const clang::ValueDecl*> diffParams,
+                      bool moveBaseToParams,
+                      llvm::ArrayRef<QualType> customParams) {
+      ASTContext& C = S.getASTContext();
+      if (mode == DiffMode::forward)
+        return FD->getType();
+
+      const auto* FnProtoTy = llvm::cast<FunctionProtoType>(FD->getType());
+      FunctionProtoType::ExtProtoInfo EPI = FnProtoTy->getExtProtoInfo();
+      llvm::SmallVector<QualType, 16> FnTypes(
+          FnProtoTy->getParamTypes().begin(), FnProtoTy->getParamTypes().end());
+
+      QualType oRetTy = FD->getReturnType();
+      QualType dRetTy = C.VoidTy;
+      bool returnVoid = mode == DiffMode::reverse ||
+                        mode == DiffMode::experimental_pullback ||
+                        mode == DiffMode::error_estimation ||
+                        mode == DiffMode::vector_forward_mode;
+      if (mode == DiffMode::reverse_mode_forward_pass) {
+        TemplateDecl* valAndAdjointTempDecl =
+            utils::LookupTemplateDeclInCladNamespace(S, "ValueAndAdjoint");
+        dRetTy = utils::InstantiateTemplate(S, valAndAdjointTempDecl,
+                                            {oRetTy, oRetTy});
+      } else if (mode == DiffMode::hessian ||
+                 mode == DiffMode::hessian_diagonal) {
+        QualType argTy = C.getPointerType(oRetTy);
+        FnTypes.push_back(argTy);
+        return C.getFunctionType(dRetTy, FnTypes, EPI);
+      } else if (!returnVoid && !oRetTy->isVoidType()) {
+        // Handle pushforwards
+        TemplateDecl* valueAndPushforward =
+            utils::LookupTemplateDeclInCladNamespace(S, "ValueAndPushforward");
+        QualType PushFwdTy = utils::GetParameterDerivativeType(S, mode, oRetTy);
+        dRetTy = utils::InstantiateTemplate(S, valueAndPushforward,
+                                            {oRetTy, PushFwdTy});
+      } else if (mode == DiffMode::experimental_pullback) {
+        // Handle pullbacks
+        QualType argTy = oRetTy.getNonReferenceType();
+        argTy = utils::getNonConstType(argTy, S);
+        if (!argTy->isVoidType() && !argTy->isPointerType())
+          FnTypes.push_back(argTy);
+      }
+
+      QualType thisTy;
+      if (const auto* MD = dyn_cast<CXXMethodDecl>(FD)) {
+        const CXXRecordDecl* RD = MD->getParent();
+        if (MD->isInstance() && !RD->isLambda() && mode != DiffMode::jacobian) {
+          thisTy = MD->getThisType();
+          QualType dthisTy = utils::GetParameterDerivativeType(S, mode, thisTy);
+          FnTypes.push_back(dthisTy);
+          if (MD->isConst()) {
+            QualType constObjTy = C.getConstType(thisTy->getPointeeType());
+            thisTy = C.getPointerType(constObjTy);
+          }
+        }
+      }
+
+      // Iterate over all but the "this" type and extend the signature to add
+      // the extra parameters.
+      for (size_t i = 0, e = FnProtoTy->getNumParams(); i < e; ++i) {
+        QualType PVDTy = FnTypes[i];
+        if (mode == DiffMode::jacobian &&
+            !(utils::isArrayOrPointerType(PVDTy) || PVDTy->isReferenceType()))
+          continue;
+        // FIXME: Make this system consistent across modes.
+        if (returnVoid) {
+          // Check if (IsDifferentiableType(PVDTy))
+          // FIXME: We can't use std::find(DVI.begin(), DVI.end()) because the
+          // operator== considers params and intervals as different entities and
+          // breaks the hessian tests. We should implement more robust checks in
+          // DiffInputVarInfo to check if this is a variable we differentiate
+          // wrt.
+          for (const ValueDecl* param : diffParams)
+            if (param == FD->getParamDecl(i))
+              FnTypes.push_back(
+                  utils::GetParameterDerivativeType(S, mode, PVDTy));
+        } else if (utils::IsDifferentiableType(PVDTy))
+          FnTypes.push_back(utils::GetParameterDerivativeType(S, mode, PVDTy));
+      }
+
+      if (moveBaseToParams && !thisTy.isNull()) {
+        FnTypes.insert(FnTypes.begin(), thisTy);
+        EPI.TypeQuals.removeConst();
+      }
+
+      for (QualType customTy : customParams)
+        FnTypes.push_back(customTy);
+
+      return C.getFunctionType(dRetTy, FnTypes, EPI);
     }
   } // namespace utils
 } // namespace clad

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -23,6 +23,7 @@
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/SemaInternal.h"
 #include "clang/Sema/Template.h"
+#include <clad/Differentiator/DiffMode.h>
 #include "clad/Differentiator/BaseForwardModeVisitor.h"
 #include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/DiffPlanner.h"

--- a/lib/Differentiator/JacobianModeVisitor.h
+++ b/lib/Differentiator/JacobianModeVisitor.h
@@ -14,8 +14,6 @@ public:
 
   DerivativeAndOverload Derive() override;
 
-  clang::QualType GetParameterDerivativeType(clang::QualType T) override;
-
   StmtDiff VisitReturnStmt(const clang::ReturnStmt* RS) override;
 };
 } // end namespace clad

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1908,11 +1908,16 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         pullbackFD = m_Builder.HandleNestedDiffRequest(pullbackRequest);
 
       if (pullbackFD) {
-        if (MD && MD->isInstance()) {
-          Expr* baseE = baseDiff.getExpr();
+        auto* pullbackMD = dyn_cast<CXXMethodDecl>(pullbackFD);
+        Expr* baseE = baseDiff.getExpr();
+        if (pullbackMD && pullbackMD->isInstance()) {
           OverloadedDerivedFn = BuildCallExprToMemFn(
               baseE, pullbackFD->getName(), pullbackCallArgs, Loc);
         } else {
+          if (baseE) {
+            baseE = BuildOp(UO_AddrOf, baseE);
+            pullbackCallArgs.insert(pullbackCallArgs.begin(), baseE);
+          }
           OverloadedDerivedFn =
               m_Sema
                   .ActOnCallExpr(getCurrentScope(), BuildDeclRef(pullbackFD),

--- a/lib/Differentiator/VectorPushForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorPushForwardModeVisitor.cpp
@@ -52,31 +52,6 @@ DerivativeAndOverload VectorPushForwardModeVisitor::Derive() {
   return BaseForwardModeVisitor::Derive();
 }
 
-QualType
-VectorPushForwardModeVisitor::GetParameterDerivativeType(QualType ParamType) {
-  QualType valueType = utils::GetNonConstValueType(ParamType);
-  QualType resType;
-  if (utils::isArrayOrPointerType(ParamType)) {
-    // If the parameter is a pointer or an array, then the derivative will be a
-    // reference to the matrix.
-    resType = GetCladMatrixOfType(valueType);
-    resType = m_Context.getLValueReferenceType(resType);
-  } else {
-    // If the parameter is not a pointer or an array, then the derivative will
-    // be a clad array.
-    resType = GetCladArrayOfType(valueType);
-
-    // Add const qualifier if the parameter is const.
-    if (ParamType.getNonReferenceType().isConstQualified())
-      resType.addConst();
-
-    // Add reference qualifier if the parameter is a reference.
-    if (ParamType->isReferenceType())
-      resType = m_Context.getLValueReferenceType(resType);
-  }
-  return resType;
-}
-
 StmtDiff
 VectorPushForwardModeVisitor::VisitReturnStmt(const clang::ReturnStmt* RS) {
   // If there is no return value, we must not attempt to differentiate

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -592,6 +592,10 @@ std::complex<double> fn10(double i, double j) {
   return c1 + c1;
 }
 
+// CHECK: constexpr clad::ValueAndPushforward<complex<double> &, complex<double> &> operator_equal_pushforward({{.*}}complex<double> &{{&?}}param, {{.*}}complex<double> *_d_this, {{.*}}complex<double> &{{&?}}_d_param) noexcept {
+// CHECK:    return {({{.*}}complex<double> &)*this, ({{.*}}complex<double> &)*_d_this};
+// CHECK-NEXT:  }
+
 // CHECK: clad::ValueAndPushforward<complex<double> &, complex<double> &> operator_plus_equal_pushforward(const complex<double> &__[[PARAM:.*]], std::complex<double> *_d_this, const complex<double> &_d___[[PARAM]]){{.*}} {
 // CHECK:    return {({{.*}}complex<double> &)*this, ({{.*}}complex<double> &)*_d_this};
 // CHECK-NEXT:  }
@@ -600,8 +604,6 @@ std::complex<double> fn10(double i, double j) {
 // CHECK:           clad::ValueAndPushforward<complex<double> &, complex<double> &> _t0 = __{{t|r}}0.operator_plus_equal_pushforward(__y, &_d___{{t|r}}, _d___y);
 // CHECK-NEXT:      return {__{{t|r}}0, _d___{{t|r}}};
 // CHECK-NEXT:  }
-
-// CHECK:  constexpr clad::ValueAndPushforward<complex<double> &, complex<double> &> operator_equal_pushforward({{.*}}complex<double> &{{.*}}param, {{.*}}complex<double> *_d_this, {{.*}}complex<double> &{{.*}}_d_param) noexcept;
 
 // CHECK: std::complex<double> fn10_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
@@ -627,6 +629,21 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:             this->data[i] = val;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<double &, double &> operator_subscript_pushforward(std::size_t idx, Tensor<double, 5> *_d_this, std::size_t _d_idx) {
+// CHECK-NEXT:     return {(double &)this->data[idx], (double &)_d_this->data[idx]};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_equal_pushforward(const Tensor<double, 5> &t, Tensor<double, 5> *_d_this, const Tensor<double, 5> &_d_t) {
+// CHECK-NEXT:     {
+// CHECK-NEXT:         unsigned int _d_i = 0;
+// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
+// CHECK-NEXT:             _d_this->data[i] = _d_t.data[i];
+// CHECK-NEXT:             this->data[i] = t.data[i];
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return {(Tensor<double, 5> &)*this, (Tensor<double, 5> &)*_d_this};
 // CHECK-NEXT: }
 
 // CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_plus_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
@@ -712,8 +729,6 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:     return {res, _d_res};
 // CHECK-NEXT: }
 
-// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_equal_pushforward(const Tensor<double, 5> &t, Tensor<double, 5> *_d_this, const Tensor<double, 5> &_d_t);
-
 // CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_plus_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_plus_pushforward(lhs, rhs, _d_lhs, _d_rhs);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
@@ -760,8 +775,6 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return {temp, _d_temp};
 // CHECK-NEXT: }
-
-// CHECK-NEXT: clad::ValueAndPushforward<double &, double &> operator_subscript_pushforward(std::size_t idx, Tensor<double, 5> *_d_this, std::size_t _d_idx);
 
 TensorD5 fn11(double i, double j) {
   TensorD5 a, b;
@@ -1261,19 +1274,4 @@ int main() {
   TEST_DIFFERENTIATE(fn16, pair_of_pairdd(), pair_of_pairdd());   // CHECK-EXEC: {2.00}
   TEST_DIFFERENTIATE(fn17, A(3.00), B(5.00));   // CHECK-EXEC: {3.00}
   TEST_DIFFERENTIATE(fn18, 7, 3);   // CHECK-EXEC: {9.00}
-
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_equal_pushforward(const Tensor<double, 5> &t, Tensor<double, 5> *_d_this, const Tensor<double, 5> &_d_t) {
-// CHECK-NEXT:     {
-// CHECK-NEXT:         unsigned int _d_i = 0;
-// CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
-// CHECK-NEXT:             _d_this->data[i] = _d_t.data[i];
-// CHECK-NEXT:             this->data[i] = t.data[i];
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return {(Tensor<double, 5> &)*this, (Tensor<double, 5> &)*_d_this};
-// CHECK-NEXT: }
-
-// CHECK: clad::ValueAndPushforward<double &, double &> operator_subscript_pushforward(std::size_t idx, Tensor<double, 5> *_d_this, std::size_t _d_idx) {
-// CHECK-NEXT:     return {(double &)this->data[idx], (double &)_d_this->data[idx]};
-// CHECK-NEXT: }
 }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -747,7 +747,17 @@ double fn19(double i, double j) {
     return (sf1 * sf2).mem_fn(i, j);
 }
 
-// CHECK: void operator_star_pullback(const SimpleFunctions1 &rhs, SimpleFunctions1 _d_y, SimpleFunctions1 *_d_this, SimpleFunctions1 *_d_rhs) const;
+// CHECK: void operator_star_pullback(const SimpleFunctions1 &rhs, SimpleFunctions1 _d_y, SimpleFunctions1 *_d_this, SimpleFunctions1 *_d_rhs) const {
+// CHECK-NEXT:    {
+// CHECK-NEXT:        double _r0 = 0.;
+// CHECK-NEXT:        double _r1 = 0.;
+// CHECK-NEXT:        SimpleFunctions1::constructor_pullback(this->x * rhs.x, this->y * rhs.y, &_d_y, &_r0, &_r1);
+// CHECK-NEXT:        _d_this->x += _r0 * rhs.x;
+// CHECK-NEXT:        (*_d_rhs).x += this->x * _r0;
+// CHECK-NEXT:        _d_this->y += _r1 * rhs.y;
+// CHECK-NEXT:        (*_d_rhs).y += this->y * _r1;
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
 
 // CHECK:  void fn19_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:      SimpleFunctions1 sf1(3, 5);
@@ -1073,8 +1083,11 @@ constructor_reverse_forw(::clad::ConstructorReverseForwTag<ptrClass>, double* mp
 }
 }}}
 
+// CHECK:  void operator_star_pullback(double _d_y, ptrClass *_d_this) {
+// CHECK-NEXT:      *_d_this->ptr += _d_y;
+// CHECK-NEXT:  }
+
 // CHECK:  static void constructor_pullback(double *mptr, ptrClass *_d_this, double *_d_mptr);
-// CHECK:  void operator_star_pullback(double _d_y, ptrClass *_d_this);
 // CHECK:  clad::ValueAndAdjoint<double &, double &> operator_star_forw(ptrClass *_d_this);
 
 double fn29(double x, double y) {
@@ -1243,18 +1256,6 @@ int main() {
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
-// CHECK: void operator_star_pullback(const SimpleFunctions1 &rhs, SimpleFunctions1 _d_y, SimpleFunctions1 *_d_this, SimpleFunctions1 *_d_rhs) const {
-// CHECK-NEXT:    {
-// CHECK-NEXT:        double _r0 = 0.;
-// CHECK-NEXT:        double _r1 = 0.;
-// CHECK-NEXT:        SimpleFunctions1::constructor_pullback(this->x * rhs.x, this->y * rhs.y, &_d_y, &_r0, &_r1);
-// CHECK-NEXT:        _d_this->x += _r0 * rhs.x;
-// CHECK-NEXT:        (*_d_rhs).x += this->x * _r0;
-// CHECK-NEXT:        _d_this->y += _r1 * rhs.y;
-// CHECK-NEXT:        (*_d_rhs).y += this->y * _r1;
-// CHECK-NEXT:    }
-// CHECK-NEXT:}
-
 // CHECK:  static void constructor_pullback(double px, SimpleFunctions1 *_d_this, double *_d_px) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          _d_this->y = 0.;
@@ -1330,10 +1331,6 @@ int main() {
 // CHECK:  static void constructor_pullback(double *mptr, ptrClass *_d_this, double *_d_mptr) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:      }
-// CHECK-NEXT:  }
-
-// CHECK:  void operator_star_pullback(double _d_y, ptrClass *_d_this) {
-// CHECK-NEXT:      *_d_this->ptr += _d_y;
 // CHECK-NEXT:  }
 
 // CHECK:  clad::ValueAndAdjoint<double &, double &> operator_star_forw(ptrClass *_d_this) {

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -140,7 +140,7 @@ namespace clad {
         FunctionDecl* FD = cast<FunctionDecl>(D);
         if (FD->isConstexpr() || !m_Multiplexer) {
           DiffCollector collector(DGR, CladEnabledRange, m_DiffRequestGraph, S,
-                                  opts);
+                                  opts, m_DFC);
           break;
         }
       }
@@ -507,7 +507,7 @@ namespace clad {
             if (FD->isConstexpr())
               continue;
           DiffCollector collector(DCI.m_DGR, CladEnabledRange,
-                                  m_DiffRequestGraph, S, opts);
+                                  m_DiffRequestGraph, S, opts, m_DFC);
           break;
         }
 


### PR DESCRIPTION
Currently, in DiffPlanner, we check if a given function has a custom derivative based on the name, i.e. we consider that ``f`` has a custom derivative if a function with the name ``f_pullback`` exists. Since names are not unique, this is insufficient and results in a fallback to dynamic derivative scheduling when names overlap. This is noticeable when we deal with operators and constructors, as they don't have unique names in Clad. This PR implements a full lookup that compares the signatures of derivatives (including templates).
Something we need to take into account:
Before this PR, we called custom derivatives every time it worked with a given set of arguments. Now, however, we only call custom derivatives if there is an exact match of parameter types. For example:
```
double g(double x) {
    return x;
}
// g_pushforward will NOT be considered a derivative for g, even if a given set of arguments can be converted to float
clad::ValueAndPushforward<float, float> g_pushforward(float x, float dx) {
    return {x, dx};
}
```
This could be both an advantage and a disadvantage. On the one hand, the lookup is more picky, making writing custom derivatives harder. On the other hand, this brings clarity to handling overloads since we require direct correspondence between functions and derivatives.

Another huge advantage is that currently, we handle custom derivative lookups separately for every generated function type (in all ``Derive``, ``VisitCallExpr``, and ``VisitCXXConstructExpr``). After this PR, lookups will be handled on a higher level, which will allow us to remove all of that logic.