### PR TITLE
Fix edge case for std::pow(0., 0.)

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -144,6 +144,8 @@ CUDA_HOST_DEVICE inline ValueAndPushforward<double, double>
 __builtin_pow_pushforward(double x, double exponent, double d_x,
                           double d_exponent) {
   auto val = __builtin_pow(x, exponent);
+  if (exponent == 0 && d_exponent == 0)
+    return {val, 0};
   double derivative = (exponent * __builtin_pow(x, exponent - 1)) * d_x;
   // Only add directional derivative of base^exp w.r.t exp if the directional
   // seed d_exponent is non-zero. This is required because if base is less than
@@ -160,6 +162,8 @@ CUDA_HOST_DEVICE inline ValueAndPushforward<float, float>
 __builtin_powf_pushforward(float x, float exponent, float d_x,
                            float d_exponent) {
   auto val = __builtin_powf(x, exponent);
+  if (exponent == 0 && d_exponent == 0)
+    return {val, 0};
   float derivative = (exponent * __builtin_powf(x, exponent - 1)) * d_x;
   // Only add directional derivative of base^exp w.r.t exp if the directional
   // seed d_exponent is non-zero. This is required because if base is less than
@@ -1296,6 +1300,8 @@ template <typename T1, typename T2, typename dT1, typename dT2,
 CUDA_HOST_DEVICE ValueAndPushforward<T_out, dT_out>
 pow_pushforward(T1 x, T2 exponent, dT1 d_x, dT2 d_exponent) {
   T_out val = ::std::pow(x, exponent);
+  if (exponent == static_cast<T2>(0) && d_exponent == static_cast<dT2>(0))
+    return {val, static_cast<dT_out>(0)};
   dT_out derivative = (exponent * ::std::pow(x, exponent - 1)) * d_x;
   // Only add directional derivative of base^exp w.r.t exp if the directional
   // seed d_exponent is non-zero. This is required because if base is less than

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -490,6 +490,14 @@ double f_erfc(double x) { return std::erfc(x); }
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
+double f_pow_zero(double x, double y) { return std::pow(x, y); }
+// CHECK: double f_pow_zero_darg0(double x, double y) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     double _d_y = 0;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<double, double> _t0 = {{.*}}pow_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT: }
+
 int main () { //expected-no-diagnostics
   float f_result[2];
   double d_result[2];
@@ -660,6 +668,9 @@ int main () { //expected-no-diagnostics
 
   auto d_erfc = clad::differentiate(f_erfc, 0);
   printf("Result is = %.6f\n", d_erfc.execute(0.5)); // CHECK-EXEC: Result is = -0.878783
-  
+
+  auto d_pow_zero =  clad::differentiate(f_pow_zero, 0);
+  printf("Result is = %.6f\n", d_pow_zero.execute(0, 0)); // CHECK-EXEC: Result is = 0.000000
+
   return 0;
 }

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -421,6 +421,20 @@ void f_norm_grad(double x,
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
+double f_pow_zero(double x, double y) {
+  return std::pow(x, y);
+}
+void f_pow_zero_grad(double x, double y, double *_d_x, double *_d_y);
+// CHECK:   void f_pow_zero_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK-NEXT:       {
+// CHECK-NEXT:           double _r0 = 0.;
+// CHECK-NEXT:           double _r1 = 0.;
+// CHECK-NEXT:           clad::custom_derivatives::std::pow_pullback(x, y, 1, &_r0, &_r1);
+// CHECK-NEXT:           *_d_x += _r0;
+// CHECK-NEXT:           *_d_y += _r1;
+// CHECK-NEXT:       }
+// CHECK-NEXT:   }
+
 double f_sin(double x, double y) {
   return (std::sin(x) + std::sin(y))*(x + y);
 }
@@ -1241,6 +1255,7 @@ int main() {
   TEST(f_if2, -5, -4); // CHECK-EXEC: Result is = {0.00, -1.00}
   clad::gradient(&S::f);
   clad::gradient(f_norm);
+  clad::gradient(f_pow_zero);
   clad::gradient(f_sin);
   clad::gradient(f_types);
   TEST(f_decls1, 3, 3); // CHECK-EXEC: Result is = {6.00, 10.00}

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -145,6 +145,10 @@ float f8(float x, float y) {
 // CHECK-NEXT:     hessianMatrix[3] = 1.;
 // CHECK-NEXT: }
 
+float f_pow_zero(float x, float y) {
+  return pow(x, y);
+}
+
 #define TEST1(F, x) {                                \
   result[0] = 0;                                     \
   auto h = clad::hessian(F);                         \
@@ -436,48 +440,78 @@ int main() {
 
 // CHECK: void pow_pushforward_pullback(float x, float exponent, float d_x, float d_exponent, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_exponent, float *_d_d_x, float *_d_d_exponent) {
 // CHECK-NEXT:     bool _cond0;
-// CHECK-NEXT:     float _t1;
+// CHECK-NEXT:     double _d_cond0;
+// CHECK-NEXT:     _d_cond0 = 0.;
+// CHECK-NEXT:     bool _cond1;
+// CHECK-NEXT:     bool _t0;
+// CHECK-NEXT:     bool _cond2;
+// CHECK-NEXT:     bool _cond3;
 // CHECK-NEXT:     float _t2;
 // CHECK-NEXT:     float _t3;
+// CHECK-NEXT:     float _t4;
 // CHECK-NEXT:     float _d_val = 0.F;
 // CHECK-NEXT:     float val = ::std::pow(x, exponent);
-// CHECK-NEXT:     float _t0 = ::std::pow(x, exponent - 1);
-// CHECK-NEXT:     float _d_derivative = 0.F;
-// CHECK-NEXT:     float derivative = (exponent * _t0) * d_x;
 // CHECK-NEXT:     {
-// CHECK-NEXT:     _cond0 = d_exponent;
-// CHECK-NEXT:     if (_cond0) {
-// CHECK-NEXT:         _t1 = derivative;
-// CHECK-NEXT:         _t3 = ::std::pow(x, exponent);
-// CHECK-NEXT:         _t2 = ::std::log(x);
-// CHECK-NEXT:         derivative += (_t3 * _t2) * d_exponent;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             _cond1 = exponent == static_cast<float>(0);
+// CHECK-NEXT:             if (_cond1) {
+// CHECK-NEXT:                 _t0 = _cond0;
+// CHECK-NEXT:                 _cond0 = d_exponent == static_cast<float>(0);
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _cond2 = _cond1 && _cond0;
+// CHECK-NEXT:         if (_cond2)
+// CHECK-NEXT:             goto _label0;
 // CHECK-NEXT:     }
+// CHECK-NEXT:     float _t1 = ::std::pow(x, exponent - 1);
+// CHECK-NEXT:     float _d_derivative = 0.F;
+// CHECK-NEXT:     float derivative = (exponent * _t1) * d_x;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _cond3 = d_exponent;
+// CHECK-NEXT:         if (_cond3) {
+// CHECK-NEXT:             _t2 = derivative;
+// CHECK-NEXT:             _t4 = ::std::pow(x, exponent);
+// CHECK-NEXT:             _t3 = ::std::log(x);
+// CHECK-NEXT:             derivative += (_t4 * _t3) * d_exponent;
+// CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_val += _d_y.value;
 // CHECK-NEXT:         _d_derivative += _d_y.pushforward;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     if (_cond0) {
-// CHECK-NEXT:         derivative = _t1;
-// CHECK-NEXT:         float _r_d0 = _d_derivative;
+// CHECK-NEXT:     if (_cond3) {
+// CHECK-NEXT:         derivative = _t2;
+// CHECK-NEXT:         float _r_d1 = _d_derivative;
 // CHECK-NEXT:         float _r4 = 0.F;
 // CHECK-NEXT:         float _r5 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(x, exponent, _r_d0 * d_exponent * _t2, &_r4, &_r5);
+// CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(x, exponent, _r_d1 * d_exponent * _t3, &_r4, &_r5);
 // CHECK-NEXT:         *_d_x += _r4;
 // CHECK-NEXT:         *_d_exponent += _r5;
 // CHECK-NEXT:         float _r6 = 0.F;
-// CHECK-NEXT:         _r6 += _t3 * _r_d0 * d_exponent * clad::custom_derivatives::std::log_pushforward(x, 1.F).pushforward;
+// CHECK-NEXT:         _r6 += _t4 * _r_d1 * d_exponent * clad::custom_derivatives::std::log_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         *_d_x += _r6;
-// CHECK-NEXT:         *_d_d_exponent += (_t3 * _t2) * _r_d0;
+// CHECK-NEXT:         *_d_d_exponent += (_t4 * _t3) * _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_exponent += _d_derivative * d_x * _t0;
+// CHECK-NEXT:         *_d_exponent += _d_derivative * d_x * _t1;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
 // CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(x, exponent - 1, exponent * _d_derivative * d_x, &_r2, &_r3);
 // CHECK-NEXT:         *_d_x += _r2;
 // CHECK-NEXT:         *_d_exponent += _r3;
-// CHECK-NEXT:         *_d_d_x += (exponent * _t0) * _d_derivative;
+// CHECK-NEXT:         *_d_d_x += (exponent * _t1) * _d_derivative;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         if (_cond2)
+// CHECK-NEXT:           _label0:
+// CHECK-NEXT:             _d_val += _d_y.value;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (_cond1) {
+// CHECK-NEXT:                 _cond0 = _t0;
+// CHECK-NEXT:                 double _r_d0 = _d_cond0;
+// CHECK-NEXT:                 _d_cond0 = 0.;
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;


### PR DESCRIPTION
This pr address #1383 by fixing the edge case for std::pow(0., 0.) in the pow_pushforward and pow_pullback functions.  