### PR TITLE
Rework SetIsReq and overlay and combine them into a single function

### DIFF
--- a/test/Analyses/TBR.cpp
+++ b/test/Analyses/TBR.cpp
@@ -232,6 +232,45 @@ double f5(double x, double y) {
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
+double f6(double x, double y) {
+  double arr[4];
+  arr[0] = y;
+  x *= arr[0]; // arr[0] gets used
+  int i = 0;
+  arr[i] = 0; // tbr should make an asumption that arr[i] might be arr[0]
+  return x; // x * y
+}
+
+//CHECK: void f6_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK-NEXT:     double _d_arr[4] = {0};
+//CHECK-NEXT:     double arr[4];
+//CHECK-NEXT:     arr[0] = y;
+//CHECK-NEXT:     double _t0 = x;
+//CHECK-NEXT:     x *= arr[0];
+//CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
+//CHECK-NEXT:     double _t1 = arr[i];
+//CHECK-NEXT:     arr[i] = 0;
+//CHECK-NEXT:     *_d_x += 1;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         arr[i] = _t1;
+//CHECK-NEXT:         double _r_d2 = _d_arr[i];
+//CHECK-NEXT:         _d_arr[i] = 0.;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     {
+//CHECK-NEXT:         x = _t0;
+//CHECK-NEXT:         double _r_d1 = *_d_x;
+//CHECK-NEXT:         *_d_x = 0.;
+//CHECK-NEXT:         *_d_x += _r_d1 * arr[0];
+//CHECK-NEXT:         _d_arr[0] += x * _r_d1;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     {
+//CHECK-NEXT:         double _r_d0 = _d_arr[0];
+//CHECK-NEXT:         _d_arr[0] = 0.;
+//CHECK-NEXT:         *_d_y += _r_d0;
+//CHECK-NEXT:     }
+//CHECK-NEXT: }
+
 
 #define TEST(F, x) { \
   result[0] = 0; \
@@ -254,4 +293,5 @@ int main() {
   TEST(f3, 3); // CHECK-EXEC: {2.00}
   TEST2(f4, 3, 4) // CHECK-EXEC: {4.00, 3.00}
   TEST2(f5, 8, 3) // CHECK-EXEC: {3.00, 7.00}
+  TEST2(f6, 5, 2) // CHECK-EXEC: {2.00, 5.00}
 }


### PR DESCRIPTION
The problem this PR solves is explained in detail in #1423. For short, when we set vars to `used`/`unused` in TBR, we handle constant array indices (like `arr[3]`) in `TBR::SetIsRequired` and partly cover the gaps in the logic in `TBR::overlay`. This PR moves handling of all cases to `TBR::SetIsRequired` and fixes the bug in #1423. Also, this PR removes the state variable `TBR::m_NonConstIndexFound` that was used to detect the cases when `TBR::overlay` should be called.
Apart from that, `ProfileID` sequences are now reversed to the right order for easier handling: the sequence of `arr[2].k` used to be `{k, 2}` and is now `{2, k}`. Iterating backwards through the sequence in recursion resulted in code that was quite hard to read.

Fixes #1423