### PR TITLE
Schedule constructor pullbacks statically

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -397,6 +397,11 @@ namespace clad {
     /// And be used in the reverse mode.
     bool canUsePushforwardInRevMode(const clang::FunctionDecl* FD);
 
+    /// We need to replace std::initializer_list with clad::array in the reverse
+    /// mode because the former is temporary by design and it's not possible to
+    /// create modifiable adjoints.
+    clang::QualType replaceStdInitListWithCladArray(clang::Sema& S,
+                                                    clang::QualType origTy);
     } // namespace utils
     } // namespace clad
 

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -8,6 +8,7 @@
 #include "clad/Differentiator/Timers.h"
 
 #include "clang/AST/Decl.h"
+#include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 
 #include "llvm/ADT/DenseSet.h"
@@ -64,7 +65,7 @@ public:
   unsigned RequestedDerivativeOrder = 1;
   /// Context in which the function is being called, or a call to
   /// clad::gradient/differentiate, where function is the first arg.
-  clang::CallExpr* CallContext = nullptr;
+  clang::Expr* CallContext = nullptr;
   /// Args provided to the call to clad::gradient/differentiate.
   const clang::Expr* Args = nullptr;
   /// Indexes of global GPU args of function as a subset of Args.
@@ -226,6 +227,7 @@ public:
                   RequestOptions& opts, DerivedFnCollector& DFC);
     bool VisitCallExpr(clang::CallExpr* E);
     bool VisitDeclRefExpr(clang::DeclRefExpr* DRE);
