### PR TITLE
Fix broken master after merging #1438 and #1437 at the same time

### DIFF
--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -729,7 +729,7 @@ template <
     typename It,
     typename ::clad::custom_derivatives::helpers::is_iterator<It>::type = 1>
 clad::ValueAndAdjoint<It, It> operator_plus_plus_reverse_forw(It* it, int,
-                                                              It* d_it, int*) {
+                                                              It* d_it, int) {
   return {++*it, ++*d_it};
 }
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2039,7 +2039,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                                   CallArgs, Loc, CUDAExecConfig)
                    .get();
       }
-      if (call->getType()->isVoidType())
+      if (!needsForwPass)
         return StmtDiff(call);
       Expr* callRes = nullptr;
       if (isInsideLoop)


### PR DESCRIPTION
This PR addresses 2 problems that arose after that: a mismatch in the signature of a new custom `reverse_forw` and a new tape popping up in a test.