### PR TITLE
Make static-only scheduling default for pullbacks

### DIFF
--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -621,5 +621,12 @@ static inline const DeclSpec& Sema_ActOnStartOfLambdaDefinition_ScopeOrDeclSpec(
   ,Node->isTransparent()
 #endif
 
+// Clang 19 renamed the enum representing template resolution results
+#if CLANG_VERSION_MAJOR >= 19
+#define CLAD_COMPAT_TemplateSuccess TemplateDeductionResult::Success
+#else
+#define CLAD_COMPAT_TemplateSuccess Sema::TDK_Success
+#endif
+
 } // namespace clad_compat
 #endif //CLAD_COMPATIBILITY

--- a/include/clad/Differentiator/DerivedFnInfo.h
+++ b/include/clad/Differentiator/DerivedFnInfo.h
@@ -16,6 +16,7 @@ struct DerivedFnInfo {
   clang::FunctionDecl* m_OverloadedDerivedFn = nullptr;
   DiffMode m_Mode = DiffMode::unknown;
   DiffInputVarsInfo m_DiffVarsInfo;
+  std::vector<size_t> m_CUDAGlobalArgsIndexes;
   bool m_UsesEnzyme = false;
   bool m_DeclarationOnly = false;
 

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -147,7 +147,8 @@ public:
            EnableVariedAnalysis == other.EnableVariedAnalysis &&
            EnableUsefulAnalysis == other.EnableUsefulAnalysis &&
            DVI == other.DVI && use_enzyme == other.use_enzyme &&
-           DeclarationOnly == other.DeclarationOnly && Global == other.Global;
+           DeclarationOnly == other.DeclarationOnly && Global == other.Global &&
+           CUDAGlobalArgsIndexes == other.CUDAGlobalArgsIndexes;
   }
 
   const clang::FunctionDecl* operator->() const { return Function; }

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -602,6 +602,12 @@ namespace clad {
     /// original derivative function internally. Used in gradient and jacobian
     /// modes.
     clang::FunctionDecl* CreateDerivativeOverload();
+    /// Find the derived function if present in the DerivedFnCollector.
+    ///
+    /// \param[in] request The request to find the derived function.
+    ///
+    /// \returns The derived function if found, nullptr otherwise.
+    clang::FunctionDecl* FindDerivedFunction(DiffRequest& request);
 
   public:
     /// Rebuild a sequence of nested namespaces ending with DC.

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -426,6 +426,14 @@ namespace clad {
     clang::QualType GetNonConstValueType(clang::QualType T) {
       QualType valueType = GetValueType(T);
       valueType.removeLocalConst();
+      // If the const-ness of the type is hidden with sugar, e.g.
+      // `class_name<double>::const_value_type`, the approach above
+      // does not work and we have to desugar the type explicitly.
+      QualType canonicalType = valueType.getCanonicalType();
+      if (canonicalType.isConstQualified()) {
+        canonicalType.removeLocalConst();
+        return canonicalType;
+      }
       return valueType;
     }
 

--- a/lib/Differentiator/DerivedFnInfo.cpp
+++ b/lib/Differentiator/DerivedFnInfo.cpp
@@ -9,13 +9,16 @@ DerivedFnInfo::DerivedFnInfo(const DiffRequest& request,
                              FunctionDecl* overloadedDerivedFn)
     : m_OriginalFn(request.Function), m_DerivedFn(derivedFn),
       m_OverloadedDerivedFn(overloadedDerivedFn), m_Mode(request.Mode),
-      m_DiffVarsInfo(request.DVI), m_UsesEnzyme(request.use_enzyme),
+      m_DiffVarsInfo(request.DVI),
+      m_CUDAGlobalArgsIndexes(request.CUDAGlobalArgsIndexes),
+      m_UsesEnzyme(request.use_enzyme),
       m_DeclarationOnly(request.DeclarationOnly) {}
 
 bool DerivedFnInfo::SatisfiesRequest(const DiffRequest& request) const {
   return (request.Function == m_OriginalFn && request.Mode == m_Mode &&
           request.DVI == m_DiffVarsInfo && request.use_enzyme == m_UsesEnzyme &&
-          request.DeclarationOnly == m_DeclarationOnly);
+          request.DeclarationOnly == m_DeclarationOnly &&
+          request.CUDAGlobalArgsIndexes == m_CUDAGlobalArgsIndexes);
 }
 
 bool DerivedFnInfo::IsValid() const { return m_OriginalFn && m_DerivedFn; }
@@ -25,6 +28,7 @@ bool DerivedFnInfo::RepresentsSameDerivative(const DerivedFnInfo& lhs,
   return lhs.m_OriginalFn == rhs.m_OriginalFn && lhs.m_Mode == rhs.m_Mode &&
          lhs.m_DiffVarsInfo == rhs.m_DiffVarsInfo &&
          lhs.m_UsesEnzyme == rhs.m_UsesEnzyme &&
-         lhs.m_DeclarationOnly == rhs.m_DeclarationOnly;
+         lhs.m_DeclarationOnly == rhs.m_DeclarationOnly &&
+         lhs.m_CUDAGlobalArgsIndexes == rhs.m_CUDAGlobalArgsIndexes;
 }
 } // namespace clad

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -1011,6 +1011,17 @@ namespace clad {
                                     customParams);
   }
 
