### PR TITLE
Move VarData element access to VarData::operator[]

### DIFF
--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -14,6 +14,7 @@
 #include "clad/Differentiator/Timers.h"
 
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/ASTLambda.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclarationName.h"
 #include "clang/AST/Expr.h"

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -647,7 +647,7 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
     if (E->getType()->isPointerType())
       return true;
 
-    if (!m_TbrRunInfo.HasAnalysisRun) {
+    if (!m_TbrRunInfo.HasAnalysisRun && !isLambdaCallOperator(Function)) {
       TimedAnalysisRegion R("TBR " + BaseFunctionName);
 
       TBRAnalyzer analyzer(Function->getASTContext(),

--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -116,7 +116,10 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer> {
     /// Used to recursively copy VarData when separating into different branches
     /// (e.g. when entering an if-else statements). Look at the Control Flow
     /// section for more information.
-    VarData copy();
+    [[nodiscard]] VarData copy() const;
+    /// Provides access to the nested VarData if the given VarData represents
+    /// an array or a structure. Generates new array elements if necessary.
+    VarData* operator[](const ProfileID& id) const;
   };
   // NOLINTEND(cppcoreguidelines-pro-type-union-access)
 

--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -112,6 +112,11 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer> {
       if (m_Type == OBJ_TYPE || m_Type == ARR_TYPE)
         m_Val.m_ArrData.reset();
     }
+
+    /// Used to recursively copy VarData when separating into different branches
+    /// (e.g. when entering an if-else statements). Look at the Control Flow
+    /// section for more information.
+    VarData copy();
   };
   // NOLINTEND(cppcoreguidelines-pro-type-union-access)
 
@@ -128,10 +133,6 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer> {
   /// (e.g. after an if-else statements). Look at the Control Flow section for
   /// more information.
   void merge(VarData& targetData, VarData& mergeData);
-  /// Used to recursively copy VarData when separating into different branches
-  /// (e.g. when entering an if-else statements). Look at the Control Flow
-  /// section for more information.
-  VarData copy(VarData& copyData);
 
   clang::CFGBlock* getCFGBlockByID(unsigned ID);
 


### PR DESCRIPTION
Element access of VarData is not trivial and sometimes requires initialization of new elements. For example, when a new element of an array is requested, it's built by copying the default index. It's better to have this logic in a single place.