### PR TITLE
Rework the time reporting.

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -8,13 +8,16 @@
 #define CLAD_DERIVATIVE_BUILDER_H
 
 #include "Compatibility.h"
-#include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/AST/StmtVisitor.h"
-#include "clang/Sema/Sema.h"
+
 #include "clad/Differentiator/DerivedFnCollector.h"
 #include "clad/Differentiator/DiffPlanner.h"
 
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/StmtVisitor.h"
+#include "clang/Sema/Sema.h"
+
 #include <array>
+#include <memory>
 #include <stack>
 #include <unordered_map>
 

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -5,6 +5,7 @@
 #include "clad/Differentiator/DiffMode.h"
 #include "clad/Differentiator/DynamicGraph.h"
 #include "clad/Differentiator/ParseDiffArgsTypes.h"
+#include "clad/Differentiator/Timers.h"
 
 #include "clang/AST/Decl.h"
 #include "clang/AST/RecursiveASTVisitor.h"
@@ -230,6 +231,7 @@ public:
       if (m_Traversed.count(FD))
         return true;
       m_Traversed.insert(FD);
+      TimedAnalysisRegion R(FD->getNameAsString());
       return TraverseDecl(const_cast<clang::FunctionDecl*>(FD));
     }
     /// Looks up if the user has defined a custom derivative for the given

--- a/include/clad/Differentiator/Timers.h
+++ b/include/clad/Differentiator/Timers.h
@@ -1,0 +1,26 @@
+#ifndef CLAD_DIFFERENTIATOR_TIMERS_H
+#define CLAD_DIFFERENTIATOR_TIMERS_H
+
+#include "llvm/ADT/StringRef.h"
+
+#include <functional>
+#include <string>
+
+namespace clad {
+
+struct TimedAnalysisRegion {
+  TimedAnalysisRegion(llvm::StringRef Name);
+  /// Only runs the lambda if timers are enabled. Useful for more complex
+  /// operations such as ::print.
+  TimedAnalysisRegion(const std::function<std::string()>& NameProvider);
+  ~TimedAnalysisRegion();
+};
+struct TimedGenerationRegion {
+  TimedGenerationRegion(llvm::StringRef Name);
+  /// Only runs the lambda if timers are enabled. Useful for more complex
+  /// operations such as ::print.
+  TimedGenerationRegion(const std::function<std::string()>& NameProvider);
+  ~TimedGenerationRegion();
+};
+} // namespace clad
+#endif // CLAD_DIFFERENTIATOR_TIMERS_H

