### PR TITLE
Avoid generating the reverse pass in RMFPV (reverse_forw)

### DIFF
--- a/include/clad/Differentiator/ReverseModeForwPassVisitor.h
+++ b/include/clad/Differentiator/ReverseModeForwPassVisitor.h
@@ -4,11 +4,13 @@
 #include "clad/Differentiator/DerivativeBuilder.h"
 #include "clad/Differentiator/ParseDiffArgsTypes.h"
 #include "clad/Differentiator/ReverseModeVisitor.h"
+#include "clad/Differentiator/VisitorBase.h"
 
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Sema/Sema.h"
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace clad {
 class ReverseModeForwPassVisitor : public ReverseModeVisitor {
@@ -21,6 +23,15 @@ public:
   ReverseModeForwPassVisitor(DerivativeBuilder& builder,
                              const DiffRequest& request);
   DerivativeAndOverload Derive() override;
+
+  // These overrides are a workaround to prevent RMFPV from generating
+  // reverse sweep derivative stmts and store/restore stmts,
+  // which are not used in reverse_forw functions
+  clang::Expr* dfdx() override { return nullptr; }
+  StmtDiff StoreAndRestore(clang::Expr* E, llvm::StringRef prefix = "_t",
+                           bool moveToTape = false) override {
+    return {};
+  }
 
   StmtDiff ProcessSingleStmt(const clang::Stmt* S);
   StmtDiff VisitCompoundStmt(const clang::CompoundStmt* CS) override;

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -101,7 +101,7 @@ namespace clad {
 
   public:
     using direction = rmv::direction;
-    clang::Expr* dfdx() {
+    virtual clang::Expr* dfdx() {
       if (m_Stack.empty())
         return nullptr;
       return m_Stack.top();
@@ -240,8 +240,9 @@ namespace clad {
     clang::Expr* GlobalStoreAndRef(clang::Expr* E,
                                    llvm::StringRef prefix = "_t",
                                    bool force = false);
-    StmtDiff StoreAndRestore(clang::Expr* E, llvm::StringRef prefix = "_t",
-                             bool moveToTape = false);
+    virtual StmtDiff StoreAndRestore(clang::Expr* E,
+                                     llvm::StringRef prefix = "_t",
+                                     bool moveToTape = false);
 
     //// A type returned by DelayedGlobalStoreAndRef
     /// .Result is a reference to the created (yet uninitialized) global

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -1059,7 +1059,6 @@ double fn25_defined_later(double x) {
 // CHECK-NEXT:     MyStruct::myFunction();
 // CHECK-NEXT:     double _d__d_i = 0.;
 // CHECK-NEXT:     double _d_i0 = i;
-// CHECK-NEXT:     double _t0 = _d_i0;
 // CHECK-NEXT:     _d_i0 += 1;
 // CHECK-NEXT:     return {i, _d_i};
 // CHECK-NEXT: }

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -878,21 +878,17 @@ int main() {
 // CHECK-NEXT:     }
 
 // CHECK: clad::ValueAndAdjoint<double &, double &> ref_mem_fn_forw(double i, SimpleFunctions *_d_this, double _d_i) {
-// CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x = +i;
-// CHECK-NEXT:     double _t1 = this->x;
 // CHECK-NEXT:     this->x = -i;
 // CHECK-NEXT:     return {this->x, _d_this->x};
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_equal_forw(double value, SimpleFunctions *_d_this, double _d_value) {
-// CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x += value;
 // CHECK-NEXT:     return {*this, *_d_this};
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_plus_forw(SimpleFunctions *_d_this) {
-// CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x += 1.;
 // CHECK-NEXT:     return {*this, *_d_this};
 // CHECK-NEXT: }

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -528,8 +528,6 @@ double listInitPtrFn (double x, double y) {
 // CHECK-NEXT:  }
 
 // CHECK: clad::ValueAndAdjoint<double *, double *> ptrValFn_forw(double *x, int n, double *_d_x, int _d_n) {
-// CHECK-NEXT:     double *_t0 = x;
-// CHECK-NEXT:     double *_t1 = _d_x;
 // CHECK-NEXT:     _d_x += n;
 // CHECK-NEXT:     x += n;
 // CHECK-NEXT:     return {x, _d_x};

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -1330,9 +1330,7 @@ int main() {
 }
 
 // CHECK: inline constexpr clad::ValueAndAdjoint<MyStruct &, MyStruct &> operator_equal_forw(MyStruct &&arg, MyStruct *_d_this, MyStruct &&_d_arg) noexcept {
-// CHECK-NEXT:    double _t0 = this->a;
 // CHECK-NEXT:    this->a = static_cast<MyStruct &&>(arg).a;
-// CHECK-NEXT:    double _t1 = this->b;
 // CHECK-NEXT:    this->b = static_cast<MyStruct &&>(arg).b;
 // CHECK-NEXT:    return {*this, *_d_this};
 // CHECK-NEXT:}


### PR DESCRIPTION
Currently, ``RMFPV`` (``ReverseModeForwardPassVisitor``, used to generate ``reverse_forw`` functions) is implemented based on the ``ReverseModeVisitor``. It works by calling ``ReverseModeVisitor::Visit`` and using the forward sweep generated this way, the reverse sweep is thrown away. While this approach is easy in implementation, it leads to some unfavourable results since some stmts are produced with the reverse sweep in mind. This produces unused stmts and errors. This PR partially addresses this issue by essentially disrupting the store/restore system (unused) and ``dfdx`` stack (effectively making all statements non-differentiable in the reverse sweep).