### PR TITLE
Check if m_AnalysisDC is valid

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -8,15 +8,19 @@
 #include "clad/Differentiator/Timers.h"
 
 #include "clang/AST/Decl.h"
+#include "clang/AST/DeclBase.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Analysis/AnalysisDeclContext.h"
 
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <iterator>
+#include <memory>
 #include <set>
 
 namespace clang {
@@ -31,7 +35,8 @@ class Type;
 } // namespace clang
 
 namespace clad {
-
+using OwnedAnalysisContexts =
+    llvm::SmallVector<std::unique_ptr<clang::AnalysisDeclContext>, 4>;
 /// A struct containing information about request to differentiate a function.
 struct DiffRequest {
 private:
@@ -123,6 +128,8 @@ public:
   /// This will be particularly useful for pushforward and pullback functions.
   bool DeclarationOnly = false;
 
+  clang::AnalysisDeclContext* m_AnalysisDC;
+
   /// Recomputes `DiffInputVarsInfo` using the current values of data members.
   ///
   /// Differentiation parameters info is computed by parsing the argument
@@ -146,6 +153,8 @@ public:
     // Note that CallContext is always different and we should ignore it.
     // CustomDerivative is an Expr* and is not always equal even if
     // the set of overloads is the same.
+    // Including AnalysisDC would complicate constructing requests to find the
+    // existing once.
     return Function == other.Function &&
            BaseFunctionName == other.BaseFunctionName &&
            CurrentDerivativeOrder == other.CurrentDerivativeOrder &&
@@ -178,6 +187,10 @@ public:
   std::string ComputeDerivativeName() const;
   bool HasIndependentParameter(const clang::ParmVarDecl* PVD) const;
 
+  std::set<clang::SourceLocation>& getToBeRecorded() const {
+    m_TbrRunInfo.HasAnalysisRun = true;
+    return m_TbrRunInfo.ToBeRecorded;
+  }
   void addVariedDecl(const clang::VarDecl* init) {
     m_ActivityRunInfo.VariedDecls.insert(init);
   }
@@ -190,6 +203,7 @@ public:
   std::set<const clang::VarDecl*>& getUsefulDecls() const {
     return m_UsefulRunInfo.UsefulDecls;
   }
+  bool HasTbrAnalysisRun() const { return m_TbrRunInfo.HasAnalysisRun; }
 };
 
   using DiffInterval = std::vector<clang::SourceRange>;
@@ -210,7 +224,10 @@ public:
     /// Graph to store the dependencies between different requests.
     ///
     clad::DynamicGraph<DiffRequest>& m_DiffRequestGraph;
-
+    /// Map that contains all AnalysisDeclContext for all declrations.
+    /// Essentially needed for prolonging the lifetime of
+    /// unique_ptr<clang::AnalysisDeclContext>.
+    OwnedAnalysisContexts& m_AllAnalysisDC;
     /// If set it means that we need to find the called functions and
     /// add them for implicit diff.
     ///
@@ -228,7 +245,7 @@ public:
   public:
     DiffCollector(clang::DeclGroupRef DGR, DiffInterval& Interval,
                   clad::DynamicGraph<DiffRequest>& requestGraph, clang::Sema& S,
-                  RequestOptions& opts);
+                  RequestOptions& opts, OwnedAnalysisContexts& AllAnalysisDC);
     bool VisitCallExpr(clang::CallExpr* E);
     bool VisitDeclRefExpr(clang::DeclRefExpr* DRE);
     bool VisitCXXConstructExpr(clang::CXXConstructExpr* e);

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -128,7 +128,7 @@ public:
   /// This will be particularly useful for pushforward and pullback functions.
   bool DeclarationOnly = false;
 
-  clang::AnalysisDeclContext* m_AnalysisDC;
+  clang::AnalysisDeclContext* m_AnalysisDC = nullptr;
 
   /// Recomputes `DiffInputVarsInfo` using the current values of data members.
   ///

