### PR TITLE
Don't differentiate w.r.t. parameters of non-differentiable types in the reverse mode

### DIFF
--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -593,6 +593,12 @@ namespace clad {
       for (auto* Attr : D->specific_attrs<clang::AnnotateAttr>())
         if (Attr->getAnnotation() == "non_differentiable")
           return true;
+      if (const auto* VD = dyn_cast<VarDecl>(D)) {
+        QualType VDElemTy = utils::GetValueType(VD->getType());
+        const CXXRecordDecl* RD = VDElemTy->getAsCXXRecordDecl();
+        if (RD && clad::utils::hasNonDifferentiableAttribute(RD))
+          return true;
+      }
       return false;
     }
 

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1148,6 +1148,11 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
         for (size_t i = 0, e = FD->getNumParams(); i < e; ++i) {
           // if (MD && isLambdaCallOperator(MD)) {
           const auto* paramDecl = FD->getParamDecl(i);
+          QualType paramElemTy = utils::GetValueType(paramDecl->getType());
+          const CXXRecordDecl* RD = paramElemTy->getAsCXXRecordDecl();
+          if (RD && clad::utils::hasNonDifferentiableAttribute(RD))
+            continue;
+
           request.DVI.push_back(paramDecl);
 
           //}

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1148,9 +1148,7 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
         for (size_t i = 0, e = FD->getNumParams(); i < e; ++i) {
           // if (MD && isLambdaCallOperator(MD)) {
           const auto* paramDecl = FD->getParamDecl(i);
-          QualType paramElemTy = utils::GetValueType(paramDecl->getType());
-          const CXXRecordDecl* RD = paramElemTy->getAsCXXRecordDecl();
-          if (RD && clad::utils::hasNonDifferentiableAttribute(RD))
+          if (clad::utils::hasNonDifferentiableAttribute(paramDecl))
             continue;
 
           request.DVI.push_back(paramDecl);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2617,8 +2617,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         VD->getInit() && isa<CXXConstructExpr>(VD->getInit()->IgnoreImplicit());
     const CXXRecordDecl* RD = VD->getType()->getAsCXXRecordDecl();
     bool isNonAggrClass = RD && !RD->isAggregate();
-    if (RD && clad::utils::hasNonDifferentiableAttribute(RD))
-      initializeDerivedVar = false;
 
     // We initialize adjoints with original variables as part of
     // the strategy to maintain the structure of the original variable.

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -231,12 +231,12 @@ int main() {
   // CHECK-NEXT:     clad::zero_init(_d_E);
   // CHECK-NEXT:     Experiment _t0 = E;
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         double _r2 = 0.;
-  // CHECK-NEXT:         double _r3 = 0.;
+  // CHECK-NEXT:         double _r0 = 0.;
+  // CHECK-NEXT:         double _r1 = 0.;
   // CHECK-NEXT:         E = _t0;
-  // CHECK-NEXT:         E.operator_call_pullback(i, j, 1, &_d_E, &_r2, &_r3);
-  // CHECK-NEXT:         *_d_i += _r2;
-  // CHECK-NEXT:         *_d_j += _r3;
+  // CHECK-NEXT:         E.operator_call_pullback(i, j, 1, &_d_E, &_r0, &_r1);
+  // CHECK-NEXT:         *_d_i += _r0;
+  // CHECK-NEXT:         *_d_j += _r1;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
@@ -284,13 +284,13 @@ int main() {
   // CHECK-NEXT:     Experiment _d_E(E);
   // CHECK-NEXT:     clad::zero_init(_d_E);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         Experiment _r2 = {};
-  // CHECK-NEXT:         double _r3 = 0.;
-  // CHECK-NEXT:         double _r4 = 0.;
-  // CHECK-NEXT:         FunctorAsArg_pullback(E, i, j, 1, &_r2, &_r3, &_r4);
-  // CHECK-NEXT:         Experiment::constructor_pullback(E, &_r2, &_d_E);
-  // CHECK-NEXT:         *_d_i += _r3;
-  // CHECK-NEXT:         *_d_j += _r4;
+  // CHECK-NEXT:         Experiment _r0 = {};
+  // CHECK-NEXT:         double _r1 = 0.;
+  // CHECK-NEXT:         double _r2 = 0.;
+  // CHECK-NEXT:         FunctorAsArg_pullback(E, i, j, 1, &_r0, &_r1, &_r2);
+  // CHECK-NEXT:         Experiment::constructor_pullback(E, &_r0, &_d_E);
+  // CHECK-NEXT:         *_d_i += _r1;
+  // CHECK-NEXT:         *_d_j += _r2;
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -95,6 +95,15 @@ double fn_non_diff_call(double i, double j) {
   return fn_non_diff(i, j) + i * j;
 }
 
+double fn_non_diff_param(double i, SimpleFunctions2& S) {
+  return S.mem_fn(i, i) + i;
+}
+
+double fn_non_diff_param_call(double i, double j) {
+  SimpleFunctions2 obj1(j, j);
+  return fn_non_diff_param(i, obj1);
+}
+
 #define INIT_EXPR(classname)                                                   \
   classname expr_1(2, 3);                                                      \
   classname expr_2(3, 5);
@@ -142,6 +151,7 @@ int main() {
 
   TEST_FUNC(fn_non_diff_call, 3, 5) // CHECK-EXEC: 5.00 3.00
 
+  TEST_FUNC(fn_non_diff_param_call, 3, 5) // CHECK-EXEC: 1.00 0.00
     // CHECK: void mem_fn_1_pullback(double i, double j, double _d_y, SimpleFunctions1 *_d_this, double *_d_i, double *_d_j) {
     // CHECK-NEXT:     {
     // CHECK-NEXT:         _d_this->x += _d_y * i;
@@ -209,4 +219,19 @@ int main() {
     // CHECK-NEXT:         *_d_j += i * 1;
     // CHECK-NEXT:     }
     // CHECK-NEXT: }
+
+    // CHECK:     void fn_non_diff_param_pullback(double i, SimpleFunctions2 &S, double _d_y, double *_d_i) {
+    // CHECK-NEXT:         *_d_i += _d_y;
+    // CHECK-NEXT:     }
+
+    // CHECK:     void fn_non_diff_param_call_grad(double i, double j, double *_d_i, double *_d_j) {
+    // CHECK-NEXT:         SimpleFunctions2 obj1(j, j);
+    // CHECK-NEXT:         SimpleFunctions2 _t0 = obj1;
+    // CHECK-NEXT:         {
+    // CHECK-NEXT:             obj1 = _t0;
+    // CHECK-NEXT:             double _r0 = 0.;
+    // CHECK-NEXT:             fn_non_diff_param_pullback(i, _t0, 1, &_r0);
+    // CHECK-NEXT:             *_d_i += _r0;
+    // CHECK-NEXT:         }
+    // CHECK-NEXT:     }
 }

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -158,12 +158,12 @@ int main() {
     // CHECK-NEXT:     clad::zero_init(_d_obj);
     // CHECK-NEXT:     SimpleFunctions1 _t0 = obj;
     // CHECK-NEXT:     {
-    // CHECK-NEXT:         double _r2 = 0.;
-    // CHECK-NEXT:         double _r3 = 0.;
+    // CHECK-NEXT:         double _r0 = 0.;
+    // CHECK-NEXT:         double _r1 = 0.;
     // CHECK-NEXT:         obj = _t0;
-    // CHECK-NEXT:         obj.mem_fn_1_pullback(i, j, 1, &_d_obj, &_r2, &_r3);
-    // CHECK-NEXT:         *_d_i += _r2;
-    // CHECK-NEXT:         *_d_j += _r3;
+    // CHECK-NEXT:         obj.mem_fn_1_pullback(i, j, 1, &_d_obj, &_r0, &_r1);
+    // CHECK-NEXT:         *_d_i += _r0;
+    // CHECK-NEXT:         *_d_j += _r1;
     // CHECK-NEXT:         *_d_i += 1 * j;
     // CHECK-NEXT:         *_d_j += i * 1;
     // CHECK-NEXT:     }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -674,13 +674,13 @@ double fn16(double i, double j) {
 // CHECK-NEXT:    SimpleFunctions1 _d_obj2(obj2);
 // CHECK-NEXT:    clad::zero_init(_d_obj2);
 // CHECK-NEXT:    {
-// CHECK-NEXT:        double _r4 = 0.;
-// CHECK-NEXT:        double _r5 = 0.;
-// CHECK-NEXT:        SimpleFunctions1 _r6 = {};
-// CHECK-NEXT:        (obj1 + obj2).mem_fn_1_pullback(i, j, 1, &_r6, &_r4, &_r5);
-// CHECK-NEXT:        *_d_i += _r4;
-// CHECK-NEXT:        *_d_j += _r5;
-// CHECK-NEXT:        obj1.operator_plus_pullback(obj2, _r6, &_d_obj1, &_d_obj2);
+// CHECK-NEXT:        double _r0 = 0.;
+// CHECK-NEXT:        double _r1 = 0.;
+// CHECK-NEXT:        SimpleFunctions1 _r2 = {};
+// CHECK-NEXT:        (obj1 + obj2).mem_fn_1_pullback(i, j, 1, &_r2, &_r0, &_r1);
+// CHECK-NEXT:        *_d_i += _r0;
+// CHECK-NEXT:        *_d_j += _r1;
+// CHECK-NEXT:        obj1.operator_plus_pullback(obj2, _r2, &_d_obj1, &_d_obj2);
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 
@@ -705,12 +705,12 @@ double fn17(double i, double j) {
 // CHECK-NEXT:    clad::zero_init(_d_sf);
 // CHECK-NEXT:    SimpleFunctions1 _t0 = sf;
 // CHECK-NEXT:    {
-// CHECK-NEXT:        double _r2 = 0.;
-// CHECK-NEXT:        double _r3 = 0.;
+// CHECK-NEXT:        double _r0 = 0.;
+// CHECK-NEXT:        double _r1 = 0.;
 // CHECK-NEXT:        sf = _t0;
-// CHECK-NEXT:        sf.mem_fn_pullback(i, j, 1, &_d_sf, &_r2, &_r3);
-// CHECK-NEXT:        *_d_i += _r2;
-// CHECK-NEXT:        *_d_j += _r3;
+// CHECK-NEXT:        sf.mem_fn_pullback(i, j, 1, &_d_sf, &_r0, &_r1);
+// CHECK-NEXT:        *_d_i += _r0;
+// CHECK-NEXT:        *_d_j += _r1;
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 
@@ -767,20 +767,20 @@ double fn19(double i, double j) {
 // CHECK-NEXT:      SimpleFunctions1 _d_sf2(sf2);
 // CHECK-NEXT:      clad::zero_init(_d_sf2);
 // CHECK-NEXT:      {
-// CHECK-NEXT:          double _r4 = 0.;
-// CHECK-NEXT:          double _r5 = 0.;
-// CHECK-NEXT:          SimpleFunctions1 _r6 = {};
-// CHECK-NEXT:          (sf1 * sf2).mem_fn_pullback(i, j, 1, &_r6, &_r4, &_r5);
-// CHECK-NEXT:          *_d_i += _r4;
-// CHECK-NEXT:          *_d_j += _r5;
-// CHECK-NEXT:          sf1.operator_star_pullback(sf2, _r6, &_d_sf1, &_d_sf2);
-// CHECK-NEXT:      }
-// CHECK-NEXT:      {
 // CHECK-NEXT:          double _r2 = 0.;
 // CHECK-NEXT:          double _r3 = 0.;
-// CHECK-NEXT:          SimpleFunctions1::constructor_pullback(i, j, &_d_sf2, &_r2, &_r3);
+// CHECK-NEXT:          SimpleFunctions1 _r4 = {};
+// CHECK-NEXT:          (sf1 * sf2).mem_fn_pullback(i, j, 1, &_r4, &_r2, &_r3);
 // CHECK-NEXT:          *_d_i += _r2;
 // CHECK-NEXT:          *_d_j += _r3;
+// CHECK-NEXT:          sf1.operator_star_pullback(sf2, _r4, &_d_sf1, &_d_sf2);
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          double _r0 = 0.;
+// CHECK-NEXT:          double _r1 = 0.;
+// CHECK-NEXT:          SimpleFunctions1::constructor_pullback(i, j, &_d_sf2, &_r0, &_r1);
+// CHECK-NEXT:          *_d_i += _r0;
+// CHECK-NEXT:          *_d_j += _r1;
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 


### PR DESCRIPTION
Currently, the diff planner does not check if parameters are of non-differentiable types. The argument corresponding to such a parameter will not have an adjoint, and RMV will request a different derivative without it. Because of this, the scheduled derivative will not be used and will possibly cause errors.
This PR also addresses a different problem: VarDecls of non-differentiable types used to be reused instead of being cloned, i.e., a declaration from `f` was directly used in `f_grad`. This leads to incorrect behavior and causes errors.