### PR TITLE
Do not ignore Imp casts when calling IsReferenceOrPointerArg in RMV::VisitCXXConstructExpr

### DIFF
--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -474,10 +474,12 @@ void at_pullback(::std::vector<T>* vec,
   (*d_vec)[idx] += d_y;
 }
 
-template <typename T, typename S, typename U>
-void constructor_pullback(S count, U val,
+template <typename T, typename U>
+void constructor_pullback(typename ::std::vector<T>::size_type count, U val,
                           typename ::std::vector<T>::allocator_type alloc,
-                          ::std::vector<T>* d_this, S* d_count, U* d_val,
+                          ::std::vector<T>* d_this,
+                          typename ::std::vector<T>::size_type* d_count,
+                          U* d_val,
                           typename ::std::vector<T>::allocator_type* d_alloc) {
   for (unsigned i = 0; i < count; ++i)
     *d_val += (*d_this)[i];

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4095,7 +4095,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       QualType ArgTy = arg->getType();
       StmtDiff argDiff{};
       Expr* adjointArg = nullptr;
-      if (utils::IsReferenceOrPointerArg(arg->IgnoreParenImpCasts())) {
+      if (utils::IsReferenceOrPointerArg(arg)) {
         argDiff = Visit(arg);
         adjointArg = argDiff.getExpr_dx();
       } else {
@@ -4128,7 +4128,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         reverseForwAdjointArgs.push_back(adjointArg);
         adjointArgs.push_back(adjointArg);
       } else {
-        if (utils::IsReferenceOrPointerArg(arg->IgnoreParenImpCasts()))
+        if (utils::IsReferenceOrPointerArg(arg))
           reverseForwAdjointArgs.push_back(adjointArg);
         else
           reverseForwAdjointArgs.push_back(getZeroInit(ArgTy));

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -1,0 +1,88 @@
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oConstructors.out 2>&1 | %filecheck %s
+// RUN: ./Constructors.out | %filecheck_exec %s
+// RUN: %cladclang %s -I%S/../../include -oConstructors.out
+// RUN: ./Constructors.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+
+#include <utility>
+#include <complex>
+
+#include "../TestUtils.h"
+#include "../PrintOverloads.h"
+
+
+struct argByVal {
+    double x, y;
+    argByVal(double val) {
+        x = val;
+        val *= val;
+        y = val;
+    }
+};
+
+namespace clad {
+namespace custom_derivatives {
+namespace class_functions {
+void constructor_pullback(double val, argByVal* d_this, double *_d_val) {
+    double x, y;
+    x = val;
+    double _t0 = val;
+    val *= val;
+    y = val;
+    {
+        double _r_d2 = d_this->y;
+        d_this->y = 0.;
+        *_d_val += _r_d2;
+    }
+    {
+        val = _t0;
+        double _r_d1 = *_d_val;
+        *_d_val = 0.;
+        *_d_val += _r_d1 * val;
+        *_d_val += val * _r_d1;
+    }
+    {
+        double _r_d0 = d_this->x;
+        d_this->x = 0.;
+        *_d_val += _r_d0;
+    }
+}
+}}}
+
+double fn1(double x, double y) {
+    argByVal g(x);
+    y = x;
+    return y + g.y;
+}
+
+// CHECK:  void fn1_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK-NEXT:      argByVal g(x);
+// CHECK-NEXT:      argByVal _d_g(g);
+// CHECK-NEXT:      clad::zero_init(_d_g);
+// CHECK-NEXT:      double _t0 = y; 
+// CHECK-NEXT:      y = x;
+// CHECK-NEXT:      {
+// CHECK-NEXT:          *_d_y += 1;
+// CHECK-NEXT:          _d_g.y += 1;
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          y = _t0;
+// CHECK-NEXT:          double _r_d0 = *_d_y;
+// CHECK-NEXT:          *_d_y = 0.;
+// CHECK-NEXT:          *_d_x += _r_d0;
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          double _r0 = 0.;
+// CHECK-NEXT:          clad::custom_derivatives::class_functions::constructor_pullback(x, &_d_g, &_r0);
+// CHECK-NEXT:          *_d_x += _r0;
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
+
+int main() {
+    double d_i, d_j;
+
+    INIT_GRADIENT(fn1);
+    TEST_GRADIENT(fn1, /*numOfDerivativeArgs=*/2, 3, 4, &d_i, &d_j);    // CHECK-EXEC: {7.00, 0.00}
+}

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -579,7 +579,7 @@ double fn6(double u, double v) {
 // CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t0 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>());
 // CHECK-NEXT:      SafeTestClass s1(_t0.value);
 // CHECK-NEXT:      SafeTestClass _d_s1 = _t0.adjoint;
-// CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t1 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), u, &v, *_d_u, &*_d_v);
+// CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t1 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), u, &v, 0., &*_d_v);
 // CHECK-NEXT:      SafeTestClass s2(_t1.value);
 // CHECK-NEXT:      SafeTestClass _d_s2 = _t1.adjoint;
 // CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t2 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), w, _d_w);
@@ -587,7 +587,11 @@ double fn6(double u, double v) {
 // CHECK-NEXT:      SafeTestClass _d_s3 = _t2.adjoint;
 // CHECK-NEXT:      *_d_v += 1;
 // CHECK-NEXT:      SafeTestClass::constructor_pullback(w, &_d_s3, &_d_w);
-// CHECK-NEXT:      {{.*}}constructor_pullback(u, &v, &_d_s2, &*_d_u, &*_d_v);
+// CHECK-NEXT:      {
+// CHECK-NEXT:          double _r0 = 0.;  
+// CHECK-NEXT:          {{.*}}constructor_pullback(u, &v, &_d_s2, &_r0, &*_d_v);
+// CHECK-NEXT:          *_d_u += _r0;
+// CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
 double fn7(double u, double v) {
@@ -856,15 +860,21 @@ int main() {
 // CHECK-NEXT:     SimpleFunctions _d_sf(sf);
 // CHECK-NEXT:     clad::zero_init(_d_sf);
 // CHECK-NEXT:     SimpleFunctions _t0 = sf;
-// CHECK-NEXT:         {
-// CHECK-NEXT:             double _r0 = 0.;
-// CHECK-NEXT:             double _r1 = 0.;
-// CHECK-NEXT:             sf = _t0;
-// CHECK-NEXT:             sf.mem_fn_pullback(i, j, 1, &_d_sf, &_r0, &_r1);
-// CHECK-NEXT:             *_d_i += _r0;
-// CHECK-NEXT:             *_d_j += _r1;
-// CHECK-NEXT:         }
-// CHECK-NEXT:     SimpleFunctions::constructor_pullback(x, y, &_d_sf, &_d_x, &_d_y);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r2 = 0.;
+// CHECK-NEXT:         double _r3 = 0.;
+// CHECK-NEXT:         sf = _t0;
+// CHECK-NEXT:         sf.mem_fn_pullback(i, j, 1, &_d_sf, &_r2, &_r3);
+// CHECK-NEXT:         *_d_i += _r2;
+// CHECK-NEXT:         *_d_j += _r3;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 0.;
+// CHECK-NEXT:         double _r1 = 0.;
+// CHECK-NEXT:         SimpleFunctions::constructor_pullback(x, y, &_d_sf, &_r0, &_r1);
+// CHECK-NEXT:         _d_x += _r0;
+// CHECK-NEXT:         _d_y += _r1;
+// CHECK-NEXT:     }
 // CHECK-NEXT:     }
 
 // CHECK: clad::ValueAndAdjoint<double &, double &> ref_mem_fn_forw(double i, SimpleFunctions *_d_this, double _d_i) {

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -560,19 +560,23 @@ int main() {
 // CHECK-NEXT:     std::vector<double> _t4 = vec;
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
-// CHECK-NEXT:             {{.*}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:             vec = _t0;
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r0);
-// CHECK-NEXT:             {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:             vec = _t2;
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r1);
-// CHECK-NEXT:             {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:             vec = _t4;
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&vec, 2, 1, &_d_vec, &_r2);
-// CHECK-NEXT:         }
-// CHECK-NEXT:         {{.*}}constructor_pullback(count, u, allocator, &_d_vec, &_d_count, &*_d_u, &_d_allocator);
-// CHECK-NEXT:        *_d_u += _d_res;
+// CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
+// CHECK-NEXT:         vec = _t0;
+// CHECK-NEXT:         {{.*}}operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r1);
+// CHECK-NEXT:         {{.*}} _r2 = {{0U|0UL}};
+// CHECK-NEXT:         vec = _t2;
+// CHECK-NEXT:         {{.*}}operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r2);
+// CHECK-NEXT:         {{.*}} _r3 = {{0U|0UL}};
+// CHECK-NEXT:         vec = _t4;
+// CHECK-NEXT:         {{.*}}operator_subscript_pullback(&vec, 2, 1, &_d_vec, &_r3);
 // CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
+// CHECK-NEXT:         {{.*}}constructor_pullback(count, u, allocator, &_d_vec, &_r0, &*_d_u, &_d_allocator);
+// CHECK-NEXT:         _d_count += _r0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_u += _d_res;
+// CHECK-NEXT: }
 
 // CHECK:      void fn14_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:          std::vector<double> a;
@@ -1153,18 +1157,20 @@ int main() {
 // CHECK-NEXT:             double _r_d0 = _d_prod;
 // CHECK-NEXT:             _d_prod = 0.;
 // CHECK-NEXT:             _d_prod += _r_d0 * clad::back(_t5).value;
-// CHECK-NEXT:             {{.*}}size_type _r1 = 0{{.*}};
+// CHECK-NEXT:             {{.*}}size_type _r2 = 0{{.*}};
 // CHECK-NEXT:             vec = clad::back(_t4);
-// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&vec, i - 1, prod * _r_d0, &_d_vec, &_r1);
-// CHECK-NEXT:             _d_i += _r1;
+// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&vec, i - 1, prod * _r_d0, &_d_vec, &_r2);
+// CHECK-NEXT:             _d_i += _r2;
 // CHECK-NEXT:             clad::pop(_t4);
 // CHECK-NEXT:             clad::pop(_t5);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}}value_type _r0 = 0.;
-// CHECK-NEXT:             clad::custom_derivatives::class_functions::constructor_pullback(i, v + u, alloc, &_d_vec, &_d_i, &_r0, &_d_alloc);
-// CHECK-NEXT:             *_d_v += _r0;
-// CHECK-NEXT:             *_d_u += _r0;
+// CHECK-NEXT:             {{.*}}size_type _r0 = 0{{.*}};
+// CHECK-NEXT:             {{.*}}value_type _r1 = 0.;
+// CHECK-NEXT:             clad::custom_derivatives::class_functions::constructor_pullback(i, v + u, alloc, &_d_vec, &_r0, &_r1, &_d_alloc);
+// CHECK-NEXT:             _d_i += _r0;
+// CHECK-NEXT:             *_d_v += _r1;
+// CHECK-NEXT:             *_d_u += _r1;
 // CHECK-NEXT:             _d_vec = clad::pop(_t1);
 // CHECK-NEXT:             vec = clad::pop(_t2);
 // CHECK-NEXT:         }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -767,15 +767,21 @@ double fn19(double i, double j) {
 // CHECK-NEXT:      SimpleFunctions1 _d_sf2(sf2);
 // CHECK-NEXT:      clad::zero_init(_d_sf2);
 // CHECK-NEXT:      {
+// CHECK-NEXT:          double _r4 = 0.;
+// CHECK-NEXT:          double _r5 = 0.;
+// CHECK-NEXT:          SimpleFunctions1 _r6 = {};
+// CHECK-NEXT:          (sf1 * sf2).mem_fn_pullback(i, j, 1, &_r6, &_r4, &_r5);
+// CHECK-NEXT:          *_d_i += _r4;
+// CHECK-NEXT:          *_d_j += _r5;
+// CHECK-NEXT:          sf1.operator_star_pullback(sf2, _r6, &_d_sf1, &_d_sf2);
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
 // CHECK-NEXT:          double _r2 = 0.;
 // CHECK-NEXT:          double _r3 = 0.;
-// CHECK-NEXT:          SimpleFunctions1 _r4 = {};
-// CHECK-NEXT:          (sf1 * sf2).mem_fn_pullback(i, j, 1, &_r4, &_r2, &_r3);
+// CHECK-NEXT:          SimpleFunctions1::constructor_pullback(i, j, &_d_sf2, &_r2, &_r3);
 // CHECK-NEXT:          *_d_i += _r2;
 // CHECK-NEXT:          *_d_j += _r3;
-// CHECK-NEXT:          sf1.operator_star_pullback(sf2, _r4, &_d_sf1, &_d_sf2);
 // CHECK-NEXT:      }
-// CHECK-NEXT:      SimpleFunctions1::constructor_pullback(i, j, &_d_sf2, &*_d_i, &*_d_j);
 // CHECK-NEXT:  }
 
 void fn20(MyStruct s) {
@@ -812,7 +818,9 @@ double fn21(double i, double j) {
 // CHECK-NEXT:          double _r0 = 0.;
 // CHECK-NEXT:          SimpleFunctions1 _r1 = {};
 // CHECK-NEXT:          operator_plus_pullback(2, SimpleFunctions1(i), 1, &_r0, &_r1);
-// CHECK-NEXT:          SimpleFunctions1::constructor_pullback(i, &_r1, &*_d_i);
+// CHECK-NEXT:          double _r2 = 0.;
+// CHECK-NEXT:          SimpleFunctions1::constructor_pullback(i, &_r1, &_r2);
+// CHECK-NEXT:          *_d_i += _r2;
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
@@ -1020,12 +1028,20 @@ double fn27(double x, double y) {
 // CHECK-NEXT:      clad::zero_init(_d_w);
 // CHECK-NEXT:      _d_w.x += 1;
 // CHECK-NEXT:      {
-// CHECK-NEXT:          Vector3 _r0 = {};
-// CHECK-NEXT:          Vector3::constructor_pullback(2 * v, &_d_w, &_r0);
-// CHECK-NEXT:          double _r1 = 0.;
-// CHECK-NEXT:          operator_star_pullback(2, v, _r0, &_r1, &_d_v);
+// CHECK-NEXT:          Vector3 _r3 = {};
+// CHECK-NEXT:          Vector3::constructor_pullback(2 * v, &_d_w, &_r3);
+// CHECK-NEXT:          double _r4 = 0.;
+// CHECK-NEXT:          operator_star_pullback(2, v, _r3, &_r4, &_d_v);
 // CHECK-NEXT:      }
-// CHECK-NEXT:      Vector3::constructor_pullback(x, x, y, &_d_v, &*_d_x, &*_d_x, &*_d_y);
+// CHECK-NEXT:      {
+// CHECK-NEXT:          double _r0 = 0.;
+// CHECK-NEXT:          double _r1 = 0.;
+// CHECK-NEXT:          double _r2 = 0.;
+// CHECK-NEXT:          Vector3::constructor_pullback(x, x, y, &_d_v, &_r0, &_r1, &_r2);
+// CHECK-NEXT:          *_d_x += _r0;
+// CHECK-NEXT:          *_d_x += _r1;
+// CHECK-NEXT:          *_d_y += _r2;
+// CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
 // CHECK:  void operator_minus_pullback(Vector3 _d_y, Vector3 *_d_this) {
@@ -1057,12 +1073,20 @@ double fn28(double x, double y) {
 // CHECK-NEXT:      clad::zero_init(_d_w);
 // CHECK-NEXT:      _d_w.x += 1;
 // CHECK-NEXT:      {
-// CHECK-NEXT:          Vector3 _r0 = {};
-// CHECK-NEXT:          Vector3::constructor_pullback(- v, &_d_w, &_r0);
+// CHECK-NEXT:          Vector3 _r3 = {};
+// CHECK-NEXT:          Vector3::constructor_pullback(- v, &_d_w, &_r3);
 // CHECK-NEXT:          v = _t0;
-// CHECK-NEXT:          v.operator_minus_pullback(_r0, &_d_v);
+// CHECK-NEXT:          v.operator_minus_pullback(_r3, &_d_v);
 // CHECK-NEXT:      }
-// CHECK-NEXT:      Vector3::constructor_pullback(x, x, y, &_d_v, &*_d_x, &*_d_x, &*_d_y);
+// CHECK-NEXT:      {
+// CHECK-NEXT:          double _r0 = 0.;
+// CHECK-NEXT:          double _r1 = 0.;
+// CHECK-NEXT:          double _r2 = 0.;
+// CHECK-NEXT:          Vector3::constructor_pullback(x, x, y, &_d_v, &_r0, &_r1, &_r2);
+// CHECK-NEXT:          *_d_x += _r0;
+// CHECK-NEXT:          *_d_x += _r1;
+// CHECK-NEXT:          *_d_y += _r2;
+// CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
 struct ptrClass {
@@ -1171,7 +1195,13 @@ double fn31(double x, double y) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          Vector3 _r0 = {};
 // CHECK-NEXT:          vecSum_pullback({x, y, x}, _d_z, &_r0);
-// CHECK-NEXT:          Vector3::constructor_pullback(x, y, x, &_r0, &*_d_x, &*_d_y, &*_d_x);
+// CHECK-NEXT:          double _r1 = 0.;
+// CHECK-NEXT:          double _r2 = 0.;
+// CHECK-NEXT:          double _r3 = 0.;
+// CHECK-NEXT:          Vector3::constructor_pullback(x, y, x, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:          *_d_x += _r1;
+// CHECK-NEXT:          *_d_y += _r2;
+// CHECK-NEXT:          *_d_x += _r3;
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 


### PR DESCRIPTION
Ignoring implicit casts results in some arguments being considered as by-reference even though they are passed by value. Doing this is incorrect because passing a parameter by value uses implicit copying, which affects the derived code.