--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -33,6 +33,7 @@ llvm_add_library(cladDifferentiator
   ReverseModeForwPassVisitor.cpp
   ReverseModeVisitor.cpp
   TBRAnalyzer.cpp
+  Timers.cpp
   StmtClone.cpp
   UsefulAnalyzer.cpp
   VectorForwardModeVisitor.cpp

--- a/lib/Differentiator/Timers.cpp
+++ b/lib/Differentiator/Timers.cpp
@@ -1,0 +1,131 @@
+#include "clad/Differentiator/Timers.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/Timer.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cassert>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace clad {
+
+// Implementation heavily inspired by llvm::TimePassesHandler.
+class CladTimeInfo {
+  /// Group of timers that are part of the analysis stage.
+  llvm::TimerGroup m_AnalysisTG;
+  /// Group of timers that are part of the transformation stage.
+  llvm::TimerGroup m_DiffTG;
+
+  using TimerVector = llvm::SmallVector<llvm::Timer, 4>;
+  llvm::StringMap<TimerVector> m_TimingData;
+
+  using Timers = llvm::SmallVector<llvm::Timer*, 8>;
+  Timers m_AnalysisTimers;
+  Timers m_DiffTimers;
+
+  /// Returns the timer for the specified \p ID or creates a new one.
+  llvm::Timer& GetTimer(llvm::StringRef ID, llvm::TimerGroup& TG) {
+    auto& Ts = m_TimingData[ID];
+    if (Ts.empty())
+      Ts.emplace_back(ID, ID, TG);
+    return Ts.front();
+  }
+
+  void StartTimer(llvm::StringRef ID, Timers& Ts, llvm::TimerGroup& TG) {
+    // Stop the previous timer to prevent double counting when an timed
+    // region requests another timer.
+    if (!Ts.empty()) {
+      assert(Ts.back()->isRunning());
+      Ts.back()->stopTimer();
+    }
+
+    llvm::Timer& T = GetTimer(ID, TG);
+    Ts.push_back(&T);
+    if (!T.isRunning())
+      T.startTimer();
+  }
+
+  static void StopTimer(Timers& Ts) {
+    assert(!Ts.empty() && "empty stack in StopTimer");
+    llvm::Timer* T = Ts.pop_back_val();
+    assert(T && "timer should be present");
+    if (T->isRunning())
+      T->stopTimer();
+
+    // Restart the previously stopped timer.
+    if (!Ts.empty()) {
+      assert(!Ts.back()->isRunning());
+      Ts.back()->startTimer();
+    }
+  }
+
+public:
+  CladTimeInfo()
+      : m_AnalysisTG("analysis", "Clad Analysis Timing Report"),
+        m_DiffTG("ast generation", "Clad AST Generation Timing Report") {}
+
+  /// Destructor handles the print action if it has not been handled before.
+  ~CladTimeInfo() { print(); }
+
+  // We intend this to be unique per-compilation, thus no copies.
+  CladTimeInfo(const CladTimeInfo&) = delete;
+  CladTimeInfo(CladTimeInfo&&) = delete;
+  void operator=(const CladTimeInfo&) = delete;
+  CladTimeInfo& operator=(CladTimeInfo&&) = delete;
+
+  void StartAnalysisTimer(llvm::StringRef Name) {
+    StartTimer(Name, m_AnalysisTimers, m_AnalysisTG);
+  }
+  void StopAnalysisTimer() { StopTimer(m_AnalysisTimers); }
+  void StartDiffTimer(llvm::StringRef Name) {
+    StartTimer(Name, m_DiffTimers, m_DiffTG);
+  }
+  void StopDiffTimer() { StopTimer(m_DiffTimers); }
+  void print() {
+    if (!CladTimeInfo::TheTimingInfo)
+      return;
+    std::unique_ptr<llvm::raw_ostream> OS = llvm::CreateInfoOutputFile();
+    m_DiffTG.print(*OS, true);
+    m_AnalysisTG.print(*OS, true);
+  }
+  static void Init();
+  static CladTimeInfo* TheTimingInfo;
+};
+CladTimeInfo* CladTimeInfo::TheTimingInfo;
+void InitTimers() {
+  assert(!CladTimeInfo::TheTimingInfo);
+  static llvm::ManagedStatic<CladTimeInfo> CTI;
+  CladTimeInfo::TheTimingInfo = &*CTI;
+}
+
+TimedAnalysisRegion::TimedAnalysisRegion(llvm::StringRef Name) {
+  if (CladTimeInfo::TheTimingInfo)
+    CladTimeInfo::TheTimingInfo->StartAnalysisTimer(Name);
+}
+TimedAnalysisRegion::TimedAnalysisRegion(
+    const std::function<std::string()>& NameProvider)
+    : TimedAnalysisRegion(CladTimeInfo::TheTimingInfo ? NameProvider() : "") {}
+TimedAnalysisRegion::~TimedAnalysisRegion() {
+  if (CladTimeInfo::TheTimingInfo)
+    CladTimeInfo::TheTimingInfo->StopAnalysisTimer();
+}
+
+TimedGenerationRegion::TimedGenerationRegion(llvm::StringRef Name) {
+  if (CladTimeInfo::TheTimingInfo)
+    CladTimeInfo::TheTimingInfo->StartDiffTimer(Name);
+}
+TimedGenerationRegion::TimedGenerationRegion(
+    const std::function<std::string()>& NameProvider)
+    : TimedGenerationRegion(CladTimeInfo::TheTimingInfo ? NameProvider() : "") {
+}
+TimedGenerationRegion::~TimedGenerationRegion() {
+  if (CladTimeInfo::TheTimingInfo)
+    CladTimeInfo::TheTimingInfo->StopDiffTimer();
+}
+} // namespace clad

