### PR TITLE
Update a test of a break-stmt to avoid regression in #1123

### DIFF
--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -2086,7 +2086,7 @@ double fn26(double i, double j) {
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         {
+// CHECK-NEXT:         if (_t0 != _numRevIterations0 || (clad::back(_t3) != 1)) {
 // CHECK-NEXT:             res = clad::pop(_t2);
 // CHECK-NEXT:             double _r_d1 = _d_res;
 // CHECK-NEXT:             _d_res = 0.;


### PR DESCRIPTION
This test wasn't updated by mistake. Since ``CHECK-NEXT:`` doesn't care about the way the line starts, a whole if-stmt could be dropped without the test failing.
Fixes #1123.