### PR TITLE
Add support for std::shared_ptr and std::weak_ptr and improve differentiation of object params

### DIFF
--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -790,6 +790,35 @@ void constructor_pullback(const ::std::shared_ptr<T>& p,
                           ::std::shared_ptr<T>* dthis,
                           ::std::shared_ptr<T>* dp) noexcept {}
 
+template <typename T, typename U>
+void constructor_pullback(const ::std::shared_ptr<T>& p, U*,
+                          ::std::weak_ptr<T>* dthis, ::std::shared_ptr<T>* dp,
+                          U*) noexcept {}
+
+// std::weak_ptr<T> custom derivatives...
+template <typename T, typename U>
+clad::ValueAndAdjoint<::std::weak_ptr<T>, ::std::weak_ptr<T>>
+constructor_reverse_forw(clad::ConstructorReverseForwTag<::std::weak_ptr<T>>,
+                         U p, U d_p) {
+  return {::std::weak_ptr<T>(p), ::std::weak_ptr<T>(d_p)};
+}
+template <typename T, typename U>
+void constructor_pullback(U&& p, ::std::weak_ptr<T>* dthis, U* dp) noexcept {}
+
+template <typename T, typename U>
+void constructor_pullback(const U& p, ::std::weak_ptr<T>* dthis,
+                          U* dp) noexcept {}
+
+template <typename T>
+clad::ValueAndAdjoint<::std::shared_ptr<T>, ::std::shared_ptr<T>>
+lock_reverse_forw(const ::std::weak_ptr<T>* p,
+                  const ::std::weak_ptr<T>* dp) noexcept {
+  return {p->lock(), dp->lock()};
+}
+
+template <typename T>
+void lock_pullback(const ::std::weak_ptr<T>* p, ::std::shared_ptr<T> dthis,
+                   ::std::weak_ptr<T>* dp) noexcept {}
 } // namespace class_functions
 
 namespace std {

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -30,6 +30,18 @@ template <class T> void zero_init(typename std::allocator<T>&) {
 namespace custom_derivatives {
 
 namespace helpers {
+template <typename From, typename To> class is_implicitly_convertible {
+private:
+  static void test(To);
+
+  template <typename F, typename = decltype(test(::std::declval<F>()))>
+  static ::std::true_type try_convert(int);
+
+  template <typename> static ::std::false_type try_convert(...);
+
+public:
+  static constexpr bool value = decltype(try_convert<From>(0))::value;
+};
 template <class T, typename U = void> struct is_iterator : ::std::false_type {};
 
 template <class T>
@@ -39,6 +51,24 @@ struct is_iterator<
     : ::std::true_type {
   using type = bool;
 };
+
+template <typename T, typename = void>
+struct is_std_smart_ptr : ::std::false_type {};
+
+template <typename T>
+struct is_std_smart_ptr<::std::unique_ptr<T>> : ::std::true_type {};
+
+template <typename T>
+struct is_std_smart_ptr<::std::weak_ptr<T>> : ::std::true_type {};
+
+// Some systems have a common base class for std::weak_ptr and std::shared_ptr,
+// so we also accept types, to which std::shared_ptr can be converted
+// implicitly.
+template <typename U>
+struct is_std_smart_ptr<
+    U, ::std::enable_if_t<is_implicitly_convertible<
+           ::std::shared_ptr<typename U::element_type>, U>::value>>
+    : ::std::true_type {};
 } // namespace helpers
 
 namespace class_functions {
@@ -681,26 +711,27 @@ constructor_reverse_forw(clad::ConstructorReverseForwTag<::std::unique_ptr<T>>,
 template <typename T>
 void constructor_pullback(T* p, ::std::unique_ptr<T>* dthis, T* dp) noexcept {};
 
+// operator* custom derivatives
 template <typename T>
-clad::ValueAndAdjoint<T&, T&>
-operator_star_reverse_forw(const ::std::unique_ptr<T>* u,
-                           const ::std::unique_ptr<T>* d_u) {
+clad::ValueAndAdjoint<decltype(*(T{}))&, decltype(*(T{}))&>
+operator_star_reverse_forw(
+    const ::std::enable_if_t<helpers::is_std_smart_ptr<T>::value ||
+                                 helpers::is_iterator<T>::value,
+                             T>* u,
+    const T* d_u) {
   return {**u, **d_u};
 }
 
 template <typename T, typename U>
-void operator_star_pullback(const ::std::unique_ptr<T>* u, U pullback,
-                            ::std::unique_ptr<T>* d_u) {
+::std::enable_if_t<(helpers::is_std_smart_ptr<T>::value ||
+                    helpers::is_iterator<T>::value) &&
+                       ::std::is_arithmetic<U>::value,
+                   void>
+operator_star_pullback(const T* u, U pullback, T* d_u) {
   **d_u += pullback;
 }
 
-template <typename It>
-clad::ValueAndAdjoint<typename ::std::iterator_traits<It>::reference,
-                      typename ::std::iterator_traits<It>::reference>
-operator_star_reverse_forw(It* it, It* d_it) {
-  return {**it, **d_it};
-}
-
+// iterator custom derivatives
 template <
     typename It,
     typename ::clad::custom_derivatives::helpers::is_iterator<It>::type = 1>
@@ -740,6 +771,24 @@ void operator_plus_plus_pullback(It* it, int, It pullback, It* d_it, int*) {
   --*it;
   --*d_it;
 }
+
+// std::shared_ptr<T> custom derivatives...
+template <typename T>
+clad::ValueAndAdjoint<::std::shared_ptr<T>, ::std::shared_ptr<T>>
+constructor_reverse_forw(clad::ConstructorReverseForwTag<::std::shared_ptr<T>>,
+                         const ::std::shared_ptr<T>& p,
+                         const ::std::shared_ptr<T>& d_p) {
+  return {::std::shared_ptr<T>(p), ::std::shared_ptr<T>(d_p)};
+}
+
+template <typename T>
+void constructor_pullback(::std::shared_ptr<T>&& p, ::std::shared_ptr<T>* dthis,
+                          ::std::shared_ptr<T>* dp) noexcept {}
+
+template <typename T>
+void constructor_pullback(const ::std::shared_ptr<T>& p,
+                          ::std::shared_ptr<T>* dthis,
+                          ::std::shared_ptr<T>* dp) noexcept {}
 
 } // namespace class_functions
 
@@ -807,6 +856,18 @@ template <typename... Args> auto make_tuple_pushforward(Args... args) noexcept {
   ::std::tuple<Args...> t = ::std::make_tuple(args...);
   return clad::make_value_and_pushforward(first_half_tuple(t),
                                           second_half_tuple(t));
+}
+
+// std::make_shared<T> custom derivatives...
+template <typename T>
+clad::ValueAndAdjoint<::std::shared_ptr<T>, ::std::shared_ptr<T>>
+make_shared_reverse_forw(T& x, T& dx) {
+  return {::std::make_shared<T>(x), ::std::make_shared<T>(dx)};
+}
+
+template <typename T>
+void make_shared_pullback(T& x, ::std::shared_ptr<T> dthis, T* dx) {
+  *dx += *dthis;
 }
 
 } // namespace std

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -599,7 +599,7 @@ double fn6(double u, double v) {
 // CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t0 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>());
 // CHECK-NEXT:      SafeTestClass s1(_t0.value);
 // CHECK-NEXT:      SafeTestClass _d_s1 = _t0.adjoint;
-// CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t1 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), u, &v, 0., &*_d_v);
+// CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t1 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), u, &v, *_d_u, &*_d_v);
 // CHECK-NEXT:      SafeTestClass s2(_t1.value);
 // CHECK-NEXT:      SafeTestClass _d_s2 = _t1.adjoint;
 // CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t2 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), w, _d_w);

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -277,6 +277,18 @@ double fn21(double x) {
     return simple_func(x_ptr);
 }
 
+double weak_fn(std::weak_ptr<double> x_ptr) {
+  std::shared_ptr<double> s = x_ptr.lock();
+  double x = *s;
+  return x * x + 2.0 * x;
+}
+
+double fn22(double x) {
+    std::shared_ptr<double> s_ptr = std::make_shared<double>(x);
+    std::weak_ptr<double> w_ptr = s_ptr;
+    return weak_fn(w_ptr);
+}
+
 int main() {
     double d_i, d_j;
     INIT_GRADIENT(fn1);
@@ -334,6 +346,8 @@ int main() {
 
     INIT_GRADIENT(fn21);
     TEST_GRADIENT(fn21, /*numOfDerivativeArgs=*/1, 3, &d_i);  // CHECK-EXEC: {8.00}
+    INIT_GRADIENT(fn22);
+    TEST_GRADIENT(fn22, /*numOfDerivativeArgs=*/1, 3, &d_i);  // CHECK-EXEC: {8.00}
 }
 
 // CHECK: void fn1_grad(double u, double v, double *_d_u, double *_d_v) {
@@ -1490,6 +1504,56 @@ int main() {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         shared_ptr<{{.*}}double{{.*}}> _r0 = _t1.adjoint;
 // CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(std::move(_t1.value), &_d_x_ptr, &_r0);
+// CHECK-NEXT:         x = _t0;
+// CHECK-NEXT:         clad::custom_derivatives::std::make_shared_pullback(x, _r0, &*_d_x);
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: void weak_fn_pullback(std::weak_ptr<double> x_ptr, double _d_y, std::weak_ptr<double> *_d_x_ptr) {
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t0 = clad::custom_derivatives::class_functions::lock_reverse_forw(&x_ptr, &(*_d_x_ptr));
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t1 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<shared_ptr<double> >(), std::move(_t0.value), _t0.adjoint);
+// CHECK-NEXT:     std::shared_ptr<double> s = _t1.value;
+// CHECK-NEXT:     std::shared_ptr<double> _d_s = _t1.adjoint;
+// CHECK-NEXT:     clad::ValueAndAdjoint<{{.*}} &, {{.*}} &> _t2 = clad::custom_derivatives::class_functions::operator_star_reverse_forw(&s, &_d_s);
+// CHECK-NEXT:     double _d_x = 0.;
+// CHECK-NEXT:     double x = _t2.value;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_x += _d_y * x;
+// CHECK-NEXT:         _d_x += x * _d_y;
+// CHECK-NEXT:         _d_x += 2. * _d_y;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     clad::custom_derivatives::class_functions::operator_star_pullback(&s, _d_x, &_d_s);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         shared_ptr<double> _r0 = _t0.adjoint;
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(std::move(_t0.value), &_d_s, &_r0);
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::lock_pullback(&x_ptr, _r0, &(*_d_x_ptr));
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: void fn22_grad(double x, double *_d_x) {
+// CHECK-NEXT:     double _t0 = x;
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t1 = clad::custom_derivatives::std::make_shared_reverse_forw(x, *_d_x);
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t2 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<shared_ptr<double> >(), std::move(_t1.value), _t1.adjoint);
+// CHECK-NEXT:     std::shared_ptr<double> s_ptr = _t2.value;
+// CHECK-NEXT:     std::shared_ptr<double> _d_s_ptr = _t2.adjoint;
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::weak_ptr<double>, ::std::weak_ptr<double> > _t3 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<weak_ptr<double> >(), s_ptr, _d_s_ptr);
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::weak_ptr<double>, ::std::weak_ptr<double> > _t4 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<weak_ptr<double> >(), std::move(_t3.value), _t3.adjoint);
+// CHECK-NEXT:     std::weak_ptr<double> w_ptr = _t4.value;
+// CHECK-NEXT:     std::weak_ptr<double> _d_w_ptr = _t4.adjoint;
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::weak_ptr<double>, ::std::weak_ptr<double> > _t5 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<weak_ptr<double> >(), w_ptr, _d_w_ptr);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         std::weak_ptr<double> _r2 = _t5.adjoint;
+// CHECK-NEXT:         weak_fn_pullback(_t5.value, 1, &_r2);
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(w_ptr, &_r2, &_d_w_ptr);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         std::weak_ptr<double> _r1 = _t3.adjoint;
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(std::move(_t3.value), &_d_w_ptr, &_r1);
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(s_ptr, &_r1, &_d_s_ptr);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         shared_ptr<{{.*}}double{{.*}}> _r0 = _t1.adjoint;
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(std::move(_t1.value), &_d_s_ptr, &_r0);
 // CHECK-NEXT:         x = _t0;
 // CHECK-NEXT:         clad::custom_derivatives::std::make_shared_pullback(x, _r0, &*_d_x);
 // CHECK-NEXT:     }


### PR DESCRIPTION
This PR adds support for ``std::shared_ptr`` and ``std::weak_ptr`` by adding custom derivatives and by fixing an issue we had when handling value-type object parameters. 
In particular, the code for the pullback of 
```
... = f(x, ...); // Assume `x` is passed by value, i.e. by copying
```
was built with the following pattern:
```
Class_type _r0 = {};
f_pullback(x, ..., &_r0, ...);
Class_type::constructor_pullback(x, &_r0, &_d_x); // corresponds to the copy constructor
```
While this logic works for purely numerical types like ``std::pair`` or ``std::complex`` (with numerical elements), it breaks for types that use pointer fields like ``std::smart_ptr`` or even ``std::vector`` as ``f_pullback`` expects all pointer fields of ``_r0`` to be properly initialized.
This PR solves this issue by initializing objects with the result of the corresponding copy-constructor in the forward pass:
```
clad::ValueAndAdjoint<...> _t0 = ...::constructor_reverse_forw(..., x, _d_x);
...
Class_type _r0 = _t0.adjoint;
f_pullback(x, ..., &_r0, ...);
Class_type::constructor_pullback(x, &_r0, &_d_x);
```
Please note that the call to ``constructor_reverse_forw`` was also generated before this PR.
It's also worth noting that this strategy reflects what we do to handle copy-initialization in object-type declarations. 

Fixes #781.