### PR TITLE
Revert "[ci] Move the debug builds to the selfhosted runners"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
             compiler: msvc
             clang-runtime: '20'
 
-          - name: selfh-ubu22-clang15-runtime18-debug
+          - name: selfh-ubu22-clang15-runtime16-debug
             os: self-hosted #ubuntu-22.04
             compiler: clang-15
             clang-runtime: '18'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,10 @@ jobs:
             compiler: msvc
             clang-runtime: '20'
 
-          - name: ubu22-clang15-runtime16-debug
+          - name: ubu22-clang15-runtime18-debug
             os: ubuntu-22.04
             compiler: clang-15
-            clang-runtime: '16'
+            clang-runtime: '18'
             debug_build: true
 
           - name: selfh-ubu22-gcc12-runtime18-analyzers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
             compiler: msvc
             clang-runtime: '20'
 
-          - name: selfh-ubu22-clang15-runtime16-debug
+          - name: ubu22-clang15-runtime16-debug
             os: self-hosted #ubuntu-22.04
             compiler: clang-15
             clang-runtime: '16'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
             clang-runtime: '20'
 
           - name: ubu22-clang15-runtime16-debug
-            os: self-hosted #ubuntu-22.04
+            os: ubuntu-22.04
             compiler: clang-15
             clang-runtime: '16'
             debug_build: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           - name: selfh-ubu22-clang15-runtime16-debug
             os: self-hosted #ubuntu-22.04
             compiler: clang-15
-            clang-runtime: '18'
+            clang-runtime: '16'
             debug_build: true
 
           - name: selfh-ubu22-gcc12-runtime18-analyzers


### PR DESCRIPTION
Reverts vgvassilev/clad#1375 as it was a bad idea. The self host machine is oversubscribed with the cuda builds and the analyzer builds. Overall, on average, it made our CI slower.