### PR TITLE
Add template specialization handling and primary template derivation for specializations

### DIFF
--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -23,6 +23,7 @@
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/SemaInternal.h"
 #include "clang/Sema/Template.h"
+#include <cinttypes>
 #include <clad/Differentiator/DiffMode.h>
 #include "clad/Differentiator/BaseForwardModeVisitor.h"
 #include "clad/Differentiator/CladUtils.h"
@@ -40,6 +41,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <memory_resource>
 #include <string>
 
 #include "clad/Differentiator/CladUtils.h"
@@ -142,6 +144,43 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
               : nullptr);
 
       returnedFD->setAccess(FD->getAccess());
+
+      if (FD->getTemplatedKind() == FunctionDecl::TK_FunctionTemplateSpecialization) {
+        FunctionTemplateDecl *returnedFTD = nullptr;
+        auto Results = m_Context.getTranslationUnitDecl()->lookup(returnedFD->getNameInfo().getName());
+        for (NamedDecl *ND : Results) {
+          if (auto *FTD = dyn_cast<FunctionTemplateDecl>(ND)) {
+            returnedFTD = FTD;
+            break;
+          }
+
+          if (auto *FD = dyn_cast<FunctionDecl>(ND)) {
+            if (auto *FTD = FD->getDescribedFunctionTemplate()) {
+              returnedFTD = FTD;
+              break;
+            }
+          }
+        }
+
+        assert((returnedFTD != nullptr) &&
+            "Function specialization derived before primary temaplate. This shouldn't happen");
+
+        const TemplateArgumentList* TAL = FD->getTemplateSpecializationArgs();
+        TemplateArgumentList* TALCopy =
+              TemplateArgumentList::CreateCopy(m_Context, TAL->asArray());
+
+        returnedFD->setFunctionTemplateSpecialization(
+              returnedFTD, TALCopy, nullptr,
+              FD->getTemplateSpecializationKindForInstantiation());
+
+        std::cout << "\n--------------------------------------------------------------------------------\n";
+        returnedFD->dump();
+        std::cout << "\n--------------------------------------------------------------------------------\n";
+        for (auto x : returnedFTD->specializations()) {
+          x->dump();
+        }
+        std::cout << "\n--------------------------------------------------------------------------------\n";
+      }
     }
 
     returnedFD->setImplicitlyInline(FD->isInlined());
@@ -495,6 +534,7 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
       if (!request.DeclarationOnly)
         FD = FD->getDefinition();
 
