### PR TITLE
Don't override VisitUnaryOperator in RMFPV

### DIFF
--- a/include/clad/Differentiator/ReverseModeForwPassVisitor.h
+++ b/include/clad/Differentiator/ReverseModeForwPassVisitor.h
@@ -37,7 +37,6 @@ public:
   StmtDiff VisitCompoundStmt(const clang::CompoundStmt* CS) override;
   StmtDiff VisitDeclRefExpr(const clang::DeclRefExpr* DRE) override;
   StmtDiff VisitReturnStmt(const clang::ReturnStmt* RS) override;
-  StmtDiff VisitUnaryOperator(const clang::UnaryOperator* UnOp) override;
 };
 } // namespace clad
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -15,6 +15,7 @@
 #include "clad/Differentiator/VisitorBase.h"
 
 #include "clang/AST/DeclCXX.h"
+#include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
@@ -383,7 +384,7 @@ namespace clad {
     StmtDiff VisitParenExpr(const clang::ParenExpr* PE);
     virtual StmtDiff VisitReturnStmt(const clang::ReturnStmt* RS);
     StmtDiff VisitStmt(const clang::Stmt* S);
-    virtual StmtDiff VisitUnaryOperator(const clang::UnaryOperator* UnOp);
+    StmtDiff VisitUnaryOperator(const clang::UnaryOperator* UnOp);
     StmtDiff
     VisitUnaryExprOrTypeTraitExpr(const clang::UnaryExprOrTypeTraitExpr* UE);
     StmtDiff VisitExprWithCleanups(const clang::ExprWithCleanups* EWC);


### PR DESCRIPTION
``RMFPV::VisitUnaryOperator`` was written when ``ReverseModeVisitor`` didn't support pointers. Now, ``RMFPV::VisitUnaryOperator`` essentially replicates  ``RMV::VisitUnaryOperator``.