### PR TITLE
Simplify `getExprVarData` in TBR and add a test

### DIFF
--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -137,16 +137,12 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer> {
 
   /// Given a MemberExpr*/ArraySubscriptExpr* return a pointer to its
   /// corresponding VarData. If the given element of an array does not have a
-  /// VarData yet it will be added automatically. If addNonConstIdx==false this
-  /// will return the last VarData before the non-constant index
-  /// (e.g. for 'x.arr[k+1].y' the return value will be the VarData of x.arr).
+  /// VarData yet it will be added automatically.
   /// Otherwise, non-const indices will be represented as index -1.
-  VarData* getMemberVarData(const clang::MemberExpr* ME,
-                            bool addNonConstIdx = false);
-  VarData* getArrSubVarData(const clang::ArraySubscriptExpr* ASE,
-                            bool addNonConstIdx = false);
+  VarData* getMemberVarData(const clang::MemberExpr* ME);
+  VarData* getArrSubVarData(const clang::ArraySubscriptExpr* ASE);
   /// Given an Expr* returns its corresponding VarData.
-  VarData* getExprVarData(const clang::Expr* E, bool addNonConstIdx = false);
+  VarData* getExprVarData(const clang::Expr* E);
 
   /// Whenever an array element with a non-constant index is set to required
   /// this function is used to set to required all the array elements that

--- a/test/Analyses/TBR.cpp
+++ b/test/Analyses/TBR.cpp
@@ -101,7 +101,7 @@ double f2(double val) {
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
-double f3 (double x){
+double f3(double x){
   double i = 1;
   double j = 0;
   double res = 0;
@@ -156,6 +156,49 @@ double f3 (double x){
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
+double f4(double x, double y) {
+  double arr[4];
+  double res = y;
+  arr[0] = x;
+  int i = 0;
+  res *= arr[i];
+  arr[0] = 0; // This test primarily checks if this arr[0] gets stored
+  return res;
+} // x * y
+
+//CHECK: void f4_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK-NEXT:     double _d_arr[4] = {0};
+//CHECK-NEXT:     double arr[4];
+//CHECK-NEXT:     double _d_res = 0.;
+//CHECK-NEXT:     double res = y;
+//CHECK-NEXT:     arr[0] = x;
+//CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
+//CHECK-NEXT:     double _t0 = res;
+//CHECK-NEXT:     res *= arr[i];
+//CHECK-NEXT:     double _t1 = arr[0];
+//CHECK-NEXT:     arr[0] = 0;
+//CHECK-NEXT:     _d_res += 1;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         arr[0] = _t1;
+//CHECK-NEXT:         double _r_d2 = _d_arr[0];
+//CHECK-NEXT:         _d_arr[0] = 0.;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     {
+//CHECK-NEXT:         res = _t0;
+//CHECK-NEXT:         double _r_d1 = _d_res;
+//CHECK-NEXT:         _d_res = 0.;
+//CHECK-NEXT:         _d_res += _r_d1 * arr[i];
+//CHECK-NEXT:         _d_arr[i] += res * _r_d1;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     {
+//CHECK-NEXT:         double _r_d0 = _d_arr[0];
+//CHECK-NEXT:         _d_arr[0] = 0.;
+//CHECK-NEXT:         *_d_x += _r_d0;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     *_d_y += _d_res;
+//CHECK-NEXT: }
+
 
 #define TEST(F, x) { \
   result[0] = 0; \
@@ -164,9 +207,17 @@ double f3 (double x){
   printf("{%.2f}\n", result[0]); \
 }
 
+#define TEST2(F, x, y) { \
+  result[0] = 0; result[1] = 0; \
+  auto F##grad = clad::gradient<clad::opts::enable_tbr>(F);\
+  F##grad.execute(x, y, &result[0], &result[1]);\
+  printf("{%.2f, %.2f}\n", result[0], result[1]); \
+}
+
 int main() {
-  double result[3] = {};
+  double result[2] = {};
   TEST(f1, 3); // CHECK-EXEC: {27.00}
   TEST(f2, 3); // CHECK-EXEC: {7.00}
   TEST(f3, 3); // CHECK-EXEC: {2.00}
+  TEST2(f4, 3, 4) // CHECK-EXEC: {4.00, 3.00}
 }


### PR DESCRIPTION
This PR solves 2 problems related to TBR:
1) ``getExprVarData`` has a parameter ``addNonConstIdx``, which was probably meant for efficiency when building ``VarData``. The difference, however, is likely negligible, as the function will return earlier only under quite specific circumstances. There's no need to overcomplicate the analysis with this.
2) The system handling array elements in TBR is quite complicated, but we don't have a single test that directly checks the produced code. This PR adds a test involving non-constant indices.