--- a/test/Misc/TimingsReport.C
+++ b/test/Misc/TimingsReport.C
@@ -1,9 +1,15 @@
 // RUN: %cladclang %s -I%S/../../include -oTimingsReport.out -ftime-report 2>&1 | %filecheck %s
-// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -plugin-arg-clad -Xclang -disable-tbr -Xclang -print-stats 2>&1 | %filecheck -check-prefix=CHECK_STATS %s
+// RUN: env CLAD_ENABLE_TIMING=1 %cladclang %s -I%S/../../include -oTimingsReport.out 2>&1 | %filecheck -check-prefix=CHECK_TIMING_ENV %s
+// RUN: %cladclang %s -I%S/../../include -fsyntax-only -DGLOBAL \
+// RUN:            -Xclang -plugin-arg-clad -Xclang -disable-tbr -Xclang \
+// RUN:             -print-stats -Xclang -verify 2>&1 | %filecheck -check-prefix=CHECK_STATS %s
 // RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -print-stats 2>&1 | %filecheck -check-prefix=CHECK_STATS_TBR %s
 
 #include "clad/Differentiator/Differentiator.h"
-// CHECK: Timers for Clad Funcs
+// CHECK: Clad AST Generation Timing Report
+// CHECK: Clad Analysis Timing Report
+// CHECK_TIMING_ENV: Clad AST Generation Timing Report
+// CHECK_TIMING_ENV: TBR func
 // CHECK_STATS: *** INFORMATION ABOUT THE DIFF REQUESTS
 // CHECK_STATS-NEXT: <double nested1(double c)>[name=nested1, order=1, mode=pushforward, args='']: #0 (source), (done)
 // CHECK_STATS-NEXT: <double test1(double x, double y)>[name=test1, order=1, mode=forward, args='"x"']: #1 (source), (done)
@@ -11,11 +17,34 @@
 // CHECK_STATS-NEXT: <double test2(double a, double b)>[name=test2, order=1, mode=reverse, args='']: #3 (source), (done)
 // CHECK_STATS-NEXT: <double addArrImpl(double *arr)>[name=addArrImpl, order=1, mode=pullback, args='arr']: #4 (source), (done)
 // CHECK_STATS-NEXT: <double addArr(double *arr)>[name=addArr, order=1, mode=reverse, args='"arr[0:1]"']: #5 (source), (done)
+// CHECK_STATS-NEXT: <float func(float *a)>[name=func, order=1, mode=reverse, args='']: #6 (source), (done)
+// CHECK_STATS-NEXT: <double g = 3.1400000000000001>[name=, order=1, mode=unknown, args='']: #7 (source), (done)
+// CHECK_STATS-NEXT: <double global_fn(double x)>[name=global_fn, order=1, mode=reverse, args='']: #8 (source), (done)
+// CHECK_STATS-NEXT: <constexpr double constexpr_fn(double x, double y)>[name=constexpr_fn, order=1, mode=reverse, args='']: #9 (source), (done)
 
 // CHECK_STATS_TBR: <double test1(double x, double y)>[name=test1, order=1, mode=forward, args='"x"', tbr]: #1 (source), (done)
 
