### PR TITLE
Support references to object array subscript exprs in TBR

### DIFF
--- a/lib/Differentiator/TBRAnalyzer.cpp
+++ b/lib/Differentiator/TBRAnalyzer.cpp
@@ -282,17 +282,6 @@ void TBRAnalyzer::addVar(const clang::VarDecl* VD, bool forceNonRefType) {
   if (utils::IsAutoOrAutoPtrType(varType))
     varType = VD->getInit()->getType();
 
-  // FIXME: If the pointer points to an object we represent it with a OBJ_TYPE
-  // VarData. This is done for '_d_this' pointer to be processed correctly in
-  // hessian mode. This should be removed once full support for pointers in
-  // analysis is introduced.
-  if (const auto* const pointerType = dyn_cast<clang::PointerType>(varType)) {
-    const auto* elemType = pointerType->getPointeeType().getTypePtrOrNull();
-    if (elemType && elemType->isRecordType()) {
-      curBranch[VD] = VarData(QualType::getFromOpaquePtr(elemType), m_Context);
-      return;
-    }
-  }
   curBranch[VD] = VarData(varType, m_Context, forceNonRefType);
 }
 

--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -89,7 +89,6 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer> {
         m_Val.m_FundData = other.m_Val.m_FundData;
       } else if (m_Type == OBJ_TYPE || m_Type == ARR_TYPE) {
         m_Val.m_ArrData = std::move(other.m_Val.m_ArrData);
-        other.m_Val.m_ArrData = nullptr;
       } else if (m_Type == REF_TYPE) {
         m_Val.m_RefData = other.m_Val.m_RefData;
       }


### PR DESCRIPTION
This PR addresses 2 issues in TBR to fix issue #1366:
1) TBR was written when Clad didn't support pointers. Because of that, ``this`` pointer was treated like an object. In practice, this meant that all structure pointers were treated like objects. The first commit removes this workaround.
2) The second commit adds support for references to compound exprs like ``sess[0]`` and not just decl refs exprs.

Fixes #1366.