### PR TITLE
Add primitive diagnostics for type mismatches of custom derivatives

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -1325,13 +1325,13 @@ CUDA_HOST_DEVICE void pow_pullback(T1 x, T2 exponent, T3 d_y, T1* d_x,
 }
 
 template <typename T>
-CUDA_HOST_DEVICE ValueAndPushforward<T, T>
+CUDA_HOST_DEVICE ValueAndPushforward<const T&, const T&>
 min_pushforward(const T& a, const T& b, const T& d_a, const T& d_b) {
   return {::std::min(a, b), a < b ? d_a : d_b};
 }
 
 template <typename T>
-CUDA_HOST_DEVICE ValueAndPushforward<T, T>
+CUDA_HOST_DEVICE ValueAndPushforward<const T&, const T&>
 max_pushforward(const T& a, const T& b, const T& d_a, const T& d_b) {
   return {::std::max(a, b), a < b ? d_b : d_a};
 }

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1108,7 +1108,8 @@ namespace clad {
 
     bool canUsePushforwardInRevMode(const FunctionDecl* FD) {
       if (FD->getNumParams() != 1 ||
-          utils::HasAnyReferenceOrPointerArgument(FD) || isa<CXXMethodDecl>(FD))
+          utils::HasAnyReferenceOrPointerArgument(FD) ||
+          isa<CXXMethodDecl>(FD) || !FD->getReturnType()->isRealType())
         return false;
       QualType paramTy = FD->getParamDecl(0)->getType();
       paramTy = paramTy.getNonReferenceType();

--- a/test/Diagnostics/CustomDerivativeDiagnostics.C
+++ b/test/Diagnostics/CustomDerivativeDiagnostics.C
@@ -1,0 +1,62 @@
+// RUN: %cladclang %s -I%S/../../include -Xclang -verify 2>&1 | %filecheck %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+namespace helpers {
+    // test using shadow decls
+    int g_pullback(int) { // expected-note {{Candidate not viable: cannot match the requested signature with 'int (int)'}}
+    return true;
+    }
+}
+
+namespace clad {
+namespace custom_derivatives {
+  // parameter `x` must be of type `double`
+  void g_pullback(float x, double y, double _d_y0, float *_d_x, double *_d_y) { // expected-note {{Candidate not viable: cannot match the requested signature with 'void (float, double, double, float *, double *)'}}
+    *_d_x += _d_y0;
+  }
+  // no pulback parameter `_d_y` is provided
+  template <typename T, typename U>
+  void g_pullback(T x, U y, T* _d_x, U* _d_y) { // expected-note {{Candidate not viable: cannot match the requested signature with 'void (T, U, T *, U *)'}}
+    *_d_x += 1;
+  }
+  // test using shadow decls
+  using ::helpers::g_pullback;
+}
+}
+
+double g(double x, double y) {
+  return x + y;
+}
+
+double f1(double x, double y) {
+  return g(x, y); // expected-warning {{A custom derivative for 'g_pullback' was found but not used because its signature does not match the expected signature 'void (double, double, double, double *, double *)'}}
+}
+
+namespace clad {
+namespace custom_derivatives {
+  // the return type should be `clad::ValueAndPushforward`
+  double h_pushforward(const double x, double y, const double _d_x, double _d_y) { // expected-note {{Candidate not viable: cannot match the requested signature with 'double (const double, double, const double, double)'}}
+    return _d_x - _d_y;
+  }
+
+  // the template does not account for const-ness
+  template <typename T>
+  T h_pushforward(T x, T y, T _d_x, T _d_y) { // expected-note {{Candidate not viable: cannot match the requested signature with 'T (T, T, T, T)'}}
+    return _d_x - _d_y;
+  }
+}
+}
+
+double h(const double x, double y) {
+  return x - y;
+}
+
+double f2(double x, double y) {
+  return h(x, y); // expected-warning {{A custom derivative for 'h_pushforward' was found but not used because its signature does not match the expected signature 'clad::ValueAndPushforward<double, double> (const double, double, const double, double)'}}
+}
+
+int main() {
+    clad::gradient(f1);
+    clad::differentiate(f2, "x");
+}


### PR DESCRIPTION
Currently, when a custom derivative is not accepted because of a signature mismatch, it's just silently ignored. This PR adds simple diagnostics telling the user explicitly that the provided derivative was not used, which signature was required, and which overloads were provided, as well as their signatures.
This is the first step to make writing custom derivatives easier. Ideally, we should add more diagnostics later, e.g., if the return type is wrong / no pullback parameter is provided for a custom pullback, etc. It would be even better to detect incorrect naming, but this seems way harder to do.