+  FunctionDecl* VisitorBase::FindDerivedFunction(DiffRequest& request) {
+    // Check if the call is recursive
+    if (request == m_DiffReq)
+      return m_Derivative;
+    // Only definitions are differentiated
+    if (request.Function->getDefinition())
+      request.Function = request.Function->getDefinition();
+    // Look for the derivative
+    return m_Builder.FindDerivedFunction(request);
+  }
+
   Expr* VisitorBase::BuildOperatorCall(OverloadedOperatorKind OOK,
                                        MutableArrayRef<Expr*> ArgExprs,
                                        SourceLocation OpLoc) {

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -109,8 +109,8 @@ float helper(float x) {
   return 2 * x;
 }
 
-// CHECK: void helper_pullback(float x, float _d_y, float *_d_x) {
-// CHECK-NEXT:     *_d_x += 2 * _d_y;
+// CHECK: clad::ValueAndPushforward<float, float> helper_pushforward(float x, float _d_x) {
+// CHECK-NEXT:     return {2 * x, 0 * x + 2 * _d_x};
 // CHECK-NEXT: }
 
 float func2(float* a) {
@@ -146,7 +146,7 @@ float func2(float* a) {
 //CHECK-NEXT:         sum = clad::pop(_t1);
 //CHECK-NEXT:         float _r_d0 = _d_sum;
 //CHECK-NEXT:         float _r0 = 0.F;
-//CHECK-NEXT:         helper_pullback(a[i], _r_d0, &_r0);
+//CHECK-NEXT:         _r0 += _r_d0 * helper_pushforward(a[i], 1.F).pushforward;
 //CHECK-NEXT:         _d_a[i] += _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }

--- a/test/CUDA/GradientKernels.cu
+++ b/test/CUDA/GradientKernels.cu
@@ -298,6 +298,13 @@ __global__ void kernel_with_device_call(double *out, const double *in, double va
   out[index] = device_fn(in[index], val);
 }
 
+// CHECK: __attribute__((device)) void device_fn_pullback_1(const double in, double val, double _d_y, double *_d_in, double *_d_val) {
+//CHECK-NEXT:    {
+//CHECK-NEXT:                *_d_in += _d_y;
+//CHECK-NEXT:                *_d_val += _d_y;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
 // CHECK: void kernel_with_device_call_grad_0_2(double *out, const double *in, double val, double *_d_out, double *_d_val) {
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x;
@@ -329,6 +336,19 @@ __global__ void dup_kernel_with_device_call_2(double *out, const double *in, dou
   out[index] = device_fn_2(in, val);
 } 
 
+//CHECK: __attribute__((device)) void device_fn_2_pullback_1(const double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
+//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
+//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        _d_in[index0] += _d_y;
+//CHECK-NEXT:        *_d_val += _d_y;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
+//CHECK: void device_fn_2_pullback_1(const double *in, double val, double _d_y, double *_d_val) __attribute__((device));
+
 // CHECK: void kernel_with_device_call_2_grad_0_2(double *out, const double *in, double val, double *_d_out, double *_d_val) {
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x;
@@ -341,6 +361,17 @@ __global__ void dup_kernel_with_device_call_2(double *out, const double *in, dou
 //CHECK-NEXT:        double _r0 = 0.;
 //CHECK-NEXT:        device_fn_2_pullback_1(in, val, _r_d0, &_r0);
 //CHECK-NEXT:        atomicAdd(_d_val, _r0);
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
+// CHECK: __attribute__((device)) void device_fn_2_pullback_0(const double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
+//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
+//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        atomicAdd(&_d_in[index0], _d_y);
+//CHECK-NEXT:        *_d_val += _d_y;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
@@ -370,6 +401,17 @@ __global__ void kernel_with_device_call_3(double *out, double *in, double *val) 
   out[index] = device_fn_3(in, val);
 } 
 
+// CHECK: __attribute__((device)) void device_fn_3_pullback_0_1(double *in, double *val, double _d_y, double *_d_in, double *_d_val) {
+//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
+//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
+//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        atomicAdd(&_d_in[index0], _d_y);
+//CHECK-NEXT:        atomicAdd(_d_val, _d_y);
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
 // CHECK: void kernel_with_device_call_3_grad(double *out, double *in, double *val, double *_d_out, double *_d_in, double *_d_val) {
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x;
@@ -396,6 +438,25 @@ __global__ void kernel_with_nested_device_call(double *out, double *in, double v
   int index = threadIdx.x;
   out[index] = device_with_device_call(in, val);
 }
+
+// CHECK: __attribute__((device)) void device_fn_4_pullback_0_1(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
+//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
+//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        atomicAdd(&_d_in[index0], _d_y);
+//CHECK-NEXT:        *_d_val += _d_y;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
+// CHECK: __attribute__((device)) void device_with_device_call_pullback_0(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+//CHECK-NEXT:    {
+//CHECK-NEXT:        double _r0 = 0.;
+//CHECK-NEXT:        device_fn_4_pullback_0_1(in, val, _d_y, _d_in, &_r0);
+//CHECK-NEXT:        *_d_val += _r0;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
 
 // CHECK: void kernel_with_nested_device_call_grad_0_1(double *out, double *in, double val, double *_d_out, double *_d_in) {
 //CHECK-NEXT:    double _d_val = 0.;
@@ -658,60 +719,12 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
 //CHECK-NEXT:    cudaFree(_d_out_dev);
 //CHECK-NEXT:}
 
-// CHECK: __attribute__((device)) void device_fn_pullback_1(const double in, double val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    {
-//CHECK-NEXT:                *_d_in += _d_y;
-//CHECK-NEXT:                *_d_val += _d_y;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
-
 // CHECK: __attribute__((device)) void device_fn_2_pullback_1(const double *in, double val, double _d_y, double *_d_val) {
 //CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
 //CHECK-NEXT:    unsigned int _t0 = blockDim.x;
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
 //CHECK-NEXT:    *_d_val += _d_y;
-//CHECK-NEXT:}
-
-// CHECK: __attribute__((device)) void device_fn_2_pullback_0(const double *in, double val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
-//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
-//CHECK-NEXT:    int _d_index = 0;
-//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        atomicAdd(&_d_in[index0], _d_y);
-//CHECK-NEXT:        *_d_val += _d_y;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
-
-// CHECK: __attribute__((device)) void device_fn_3_pullback_0_1(double *in, double *val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
-//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
-//CHECK-NEXT:    int _d_index = 0;
-//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        atomicAdd(&_d_in[index0], _d_y);
-//CHECK-NEXT:        atomicAdd(_d_val, _d_y);
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
-
-// CHECK: __attribute__((device)) void device_with_device_call_pullback_0(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = 0.;
-//CHECK-NEXT:        device_fn_4_pullback_0_1(in, val, _d_y, _d_in, &_r0);
-//CHECK-NEXT:        *_d_val += _r0;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
-
-// CHECK: __attribute__((device)) void device_fn_4_pullback_0_1(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    unsigned int _t1 = blockIdx.x;
-//CHECK-NEXT:    unsigned int _t0 = blockDim.x;
-//CHECK-NEXT:    int _d_index = 0;
-//CHECK-NEXT:    int index0 = threadIdx.x + _t1 * _t0;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        atomicAdd(&_d_in[index0], _d_y);
-//CHECK-NEXT:        *_d_val += _d_y;
-//CHECK-NEXT:    }
 //CHECK-NEXT:}
 
 #define TEST(F, grid, block, shared_mem, use_stream, x, dx, N)              \

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -676,7 +676,6 @@ double recFun (double x, double y) {
     return x * y;
 }
 
-//CHECK: void recFun_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y);
 //CHECK: void recFun_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     {

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -1197,6 +1197,18 @@ double f_reuse_global(double x, double t) {
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
+double f_static_assert(double x, double y) {
+  static_assert(sizeof(double) == 8, "unexpected double size");
+  return x + y;
+}
+
+//CHECK: void f_static_assert_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK-NEXT:     {
+//CHECK-NEXT:         *_d_x += 1;
+//CHECK-NEXT:         *_d_y += 1;
+//CHECK-NEXT:     }
+//CHECK-NEXT: }
+
 #define TEST(F, x, y)                                                          \
   {                                                                            \
     result[0] = 0;                                                             \
@@ -1296,4 +1308,7 @@ int main() {
 
   INIT_GRADIENT(f_reuse_global);
   TEST_GRADIENT(f_reuse_global, /*numOfDerivativeArgs=*/2, -3, 4, &d_i, &d_j);  // CHECK-EXEC: {-4.00, 3.00}
+
+  INIT_GRADIENT(f_static_assert);
+  TEST_GRADIENT(f_static_assert, /*numOfDerivativeArgs=*/2, -3, 4, &d_i, &d_j);  // CHECK-EXEC: {1.00, 1.00}
 }

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -321,11 +321,8 @@ double f_sum(double *p, int n) {
 // CHECK-NEXT: }
 
 double sq(double x) { return x * x; }
-//CHECK:   void sq_pullback(double x, double _d_y, double *_d_x) {
-//CHECK-NEXT:       {
-//CHECK-NEXT:           *_d_x += _d_y * x;
-//CHECK-NEXT:           *_d_x += x * _d_y;
-//CHECK-NEXT:       }
+//CHECK:   clad::ValueAndPushforward<double, double> sq_pushforward(double x, double _d_x) {
+//CHECK-NEXT:       return {x * x, _d_x * x + x * _d_x};
 //CHECK-NEXT:   }
 
 double f_sum_squares(double *p, int n) {
@@ -362,7 +359,7 @@ double f_sum_squares(double *p, int n) {
 // CHECK-NEXT:         s = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_s;
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         sq_pullback(p[i], _r_d0, &_r0);
+// CHECK-NEXT:         _r0 += _r_d0 * sq_pushforward(p[i], 1.).pushforward;
 // CHECK-NEXT:         _d_p[i] += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -428,7 +425,7 @@ double f_log_gaus(const double* x, double* p /*means*/, double n, double sigma) 
 // CHECK-NEXT:         _d_power += -_r_d1 / _t3;
 // CHECK-NEXT:         double _r1 = _r_d1 * -(-power / (_t3 * _t3));
 // CHECK-NEXT:         double _r2 = 0.;
-// CHECK-NEXT:         sq_pullback(sigma, 2 * _r1, &_r2);
+// CHECK-NEXT:         _r2 += 2 * _r1 * sq_pushforward(sigma, 1.).pushforward;
 // CHECK-NEXT:         _d_sigma += _r2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     for (;; _t0--) {
@@ -440,7 +437,7 @@ double f_log_gaus(const double* x, double* p /*means*/, double n, double sigma) 
 // CHECK-NEXT:         power = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_power;
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         sq_pullback(x[i] - p[i], _r_d0, &_r0);
+// CHECK-NEXT:         _r0 += _r_d0 * sq_pushforward(x[i] - p[i], 1.).pushforward;
 // CHECK-NEXT:         _d_p[i] += -_r0;
 // CHECK-NEXT:     }
 
@@ -2963,7 +2960,7 @@ double fn36(double x, double y){
 //CHECK-NEXT:                             sum = clad::pop(_t2);
 //CHECK-NEXT:                             double _r_d0 = _d_sum;
 //CHECK-NEXT:                             double _r0 = 0.;
-//CHECK-NEXT:                             _r0 += _r_d0 * x * clad::custom_derivatives::sin_pushforward(i, 1.).pushforward;
+//CHECK-NEXT:                             _r0 += _r_d0 * x * clad::custom_derivatives::std::sin_pushforward(i, 1.).pushforward;
 //CHECK-NEXT:                             _d_i += _r0;
 //CHECK-NEXT:                             *_d_x += clad::back(_t3) * _r_d0;
 //CHECK-NEXT:                             clad::pop(_t3);

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -379,7 +379,7 @@ int main() {
 // CHECK: void f7_darg0_grad(float x, float y, float *_d_x, float *_d_y) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
-// CHECK-NEXT:         _r0 += 1 * clad::custom_derivatives::cos_pushforward(x, 1.F).pushforward;
+// CHECK-NEXT:         _r0 += 1 * clad::custom_derivatives::std::cos_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Misc/TimingsReport.C
+++ b/test/Misc/TimingsReport.C
@@ -5,7 +5,7 @@
 #include "clad/Differentiator/Differentiator.h"
 // CHECK: Timers for Clad Funcs
 // CHECK_STATS: *** INFORMATION ABOUT THE DIFF REQUESTS
-// CHECK_STATS-NEXT: <double nested1(double c)>[name=nested1, order=1, mode=pushforward, args='c']: #0 (source), (done)
+// CHECK_STATS-NEXT: <double nested1(double c)>[name=nested1, order=1, mode=pushforward, args='']: #0 (source), (done)
 // CHECK_STATS-NEXT: <double test1(double x, double y)>[name=test1, order=1, mode=forward, args='"x"']: #1 (source), (done)
 // CHECK_STATS-NEXT: <double nested2(double z, double j)>[name=nested2, order=1, mode=pullback, args='z,j']: #2 (source), (done)
 // CHECK_STATS-NEXT: <double test2(double a, double b)>[name=test2, order=1, mode=reverse, args='']: #3 (source), (done)


### PR DESCRIPTION
The goal of this PR is to mostly remove dynamic pullback scheduling and dynamic custom derivative lookups. There are 3 temporary exceptions that were too complex to address in this PR:
1) Error estimation. It currently uses singleton objects m_ErrorEstHandler and m_EstModel, which are cleared after each error_estimate request. This requires the pullback to be derived at the same time to access the singleton objects.
2) Hessians. All high-order derivatives are still scheduled dynamically.
3) Calls that have non-differentiable arguments. This only happens when the user doesn't request derivatives with respect to certain const pointer parameters. Such information is only deduced during visitation. The only way to know it in the diffplanner is with activity analysis. Once activity analysis is enabled by default, we can deprecate this feature with activity analysis off.

The second commit of this PR makes pushforward scheduling in RMV more consistent. Currently, when dealing with simple single-argument functions in the reverse mode, we look up custom pushforwards but generate pullbacks. In this PR, we also start generating pushforwards in such cases. The primary goal is to make the generation/lookup of such derivatives fully static.