### PR TITLE
Improve support for rvalue references in the reverse mode

### DIFF
--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -354,7 +354,7 @@ namespace clad {
       const Expr* subExpr = arg->IgnoreImplicit();
       if (const auto* DAE = dyn_cast<CXXDefaultArgExpr>(subExpr))
         subExpr = DAE->getExpr()->IgnoreImplicit();
-      bool isRefType = arg->isLValue() && subExpr->isLValue();
+      bool isRefType = arg->isGLValue() && subExpr->isGLValue();
       return isRefType || isArrayOrPointerType(arg->getType());
     }
 


### PR DESCRIPTION
This PR improves support for static casts to rvalue references, which used to be ignored by Clad in the reverse mode. They are often generated by the compiler as part of move operators. This PR also improves support for rvalue reference arguments in ``_pullback`` and ``_reverse_forw`` functions. A test for the newly supported functionality is also added.