### PR TITLE
[ci] Move the debug builds to the selfhosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
             clang-runtime: '20'
 
           - name: ubu22-clang15-runtime16-debug
-            os: ubuntu-22.04
+            os: self-hosted #ubuntu-22.04
             compiler: clang-15
             clang-runtime: '16'
             debug_build: true


### PR DESCRIPTION
This patch should speed up the running of debug clang which currently takes around 20 minutes.