### PR TITLE
Only generate pushforwards of functions of real params in the reverse mode

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -393,6 +393,10 @@ namespace clad {
 
     bool IsDifferentiableType(clang::QualType T);
 
+    /// Returns true if FD can be differentiated as a pushforward
+    /// And be used in the reverse mode.
+    bool canUsePushforwardInRevMode(const clang::FunctionDecl* FD);
+
     } // namespace utils
     } // namespace clad
 

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1058,5 +1058,14 @@ namespace clad {
 
       return C.getFunctionType(dRetTy, FnTypes, EPI);
     }
+
+    bool canUsePushforwardInRevMode(const FunctionDecl* FD) {
+      if (FD->getNumParams() != 1 ||
+          utils::HasAnyReferenceOrPointerArgument(FD) || isa<CXXMethodDecl>(FD))
+        return false;
+      QualType paramTy = FD->getParamDecl(0)->getType();
+      paramTy = paramTy.getNonReferenceType();
+      return paramTy->isRealType();
+    }
   } // namespace utils
 } // namespace clad

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1115,16 +1115,15 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
         return true;
 
       request.Function = FD;
+      bool canUsePushforwardInRevMode =
+          m_TopMostReq->Mode == DiffMode::reverse &&
+          utils::canUsePushforwardInRevMode(FD);
 
-      bool usePushforwardInRevMode =
-          m_TopMostReq->Mode == DiffMode::reverse && FD->getNumParams() == 1 &&
-          !utils::HasAnyReferenceOrPointerArgument(FD) &&
-          !isa<CXXMethodDecl>(FD);
       // FIXME: hessians require second derivatives,
       // i.e. apart from the pushforward, we also need
       // to schedule pushforward_pullback.
       if (m_TopMostReq->Mode == DiffMode::forward ||
-          m_TopMostReq->Mode == DiffMode::hessian || usePushforwardInRevMode)
+          m_TopMostReq->Mode == DiffMode::hessian || canUsePushforwardInRevMode)
         request.Mode = DiffMode::pushforward;
       else if (m_TopMostReq->Mode == DiffMode::reverse)
         request.Mode = DiffMode::pullback;

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1828,8 +1828,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // If the function has a single arg and does not return a reference or take
     // arg by reference, we can request a derivative w.r.t. to this arg using
     // the forward mode.
-    bool asGrad = NArgs != 1 || utils::HasAnyReferenceOrPointerArgument(FD) ||
-                  isa<CXXMethodDecl>(FD);
+    bool asGrad = !utils::canUsePushforwardInRevMode(FD);
     if (!asGrad) {
       pullbackCallArgs.resize(1);
       pullbackCallArgs.push_back(ConstantFolder::synthesizeLiteral(

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -1147,6 +1147,34 @@ double fn30(double x, double y) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
+double vecSum(const Vector3& v) {
+  return v.x + v.y + v.z;
+}
+
+// CHECK:  void vecSum_pullback(const Vector3 &v, double _d_y, Vector3 *_d_v) {
+// CHECK-NEXT:      {
+// CHECK-NEXT:          (*_d_v).x += _d_y;
+// CHECK-NEXT:          (*_d_v).y += _d_y;
+// CHECK-NEXT:          (*_d_v).z += _d_y;
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
+
+double fn31(double x, double y) {
+  double z = vecSum({x, y, x});
+  return z;
+}
+
+// CHECK:  void fn31_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK-NEXT:      double _d_z = 0.;
+// CHECK-NEXT:      double z = vecSum({x, y, x});
+// CHECK-NEXT:      _d_z += 1;
+// CHECK-NEXT:      {
+// CHECK-NEXT:          Vector3 _r0 = {};
+// CHECK-NEXT:          vecSum_pullback({x, y, x}, _d_z, &_r0);
+// CHECK-NEXT:          Vector3::constructor_pullback(x, y, x, &_r0, &*_d_x, &*_d_y, &*_d_x);
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
+
 void print(const Tangent& t) {
   for (int i = 0; i < 5; ++i) {
     printf("%.2f", t.data[i]);
@@ -1266,6 +1294,9 @@ int main() {
 
     INIT_GRADIENT(fn30);
     TEST_GRADIENT(fn30, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);    // CHECK-EXEC: {30.00, 22.00}
+
+    INIT_GRADIENT(fn31);
+    TEST_GRADIENT(fn31, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);    // CHECK-EXEC: {2.00, 1.00}
 }
 
 // CHECK: inline constexpr clad::ValueAndAdjoint<MyStruct &, MyStruct &> operator_equal_forw(MyStruct &&arg, MyStruct *_d_this, MyStruct &&_d_arg) noexcept {


### PR DESCRIPTION
Currently, in the reverse mode, if a nested function has only one non-reference/pointer parameter, we generate a pushforward instead of a pullback for efficiency and simplicity. However, we also need to check that the parameter is of a real type. Since class types usually represent multiple real numbers, such functions cannot be differentiated in forward mode.