### PR TITLE
Move ProfileID generation to a single point in TBR

### DIFF
--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -123,6 +123,12 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer> {
   /// current index/member.
   void overlay(VarData& targetData, llvm::SmallVector<ProfileID, 2>& IDSequence,
                size_t i);
+  /// For a compound lvalue expr, generates a sequence of ProfileID's of it's
+  /// indices/fields and returns the VarDecl of the base, e.g.
+  /// ``arr[k].y`` --> returns `arr`, IDSequence = `{k, y}`.
+  const clang::VarDecl*
+  getIDSequence(const clang::Expr* E,
+                llvm::SmallVectorImpl<ProfileID>& IDSequence);
   /// Returns true if there is at least one required to store node among
   /// child nodes.
   bool findReq(const VarData& varData);

--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -145,7 +145,7 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer> {
 
   /// Given an Expr* returns its corresponding VarData. If the given element of
   /// an array does not have a VarData yet it will be added automatically.
-  VarData* getExprVarData(const clang::Expr* E);
+  VarData* getVarDataFromExpr(const clang::Expr* E);
   /// Finds VD in the most recent block.
   VarData* getVarDataFromDecl(const clang::VarDecl* VD);
 

--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -143,13 +143,8 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer> {
 
   clang::CFGBlock* getCFGBlockByID(unsigned ID);
 
-  /// Given a MemberExpr*/ArraySubscriptExpr* return a pointer to its
-  /// corresponding VarData. If the given element of an array does not have a
-  /// VarData yet it will be added automatically.
-  /// Otherwise, non-const indices will be represented as index -1.
-  VarData* getMemberVarData(const clang::MemberExpr* ME);
-  VarData* getArrSubVarData(const clang::ArraySubscriptExpr* ASE);
-  /// Given an Expr* returns its corresponding VarData.
+  /// Given an Expr* returns its corresponding VarData. If the given element of
+  /// an array does not have a VarData yet it will be added automatically.
   VarData* getExprVarData(const clang::Expr* E);
   /// Finds VD in the most recent block.
   VarData* getVarDataFromDecl(const clang::VarDecl* VD);


### PR DESCRIPTION
TBR has a complicated logic that parses `Expr`. There is a function `getExprVarData` that converts it to the type `VarData` that represents information about variables, e.g.
```getExprVarData:  arr[4].k  -->  VarData{arr, 4, k}```
However, VarData does not store information about every element in the sequence, rather points to the end of it. While this is enough as an identifier of the underlying value, it's not enough for more complex analysis. The function `overlay` needs the whole sequence and so it performs its own parsing. This has lead to bugs like #1369, where certain cases were accounted for in `getExprVarData` but not in `overlay`, which is used less frequently. This PR moves the parsing of `Expr` to a single point in `getIDSequence`. `getExprVarData` then uses the sequence to get the VarData. 

I think we should also consider dropping `VarData` altogether and using the sequence of IDs as the identifier.