### PR TITLE
Add support for sparsity pattern generation for jacobians

### DIFF
--- a/include/clad/Differentiator/CladConfig.h
+++ b/include/clad/Differentiator/CladConfig.h
@@ -31,6 +31,7 @@ enum opts : unsigned {
   disable_tbr = 1 << (ORDER_BITS + 3),
   enable_va = 1 << (ORDER_BITS + 5),
   disable_va = 1 << (ORDER_BITS + 6),
+  enable_sp = 1 << (ORDER_BITS + 8),
   enable_ua = 1 << (ORDER_BITS + 9),
   disable_ua = 1 << (ORDER_BITS + 10),
 

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -15,6 +15,7 @@
 #include "llvm/ADT/StringRef.h"
 
 #include <string>
+#include <utility>
 
 namespace clang {
   class ASTContext;
@@ -24,6 +25,15 @@ namespace clang {
 
 namespace clad {
   namespace utils {
+  // move
+  struct compare {
+    bool operator()(const std::pair<int, int> a,
+                    const std::pair<int, int> b) const {
+      if (a.second == b.second)
+        return (a.first < b.first);
+      return (a.second <= b.second);
+    }
+  };
     /// If `FD` is an overloaded operator, returns a name, unique for
     /// each operator, that can be used to create valid C++ identifiers.
     /// Otherwise if `FD` is an ordinary function, returns the name of the

--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -80,6 +80,7 @@ namespace clad {
     friend class HessianModeVisitor;
     friend class JacobianModeVisitor;
     friend class ReverseModeForwPassVisitor;
+    friend class SparseJacobianModeVisitor;
     clang::Sema& m_Sema;
     plugin::CladPlugin& m_CladPlugin;
     clang::ASTContext& m_Context;

--- a/include/clad/Differentiator/DerivedFnInfo.h
+++ b/include/clad/Differentiator/DerivedFnInfo.h
@@ -19,6 +19,7 @@ struct DerivedFnInfo {
   std::vector<size_t> m_CUDAGlobalArgsIndexes;
   bool m_UsesEnzyme = false;
   bool m_DeclarationOnly = false;
+  bool m_EnableSparsity = false;
 
   DerivedFnInfo() = default;
   DerivedFnInfo(const DiffRequest& request, clang::FunctionDecl* derivedFn,

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -1,6 +1,7 @@
 #ifndef CLAD_DIFF_PLANNER_H
 #define CLAD_DIFF_PLANNER_H
 
+#include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/DerivedFnCollector.h"
 #include "clad/Differentiator/DiffMode.h"
 #include "clad/Differentiator/DynamicGraph.h"
@@ -18,6 +19,7 @@
 
 #include <iterator>
 #include <set>
+#include <utility>
 
 namespace clang {
 class CallExpr;
@@ -52,6 +54,11 @@ private:
     std::set<const clang::VarDecl*> UsefulDecls;
     bool HasAnalysisRun = false;
   } m_UsefulRunInfo;
+
+  mutable struct DependencySparsityInfo {
+    std::set<std::pair<int, int>, utils::compare> OutputDependencySet;
+    bool HasAnalysisRun = false;
+  } m_DependencySparsityInfo;
 
 public:
   /// Function to be differentiated.
@@ -191,6 +198,9 @@ public:
   }
   std::set<const clang::VarDecl*>& getUsefulDecls() const {
     return m_UsefulRunInfo.UsefulDecls;
+  }
+  std::set<std::pair<int, int>, utils::compare>& getDependencySet() const {
+    return m_DependencySparsityInfo.OutputDependencySet;
   }
 };
 

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -81,6 +81,7 @@ public:
   bool EnableTBRAnalysis = false;
   bool EnableVariedAnalysis = false;
   bool EnableUsefulAnalysis = false;
+  bool EnableSparsity = false;
   /// A flag specifying whether this differentiation is to be used
   /// in immediate contexts.
   bool ImmediateMode = false;
@@ -153,6 +154,7 @@ public:
            Args == other.Args && Mode == other.Mode &&
            EnableTBRAnalysis == other.EnableTBRAnalysis &&
            EnableVariedAnalysis == other.EnableVariedAnalysis &&
+           EnableSparsity == other.EnableSparsity &&
            EnableUsefulAnalysis == other.EnableUsefulAnalysis &&
            DVI == other.DVI && use_enzyme == other.use_enzyme &&
            DeclarationOnly == other.DeclarationOnly && Global == other.Global &&
@@ -200,6 +202,7 @@ public:
     bool EnableTBRAnalysis = false;
     bool EnableVariedAnalysis = false;
     bool EnableUsefulAnalysis = false;
+    bool EnableSparsity = false;
   };
 
   class DiffCollector: public clang::RecursiveASTVisitor<DiffCollector> {

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -17,6 +17,7 @@
 #include "FunctionTraits.h"
 #include "Matrix.h"
 #include "NumericalDiff.h"
+#include "SparsityPattern.h"
 #include "Tape.h"
 
 #include <array>
@@ -395,7 +396,7 @@ CUDA_HOST_DEVICE T push(tape<T>& to, ArgsT... val) {
       template <class Fn, class... Args>
       constexpr CUDA_HOST_DEVICE return_type_t<CladFunctionType>
       execute_helper(Fn f, CUDA_ARGS Args&&... args) const {
-        // `static_cast` is required here for perfect forwarding.
+        //  `static_cast` is required here for perfect forwarding.
 #if defined(__CUDACC__)
         if constexpr (sizeof...(Args) >= 2) {
           auto secondArg =

--- a/include/clad/Differentiator/SparsityPattern.h
+++ b/include/clad/Differentiator/SparsityPattern.h
@@ -1,0 +1,64 @@
+#ifndef CLAD_DIFFERENTIATOR_SPARSITYPATTERN_H
+#define CLAD_DIFFERENTIATOR_SPARSITYPATTERN_H
+
+#include <assert.h>
+
+#include <cstddef>
+#include <initializer_list>
+#include <type_traits>
+
+namespace clad {
+template <typename T> class sparsity_pattern {
+  int* m_col = nullptr;
+  int* m_row = nullptr;
+  T* m_vals = nullptr;
+
+  std::size_t m_col_size;
+  std::size_t m_row_size;
+
+public:
+  sparsity_pattern() = default;
+
+  void set_col_idx(std::initializer_list<int> col) {
+    m_col_size = col.size();
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    m_col = new int[m_col_size];
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    m_vals = new T[m_col_size];
+
+    std::size_t i = 0;
+    for (const auto& e : col)
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      m_col[i++] = e;
+  }
+
+  void set_row_idx(std::initializer_list<int> row) {
+    m_row_size = row.size();
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    m_row = new int[m_row_size];
+    std::size_t i = 0;
+    for (const auto& e : row)
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      m_row[i++] = e;
+  }
+
+  T& operator[](int i) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return m_vals[i];
+  }
+
+  int get_col(int idx) {
+    assert(idx < m_col_size);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return m_col[idx];
+  }
+
+  int get_row(int idx) {
+    assert(idx < m_row_size);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return m_row[idx];
+  }
+};
+} // namespace clad
+
+#endif // CLAD_DIFFERENTIATOR_SPARSITYPATTERN_H

--- a/include/clad/Differentiator/SparsityPattern.h
+++ b/include/clad/Differentiator/SparsityPattern.h
@@ -18,7 +18,11 @@ template <typename T> class sparsity_pattern {
 
 public:
   sparsity_pattern() = default;
-
+  ~sparsity_pattern() {
+      delete[] m_col;
+      delete[] m_row;  
+      delete[] m_vals;
+  }
   void set_col_idx(std::initializer_list<int> col) {
     m_col_size = col.size();
     // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)

--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -42,6 +42,7 @@ llvm_add_library(cladDifferentiator
   BaseForwardModeVisitor.cpp
   CladUtils.cpp
   ConstantFolder.cpp
+  DependencySparsityAnalyzer.cpp
   DerivativeBuilder.cpp
   DerivedFnCollector.cpp
   DerivedFnInfo.cpp

--- a/lib/Differentiator/DependencySparsityAnalyzer.cpp
+++ b/lib/Differentiator/DependencySparsityAnalyzer.cpp
@@ -1,0 +1,105 @@
+#include "DependencySparsityAnalyzer.h"
+#include "clang/AST/Type.h"
+
+using namespace clang;
+
+namespace clad {
+
+void DependencySparsityAnalyzer::Analyze(const FunctionDecl* FD) {
+  // Build the CFG (control-flow graph) of FD.
+  clang::CFG::BuildOptions Options;
+  m_CFG = clang::CFG::buildCFG(FD, FD->getBody(), &m_Context, Options);
+
+  // Set current block ID to the ID of entry the block.
+  CFGBlock* entry = &m_CFG->getEntry();
+  m_CurBlockID = entry->getBlockID();
+
+  int i = 0;
+  for (const auto& par : FD->parameters()) {
+    if (!utils::isArrayOrPointerType(par->getType())) {
+      m_ParameterNum[dyn_cast<VarDecl>(par)] = i;
+      i++;
+    }
+  }
+
+  // Add the entry block to the queue.
+  m_CFGQueue.insert(m_CurBlockID);
+
+  // Visit CFG blocks in the queue until it's empty.
+  while (!m_CFGQueue.empty()) {
+    auto IDIter = std::prev(m_CFGQueue.end());
+    m_CurBlockID = *IDIter;
+    m_CFGQueue.erase(IDIter);
+    CFGBlock& nextBlock = *getCFGBlockByID(m_CurBlockID);
+    AnalyzeCFGBlock(nextBlock);
+  }
+}
+
+void DependencySparsityAnalyzer::AnalyzeCFGBlock(const CFGBlock& block) {
+  // Visit all the statements inside the block.
+  for (const clang::CFGElement& Element : block) {
+    if (Element.getKind() == clang::CFGElement::Statement) {
+      const clang::Stmt* S = Element.castAs<clang::CFGStmt>().getStmt();
+      // The const_cast is inevitable, since there is no
+      // ConstRecusiveASTVisitor.
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+      TraverseStmt(const_cast<clang::Stmt*>(S));
+    }
+  }
+
+  for (const clang::CFGBlock::AdjacentBlock succ : block.succs()) {
+    if (!succ)
+      continue;
+    m_CFGQueue.insert(succ->getBlockID());
+  }
+}
+
+CFGBlock* DependencySparsityAnalyzer::getCFGBlockByID(unsigned ID) {
+  return *(m_CFG->begin() + ID);
+}
+
+bool DependencySparsityAnalyzer::VisitBinaryOperator(BinaryOperator* BinOp) {
+  Expr* L = BinOp->getLHS();
+  Expr* R = BinOp->getRHS();
+  const auto opCode = BinOp->getOpcode();
+  if (BinOp->isAssignmentOp()) {
+    TraverseStmt(L);
+    // m_MarkingMode = true;
+    TraverseStmt(R);
+  } else if (opCode == BO_Add || opCode == BO_Sub || opCode == BO_Mul ||
+             opCode == BO_Div) {
+    for (auto* subexpr : BinOp->children())
+      if (!isa<BinaryOperator>(subexpr))
+        TraverseStmt(subexpr);
+  }
+  return true;
+}
+
+bool DependencySparsityAnalyzer::VisitDeclRefExpr(DeclRefExpr* DRE) {
+  if (m_MarkingMode) {
+    auto* VD = dyn_cast<VarDecl>(DRE->getDecl());
+    if (m_ParameterNum.find(VD) != m_ParameterNum.end()) {
+      auto parr =
+          std::make_pair(m_ParameterNum.find(VD)->second, m_CurrOutputInd);
+      m_OutputDependencySet.insert(parr);
+    }
+  }
+  return true;
+}
+
+bool DependencySparsityAnalyzer::VisitArraySubscriptExpr(
+    ArraySubscriptExpr* ASE) {
+  auto* dASE = dyn_cast<DeclRefExpr>(ASE->getBase()->IgnoreImpCasts());
+  llvm::StringRef Name = dASE->getDecl()->getName();
+
+  if (Name.contains("_clad_out_")) {
+    const Expr* idx = ASE->getIdx();
+    if (isa<IntegerLiteral>(idx)) {
+      m_CurrOutputInd =
+          dyn_cast<IntegerLiteral>(idx)->getValue().getLimitedValue();
+      m_MarkingMode = true;
+    }
+  }
+  return true;
+}
+} // namespace clad

--- a/lib/Differentiator/DependencySparsityAnalyzer.h
+++ b/lib/Differentiator/DependencySparsityAnalyzer.h
@@ -1,0 +1,62 @@
+#ifndef CLAD_DIFFERENTIATOR_DEPENDENCYSPARSITYANALYZER_H
+#define CLAD_DIFFERENTIATOR_DEPENDENCYSPARSITYANALYZER_H
+
+#include "clang/AST/Expr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Analysis/CFG.h"
+
+#include "clad/Differentiator/CladUtils.h"
+#include "clad/Differentiator/Compatibility.h"
+
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <utility>
+
+namespace clad {
+
+class DependencySparsityAnalyzer
+    : public clang::RecursiveASTVisitor<DependencySparsityAnalyzer> {
+
+  unsigned m_CurBlockID{};
+  unsigned m_CurrOutputInd{};
+  bool m_MarkingMode = true;
+  std::unordered_map<clang::VarDecl*, int> m_ParameterNum;
+  std::unique_ptr<clang::CFG> m_CFG;
+
+  clang::ASTContext& m_Context;
+  std::set<unsigned> m_CFGQueue;
+  clang::CFGBlock* getCFGBlockByID(unsigned ID);
+
+  std::set<std::pair<int, int>, utils::compare>& m_OutputDependencySet;
+
+  // FIXME: Once VarData is reworked for AA and TBR, implement by-block
+  // analysis.
+  // std::map<unsigned, std::set<std::pair<int, int>>> m_BlockData;
+
+  void AnalyzeCFGBlock(const clang::CFGBlock& block);
+
+public:
+  DependencySparsityAnalyzer(
+      clang::ASTContext& Context,
+      std::set<std::pair<int, int>, utils::compare>& OutputDependencySet)
+      : m_Context(Context), m_OutputDependencySet(OutputDependencySet) {}
+  ~DependencySparsityAnalyzer() = default;
+
+  DependencySparsityAnalyzer(const DependencySparsityAnalyzer&) = delete;
+  DependencySparsityAnalyzer&
+  operator=(const DependencySparsityAnalyzer&) = delete;
+  DependencySparsityAnalyzer(const DependencySparsityAnalyzer&&) = delete;
+  DependencySparsityAnalyzer&
+  operator=(const DependencySparsityAnalyzer&&) = delete;
+
+  void Analyze(const clang::FunctionDecl* FD);
+  bool VisitBinaryOperator(clang::BinaryOperator* BinOp);
+  bool VisitDeclRefExpr(clang::DeclRefExpr* DRE);
+  // bool VisitDeclStmt(clang::DeclStmt* DS);
+  bool VisitArraySubscriptExpr(clang::ArraySubscriptExpr* ASE);
+};
+
+} // namespace clad
+
+#endif // CLAD_DIFFERENTIATOR_DEPENDENCYSPARSITYANALYZER_H

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -609,6 +609,9 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
                request.Mode == DiffMode::hessian_diagonal) {
       HessianModeVisitor H(*this, request);
       result = H.Derive();
+    } else if (request.Mode == DiffMode::jacobian && request.EnableSparsity) {
+      SparseJacobianModeVisitor SJ(*this, request);
+      result = SJ.Derive();
     } else if (request.Mode == DiffMode::jacobian) {
       JacobianModeVisitor J(*this, request);
       result = J.Derive();

--- a/lib/Differentiator/DerivedFnCollector.cpp
+++ b/lib/Differentiator/DerivedFnCollector.cpp
@@ -3,10 +3,13 @@
 
 namespace clad {
 void DerivedFnCollector::Add(const DerivedFnInfo& DFI) {
-  assert(!AlreadyExists(DFI) &&
-         "We are generating same derivative more than once, or calling "
-         "`DerivedFnCollector::Add` more than once for the same derivative "
-         ". Ideally, we shouldn't do either.");
+  // FIXME: DerivedFnInfo doesn't account for passed options, remove when it is
+  // reworked.
+  assert(DFI.m_EnableSparsity ||
+         (!AlreadyExists(DFI) &&
+          "We are generating same derivative more than once, or calling "
+          "`DerivedFnCollector::Add` more than once for the same derivative "
+          ". Ideally, we shouldn't do either."));
   m_DerivedFnInfoCollection[DFI.OriginalFn()].push_back(DFI);
   AddToDerivativeSet(DFI.DerivedFn());
 }
@@ -34,6 +37,8 @@ bool DerivedFnCollector::AlreadyExists(const DerivedFnInfo& DFI) const {
 }
 
 DerivedFnInfo DerivedFnCollector::Find(const DiffRequest& request) const {
+  if (request.EnableSparsity)
+    return DerivedFnInfo();
   auto subCollectionIt = m_DerivedFnInfoCollection.find(request.Function);
   if (subCollectionIt == m_DerivedFnInfoCollection.end())
     return DerivedFnInfo();

--- a/lib/Differentiator/DerivedFnInfo.cpp
+++ b/lib/Differentiator/DerivedFnInfo.cpp
@@ -12,7 +12,8 @@ DerivedFnInfo::DerivedFnInfo(const DiffRequest& request,
       m_DiffVarsInfo(request.DVI),
       m_CUDAGlobalArgsIndexes(request.CUDAGlobalArgsIndexes),
       m_UsesEnzyme(request.use_enzyme),
-      m_DeclarationOnly(request.DeclarationOnly) {}
+      m_DeclarationOnly(request.DeclarationOnly),
+      m_EnableSparsity(request.EnableSparsity) {}
 
 bool DerivedFnInfo::SatisfiesRequest(const DiffRequest& request) const {
   return (request.Function == m_OriginalFn && request.Mode == m_Mode &&

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -807,6 +807,7 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
     request.EnableTBRAnalysis = ReqOpts.EnableTBRAnalysis;
     request.EnableVariedAnalysis = ReqOpts.EnableVariedAnalysis;
     request.EnableUsefulAnalysis = ReqOpts.EnableUsefulAnalysis;
+    request.EnableSparsity = ReqOpts.EnableSparsity;
 
     const TemplateArgumentList* TAL = FD->getTemplateSpecializationArgs();
     assert(TAL && "Call must have specialization args!");
@@ -831,6 +832,8 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
         clad::HasOption(bitmasked_opts_value, clad::opts::enable_ua);
     bool disable_ua_in_req =
         clad::HasOption(bitmasked_opts_value, clad::opts::disable_ua);
+    bool enable_sp_in_req =
+        clad::HasOption(bitmasked_opts_value, clad::opts::enable_sp);
     // Sanity checks.
     if (enable_tbr_in_req && disable_tbr_in_req) {
       utils::EmitDiag(S, DiagnosticsEngine::Error, endLoc,
@@ -852,6 +855,8 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
                       "TBR analysis is not meant for forward mode AD.");
       return true;
     }
+    if (enable_sp_in_req)
+      request.EnableSparsity = enable_sp_in_req;
 
     // reverse vector mode is not yet supported.
     if (request.Mode == DiffMode::reverse &&

--- a/lib/Differentiator/JacobianModeVisitor.cpp
+++ b/lib/Differentiator/JacobianModeVisitor.cpp
@@ -4,6 +4,8 @@
 #include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/DerivativeBuilder.h"
 
+#include "clang/Sema/Lookup.h"
+
 #include "llvm/Support/SaveAndRestore.h"
 
 using namespace clang;
@@ -258,6 +260,243 @@ DerivativeAndOverload JacobianModeVisitor::Derive() {
   // Create the overload declaration for the derivative.
   FunctionDecl* overloadFD = CreateDerivativeOverload();
   return DerivativeAndOverload{vectorDiffFD, overloadFD};
+}
+
+clang::Expr*
+ComputeColIdx(clang::ASTContext& m_Context, clang::Sema& m_Sema,
+              const std::set<std::pair<int, int>, utils::compare>& depset) {
+  llvm::SmallVector<Expr*, 8> Elements;
+  for (auto p : depset) {
+    Expr* colIdxE = IntegerLiteral::Create(m_Context, llvm::APInt(32, p.first),
+                                           m_Context.IntTy, noLoc);
+    Elements.emplace_back(colIdxE);
+  }
+  return m_Sema.ActOnInitList(noLoc, Elements, noLoc).get();
+}
+
+clang::Expr*
+ComputeRowIdx(clang::ASTContext& m_Context, clang::Sema& m_Sema,
+              const std::set<std::pair<int, int>, utils::compare>& depset) {
+  llvm::SmallVector<Expr*, 8> Elements;
+  int nonZeroAbove = 0;
+  int currentRow = -1;
+  for (auto p : depset) {
+    if (currentRow != p.second) {
+      Expr* nonZeroAboveE = IntegerLiteral::Create(
+          m_Context, llvm::APInt(32, nonZeroAbove), m_Context.IntTy, noLoc);
+      Elements.emplace_back(nonZeroAboveE);
+      currentRow += 1;
+    }
+    nonZeroAbove++;
+  }
+  Expr* nonZeroAboveE = IntegerLiteral::Create(
+      m_Context, llvm::APInt(32, nonZeroAbove), m_Context.IntTy, noLoc);
+  Elements.emplace_back(nonZeroAboveE);
+  return m_Sema.ActOnInitList(noLoc, Elements, noLoc).get();
+}
+
+SparseJacobianModeVisitor::SparseJacobianModeVisitor(DerivativeBuilder& builder,
+                                                     const DiffRequest& request)
+    : VisitorBase(builder, request) {}
+
+DerivativeAndOverload SparseJacobianModeVisitor::Derive() {
+  const FunctionDecl* FD = m_DiffReq.Function;
+  assert(m_DiffReq.Mode == DiffMode::jacobian && m_DiffReq.EnableSparsity);
+
+  DiffParams args{};
+  QualType outputType;
+
+  for (const DiffInputVarInfo& dParam : m_DiffReq.DVI) {
+    // rework
+    if (llvm::StringRef(dParam.param->getName()).contains("_clad_out_"))
+      outputType = dParam.param->getType()->getPointeeType();
+    args.push_back(dParam.param);
+  }
+  // FIXME: Add proper directional derivative handling. Dependency analysis does
+  // not account for parameters that are not in DVI, but it should.
+  std::string derivedFnName = m_DiffReq.BaseFunctionName + "_sparse_jac";
+  std::string jacName = m_DiffReq.BaseFunctionName + "_jac";
+
+  if (args.size() != FD->getNumParams()) {
+    for (const ValueDecl* arg : args) {
+      const auto* it = std::find(FD->param_begin(), FD->param_end(), arg);
+      auto idx = std::distance(FD->param_begin(), it);
+      derivedFnName += ('_' + std::to_string(idx));
+      jacName += ('_' + std::to_string(idx));
+    }
+  }
+
+  IdentifierInfo* II = &m_Context.Idents.get(derivedFnName);
+  SourceLocation loc{m_DiffReq->getLocation()};
+  DeclarationNameInfo name(II, loc);
+
+  static TemplateDecl* sparsityDecl = utils::LookupTemplateDeclInCladNamespace(
+      m_Sema, /*ClassName=*/"sparsity_pattern");
+
+  QualType sparsityQT =
+      utils::InstantiateTemplate(m_Sema, sparsityDecl, {outputType});
+  sparsityQT = m_Context.getPointerType(sparsityQT);
+  QualType vectorDiffFunctionType = GetDerivativeType(sparsityQT);
+
+  auto* jacDC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
+  m_Sema.CurContext = jacDC;
+  DeclWithContext result = m_Builder.cloneFunction(
+      m_DiffReq.Function, *this, jacDC, loc, name, vectorDiffFunctionType);
+  FunctionDecl* vectorSparseDiffFD = result.first;
+  m_Derivative = vectorSparseDiffFD;
+
+  clang::LookupResult jacLR =
+      utils::LookupQualifiedName(jacName, m_Sema, jacDC);
+  FunctionDecl* jacFD = dyn_cast<FunctionDecl>(jacLR.getRepresentativeDecl());
+
+  CXXScopeSpec CSS;
+  Expr* UnresolvedLookup =
+      m_Sema.BuildDeclarationNameExpr(CSS, jacLR, /*ADL=*/true).get();
+
+  llvm::SmallVector<Expr*, 16> callArgs;
+  llvm::SmallVector<ParmVarDecl*, 16> paramsNew;
+
+  unsigned indVarCount = 0;
+  ParmVarDecl* outputPVD = nullptr;
+  for (auto* PVD : jacFD->parameters()) {
+    auto* newPVD = CloneParmVarDecl(PVD, PVD->getIdentifier(),
+                                    /*pushOnScopeChains=*/false,
+                                    /*cloneDefaultArg=*/false);
+    // this is bad
+    if (!utils::isArrayOrPointerType(PVD->getType()))
+      ++indVarCount;
+    if (llvm::StringRef(PVD->getName()).contains("_clad_out_"))
+      outputPVD = newPVD;
+
+    paramsNew.push_back(newPVD);
+    callArgs.push_back(BuildDeclRef(cast<VarDecl>(newPVD)));
+  }
+
+  llvm::StringRef sName = "sparsity_patern";
+  IdentifierInfo* sII = CreateUniqueIdentifier(sName);
+  ParmVarDecl* sparsityPVD =
+      utils::BuildParmVarDecl(m_Sema, m_Derivative, sII, sparsityQT);
+  paramsNew.push_back(sparsityPVD);
+
+  vectorSparseDiffFD->setParams(
+      clad_compat::makeArrayRef(paramsNew.data(), paramsNew.size()));
+  vectorSparseDiffFD->setBody(nullptr);
+
+  llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
+  llvm::SaveAndRestore<Scope*> SaveScope(getCurrentScope());
+  beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
+             Scope::DeclScope);
+  m_Sema.PushFunctionScope();
+  m_Sema.PushDeclContext(getCurrentScope(), m_Derivative);
+  beginScope(Scope::FnScope | Scope::DeclScope);
+  m_DerivativeFnScope = getCurrentScope();
+  beginBlock();
+
+  Expr* jacobianCall =
+      m_Sema
+          .ActOnCallExpr(getCurrentScope(), UnresolvedLookup, loc,
+                         llvm::MutableArrayRef<Expr*>(callArgs),
+                         m_DiffReq->getLocation())
+          .get();
+
+  llvm::SmallVector<Expr*, 8> Elements;
+  for (auto idx : m_DiffReq.getDependencySet()) {
+    Expr* idxIL = IntegerLiteral::Create(
+        m_Context, llvm::APInt(32, idx.first + idx.second * indVarCount),
+        m_Context.IntTy, noLoc);
+    Elements.emplace_back(idxIL);
+  }
+
+  Expr* InitExprFull = m_Sema.ActOnInitList(loc, Elements, loc).get();
+
+#if CLANG_VERSION_MAJOR >= 18
+  QualType arrayTyInt = m_Context.getIncompleteArrayType(
+      m_Context.IntTy, clang::ArraySizeModifier::Normal,
+      /*IndexTypeQuals=*/0);
+#else
+  QualType arrayTyInt = m_Context.getIncompleteArrayType(
+      m_Context.IntTy, clang::VariableArrayType::Normal,
+      /*IndexTypeQuals=*/0);
+#endif
+
+  VarDecl* depSetDecl =
+      BuildVarDecl(arrayTyInt, "dependency_set", InitExprFull);
+  Expr* colIdxInitList =
+      ComputeColIdx(m_Context, m_Sema, m_DiffReq.getDependencySet());
+  Expr* rowIdxInitList =
+      ComputeRowIdx(m_Context, m_Sema, m_DiffReq.getDependencySet());
+  Expr* setColIdxE = BuildCallExprToMemFn(
+      BuildDeclRef(dyn_cast<VarDecl>(sparsityPVD)),
+      /*MemberFunctionName=*/"set_col_idx", {colIdxInitList});
+  Expr* setRowIdxE = BuildCallExprToMemFn(
+      BuildDeclRef(dyn_cast<VarDecl>(sparsityPVD)),
+      /*MemberFunctionName=*/"set_row_idx", {rowIdxInitList});
+
+  VarDecl* counterVD =
+      BuildVarDecl(m_Context.IntTy, "i", getZeroInit(m_Context.IntTy));
+  Expr* counterDRE = BuildDeclRef(counterVD);
+  Expr* counterInc = BuildOp(UO_PreInc, counterDRE);
+  Expr* forCond = BuildOp(
+      BO_LT, counterDRE,
+      IntegerLiteral::Create(
+          m_Context,
+          llvm::APInt(/*bitwidth=*/32, m_DiffReq.getDependencySet().size()),
+          m_Context.IntTy, loc));
+
+  Expr* dependencySetASE =
+      m_Sema
+          .ActOnArraySubscriptExpr(getCurrentScope(), BuildDeclRef(depSetDecl),
+                                   loc, counterDRE, loc)
+          .get();
+
+  Expr* sparsityE = BuildOp(UO_Deref, BuildDeclRef(sparsityPVD));
+  sparsityE = utils::BuildParenExpr(m_Sema, sparsityE);
+
+  Expr* nnzValsASE = m_Sema
+                         .ActOnArraySubscriptExpr(getCurrentScope(), sparsityE,
+                                                  loc, counterDRE, loc)
+                         .get();
+
+  Expr* indVarExpr = IntegerLiteral::Create(
+      m_Context, llvm::APInt(32, indVarCount), m_Context.IntTy, loc);
+  Expr* matrixFirstIdx = BuildOp(BO_Div, dependencySetASE, indVarExpr);
+  Expr* matrixSecondIdx = BuildOp(BO_Rem, dependencySetASE, indVarExpr);
+
+  Expr* outputE = BuildParens(BuildOp(UO_Deref, BuildDeclRef(outputPVD)));
+  outputE = utils::BuildParenExpr(m_Sema, outputE);
+
+  Expr* outputFirstASE =
+      m_Sema
+          .ActOnArraySubscriptExpr(getCurrentScope(), outputE, loc,
+                                   matrixFirstIdx, loc)
+          .get();
+
+  Expr* outputFullASE =
+      m_Sema
+          .ActOnArraySubscriptExpr(getCurrentScope(), outputFirstASE, loc,
+                                   matrixSecondIdx, loc)
+          .get();
+
+  Expr* assignVals = BuildOp(BO_Assign, nnzValsASE, outputFullASE);
+
+  Stmt* forAssignVals = new (m_Context)
+      ForStmt(m_Context, /*Init=*/BuildDeclStmt(counterVD), forCond,
+              /*CondVar=*/nullptr, counterInc, assignVals, loc, loc, loc);
+
+  addToCurrentBlock(jacobianCall);
+  addToCurrentBlock(BuildDeclStmt(depSetDecl));
+  addToCurrentBlock(setColIdxE);
+  addToCurrentBlock(setRowIdxE);
+  addToCurrentBlock(forAssignVals);
+
+  Stmt* vectorDiffBody = endBlock();
+  m_Derivative->setBody(vectorDiffBody);
+  endScope(); // Function body scope
+  m_Sema.PopFunctionScopeInfo();
+  m_Sema.PopDeclContext();
+  endScope(); // Function decl scope
+  FunctionDecl* overloadFD = CreateDerivativeOverload();
+  return DerivativeAndOverload{vectorSparseDiffFD, overloadFD};
 }
 
 StmtDiff JacobianModeVisitor::VisitReturnStmt(const clang::ReturnStmt* RS) {

--- a/lib/Differentiator/JacobianModeVisitor.h
+++ b/lib/Differentiator/JacobianModeVisitor.h
@@ -16,6 +16,16 @@ public:
 
   StmtDiff VisitReturnStmt(const clang::ReturnStmt* RS) override;
 };
+
+// not really a visitor
+class SparseJacobianModeVisitor : public VisitorBase {
+
+public:
+  SparseJacobianModeVisitor(DerivativeBuilder& builder,
+                            const DiffRequest& request);
+
+  DerivativeAndOverload Derive() override;
+};
 } // end namespace clad
 
 #endif // CLAD_DIFFERENTIATOR_JACOBIANMODEVISITOR_H

--- a/test/Jacobian/Sparsity.C
+++ b/test/Jacobian/Sparsity.C
@@ -1,0 +1,80 @@
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -Xclang -plugin-arg-clad -Xclang -enable-sp %s -I%S/../../include -std=c++14 -oSparsity.out 2>&1 | %filecheck %s
+// RUN: ./Sparsity.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-sp %s -I%S/../../include -std=c++14 -oSparsity.out
+// RUN: ./Sparsity.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+void f1(double a, double b, double c, double _clad_out_output[]) {
+  _clad_out_output[0] = a;
+  _clad_out_output[1] = 2*a + 3*b;
+  _clad_out_output[2] = 4*a + 5*b + 6*c;
+}
+
+// CHECK: void f1_jac(double a, double b, double c, double _clad_out_output[], clad::matrix<double> *_d_vector__clad_out_output) {
+// CHECK-NEXT:     unsigned long indepVarCount = 3UL;
+// CHECK-NEXT:     clad::array<double> _d_vector_a = clad::one_hot_vector(indepVarCount, 0UL);
+// CHECK-NEXT:     clad::array<double> _d_vector_b = clad::one_hot_vector(indepVarCount, 1UL);
+// CHECK-NEXT:     clad::array<double> _d_vector_c = clad::one_hot_vector(indepVarCount, 2UL);
+// CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, 3UL);
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = _d_vector_a;
+// CHECK-NEXT:     _clad_out_output[0] = a;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (clad::zero_vector(indepVarCount)) * a + 2 * _d_vector_a + (clad::zero_vector(indepVarCount)) * b + 3 * _d_vector_b;
+// CHECK-NEXT:     _clad_out_output[1] = 2 * a + 3 * b;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[2] = (clad::zero_vector(indepVarCount)) * a + 4 * _d_vector_a + (clad::zero_vector(indepVarCount)) * b + 5 * _d_vector_b + (clad::zero_vector(indepVarCount)) * c + 6 * _d_vector_c;
+// CHECK-NEXT:     _clad_out_output[2] = 4 * a + 5 * b + 6 * c;
+// CHECK-NEXT: }
+
+// CHECK: void f1_sparse_jac(double a, double b, double c, double _clad_out_output[], clad::matrix<double> *_d_vector__clad_out_output, clad::sparsity_pattern<double> *sparsity_patern) {
+// CHECK-NEXT:     f1_jac(a, b, c, _clad_out_output, _d_vector__clad_out_output);
+// CHECK-NEXT:     int dependency_set[6] = {0, 3, 4, 6, 7, 8};
+// CHECK-NEXT:     sparsity_patern->set_col_idx({0, 0, 1, 0, 1, 2});
+// CHECK-NEXT:     sparsity_patern->set_row_idx({0, 1, 3, 6});
+// CHECK-NEXT:     for (int i = 0; i < 6; ++i)
+// CHECK-NEXT:         (*sparsity_patern)[i] = (*_d_vector__clad_out_output)[dependency_set[i] / 3][dependency_set[i] % 3];
+// CHECK-NEXT: }
+
+void f2(double a, double b, double _clad_out_out[]){
+  if(0){
+    a++;
+  }
+  _clad_out_out[0] = a + b;
+}
+
+// CHECK: void f2_jac_0_2(double a, double b, double _clad_out_out[], clad::matrix<double> *_d_vector__clad_out_out) {
+// CHECK-NEXT:     unsigned long indepVarCount = 2UL;
+// CHECK-NEXT:     clad::array<double> _d_vector_a = clad::one_hot_vector(indepVarCount, 0UL);
+// CHECK-NEXT:     clad::array<double> _d_vector_b = clad::zero_vector(indepVarCount);
+// CHECK-NEXT:     *_d_vector__clad_out_out = clad::identity_matrix(_d_vector__clad_out_out->rows(), indepVarCount, 1UL);
+// CHECK-NEXT:     if (0) {
+// CHECK-NEXT:         a++;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     (*_d_vector__clad_out_out)[0] = _d_vector_a + _d_vector_b;
+// CHECK-NEXT:     _clad_out_out[0] = a + b;
+// CHECK-NEXT: }
+
+// CHECK: void f2_sparse_jac_0_2(double a, double b, double _clad_out_out[], clad::matrix<double> *_d_vector__clad_out_out, clad::sparsity_pattern<double> *sparsity_patern) {
+// CHECK-NEXT:     f2_jac_0_2(a, b, _clad_out_out, _d_vector__clad_out_out);
+// CHECK-NEXT:     int dependency_set[2] = {0, 1};
+// CHECK-NEXT:     sparsity_patern->set_col_idx({0, 1});
+// CHECK-NEXT:     sparsity_patern->set_row_idx({0, 2});
+// CHECK-NEXT:     for (int i = 0; i < 2; ++i)
+// CHECK-NEXT:         (*sparsity_patern)[i] = (*_d_vector__clad_out_out)[dependency_set[i] / 2][dependency_set[i] % 2];
+// CHECK-NEXT: }
+
+int main(){
+    clad::matrix<double> jacobian(3, 3);
+    double outputarr[9];
+    clad::sparsity_pattern<double> pattern_f1;
+
+    auto df1 = clad::jacobian(f1);
+    df1.execute(1, 2, 3, outputarr, &jacobian, &pattern_f1);
+    printf("Jacobian is = {%.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f}\n", jacobian[0][0], jacobian[0][1], jacobian[0][2], jacobian[1][0], jacobian[1][1], jacobian[1][2], jacobian[2][0], jacobian[2][1], jacobian[2][2]); // CHECK-EXEC: Jacobian is = {1.00, 0.00, 0.00, 2.00, 3.00, 0.00, 4.00, 5.00, 6.00}
+    printf("nnz: %.2f, %.2f, %.2f, %.2f, %.2f, %.2f", pattern_f1[0], pattern_f1[1], pattern_f1[2], pattern_f1[3], pattern_f1[4], pattern_f1[5]); // CHECK-EXEC: nnz: 1.00, 2.00, 3.00, 4.00, 5.00, 6.00
+    
+    clad::sparsity_pattern<double> pattern_f2;
+    auto df2 = clad::jacobian(f2, "a, _clad_out_out");
+    df2.execute(1, 2, outputarr, &jacobian, &pattern_f2);
+    printf("Jacobian is = {%.2f, %.2f}\n", jacobian[0][0], jacobian[0][1]); // CHECK-EXEC: Jacobian is = {1.00, 0.00}
+    printf("nnz: %.2f, %.2f", pattern_f2[0], pattern_f2[1]); // CHECK-EXEC: nnz: 1.00, 0.00
+}

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -459,10 +459,10 @@ void InitTimers();
     }
 
     static void SetSparsityOptions(const DifferentiationOptions& DO,
-                                           RequestOptions& opts) {
+                                   RequestOptions& opts) {
       opts.EnableSparsity = DO.EnableSparsity;
     }
-    
+
     void CladPlugin::SetRequestOptions(RequestOptions& opts) const {
       SetTBRAnalysisOptions(m_DO, opts);
       SetActivityAnalysisOptions(m_DO, opts);

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -457,10 +457,17 @@ void InitTimers();
       else
         opts.EnableUsefulAnalysis = false; // Default mode.
     }
+
+    static void SetSparsityOptions(const DifferentiationOptions& DO,
+                                           RequestOptions& opts) {
+      opts.EnableSparsity = DO.EnableSparsity;
+    }
+    
     void CladPlugin::SetRequestOptions(RequestOptions& opts) const {
       SetTBRAnalysisOptions(m_DO, opts);
       SetActivityAnalysisOptions(m_DO, opts);
       SetUsefulAnalysisOptions(m_DO, opts);
+      SetSparsityOptions(m_DO, opts);
     }
 
     void CladPlugin::FinalizeTranslationUnit() {

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -48,8 +48,8 @@ struct DifferentiationOptions {
         ValidateClangVersion(true), EnableTBRAnalysis(false),
         DisableTBRAnalysis(false), EnableVariedAnalysis(false),
         DisableVariedAnalysis(false), EnableUsefulAnalysis(false),
-        DisableUsefulAnalysis(false), EnableSparsity(false), CustomEstimationModel(false),
-        PrintNumDiffErrorInfo(false) {}
+        DisableUsefulAnalysis(false), EnableSparsity(false),
+        CustomEstimationModel(false), PrintNumDiffErrorInfo(false) {}
 
   bool DumpSourceFn : 1;
   bool DumpSourceFnAST : 1;

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -48,7 +48,7 @@ struct DifferentiationOptions {
         ValidateClangVersion(true), EnableTBRAnalysis(false),
         DisableTBRAnalysis(false), EnableVariedAnalysis(false),
         DisableVariedAnalysis(false), EnableUsefulAnalysis(false),
-        DisableUsefulAnalysis(false), CustomEstimationModel(false),
+        DisableUsefulAnalysis(false), EnableSparsity(false), CustomEstimationModel(false),
         PrintNumDiffErrorInfo(false) {}
 
   bool DumpSourceFn : 1;
@@ -63,6 +63,8 @@ struct DifferentiationOptions {
   bool DisableVariedAnalysis : 1;
   bool EnableUsefulAnalysis : 1;
   bool DisableUsefulAnalysis : 1;
+  bool EnableSparsity : 1;
+
   bool CustomEstimationModel : 1;
   bool PrintNumDiffErrorInfo : 1;
   std::string CustomModelName;
@@ -320,6 +322,8 @@ struct DifferentiationOptions {
             m_DO.EnableUsefulAnalysis = true;
           } else if (args[i] == "-disable-ua") {
             m_DO.DisableUsefulAnalysis = true;
+          } else if (args[i] == "-enable-sp") {
+            m_DO.EnableSparsity = true;
           } else if (args[i] == "-fcustom-estimation-model") {
             m_DO.CustomEstimationModel = true;
             if (++i == e) {


### PR DESCRIPTION
This PR introduces very basic support for sparsity patterns for jacobians. Sparsity pattern that is used here is called **Compressed Sparse Row** a collection of three sets: `vals, column_index, row_index`. See more [here](https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_(CSR,_CRS_or_Yale_format)). 

Consider following example:
```cpp
void f1(double a, double b, double c, double _clad_out_output[]) {
  _clad_out_output[0] = a;
  _clad_out_output[1] = a + b;
  _clad_out_output[2] = a + b + c;
}
```
Essentially we need to determine whether `_clad_out_output[i]` depends on a certain input variable. For that Dependency Analysis is implemented, which traverses the body of the function and does the following:

1. Identifies `_clad_out_output[i] = LHS` expressions.
2. Traverses LHS and adds `{i, independent_variable_index}` to the `OutputDependencySet` that idicates that `i-th` output depends on certain `independent_variable`(we numerate independent variables for consistency, hence `independent_variable_index`).

Having `OutputDependencySet` enables us to compute `column_index` and`row_index`. Iterating over it and assigning respective jacobian entry to `vals` give us the desired pattern.

TODO(not in this PR tho):

1. Enable handling of array parameters. Since we numerate independent variables we also have to account for fixed-size array parameters.
2. Add loop support. For that we would need some kind of analysis to determine if a loop is "standard" and keep info about it.
3. Enable branches. Right now we do not have branch-merging like on TBR or AA.
4. Don't account for the input parameters that are not in the DVI.