+
       // check if the function is non-differentiable.
       if (clad::utils::hasNonDifferentiableAttribute(FD)) {
         diag(DiagnosticsEngine::Error,
@@ -517,6 +557,43 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
                "non-differentiable",
                {MD->getNameAsString(), CD->getNameAsString()});
           return {};
+        }
+      }
+
+      if (FD->getTemplatedKind() == FunctionDecl::TK_FunctionTemplateSpecialization) {
+        DiffRequest primaryFDRequest = request;
+        primaryFDRequest.Function = FD->getPrimaryTemplate()->getTemplatedDecl();
+
+        auto *primaryFD = HandleNestedDiffRequest(primaryFDRequest);
+
+        FunctionTemplateDecl *NewFTD = nullptr;
+        auto Results = m_Context.getTranslationUnitDecl()->lookup(primaryFD->getNameInfo().getName());
+
+        for (NamedDecl *ND : Results) {
+          // Direct match
+          if (auto *FTD = dyn_cast<FunctionTemplateDecl>(ND)) {
+            NewFTD = FTD;
+            break;
+          }
+
+          if (auto *FD = dyn_cast<FunctionDecl>(ND)) {
+            if (auto *FTD = FD->getDescribedFunctionTemplate()) {
+              NewFTD = FTD;
+              break;
+            }
+          }
+        }
+
+        if (NewFTD == nullptr) {
+            TemplateParameterList* TemplateParams =
+                    FD->getPrimaryTemplate()->getTemplateParameters();
+
+            NewFTD = FunctionTemplateDecl::Create(
+                        m_Context,
+                        m_Sema.CurContext, noLoc, primaryFD->getNameInfo().getName(),
+                        TemplateParams, primaryFD);
+            NewFTD->setLexicalDeclContext(m_Sema.CurContext);
+            primaryFD->setDescribedFunctionTemplate(NewFTD);
         }
       }
     } else if (const VarDecl* VD = request.Global) {

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -7,6 +7,17 @@
 #include "clad/Differentiator/DerivativeBuilder.h"
 
 #include "JacobianModeVisitor.h"
+#include "clad/Differentiator/BaseForwardModeVisitor.h"
+#include "clad/Differentiator/CladUtils.h"
+#include "clad/Differentiator/DiffPlanner.h"
+#include "clad/Differentiator/ErrorEstimator.h"
+#include "clad/Differentiator/HessianModeVisitor.h"
+#include "clad/Differentiator/PushForwardModeVisitor.h"
+#include "clad/Differentiator/ReverseModeForwPassVisitor.h"
+#include "clad/Differentiator/ReverseModeVisitor.h"
+#include "clad/Differentiator/StmtClone.h"
+#include "clad/Differentiator/VectorForwardModeVisitor.h"
+#include "clad/Differentiator/VectorPushForwardModeVisitor.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
@@ -25,17 +36,6 @@
 #include "clang/Sema/Template.h"
 #include <cinttypes>
 #include <clad/Differentiator/DiffMode.h>
-#include "clad/Differentiator/BaseForwardModeVisitor.h"
-#include "clad/Differentiator/CladUtils.h"
-#include "clad/Differentiator/DiffPlanner.h"
-#include "clad/Differentiator/ErrorEstimator.h"
-#include "clad/Differentiator/HessianModeVisitor.h"
-#include "clad/Differentiator/PushForwardModeVisitor.h"
-#include "clad/Differentiator/ReverseModeForwPassVisitor.h"
-#include "clad/Differentiator/ReverseModeVisitor.h"
-#include "clad/Differentiator/StmtClone.h"
-#include "clad/Differentiator/VectorForwardModeVisitor.h"
-#include "clad/Differentiator/VectorPushForwardModeVisitor.h"
 
 #include "llvm/Support/SaveAndRestore.h"
 
@@ -145,17 +145,19 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
 
       returnedFD->setAccess(FD->getAccess());
 
-      if (FD->getTemplatedKind() == FunctionDecl::TK_FunctionTemplateSpecialization) {
-        FunctionTemplateDecl *returnedFTD = nullptr;
-        auto Results = m_Context.getTranslationUnitDecl()->lookup(returnedFD->getNameInfo().getName());
-        for (NamedDecl *ND : Results) {
-          if (auto *FTD = dyn_cast<FunctionTemplateDecl>(ND)) {
+      if (FD->getTemplatedKind() ==
+          FunctionDecl::TK_FunctionTemplateSpecialization) {
+        FunctionTemplateDecl* returnedFTD = nullptr;
+        auto Results = m_Context.getTranslationUnitDecl()->lookup(
+            returnedFD->getNameInfo().getName());
+        for (NamedDecl* ND : Results) {
+          if (auto* FTD = dyn_cast<FunctionTemplateDecl>(ND)) {
             returnedFTD = FTD;
             break;
           }
 
-          if (auto *FD = dyn_cast<FunctionDecl>(ND)) {
-            if (auto *FTD = FD->getDescribedFunctionTemplate()) {
+          if (auto* FD = dyn_cast<FunctionDecl>(ND)) {
+            if (auto* FTD = FD->getDescribedFunctionTemplate()) {
               returnedFTD = FTD;
               break;
             }
@@ -163,23 +165,26 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
         }
 
         assert((returnedFTD != nullptr) &&
-            "Function specialization derived before primary temaplate. This shouldn't happen");
+               "Function specialization derived before primary temaplate. This "
+               "shouldn't happen");
 
         const TemplateArgumentList* TAL = FD->getTemplateSpecializationArgs();
         TemplateArgumentList* TALCopy =
-              TemplateArgumentList::CreateCopy(m_Context, TAL->asArray());
+            TemplateArgumentList::CreateCopy(m_Context, TAL->asArray());
 
         returnedFD->setFunctionTemplateSpecialization(
-              returnedFTD, TALCopy, nullptr,
-              FD->getTemplateSpecializationKindForInstantiation());
+            returnedFTD, TALCopy, nullptr,
+            FD->getTemplateSpecializationKindForInstantiation());
 
-        std::cout << "\n--------------------------------------------------------------------------------\n";
+        std::cout << "\n-------------------------------------------------------"
+                     "-------------------------\n";
         returnedFD->dump();
-        std::cout << "\n--------------------------------------------------------------------------------\n";
-        for (auto x : returnedFTD->specializations()) {
+        std::cout << "\n-------------------------------------------------------"
+                     "-------------------------\n";
+        for (auto x : returnedFTD->specializations())
           x->dump();
-        }
-        std::cout << "\n--------------------------------------------------------------------------------\n";
+        std::cout << "\n-------------------------------------------------------"
+                     "-------------------------\n";
       }
     }
 
@@ -534,7 +539,6 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
       if (!request.DeclarationOnly)
         FD = FD->getDefinition();
 
-
       // check if the function is non-differentiable.
       if (clad::utils::hasNonDifferentiableAttribute(FD)) {
         diag(DiagnosticsEngine::Error,
@@ -560,24 +564,27 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
         }
       }
 
-      if (FD->getTemplatedKind() == FunctionDecl::TK_FunctionTemplateSpecialization) {
+      if (FD->getTemplatedKind() ==
+          FunctionDecl::TK_FunctionTemplateSpecialization) {
         DiffRequest primaryFDRequest = request;
-        primaryFDRequest.Function = FD->getPrimaryTemplate()->getTemplatedDecl();
+        primaryFDRequest.Function =
+            FD->getPrimaryTemplate()->getTemplatedDecl();
 
-        auto *primaryFD = HandleNestedDiffRequest(primaryFDRequest);
+        auto* primaryFD = HandleNestedDiffRequest(primaryFDRequest);
 
-        FunctionTemplateDecl *NewFTD = nullptr;
-        auto Results = m_Context.getTranslationUnitDecl()->lookup(primaryFD->getNameInfo().getName());
+        FunctionTemplateDecl* NewFTD = nullptr;
+        auto Results = m_Context.getTranslationUnitDecl()->lookup(
+            primaryFD->getNameInfo().getName());
 
-        for (NamedDecl *ND : Results) {
+        for (NamedDecl* ND : Results) {
           // Direct match
-          if (auto *FTD = dyn_cast<FunctionTemplateDecl>(ND)) {
+          if (auto* FTD = dyn_cast<FunctionTemplateDecl>(ND)) {
             NewFTD = FTD;
             break;
           }
 
-          if (auto *FD = dyn_cast<FunctionDecl>(ND)) {
-            if (auto *FTD = FD->getDescribedFunctionTemplate()) {
+          if (auto* FD = dyn_cast<FunctionDecl>(ND)) {
+            if (auto* FTD = FD->getDescribedFunctionTemplate()) {
               NewFTD = FTD;
               break;
             }
@@ -585,15 +592,14 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
         }
 
         if (NewFTD == nullptr) {
-            TemplateParameterList* TemplateParams =
-                    FD->getPrimaryTemplate()->getTemplateParameters();
+          TemplateParameterList* TemplateParams =
+              FD->getPrimaryTemplate()->getTemplateParameters();
 
-            NewFTD = FunctionTemplateDecl::Create(
-                        m_Context,
-                        m_Sema.CurContext, noLoc, primaryFD->getNameInfo().getName(),
-                        TemplateParams, primaryFD);
-            NewFTD->setLexicalDeclContext(m_Sema.CurContext);
-            primaryFD->setDescribedFunctionTemplate(NewFTD);
+          NewFTD = FunctionTemplateDecl::Create(
+              m_Context, m_Sema.CurContext, noLoc,
+              primaryFD->getNameInfo().getName(), TemplateParams, primaryFD);
+          NewFTD->setLexicalDeclContext(m_Sema.CurContext);
+          primaryFD->setDescribedFunctionTemplate(NewFTD);
         }
       }
     } else if (const VarDecl* VD = request.Global) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,9 +31,9 @@ if(CUDAToolkit_FOUND)
 
   set(LIBOMPTARGET_DEP_CUDA_ARCH "sm_60")
 
-  if(TARGET nvptx-arch)
-    get_property(LIBOMPTARGET_NVPTX_ARCH TARGET nvptx-arch PROPERTY LOCATION)
-  endif()
+  # if(TARGET nvptx-arch)
+  #   get_property(LIBOMPTARGET_NVPTX_ARCH TARGET nvptx-arch PROPERTY LOCATION)
+  # endif()
   if (NOT EXISTS ${LIBOMPTARGET_NVPTX_ARCH})
     find_program(LIBOMPTARGET_NVPTX_ARCH NAMES nvptx-arch)
   endif()


### PR DESCRIPTION
This merge request is a repeat of #1277 . Clang-20 has improved handling of template definitions, and it recursed infinitely on the previous implementation, this pull request is to handle  template specializations properly and mend the issue