-double nested1(double c){
-  return c*3*c;
+#ifdef GLOBAL
+double g = 3.14; // expected-warning {{The gradient utilizes a global variable 'g'}}
+double global_fn(double x) {
+  return g * x;
+}
+#endif // GLOBAL
+
+constexpr double constexpr_fn(double x, double y) { return x * y; }
+
+float func(float* a) {
+  float sum = 0;
+  for (int i = 0; i < 3; i++)
+    sum += a[i];
+  return sum;
+}
+
+double nested1(double c) {
+  double t = 1;
+  for (int i = 0; i < 3; i++)
+    t *= c;
+  return t; // == c^3
 }
 
 double nested2(double z, double j){
@@ -46,5 +75,10 @@ int main() {
   printf("Result is = %f\n", d_fn_1.execute(3,4));
   printf("Result is = %f %f\n", dp, dq);
   clad::gradient(addArr, "arr[0:1]");
+  clad::gradient(func);
+#ifdef GLOBAL
+  clad::gradient(global_fn);
+#endif // GLOBAL
+  clad::gradient(constexpr_fn);
   return 0;
 }

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -24,7 +24,8 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
-#include "llvm/Support/Timer.h"
+
+#include <string>
 
 namespace clang {
   class ASTContext;
@@ -39,16 +40,6 @@ namespace clang {
 namespace clad {
 
 bool checkClangVersion();
-class CladTimerGroup {
-  llvm::TimerGroup m_Tg;
-  std::vector<std::unique_ptr<llvm::Timer>> m_Timers;
-
-public:
-  CladTimerGroup();
-  void StartNewTimer(llvm::StringRef TimerName, llvm::StringRef TimerDesc);
-  void StopTimer();
-};
-
   namespace plugin {
     struct DifferentiationOptions {
       DifferentiationOptions()
@@ -107,7 +98,6 @@ public:
     DifferentiationOptions m_DO;
     std::unique_ptr<DerivativeBuilder> m_DerivativeBuilder;
     bool m_HasRuntime = false;
-    CladTimerGroup m_CTG;
     DerivedFnCollector m_DFC;
     DynamicGraph<DiffRequest> m_DiffRequestGraph;
     enum class CallKind {

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -40,33 +40,33 @@ namespace clang {
 namespace clad {
 
 bool checkClangVersion();
-  namespace plugin {
-    struct DifferentiationOptions {
-      DifferentiationOptions()
-          : DumpSourceFn(false), DumpSourceFnAST(false), DumpDerivedFn(false),
-            DumpDerivedAST(false), GenerateSourceFile(false),
-            ValidateClangVersion(true), EnableTBRAnalysis(false),
-            DisableTBRAnalysis(false), EnableVariedAnalysis(false),
-            DisableVariedAnalysis(false), EnableUsefulAnalysis(false),
-            DisableUsefulAnalysis(false), CustomEstimationModel(false),
-            PrintNumDiffErrorInfo(false) {}
+namespace plugin {
+struct DifferentiationOptions {
+  DifferentiationOptions()
+      : DumpSourceFn(false), DumpSourceFnAST(false), DumpDerivedFn(false),
+        DumpDerivedAST(false), GenerateSourceFile(false),
+        ValidateClangVersion(true), EnableTBRAnalysis(false),
+        DisableTBRAnalysis(false), EnableVariedAnalysis(false),
+        DisableVariedAnalysis(false), EnableUsefulAnalysis(false),
+        DisableUsefulAnalysis(false), CustomEstimationModel(false),
+        PrintNumDiffErrorInfo(false) {}
 
-      bool DumpSourceFn : 1;
-      bool DumpSourceFnAST : 1;
-      bool DumpDerivedFn : 1;
-      bool DumpDerivedAST : 1;
-      bool GenerateSourceFile : 1;
-      bool ValidateClangVersion : 1;
-      bool EnableTBRAnalysis : 1;
-      bool DisableTBRAnalysis : 1;
-      bool EnableVariedAnalysis : 1;
-      bool DisableVariedAnalysis : 1;
-      bool EnableUsefulAnalysis : 1;
-      bool DisableUsefulAnalysis : 1;
-      bool CustomEstimationModel : 1;
-      bool PrintNumDiffErrorInfo : 1;
-      std::string CustomModelName;
-    };
+  bool DumpSourceFn : 1;
+  bool DumpSourceFnAST : 1;
+  bool DumpDerivedFn : 1;
+  bool DumpDerivedAST : 1;
+  bool GenerateSourceFile : 1;
+  bool ValidateClangVersion : 1;
+  bool EnableTBRAnalysis : 1;
+  bool DisableTBRAnalysis : 1;
+  bool EnableVariedAnalysis : 1;
+  bool DisableVariedAnalysis : 1;
+  bool EnableUsefulAnalysis : 1;
+  bool DisableUsefulAnalysis : 1;
+  bool CustomEstimationModel : 1;
+  bool PrintNumDiffErrorInfo : 1;
+  std::string CustomModelName;
+};
 
     class CladExternalSource : public clang::ExternalSemaSource {
     // ExternalSemaSource


### PR DESCRIPTION
This patch implements two separate timers. One per Analysis and one per DiffRequest. It also allows this logic to be triggered by setting the env variable CLAD_ENABLE_TIMING.