--- a/lib/Differentiator/ActivityAnalyzer.cpp
+++ b/lib/Differentiator/ActivityAnalyzer.cpp
@@ -6,14 +6,10 @@ using namespace clang;
 namespace clad {
 
 void VariedAnalyzer::Analyze(const FunctionDecl* FD) {
-  // Build the CFG (control-flow graph) of FD.
-  clang::CFG::BuildOptions Options;
-  m_CFG = clang::CFG::buildCFG(FD, FD->getBody(), &m_Context, Options);
-
-  m_BlockData.resize(m_CFG->size());
+  m_BlockData.resize(m_AnalysisDC->getCFG()->size());
   // Set current block ID to the ID of entry the block.
-  CFGBlock* entry = &m_CFG->getEntry();
-  m_CurBlockID = entry->getBlockID();
+  CFGBlock& entry = m_AnalysisDC->getCFG()->getEntry();
+  m_CurBlockID = entry.getBlockID();
   m_BlockData[m_CurBlockID] = createNewVarsData({});
   for (const VarDecl* i : m_VariedDecls)
     m_BlockData[m_CurBlockID]->insert(i);
@@ -38,7 +34,7 @@ void mergeVarsData(std::set<const clang::VarDecl*>* targetData,
 }
 
 CFGBlock* VariedAnalyzer::getCFGBlockByID(unsigned ID) {
-  return *(m_CFG->begin() + ID);
+  return *(m_AnalysisDC->getCFG()->begin() + ID);
 }
 
 void VariedAnalyzer::AnalyzeCFGBlock(const CFGBlock& block) {

--- a/lib/Differentiator/ActivityAnalyzer.h
+++ b/lib/Differentiator/ActivityAnalyzer.h
@@ -2,6 +2,7 @@
 #define CLAD_DIFFERENTIATOR_ACTIVITYANALYZER_H
 
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Analysis/CFG.h"
 
 #include "clad/Differentiator/CladUtils.h"
@@ -35,8 +36,7 @@ class VariedAnalyzer : public clang::RecursiveASTVisitor<VariedAnalyzer> {
 
   clang::CFGBlock* getCFGBlockByID(unsigned ID);
 
-  clang::ASTContext& m_Context;
-  std::unique_ptr<clang::CFG> m_CFG;
+  clang::AnalysisDeclContext* m_AnalysisDC;
   std::vector<std::unique_ptr<VarsData>> m_BlockData;
   unsigned m_CurBlockID{};
   std::set<unsigned> m_CFGQueue;
@@ -55,9 +55,9 @@ class VariedAnalyzer : public clang::RecursiveASTVisitor<VariedAnalyzer> {
 
 public:
   /// Constructor
-  VariedAnalyzer(clang::ASTContext& Context,
+  VariedAnalyzer(clang::AnalysisDeclContext* AnalysisDC,
                  std::set<const clang::VarDecl*>& Decls)
-      : m_VariedDecls(Decls), m_Context(Context) {}
+      : m_VariedDecls(Decls), m_AnalysisDC(AnalysisDC) {}
 
   /// Destructor
   ~VariedAnalyzer() = default;

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -650,7 +650,8 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
     if (E->getType()->isPointerType())
       return true;
 
-    if (!m_TbrRunInfo.HasAnalysisRun && !isLambdaCallOperator(Function)) {
+    if (!m_TbrRunInfo.HasAnalysisRun && !isLambdaCallOperator(Function) &&
+        Function->isDefined() && m_AnalysisDC) {
       TimedAnalysisRegion R("TBR " + BaseFunctionName);
       TBRAnalyzer analyzer(m_AnalysisDC, getToBeRecorded());
       analyzer.Analyze(*this);

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -21,7 +21,7 @@
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/ExprObjC.h"
 #include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/Analysis/CallGraph.h"
+#include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LLVM.h" // isa, dyn_cast
 #include "clang/Basic/SourceLocation.h"
@@ -32,6 +32,7 @@
 #include "clang/Sema/TemplateDeduction.h"
 
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -273,9 +274,10 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
 
   DiffCollector::DiffCollector(DeclGroupRef DGR, DiffInterval& Interval,
                                clad::DynamicGraph<DiffRequest>& requestGraph,
-                               clang::Sema& S, RequestOptions& opts)
-      : m_Interval(Interval), m_DiffRequestGraph(requestGraph), m_Sema(S),
-        m_Options(opts) {
+                               clang::Sema& S, RequestOptions& opts,
+                               OwnedAnalysisContexts& AllAnalysisDC)
+      : m_Interval(Interval), m_DiffRequestGraph(requestGraph),
+        m_AllAnalysisDC(AllAnalysisDC), m_Sema(S), m_Options(opts) {
 
     if (Interval.empty())
       return;
@@ -650,11 +652,8 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
 
     if (!m_TbrRunInfo.HasAnalysisRun && !isLambdaCallOperator(Function)) {
       TimedAnalysisRegion R("TBR " + BaseFunctionName);
-
-      TBRAnalyzer analyzer(Function->getASTContext(),
-                           m_TbrRunInfo.ToBeRecorded);
-      analyzer.Analyze(Function);
-      m_TbrRunInfo.HasAnalysisRun = true;
+      TBRAnalyzer analyzer(m_AnalysisDC, getToBeRecorded());
+      analyzer.Analyze(*this);
     }
     auto found = m_TbrRunInfo.ToBeRecorded.find(E->getBeginLoc());
     return found != m_TbrRunInfo.ToBeRecorded.end();
@@ -1263,21 +1262,26 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
     }
 
     if (!LookupCustomDerivativeDecl(request)) {
-      if (m_TopMostReq->EnableVariedAnalysis &&
-          m_TopMostReq->Mode == DiffMode::reverse) {
+      clang::CFG::BuildOptions Options;
+      std::unique_ptr<AnalysisDeclContext> AnalysisDC =
+          std::make_unique<AnalysisDeclContext>(
+              /*AnalysisDeclContextManager=*/nullptr, request.Function,
+              Options);
+
+      if (m_TopMostReq->EnableVariedAnalysis) {
         TimedAnalysisRegion R("VA " + request.BaseFunctionName);
-        VariedAnalyzer analyzer(request.Function->getASTContext(),
-                                request.getVariedDecls());
+        VariedAnalyzer analyzer(AnalysisDC.get(), request.getVariedDecls());
         analyzer.Analyze(request.Function);
       }
 
       if (m_TopMostReq->EnableUsefulAnalysis) {
         TimedAnalysisRegion R("UA " + request.BaseFunctionName);
-
-        UsefulAnalyzer analyzer(request.Function->getASTContext(),
-                                request.getUsefulDecls());
+        UsefulAnalyzer analyzer(AnalysisDC.get(), request.getUsefulDecls());
         analyzer.Analyze(request.Function);
       }
+
+      m_AllAnalysisDC.push_back(std::move(AnalysisDC));
+      request.m_AnalysisDC = m_AllAnalysisDC.back().get();
 
       // Recurse into call graph.
       TraverseFunctionDeclOnce(request.Function);
@@ -1362,9 +1366,19 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
     if (m_Sema.isStdInitializerList(recordTy, /*elemType=*/nullptr))
       return true;
 
-    if (!LookupCustomDerivativeDecl(request))
+    if (!LookupCustomDerivativeDecl(request)) {
+      clang::CFG::BuildOptions Options;
+      std::unique_ptr<AnalysisDeclContext> AnalysisDC =
+          std::make_unique<AnalysisDeclContext>(
+              /*AnalysisDeclContextManager=*/nullptr, request.Function,
+              Options);
+      // FIXME: Add proper support for objects in VA and UA.
+      m_AllAnalysisDC.push_back(std::move(AnalysisDC));
+      request.m_AnalysisDC = m_AllAnalysisDC.back().get();
+
       // Recurse into call graph.
       TraverseFunctionDeclOnce(request.Function);
+    }
     m_DiffRequestGraph.addNode(request, /*isSource=*/true);
 
     return true;

--- a/lib/Differentiator/UsefulAnalyzer.cpp
+++ b/lib/Differentiator/UsefulAnalyzer.cpp
@@ -6,13 +6,10 @@ namespace clad {
 
 void UsefulAnalyzer::Analyze(const FunctionDecl* FD) {
   // Build the CFG (control-flow graph) of FD.
-  clang::CFG::BuildOptions Options;
-  m_CFG = clang::CFG::buildCFG(FD, FD->getBody(), &m_Context, Options);
-
-  m_BlockData.resize(m_CFG->size());
+  m_BlockData.resize(m_AnalysisDC->getCFG()->size());
   // Set current block ID to the ID of entry the block.
-  CFGBlock* exit = &m_CFG->getExit();
-  m_CurBlockID = exit->getBlockID();
+  CFGBlock& exit = m_AnalysisDC->getCFG()->getExit();
+  m_CurBlockID = exit.getBlockID();
   m_BlockData[m_CurBlockID] = createNewVarsData({});
   // Add the entry block to the queue.
   m_CFGQueue.insert(m_CurBlockID);
@@ -28,7 +25,7 @@ void UsefulAnalyzer::Analyze(const FunctionDecl* FD) {
 }
 
 CFGBlock* UsefulAnalyzer::getCFGBlockByID(unsigned ID) {
-  return *(m_CFG->begin() + ID);
+  return *(m_AnalysisDC->getCFG()->begin() + ID);
 }
 
 bool UsefulAnalyzer::isUseful(const VarDecl* VD) const {

--- a/lib/Differentiator/UsefulAnalyzer.h
+++ b/lib/Differentiator/UsefulAnalyzer.h
@@ -1,6 +1,7 @@
 #ifndef CLAD_DIFFERENTIATOR_USEFULANALYZER_H
 #define CLAD_DIFFERENTIATOR_USEFULANALYZER_H
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Analysis/CFG.h"
 
 #include "clad/Differentiator/CladUtils.h"
@@ -30,7 +31,7 @@ class UsefulAnalyzer : public clang::RecursiveASTVisitor<UsefulAnalyzer> {
 
   clang::CFGBlock* getCFGBlockByID(unsigned ID);
 
-  clang::ASTContext& m_Context;
+  clang::AnalysisDeclContext* m_AnalysisDC;
   std::unique_ptr<clang::CFG> m_CFG;
   std::vector<std::unique_ptr<VarsData>> m_BlockData;
   unsigned m_CurBlockID{};
@@ -45,9 +46,9 @@ class UsefulAnalyzer : public clang::RecursiveASTVisitor<UsefulAnalyzer> {
 
 public:
   /// Constructor
-  UsefulAnalyzer(clang::ASTContext& Context,
+  UsefulAnalyzer(clang::AnalysisDeclContext* AnalysisDC,
                  std::set<const clang::VarDecl*>& Decls)
-      : m_UsefulDecls(Decls), m_Context(Context) {}
+      : m_UsefulDecls(Decls), m_AnalysisDC(AnalysisDC) {}
 
   /// Destructor
   ~UsefulAnalyzer() = default;

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -154,7 +154,7 @@ void InitTimers();
           auto* FD = cast<FunctionDecl>(D);
           if (FD->isConstexpr() || !m_Multiplexer) {
             DiffCollector collector(DGR, CladEnabledRange, m_DiffRequestGraph,
-                                    S, opts);
+                                    S, opts, m_AllAnalysisDC);
             break;
           }
         }
@@ -511,7 +511,7 @@ void InitTimers();
             if (FD->isConstexpr())
               continue;
           DiffCollector collector(DCI.m_DGR, CladEnabledRange,
-                                  m_DiffRequestGraph, S, opts);
+                                  m_DiffRequestGraph, S, opts, m_AllAnalysisDC);
           break;
         }
 

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -100,6 +100,7 @@ struct DifferentiationOptions {
     bool m_HasRuntime = false;
     DerivedFnCollector m_DFC;
     DynamicGraph<DiffRequest> m_DiffRequestGraph;
+    OwnedAnalysisContexts m_AllAnalysisDC;
     enum class CallKind {
       HandleCXXStaticMemberVarInstantiation,
       HandleTopLevelDecl,


### PR DESCRIPTION
Fixes: #1457 

In the example 

```cpp

inline double innerFunc(double const *params, unsigned int n, double const *low, double const *high)
{
   double total = 0.;
   for (std::size_t i = 0; i < n; ++i) {
      total += high[i] - low[i] + params[i] + total; // random compute
   }

   return total;
}
```

we have non-diff parameters, which is deduced during the visitation process, so the pullback is scheduled both statically and dynamically. TBR has to be run only on the pullbacks with defined `m_AnalysisDC`, hence the check in the `shouldBeRecorded` is added.

Once AA is default we wouldn't need to schedule those pullbacks dynamically, so this fix is somewhat temporary.