### PR TITLE
Move some tests from UserDefinedTypes.C to Constructor.C

### DIFF
--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -831,13 +831,13 @@ class Identity {
 // CHECK-NEXT:}
 
 
-double fn22(double x, double y) {
+double fn21(double x, double y) {
     Identity di{};
     double val = di(x);
     return val * val;
 }
 
-// CHECK:  void fn22_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK:  void fn21_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      Identity _d_di = {};
 // CHECK-NEXT:      Identity di{};
 // CHECK-NEXT:      Identity _t0 = di;
@@ -859,12 +859,12 @@ struct StructNoDefConstr {
   StructNoDefConstr(int){}
 };
 
-double fn23(double x){
+double fn22(double x){
   StructNoDefConstr t{0};
   return x;
 }
 
-// CHECK:  void fn23_grad(double x, double *_d_x) {
+// CHECK:  void fn22_grad(double x, double *_d_x) {
 // CHECK-NEXT:      StructNoDefConstr t(0);
 // CHECK-NEXT:      StructNoDefConstr _d_t(t);
 // CHECK-NEXT:      clad::zero_init(_d_t);
@@ -887,7 +887,7 @@ double add(B b, double u) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
-double fn24(double u, double v) {
+double fn23(double u, double v) {
     B b;
     b.data = v;
     double res = 0;
@@ -902,7 +902,7 @@ double fn24(double u, double v) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
-// CHECK:  void fn24_grad(double u, double v, double *_d_u, double *_d_v) {
+// CHECK:  void fn23_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:      B _d_b = {0.};
 // CHECK-NEXT:      B b;
 // CHECK-NEXT:      double _t0 = b.data;
@@ -987,13 +987,13 @@ const Vector3 operator*(double a, const Vector3& v) {
   return {a * v.x, a * v.y, a * v.z};
 }
 
-double fn27(double x, double y) {
+double fn24(double x, double y) {
   Vector3 v(x, x, y);
   Vector3 w = 2*v;
   return w.x;
 }
 
-// CHECK:  void fn27_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK:  void fn24_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      Vector3 v(x, x, y);
 // CHECK-NEXT:      Vector3 _d_v(v);
 // CHECK-NEXT:      clad::zero_init(_d_v);
@@ -1045,13 +1045,13 @@ double fn27(double x, double y) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
-double fn28(double x, double y) {
+double fn25(double x, double y) {
   Vector3 v{x, x, y};
   Vector3 w = -v;
   return w.x;
 }
 
-// CHECK:  void fn28_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK:  void fn25_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      Vector3 v{x, x, y};
 // CHECK-NEXT:      Vector3 _d_v(v);
 // CHECK-NEXT:      clad::zero_init(_d_v);
@@ -1106,12 +1106,12 @@ constructor_reverse_forw(::clad::ConstructorReverseForwTag<ptrClass>, double* mp
 
 // CHECK:  clad::ValueAndAdjoint<double &, double &> operator_star_forw(ptrClass *_d_this);
 
-double fn29(double x, double y) {
+double fn26(double x, double y) {
   ptrClass p(&x);
   return *p;
 }
 
-// CHECK:  void fn29_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK:  void fn26_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      ::clad::ValueAndAdjoint<ptrClass, ptrClass> _t0 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<ptrClass>(), &x, &*_d_x);
 // CHECK-NEXT:      ptrClass p(_t0.value);
 // CHECK-NEXT:      ptrClass _d_p = _t0.adjoint;
@@ -1137,7 +1137,7 @@ struct MyStructWrapper {
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
-double fn30(double x, double y) {
+double fn27(double x, double y) {
   MyStructWrapper s;
   s = {2 * y, 3 * x + 2};
   return s.val.a * s.val.b;
@@ -1145,7 +1145,7 @@ double fn30(double x, double y) {
 
 // CHECK:  inline constexpr clad::ValueAndAdjoint<MyStructWrapper &, MyStructWrapper &> operator_equal_forw(MyStructWrapper &&arg, MyStructWrapper *_d_this, MyStructWrapper &&_d_arg) noexcept;
 
-// CHECK:  void fn30_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK:  void fn27_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      MyStructWrapper _d_s = {{.*0., 0..*}};
 // CHECK-NEXT:      MyStructWrapper s;
 // CHECK-NEXT:      MyStructWrapper _t0 = s;
@@ -1175,12 +1175,12 @@ double vecSum(const Vector3& v) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
-double fn31(double x, double y) {
+double fn28(double x, double y) {
   double z = vecSum({x, y, x});
   return z;
 }
 
-// CHECK:  void fn31_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK:  void fn28_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      double _d_z = 0.;
 // CHECK-NEXT:      double z = vecSum({x, y, x});
 // CHECK-NEXT:      _d_z += 1;
@@ -1288,29 +1288,29 @@ int main() {
     fn20_test.execute(s, &d_s);
     print(d_s); // CHECK-EXEC: {2.00, 2.00}
 
+    INIT_GRADIENT(fn21);
+    TEST_GRADIENT(fn21, /*numOfDerivativeArgs=*/2, 3, 2, &d_i, &d_j);    // CHECK-EXEC: {8.00, 0.00}
+
     INIT_GRADIENT(fn22);
-    TEST_GRADIENT(fn22, /*numOfDerivativeArgs=*/2, 3, 2, &d_i, &d_j);    // CHECK-EXEC: {8.00, 0.00}
 
     INIT_GRADIENT(fn23);
+    TEST_GRADIENT(fn23, /*numOfDerivativeArgs=*/2, 3, 2, &d_i, &d_j);    // CHECK-EXEC: {1.00, 1.00}
+
 
     INIT_GRADIENT(fn24);
-    TEST_GRADIENT(fn24, /*numOfDerivativeArgs=*/2, 3, 2, &d_i, &d_j);    // CHECK-EXEC: {1.00, 1.00}
+    TEST_GRADIENT(fn24, /*numOfDerivativeArgs=*/2, 2, 3, &d_i, &d_j);    // CHECK-EXEC: {2.00, 0.00}
 
+    INIT_GRADIENT(fn25);
+    TEST_GRADIENT(fn25, /*numOfDerivativeArgs=*/2, 2, 3, &d_i, &d_j);    // CHECK-EXEC: {-1.00, 0.00}
+
+    INIT_GRADIENT(fn26);
+    TEST_GRADIENT(fn26, /*numOfDerivativeArgs=*/2, 2, 3, &d_i, &d_j);    // CHECK-EXEC: {1.00, 0.00}
 
     INIT_GRADIENT(fn27);
-    TEST_GRADIENT(fn27, /*numOfDerivativeArgs=*/2, 2, 3, &d_i, &d_j);    // CHECK-EXEC: {2.00, 0.00}
+    TEST_GRADIENT(fn27, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);    // CHECK-EXEC: {30.00, 22.00}
 
     INIT_GRADIENT(fn28);
-    TEST_GRADIENT(fn28, /*numOfDerivativeArgs=*/2, 2, 3, &d_i, &d_j);    // CHECK-EXEC: {-1.00, 0.00}
-
-    INIT_GRADIENT(fn29);
-    TEST_GRADIENT(fn29, /*numOfDerivativeArgs=*/2, 2, 3, &d_i, &d_j);    // CHECK-EXEC: {1.00, 0.00}
-
-    INIT_GRADIENT(fn30);
-    TEST_GRADIENT(fn30, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);    // CHECK-EXEC: {30.00, 22.00}
-
-    INIT_GRADIENT(fn31);
-    TEST_GRADIENT(fn31, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);    // CHECK-EXEC: {2.00, 1.00}
+    TEST_GRADIENT(fn28, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);    // CHECK-EXEC: {2.00, 1.00}
 }
 
 // CHECK: inline constexpr clad::ValueAndAdjoint<MyStruct &, MyStruct &> operator_equal_forw(MyStruct &&arg, MyStruct *_d_this, MyStruct &&_d_arg) noexcept {


### PR DESCRIPTION
We originally had 2 test files for OOP in the reverse mode: ``Gradient/UserDefinedTypes.C`` and ``Gradient/MemberFunctions.C``. As the support for OOP improved, both of them became too huge (around 1000 lines or more). This PR moves about 150 lines of tests for constructors to ``Gradient/Constructors.C``.