### PR TITLE
Call UpdateDiffParamsInfo in the Diffplanner unconditionally

### DIFF
--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -424,10 +424,12 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
         llvm::SaveAndRestore<unsigned> origFnOrder(
             request.CurrentDerivativeOrder);
 
+        request.UpdateDiffParamsInfo(m_Sema);
         // Derive declaration of the the forward mode derivative.
         request.DeclarationOnly = true;
         derivative = plugin::ProcessDiffRequest(m_CladPlugin, request);
       }
+      request.UpdateDiffParamsInfo(m_Sema);
 
       // It is possible that user has provided a custom derivative for the
       // derivative function. In that case, we should not derive the definition

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -59,7 +59,6 @@ static FunctionDecl* DeriveUsingForwardAndReverseMode(
   IndependentArgRequest.Args = ForwardModeArgs;
   IndependentArgRequest.Mode = DiffMode::forward;
   IndependentArgRequest.CallUpdateRequired = false;
-  IndependentArgRequest.UpdateDiffParamsInfo(SemaRef);
   // FIXME: Find a way to do this without accessing plugin namespace functions
   FunctionDecl* firstDerivative =
       Builder.HandleNestedDiffRequest(IndependentArgRequest);
@@ -70,7 +69,6 @@ static FunctionDecl* DeriveUsingForwardAndReverseMode(
   ReverseModeRequest.Function = firstDerivative;
   ReverseModeRequest.Args = ReverseModeArgs;
   ReverseModeRequest.BaseFunctionName = firstDerivative->getNameAsString();
-  ReverseModeRequest.UpdateDiffParamsInfo(SemaRef);
 
   FunctionDecl* secondDerivative =
       Builder.HandleNestedDiffRequest(ReverseModeRequest);
@@ -88,7 +86,6 @@ static FunctionDecl* DeriveUsingForwardModeTwice(
   IndependentArgRequest.Args = ForwardModeArgs;
   IndependentArgRequest.Mode = DiffMode::forward;
   IndependentArgRequest.CallUpdateRequired = false;
-  IndependentArgRequest.UpdateDiffParamsInfo(SemaRef);
   // Derive the function twice in forward mode.
   FunctionDecl* secondDerivative =
       Builder.HandleNestedDiffRequest(IndependentArgRequest);

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -226,7 +226,11 @@ void InitTimers();
       S.PerformPendingInstantiations();
       if (request.Function->getDefinition())
         request.Function = request.Function->getDefinition();
-      request.UpdateDiffParamsInfo(m_CI.getSema());
+      // FIXME: These requests are not fully generated in the diffplanner and we
+      // have to update diff params on this stage.
+      if (request.CurrentDerivativeOrder > 1 ||
+          m_DFC.IsCladDerivative(request.Function))
+        request.UpdateDiffParamsInfo(m_CI.getSema());
       const FunctionDecl* FD = request.Function;
       ASTContext& C = S.getASTContext();
       clang::PrintingPolicy Policy = C.getPrintingPolicy();


### PR DESCRIPTION
Before this PR, ``UpdateDiffParamsInfo`` was called either in the ``Diffplanner`` or ``ProcessDiffRequest`` depending on certain conditions. This leads to inconsistency in when ``DVI`` (diff params) is built and whether it's accessible in the ``DiffPlanner``. Also, some diagnostics are done in ``UpdateDiffParamsInfo`` and could therefore be accidentally duplicated. This PR makes the call to ``UpdateDiffParamsInfo`` in the ``Diffplanner`` unconditional, and only leaves other calls for dynamic derivative scheduling and high-order derivatives.