### PR TITLE
Fix #1392: passing non differentiable arguments to member functions

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1872,11 +1872,15 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         FD->getNameAsString() == "cudaMemcpy") {
       // Try to find it in builtin derivatives.
       std::string customPullback = pullbackRequest.ComputeDerivativeName();
+      if (MD && MD->isInstance())
+        pullbackCallArgs.insert(pullbackCallArgs.begin(), baseExpr);
       OverloadedDerivedFn =
           m_Builder.BuildCallToCustomDerivativeOrNumericalDiff(
               customPullback, pullbackCallArgs, getCurrentScope(), CE,
               /*forCustomDerv=*/true, /*namespaceShouldExist=*/true,
               CUDAExecConfig);
+      if (MD && MD->isInstance())
+        pullbackCallArgs.erase(pullbackCallArgs.begin());
       if (auto* foundCE = cast_or_null<CallExpr>(OverloadedDerivedFn))
         pullbackFD = foundCE->getDirectCallee();
 


### PR DESCRIPTION
Closes #1392. The code in `DerivativeBuilder` takes the first argument as the base expression when it's a member function, which `ReverseModeVisitor` didn't account for, so this modifies the call arguments to fix that.

Added a test to check that it works.

