### PR TITLE
Remove `experimental_` part from the naming of pushforward/pullback modes

### DIFF
--- a/include/clad/Differentiator/DiffMode.h
+++ b/include/clad/Differentiator/DiffMode.h
@@ -6,9 +6,9 @@ enum class DiffMode {
   unknown = 0,
   forward,
   vector_forward_mode,
-  experimental_pushforward,
-  experimental_pullback,
-  experimental_vector_pushforward,
+  pushforward,
+  pullback,
+  vector_pushforward,
   reverse,
   hessian,
   hessian_diagonal,
@@ -24,11 +24,11 @@ inline const char* DiffModeToString(DiffMode mode) {
     return "forward";
   case DiffMode::vector_forward_mode:
     return "vector_forward_mode";
-  case DiffMode::experimental_pushforward:
+  case DiffMode::pushforward:
     return "pushforward";
-  case DiffMode::experimental_pullback:
+  case DiffMode::pullback:
     return "pullback";
-  case DiffMode::experimental_vector_pushforward:
+  case DiffMode::vector_pushforward:
     return "vector_pushforward";
   case DiffMode::reverse:
     return "reverse";

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -58,8 +58,8 @@ bool IsRealNonReferenceType(QualType T) {
 DerivativeAndOverload BaseForwardModeVisitor::Derive() {
   const FunctionDecl* FD = m_DiffReq.Function;
   assert(m_DiffReq.Mode == DiffMode::forward ||
-         m_DiffReq.Mode == DiffMode::experimental_pushforward ||
-         m_DiffReq.Mode == DiffMode::experimental_vector_pushforward);
+         m_DiffReq.Mode == DiffMode::pushforward ||
+         m_DiffReq.Mode == DiffMode::vector_pushforward);
   assert(!m_DerivativeInFlight &&
          "Doesn't support recursive diff. Use DiffPlan.");
 
@@ -173,7 +173,7 @@ DerivativeAndOverload BaseForwardModeVisitor::Derive() {
     beginBlock();
 
     // FIXME: Remove the override in VectorPushForwardModeVisitor.
-    if (m_DiffReq.Mode == DiffMode::experimental_vector_pushforward)
+    if (m_DiffReq.Mode == DiffMode::vector_pushforward)
       ExecuteInsidePushforwardFunctionBlock();
 
     if (m_DiffReq.Mode == DiffMode::forward)
@@ -978,7 +978,7 @@ std::string BaseForwardModeVisitor::GetPushForwardFunctionSuffix() {
 }
 
 DiffMode BaseForwardModeVisitor::GetPushForwardMode() {
-  return DiffMode::experimental_pushforward;
+  return DiffMode::pushforward;
 }
 
 StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -921,8 +921,7 @@ namespace clad {
 
     QualType GetParameterDerivativeType(Sema& S, DiffMode Mode, QualType Type) {
       ASTContext& C = S.getASTContext();
-      if (Mode == DiffMode::experimental_vector_pushforward ||
-          Mode == DiffMode::jacobian) {
+      if (Mode == DiffMode::vector_pushforward || Mode == DiffMode::jacobian) {
         QualType valueType = GetNonConstValueType(Type);
         QualType resType;
         if (isArrayOrPointerType(Type)) {
@@ -948,8 +947,7 @@ namespace clad {
         return resType;
       }
 
-      if (Mode == DiffMode::reverse ||
-          Mode == DiffMode::experimental_pullback ||
+      if (Mode == DiffMode::reverse || Mode == DiffMode::pullback ||
           Mode == DiffMode::error_estimation) {
         QualType ValueType = GetNonConstValueType(Type);
         QualType nonRefValueType = ValueType.getNonReferenceType();
@@ -985,7 +983,7 @@ namespace clad {
       QualType oRetTy = FD->getReturnType();
       QualType dRetTy = C.VoidTy;
       bool returnVoid = mode == DiffMode::reverse ||
-                        mode == DiffMode::experimental_pullback ||
+                        mode == DiffMode::pullback ||
                         mode == DiffMode::error_estimation ||
                         mode == DiffMode::vector_forward_mode;
       if (mode == DiffMode::reverse_mode_forward_pass) {
@@ -1005,7 +1003,7 @@ namespace clad {
         QualType PushFwdTy = utils::GetParameterDerivativeType(S, mode, oRetTy);
         dRetTy = utils::InstantiateTemplate(S, valueAndPushforward,
                                             {oRetTy, PushFwdTy});
-      } else if (mode == DiffMode::experimental_pullback) {
+      } else if (mode == DiffMode::pullback) {
         // Handle pullbacks
         QualType argTy = oRetTy.getNonReferenceType();
         argTy = utils::getNonConstType(argTy, S);

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -533,19 +533,19 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
     if (request.Mode == DiffMode::forward) {
       BaseForwardModeVisitor V(*this, request);
       result = V.Derive();
-    } else if (request.Mode == DiffMode::experimental_pushforward) {
+    } else if (request.Mode == DiffMode::pushforward) {
       PushForwardModeVisitor V(*this, request);
       result = V.Derive();
     } else if (request.Mode == DiffMode::vector_forward_mode) {
       VectorForwardModeVisitor V(*this, request);
       result = V.Derive();
-    } else if (request.Mode == DiffMode::experimental_vector_pushforward) {
+    } else if (request.Mode == DiffMode::vector_pushforward) {
       VectorPushForwardModeVisitor V(*this, request);
       result = V.Derive();
     } else if (request.Mode == DiffMode::reverse) {
       ReverseModeVisitor V(*this, request);
       result = V.Derive();
-    } else if (request.Mode == DiffMode::experimental_pullback) {
+    } else if (request.Mode == DiffMode::pullback) {
       ReverseModeVisitor V(*this, request);
       if (!m_ErrorEstHandler.empty()) {
         InitErrorEstimation(m_ErrorEstHandler, m_EstModel, *this, request);

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -312,7 +312,7 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
   void DiffRequest::UpdateDiffParamsInfo(Sema& semaRef) {
     // Diff info for pullbacks is generated automatically,
     // its parameters are not provided by the user.
-    if (Mode == DiffMode::experimental_pullback)
+    if (Mode == DiffMode::pullback)
       return;
 
     DVI.clear();
@@ -1112,14 +1112,13 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
       // to schedule pushforward_pullback.
       if (m_TopMostReq->Mode == DiffMode::forward ||
           m_TopMostReq->Mode == DiffMode::hessian || usePushforwardInRevMode)
-        request.Mode = DiffMode::experimental_pushforward;
+        request.Mode = DiffMode::pushforward;
       else if (m_TopMostReq->Mode == DiffMode::reverse)
-        request.Mode = DiffMode::experimental_pullback;
+        request.Mode = DiffMode::pullback;
       else if (m_TopMostReq->Mode == DiffMode::vector_forward_mode ||
                m_TopMostReq->Mode == DiffMode::jacobian ||
-               m_TopMostReq->Mode ==
-                   DiffMode::experimental_vector_pushforward) {
-        request.Mode = DiffMode::experimental_vector_pushforward;
+               m_TopMostReq->Mode == DiffMode::vector_pushforward) {
+        request.Mode = DiffMode::vector_pushforward;
       } else if (m_TopMostReq->Mode == DiffMode::error_estimation) {
         // FIXME: Add support for static graphs in error estimation.
         return true;
@@ -1133,7 +1132,7 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
       request.EnableUsefulAnalysis = m_TopMostReq->EnableUsefulAnalysis;
       request.CallContext = E;
 
-      if (request.Mode != DiffMode::experimental_pushforward) {
+      if (request.Mode != DiffMode::pushforward) {
         for (size_t i = 0, e = FD->getNumParams(); i < e; ++i) {
           // if (MD && isLambdaCallOperator(MD)) {
           const auto* paramDecl = FD->getParamDecl(i);
@@ -1211,7 +1210,7 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
       return true;
     // FIXME: Add support for globals in other modes.
     if (m_ParentReq->Mode != DiffMode::reverse &&
-        m_ParentReq->Mode != DiffMode::experimental_pullback)
+        m_ParentReq->Mode != DiffMode::pullback)
       return true;
 
     // FIXME: In some cases, custom overloads are not found by DiffPlanner and

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1837,8 +1837,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
 
     pullbackRequest.BaseFunctionName = clad::utils::ComputeEffectiveFnName(FD);
-    pullbackRequest.Mode = asGrad ? DiffMode::experimental_pullback
-                                  : DiffMode::experimental_pushforward;
+    pullbackRequest.Mode = asGrad ? DiffMode::pullback : DiffMode::pushforward;
     bool hasDynamicNonDiffParams = false;
 
     // Silence diag outputs in nested derivation process.
@@ -4206,7 +4205,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         // pullbackRequest.CUDAGlobalArgsIndexes = globalCallArgs;
 
         pullbackRequest.BaseFunctionName = "constructor";
-        pullbackRequest.Mode = DiffMode::experimental_pullback;
+        pullbackRequest.Mode = DiffMode::pullback;
         // Silence diag outputs in nested derivation process.
         pullbackRequest.VerboseDiags = false;
         pullbackRequest.EnableTBRAnalysis = m_DiffReq.EnableTBRAnalysis;
@@ -4391,8 +4390,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // FIXME: We ignore the pointer return type for pullbacks.
     QualType dRetTy = FD->getReturnType().getNonReferenceType();
     dRetTy = utils::getNonConstType(dRetTy, m_Sema);
-    if (m_DiffReq.Mode == DiffMode::experimental_pullback &&
-        !dRetTy->isVoidType() && !dRetTy->isPointerType()) {
+    if (m_DiffReq.Mode == DiffMode::pullback && !dRetTy->isVoidType() &&
+        !dRetTy->isPointerType()) {
       auto paramNameExists = [&params](llvm::StringRef name) {
         for (ParmVarDecl* PVD : params)
           if (PVD->getName() == name)

--- a/lib/Differentiator/VectorForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorForwardModeVisitor.cpp
@@ -25,7 +25,7 @@ std::string VectorForwardModeVisitor::GetPushForwardFunctionSuffix() {
 }
 
 DiffMode VectorForwardModeVisitor::GetPushForwardMode() {
-  return DiffMode::experimental_vector_pushforward;
+  return DiffMode::vector_pushforward;
 }
 
 void VectorForwardModeVisitor::SetIndependentVarsExpr(Expr* IndVarCountExpr) {


### PR DESCRIPTION
Pushforwards and pullbacks are now an integral part of Clad, and there's likely no reason to label them as experimental.