+    bool VisitCXXConstructExpr(clang::CXXConstructExpr* e);
     bool TraverseFunctionDeclOnce(const clang::FunctionDecl* FD) {
       llvm::SaveAndRestore<bool> Saved(m_IsTraversingTopLevelDecl, false);
       if (m_Traversed.count(FD))

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -475,12 +475,11 @@ void at_pullback(::std::vector<T>* vec,
 }
 
 template <typename T, typename U>
-void constructor_pullback(typename ::std::vector<T>::size_type count, U val,
-                          typename ::std::vector<T>::allocator_type alloc,
-                          ::std::vector<T>* d_this,
-                          typename ::std::vector<T>::size_type* d_count,
-                          U* d_val,
-                          typename ::std::vector<T>::allocator_type* d_alloc) {
+void constructor_pullback(
+    typename ::std::vector<T>::size_type count, const U& val,
+    const typename ::std::vector<T>::allocator_type& alloc,
+    ::std::vector<T>* d_this, typename ::std::vector<T>::size_type* d_count,
+    U* d_val, typename ::std::vector<T>::allocator_type* d_alloc) {
   for (unsigned i = 0; i < count; ++i)
     *d_val += (*d_this)[i];
   d_this->clear();
@@ -492,7 +491,7 @@ template <typename T>
 void constructor_pullback(
     clad::array<T> init, const typename ::std::vector<T>::allocator_type& alloc,
     ::std::vector<T>* d_this, clad::array<T>* d_init,
-    const typename ::std::vector<T>::allocator_type* d_alloc) {
+    typename ::std::vector<T>::allocator_type* d_alloc) {
   for (unsigned i = 0; i < init.size(); ++i) {
     (*d_init)[i] += (*d_this)[i];
     (*d_this)[i] = 0;

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1073,5 +1073,16 @@ namespace clad {
       paramTy = paramTy.getNonReferenceType();
       return paramTy->isRealType();
     }
+
+    QualType replaceStdInitListWithCladArray(Sema& S, QualType origTy) {
+      QualType T = origTy.getNonReferenceType();
+      QualType elemType;
+      if (!S.isStdInitializerList(utils::GetValueType(T), &elemType))
+        return origTy;
+      T = utils::GetCladArrayOfType(S, elemType);
+      if (origTy->isLValueReferenceType())
+        return S.getASTContext().getLValueReferenceType(T);
+      return T;
+    }
   } // namespace utils
 } // namespace clad

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -986,6 +986,10 @@ namespace clad {
       llvm::SmallVector<QualType, 16> FnTypes(
           FnProtoTy->getParamTypes().begin(), FnProtoTy->getParamTypes().end());
 
+      if (mode == DiffMode::reverse || mode == DiffMode::pullback)
+        for (QualType& T : FnTypes)
+          T = utils::replaceStdInitListWithCladArray(S, T);
+
       QualType oRetTy = FD->getReturnType();
       QualType dRetTy = C.VoidTy;
       bool returnVoid = mode == DiffMode::reverse ||
@@ -1054,7 +1058,8 @@ namespace clad {
           FnTypes.push_back(utils::GetParameterDerivativeType(S, mode, PVDTy));
       }
 
-      if (moveBaseToParams && !thisTy.isNull()) {
+      if (moveBaseToParams && !thisTy.isNull() &&
+          !isa<CXXConstructorDecl>(FD)) {
         FnTypes.insert(FnTypes.begin(), thisTy);
         EPI.TypeQuals.removeConst();
       }

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2554,21 +2554,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
   QualType ReverseModeVisitor::CloneType(QualType T) {
     QualType dT = VisitorBase::CloneType(T);
-
-    bool isLValueRefType = dT->isLValueReferenceType();
-    dT = dT.getNonReferenceType();
-
-    // We need to replace std::initializer_list with clad::array because the
-    // former is temporary by design and it's not possible to create modifiable
-    // adjoints.
-    QualType elemType;
-    if (m_Sema.isStdInitializerList(utils::GetValueType(T), &elemType))
-      dT = utils::GetCladArrayOfType(m_Sema, elemType);
-
-    if (isLValueRefType)
-      return m_Context.getLValueReferenceType(dT);
-
-    return dT;
+    return utils::replaceStdInitListWithCladArray(m_Sema, dT);
   }
 
   DeclDiff<VarDecl> ReverseModeVisitor::DifferentiateVarDecl(const VarDecl* VD,

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -262,6 +262,15 @@ namespace clad {
                                          ExprValueKind VK /*=VK_LValue*/) {
     CXXScopeSpec CSS;
     SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
+    // FIXME: Remove once BuildDeclRef can automatically deduce class
+    // namespace specifiers.
+    auto* MD = dyn_cast<CXXMethodDecl>(D);
+    if (!NNS && MD && MD->isStatic()) {
+      const CXXRecordDecl* RD = MD->getParent();
+      IdentifierInfo* II = &m_Context.Idents.get(RD->getNameAsString());
+      NNS = NestedNameSpecifier::Create(m_Context, II);
+    }
+
     if (NNS) {
       CSS.MakeTrivial(m_Context, NNS, fakeLoc);
     } else {

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -277,7 +277,16 @@ int main() {
   // CHECK-NEXT:     }
   // CHECK-NEXT: }
 
-  // CHECK: static inline constexpr void constructor_pullback(const Experiment &arg, Experiment *_d_this, Experiment *_d_arg) noexcept;
+  // CHECK: static inline constexpr void constructor_pullback(const Experiment &arg, Experiment *_d_this, Experiment *_d_arg) noexcept {
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         (*_d_arg).y += _d_this->y;
+  // CHECK-NEXT:         _d_this->y = 0.;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     {
+  // CHECK-NEXT:         (*_d_arg).x += _d_this->x;
+  // CHECK-NEXT:         _d_this->x = 0.;
+  // CHECK-NEXT:     }
+  // CHECK-NEXT: }
 
   // CHECK: void FunctorAsArgWrapper_grad(double i, double j, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     Experiment E(3, 5);
@@ -300,14 +309,3 @@ int main() {
   FunctorAsArgWrapper_grad.execute(7, 9, &di, &dj);
   printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 27.00 21.00
 }
-
-// CHECK: static inline constexpr void constructor_pullback(const Experiment &arg, Experiment *_d_this, Experiment *_d_arg) noexcept {
-// CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_arg).y += _d_this->y;
-// CHECK-NEXT:         _d_this->y = 0.;
-// CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         (*_d_arg).x += _d_this->x;
-// CHECK-NEXT:         _d_this->x = 0.;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }

--- a/test/Gradient/Lambdas.C
+++ b/test/Gradient/Lambdas.C
@@ -39,7 +39,7 @@ double f2(double i, double j) {
   return x;
 }
 
-// CHECK-NEXT:     inline void operator_call_pullback(double t, double k, double _d_y, double *_d_t, double *_d_k) const {
+// CHECK:     inline void operator_call_pullback(double t, double k, double _d_y, double *_d_t, double *_d_k) const {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             *_d_t += _d_y;
 // CHECK-NEXT:             *_d_k += _d_y;

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -571,7 +571,8 @@ double fn6(double u, double v) {
     return v;
 }
 
-// CHECK:  static void constructor_pullback(double &x, SafeTestClass *_d_this, double *_d_x);
+// CHECK: static void constructor_pullback(double &x, SafeTestClass *_d_this, double *_d_x) {
+// CHECK-NEXT: }
 
 // CHECK: void fn6_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:      double &_d_w = *_d_u;
@@ -853,6 +854,17 @@ int main() {
   d_fn3.execute(2, 3, 4, 5, &result[0], &result[1]);
   printf("%.2f %.2f", result[0], result[1]); // CHECK-EXEC: 10.00 4.00
 
+// CHECK: static void constructor_pullback(double p_x, double p_y, SimpleFunctions *_d_this, double *_d_p_x, double *_d_p_y) {
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_p_y += _d_this->y;
+// CHECK-NEXT:         _d_this->y = 0.;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_p_x += _d_this->x;
+// CHECK-NEXT:         _d_this->x = 0.;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
 // CHECK: void fn3_grad_2_3(double x, double y, double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_x = 0.;
 // CHECK-NEXT:     double _d_y = 0.;
@@ -891,19 +903,5 @@ int main() {
 // CHECK: clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> operator_plus_plus_forw(SimpleFunctions *_d_this) {
 // CHECK-NEXT:     this->x += 1.;
 // CHECK-NEXT:     return {*this, *_d_this};
-// CHECK-NEXT: }
-
-// CHECK: static void constructor_pullback(double &x, SafeTestClass *_d_this, double *_d_x) {
-// CHECK-NEXT: }
-
-// CHECK: static void constructor_pullback(double p_x, double p_y, SimpleFunctions *_d_this, double *_d_p_x, double *_d_p_y) {
-// CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_p_y += _d_this->y;
-// CHECK-NEXT:         _d_this->y = 0.;
-// CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_p_x += _d_this->x;
-// CHECK-NEXT:         _d_this->x = 0.;
-// CHECK-NEXT:     }
 // CHECK-NEXT: }
 }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -658,7 +658,27 @@ double operator+(const double& val, const SimpleFunctions1& a) {
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 
-// CHECK: static void constructor_pullback(double p_x, double p_y, SimpleFunctions1 *_d_this, double *_d_p_x, double *_d_p_y) noexcept;
+// CHECK: static void constructor_pullback(double p_x, double p_y, SimpleFunctions1 *_d_this, double *_d_p_x, double *_d_p_y) noexcept {
+// CHECK-NEXT:    {
+// CHECK-NEXT:        *_d_p_y += _d_this->y;
+// CHECK-NEXT:        _d_this->y = 0.;
+// CHECK-NEXT:    }
+// CHECK-NEXT:    {
+// CHECK-NEXT:        *_d_p_x += _d_this->x;
+// CHECK-NEXT:        _d_this->x = 0.;
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+
+// CHECK: static inline constexpr void constructor_pullback(SimpleFunctions1 &&arg, SimpleFunctions1 *_d_this, SimpleFunctions1 *_d_arg) noexcept {
+// CHECK-NEXT:      {
+// CHECK-NEXT:          (*_d_arg).y += _d_this->y;
+// CHECK-NEXT:          _d_this->y = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          (*_d_arg).x += _d_this->x;
+// CHECK-NEXT:          _d_this->x = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
 
 double fn16(double i, double j) {
   SimpleFunctions1 obj1(2, 3);
@@ -811,7 +831,15 @@ double fn21(double i, double j) {
     return 2 + SimpleFunctions1(i);
 }
 
-// CHECK: static void constructor_pullback(double px, SimpleFunctions1 *_d_this, double *_d_px);
+// CHECK: static void constructor_pullback(double px, SimpleFunctions1 *_d_this, double *_d_px) {
+// CHECK-NEXT:      {
+// CHECK-NEXT:          _d_this->y = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          *_d_px += _d_this->x;
+// CHECK-NEXT:          _d_this->x = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
 
 // CHECK:  void fn21_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:      {
@@ -898,7 +926,12 @@ double fn24(double u, double v) {
     return res;
 }
 
-// CHECK:  static inline constexpr void constructor_pullback(const B &arg, B *_d_this, B *_d_arg) noexcept;
+// CHECK: static inline constexpr void constructor_pullback(const B &arg, B *_d_this, B *_d_arg) noexcept {
+// CHECK-NEXT:      {
+// CHECK-NEXT:          (*_d_arg).data += _d_this->data;
+// CHECK-NEXT:          _d_this->data = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
 
 // CHECK:  void fn24_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:      B _d_b = {0.};
@@ -954,6 +987,16 @@ struct S4{
   S4(double x) : p(x) {}
 };
 
+// CHECK: static void constructor_pullback(double x, S4 *_d_this, double *_d_x) {
+// CHECK-NEXT:    {
+// CHECK-NEXT:        *_d_x += _d_this->p;
+// CHECK-NEXT:        _d_this->p = 0.;
+// CHECK-NEXT:    }
+// CHECK-NEXT:   {
+// CHECK-NEXT:        _d_this->i = 0.;
+// CHECK-NEXT:    }
+// CHECK-NEXT:}
+
 struct S5{
   double i;
   S5(double x) 
@@ -990,7 +1033,35 @@ struct Vector3 {
     }
 };
 
-// CHECK:  static void constructor_pullback(double px, double py, double pz, Vector3 *_d_this, double *_d_px, double *_d_py, double *_d_pz);
+// CHECK: static void constructor_pullback(double px, double py, double pz, Vector3 *_d_this, double *_d_px, double *_d_py, double *_d_pz) {
+// CHECK-NEXT:      {
+// CHECK-NEXT:          *_d_pz += _d_this->z;
+// CHECK-NEXT:          _d_this->z = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          *_d_py += _d_this->y;
+// CHECK-NEXT:          _d_this->y = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          *_d_px += _d_this->x;
+// CHECK-NEXT:          _d_this->x = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
+
+// CHECK: static inline constexpr void constructor_pullback(const Vector3 &arg, Vector3 *_d_this, Vector3 *_d_arg) noexcept {
+// CHECK-NEXT:      {
+// CHECK-NEXT:          (*_d_arg).z += _d_this->z;
+// CHECK-NEXT:          _d_this->z = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          (*_d_arg).y += _d_this->y;
+// CHECK-NEXT:          _d_this->y = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          (*_d_arg).x += _d_this->x;
+// CHECK-NEXT:          _d_this->x = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
 
 // CHECK:  void operator_star_pullback(double a, const Vector3 &v, Vector3 _d_y, double *_d_a, Vector3 *_d_v) {
 // CHECK-NEXT:      {
@@ -1017,8 +1088,6 @@ double fn27(double x, double y) {
   return w.x;
 }
 
-// CHECK:  static inline constexpr void constructor_pullback(const Vector3 &arg, Vector3 *_d_this, Vector3 *_d_arg) noexcept;
-
 // CHECK:  void fn27_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      Vector3 v(x, x, y);
 // CHECK-NEXT:      Vector3 _d_v(v);
@@ -1044,6 +1113,21 @@ double fn27(double x, double y) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
+// CHECK: static inline constexpr void constructor_pullback(Vector3 &&arg, Vector3 *_d_this, Vector3 *_d_arg) noexcept {
+// CHECK-NEXT:      {
+// CHECK-NEXT:          (*_d_arg).z += _d_this->z;
+// CHECK-NEXT:          _d_this->z = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          (*_d_arg).y += _d_this->y;
+// CHECK-NEXT:          _d_this->y = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:      {
+// CHECK-NEXT:          (*_d_arg).x += _d_this->x;
+// CHECK-NEXT:          _d_this->x = 0.;
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
+
 // CHECK:  void operator_minus_pullback(Vector3 _d_y, Vector3 *_d_this) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
@@ -1055,7 +1139,6 @@ double fn27(double x, double y) {
 // CHECK-NEXT:          _d_this->z += -_r2;
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
-// CHECK:  static inline constexpr void constructor_pullback(Vector3 &&arg, Vector3 *_d_this, Vector3 *_d_arg) noexcept;
 
 double fn28(double x, double y) {
   Vector3 v{x, x, y};
@@ -1107,11 +1190,15 @@ constructor_reverse_forw(::clad::ConstructorReverseForwTag<ptrClass>, double* mp
 }
 }}}
 
+// CHECK: static void constructor_pullback(double *mptr, ptrClass *_d_this, double *_d_mptr) {
+// CHECK-NEXT:      {
+// CHECK-NEXT:      }
+// CHECK-NEXT:  }
+
 // CHECK:  void operator_star_pullback(double _d_y, ptrClass *_d_this) {
 // CHECK-NEXT:      *_d_this->ptr += _d_y;
 // CHECK-NEXT:  }
 
-// CHECK:  static void constructor_pullback(double *mptr, ptrClass *_d_this, double *_d_mptr);
 // CHECK:  clad::ValueAndAdjoint<double &, double &> operator_star_forw(ptrClass *_d_this);
 
 double fn29(double x, double y) {
@@ -1334,105 +1421,6 @@ int main() {
 // CHECK-NEXT:    this->b = static_cast<MyStruct &&>(arg).b;
 // CHECK-NEXT:    return {*this, *_d_this};
 // CHECK-NEXT:}
-
-// CHECK:   static void constructor_pullback(double p_x, double p_y, SimpleFunctions1 *_d_this, double *_d_p_x, double *_d_p_y) noexcept {
-// CHECK-NEXT:    {
-// CHECK-NEXT:        *_d_p_y += _d_this->y;
-// CHECK-NEXT:        _d_this->y = 0.;
-// CHECK-NEXT:    }
-// CHECK-NEXT:    {
-// CHECK-NEXT:        *_d_p_x += _d_this->x;
-// CHECK-NEXT:        _d_this->x = 0.;
-// CHECK-NEXT:    }
-// CHECK-NEXT:}
-
-// CHECK:  static inline constexpr void constructor_pullback(SimpleFunctions1 &&arg, SimpleFunctions1 *_d_this, SimpleFunctions1 *_d_arg) noexcept {
-// CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_arg).y += _d_this->y;
-// CHECK-NEXT:          _d_this->y = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_arg).x += _d_this->x;
-// CHECK-NEXT:          _d_this->x = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:  }
-
-// CHECK:  static void constructor_pullback(double px, SimpleFunctions1 *_d_this, double *_d_px) {
-// CHECK-NEXT:      {
-// CHECK-NEXT:          _d_this->y = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:      {
-// CHECK-NEXT:          *_d_px += _d_this->x;
-// CHECK-NEXT:          _d_this->x = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:  }
-
-// CHECK:  static inline constexpr void constructor_pullback(const B &arg, B *_d_this, B *_d_arg) noexcept {
-// CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_arg).data += _d_this->data;
-// CHECK-NEXT:          _d_this->data = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:  }
-
-// CHECK:   static void constructor_pullback(double x, S4 *_d_this, double *_d_x) {
-// CHECK-NEXT:    {
-// CHECK-NEXT:        *_d_x += _d_this->p;
-// CHECK-NEXT:        _d_this->p = 0.;
-// CHECK-NEXT:    }
-// CHECK-NEXT:   {
-// CHECK-NEXT:        _d_this->i = 0.;
-// CHECK-NEXT:    }
-// CHECK-NEXT:}
-
-// CHECK:  static void constructor_pullback(double px, double py, double pz, Vector3 *_d_this, double *_d_px, double *_d_py, double *_d_pz) {
-// CHECK-NEXT:      {
-// CHECK-NEXT:          *_d_pz += _d_this->z;
-// CHECK-NEXT:          _d_this->z = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:      {
-// CHECK-NEXT:          *_d_py += _d_this->y;
-// CHECK-NEXT:          _d_this->y = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:      {
-// CHECK-NEXT:          *_d_px += _d_this->x;
-// CHECK-NEXT:          _d_this->x = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:  }
-
-// CHECK:  static inline constexpr void constructor_pullback(const Vector3 &arg, Vector3 *_d_this, Vector3 *_d_arg) noexcept {
-// CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_arg).z += _d_this->z;
-// CHECK-NEXT:          _d_this->z = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_arg).y += _d_this->y;
-// CHECK-NEXT:          _d_this->y = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_arg).x += _d_this->x;
-// CHECK-NEXT:          _d_this->x = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:  }
-
-// CHECK:  static inline constexpr void constructor_pullback(Vector3 &&arg, Vector3 *_d_this, Vector3 *_d_arg) noexcept {
-// CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_arg).z += _d_this->z;
-// CHECK-NEXT:          _d_this->z = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_arg).y += _d_this->y;
-// CHECK-NEXT:          _d_this->y = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:      {
-// CHECK-NEXT:          (*_d_arg).x += _d_this->x;
-// CHECK-NEXT:          _d_this->x = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:  }
-
-// CHECK:  static void constructor_pullback(double *mptr, ptrClass *_d_this, double *_d_mptr) {
-// CHECK-NEXT:      {
-// CHECK-NEXT:      }
-// CHECK-NEXT:  }
 
 // CHECK:  clad::ValueAndAdjoint<double &, double &> operator_star_forw(ptrClass *_d_this) {
 // CHECK-NEXT:      return {*this->ptr, *_d_this->ptr};


### PR DESCRIPTION
This PR makes the constructor pullback scheduling the default for both custom and clad-generated derivatives. The only exception is Hessians, which still only support dynamical scheduling.