### PR TITLE
Cladtorch and GPT-2 implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
             compiler: gcc-13
             clang-runtime: '20'
             extra_cmake_options: '-DCLAD_ENABLE_BENCHMARKS=On -DCLAD_ENABLE_ENZYME_BACKEND=On'
+            extra_packages: "libomp-20-dev libopenblas-dev"
             benchmark: true
 
           - name: ubu22-clang13-runtime13-cuda

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -34,7 +34,7 @@ jobs:
         id: review
         with:
           build_dir: build
-          apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libthrust-dev,libbenchmark-dev
+          apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libthrust-dev,libbenchmark-dev,libomp-20-dev,libopenblas-dev
           exclude: "test/*,unittests/*"
           split_workflow: true
           config_file: .clang-tidy
@@ -45,6 +45,7 @@ jobs:
             -DCMAKE_BUILD_TYPE="Release"
             -DLLVM_EXTERNAL_LIT="`which lit`"
             -DCMAKE_EXPORT_COMPILE_COMMANDS=On
+            -DCMAKE_CXX_FLAGS="-fexceptions" # Clad demos can have exceptions
 
       - name: Upload artifacts
         uses: ZedThree/clang-tidy-review/upload@v0.20.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 enable_language(CXX)
 set(CMAKE_CXX_EXTENSIONS NO)
-
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 include(GNUInstallDirs)
 
 # MUST be done before call to clad project

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -32,6 +32,29 @@ target_compile_definitions(tapenade_support PRIVATE
 CB_ADD_GBENCHMARK(VectorModeComparison VectorModeComparison.cpp)
 CB_ADD_GBENCHMARK(MemoryComplexity_tapenade MemoryComplexity.cpp)
 CB_ADD_GBENCHMARK(Multithreading Multithreading.cpp)
+CB_ADD_GBENCHMARK(Hessians Hessians.cpp)
+CB_ADD_GBENCHMARK(GPT2Training GPT2Training.cpp)
+
+if(APPLE)
+  # On macOS, we want to explicitly use the high-performance Accelerate framework for BLAS.
+  # We also need to give CMake a hint to find the Homebrew OpenMP library.
+  list(APPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/libomp")
+  find_package(OpenMP REQUIRED)
+  # Link explicitly against Accelerate and the found OpenMP library.
+  target_link_libraries(GPT2Training PRIVATE "-framework Accelerate" OpenMP::OpenMP_CXX)
+else()
+  # On all other platforms (e.g., Linux), find the best available BLAS and OpenMP.
+  find_package(BLAS REQUIRED)
+  find_package(OpenMP REQUIRED)
+  # find_package(MKL CONFIG REQUIRED)
+  target_link_libraries(GPT2Training PRIVATE ${BLAS_LIBRARIES} "-fopenmp=libomp" OpenMP::OpenMP_CXX)
+  target_compile_options(GPT2Training PRIVATE -I/usr/include/mkl)
+endif()
+target_compile_options(GPT2Training PRIVATE -O3 -ffast-math)
+target_compile_definitions(GPT2Training PRIVATE OMP)
+if (BLAS_FOUND)
+    target_compile_definitions(GPT2Training PRIVATE HAVE_CBLAS)
+endif()
 
 target_link_libraries(MemoryComplexity_tapenade PRIVATE tapenade_support)
 

--- a/benchmark/GPT2Training.cpp
+++ b/benchmark/GPT2Training.cpp
@@ -1,0 +1,179 @@
+#include "benchmark/benchmark.h"
+
+#include <clad/Differentiator/CladtorchBuiltins.h>
+#include <clad/Differentiator/Differentiator.h>
+#include <clad/Differentiator/STLBuiltins.h>
+#include <cstddef>
+#include <string>
+#include "../demos/cladtorch/llm.hpp"
+#include "../demos/cladtorch/llm_opt.hpp"
+
+// NOLINTBEGIN(cppcoreguidelines-*)
+class GPT2Optimized : public benchmark::Fixture {
+public:
+  GPT2* model;
+  GPT2* d_model;
+  int* inputs;
+  int* targets;
+
+  void SetUp(const ::benchmark::State& state) override {
+    GPT2Config config{};
+    config.max_seq_len = 1024;
+    config.vocab_size = 50257;
+    config.padded_vocab_size = 50304;
+    config.num_layers = 12;
+    config.num_heads = 12;
+    config.channels = 768;
+
+    model = new GPT2(config);
+    d_model = new GPT2(config);
+
+    // Get batch size (B) and sequence length (T) from the benchmark state
+    int B = (int)state.range(0);
+    int T = (int)state.range(1);
+
+    model->allocate(B, T);
+    d_model->allocate(B, T);
+
+    // Allocate and fill dummy input data
+    inputs = new int[B * T];
+    targets = new int[B * T];
+    for (int i = 0; i < B * T; ++i) {
+      inputs[i] = i % model->config.vocab_size;
+      targets[i] = (i + 1) % model->config.vocab_size;
+    }
+  }
+
+  void TearDown(const ::benchmark::State& state) override {
+    // This runs once after each benchmark test
+    delete model;
+    delete d_model;
+    delete[] inputs;
+    delete[] targets;
+  }
+};
+
+static float gpt2forw_opt(GPT2* model, const int* inputs, const int* targets) {
+  model->forward(inputs, targets);
+  return model->mean_loss;
+}
+
+// The benchmark itself
+BENCHMARK_DEFINE_F(GPT2Optimized, FullTrainingIteration)
+(benchmark::State& state) {
+  auto grad = clad::gradient(gpt2forw_opt, "0");
+  int B = state.range(0);
+  int T = state.range(1);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    d_model->zero_all();
+
+    state.ResumeTiming();
+    // The single training iteration:
+    // forward pass (calculated as part of gradient), backward pass, and
+    // update
+    grad.execute(model, inputs, targets, d_model);
+    model->update(d_model, /*lr=*/1e-3F);
+  }
+  state.SetLabel("B=" + std::to_string(B) + " T=" + std::to_string(T));
+}
+
+BENCHMARK_REGISTER_F(GPT2Optimized, FullTrainingIteration)
+    ->Args({1, 16}) // B=1, T=16
+    ->Args({1, 32}) // B=1, T=32
+    ->Args({2, 16}) // B=2, T=16
+    ->Args({1, 64}) // B=1, T=64
+    ->Args({2, 32})
+    ->Args({4, 32})
+    ->Args({4, 64}) // B=4, T=64
+    ->Unit(benchmark::kMillisecond);
+
+class GPT2Cladtorch : public benchmark::Fixture {
+public:
+  gpt2::GPT2* model;
+  gpt2::GPT2* d_model;
+  int* inputs;
+  int* targets;
+
+  void SetUp(const ::benchmark::State& state) override {
+    const gpt2::Config config = {
+        .max_seq_len = 1024,
+        .vocab_size = 50257,
+        .padded_vocab_size = 50304,
+        .num_layers = 12,
+        .num_heads = 12,
+        .channels = 768,
+    };
+    model = new gpt2::GPT2(config);
+    d_model = new gpt2::GPT2(config);
+
+    // Get batch size (B) and sequence length (T) from the benchmark state
+    int B = state.range(0);
+    int T = state.range(1);
+
+    // Allocate and fill dummy input data
+    inputs = new int[B * T];
+    targets = new int[B * T];
+    for (int i = 0; i < B * T; ++i) {
+      inputs[i] = i % model->config.vocab_size;
+      targets[i] = (i + 1) % model->config.vocab_size;
+    }
+  }
+
+  void TearDown(const ::benchmark::State& state) override {
+    // This runs once after each benchmark test
+    delete model;
+    delete d_model;
+    delete[] inputs;
+    delete[] targets;
+  }
+};
+
+static float gpt2_loss(const gpt2::GPT2& model, const gpt2::ITensor& input,
+                       const gpt2::ITensor& targets) {
+  auto probs = model.forward(input);
+  auto loss = cross_entropy_loss(probs, targets);
+  return loss.scalar();
+}
+
+// The benchmark itself
+BENCHMARK_DEFINE_F(GPT2Cladtorch, FullTrainingIteration)
+(benchmark::State& state) {
+  auto grad = clad::gradient(gpt2_loss, "0");
+  int B = (int)state.range(0);
+  int T = (int)state.range(1);
+  const gpt2::ITensor inp({B, T}, inputs);
+  const gpt2::ITensor tar({B, T}, targets);
+  for (auto _ : state) {
+    state.PauseTiming();
+    d_model->for_each_parameter([&](gpt2::FTensor* t) { t->fill(0); });
+    state.ResumeTiming();
+    // The single training iteration: forward pass, backward pass, and update
+    grad.execute(*model, inp, tar, d_model);
+    std::vector<gpt2::FTensor*> params = model->get_parameter_tensors();
+    std::vector<gpt2::FTensor*> grads = d_model->get_parameter_tensors();
+    for (size_t i = 0; i < params.size(); ++i) {
+      // Update parameters with a learning rate of 1e-4
+      *params[i] += (*grads[i]) * -1e-3F;
+    }
+  }
+
+  // You can set custom counters to report B and T
+  state.SetLabel("B=" + std::to_string(B) + " T=" + std::to_string(T));
+}
+
+// Register the benchmark with different arguments
+// This will run the benchmark for various combinations of batch size (B) and
+// sequence length (T)
+BENCHMARK_REGISTER_F(GPT2Cladtorch, FullTrainingIteration)
+    ->Args({1, 16}) // B=1, T=16
+    ->Args({1, 32}) // B=1, T=32
+    ->Args({2, 16}) // B=2, T=16
+    ->Args({1, 64}) // B=1, T=64
+    ->Args({2, 32})
+    ->Unit(benchmark::kMillisecond);
+
+// Define our main.
+BENCHMARK_MAIN();
+// NOLINTEND(cppcoreguidelines-*)

--- a/demos/cladtorch/dataloader.hpp
+++ b/demos/cladtorch/dataloader.hpp
@@ -1,0 +1,618 @@
+#ifndef DATALOADER_HPP
+#define DATALOADER_HPP
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <glob.h>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-*, *-avoid-c-arrays,
+// modernize-use-nodiscard, clang-diagnostic-error)
+namespace gpt2 {
+
+// Error-checking utility functions similar to the C version
+namespace utils {
+inline FILE* fopen_check(const char* path, const char* mode) {
+  FILE* fp = fopen(path, mode); // NOLINT
+  if (fp == nullptr)
+    throw std::runtime_error("Failed to open file: " + std::string(path) +
+                             " with mode: " + std::string(mode));
+  return fp;
+}
+
+inline void fread_check(void* ptr, size_t size, size_t nmemb, FILE* stream) {
+  size_t result = fread(ptr, size, nmemb, stream);
+  if (result != nmemb) {
+    if (feof(stream))
+      throw std::runtime_error("Unexpected end of file");
+    if (ferror(stream))
+      throw std::runtime_error("File read error");
+    throw std::runtime_error("Partial read. Expected " + std::to_string(nmemb) +
+                             " elements, read " + std::to_string(result));
+  }
+}
+
+inline void fseek_check(FILE* fp, long off, int whence) {
+  if (fseek(fp, off, whence) != 0) {
+    throw std::runtime_error(
+        "Failed to seek in file. Offset: " + std::to_string(off) +
+        ", Whence: " + std::to_string(whence));
+  }
+}
+} // namespace utils
+
+class DataLoader {
+private:
+  static constexpr int HEADER_SIZE = 256;
+  static constexpr uint32_t MAGIC_NUMBER = 20240520;
+  static constexpr int DATA_VERSION = 1;
+
+  // Distributed training variables
+  int m_ProcessRank;
+  int m_NumProcesses;
+
+  // Batch and token information
+  size_t m_B;
+  size_t m_T;
+  size_t m_NumTokens;
+  size_t m_ShardNumSamples{};
+
+  // Shards and current position
+  glob_t m_GlobResult{};
+  size_t m_CurrentShardIdx{};
+  size_t m_CurrentSampleIdx{};
+
+  // File handle
+  std::unique_ptr<FILE, decltype(&fclose)> m_TokenFile;
+
+  // Data buffers
+  std::vector<uint16_t> m_Buffer;
+  std::vector<int> m_Inputs;
+  std::vector<int> m_Targets;
+
+  // Random shuffle related variables
+  std::mt19937 m_Rng;
+  // mt19937_state shuffle_rng_;
+  bool m_ShouldShuffle;
+  std::vector<int> m_ShardIndices;
+  std::vector<int> m_IntraShardIndices;
+
+  // Sizes in bytes
+  size_t m_TotalBatchSizeBytes;
+  size_t m_LocalBatchOffsetBytes;
+  size_t m_HeaderBytes;
+  uint64_t m_FileSizeBytes{};
+
+  bool m_InitOk{};
+
+  static void validate_file_header(FILE* file) {
+    int header[HEADER_SIZE];
+    utils::fread_check(header, sizeof(int), HEADER_SIZE, file);
+    if (header[0] != MAGIC_NUMBER) {
+      throw std::runtime_error(
+          "Bad magic number in data file. "
+          "Are you passing in a correct file? "
+          "The data encoding may have changed, re-run data preprocessing.");
+    }
+    if (header[1] != DATA_VERSION)
+      throw std::runtime_error("Bad version in data file");
+  }
+
+  uint64_t load_shard(int shard_index) {
+    if (m_ShouldShuffle)
+      shard_index = m_ShardIndices[shard_index];
+
+    const char* filename = m_GlobResult.gl_pathv[shard_index];
+
+    // Close previous file if open
+    if (m_TokenFile)
+      m_TokenFile.reset();
+
+    // Open new file
+    FILE* file = utils::fopen_check(filename, /*mode=*/"rb");
+    m_TokenFile.reset(file);
+
+    // Validate header
+    validate_file_header(file);
+
+    // Get number of tokens from header[2]
+    utils::fseek_check(file, 2 * sizeof(int), SEEK_SET);
+    int ntok_int = 0;
+    utils::fread_check(&ntok_int, sizeof(int), /*nmemb=*/1, file);
+    int64_t ntok = ntok_int;
+
+    if (ntok <= 0)
+      throw std::runtime_error("Invalid token count in data file");
+
+    // Determine file size and validate consistency
+    utils::fseek_check(file, /*off=*/0, SEEK_END);
+    m_FileSizeBytes = ftell(file);
+    utils::fseek_check(file, /*off=*/0, SEEK_SET);
+
+    uint64_t expected_file_size =
+        (HEADER_SIZE * sizeof(int)) + (ntok * sizeof(uint16_t));
+    if (m_FileSizeBytes != expected_file_size)
+      throw std::runtime_error("File size is not as expected");
+
+    // Calculate shard samples
+    m_ShardNumSamples =
+        (ntok * sizeof(uint16_t) - sizeof(uint16_t)) / m_TotalBatchSizeBytes;
+
+    return ntok;
+  }
+
+  void prepare_intra_shard_indices() {
+    if (m_ShouldShuffle) {
+      m_IntraShardIndices.resize(m_ShardNumSamples);
+      for (size_t i = 0; i < m_ShardNumSamples; ++i)
+        m_IntraShardIndices[i] = static_cast<int>(i);
+      std::shuffle(m_IntraShardIndices.begin(), m_IntraShardIndices.end(),
+                   m_Rng);
+    }
+  }
+
+  void advance() {
+    if (m_CurrentShardIdx == m_GlobResult.gl_pathc - 1) {
+      reset();
+      return;
+    }
+
+    m_CurrentShardIdx = (m_CurrentShardIdx + 1) % m_GlobResult.gl_pathc;
+    m_CurrentSampleIdx = 0;
+    load_shard(static_cast<int>(m_CurrentShardIdx));
+
+    if (m_ShouldShuffle)
+      prepare_intra_shard_indices();
+  }
+
+public:
+  DataLoader(const std::string& filename_pattern, size_t B, size_t T,
+             int process_rank = 0, int num_processes = 1,
+             bool should_shuffle = false)
+      : m_ProcessRank(process_rank), m_NumProcesses(num_processes), m_B(B),
+        m_T(T), m_TokenFile(nullptr, fclose), m_Rng(37 + m_ProcessRank),
+        m_ShouldShuffle(should_shuffle),
+        m_TotalBatchSizeBytes(m_NumProcesses * m_B * m_T * sizeof(uint16_t)),
+        m_LocalBatchOffsetBytes(m_ProcessRank * m_B * m_T * sizeof(uint16_t)),
+        m_HeaderBytes(HEADER_SIZE * sizeof(int)) {
+    std::memset(&m_GlobResult, 0, sizeof(m_GlobResult));
+
+    // Glob to get list of files
+    int glob_status = glob(filename_pattern.c_str(), 0, nullptr, &m_GlobResult);
+    if (glob_status != 0)
+      throw std::runtime_error("Failed to glob pattern: " + filename_pattern);
+
+    if (m_GlobResult.gl_pathc == 0)
+      throw std::runtime_error("No files found matching pattern: " +
+                               filename_pattern);
+
+    // Initialize shuffle state if needed
+    if (m_ShouldShuffle) {
+      // rng_.seed(42 + process_rank_);
+      m_ShardIndices.resize(m_GlobResult.gl_pathc);
+      for (size_t i = 0; i < m_GlobResult.gl_pathc; ++i)
+        m_ShardIndices[i] = static_cast<int>(i);
+    }
+
+    // Validate all shards
+    uint64_t ntok_total = 0;
+    for (size_t shard_index = 0; shard_index < m_GlobResult.gl_pathc;
+         ++shard_index) {
+      uint64_t shard_ntok = load_shard(static_cast<int>(shard_index));
+      if (shard_ntok < ((m_NumProcesses * m_B * m_T) + 1))
+        throw std::runtime_error("Shard has insufficient tokens");
+      ntok_total += shard_ntok;
+    }
+
+    // Allocate buffers
+    m_Buffer.resize((m_B * m_T) + 1);
+    m_Inputs.resize(m_B * m_T);
+    m_Targets.resize(m_B * m_T);
+    m_NumTokens = ntok_total;
+
+    m_InitOk = true;
+    reset();
+  }
+
+  ~DataLoader() {
+    if (m_InitOk)
+      globfree(&m_GlobResult);
+  }
+
+  // Disable copy operations
+  DataLoader(const DataLoader&) = delete;
+  DataLoader& operator=(const DataLoader&) = delete;
+
+  // Enable move operations
+  DataLoader(DataLoader&& other) noexcept = default;
+  DataLoader& operator=(DataLoader&& other) noexcept = default;
+
+  void reset() {
+    if (!m_InitOk)
+      throw std::runtime_error("DataLoader not initialized");
+
+    m_CurrentShardIdx = 0;
+    m_CurrentSampleIdx = 0;
+
+    if (m_ShouldShuffle)
+      std::shuffle(m_ShardIndices.begin(), m_ShardIndices.end(), m_Rng);
+    load_shard(static_cast<int>(m_CurrentShardIdx));
+    if (m_ShouldShuffle)
+      prepare_intra_shard_indices();
+  }
+
+  void load_batch() {
+    if (!m_InitOk)
+      throw std::runtime_error("DataLoader not initialized");
+
+    if (m_CurrentSampleIdx >= m_ShardNumSamples)
+      throw std::runtime_error("Current sample index out of bounds");
+
+    size_t idx =
+        m_ShouldShuffle
+            ? static_cast<size_t>(m_IntraShardIndices[m_CurrentSampleIdx])
+            : m_CurrentSampleIdx;
+
+    size_t global_batch_offset_bytes = idx * m_TotalBatchSizeBytes;
+    uint64_t current_offset =
+        m_HeaderBytes + global_batch_offset_bytes + m_LocalBatchOffsetBytes;
+
+    // Read B*T+1 tokens from file
+    utils::fseek_check(m_TokenFile.get(), static_cast<long>(current_offset),
+                       SEEK_SET);
+    utils::fread_check(m_Buffer.data(), sizeof(uint16_t), (m_B * m_T) + 1,
+                       m_TokenFile.get());
+
+    // Decode buffer into inputs and targets
+    for (size_t i = 0; i < m_B * m_T; ++i) {
+      m_Inputs[i] = static_cast<int>(m_Buffer[i]);
+      m_Targets[i] = static_cast<int>(m_Buffer[i + 1]);
+    }
+  }
+
+  void next_batch() {
+    if (m_CurrentSampleIdx >= m_ShardNumSamples)
+      advance();
+    load_batch();
+    m_CurrentSampleIdx += 1;
+  }
+
+  void resume(size_t current_shard_idx, size_t current_sample_idx) {
+    if (!m_InitOk)
+      throw std::runtime_error("DataLoader not initialized");
+
+    m_CurrentShardIdx = current_shard_idx;
+    m_CurrentSampleIdx = current_sample_idx;
+    load_shard(static_cast<int>(m_CurrentShardIdx));
+  }
+
+  // Getters
+  size_t batch_size() const { return m_B; }
+  size_t sequence_length() const { return m_T; }
+  size_t num_tokens() const { return m_NumTokens; }
+  size_t current_shard_idx() const { return m_CurrentShardIdx; }
+  size_t current_sample_idx() const { return m_CurrentSampleIdx; }
+  bool is_initialized() const { return m_InitOk; }
+
+  const int* inputs() const { return m_Inputs.data(); }
+  const int* targets() const { return m_Targets.data(); }
+};
+
+class EvalLoader {
+private:
+  static constexpr int HEADER_SIZE = 256;
+  static constexpr uint32_t MAGIC_NUMBER = 20240522;
+  static constexpr int DATA_VERSION = 1;
+  static constexpr int ASSUMED_NUM_COMPLETIONS = 4;
+
+  // Distributed training variables
+  int m_ProcessRank;
+  int m_NumProcesses;
+
+  // Hyperparameters
+  size_t m_B;
+  size_t m_T;
+
+  // File handling
+  std::unique_ptr<FILE, decltype(&fclose)> m_EvalFile;
+  std::vector<uint16_t> m_Buffer;
+
+  // Public variables
+  int m_NumExamples;
+  int m_NumBatches;
+  int m_StartExampleIndex;
+  int m_EndExampleIndex;
+  int m_CurrentExampleIndex;
+
+  // Data arrays
+  std::vector<int> m_Inputs;
+  std::vector<int> m_Targets;
+  std::vector<char> m_Mask;
+  std::vector<int> m_Label;
+  int m_NumCompletions;
+
+  bool m_InitOk;
+
+  static constexpr int ceil_div(int m, int n) { return (m + n - 1) / n; }
+
+  static void validate_file_header(FILE* file) {
+    int header[HEADER_SIZE];
+    utils::fread_check(header, sizeof(int), HEADER_SIZE, file);
+
+    if (header[0] != MAGIC_NUMBER)
+      throw std::runtime_error("Bad magic number in eval file");
+
+    if (header[1] != DATA_VERSION)
+      throw std::runtime_error("Bad version in eval file");
+  }
+
+  void next_example(int example_batch_index) {
+    int batch_dim_offset = example_batch_index * ASSUMED_NUM_COMPLETIONS;
+
+    // Read example header
+    uint16_t example_header[3];
+    utils::fread_check(example_header, sizeof(uint16_t), /*nmemb=*/3,
+                       m_EvalFile.get());
+
+    // Validate header
+    if (example_header[0] != 65535)
+      throw std::runtime_error("Invalid example delimiter");
+
+    if (example_header[2] != m_CurrentExampleIndex)
+      throw std::runtime_error("Example index mismatch");
+
+    // Read rest of example
+    size_t example_bytes = example_header[1] - (sizeof(uint16_t) * 3);
+    utils::fread_check(m_Buffer.data(), sizeof(char), example_bytes,
+                       m_EvalFile.get());
+
+    // Process example
+    int label = static_cast<int>(m_Buffer[0]);
+    int can_fit_examples = static_cast<int>(m_B / ASSUMED_NUM_COMPLETIONS);
+
+    if (label < 0 || label >= ASSUMED_NUM_COMPLETIONS)
+      throw std::runtime_error("Invalid label");
+
+    if (example_batch_index >= can_fit_examples)
+      throw std::runtime_error("Example batch index out of bounds");
+
+    m_Label[example_batch_index] = label;
+
+    int num_completions = static_cast<int>(m_Buffer[1]);
+    if (num_completions != ASSUMED_NUM_COMPLETIONS)
+      throw std::runtime_error("Unexpected number of completions");
+
+    m_NumCompletions = num_completions;
+
+    // Process context
+    int context_length = static_cast<int>(m_Buffer[2]);
+    uint16_t* context_tokens_start = &m_Buffer[3];
+
+    if (context_length <= 0 || context_length >= static_cast<int>(m_T))
+      throw std::runtime_error("Invalid context length");
+
+    for (int b = 0; b < num_completions; ++b) {
+      for (int i = 0; i < context_length; ++i) {
+        int boff = batch_dim_offset + b;
+        int tok_cur = static_cast<int>(context_tokens_start[i]);
+        m_Inputs[(boff * m_T) + i] = tok_cur;
+      }
+    }
+
+    // Process completions
+    uint16_t* completions_iter = m_Buffer.data() + 3 + context_length;
+    for (int c = 0; c < num_completions; ++c) {
+      int coff = batch_dim_offset + c;
+      int completion_length = static_cast<int>(completions_iter[0]);
+      uint16_t* completion_tokens_start = completions_iter + 1;
+
+      if (completion_length <= 0 ||
+          context_length + completion_length >= static_cast<int>(m_T))
+        throw std::runtime_error("Invalid completion length");
+
+      for (int i = 0; i < completion_length; ++i) {
+        int tok_cur = static_cast<int>(completion_tokens_start[i]);
+        m_Inputs[(coff * m_T) + context_length + i] = tok_cur;
+        m_Targets[(coff * m_T) + context_length + i - 1] = tok_cur;
+        m_Mask[(coff * m_T) + context_length + i - 1] = 1;
+      }
+
+      completions_iter += 1 + completion_length;
+    }
+
+    m_CurrentExampleIndex += 1;
+  }
+
+public:
+  EvalLoader()
+      : m_ProcessRank(0), m_NumProcesses(1), m_B(0), m_T(0),
+        m_EvalFile(nullptr, fclose), m_NumExamples(0), m_NumBatches(0),
+        m_StartExampleIndex(0), m_EndExampleIndex(0), m_CurrentExampleIndex(0),
+        m_NumCompletions(0), m_InitOk(false) {}
+
+  explicit EvalLoader(const std::string& filename, size_t B, size_t T,
+                      int process_rank = 0, int num_processes = 1)
+      : EvalLoader() {
+    init(filename, B, T, process_rank, num_processes);
+  }
+
+  // Disable copy operations
+  EvalLoader(const EvalLoader&) = delete;
+  EvalLoader& operator=(const EvalLoader&) = delete;
+
+  // Enable move operations
+  EvalLoader(EvalLoader&& other) noexcept = default;
+  EvalLoader& operator=(EvalLoader&& other) noexcept = default;
+  ~EvalLoader() = default;
+
+  void init(const std::string& filename, size_t B, size_t T,
+            int process_rank = 0, int num_processes = 1) {
+    m_ProcessRank = process_rank;
+    m_NumProcesses = num_processes;
+    m_B = B;
+    m_T = T;
+
+    // Open file
+    FILE* file = utils::fopen_check(filename.c_str(), /*mode=*/"rb");
+    m_EvalFile.reset(file);
+
+    // Validate header
+    validate_file_header(file);
+
+    // Get file info from header
+    utils::fseek_check(file, 2 * sizeof(int), SEEK_SET);
+
+    utils::fread_check(&m_NumExamples, sizeof(int), /*nmemb=*/1, file);
+
+    if (m_NumExamples < m_NumProcesses)
+      throw std::runtime_error("Not enough examples for all processes");
+
+    int longest_example_bytes = 0;
+    utils::fread_check(&longest_example_bytes, sizeof(int), /*nmemb=*/1, file);
+
+    if (longest_example_bytes <= 0 ||
+        longest_example_bytes >=
+            static_cast<int>((1 + ASSUMED_NUM_COMPLETIONS) * m_T * 2))
+      throw std::runtime_error("Invalid longest example size");
+
+    // Allocate buffers
+    int can_fit_examples = static_cast<int>(m_B / ASSUMED_NUM_COMPLETIONS);
+    m_Buffer.resize(longest_example_bytes);
+    m_Inputs.resize(m_B * m_T);
+    m_Targets.resize(m_B * m_T);
+    m_Mask.resize(m_B * m_T);
+    m_Label.resize(can_fit_examples);
+
+    m_InitOk = true;
+    reset();
+  }
+
+  void reset() {
+    if (!m_InitOk)
+      throw std::runtime_error("EvalLoader not initialized");
+
+    int examples_per_process = ceil_div(m_NumExamples, m_NumProcesses);
+    int can_fit_examples = static_cast<int>(m_B / ASSUMED_NUM_COMPLETIONS);
+
+    if (can_fit_examples == 0) {
+      throw std::runtime_error(
+          "Batch size too small for assumed number of completions. "
+          "Disable HellaSwag eval or increase batch size.");
+    }
+
+    m_NumBatches = ceil_div(examples_per_process, can_fit_examples);
+
+    m_StartExampleIndex = examples_per_process * m_ProcessRank;
+    m_EndExampleIndex = examples_per_process * (m_ProcessRank + 1);
+
+    m_EndExampleIndex = std::min(m_EndExampleIndex, m_NumExamples);
+
+    // Seek to start example
+    int64_t header_bytes = HEADER_SIZE * sizeof(int);
+    utils::fseek_check(m_EvalFile.get(), static_cast<long>(header_bytes),
+                       SEEK_SET);
+
+    for (int i = 0; i < m_StartExampleIndex; ++i) {
+      uint16_t example_header[3];
+      utils::fread_check(example_header, sizeof(uint16_t), /*nmemb=*/3,
+                         m_EvalFile.get());
+
+      if (example_header[0] != 65535)
+        throw std::runtime_error("Invalid example delimiter during seek");
+
+      if (example_header[2] != i)
+        throw std::runtime_error("Example index mismatch during seek");
+
+      size_t remaining_bytes = example_header[1] - (sizeof(uint16_t) * 3);
+      if (remaining_bytes == 0)
+        throw std::runtime_error("Invalid remaining bytes in example");
+      utils::fseek_check(m_EvalFile.get(), static_cast<long>(remaining_bytes),
+                         SEEK_CUR);
+    }
+
+    m_CurrentExampleIndex = m_StartExampleIndex;
+  }
+
+  void next_batch() {
+    if (!m_InitOk)
+      throw std::runtime_error("EvalLoader not initialized");
+
+    // Clear mask
+    std::fill(m_Mask.begin(), m_Mask.end(), 0);
+
+    int can_fit_examples = static_cast<int>(m_B / ASSUMED_NUM_COMPLETIONS);
+    for (int i = 0; i < can_fit_examples; ++i) {
+      if (m_CurrentExampleIndex >= m_EndExampleIndex)
+        break;
+      next_example(i);
+    }
+  }
+
+  int stat_losses(const float* losses) const {
+    if (!m_InitOk)
+      throw std::runtime_error("EvalLoader not initialized");
+
+    int correct = 0;
+    int can_fit_examples = static_cast<int>(m_B / ASSUMED_NUM_COMPLETIONS);
+
+    for (int i = 0; i < can_fit_examples; ++i) {
+      float min_loss = 0.0F;
+      int min_loss_index = -1;
+      bool active = false;
+
+      for (int b = 0; b < ASSUMED_NUM_COMPLETIONS; ++b) {
+        int boff = (i * ASSUMED_NUM_COMPLETIONS) + b;
+
+        float average_loss = 0.0F;
+        int count = 0;
+
+        for (size_t t = 0; t < m_T; ++t) {
+          if (m_Mask[(boff * m_T) + t] == 1) {
+            active = true;
+            average_loss += losses[(boff * m_T) + t];
+            count++;
+          }
+        }
+
+        if (count > 0)
+          average_loss /= static_cast<float>(count);
+
+        if (b == 0 || average_loss < min_loss) {
+          min_loss = average_loss;
+          min_loss_index = b;
+        }
+      }
+
+      if (active && min_loss_index == m_Label[i])
+        correct += 1;
+    }
+
+    return correct;
+  }
+
+  // Getters
+  size_t batch_size() const { return m_B; }
+  size_t sequence_length() const { return m_T; }
+  int num_examples() const { return m_NumExamples; }
+  int num_batches() const { return m_NumBatches; }
+  int current_example_index() const { return m_CurrentExampleIndex; }
+  bool is_initialized() const { return m_InitOk; }
+
+  const int* inputs() const { return m_Inputs.data(); }
+  const int* targets() const { return m_Targets.data(); }
+  const char* mask() const { return m_Mask.data(); }
+  const int* labels() const { return m_Label.data(); }
+};
+
+} // namespace gpt2
+// NOLINTEND(cppcoreguidelines-pro-bounds-*, *-avoid-c-arrays,
+// modernize-use-nodiscard, clang-diagnostic-error)
+
+#endif // DATALOADER_HPP

--- a/demos/cladtorch/download_training_data.sh
+++ b/demos/cladtorch/download_training_data.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# This script is taken from Andrej Karpathy's `llm.c`: https://github.com/karpathy/llm.c
+
+# Get the directory of the script
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+
+# Base URL
+BASE_URL="https://huggingface.co/datasets/karpathy/llmc-starter-pack/resolve/main/"
+
+# Directory paths based on script location
+SAVE_DIR_PARENT="$SCRIPT_DIR/"
+SAVE_DIR_TINY="$SCRIPT_DIR/data/tinyshakespeare"
+SAVE_DIR_HELLA="$SCRIPT_DIR/data/hellaswag"
+
+# Create the directories if they don't exist
+mkdir -p "$SAVE_DIR_TINY"
+mkdir -p "$SAVE_DIR_HELLA"
+
+# Files to download
+FILES=(
+    "gpt2_124M.bin"
+    "gpt2_tokenizer.bin"
+    "tiny_shakespeare_train.bin"
+    "tiny_shakespeare_val.bin"
+)
+
+# Function to download files to the appropriate directory
+download_file() {
+    local FILE_NAME=$1
+    local FILE_URL="${BASE_URL}${FILE_NAME}?download=true"
+    local FILE_PATH
+
+    # Determine the save directory based on the file name
+    if [[ "$FILE_NAME" == tiny_shakespeare* ]]; then
+        FILE_PATH="${SAVE_DIR_TINY}/${FILE_NAME}"
+    elif [[ "$FILE_NAME" == hellaswag* ]]; then
+        FILE_PATH="${SAVE_DIR_HELLA}/${FILE_NAME}"
+    else
+        FILE_PATH="${SAVE_DIR_PARENT}/${FILE_NAME}"
+    fi
+
+    # Download the file
+    curl -s -L -o "$FILE_PATH" "$FILE_URL"
+    echo "Downloaded $FILE_NAME to $FILE_PATH"
+}
+
+# Export the function so it's available in subshells
+export -f download_file
+
+# Generate download commands
+download_commands=()
+for FILE in "${FILES[@]}"; do
+    download_commands+=("download_file \"$FILE\"")
+done
+
+# Function to manage parallel jobs in increments of a given size
+run_in_parallel() {
+    local batch_size=$1
+    shift
+    local i=0
+    local command
+
+    for command; do
+        eval "$command" &
+        ((i = (i + 1) % batch_size))
+        if [ "$i" -eq 0 ]; then
+            wait
+        fi
+    done
+
+    # Wait for any remaining jobs to finish
+    wait
+}
+
+# Run the download commands in parallel in batches of 2
+run_in_parallel 6 "${download_commands[@]}"
+
+echo "All files downloaded and saved in their respective directories"

--- a/demos/cladtorch/inference.cpp
+++ b/demos/cladtorch/inference.cpp
@@ -1,0 +1,75 @@
+#include "llm.hpp"
+#include "tokenizer.hpp"
+#include <cstdint>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+using namespace gpt2;
+
+static uint32_t random_u32(uint64_t* state) {
+  // xorshift rng: https://en.wikipedia.org/wiki/Xorshift#xorshift.2A
+  *state ^= *state >> 12;
+  *state ^= *state << 25;
+  *state ^= *state >> 27;
+  return (*state * 0x2545F4914F6CDD1DULL) >> 32;
+}
+
+// random float32 in [0, 1)
+static float random_f32(uint64_t* state) {
+  return static_cast<float>(random_u32(state) >> 8) / 16777216.0F;
+}
+
+static int sample_mult(const float* probs, int n, float coin) {
+  // sample index from probs (they must sum to 1!)
+  // coin is a random number in [0, 1), usually from random_f32()
+  float cdf = 0.0F;
+  for (int i = 0; i < n; i++) {
+    cdf += probs[i]; // NOLINT
+    if (coin < cdf)
+      return i;
+  }
+  return n - 1; // in case of rounding errors
+}
+
+int main() {
+  GPT2 model("gpt2_124M.bin");
+  const Config config = model.config;
+
+  int B = 1;
+  int T = 64;
+
+  Tokenizer tokenizer("gpt2_tokenizer.bin");
+
+  uint64_t rng_state = 1337;
+  const int gen_max_length = 64;
+  ITensor gen_tokens({B, T});
+  gen_tokens.fill(tokenizer.eot_token()); // Initialize with end-of-text token
+
+  std::cout << "generating:\n---\n";
+  std::cerr << std::setprecision(4);
+  struct timespec start {};
+  struct timespec end {}; // timersg for benchmarking per token
+
+  for (int t = 1; t < gen_max_length; t++) {
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    auto probs_t = model.forward(gen_tokens);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    float* probs = new float[config.padded_vocab_size]; // NOLINT
+    // Get probabilities for the first batch
+    for (int v = 0; v < config.padded_vocab_size; v++)
+      probs[v] = probs_t.at(0, t - 1, v); // NOLINT
+
+    float coin = random_f32(&rng_state);
+    int next_token = sample_mult(probs, model.config.vocab_size, coin);
+    gen_tokens.at(0, t) = next_token; // Use the first batch for generation
+    delete[] probs;                   // NOLINT
+    double time_taken = ((double)(end.tv_sec - start.tv_sec) * 1000.0) +
+                        ((double)(end.tv_nsec - start.tv_nsec) / 1e6);
+    std::cerr << "[step " << t << ", " << time_taken << "ms] ";
+
+    tokenizer.safe_print(next_token);
+    std::cout << std::flush;
+  }
+  std::cout << "\n---\n";
+}

--- a/demos/cladtorch/llm.hpp
+++ b/demos/cladtorch/llm.hpp
@@ -1,0 +1,369 @@
+#pragma once
+
+#include <cassert>
+#include <clad/Differentiator/Differentiator.h>
+#include <cladtorch/cladtorch.hpp>
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+// NOLINTBEGIN(modernize-use-nodiscard)
+namespace gpt2 {
+
+namespace ct = cladtorch;
+using FTensor = ct::Tensor<float>;
+using ITensor = ct::Tensor<int>;
+
+struct Config {
+  int max_seq_len;
+  int vocab_size;
+  int padded_vocab_size;
+  int num_layers;
+  int num_heads;
+  int channels;
+
+  int head_size() const { return channels / num_heads; }
+  int mlp_hidden_size() const { return 4 * channels; }
+};
+
+class Linear {
+public:
+  FTensor weight, bias;
+  Linear(int in_features, int out_features)
+      : weight({out_features, in_features}), bias({out_features}) {}
+  FTensor forward(const FTensor& input) const {
+    auto linear_out = linear(input, weight, bias);
+    return linear_out;
+  }
+};
+
+class LayerNorm {
+public:
+  FTensor weight, bias;
+  explicit LayerNorm(int channels) : weight({channels}), bias({channels}) {}
+  FTensor forward(const FTensor& input) const {
+    auto norm_out = input.norm();
+    auto weighted = norm_out * weight;
+    auto result = weighted + bias;
+    return result;
+  }
+};
+
+class Encoder {
+public:
+  FTensor wte, wpe;
+  Encoder(int padded_vocab_size, int max_seq_len, int channels)
+      : wte({padded_vocab_size, channels}), wpe({max_seq_len, channels}) {}
+  FTensor forward(const ITensor& input, const ITensor& input_pos) const {
+    auto token_embeddings = wte.lookup(input);
+    auto position_embeddings = wpe.lookup(input_pos);
+    auto embeddings = token_embeddings + position_embeddings;
+    return embeddings;
+  }
+};
+
+class CausalSelfAttention {
+public:
+  Linear qkv, proj;
+  int num_heads, channels, head_size;
+
+  CausalSelfAttention(int num_heads, int channels)
+      : qkv(channels, 3 * channels), proj(channels, channels),
+        num_heads(num_heads), channels(channels),
+        head_size(channels / num_heads) {
+    assert(channels % num_heads == 0 &&
+           "channels must be divisible by num_heads");
+  }
+
+  FTensor forward(const FTensor& input) const {
+    const int B = input.size(0);
+    const int T = input.size(1);
+    std::vector<int> qkv_shape{{B, T, num_heads, head_size}};
+    std::vector<int> reshaped_shape{{B, T, channels}};
+
+    // Compute Q, K, V
+    auto qkv_out = qkv.forward(input);
+    auto qkv_split = qkv_out.split(channels, 2);
+    auto q_reshaped = qkv_split[0].reshape(qkv_shape);
+    auto q = q_reshaped.transpose(1, 2);
+    auto k_reshaped = qkv_split[1].reshape(qkv_shape);
+    auto k = k_reshaped.transpose(1, 2);
+    auto v_reshaped = qkv_split[2].reshape(qkv_shape);
+    auto v = v_reshaped.transpose(1, 2);
+
+    // Attention computation
+    const float scale = 1.0F / std::sqrt(static_cast<float>(head_size));
+    auto k_transposed = k.transpose(2, 3);
+    auto scores_raw = matmul(q, k_transposed);
+    auto scores = scores_raw * scale;
+    auto weights = softmax(scores, true, 0);
+    auto attention_out = matmul(weights, v);
+
+    // Reshape and project
+    auto transposed = attention_out.transpose(1, 2);
+    auto reshaped = transposed.reshape(reshaped_shape);
+    auto projected = proj.forward(reshaped);
+    return projected;
+  }
+};
+
+class Block {
+public:
+  LayerNorm ln1;
+  CausalSelfAttention attn;
+  LayerNorm ln2;
+  Linear mlp_fc, mlp_proj;
+  inline static int nh = 0, ch = 0;
+  Block(int num_heads, int channels)
+      : ln1(channels), attn(num_heads, channels), ln2(channels),
+        mlp_fc(channels, 4 * channels), mlp_proj(4 * channels, channels) {
+    nh = num_heads;
+    ch = channels;
+  }
+
+  Block()
+      : ln1(ch), attn(nh, ch), ln2(ch), mlp_fc(ch, 4 * ch),
+        mlp_proj(4 * ch, ch) {}
+  FTensor forward(const FTensor& input) const {
+    // Attention block with residual connection
+    auto ln1_out = ln1.forward(input);
+    auto attn_out = attn.forward(ln1_out);
+    auto x = input + attn_out;
+
+    // MLP block with residual connection
+    auto ln2_out = ln2.forward(x);
+    auto mlp_fc_out = mlp_fc.forward(ln2_out);
+    auto gelu_out = gelu(mlp_fc_out);
+    auto mlp_proj_out = mlp_proj.forward(gelu_out);
+    auto result = x + mlp_proj_out;
+    return result;
+  }
+  void operator+=(const Block& other) {
+    ln1.weight += other.ln1.weight;
+    ln1.bias += other.ln1.bias;
+    attn.qkv.weight += other.attn.qkv.weight;
+    attn.qkv.bias += other.attn.qkv.bias;
+    attn.proj.weight += other.attn.proj.weight;
+    attn.proj.bias += other.attn.proj.bias;
+    ln2.weight += other.ln2.weight;
+    ln2.bias += other.ln2.bias;
+    mlp_fc.weight += other.mlp_fc.weight;
+    mlp_fc.bias += other.mlp_fc.bias;
+    mlp_proj.weight += other.mlp_proj.weight;
+    mlp_proj.bias += other.mlp_proj.bias;
+  }
+};
+
+class Transformer {
+public:
+  Encoder encoder;
+  std::vector<Block> blocks;
+  LayerNorm ln_f;
+
+  explicit Transformer(const Config& config)
+      : encoder(config.padded_vocab_size, config.max_seq_len, config.channels),
+        ln_f(config.channels) {
+    blocks.reserve(config.num_layers);
+    for (int i = 0; i < config.num_layers; ++i)
+      blocks.emplace_back(config.num_heads, config.channels);
+  }
+
+  FTensor forward(const ITensor& input, const ITensor& input_pos) const {
+    auto x = encoder.forward(input, input_pos);
+    // for (size_t i = 0; i < blocks.size(); i++) {
+    //   auto block_out = blocks[i].forward(x);
+    //   x = block_out;
+    // }
+    auto final_norm = ln_f.forward(x);
+    return final_norm;
+  }
+};
+
+ND static ITensor get_input_pos(int B, int T) {
+  ITensor input_pos({B, T}); // Create position indices
+  for (int b = 0; b < B; ++b)
+    for (int t = 0; t < T; ++t)
+      input_pos.data()[(b * T) + t] = t; // NOLINT
+  // Fill with sequential positions 0, 1, ..., T-1 for each batch
+  return input_pos;
+}
+
+class GPT2 {
+private:
+  static constexpr int MAGIC_NUMBER = 20240326;
+  static constexpr int VERSION = 3;
+  static constexpr int HEADER_SIZE = 256;
+
+public:
+  template <typename Func> void for_each_parameter(Func func) {
+    // Embedding parameters
+    func(&transformer.encoder.wte);
+    func(&transformer.encoder.wpe);
+
+    // Block parameters in checkpoint order
+    for (auto& block : transformer.blocks)
+      func(&block.ln1.weight);
+    for (auto& block : transformer.blocks)
+      func(&block.ln1.bias);
+    for (auto& block : transformer.blocks)
+      func(&block.attn.qkv.weight);
+    for (auto& block : transformer.blocks)
+      func(&block.attn.qkv.bias);
+    for (auto& block : transformer.blocks)
+      func(&block.attn.proj.weight);
+    for (auto& block : transformer.blocks)
+      func(&block.attn.proj.bias);
+    for (auto& block : transformer.blocks)
+      func(&block.ln2.weight);
+    for (auto& block : transformer.blocks)
+      func(&block.ln2.bias);
+    for (auto& block : transformer.blocks)
+      func(&block.mlp_fc.weight);
+    for (auto& block : transformer.blocks)
+      func(&block.mlp_fc.bias);
+    for (auto& block : transformer.blocks)
+      func(&block.mlp_proj.weight);
+    for (auto& block : transformer.blocks)
+      func(&block.mlp_proj.bias);
+
+    // Final layer norm
+    func(&transformer.ln_f.weight);
+    func(&transformer.ln_f.bias);
+  }
+
+private:
+  static Config read_config_from_file(FILE* file) {
+    int header[HEADER_SIZE]; // NOLINT
+    // NOLINTNEXTLINE
+    if (fread(header, sizeof(int), HEADER_SIZE, file) != HEADER_SIZE)
+      throw std::runtime_error("Failed to read checkpoint header");
+
+    if (header[0] != MAGIC_NUMBER)
+      throw std::runtime_error("Invalid magic number in checkpoint");
+    if (header[1] != VERSION)
+      throw std::runtime_error("Unsupported checkpoint version");
+
+    Config config{
+        header[2], // max_seq_len
+        header[3], // vocab_size
+        header[7], // padded_vocab_size
+        header[4], // num_layers
+        header[5], // num_heads
+        header[6]  // channels
+    };
+
+    std::cerr << "[GPT-2 Config] seq_len:" << config.max_seq_len
+              << " vocab:" << config.vocab_size
+              << " layers:" << config.num_layers
+              << " heads:" << config.num_heads
+              << " channels:" << config.channels << '\n';
+
+    return config;
+  }
+
+  void load_weights_from_file(FILE* file) {
+    num_parameters = 0;
+    for_each_parameter([&](FTensor* tensor) {
+      const int elements = tensor->num_elements();
+      if (fread(tensor->data(), sizeof(float), static_cast<size_t>(elements),
+                file) != static_cast<size_t>(elements))
+        throw std::runtime_error("Failed to read tensor data");
+      num_parameters += elements;
+    });
+  }
+
+public:
+  Config config;
+  Transformer transformer;
+  int num_parameters = 0;
+
+  explicit GPT2(const Config& cfg) : config(cfg), transformer(cfg) {}
+
+  explicit GPT2(const std::string& checkpoint_path)
+      : config(load_config_from_checkpoint(checkpoint_path)),
+        transformer(config) {
+    load_weights_from_checkpoint(checkpoint_path);
+  }
+
+  FTensor forward(const ITensor& input) const {
+    const int B = input.size(0);
+    const int T = input.size(1);
+    ITensor input_pos = get_input_pos(B, T); // Get position indices
+
+    auto hidden = transformer.forward(input, input_pos);
+    auto weight_transposed = transformer.encoder.wte.transpose(0, 1);
+    auto logits = matmul(hidden, weight_transposed);
+    auto probabilities = softmax(logits, false, config.vocab_size);
+    return probabilities;
+  }
+
+  std::vector<FTensor*> get_parameter_tensors() {
+    std::vector<FTensor*> params;
+    for_each_parameter([&](FTensor* tensor) { params.push_back(tensor); });
+    return params;
+  }
+
+  static Config load_config_from_checkpoint(const std::string& path) {
+    auto file = std::unique_ptr<FILE, decltype(&fclose)>(
+        fopen(path.c_str(), "rb"), fclose);
+    if (!file)
+      throw std::runtime_error("Could not open checkpoint: " + path);
+    return read_config_from_file(file.get());
+  }
+
+  void load_weights_from_checkpoint(const std::string& path) {
+    auto file = std::unique_ptr<FILE, decltype(&fclose)>(
+        fopen(path.c_str(), "rb"), fclose);
+    if (!file)
+      throw std::runtime_error("Could not open checkpoint: " + path);
+
+    // Skip header
+    fseek(file.get(), HEADER_SIZE * sizeof(int), SEEK_SET);
+    load_weights_from_file(file.get());
+
+    std::cerr << "Loaded " << num_parameters << " parameters from " << path
+              << '\n';
+  }
+
+  void load_checkpoint(const std::string& path) {
+    auto file = std::unique_ptr<FILE, decltype(&fclose)>(
+        fopen(path.c_str(), "rb"), fclose);
+    if (!file)
+      throw std::runtime_error("Could not open checkpoint: " + path);
+
+    auto file_config = read_config_from_file(file.get());
+
+    // Verify config matches
+    if (file_config.max_seq_len != config.max_seq_len ||
+        file_config.vocab_size != config.vocab_size ||
+        file_config.num_layers != config.num_layers ||
+        file_config.num_heads != config.num_heads ||
+        file_config.channels != config.channels ||
+        file_config.padded_vocab_size != config.padded_vocab_size) {
+      throw std::runtime_error("Configuration mismatch with checkpoint");
+    }
+
+    load_weights_from_file(file.get());
+    std::cerr << "Checkpoint loaded: " << num_parameters << " parameters"
+              << '\n';
+  }
+};
+
+} // namespace gpt2
+// NOLINTEND(modernize-use-nodiscard)
+
+// NOLINTBEGIN(readability-identifier-naming,
+// performance-unnecessary-value-param)
+namespace clad::custom_derivatives::gpt2 {
+static void get_input_pos_pullback(int B, int T, ::gpt2::ITensor _d_y, // NOLINT
+                                   int* _d_B, int* _d_T) {}
+static ::clad::ValueAndAdjoint<::gpt2::ITensor, ::gpt2::ITensor>
+get_input_pos_reverse_forw(int B, int T, int _d_B, int _d_T) { // NOLINT
+  return {::gpt2::get_input_pos(B, T), ::gpt2::get_input_pos(B, T)};
+}
+} // namespace clad::custom_derivatives::gpt2
+// NOLINTEND(readability-identifier-naming,
+// performance-unnecessary-value-param)

--- a/demos/cladtorch/llm_opt.hpp
+++ b/demos/cladtorch/llm_opt.hpp
@@ -1,0 +1,1033 @@
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <iostream>
+
+#ifdef OMP
+#include <omp.h>
+#endif
+
+#ifdef __APPLE__
+#include <Accelerate/Accelerate.h>
+#else
+#include <cblas.h>
+#endif
+
+#include <clad/Differentiator/Differentiator.h>
+
+#include "dataloader.hpp"
+
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-*, *-avoid-c-arrays,
+// misc-definitions-in-headers)
+// ----------------------------------------------------------------------------
+// all the individual layers' forward and backward passes
+// B = batch_size, T = sequence_length, C = channels, V = vocab_size
+
+void encoder_forward(float* out, const int* inp, float* wte, float* wpe, int B,
+                     int T, int C) {
+  // out is (B,T,C). At each position (b,t), a C-dimensional vector summarizing
+  // token & position inp is (B,T) of integers, holding the token ids at each
+  // (b,t) position wte is (V,C) of token embeddings, short for "weight token
+  // embeddings" wpe is (maxT,C) of position embeddings, short for "weight
+  // positional embedding"
+  for (int b = 0; b < B; b++) {
+    for (int t = 0; t < T; t++) {
+      // seek to the output position in out[b,t,:]
+      float* out_bt = out + (b * T * C) + (t * C);
+      // get the index of the token at inp[b, t]
+      int ix = inp[(b * T) + t];
+      // seek to the position in wte corresponding to the token
+      float* wte_ix = wte + (ix * C);
+      // seek to the position in wpe corresponding to the position
+      float* wpe_t = wpe + (t * C);
+      // add the two vectors and store the result in out[b,t,:]
+      for (int i = 0; i < C; i++)
+        out_bt[i] = wte_ix[i] + wpe_t[i];
+    }
+  }
+}
+
+void encoder_backward(float* dwte, float* dwpe, float* dout, const int* inp,
+                      int B, int T, int C) {
+  for (int b = 0; b < B; b++) {
+    for (int t = 0; t < T; t++) {
+      float* dout_bt = dout + (b * T * C) + (t * C);
+      int ix = inp[(b * T) + t];
+      float* dwte_ix = dwte + (ix * C);
+      float* dwpe_t = dwpe + (t * C);
+      for (int i = 0; i < C; i++) {
+        float d = dout_bt[i];
+        dwte_ix[i] += d;
+        dwpe_t[i] += d;
+      }
+    }
+  }
+}
+
+void layernorm_forward(float* out, float* mean, float* rstd, float* inp,
+                       const float* weight, const float* bias, int B, int T,
+                       int C) {
+  // reference:
+  // https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html both inp
+  // and out are (B,T,C) of the activations mean and rstd are (B,T) buffers, to
+  // be used later in backward pass at each position (b,t) of the input, the
+  // C-dimensional vector of activations gets normalized, then scaled and
+  // shifted
+  float eps = 1e-5F;
+  for (int b = 0; b < B; b++) {
+    for (int t = 0; t < T; t++) {
+      // seek to the input position inp[b,t,:]
+      float* x = inp + (b * T * C) + (t * C);
+      // calculate the mean
+      float m = 0.0F;
+      for (int i = 0; i < C; i++)
+        m += x[i];
+      m = m / static_cast<float>(C);
+      // calculate the variance (without any bias correction)
+      float v = 0.0F;
+      for (int i = 0; i < C; i++) {
+        float xshift = x[i] - m;
+        v += xshift * xshift;
+      }
+      v = v / static_cast<float>(C);
+      // calculate the rstd (reciprocal standard deviation)
+      float s = 1.0F / std::sqrt(v + eps);
+      // seek to the output position in out[b,t,:]
+      float* out_bt = out + (b * T * C) + (t * C);
+      for (int i = 0; i < C; i++) {
+        float n = (s * (x[i] - m));          // normalize
+        float o = (n * weight[i]) + bias[i]; // scale and shift
+        out_bt[i] = o;                       // write
+      }
+      // cache the mean and rstd for the backward pass later
+      mean[(b * T) + t] = m;
+      rstd[(b * T) + t] = s;
+    }
+  }
+}
+
+void layernorm_backward(float* dinp, float* dweight, float* dbias, float* dout,
+                        float* inp, const float* weight, const float* mean,
+                        const float* rstd, int B, int T, int C) {
+  for (int b = 0; b < B; b++) {
+    for (int t = 0; t < T; t++) {
+      float* dout_bt = dout + (b * T * C) + (t * C);
+      float* inp_bt = inp + (b * T * C) + (t * C);
+      float* dinp_bt = dinp + (b * T * C) + (t * C);
+      float mean_bt = mean[(b * T) + t];
+      float rstd_bt = rstd[(b * T) + t];
+
+      // first: two reduce operations
+      float dnorm_mean = 0.0F;
+      float dnorm_norm_mean = 0.0F;
+      for (int i = 0; i < C; i++) {
+        float norm_bti = (inp_bt[i] - mean_bt) * rstd_bt;
+        float dnorm_i = weight[i] * dout_bt[i];
+        dnorm_mean += dnorm_i;
+        dnorm_norm_mean += dnorm_i * norm_bti;
+      }
+      dnorm_mean = dnorm_mean / static_cast<float>(C);
+      dnorm_norm_mean = dnorm_norm_mean / static_cast<float>(C);
+
+      // now iterate again and accumulate all the gradients
+      for (int i = 0; i < C; i++) {
+        float norm_bti = (inp_bt[i] - mean_bt) * rstd_bt;
+        float dnorm_i = weight[i] * dout_bt[i];
+        // gradient contribution to bias
+        dbias[i] += dout_bt[i];
+        // gradient contribution to weight
+        dweight[i] += norm_bti * dout_bt[i];
+        // gradient contribution to input
+        float dval = 0.0F;
+        dval += dnorm_i;                    // term 1
+        dval -= dnorm_mean;                 // term 2
+        dval -= norm_bti * dnorm_norm_mean; // term 3
+        dval *= rstd_bt;                    // final scale
+        dinp_bt[i] += dval;
+      }
+    }
+  }
+}
+
+void matmul_forward(float* out, const float* inp, const float* weight,
+                    const float* bias, int B, int T, int C, int OC) {
+  // BLAS implementation of matrix multiplication: out = inp @ weight^T + bias
+  // inp is (B*T, C), weight is (OC, C), out is (B*T, OC)
+
+  // First, perform the matrix multiplication: C = A * B^T
+  // A = inp, B = weight, C = out
+  // The BLAS sgemm function computes: C = alpha * op(A) * op(B) + beta * C
+  // Here:
+  // op(A) = inp (no transpose), op(B) = weight^T (transpose)
+  // M = rows of op(A) = B * T
+  // N = columns of op(B) = OC
+  // K = columns of op(A) = C
+  // alpha = 1.0, beta = 0.0 (to overwrite 'out' with the result)
+  cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans, B * T, OC, C, 1.0F, inp,
+              C, weight, C, 0.0F, out, OC);
+
+  // If bias is provided, add it to the output
+  if (bias != nullptr) {
+#pragma omp parallel for
+    for (int bt = 0; bt < B * T; bt++)
+      for (int o = 0; o < OC; o++)
+        out[(bt * OC) + o] += bias[o];
+  }
+}
+
+/* Same layout as forward:
+ *
+ *   inp : (B*T, C)  row-major   called A in BLAS comments
+ *   weight : (OC, C) row-major   called B
+ *   out  : (B*T, OC)             called C   (here we only have its grad ---
+ * dout)
+ *
+ * Backward requirements:
+ *
+ *   dinp     = dout * weight      (1)   (B*T,OC) · (OC,C) → (B*T,C)
+ *   dweight  = Σ_{b,t} dout[b,t,o] * inp[b,t]ᵀ   (2)   (OC,B*T) · (B*T,C) →
+ * (OC,C) dbias[o] = Σ_{b,t} dout[b,t,o]               (3)
+ *
+ */
+
+void matmul_backward(float* dinp, float* dweight, float* dbias,
+                     const float* dout, const float* inp, const float* weight,
+                     int B, int T, int C, int OC) {
+  // In the forward pass, out = inp @ weight^T + bias
+  // The gradients are calculated as follows:
+  // 1. dinp    (dL/dinp)   = dout @ weight
+  // 2. dweight (dL/dweight) = dout^T @ inp
+  // 3. dbias   (dL/dbias)  = sum(dout, axis=0)
+  // The original code accumulates gradients (+=), so we use beta=1.0f in BLAS
+  // calls.
+
+  // 1. Calculate gradient for input: dinp += dout @ weight
+  //    - dout:   (B*T, OC) -> A
+  //    - weight: (OC, C)   -> B
+  //    - dinp:   (B*T, C)   -> C
+  //    - op(A) is NoTrans, op(B) is NoTrans
+  cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, B * T, C, OC, 1.0F,
+              dout, OC, weight, C, 1.0F, dinp, C);
+
+  // 2. Calculate gradient for weights: dweight += dout^T @ inp
+  //    - dout^T: (OC, B*T) -> op(A)
+  //    - inp:    (B*T, C)  -> B
+  //    - dweight: (OC, C)   -> C
+  //    - op(A) is Trans, op(B) is NoTrans
+  cblas_sgemm(CblasRowMajor, CblasTrans, CblasNoTrans, OC, C, B * T, 1.0F, dout,
+              OC, inp, C, 1.0F, dweight, C);
+
+  // 3. Calculate gradient for bias: dbias += sum of dout rows
+  if (dbias != nullptr) {
+    // This is a reduction of dout over the batch dimension (B*T).
+    // It can be expressed as a matrix-vector product: dbias += dout^T @
+    // ones_vector. We use the BLAS sgemv routine: y = alpha*A*x + beta*y Here,
+    // y=dbias, A=dout^T, x=ones_vector.
+
+    // Create a temporary vector of ones for the reduction.
+    std::vector<float> ones(B * T, 1.0F);
+
+    // A = dout (B*T, OC)
+    // We use dout^T, so trans = CblasTrans
+    cblas_sgemv(CblasRowMajor, CblasTrans, B * T, OC, 1.0F, dout, OC,
+                ones.data(), 1, 1.0F, dbias, 1);
+  }
+}
+
+void attention_forward(float* out, float* preatt, float* att, float* inp, int B,
+                       int T, int C, int NH) {
+  // input is (B, T, 3C) holding the query, key, value (Q, K, V) vectors
+  // preatt, att are (B, NH, T, T). NH = number of heads, T = sequence length
+  // that holds the pre-attention and post-attention scores (used in backward)
+  // output is (B, T, C)
+  // attention is the only layer that mixes information across time
+  // every other operation is applied at every (b,t) position independently
+  // (and of course, no layer mixes information across batch)
+  int C3 = C * 3;
+  int hs = C / NH; // head size
+  float hs_f = static_cast<float>(hs);
+  float scale = 1.0F / std::sqrt(hs_f);
+
+#pragma omp parallel for collapse(3)
+  for (int b = 0; b < B; b++) {
+    for (int t = 0; t < T; t++) {
+      for (int h = 0; h < NH; h++) {
+        float* query_t = inp + (b * T * C3) + (t * C3) + (h * hs);
+        float* preatt_bth = preatt + (b * NH * T * T) + (h * T * T) + (t * T);
+        float* att_bth = att + (b * NH * T * T) + (h * T * T) + (t * T);
+
+        // pass 1: calculate query dot key and maxval
+        float maxval = -10000.0F; // TODO something better
+        for (int t2 = 0; t2 <= t; t2++) {
+          float* key_t2 = inp + (b * T * C3) + (t2 * C3) + (h * hs) +
+                          C; // +C because it's key
+
+          // (query_t) dot (key_t2)
+          float val = 0.0F;
+          for (int i = 0; i < hs; i++)
+            val += query_t[i] * key_t2[i];
+          val *= scale;
+          maxval = std::max(val, maxval);
+
+          preatt_bth[t2] = val;
+        }
+
+        // pass 2: calculate the exp and keep track of sum
+        // maxval is being calculated and subtracted only for numerical
+        // stability
+        float expsum = 0.0F;
+        for (int t2 = 0; t2 <= t; t2++) {
+          float expv = expf(preatt_bth[t2] - maxval);
+          expsum += expv;
+          att_bth[t2] = expv;
+        }
+        float expsum_inv = expsum == 0.0F ? 0.0F : 1.0F / expsum;
+
+        // pass 3: normalize to get the softmax
+        for (int t2 = 0; t2 < T; t2++) {
+          if (t2 <= t) {
+            att_bth[t2] *= expsum_inv;
+          } else {
+            // causal attention mask. not strictly necessary to set to zero here
+            // only doing this explicitly for debugging and checking to PyTorch
+            att_bth[t2] = 0.0F;
+          }
+        }
+
+        // pass 4: accumulate weighted values into the output of attention
+        float* out_bth = out + (b * T * C) + (t * C) + (h * hs);
+        for (int i = 0; i < hs; i++)
+          out_bth[i] = 0.0F;
+        for (int t2 = 0; t2 <= t; t2++) {
+          // +C*2 because it's value
+          float* value_t2 = inp + (b * T * C3) + (t2 * C3) + (h * hs) + (C * 2);
+          float att_btht2 = att_bth[t2];
+          for (int i = 0; i < hs; i++)
+            out_bth[i] += att_btht2 * value_t2[i];
+        }
+      }
+    }
+  }
+}
+
+void attention_backward(float* __restrict dinp, float* __restrict dpreatt,
+                        float* __restrict datt, float* __restrict dout,
+                        float* __restrict inp, float* __restrict att, int B,
+                        int T, int C, int NH) {
+  const int C3 = 3 * C;
+  const int hs = C / NH;
+  const float scale = 1.0F / std::sqrt(static_cast<float>(hs));
+
+  for (int b = 0; b < B; ++b) {
+    for (int t = 0; t < T; ++t) {
+      for (int h = 0; h < NH; ++h) {
+        // Pointers for this (b,t,h)
+        // length T, but only 0..t used
+        float* att_bth = att + (((size_t)b * NH * T + h * T + t) * T);
+        float* datt_bth = datt + (((size_t)b * NH * T + h * T + t) * T);
+        float* dpreatt_bt = dpreatt + (((size_t)b * NH * T + h * T + t) * T);
+
+        float* q = inp + (((size_t)b * T + t) * C3) + (h * hs);   // query_t
+        float* dq = dinp + (((size_t)b * T + t) * C3) + (h * hs); // dquery_t
+        float* dout_h =
+            dout + (((size_t)b * T + t) * C) + (h * hs); // dout head slice
+
+        // Build views K_{<=t}, V_{<=t}, dK_{<=t}, dV_{<=t}
+        // Each row corresponds to timestep t2 in 0..t
+        auto row_ptr = [&](float* base, int t2, int offset) -> float* {
+          return base + (((size_t)b * T + t2) * C3) + (h * hs) + offset;
+        };
+        float* K0 = inp; // +C offset for keys
+        float* V0 = inp; // +2C offset for values
+        float* dK0 = dinp;
+        float* dV0 = dinp;
+
+        const int M = t + 1; // number of rows (timesteps included)
+        // Row-major: matrices are M x hs with leading dimension hs.
+
+        // A) Through value accumulation: y = A V
+        // dy/dV += A^T dout_h  → dV_{i,:} += a[i] * dout_h
+        // dy/dA = V dout_h     → vector length M
+        // 1) da_val = V_{<=t} * dout_h   (M×hs)·(hs) -> (M)
+        //    GEMV row-major: m=M, n=hs
+        {
+          cblas_sgemv(CblasRowMajor, CblasNoTrans, M, hs, 1.0F,
+                      row_ptr(V0, 0, 2 * C), hs, // matrix V_{<=t}
+                      dout_h, 1, 1.0F, datt_bth,
+                      1); // accumulate into datt_bth[0..t]
+        }
+
+        // 2) dV += outer(a, dout_h)  (rank-1 updates for rows 0..t)
+        //    Use BLAS GER: A := alpha * x * y^T + A
+        //    For each row i: dV[i,:] += a[i] * dout_h
+        //    That’s exactly sger with x=a (length M), y=dout_h (length hs),
+        //    A=dV (M x hs)
+        {
+          cblas_sger(CblasRowMajor, M, hs, 1.0F, att_bth, 1, // x = a (length M)
+                     dout_h, 1,                   // y = dout_h (length hs)
+                     row_ptr(dV0, 0, 2 * C), hs); // A = dV matrix
+        }
+
+        // B) Softmax backward: ds = (da - dot(a,da)) ⊙ a
+        // We already have da = datt_bth (accumulated above and potentially from
+        // previous passes). Compute dot = <a, da>, then ds in-place into
+        // dpreatt_bt[0..t].
+        float dot = 0.0F;
+        for (int i = 0; i < M; ++i)
+          dot += att_bth[i] * datt_bth[i];
+        for (int i = 0; i < M; ++i) {
+          float ds = (datt_bth[i] - dot) * att_bth[i];
+          dpreatt_bt[i] += ds; // accumulate
+        }
+
+        // C) s = (K q) * scale
+        // dq += scale * K^T ds
+        // dK += scale * ds q^T
+        // 1) dq: GEMV with K^T and vector ds (length M)
+        {
+          // dq += scale * K_{<=t}^T * ds
+          // Row-major GEMV with transposed matrix:
+          //   y = alpha * A^T * x + beta*y
+          // A is M x hs (rows=t2, cols=i)
+          cblas_sgemv(CblasRowMajor, CblasTrans, M, hs, scale,
+                      row_ptr(K0, 0, C), hs, // K_{<=t}
+                      dpreatt_bt, 1,         // x = ds
+                      1.0F, dq, 1);          // y = dq
+        }
+
+        // 2) dK += scale * ds q^T     (GER rank-1 update onto dK matrix M×hs)
+        {
+          cblas_sger(CblasRowMajor, M, hs, scale, dpreatt_bt,
+                     1,                       // x = ds (length M)
+                     q, 1,                    // y = q  (length hs)
+                     row_ptr(dK0, 0, C), hs); // A = dK matrix
+        }
+      }
+    }
+  }
+}
+
+inline float fast_tanhf(float x) {
+  return (2.F / (1.F + expf(-2.F * x))) - 1.F;
+}
+
+void gelu_forward(float* out, const float* inp, int N) {
+  const float scale = 0.7978845608028654F; // sqrt(2/pi)
+  const float beta = 0.044715F;
+#pragma omp simd
+  for (int i = 0; i < N; i++) {
+    float x = inp[i];
+    float cube = beta * x * x * x;
+    float tanh_arg = scale * (x + cube);
+    out[i] = 0.5F * x * (1.0F + fast_tanhf(tanh_arg));
+  }
+}
+
+void gelu_backward(float* dinp, const float* inp, const float* dout, int N) {
+  const float s = 0.7978845608028654F; // sqrt(2/pi)
+  const float b = 0.044715F;
+#pragma omp simd
+  for (int i = 0; i < N; ++i) {
+    float x = inp[i];
+    float x2 = x * x;
+    float u = s * (x + b * x2 * x);
+    float t = fast_tanhf(u);               // tanh(u)
+    float dt = 1.0F - (t * t);             // sech^2(u) but via tanh
+    float du = s * (1.0F + 3.0F * b * x2); // du/dx
+    float local_grad = (0.5F * (1.0F + t)) + (0.5F * x * dt * du);
+    dinp[i] += local_grad * dout[i];
+  }
+}
+
+void residual_forward(float* out, const float* inp1, const float* inp2, int N) {
+#pragma omp simd
+  for (int i = 0; i < N; i++)
+    out[i] = inp1[i] + inp2[i];
+}
+
+void residual_backward(float* dinp1, float* dinp2, const float* dout, int N) {
+#pragma omp simd
+  for (int i = 0; i < N; i++) {
+    dinp1[i] += dout[i];
+    dinp2[i] += dout[i];
+  }
+}
+
+void softmax_forward(float* probs, float* logits, int B, int T, int V, int Vp) {
+// output: probs are (B,T,Vp) of the probabilities (sums to 1.0 in each b,t
+// position) input: logits is (B,T,Vp) of the unnormalized log probabilities Vp
+// is the padded vocab size (for efficiency), V is the "real" vocab size
+// example: Vp is 50304 and V is 50257
+#pragma omp parallel for collapse(2)
+  for (int b = 0; b < B; b++) {
+    for (int t = 0; t < T; t++) {
+      // probs <- softmax(logits)
+      float* logits_bt = logits + (b * T * Vp) + (t * Vp);
+      float* probs_bt = probs + (b * T * Vp) + (t * Vp);
+
+      // maxval is only calculated and subtracted for numerical stability
+      float maxval = -10000.0F; // TODO something better
+      for (int i = 0; i < V; i++)
+        maxval = std::max(logits_bt[i], maxval);
+      float sum = 0.0F;
+      for (int i = 0; i < V; i++) {
+        probs_bt[i] = expf(logits_bt[i] - maxval);
+        sum += probs_bt[i];
+      }
+      // note we only loop to V, leaving the padded dimensions
+      for (int i = 0; i < V; i++)
+        probs_bt[i] /= sum;
+      // for extra super safety we may wish to include this too,
+      // forcing the probabilities here to be zero, but it shouldn't matter
+      for (int i = V; i < Vp; i++)
+        probs_bt[i] = 0.0F;
+    }
+  }
+}
+void softmax_backward(float* dlogits, float* dprobs, float* probs, int B, int T,
+                      int V, int Vp) {
+  // backwards through softmax
+  for (int b = 0; b < B; b++) {
+    for (int t = 0; t < T; t++) {
+      float* dlogits_bt = dlogits + (b * T * Vp) + (t * Vp);
+      float* dprobs_bt = dprobs + (b * T * Vp) + (t * Vp);
+      float* probs_bt = probs + (b * T * Vp) + (t * Vp);
+
+      // sum over all outputs. s = sum(dprobs[i] * probs[i])
+      float sum = 0.0F;
+      for (int i = 0; i < V; i++)
+        sum += dprobs_bt[i] * probs_bt[i];
+
+      // dlogits[i] = probs[i] * (dprobs[i] - sum)
+      for (int i = 0; i < V; i++)
+        dlogits_bt[i] += probs_bt[i] * (dprobs_bt[i] - sum);
+    }
+  }
+}
+
+void crossentropy_forward(float* losses, float* probs, const int* targets,
+                          int B, int T, int Vp) {
+  // output: losses is (B,T) of the individual losses at each position
+  // input: probs are (B,T,Vp) of the probabilities
+  // input: targets is (B,T) of integers giving the correct index in logits
+  for (int b = 0; b < B; b++) {
+    for (int t = 0; t < T; t++) {
+      // loss = -log(probs[target])
+      float* probs_bt = probs + (b * T * Vp) + (t * Vp);
+      int ix = targets[(b * T) + t];
+      losses[(b * T) + t] = -logf(probs_bt[ix]);
+    }
+  }
+}
+void crossentropy_backward(float* dprobs, const float* dlosses,
+                           const float* probs, const int* targets, int B, int T,
+                           int Vp) {
+  // backwards through crossentropy
+  for (int b = 0; b < B; b++) {
+    for (int t = 0; t < T; t++) {
+      float* dprobs_bt = dprobs + (b * T * Vp) + (t * Vp);
+      const float* probs_bt = probs + (b * T * Vp) + (t * Vp);
+      int ix = targets[(b * T) + t];
+      float dloss = dlosses[(b * T) + t];
+      // the gradient of cross-entropy loss w.r.t. the probabilities is:
+      // dL/dprobs[i] = -1/probs[i] for i=target, and 0 otherwise
+      // so we get this gradient, scaled by dloss
+      dprobs_bt[ix] += -dloss / probs_bt[ix];
+    }
+  }
+}
+
+namespace clad::custom_derivatives {
+void matmul_forward_pullback(float* out, const float* inp, const float* weight,
+                             const float* bias, int B, int T, int C, int OC,
+                             float* dout, float* dinp, float* dweight,
+                             float* dbias, int* dB, int* dT, int* dC,
+                             int* dOC) {
+  matmul_backward(dinp, dweight, dbias, dout, inp, weight, B, T, C, OC);
+}
+void encoder_forward_pullback(float* out, const int* inp, float* wte,
+                              float* wpe, int B, int T, int C, float* dout,
+                              float* dwte, float* dwpe, int* dB, int* dT,
+                              int* dC) {
+  encoder_backward(dwte, dwpe, dout, inp, B, T, C);
+}
+void layernorm_forward_pullback(float* out, float* mean, float* rstd,
+                                float* inp, const float* weight,
+                                const float* bias, int B, int T, int C,
+                                float* dout, float* dmean, float* drstd,
+                                float* dinp, float* dweight, float* dbias,
+                                int* dB, int* dT, int* dC) {
+  layernorm_backward(dinp, dweight, dbias, dout, inp, weight, mean, rstd, B, T,
+                     C);
+}
+void attention_forward_pullback(float* out, float* preatt, float* att,
+                                float* inp, int B, int T, int C, int NH,
+                                float* dout, float* dpreatt, float* datt,
+                                float* dinp, int* dB, int* dT, int* dC,
+                                int* dNH) {
+  attention_backward(dinp, dpreatt, datt, dout, inp, att, B, T, C, NH);
+}
+void residual_forward_pullback(float* out, const float* inp1, const float* inp2,
+                               int N, float* dout, float* dinp1, float* dinp2,
+                               int* dN) {
+  residual_backward(dinp1, dinp2, dout, N);
+}
+void softmax_forward_pullback(float* probs, float* logits, int B, int T, int V,
+                              int Vp, float* dprobs, float* dlogits, int* dB,
+                              int* dT, int* dV, int* dVp) {
+  softmax_backward(dlogits, dprobs, probs, B, T, V, Vp);
+}
+void crossentropy_forward_pullback(float* losses, float* probs,
+                                   const int* targets, int B, int T, int Vp,
+                                   float* dlosses, float* dprobs, int* dB,
+                                   int* dT, int* dVp) {
+  crossentropy_backward(dprobs, dlosses, probs, targets, B, T, Vp);
+}
+void gelu_forward_pullback(float* out, const float* inp, int N, float* dout,
+                           float* dinp, int* dN) {
+  gelu_backward(dinp, inp, dout, N);
+}
+// For matmul_forward_pullback
+void matmul_forward_reverse_forw(float* out, const float* inp,
+                                 const float* weight, const float* bias, int B,
+                                 int T, int C, int OC, float* d_out,
+                                 const float* d_inp, const float* d_weight,
+                                 const float* d_bias, int d_B, int d_T, int d_C,
+                                 int d_OC) {}
+
+// For encoder_forward_pullback
+void encoder_forward_reverse_forw(float* out, const int* inp, float* wte,
+                                  float* wpe, int B, int T, int C, float* d_out,
+                                  const int* d_inp, float* d_wte, float* d_wpe,
+                                  int d_B, int d_T, int d_C) {}
+
+// For layernorm_forward_pullback
+void layernorm_forward_reverse_forw(float* out, float* mean, float* rstd,
+                                    float* inp, const float* weight,
+                                    const float* bias, int B, int T, int C,
+                                    float* d_out, float* d_mean, float* d_rstd,
+                                    float* d_inp, const float* d_weight,
+                                    const float* d_bias, int d_B, int d_T,
+                                    int d_C) {}
+
+// For attention_forward_pullback
+void attention_forward_reverse_forw(float* out, float* preatt, float* att,
+                                    float* inp, int B, int T, int C, int NH,
+                                    float* d_out, float* d_preatt, float* d_att,
+                                    float* d_inp, int d_B, int d_T, int d_C,
+                                    int d_NH) {}
+
+// For residual_forward_pullback
+void residual_forward_reverse_forw(float* out, const float* inp1,
+                                   const float* inp2, int N, float* d_out,
+                                   const float* d_inp1, const float* d_inp2,
+                                   int d_N) {}
+
+// For softmax_forward_pullback
+void softmax_forward_reverse_forw(float* probs, float* logits, int B, int T,
+                                  int V, int Vp, float* d_probs,
+                                  float* d_logits, int d_B, int d_T, int d_V,
+                                  int d_Vp) {}
+
+// For crossentropy_forward_pullback
+void crossentropy_forward_reverse_forw(float* losses, float* probs,
+                                       const int* targets, int B, int T, int Vp,
+                                       float* d_losses, float* d_probs,
+                                       const int* d_targets, int d_B, int d_T,
+                                       int d_Vp) {}
+
+// For gelu_forward_pullback
+void gelu_forward_reverse_forw(float* out, const float* inp, int N,
+                               float* d_out, const float* d_inp, int d_N) {}
+} // namespace clad::custom_derivatives
+
+// ----------------------------------------------------------------------------
+// GPT-2 model definition
+
+struct GPT2Config {
+  int max_seq_len;       // max sequence length, e.g. 1024
+  int vocab_size;        // vocab size, e.g. 50257
+  int padded_vocab_size; // padded to e.g. %128==0, 50304
+  int num_layers;        // number of layers, e.g. 12
+  int num_heads;         // number of heads in attention, e.g. 12
+  int channels;          // number of channels, e.g. 768
+  GPT2Config() = default;
+  GPT2Config(const char* checkpoint_path) {
+    // read in model from a checkpoint file
+    // gpt2::utils::fread_check(void *ptr, size_t size, size_t nmemb, FILE
+    // *stream)
+    FILE* model_file = gpt2::utils::fopen_check(checkpoint_path, /*mode=*/"rb");
+    int model_header[256];
+    gpt2::utils::fread_check(model_header, sizeof(int), /*nmemb=*/256,
+                             model_file);
+    fclose(model_file); // NOLINT
+    if (model_header[0] != 20240326) {
+      std::cerr << "Bad magic model file\n";
+      exit(1);
+    }
+    if (model_header[1] != 3) {
+      std::cerr << "Bad version in model file\n";
+      std::cerr << "---> HINT: try to re-run `python train_gpt2.py`\n";
+      exit(1);
+    }
+    // read in hyperparameters
+    max_seq_len = model_header[2];
+    vocab_size = model_header[3];
+    num_layers = model_header[4];
+    num_heads = model_header[5];
+    channels = model_header[6];
+    padded_vocab_size = model_header[7];
+  }
+};
+
+// the parameters of the model
+struct ParameterTensors {
+  static constexpr size_t NUM_PARAMETER_TENSORS = 16;
+  float* wte;      // (V, C)
+  float* wpe;      // (maxT, C)
+  float* ln1w;     // (L, C)
+  float* ln1b;     // (L, C)
+  float* qkvw;     // (L, 3*C, C)
+  float* qkvb;     // (L, 3*C)
+  float* attprojw; // (L, C, C)
+  float* attprojb; // (L, C)
+  float* ln2w;     // (L, C)
+  float* ln2b;     // (L, C)
+  float* fcw;      // (L, 4*C, C)
+  float* fcb;      // (L, 4*C)
+  float* fcprojw;  // (L, C, 4*C)
+  float* fcprojb;  // (L, C)
+  float* lnfw;     // (C)
+  float* lnfb;     // (C)
+
+  float* memory;
+  size_t sizes[NUM_PARAMETER_TENSORS];
+
+  // allocate memory for the parameters and point the individual tensors to the
+  // right places NOLINTNEXTLINE: the tensors are initialized in the inner loop
+  ParameterTensors(GPT2Config config) {
+    size_t Vp = config.padded_vocab_size;
+    size_t C = config.channels;
+    size_t maxT = config.max_seq_len;
+    size_t L = config.num_layers;
+    sizes[0] = Vp * C;           // wte
+    sizes[1] = maxT * C;         // wpe
+    sizes[2] = L * C;            // ln1w
+    sizes[3] = L * C;            // ln1b
+    sizes[4] = L * (3 * C) * C;  // qkvw
+    sizes[5] = L * (3 * C);      // qkvb
+    sizes[6] = L * C * C;        // attprojw
+    sizes[7] = L * C;            // attprojb
+    sizes[8] = L * C;            // ln2w
+    sizes[9] = L * C;            // ln2b
+    sizes[10] = L * (4 * C) * C; // fcw
+    sizes[11] = L * (4 * C);     // fcb
+    sizes[12] = L * C * (4 * C); // fcprojw
+    sizes[13] = L * C;           // fcprojb
+    sizes[14] = C;               // lnfw
+    sizes[15] = C;               // lnfb
+    size_t num_parameters = 0;
+    for (size_t size : sizes)
+      num_parameters += size;
+    // malloc all parameters all at once
+    memory = new float[num_parameters]; // NOLINT: allocates raw memory
+    // assign all the tensors
+    float** ptrs[] = {&wte,      &wpe,      &ln1w, &ln1b, &qkvw, &qkvb,
+                      &attprojw, &attprojb, &ln2w, &ln2b, &fcw,  &fcb,
+                      &fcprojw,  &fcprojb,  &lnfw, &lnfb};
+    float* params_memory_iterator = memory;
+    for (size_t i = 0; i < NUM_PARAMETER_TENSORS; i++) {
+      *(ptrs[i]) = params_memory_iterator;
+      params_memory_iterator += sizes[i];
+    }
+  }
+  ParameterTensors(const ParameterTensors&) = delete;
+  ParameterTensors& operator=(const ParameterTensors&) = delete;
+
+  ParameterTensors(ParameterTensors&& other) noexcept = delete;
+  ParameterTensors& operator=(ParameterTensors&& other) noexcept = delete;
+
+  ~ParameterTensors() { delete[] memory; }
+};
+
+// NOLINTNEXTLINE
+struct ActivationTensors {
+  static constexpr size_t NUM_ACTIVATION_TENSORS = 23;
+  float* encoded;   // (B, T, C)
+  float* ln1;       // (L, B, T, C)
+  float* ln1_mean;  // (L, B, T)
+  float* ln1_rstd;  // (L, B, T)
+  float* qkv;       // (L, B, T, 3*C)
+  float* atty;      // (L, B, T, C)
+  float* preatt;    // (L, B, NH, T, T)
+  float* att;       // (L, B, NH, T, T)
+  float* attproj;   // (L, B, T, C)
+  float* residual2; // (L, B, T, C)
+  float* ln2;       // (L, B, T, C)
+  float* ln2_mean;  // (L, B, T)
+  float* ln2_rstd;  // (L, B, T)
+  float* fch;       // (L, B, T, 4*C)
+  float* fch_gelu;  // (L, B, T, 4*C)
+  float* fcproj;    // (L, B, T, C)
+  float* residual3; // (L, B, T, C)
+  float* lnf;       // (B, T, C)
+  float* lnf_mean;  // (B, T)
+  float* lnf_rstd;  // (B, T)
+  float* logits;    // (B, T, V)
+  float* probs;     // (B, T, V)
+  float* losses;    // (B, T)
+
+  float* memory = nullptr;
+  size_t sizes[NUM_ACTIVATION_TENSORS];
+  void fill_in_activation_sizes(GPT2Config config, int B, int T) {
+    size_t C = config.channels;
+    size_t NH = config.num_heads;
+    size_t L = config.num_layers;
+    size_t Vp = config.padded_vocab_size;
+    sizes[0] = B * T * C;          // encoded
+    sizes[1] = L * B * T * C;      // ln1
+    sizes[2] = L * B * T;          // ln1_mean
+    sizes[3] = L * B * T;          // ln1_rstd
+    sizes[4] = L * B * T * 3 * C;  // qkv
+    sizes[5] = L * B * T * C;      // atty
+    sizes[6] = L * B * NH * T * T; // preatt
+    sizes[7] = L * B * NH * T * T; // att
+    sizes[8] = L * B * T * C;      // attproj
+    sizes[9] = L * B * T * C;      // residual2
+    sizes[10] = L * B * T * C;     // ln2
+    sizes[11] = L * B * T;         // ln2_mean
+    sizes[12] = L * B * T;         // ln2_rstd
+    sizes[13] = L * B * T * 4 * C; // fch
+    sizes[14] = L * B * T * 4 * C; // fch_gelu
+    sizes[15] = L * B * T * C;     // fcproj
+    sizes[16] = L * B * T * C;     // residual3
+    sizes[17] = B * T * C;         // lnf
+    sizes[18] = B * T;             // lnf_mean
+    sizes[19] = B * T;             // lnf_rstd
+    sizes[20] = B * T * Vp;        // logits
+    sizes[21] = B * T * Vp;        // probs
+    sizes[22] = B * T;             // losses
+    size_t num_activations = 0;
+    for (size_t size : sizes)
+      num_activations += size;
+    memory = new float[num_activations]; // NOLINT: allocates raw memory
+    float** ptrs[] = {&encoded, &ln1,       &ln1_mean, &ln1_rstd, &qkv,
+                      &atty,    &preatt,    &att,      &attproj,  &residual2,
+                      &ln2,     &ln2_mean,  &ln2_rstd, &fch,      &fch_gelu,
+                      &fcproj,  &residual3, &lnf,      &lnf_mean, &lnf_rstd,
+                      &logits,  &probs,     &losses};
+    float* acts_memory_iterator = memory;
+    for (size_t i = 0; i < NUM_ACTIVATION_TENSORS; i++) {
+      *(ptrs[i]) = acts_memory_iterator;
+      acts_memory_iterator += sizes[i];
+    }
+  }
+  ActivationTensors() = default; // NOLINT
+  ActivationTensors(const ActivationTensors&) = delete;
+  ActivationTensors& operator=(const ActivationTensors&) = delete;
+
+  ActivationTensors(ActivationTensors&& other) noexcept = delete;
+  ActivationTensors& operator=(ActivationTensors&& other) noexcept = delete;
+
+  ~ActivationTensors() { delete[] memory; }
+};
+
+struct GPT2 {
+  GPT2Config config;
+  // the weights (parameters) of the model, and their sizes
+  ParameterTensors params;
+  size_t num_parameters;
+  // buffers for the AdamW optimizer
+  // float* m_memory;
+  // float* v_memory;
+  // the activations of the model, and their sizes
+  ActivationTensors acts;
+  size_t num_activations;
+  // other run state configuration
+  int batch_size;  // the batch size (B) of current forward pass
+  int seq_len;     // the sequence length (T) of current forward pass
+  float mean_loss; // after a forward pass with targets, will be populated with
+                   // the mean loss
+
+  GPT2(const char* checkpoint_path)
+      : config(checkpoint_path), params(config), num_parameters(0),
+        num_activations(0), batch_size(0), seq_len(0), mean_loss(-1.0F) {
+    FILE* model_file = gpt2::utils::fopen_check(checkpoint_path, /*mode=*/"rb");
+    int model_header[256];
+    gpt2::utils::fread_check(model_header, sizeof(int), /*nmemb=*/256,
+                             model_file);
+    // count the number of parameters
+    for (size_t size : this->params.sizes)
+      num_parameters += size;
+    // read in all the parameters from file
+    gpt2::utils::fread_check(this->params.memory, sizeof(float), num_parameters,
+                             model_file);
+    fclose(model_file); // NOLINT
+  }
+
+  // -1.0F will designate no loss
+  GPT2(GPT2Config config)
+      : config(config), params(config), num_parameters(0), num_activations(0),
+        batch_size(0), seq_len(0), mean_loss(-1.0F) {
+    // count the number of parameters
+    for (size_t size : this->params.sizes)
+      num_parameters += size;
+  }
+
+  void allocate(int B, int T) {
+    if (acts.memory)
+      return;
+    // record the current B,T as well
+    batch_size = B;
+    seq_len = T;
+    // and now allocate the space
+    acts.fill_in_activation_sizes(config, B, T);
+    num_activations = 0;
+    for (unsigned long size : acts.sizes)
+      num_activations += size;
+  }
+
+  void zero_all() {
+    mean_loss = 0;
+    std::fill_n(params.memory, num_parameters, 0.0F);
+    if (acts.memory)
+      std::fill_n(acts.memory, num_activations, 0.0F);
+  }
+  // NOLINTNEXTLINE: not const because it modifies the object
+  void update(const GPT2* d_model, const float lr) {
+#pragma omp simd
+    for (size_t i = 0; i < num_parameters; i++)
+      params.memory[i] -= lr * d_model->params.memory[i];
+  }
+
+  void forward(const int* inputs, const int* targets) {
+    int V = config.vocab_size;
+    int Vp = config.padded_vocab_size;
+    int L = config.num_layers;
+    int NH = config.num_heads;
+    int C = config.channels;
+    int B = batch_size;
+    int T = seq_len;
+
+    // validate inputs, all indices must be in the range [0, V)
+    // for (int i = 0; i < B * T; i++) {
+    //   assert(0 <= inputs[i] && inputs[i] < V);
+    //   if (targets != nullptr)
+    //     assert(0 <= targets[i] && targets[i] < V);
+    // }
+
+    // forward pass
+    float* residual = acts.encoded;
+    encoder_forward(acts.encoded, inputs, params.wte, params.wpe, B, T,
+                    C); // encoding goes into residual[0]
+    for (int l = 0; l < L; l++) {
+      if (l > 0)
+        residual = acts.residual3 + (l - 1) * B * T * C;
+
+      // get the pointers of the weights for this layer
+      float* l_ln1w = params.ln1w + (l * C);
+      float* l_ln1b = params.ln1b + (l * C);
+      float* l_qkvw = params.qkvw + (l * 3 * C * C);
+      float* l_qkvb = params.qkvb + (l * 3 * C);
+      float* l_attprojw = params.attprojw + (l * C * C);
+      float* l_attprojb = params.attprojb + (l * C);
+      float* l_ln2w = params.ln2w + (l * C);
+      float* l_ln2b = params.ln2b + (l * C);
+      float* l_fcw = params.fcw + (l * 4 * C * C);
+      float* l_fcb = params.fcb + (l * 4 * C);
+      float* l_fcprojw = params.fcprojw + (l * C * 4 * C);
+      float* l_fcprojb = params.fcprojb + (l * C);
+
+      // get the pointers of the activations for this layer
+      float* l_ln1 = acts.ln1 + (l * B * T * C);
+      float* l_ln1_mean = acts.ln1_mean + (l * B * T);
+      float* l_ln1_rstd = acts.ln1_rstd + (l * B * T);
+      float* l_qkv = acts.qkv + (l * B * T * 3 * C);
+      float* l_atty = acts.atty + (l * B * T * C);
+      float* l_preatt = acts.preatt + (l * B * NH * T * T);
+      float* l_att = acts.att + (l * B * NH * T * T);
+      float* l_attproj = acts.attproj + (l * B * T * C);
+      float* l_residual2 = acts.residual2 + (l * B * T * C);
+      float* l_ln2 = acts.ln2 + (l * B * T * C);
+      float* l_ln2_mean = acts.ln2_mean + (l * B * T);
+      float* l_ln2_rstd = acts.ln2_rstd + (l * B * T);
+      float* l_fch = acts.fch + (l * B * T * 4 * C);
+      float* l_fch_gelu = acts.fch_gelu + (l * B * T * 4 * C);
+      float* l_fcproj = acts.fcproj + (l * B * T * C);
+      float* l_residual3 = acts.residual3 + (l * B * T * C);
+
+      // now do the forward pass
+      layernorm_forward(l_ln1, l_ln1_mean, l_ln1_rstd, residual, l_ln1w, l_ln1b,
+                        B, T, C);
+      matmul_forward(l_qkv, l_ln1, l_qkvw, l_qkvb, B, T, C, 3 * C);
+      attention_forward(l_atty, l_preatt, l_att, l_qkv, B, T, C, NH);
+      matmul_forward(l_attproj, l_atty, l_attprojw, l_attprojb, B, T, C, C);
+      residual_forward(l_residual2, residual, l_attproj, B * T * C);
+      layernorm_forward(l_ln2, l_ln2_mean, l_ln2_rstd, l_residual2, l_ln2w,
+                        l_ln2b, B, T, C);
+      matmul_forward(l_fch, l_ln2, l_fcw, l_fcb, B, T, C, 4 * C);
+      gelu_forward(l_fch_gelu, l_fch, B * T * 4 * C);
+      matmul_forward(l_fcproj, l_fch_gelu, l_fcprojw, l_fcprojb, B, T, 4 * C,
+                     C);
+      residual_forward(l_residual3, l_residual2, l_fcproj, B * T * C);
+    }
+    residual =
+        acts.residual3 + (L - 1) * B * T * C; // last residual is in residual3
+    layernorm_forward(acts.lnf, acts.lnf_mean, acts.lnf_rstd, residual,
+                      params.lnfw, params.lnfb, B, T, C);
+    matmul_forward(acts.logits, acts.lnf, params.wte, /*bias=*/nullptr, B, T, C,
+                   Vp);
+    softmax_forward(acts.probs, acts.logits, B, T, V, Vp);
+
+    // also forward the cross-entropy loss function if we have the targets
+    if (targets != nullptr) {
+      crossentropy_forward(acts.losses, acts.probs, targets, B, T, Vp);
+      // for convenience also evaluate the mean loss
+      mean_loss = 0.0F;
+      for (int i = 0; i < B * T; i++)
+        mean_loss += acts.losses[i];
+      mean_loss /= static_cast<float>(B * T);
+    } else {
+      // if we don't have targets, we don't have a loss
+      mean_loss = -1.0F;
+    }
+  }
+};
+
+// void gpt2_update(GPT2* model, float learning_rate, float beta1, float beta2,
+// float eps, float weight_decay, int t) {
+//   // reference:
+//   https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html
+
+//   // lazily allocate the memory for m_memory and v_memory
+//   if (model->m_memory == nullptr) {
+//     model->m_memory = (float*)calloc(model->num_parameters, sizeof(float));
+//     model->v_memory = (float*)calloc(model->num_parameters, sizeof(float));
+//   }
+
+//   for (size_t i = 0; i < model->num_parameters; i++) {
+//     float param = model->params.memory[i];
+//     float grad = model->grads_memory[i];
+
+//     // update the first moment (momentum)
+//     float m = beta1 * model->m_memory[i] + (1.0f - beta1) * grad;
+//     // update the second moment (RMSprop)
+//     float v = beta2 * model->v_memory[i] + (1.0f - beta2) * grad * grad;
+//     // bias-correct both moments
+//     float m_hat = m / (1.0f - powf(beta1, t));
+//     float v_hat = v / (1.0f - powf(beta2, t));
+
+//     // update
+//     model->m_memory[i] = m;
+//     model->v_memory[i] = v;
+//     model->params.memory[i] -= learning_rate * (m_hat / (std::sqrt(v_hat) +
+//     eps) + weight_decay * param);
+//   }
+// }
+
+// NOLINTEND(cppcoreguidelines-pro-bounds-*, *-avoid-c-arrays,
+// misc-definitions-in-headers)

--- a/demos/cladtorch/tokenizer.hpp
+++ b/demos/cladtorch/tokenizer.hpp
@@ -1,0 +1,131 @@
+#ifndef TOKENIZER_HPP
+#define TOKENIZER_HPP
+
+#include <cassert>
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// NOLINTBEGIN(modernize-use-nodiscard, clang-diagnostic-error)
+namespace gpt2 {
+
+class Tokenizer {
+private:
+  static constexpr uint32_t MAGIC_NUMBER = 20240328;
+  static constexpr int HEADER_SIZE = 256;
+
+  uint32_t m_VocabSize = 0;
+  int m_EotToken = 0;
+  std::vector<std::string> m_TokenTable;
+
+  void read_tokenizer_file(FILE* file) {
+    // Read header
+    uint32_t header[HEADER_SIZE]; // NOLINT
+    if (HEADER_SIZE !=
+        fread(header, sizeof(uint32_t), HEADER_SIZE, file)) // NOLINT
+      throw std::runtime_error("Failed to read tokenizer header");
+    if (header[0] != MAGIC_NUMBER)
+      throw std::runtime_error("Invalid magic number in tokenizer file");
+    auto version = header[1];
+    m_VocabSize = header[2];
+
+    if (version == 1) {
+      // Version 1 didn't include the EOT token id
+      // so we assume it is 50256, the EOT in GPT-2
+      if (m_VocabSize != 50257) {
+        throw std::runtime_error(
+            "Expected vocab_size 50257 for tokenizer version 1");
+      }
+      m_EotToken = 50256;
+    } else if (version == 2)
+      m_EotToken = static_cast<int>(header[3]);
+    else
+      throw std::runtime_error("Unsupported tokenizer version: " +
+                               std::to_string(version));
+
+    // Read all tokens
+    m_TokenTable.reserve(m_VocabSize);
+    for (uint32_t i = 0; i < m_VocabSize; ++i) {
+      unsigned char length = 0;
+      if (fread(&length, sizeof(unsigned char), 1, file) != 1)
+        throw std::runtime_error("Failed to read token length");
+      if (length == 0)
+        throw std::runtime_error("Invalid token length: 0");
+
+      std::string token(length, '\0');
+      if (fread(token.data(), sizeof(char), length, file) != length)
+        throw std::runtime_error("Failed to read token data");
+      m_TokenTable.emplace_back(std::move(token));
+    }
+  }
+
+public:
+  explicit Tokenizer(const std::string& filename) { load(filename); }
+  // Disable copy operations for simplicity
+  Tokenizer(const Tokenizer&) = delete;
+  Tokenizer& operator=(const Tokenizer&) = delete;
+
+  // Enable move operations
+  Tokenizer(Tokenizer&&) = default;
+  Tokenizer& operator=(Tokenizer&&) = default;
+  ~Tokenizer() = default;
+
+  void load(const std::string& filename) {
+    auto file = std::unique_ptr<FILE, decltype(&fclose)>(
+        fopen(filename.c_str(), "rb"), fclose);
+    if (!file) {
+      std::cerr << "---\n";
+      std::cerr << "WARNING: Failed to open the tokenizer file " << filename
+                << '\n';
+      std::cerr << "The Tokenizer is a new feature added April 14 2024.\n";
+      std::cerr << "Re-run `python train_gpt2.py` to write it\n";
+      std::cerr << "---\n";
+      throw std::runtime_error("Failed to open tokenizer file");
+    }
+    try {
+      read_tokenizer_file(file.get());
+      std::cerr << "Tokenizer loaded: " << m_VocabSize << " tokens from "
+                << filename << '\n';
+    } catch (const std::exception& e) {
+      std::cerr << "Error loading tokenizer: " << e.what() << '\n';
+      throw;
+    }
+  }
+
+  std::string decode(uint32_t token_id) const {
+    if (token_id >= m_VocabSize)
+      throw std::runtime_error("Invalid token id: " + std::to_string(token_id));
+    return m_TokenTable[token_id];
+  }
+
+  void safe_print(uint32_t token_id) const {
+    if (token_id >= m_VocabSize) {
+      std::cerr << "Invalid token id " << token_id << "!\n";
+      return;
+    }
+    const std::string& token = m_TokenTable[token_id];
+    if (token.empty())
+      return;
+    // Handle individual byte tokens
+    if (token.length() == 1) {
+      auto byte_val = static_cast<unsigned char>(token[0]);
+      if (!(std::isprint(byte_val) || std::isspace(byte_val)))
+        return; // weird byte, don't print it
+    }
+    std::cout << token;
+  }
+
+  // Getters
+  uint32_t vocab_size() const { return m_VocabSize; }
+  int eot_token() const { return m_EotToken; }
+};
+
+} // namespace gpt2
+// NOLINTEND(modernize-use-nodiscard, clang-diagnostic-error)
+
+#endif // TOKENIZER_HPP

--- a/demos/cladtorch/train_llm.cpp
+++ b/demos/cladtorch/train_llm.cpp
@@ -1,0 +1,148 @@
+#include "dataloader.hpp"
+#include "llm.hpp"
+#include "tokenizer.hpp"
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdint>
+#include <ctime>
+#include <iostream>
+#include <string>
+#include <time.h>
+
+using namespace gpt2;
+
+static uint32_t random_u32(uint64_t* state) {
+  // xorshift rng: https://en.wikipedia.org/wiki/Xorshift#xorshift.2A
+  *state ^= *state >> 12;
+  *state ^= *state << 25;
+  *state ^= *state >> 27;
+  return (*state * 0x2545F4914F6CDD1DULL) >> 32;
+}
+
+// random float32 in [0, 1)
+static float random_f32(uint64_t* state) {
+  return static_cast<float>(random_u32(state) >> 8) / 16777216.0F;
+}
+
+static int sample_mult(const float* probs, int n, float coin) {
+  // sample index from probs (they must sum to 1!)
+  // coin is a random number in [0, 1), usually from random_f32()
+  float cdf = 0.0F;
+  for (int i = 0; i < n; i++) {
+    cdf += probs[i]; // NOLINT
+    if (coin < cdf)
+      return i;
+  }
+  return n - 1; // in case of rounding errors
+}
+
+static float gpt2_loss(const GPT2& model, const ITensor& input,
+                       const ITensor& targets) {
+  auto probs = model.forward(input);
+  auto loss = cross_entropy_loss(probs, targets);
+  return loss.scalar();
+}
+
+int main() {
+  GPT2 model("gpt2_124M.bin");
+  const Config config = model.config;
+
+  int B = 4;
+  int T = 64;
+
+  Tokenizer tokenizer("gpt2_tokenizer.bin");
+
+  const std::string tiny_shakespeare_train =
+      "data/tinyshakespeare/tiny_shakespeare_train.bin";
+  const std::string tiny_shakespeare_val =
+      "data/tinyshakespeare/tiny_shakespeare_val.bin";
+  const std::string& train_token = tiny_shakespeare_train;
+  const std::string& val_token = tiny_shakespeare_val;
+  DataLoader train_loader(train_token, B, T, /*process_rank=*/0,
+                          /*num_processes=*/1, /*should_shuffle=*/true);
+  DataLoader val_loader(val_token, B, T, /*process_rank=*/0,
+                        /*num_processes=*/1, /*should_shuffle=*/false);
+
+  std::cout << "train dataset num_batches: "
+            << train_loader.num_tokens() / (B * T) << '\n';
+  std::cout << "val dataset num_batches: " << val_loader.num_tokens() / (B * T)
+            << '\n';
+  int val_num_batches = 5;
+
+  uint64_t rng_state = 1337;
+  const int gen_max_length = 64;
+
+  // Initialize with end-of-text token
+  ITensor gen_tokens({1, T}, tokenizer.eot_token());
+
+  GPT2 d_model(config);
+
+  auto grad = clad::gradient(gpt2_loss, "0");
+  grad.dump(); // Dump the gradient function for debugging
+
+  struct timespec start {};
+  struct timespec end {};
+  for (int step = 0; step <= 40; step++) {
+    // once in a while, estimate the validation loss
+    if (step % 10 == 0) {
+      float val_loss = 0.0F;
+      // Reset the validation loader to start from the beginning
+      val_loader.reset();
+      for (int i = 0; i < val_num_batches; i++) {
+        val_loader.next_batch();
+        const ITensor input = ITensor({B, T}, val_loader.inputs());
+        const ITensor targets = ITensor({B, T}, val_loader.targets());
+        val_loss += gpt2_loss(model, input, targets);
+      }
+      val_loss /= (float)val_num_batches;
+      std::cout << "val loss: " << val_loss << '\n';
+    }
+
+    // once in a while do model inference to print generated text
+    if (step > 0 && step % 20 == 0) {
+      gen_tokens.fill(tokenizer.eot_token());
+
+      std::cout << "generating:\n---\n";
+      for (int t = 1; t < gen_max_length; t++) {
+        auto probs_t = model.forward(gen_tokens);
+        float* probs = new float[config.padded_vocab_size]; // NOLINT
+        // Get probabilities for the first batch
+        for (int v = 0; v < config.padded_vocab_size; v++)
+          probs[v] = probs_t.at(0, t - 1, v); // NOLINT
+
+        float coin = random_f32(&rng_state);
+        int next_token = sample_mult(probs, model.config.vocab_size, coin);
+        gen_tokens.at(0, t) = next_token; // Use the first batch for generation
+        delete[] probs;                   // NOLINT
+
+        tokenizer.safe_print(next_token);
+        std::cout << std::flush;
+      }
+      std::cout << "\n---\n";
+    }
+
+    // Perform a training step
+    train_loader.next_batch();
+    const ITensor input = ITensor({B, T}, train_loader.inputs());
+    const ITensor targets = ITensor({B, T}, train_loader.targets());
+
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    auto mean_loss = gpt2_loss(model, input, targets);
+    d_model.for_each_parameter(
+        [&](FTensor* t) { t->fill(0); }); // Zero out gradients
+    grad.execute(model, input, targets, &d_model);
+    std::vector<FTensor*> params = model.get_parameter_tensors();
+    std::vector<FTensor*> grads = d_model.get_parameter_tensors();
+    for (size_t i = 0; i < params.size(); ++i) {
+      // Update parameters with a learning rate of 1e-4
+      *params[i] += (*grads[i]) * -1e-4F;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    double time_elapsed_s = (double)(end.tv_sec - start.tv_sec) +
+                            ((double)(end.tv_nsec - start.tv_nsec) / 1e9);
+    std::cout << "step " << step << " train Loss: " << mean_loss << " (took "
+              << time_elapsed_s * 1000 << " ms)" << '\n';
+  }
+}

--- a/demos/cladtorch/train_llm_opt.cpp
+++ b/demos/cladtorch/train_llm_opt.cpp
@@ -1,0 +1,160 @@
+/*
+This file trains the GPT-2 model.
+*/
+#include "llm_opt.hpp"
+#include "tokenizer.hpp"
+
+#include <ctime>
+
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-*, *-avoid-c-arrays)
+
+static uint32_t random_u32(uint64_t* state) {
+  // xorshift rng: https://en.wikipedia.org/wiki/Xorshift#xorshift.2A
+  *state ^= *state >> 12;
+  *state ^= *state << 25;
+  *state ^= *state >> 27;
+  return (*state * 0x2545F4914F6CDD1DULL) >> 32;
+}
+
+// random float32 in [0, 1)
+static float random_f32(uint64_t* state) {
+  return static_cast<float>(random_u32(state) >> 8) / 16777216.0F;
+}
+
+static int sample_mult(const float* probs, int n, float coin) {
+  // sample index from probs (they must sum to 1!)
+  // coin is a random number in [0, 1), usually from random_f32()
+  float cdf = 0.0F;
+  for (int i = 0; i < n; i++) {
+    cdf += probs[i]; // NOLINT
+    if (coin < cdf)
+      return i;
+  }
+  return n - 1; // in case of rounding errors
+}
+
+static float gpt2forw(GPT2* model, const int* inputs, const int* targets) {
+  model->forward(inputs, targets);
+  return model->mean_loss;
+}
+
+// ----------------------------------------------------------------------------
+// main training loop
+int main() {
+  // build the GPT-2 model from a checkpoint
+  GPT2 model(/*checkpoint_path=*/"gpt2_124M.bin");
+  GPT2 d_model(/*checkpoint_path=*/"gpt2_124M.bin");
+
+  std::cout << "[GPT-2]\n";
+  std::cout << "max_seq_len: " << model.config.max_seq_len << "\n";
+  std::cout << "vocab_size: " << model.config.vocab_size << "\n";
+  std::cout << "padded_vocab_size: " << model.config.padded_vocab_size << "\n";
+  std::cout << "num_layers: " << model.config.num_layers << "\n";
+  std::cout << "num_heads: " << model.config.num_heads << "\n";
+  std::cout << "channels: " << model.config.channels << "\n";
+  std::cout << "num_parameters: " << model.num_parameters << "\n";
+
+  // build the DataLoaders from tokens files. for now use tiny_shakespeare if
+  // available, else tiny_stories
+  std::string tiny_shakespeare_train =
+      "data/tinyshakespeare/tiny_shakespeare_train.bin";
+  std::string tiny_shakespeare_val =
+      "data/tinyshakespeare/tiny_shakespeare_val.bin";
+  const std::string& train_tokens = tiny_shakespeare_train;
+  const std::string& val_tokens = tiny_shakespeare_val;
+  // batch size 4 (i.e. 4 independent token sequences will be trained on)
+  int B = 4;
+  // sequence length 64 (i.e. each sequence is 64 tokens long). must be <= maxT,
+  // which is 1024 for GPT-2
+  int T = 64;
+  gpt2::DataLoader train_loader(train_tokens, B, T, /*process_rank=*/0,
+                                /*num_processes=*/1, /*should_shuffle=*/true);
+  gpt2::DataLoader val_loader(val_tokens, B, T, /*process_rank=*/0,
+                              /*num_processes=*/1, /*should_shuffle=*/false);
+
+  std::cout << "train dataset num_batches: "
+            << train_loader.num_tokens() / (B * T) << '\n';
+  std::cout << "val dataset num_batches: " << val_loader.num_tokens() / (B * T)
+            << '\n';
+  int val_num_batches = 5;
+
+  auto grad = clad::gradient(gpt2forw, "0");
+  grad.dump();
+  model.allocate(B, T);
+  d_model.allocate(B, T);
+  d_model.zero_all();
+
+  // build the Tokenizer
+  gpt2::Tokenizer tokenizer("gpt2_tokenizer.bin");
+
+  // some memory for generating samples from the model
+  uint64_t rng_state = 1337;
+  std::vector<int> gen_tokens(B * T);
+  const int genT = 64; // number of steps of inference we will do
+
+  // train
+  struct timespec start {};
+  struct timespec end {};
+  for (int step = 0; step <= 40; step++) {
+    // once in a while estimate the validation loss
+    if (step % 10 == 0) {
+      float val_loss = 0.0F;
+      val_loader.reset();
+      for (int i = 0; i < val_num_batches; i++) {
+        val_loader.next_batch();
+        model.forward(val_loader.inputs(), val_loader.targets());
+        val_loss += model.mean_loss;
+      }
+      val_loss /= static_cast<float>(val_num_batches);
+      std::cout << "val loss " << val_loss << "\n";
+    }
+
+    // once in a while do model inference to print generated text
+    if (step > 0 && step % 20 == 0) {
+      // fill up gen_tokens with the GPT2_EOT, which kicks off the generation
+      gen_tokens.assign(B * T, tokenizer.eot_token());
+      // now sample from the model autoregressively
+      std::cout << "generating:\n---\n";
+      for (int t = 1; t < genT; t++) {
+        // note that inference is very wasteful here because for each token
+        // we re-calculate the forward pass for all of (B,T) positions from
+        // scratch but the inference here is just for sanity checking anyway and
+        // we can maybe optimize a bit more later, with careful tests
+        model.forward(gen_tokens.data(), /*targets=*/nullptr);
+        // furthermore, below we're only using b=0 (i.e. the first row) of all B
+        // rows we're in principle running B "inference streams" in parallel
+        // here but only using position 0 get the Vp-dimensional vector
+        // probs[0,t-1,:]
+        float* probs =
+            model.acts.probs + ((t - 1) * model.config.padded_vocab_size);
+        float coin = random_f32(&rng_state);
+        // note we're only sampling from the first V elements, ignoring padding
+        // (the probabilities in the padded region should be zero anyway)
+        int next_token = sample_mult(probs, model.config.vocab_size, coin);
+        gen_tokens[t] = next_token;
+        // print the generated token, either using the Tokenizer or a fallback
+        tokenizer.safe_print(next_token);
+        fflush(stdout);
+      }
+      std::cout << "\n---\n";
+    }
+
+    // Perform a training step
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+    train_loader.next_batch();
+    d_model.zero_all();
+    grad.execute(&model, train_loader.inputs(), train_loader.targets(),
+                 &d_model);
+    model.update(&d_model, /*lr=*/1e-3F);
+
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    double time_elapsed_s =
+        static_cast<double>(end.tv_sec - start.tv_sec) +
+        (static_cast<double>(end.tv_nsec - start.tv_nsec) / 1e9);
+    std::cout << "step " << step << ": train loss " << model.mean_loss
+              << " (took " << time_elapsed_s * 1000 << " ms)\n";
+  }
+}
+
+// NOLINTEND(cppcoreguidelines-pro-bounds-*, *-avoid-c-arrays)

--- a/include/clad/Differentiator/CladtorchBuiltins.h
+++ b/include/clad/Differentiator/CladtorchBuiltins.h
@@ -1,0 +1,1299 @@
+#ifndef CLAD_DIFFERENTIATOR_CLADTORCHBUILTINS_H
+#define CLAD_DIFFERENTIATOR_CLADTORCHBUILTINS_H
+
+#include "clad/Differentiator/BuiltinDerivatives.h"
+
+#include "cladtorch/cladtorch.hpp"
+
+#include <vector>
+
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-*, *-avoid-c-arrays,
+// misc-definitions-in-headers, readability-identifier-naming)
+
+namespace clad {
+// specialize the zero_init function for Tensor
+template <typename T> void zero_init(::cladtorch::Tensor<T>& tensor) {
+  tensor.fill(0);
+}
+template <class T> void zero_init(::std::vector<::cladtorch::Tensor<T>>& p) {
+  for (auto& elem : p)
+    elem.fill(0);
+}
+
+namespace custom_derivatives {
+namespace cladtorch {
+inline ::clad::ValueAndPushforward<float, float>
+gelu_kernel_pushforward(float x, float d_x) {
+  const float d_sqrt_2_over_pi = 0.F;
+  const float sqrt_2_over_pi = 0.797884583F;
+  float t0 = 0.0447149985F * x;
+  float t1 = t0 * x;
+  float t2 = (x + (t1 * x));
+  ValueAndPushforward<float, float> t3 =
+      ::clad::custom_derivatives::std::tanh_pushforward(
+          sqrt_2_over_pi * t2,
+          (d_sqrt_2_over_pi * t2) +
+              (sqrt_2_over_pi *
+               (d_x + ((0.F * x + 0.0447149985F * d_x) * x + t0 * d_x) * x +
+                t1 * d_x)));
+  float t4 = 0.5F * x;
+  float t5 = (1.F + t3.value);
+  return {t4 * t5,
+          ((0.F * x + 0.5F * d_x) * t5) + (t4 * (0.F + t3.pushforward))};
+}
+void gelu_pullback(const ::cladtorch::Tensor<float>& in,
+                   ::cladtorch::Tensor<float> d_y,
+                   ::cladtorch::Tensor<float>* d_in) {
+  for (int i = 0; i < d_y.num_elements(); i++) {
+    float d_r_d0 = d_y.data()[i];
+    float r0 = 0.F;
+    r0 +=
+        d_r_d0 * gelu_kernel_pushforward(in.data()[i], /*d_x=*/1.F).pushforward;
+    (*d_in).data()[i] += r0;
+  }
+}
+// Matrix multiplication pullback
+template <typename T>
+void matmul_pullback(const ::cladtorch::Tensor<T>& a,
+                     const ::cladtorch::Tensor<T>& b,
+                     ::cladtorch::Tensor<T> _d_y, ::cladtorch::Tensor<T>* _d_a,
+                     ::cladtorch::Tensor<T>* _d_b) {
+  // For C = matmul(A, B), the gradients are:
+  // dA = matmul(dC, B^T)
+  // dB = matmul(A^T, dC)
+
+  // Handle different cases based on tensor dimensions
+  if (a.ndim() == 2 && b.ndim() == 2) {
+    // Case: 2D x 2D matrix multiplication
+    // A: (R, C1), B: (C1, C2), C: (R, C2)
+    // dA = matmul(dC, B^T) -> (R, C2) x (C2, C1) = (R, C1)
+    // dB = matmul(A^T, dC) -> (C1, R) x (R, C2) = (C1, C2)
+    auto b_transposed = b.transpose(0, 1);
+    auto a_transposed = a.transpose(0, 1);
+
+    auto grad_a = ::cladtorch::matmul(_d_y, b_transposed);
+    auto grad_b = ::cladtorch::matmul(a_transposed, _d_y);
+
+    *_d_a += grad_a;
+    *_d_b += grad_b;
+  } else if (a.ndim() == 3 && b.ndim() == 2) {
+    // Case: 3D x 2D batched matrix multiplication
+    // A: (B, T, C), B: (C, out_features), C: (B, T, out_features)
+    // dA = matmul(dC, B^T) -> (B, T, out_features) x (out_features, C) = (B, T,
+    // C) dB = matmul(A^T, dC) -> sum over batch of (C, T) x (T, out_features) =
+    // (C, out_features)
+
+    auto b_transposed = b.transpose(0, 1);
+    auto grad_a = ::cladtorch::matmul(_d_y, b_transposed);
+    *_d_a += grad_a;
+
+    // For dB, we need to sum contributions from all batch elements
+    // Reshape A from (B, T, C) to (B*T, C), then transpose to (C, B*T)
+    const int batch_size = a.size(0);
+    const int seq_len = a.size(1);
+    const int channels = a.size(2);
+    auto a_reshaped = a.reshape({batch_size * seq_len, channels});
+    auto a_reshaped_transposed = a_reshaped.transpose(0, 1);
+
+    // Reshape dC from (B, T, out_features) to (B*T, out_features)
+    auto dy_reshaped = _d_y.reshape({batch_size * seq_len, _d_y.size(2)});
+
+    auto grad_b = ::cladtorch::matmul(a_reshaped_transposed, dy_reshaped);
+    *_d_b += grad_b;
+  } else if (a.ndim() == 3 && b.ndim() == 3) {
+    // Case: 3D x 3D batched matrix multiplication
+    // A: (B, R, C1), B: (B, C1, C2), C: (B, R, C2)
+
+    int B = a.size(0);
+    for (int batch = 0; batch < B; ++batch) {
+      // Extract batch slices - this is a simplified approach
+      // In practice, you might want to implement batch-aware transpose and
+      // matmul For now, we'll handle this case similarly to 2D but for each
+      // batch
+
+      // This is a placeholder - a full implementation would need proper batch
+      // slicing For now, we'll use the same logic as 2D case
+      auto b_transposed = b.transpose(1, 2);
+      auto a_transposed = a.transpose(1, 2);
+
+      auto grad_a = ::cladtorch::matmul(_d_y, b_transposed);
+      auto grad_b = ::cladtorch::matmul(a_transposed, _d_y);
+
+      *_d_a += grad_a;
+      *_d_b += grad_b;
+    }
+  } else if (a.ndim() == 4 && b.ndim() == 4) {
+    // Case: 4D x 4D multi-head attention matmul
+    // A: (B, H, T1, d), B: (B, H, d, T2), C: (B, H, T1, T2)
+
+    // For 4D case, handle batch and head dimensions
+
+    // For each batch and head, compute gradients
+    // This is a simplified approach - a full implementation would be more
+    // efficient
+    auto b_transposed = b.transpose(2, 3); // Transpose last two dimensions
+    auto a_transposed = a.transpose(2, 3); // Transpose last two dimensions
+
+    auto grad_a = ::cladtorch::matmul(_d_y, b_transposed);
+    auto grad_b = ::cladtorch::matmul(a_transposed, _d_y);
+
+    *_d_a += grad_a;
+    *_d_b += grad_b;
+  } else if (a.ndim() == 2 && b.ndim() == 1) {
+    // Case: 2D x 1D matrix-vector multiplication
+    // A: (R, C), B: (C,), C: (R,)
+    // dA = outer_product(dC, B) -> (R,) outer (C,) = (R, C)
+    // dB = matmul(A^T, dC) -> (C, R) x (R,) = (C,)
+
+    // For dA: outer product of _d_y and b
+    auto grad_a = ::cladtorch::Tensor<T>({a.size(0), a.size(1)});
+    for (int r = 0; r < a.size(0); ++r)
+      for (int c = 0; c < a.size(1); ++c)
+        grad_a.at(r, c) = _d_y.at(r) * b.at(c);
+    *_d_a += grad_a;
+
+    // For dB: A^T * _d_y
+    auto a_transposed = a.transpose(0, 1);
+    auto grad_b = ::cladtorch::matmul(a_transposed, _d_y);
+    *_d_b += grad_b;
+  } else {
+    // Unsupported case - should not happen if matmul worked
+    assert(false && "Unsupported tensor dimensions for matmul pullback");
+  }
+}
+
+// Softmax pullback
+template <typename T>
+void softmax_pullback(const ::cladtorch::Tensor<T>& input, bool is_casual,
+                      int vocab_size, ::cladtorch::Tensor<T> _d_y,
+                      ::cladtorch::Tensor<T>* _d_input, bool* _d_is_casual,
+                      int* _d_vocab_size) {
+  // For softmax, if y = softmax(x), then:
+  // dy/dx_i = y_i * (delta_ij - y_j) where delta_ij is Kronecker delta
+  // This can be written as: dy/dx = y * (grad_y - sum(grad_y * y))
+
+  auto softmax_output = ::cladtorch::softmax(input, is_casual, vocab_size);
+
+  // Compute sum(grad_y * y) along the last dimension
+  int last_dim = input.shape().back();
+  int num_vectors = input.num_elements() / last_dim;
+
+  for (int vec = 0; vec < num_vectors; ++vec) {
+    T sum_grad_y_times_y = 0;
+
+    // Calculate the sum for this vector
+    for (int i = 0; i < last_dim; ++i) {
+      int idx = (vec * last_dim) + i;
+      sum_grad_y_times_y += _d_y.data()[idx] * softmax_output.data()[idx];
+    }
+
+    // Compute gradient for each element in this vector
+    for (int i = 0; i < last_dim; ++i) {
+      int idx = (vec * last_dim) + i;
+      T grad =
+          softmax_output.data()[idx] * (_d_y.data()[idx] - sum_grad_y_times_y);
+      _d_input->data()[idx] += grad;
+    }
+  }
+
+  // Gradients for bool and int parameters are typically zero for softmax
+  // *_d_is_casual remains unchanged (no contribution)
+  // *_d_vocab_size remains unchanged (no contribution)
+}
+
+template <typename T, typename U>
+void cross_entropy_loss_pullback(const ::cladtorch::Tensor<T>& probs,
+                                 const ::cladtorch::Tensor<U>& targets,
+                                 ::cladtorch::Tensor<T> _d_y,
+                                 ::cladtorch::Tensor<T>* _d_probs,
+                                 ::cladtorch::Tensor<U>* _d_targets) {
+  // For cross entropy loss L = -log(p_target), the gradient is:
+  // dL/dp_i = -1/p_target if i == target, 0 otherwise
+  // But since we typically use softmax + cross entropy, the combined gradient
+  // is: dL/dx_i = p_i - 1 if i == target, p_i otherwise However, here we only
+  // have probs, so: dL/dp_i = -1/p_target if i == target
+
+  int num_classes = probs.size(probs.ndim() - 1);
+  int batch_size = probs.num_elements() / num_classes;
+
+  // _d_y is a scalar (the loss), so we need to broadcast its gradient
+  T loss_grad = _d_y.scalar();              // Extract scalar value
+  T avg_loss_grad = loss_grad / batch_size; // Since we return mean loss
+
+  for (int batch = 0; batch < batch_size; ++batch) {
+    int target = targets.data()[batch];
+    for (int cls = 0; cls < num_classes; ++cls) {
+      int idx = (batch * num_classes) + cls;
+      if (cls == target) {
+        // Gradient is -1/p_target for the target class
+        T prob_val = probs.data()[idx];
+        _d_probs->data()[idx] += avg_loss_grad * (-1.0F / prob_val);
+      }
+      // Gradient is 0 for non-target classes (no addition needed)
+    }
+  }
+  // Targets don't have gradients in typical scenarios
+  // *_d_targets remains unchanged
+}
+
+// Cross entropy loss pullback for single instance version
+template <typename T>
+void cross_entropy_loss_pullback(const ::cladtorch::Tensor<T>& probs,
+                                 int target_class, ::cladtorch::Tensor<T> _d_y,
+                                 ::cladtorch::Tensor<T>* _d_probs,
+                                 int* _d_target_class) {
+  // For single instance cross entropy loss
+  CLAD_ASSERT(probs.ndim() == 1,
+              "Probs tensor must be 1D for single cross entropy loss.");
+  int num_classes = probs.num_elements();
+
+  T loss_grad = _d_y.scalar(); // Extract scalar value
+
+  for (int cls = 0; cls < num_classes; ++cls) {
+    if (cls == target_class) {
+      // Gradient is -1/p_target for the target class
+      T prob_val = probs.data()[cls];
+      _d_probs->data()[cls] += loss_grad * (-1.0F / prob_val);
+    }
+    // Gradient is 0 for non-target classes (no addition needed)
+  }
+  // Target class doesn't have gradients in typical scenarios
+  // *_d_target_class remains unchanged
+}
+
+// Linear kernel pullbacks
+namespace kernels {
+
+// Linear kernel naive pullback
+void linear_kernel_naive_pullback(const float* input, const float* weight,
+                                  const float* bias, float* output,
+                                  size_t batch_seq, size_t in_features,
+                                  size_t out_features, const float* d_output,
+                                  float* d_input, float* d_weight,
+                                  float* d_bias) {
+  // For linear: output = input @ weight.T + bias
+  // Gradients are:
+  // d_input[i, k] = sum_j(d_output[i, j] * weight[j, k])
+  // d_weight[j, k] = sum_i(d_output[i, j] * input[i, k])
+  // d_bias[j] = sum_i(d_output[i, j])
+
+#pragma omp parallel for
+  for (size_t i = 0; i < batch_seq; ++i) {
+    for (size_t k = 0; k < in_features; ++k) {
+      float grad_input = 0.0F;
+      for (size_t j = 0; j < out_features; ++j)
+        grad_input +=
+            d_output[(i * out_features) + j] * weight[(j * in_features) + k];
+      d_input[(i * in_features) + k] += grad_input;
+    }
+  }
+
+#pragma omp parallel for
+  for (size_t j = 0; j < out_features; ++j) {
+    float grad_bias = 0.0F;
+    for (size_t i = 0; i < batch_seq; ++i)
+      grad_bias += d_output[(i * out_features) + j];
+    d_bias[j] += grad_bias;
+
+    for (size_t k = 0; k < in_features; ++k) {
+      float grad_weight = 0.0F;
+      for (size_t i = 0; i < batch_seq; ++i)
+        grad_weight +=
+            d_output[(i * out_features) + j] * input[(i * in_features) + k];
+      d_weight[(j * in_features) + k] += grad_weight;
+    }
+  }
+}
+constexpr int UNROLL = 8;
+
+/*  Pull-back for y = x Wᵀ + b
+ *
+ *  input   : [batch_seq , in_features]   (row major)
+ *  weight  : [out_feat  , in_features]   (row major)
+ *  d_output: [batch_seq , out_features]  (row major)
+ *
+ *  All gradient buffers are assumed to be zero-initialised by the caller.
+ *  Thread-safe: every parallel section writes to a disjoint slice.
+ */
+inline void linear_kernel_unrolled_pullback(
+    const float* input, const float* weight, const float* /*bias*/,
+    float* /*output*/, // not needed here
+    size_t batch_seq, size_t in_features, size_t out_features,
+    const float* d_output, float* d_input, float* d_weight, float* d_bias) {
+// ---------- 1. d_input = d_output · W  -----------------------------------
+#pragma omp parallel for schedule(static)
+  for (size_t i0 = 0; i0 < batch_seq; i0 += UNROLL) {
+    for (size_t k = 0; k < in_features; ++k) {
+      float accum[UNROLL] = {0};
+
+      for (size_t j = 0; j < out_features; ++j) {
+        const float w_jk = weight[(j * in_features) + k]; // W[j,k]
+#pragma omp simd
+        for (int u = 0; u < UNROLL; ++u)
+          accum[u] += d_output[((i0 + u) * out_features) + j] * w_jk;
+      }
+
+#pragma omp simd
+      for (int u = 0; u < UNROLL; ++u)
+        d_input[((i0 + u) * in_features) + k] += accum[u];
+    }
+  }
+
+// ---------- 2. d_weight & d_bias  ----------------------------------------
+#pragma omp parallel for schedule(static)
+  for (size_t j = 0; j < out_features; ++j) {
+    ::std::vector<float> local_dw(in_features, 0.0F); // private to this thread
+    float local_db = 0.0F;
+
+    for (size_t i0 = 0; i0 < batch_seq; i0 += UNROLL) {
+      float dout_blk[UNROLL];
+
+#pragma omp simd
+      for (int u = 0; u < UNROLL; ++u) {
+        dout_blk[u] = d_output[((i0 + u) * out_features) + j];
+        local_db += dout_blk[u]; // bias grad
+      }
+
+      for (size_t k = 0; k < in_features; ++k) {
+        float acc = 0.0F;
+#pragma omp simd reduction(+ : acc)
+        for (int u = 0; u < UNROLL; ++u)
+          acc += dout_blk[u] * input[((i0 + u) * in_features) + k];
+        local_dw[k] += acc; // weight grad
+      }
+    }
+
+    // write-back – this thread is the *sole* owner of (j, :)
+    d_bias[j] += local_db;
+    for (size_t k = 0; k < in_features; ++k)
+      d_weight[(j * in_features) + k] += local_dw[k];
+  }
+}
+
+// Apple Accelerate optimized linear kernel pullback
+inline void linear_kernel_accelerate_pullback(
+    const float* input, const float* weight, const float* bias, float* output,
+    size_t batch_seq, size_t in_features, size_t out_features,
+    const float* d_output, float* d_input, float* d_weight, float* d_bias) {
+#ifdef __APPLE__
+  // For linear: output = input @ weight.T + bias
+  // Gradients are:
+  // d_input[i, k] = sum_j(d_output[i, j] * weight[j, k])  ->  d_input =
+  // d_output @ weight d_weight[j, k] = sum_i(d_output[i, j] * input[i, k])  ->
+  // d_weight = d_output.T @ input d_bias[j] = sum_i(d_output[i, j]) ->  sum
+  // over batch dimension
+
+  // 1. Compute d_input = d_output @ weight
+  // d_output: [batch_seq, out_features] (row major)
+  // weight:   [out_features, in_features] (row major)
+  // d_input:  [batch_seq, in_features] (row major)
+  //
+  // BLAS: C := α·A·B + β·C
+  // A = d_output, B = weight, C = d_input
+  cblas_sgemm(
+      /* order     */ CblasRowMajor,
+      /* transA    */ CblasNoTrans,
+      /* transB    */ CblasNoTrans,
+      /* M,N,K     */ (int)batch_seq, (int)in_features, (int)out_features,
+      /* α         */ 1.0F,
+      /* A, lda    */ d_output, (int)out_features,
+      /* B, ldb    */ weight, (int)in_features,
+      /* β, C, ldc */ 1.0F, d_input, (int)in_features);
+
+  // 2. Compute d_weight = d_output.T @ input
+  // d_output: [batch_seq, out_features] -> transpose to [out_features,
+  // batch_seq] input:    [batch_seq, in_features] d_weight: [out_features,
+  // in_features] (row major)
+  //
+  // BLAS: C := α·A^T·B + β·C
+  // A = d_output (transposed), B = input, C = d_weight
+  cblas_sgemm(
+      /* order     */ CblasRowMajor,
+      /* transA    */ CblasTrans,
+      /* transB    */ CblasNoTrans,
+      /* M,N,K     */ (int)out_features, (int)in_features, (int)batch_seq,
+      /* α         */ 1.0F,
+      /* A, lda    */ d_output, (int)out_features,
+      /* B, ldb    */ input, (int)in_features,
+      /* β, C, ldc */ 1.0F, d_weight, (int)in_features);
+
+  // 3. Compute d_bias = sum(d_output, dim=0)
+  // x = ones [batch_seq]
+  // y = d_bias [out_features]
+  // Simple loop is efficient for bias computation and avoids memory allocation
+  for (size_t j = 0; j < out_features; ++j) {
+    float grad_bias = 0.0F;
+    for (size_t i = 0; i < batch_seq; ++i)
+      grad_bias += d_output[(i * out_features) + j];
+    d_bias[j] += grad_bias;
+  }
+#else
+  // Fallback to unrolled implementation on non-Apple platforms
+  if (batch_seq % 8 == 0 && batch_seq >= 8)
+    linear_kernel_unrolled_pullback(input, weight, bias, output, batch_seq,
+                                    in_features, out_features, d_output,
+                                    d_input, d_weight, d_bias);
+  else
+    linear_kernel_naive_pullback(input, weight, bias, output, batch_seq,
+                                 in_features, out_features, d_output, d_input,
+                                 d_weight, d_bias);
+#endif
+}
+
+// Linear kernel pullback dispatcher
+void linear_kernel_pullback(const float* input, const float* weight,
+                            const float* bias, float* output, size_t batch_seq,
+                            size_t in_features, size_t out_features,
+                            const float* d_output, float* d_input,
+                            float* d_weight, float* d_bias) {
+#ifdef __APPLE__
+  // Use Apple Accelerate optimized version on macOS
+  linear_kernel_accelerate_pullback(input, weight, bias, output, batch_seq,
+                                    in_features, out_features, d_output,
+                                    d_input, d_weight, d_bias);
+#else
+  // Dispatch to unrolled or regular kernel based on batch_seq
+  if (batch_seq % 8 == 0 && batch_seq >= 8)
+    linear_kernel_unrolled_pullback(input, weight, bias, output, batch_seq,
+                                    in_features, out_features, d_output,
+                                    d_input, d_weight, d_bias);
+  else
+    linear_kernel_naive_pullback(input, weight, bias, output, batch_seq,
+                                 in_features, out_features, d_output, d_input,
+                                 d_weight, d_bias);
+#endif
+}
+
+} // namespace kernels
+
+// Linear function pullback
+template <typename T>
+void linear_pullback(const ::cladtorch::Tensor<T>& input,
+                     const ::cladtorch::Tensor<T>& weight,
+                     const ::cladtorch::Tensor<T>& bias,
+                     ::cladtorch::Tensor<T> _d_y,
+                     ::cladtorch::Tensor<T>* _d_input,
+                     ::cladtorch::Tensor<T>* _d_weight,
+                     ::cladtorch::Tensor<T>* _d_bias) {
+  static_assert(::std::is_same<T, float>::value,
+                "Linear pullback currently only supports float tensors");
+
+  // Extract dimensions (same as forward pass)
+  const auto& input_shape = input.shape();
+  const auto& weight_shape = weight.shape();
+  const auto& bias_shape = bias.shape();
+
+  const int in_features = input_shape[input.ndim() - 1];
+  const int out_features = weight_shape[0];
+  const int batch_seq = input.num_elements() / in_features;
+
+  // Call the kernel pullback
+  kernels::linear_kernel_pullback(
+      input.data(), weight.data(), bias.data(),
+      /*output=*/nullptr, // output not needed for pullback
+      static_cast<size_t>(batch_seq), static_cast<size_t>(in_features),
+      static_cast<size_t>(out_features), _d_y.data(), _d_input->data(),
+      _d_weight->data(), _d_bias->data());
+}
+
+// gelu_reverse_forw
+inline ::clad::ValueAndAdjoint<::cladtorch::Tensor<float>,
+                               ::cladtorch::Tensor<float>>
+gelu_reverse_forw(const ::cladtorch::Tensor<float>& in,
+                  const ::cladtorch::Tensor<float>& d_in) {
+  ::cladtorch::Tensor<float> result = ::cladtorch::gelu(in);
+  ::cladtorch::Tensor<float> d_result = ::cladtorch::Tensor<float>(in.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// matmul_reverse_forw
+template <typename T>
+::clad::ValueAndAdjoint<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+matmul_reverse_forw(const ::cladtorch::Tensor<T>& a,
+                    const ::cladtorch::Tensor<T>& b,
+                    const ::cladtorch::Tensor<T>& _d_a,
+                    const ::cladtorch::Tensor<T>& _d_b) {
+  ::cladtorch::Tensor<T> result = ::cladtorch::matmul(a, b);
+  ::cladtorch::Tensor<T> d_result = ::cladtorch::Tensor<T>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// softmax_reverse_forw
+template <typename T>
+::clad::ValueAndAdjoint<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+softmax_reverse_forw(const ::cladtorch::Tensor<T>& input, bool is_casual,
+                     int vocab_size, const ::cladtorch::Tensor<T>& _d_input,
+                     bool _d_is_casual, int _d_vocab_size) {
+  ::cladtorch::Tensor<T> result =
+      ::cladtorch::softmax(input, is_casual, vocab_size);
+  ::cladtorch::Tensor<T> d_result = ::cladtorch::Tensor<T>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// cross_entropy_loss_reverse_forw (batched version)
+template <typename T, typename U>
+::clad::ValueAndAdjoint<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+cross_entropy_loss_reverse_forw(const ::cladtorch::Tensor<T>& probs,
+                                const ::cladtorch::Tensor<U>& targets,
+                                const ::cladtorch::Tensor<T>& _d_probs,
+                                const ::cladtorch::Tensor<U>& _d_targets) {
+  ::cladtorch::Tensor<T> result =
+      ::cladtorch::cross_entropy_loss(probs, targets);
+  ::cladtorch::Tensor<T> d_result = ::cladtorch::Tensor<T>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// cross_entropy_loss_reverse_forw (single instance version)
+template <typename T>
+::clad::ValueAndAdjoint<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+cross_entropy_loss_reverse_forw(const ::cladtorch::Tensor<T>& probs,
+                                int target_class,
+                                const ::cladtorch::Tensor<T>& _d_probs,
+                                int _d_target_class) {
+  ::cladtorch::Tensor<T> result =
+      ::cladtorch::cross_entropy_loss(probs, target_class);
+  ::cladtorch::Tensor<T> d_result = ::cladtorch::Tensor<T>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// linear_reverse_forw
+template <typename T>
+::clad::ValueAndAdjoint<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+linear_reverse_forw(const ::cladtorch::Tensor<T>& input,
+                    const ::cladtorch::Tensor<T>& weight,
+                    const ::cladtorch::Tensor<T>& bias,
+                    const ::cladtorch::Tensor<T>& _d_input,
+                    const ::cladtorch::Tensor<T>& _d_weight,
+                    const ::cladtorch::Tensor<T>& _d_bias) {
+  ::cladtorch::Tensor<T> result = ::cladtorch::linear(input, weight, bias);
+  ::cladtorch::Tensor<T> d_result = ::cladtorch::Tensor<T>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+} // namespace cladtorch
+namespace class_functions {
+
+// scalar_reverse_forw
+template <typename T>
+::clad::ValueAndAdjoint<T, T>
+scalar_reverse_forw(const ::cladtorch::Tensor<T>* _this,
+                    const ::cladtorch::Tensor<T>* _d_this) {
+  T result = _this->scalar();
+  T d_result = 0;
+  return {result, d_result};
+}
+
+// operator_plus_equal_reverse_forw
+inline ::clad::ValueAndAdjoint<::cladtorch::Tensor<float>&,
+                               ::cladtorch::Tensor<float>&>
+operator_plus_equal_reverse_forw(::cladtorch::Tensor<float>* _this,
+                                 const ::cladtorch::Tensor<float>& other,
+                                 ::cladtorch::Tensor<float>* _d_this,
+                                 const ::cladtorch::Tensor<float>& _d_other) {
+  *_this += other;
+  return {*_this, *_d_this};
+}
+
+// operator_plus_reverse_forw
+inline ::clad::ValueAndAdjoint<::cladtorch::Tensor<float>,
+                               ::cladtorch::Tensor<float>>
+operator_plus_reverse_forw(const ::cladtorch::Tensor<float>* _this,
+                           const ::cladtorch::Tensor<float>& other,
+                           const ::cladtorch::Tensor<float>* _d_this,
+                           const ::cladtorch::Tensor<float>& _d_other) {
+  ::cladtorch::Tensor<float> result = *_this + other;
+  ::cladtorch::Tensor<float> d_result =
+      ::cladtorch::Tensor<float>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// operator_minus_equal_reverse_forw
+inline ::clad::ValueAndAdjoint<::cladtorch::Tensor<float>&,
+                               ::cladtorch::Tensor<float>&>
+operator_minus_equal_reverse_forw(::cladtorch::Tensor<float>* _this,
+                                  const ::cladtorch::Tensor<float>& other,
+                                  ::cladtorch::Tensor<float>* _d_this,
+                                  const ::cladtorch::Tensor<float>& _d_other) {
+  *_this -= other;
+  return {*_this, *_d_this};
+}
+
+// operator_minus_reverse_forw
+inline ::clad::ValueAndAdjoint<::cladtorch::Tensor<float>,
+                               ::cladtorch::Tensor<float>>
+operator_minus_reverse_forw(const ::cladtorch::Tensor<float>* _this,
+                            const ::cladtorch::Tensor<float>& other,
+                            const ::cladtorch::Tensor<float>* _d_this,
+                            const ::cladtorch::Tensor<float>& _d_other) {
+  ::cladtorch::Tensor<float> result = *_this - other;
+  ::cladtorch::Tensor<float> d_result =
+      ::cladtorch::Tensor<float>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// operator_star_equal_reverse_forw (tensor * tensor)
+inline ::clad::ValueAndAdjoint<::cladtorch::Tensor<float>&,
+                               ::cladtorch::Tensor<float>&>
+operator_star_equal_reverse_forw(::cladtorch::Tensor<float>* _this,
+                                 const ::cladtorch::Tensor<float>& other,
+                                 ::cladtorch::Tensor<float>* _d_this,
+                                 const ::cladtorch::Tensor<float>& _d_other) {
+  *_this *= other;
+  return {*_this, *_d_this};
+}
+
+// operator_star_reverse_forw (tensor * tensor)
+inline ::clad::ValueAndAdjoint<::cladtorch::Tensor<float>,
+                               ::cladtorch::Tensor<float>>
+operator_star_reverse_forw(const ::cladtorch::Tensor<float>* _this,
+                           const ::cladtorch::Tensor<float>& other,
+                           const ::cladtorch::Tensor<float>* _d_this,
+                           const ::cladtorch::Tensor<float>& _d_other) {
+  ::cladtorch::Tensor<float> result = *_this * other;
+  ::cladtorch::Tensor<float> d_result =
+      ::cladtorch::Tensor<float>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// operator_star_equal_reverse_forw (tensor * scalar)
+inline ::clad::ValueAndAdjoint<::cladtorch::Tensor<float>&,
+                               ::cladtorch::Tensor<float>&>
+operator_star_equal_reverse_forw(::cladtorch::Tensor<float>* _this,
+                                 float scalar,
+                                 ::cladtorch::Tensor<float>* _d_this,
+                                 float _d_scalar) {
+  *_this *= scalar;
+  return {*_this, *_d_this};
+}
+
+// operator_star_reverse_forw (tensor * scalar)
+inline ::clad::ValueAndAdjoint<::cladtorch::Tensor<float>,
+                               ::cladtorch::Tensor<float>>
+operator_star_reverse_forw(const ::cladtorch::Tensor<float>* _this,
+                           float scalar,
+                           const ::cladtorch::Tensor<float>* _d_this,
+                           float _d_scalar) {
+  ::cladtorch::Tensor<float> result = *_this * scalar;
+  ::cladtorch::Tensor<float> d_result =
+      ::cladtorch::Tensor<float>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// operator_divide_equal_reverse_forw
+inline ::clad::ValueAndAdjoint<::cladtorch::Tensor<float>&,
+                               ::cladtorch::Tensor<float>&>
+operator_divide_equal_reverse_forw(::cladtorch::Tensor<float>* _this,
+                                   float scalar,
+                                   ::cladtorch::Tensor<float>* _d_this,
+                                   float _d_scalar) {
+  *_this /= scalar;
+  return {*_this, *_d_this};
+}
+
+// operator_divide_reverse_forw
+inline ::clad::ValueAndAdjoint<::cladtorch::Tensor<float>,
+                               ::cladtorch::Tensor<float>>
+operator_divide_reverse_forw(const ::cladtorch::Tensor<float>* _this,
+                             float scalar,
+                             const ::cladtorch::Tensor<float>* _d_this,
+                             float _d_scalar) {
+  ::cladtorch::Tensor<float> result = *_this / scalar;
+  ::cladtorch::Tensor<float> d_result =
+      ::cladtorch::Tensor<float>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// transpose_reverse_forw
+template <typename T>
+::clad::ValueAndAdjoint<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+transpose_reverse_forw(const ::cladtorch::Tensor<T>* _this, int dim0, int dim1,
+                       const ::cladtorch::Tensor<T>* _d_this, int _d_dim0,
+                       int _d_dim1) {
+  ::cladtorch::Tensor<T> result = _this->transpose(dim0, dim1);
+  ::cladtorch::Tensor<T> d_result = ::cladtorch::Tensor<T>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// lookup_reverse_forw
+template <typename T, typename U>
+::clad::ValueAndAdjoint<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+lookup_reverse_forw(const ::cladtorch::Tensor<T>* _this,
+                    const ::cladtorch::Tensor<U>& indices,
+                    const ::cladtorch::Tensor<T>* _d_this,
+                    const ::cladtorch::Tensor<U>& _d_indices) {
+  ::cladtorch::Tensor<T> result = _this->lookup(indices);
+  ::cladtorch::Tensor<T> d_result = ::cladtorch::Tensor<T>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// reshape_reverse_forw
+template <typename T, typename U>
+::clad::ValueAndAdjoint<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+reshape_reverse_forw(const ::cladtorch::Tensor<T>* _this,
+                     const ::std::vector<U>& new_shape,
+                     const ::cladtorch::Tensor<T>* _d_this,
+                     const ::std::vector<U>& _d_new_shape) {
+  ::cladtorch::Tensor<T> result = _this->reshape(new_shape);
+  ::cladtorch::Tensor<T> d_result = ::cladtorch::Tensor<T>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// norm_reverse_forw
+template <typename T>
+::clad::ValueAndAdjoint<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+norm_reverse_forw(const ::cladtorch::Tensor<T>* _this,
+                  const ::cladtorch::Tensor<T>* _d_this) {
+  ::cladtorch::Tensor<T> result = _this->norm();
+  ::cladtorch::Tensor<T> d_result = ::cladtorch::Tensor<T>(result.shape());
+  d_result.fill(0);
+  return {result, d_result};
+}
+
+// split_reverse_forw
+template <typename T>
+::clad::ValueAndAdjoint<::std::vector<::cladtorch::Tensor<T>>,
+                        ::std::vector<::cladtorch::Tensor<T>>>
+split_reverse_forw(const ::cladtorch::Tensor<T>* _this, int size, int axis,
+                   const ::cladtorch::Tensor<T>* _d_this, int _d_size,
+                   int _d_axis) {
+  ::std::vector<::cladtorch::Tensor<T>> result = _this->split(size, axis);
+  ::std::vector<::cladtorch::Tensor<T>> d_result;
+  for (const auto& tensor : result) {
+    ::cladtorch::Tensor<T> d_tensor = ::cladtorch::Tensor<T>(tensor.shape());
+    d_tensor.fill(0);
+    d_result.push_back(d_tensor);
+  }
+  return {result, d_result};
+}
+
+template <typename T>
+void scalar_pullback(const ::cladtorch::Tensor<T>* _this, T _d_y,
+                     ::cladtorch::Tensor<T>* _d_this) {
+  _d_this->data()[0] += _d_y;
+}
+
+template <typename T>
+clad::ValueAndAdjoint<T*, T*>
+data_reverse_forw(::cladtorch::Tensor<T>* _this,
+                  ::cladtorch::Tensor<T>* _d_this) {
+  return {_this->data(), _d_this->data()};
+}
+
+template <typename T>
+void data_pullback(::cladtorch::Tensor<T>* _this,
+                   ::cladtorch::Tensor<T>* _d_this) {}
+
+void operator_plus_equal_pullback(::cladtorch::Tensor<float>* _this,
+                                  const ::cladtorch::Tensor<float>& other,
+                                  ::cladtorch::Tensor<float> _d_y,
+                                  ::cladtorch::Tensor<float>* _d_this,
+                                  ::cladtorch::Tensor<float>* _d_other) {
+  // For +=, _d_y flows to _d_this
+  *_d_this += _d_y;
+  *_d_other += _d_y;
+}
+
+void operator_plus_pullback(const ::cladtorch::Tensor<float>* _this,
+                            const ::cladtorch::Tensor<float>& other,
+                            ::cladtorch::Tensor<float> _d_y,
+                            ::cladtorch::Tensor<float>* _d_this,
+                            ::cladtorch::Tensor<float>* _d_other) {
+  // For +, gradient flows to both operands
+  *_d_this += _d_y;
+  if (_d_other->shape() == _d_y.shape()) {
+    *_d_other += _d_y;
+  } else {
+    // If shapes don't match, we assume _d_y is batched, and _d_other is not
+    CLAD_ASSERT(_d_other->ndim() == 1, "_d_other needs to be 1D");
+    CLAD_ASSERT(_d_y.size(_d_y.ndim() - 1) == _d_other->num_elements(),
+                "Shape mismatch in operator+ pullback: _d_y and _d_other must "
+                "have compatible shapes.");
+    int batch_size = _d_y.num_elements() / _d_other->num_elements();
+    int len = _d_other->num_elements();
+    for (int i = 0; i < batch_size; i++)
+      for (int j = 0; j < len; j++)
+        _d_other->data()[j] += _d_y.data()[(i * len) + j];
+    // *_d_other += _d_y; // Assuming _d_y can be broadcasted to both shapes
+  }
+}
+
+// Subtraction operators
+void operator_minus_equal_pullback(::cladtorch::Tensor<float>* _this,
+                                   const ::cladtorch::Tensor<float>& other,
+                                   ::cladtorch::Tensor<float> _d_y,
+                                   ::cladtorch::Tensor<float>* _d_this,
+                                   ::cladtorch::Tensor<float>* _d_other) {
+  // For -=, _d_y flows to _d_this
+  *_d_this += _d_y;
+  *_d_other -= _d_y; // Negate gradient for _d_other
+}
+
+void operator_minus_pullback(const ::cladtorch::Tensor<float>* _this,
+                             const ::cladtorch::Tensor<float>& other,
+                             ::cladtorch::Tensor<float> _d_y,
+                             ::cladtorch::Tensor<float>* _d_this,
+                             ::cladtorch::Tensor<float>* _d_other) {
+  // For -, gradient flows to first operand as-is
+  *_d_this += _d_y;
+  *_d_other -= _d_y; // Negate gradient for second operand
+}
+
+// Multiplication operators
+void operator_star_equal_pullback(::cladtorch::Tensor<float>* _this,
+                                  const ::cladtorch::Tensor<float>& other,
+                                  ::cladtorch::Tensor<float> _d_y,
+                                  ::cladtorch::Tensor<float>* _d_this,
+                                  ::cladtorch::Tensor<float>* _d_other) {
+  // For *=, d_this += d_y * other
+  auto grad_this = _d_y * other;
+  *_d_this += grad_this;
+  assert(0 && "Not implemented yet");
+  // For d_other, gradient is d_y * _this (before the operation)
+  // Note: we need the original value of _this before the *= operation
+  // This is a limitation - we'd need the original value stored
+  // For now, assuming _this still contains the result after *=
+  // auto current_this = *_this;
+  // auto original_this = current_this / other;  // Reconstruct original value
+  // auto grad_other = _d_y * original_this;
+  // *_d_other += grad_other;
+}
+
+void operator_star_pullback(const ::cladtorch::Tensor<float>* _this,
+                            const ::cladtorch::Tensor<float>& other,
+                            ::cladtorch::Tensor<float> _d_y,
+                            ::cladtorch::Tensor<float>* _d_this,
+                            ::cladtorch::Tensor<float>* _d_other) {
+  // For *, d_this += d_y * other
+  auto grad_this = _d_y * other;
+  *_d_this += grad_this;
+
+  // For d_other, gradient is d_y * _this
+  auto grad_other = _d_y * (*_this);
+  if (grad_other.shape() == _d_other->shape()) {
+    *_d_other += grad_other; // If shapes match, add directly
+  } else {
+    // If shapes don't match, we assume _d_y is batched, and _d_other is not
+    CLAD_ASSERT(_d_other->ndim() == 1, "_d_other needs to be 1D");
+    CLAD_ASSERT(_d_y.size(_d_y.ndim() - 1) == _d_other->num_elements(),
+                "Shape mismatch in operator* pullback: _d_y and _d_other must "
+                "have compatible shapes.");
+    int batch_size = _d_y.num_elements() / _d_other->num_elements();
+    int len = _d_other->num_elements();
+    for (int i = 0; i < batch_size; i++)
+      for (int j = 0; j < len; j++)
+        _d_other->data()[j] += grad_other.data()[(i * len) + j];
+  }
+}
+
+// Scalar multiplication operators
+void operator_star_equal_pullback(::cladtorch::Tensor<float>* _this,
+                                  float scalar, ::cladtorch::Tensor<float> _d_y,
+                                  ::cladtorch::Tensor<float>* _d_this,
+                                  float* _d_scalar) {
+  // For tensor *= scalar
+  auto grad_this = _d_y * scalar;
+  *_d_this += grad_this;
+
+  // For scalar gradient, sum all elements of (_d_y * original_this)
+  auto current_this = *_this;
+  auto original_this = current_this / scalar; // Reconstruct original value
+  auto grad_scalar_tensor = _d_y * original_this;
+
+  float grad_scalar_sum = 0;
+  for (int i = 0; i < grad_scalar_tensor.num_elements(); ++i)
+    grad_scalar_sum += grad_scalar_tensor.data()[i];
+  *_d_scalar += grad_scalar_sum;
+}
+
+void operator_star_pullback(const ::cladtorch::Tensor<float>* _this,
+                            float scalar, ::cladtorch::Tensor<float> _d_y,
+                            ::cladtorch::Tensor<float>* _d_this,
+                            float* _d_scalar) {
+  // For tensor * scalar
+  auto grad_this = _d_y * scalar;
+  *_d_this += grad_this;
+
+  // For scalar gradient, sum all elements of (_d_y * _this)
+  auto grad_scalar_tensor = _d_y * (*_this);
+
+  float grad_scalar_sum = 0;
+  for (int i = 0; i < grad_scalar_tensor.num_elements(); ++i)
+    grad_scalar_sum += grad_scalar_tensor.data()[i];
+  *_d_scalar += grad_scalar_sum;
+}
+
+// Division operators
+void operator_divide_equal_pullback(::cladtorch::Tensor<float>* _this,
+                                    float scalar,
+                                    ::cladtorch::Tensor<float> _d_y,
+                                    ::cladtorch::Tensor<float>* _d_this,
+                                    float* _d_scalar) {
+  // For tensor /= scalar
+  auto grad_this = _d_y / scalar;
+  *_d_this += grad_this;
+
+  // For scalar gradient: d_scalar = -sum(_d_y * original_this) / (scalar^2)
+  auto current_this = *_this;
+  auto original_this = current_this * scalar; // Reconstruct original value
+  auto grad_scalar_tensor = _d_y * original_this;
+
+  float grad_scalar_sum = 0;
+  for (int i = 0; i < grad_scalar_tensor.num_elements(); ++i)
+    grad_scalar_sum += grad_scalar_tensor.data()[i];
+  *_d_scalar += -grad_scalar_sum / (scalar * scalar);
+}
+
+void operator_divide_pullback(const ::cladtorch::Tensor<float>* _this,
+                              float scalar, ::cladtorch::Tensor<float> _d_y,
+                              ::cladtorch::Tensor<float>* _d_this,
+                              float* _d_scalar) {
+  // For tensor / scalar
+  auto grad_this = _d_y / scalar;
+  *_d_this += grad_this;
+
+  // For scalar gradient: d_scalar = -sum(_d_y * _this) / (scalar^2)
+  auto grad_scalar_tensor = _d_y * (*_this);
+
+  float grad_scalar_sum = 0;
+  for (int i = 0; i < grad_scalar_tensor.num_elements(); ++i)
+    grad_scalar_sum += grad_scalar_tensor.data()[i];
+  *_d_scalar += -grad_scalar_sum / (scalar * scalar);
+}
+
+template <typename T>
+::clad::ValueAndPushforward<::cladtorch::Tensor<T>&, ::cladtorch::Tensor<T>&>
+operator_equal_pushforward(::cladtorch::Tensor<T>* _this,
+                           const ::cladtorch::Tensor<T>& other,
+                           ::cladtorch::Tensor<T>* _d_this,
+                           const ::cladtorch::Tensor<T>& _d_other) {
+  *_this = other;
+  *_d_this = _d_other;
+  return {*_this, *_d_this};
+}
+
+template <typename T>
+::clad::ValueAndPushforward<::cladtorch::Tensor<T>&, ::cladtorch::Tensor<T>&>
+operator_equal_reverse_forw(::cladtorch::Tensor<T>* _this,
+                            const ::cladtorch::Tensor<T>& other,
+                            ::cladtorch::Tensor<T>* _d_this,
+                            const ::cladtorch::Tensor<T>& _d_other) {
+  *_this = other;
+  *_d_this = _d_other;
+  return {*_this, *_d_this};
+}
+
+// template <typename T>
+// ::clad::ValueAndPushforward<::cladtorch::Tensor<T>&, ::cladtorch::Tensor<T>&>
+// operator_equal_reverse_forw(::cladtorch::Tensor<T>* _this,
+// ::cladtorch::Tensor<T>&& other, ::cladtorch::Tensor<T>* _d_this,
+//                            ::cladtorch::Tensor<T>&& _d_other) {
+//   *_this = other;
+//   *_d_this = _d_other;
+//   return {*_this, *_d_this};
+// }
+
+// template <typename T>
+// ::clad::ValueAndPushforward<::cladtorch::Tensor<T>&, ::cladtorch::Tensor<T>&>
+// operator_equal_pushforward(::cladtorch::Tensor<T>* _this,
+// ::cladtorch::Tensor<T>&& other, ::cladtorch::Tensor<T>* _d_this,
+//                            ::cladtorch::Tensor<T>&& _d_other) {
+//   *_this = other;
+//   *_d_this = _d_other;
+//   return {*_this, *_d_this};
+// }
+
+// template <typename T>
+// ::clad::ValueAndAdjoint<::cladtorch::Tensor<T>&, ::cladtorch::Tensor<T>&>
+// operator_equal_reverse_forw(::cladtorch::Tensor<T>* _this, const
+// ::cladtorch::Tensor<T>& other,
+//                             ::cladtorch::Tensor<T>* _d_this, const
+//                             ::cladtorch::Tensor<T>& _d_other) {
+//   *_this = other;
+//   *_d_this = _d_other;
+//   return {*_this, *_d_this};
+// }
+
+template <typename T>
+void operator_equal_pullback(::cladtorch::Tensor<T>* _this,
+                             const ::cladtorch::Tensor<T>& other,
+                             ::cladtorch::Tensor<T> _d_y,
+                             ::cladtorch::Tensor<T>* _d_this,
+                             ::cladtorch::Tensor<T>* _d_other) {
+  // For assignment, the gradient flows to both tensors
+  *_d_other += *_d_this;
+}
+
+template <typename T>
+void operator_equal_pullback(::cladtorch::Tensor<T>* _this,
+                             ::cladtorch::Tensor<T>&& other,
+                             ::cladtorch::Tensor<T> _d_y,
+                             ::cladtorch::Tensor<T>* _d_this,
+                             ::cladtorch::Tensor<T>* _d_other) {
+  // For assignment, the gradient flows to both tensors
+  // *_d_this += _d_y;
+  *_d_other += *_d_this;
+}
+
+template <typename T>
+::clad::ValueAndPushforward<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+constructor_pushforward(ConstructorPushforwardTag<::cladtorch::Tensor<T>>,
+                        const ::cladtorch::Tensor<T>& p,
+                        const ::cladtorch::Tensor<T>& d_p) {
+  ::cladtorch::Tensor<T> v(p);
+  ::cladtorch::Tensor<T> d_v(d_p);
+  return {v, d_v};
+}
+
+template <typename T>
+void constructor_pullback(const ::cladtorch::Tensor<T>& other,
+                          ::cladtorch::Tensor<T>* _d_this,
+                          ::cladtorch::Tensor<T>* _d_other) {
+  *_d_other += *_d_this;
+  _d_this->fill(0);
+}
+
+template <typename T>
+::clad::ValueAndPushforward<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+constructor_pushforward(ConstructorPushforwardTag<::cladtorch::Tensor<T>>,
+                        ::cladtorch::Tensor<T>&& p,
+                        ::cladtorch::Tensor<T>&& d_p) {
+  ::cladtorch::Tensor<T> v(::std::move(p));
+  ::cladtorch::Tensor<T> d_v(d_p);
+  return {v, d_v};
+}
+
+template <typename T>
+void constructor_pullback(::cladtorch::Tensor<T>&& other,
+                          ::cladtorch::Tensor<T>* _d_this,
+                          ::cladtorch::Tensor<T>* _d_other) {
+  *_d_other += *_d_this;
+  _d_this->fill(0);
+}
+
+template <typename T>
+::clad::ValueAndPushforward<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+constructor_pushforward(ConstructorPushforwardTag<::cladtorch::Tensor<T>>,
+                        const ::std::vector<int>& shape,
+                        const ::std::vector<int>& d_shape) {
+  ::cladtorch::Tensor<T> v(shape);
+  ::cladtorch::Tensor<T> d_v(d_shape);
+  return {v, d_v};
+}
+
+template <typename T>
+void constructor_pullback(const ::std::vector<int>& shape,
+                          ::cladtorch::Tensor<T>* _d_this,
+                          ::std::vector<int>* d_shape) {
+  // *_d_other += *_d_this;
+  // _d_this->fill(0);
+}
+template <typename T>
+::clad::ValueAndAdjoint<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+constructor_reverse_forw(ConstructorPushforwardTag<::cladtorch::Tensor<T>>,
+                         const ::cladtorch::Tensor<T>& p,
+                         const ::cladtorch::Tensor<T>& d_p) {
+  ::cladtorch::Tensor<T> v(p);
+  ::cladtorch::Tensor<T> d_v(d_p);
+  return {v, d_v};
+}
+
+template <typename T>
+::clad::ValueAndAdjoint<::cladtorch::Tensor<T>, ::cladtorch::Tensor<T>>
+constructor_reverse_forw(ConstructorPushforwardTag<::cladtorch::Tensor<T>>,
+                         ::cladtorch::Tensor<T>&& p,
+                         ::cladtorch::Tensor<T>&& d_p) {
+  ::cladtorch::Tensor<T> v(::std::move(p));
+  ::cladtorch::Tensor<T> d_v(d_p);
+  return {v, d_v};
+}
+
+template <typename T>
+void transpose_pullback(const ::cladtorch::Tensor<T>* _this, int dim0, int dim1,
+                        ::cladtorch::Tensor<float> _d_y,
+                        ::cladtorch::Tensor<T>* _d_this, int* _d_dim0,
+                        int* _d_dim1) {
+  // The pullback of transpose is the transpose of the gradient with swapped
+  // dimensions _d_this->print(); _d_y.print();
+  *_d_this += _d_y.transpose(dim0, dim1);
+  // _d_result->fill(0);
+}
+
+template <typename T, typename U>
+void lookup_pullback(const ::cladtorch::Tensor<T>* _this,
+                     const ::cladtorch::Tensor<U>& indices,
+                     ::cladtorch::Tensor<T> _d_y,
+                     ::cladtorch::Tensor<T>* _d_this,
+                     ::cladtorch::Tensor<U>* _d_indices) {
+  // Indices don't have gradients since they are integers
+  (void)_d_indices;
+
+  // Calculate the size of each slice (everything after the first dimension)
+  int slice_size = 1;
+  for (int i = 1; i < _this->ndim(); ++i)
+    slice_size *= _this->shape()[i];
+
+  // Accumulate gradients back to the original tensor
+  for (int i = 0; i < indices.num_elements(); ++i) {
+    int idx = indices.data()[i];
+
+    // Get pointers to the relevant slices
+    const T* grad_slice = _d_y.data() + i * slice_size;
+    T* orig_slice = _d_this->data() + idx * slice_size;
+
+    // Accumulate gradients
+    for (int j = 0; j < slice_size; ++j)
+      orig_slice[j] += grad_slice[j];
+  }
+}
+
+template <typename T, typename U>
+void reshape_pullback(const ::cladtorch::Tensor<T>* _this,
+                      const ::std::vector<U>& new_shape,
+                      ::cladtorch::Tensor<T> _d_y,
+                      ::cladtorch::Tensor<T>* _d_this,
+                      ::std::vector<U>* _d_new_shape) {
+  // new_shape doesn't have gradients since it's a shape specification
+  (void)_d_new_shape;
+
+  // Reshape is just a reinterpretation of the same data, so we need to
+  // reshape the gradient back to the original shape and accumulate
+  // ::cladtorch::Tensor<T> reshaped_grad = ;
+  *_d_this += _d_y.reshape(_this->shape());
+}
+
+template <typename T>
+void norm_pullback(const ::cladtorch::Tensor<T>* _this,
+                   ::cladtorch::Tensor<T> _d_y,
+                   ::cladtorch::Tensor<T>* _d_this) {
+  static_assert(::std::is_same<T, float>::value,
+                "norm_pullback() is only supported for float tensors.");
+
+  if (_this->num_elements() == 0)
+    return;
+
+  // Calculate number of vectors and vector size
+  int vec_size = _this->shape().back(); // Last dimension
+  int num_vectors = _this->num_elements() / vec_size;
+  float eps = 1e-5F;
+  float vec_sizef = static_cast<float>(vec_size);
+
+  for (int idx = 0; idx < num_vectors; ++idx) {
+    const float* x_vec = _this->data() + idx * vec_size;
+    const float* grad_out = _d_y.data() + idx * vec_size;
+    float* grad_in = _d_this->data() + idx * vec_size;
+
+    // Compute mean and rstd (same as forward pass)
+    float mean = 0.0F;
+    for (int i = 0; i < vec_size; i++)
+      mean += x_vec[i];
+    mean /= vec_sizef;
+
+    float var = 0.0F;
+    for (int i = 0; i < vec_size; i++) {
+      float diff = x_vec[i] - mean;
+      var += diff * diff;
+    }
+    var /= vec_sizef;
+    float rstd = 1.0F / ::std::sqrt(var + eps);
+
+    // Compute gradient statistics
+    float grad_mean = 0.0F;
+    for (int i = 0; i < vec_size; i++)
+      grad_mean += grad_out[i];
+    grad_mean /= vec_sizef;
+
+    float grad_norm_mean = 0.0F;
+    for (int i = 0; i < vec_size; i++)
+      grad_norm_mean += grad_out[i] * (x_vec[i] - mean);
+    grad_norm_mean /= vec_sizef;
+
+    // Apply layer norm gradient formula
+    for (int i = 0; i < vec_size; i++) {
+      float normalized = (x_vec[i] - mean) * rstd;
+      grad_in[i] +=
+          rstd * (grad_out[i] - grad_mean - normalized * grad_norm_mean * rstd);
+    }
+  }
+}
+
+template <typename T>
+void split_pullback(const ::cladtorch::Tensor<T>* _this, int size, int axis,
+                    ::std::vector<::cladtorch::Tensor<T>> _d_y,
+                    ::cladtorch::Tensor<T>* _d_this, int* _d_size,
+                    int* _d_axis) {
+  // size and axis don't have gradients since they are parameters
+  (void)_d_size;
+  (void)_d_axis;
+
+  // Split creates multiple tensors from one, so the pullback needs to
+  // concatenate the gradients back along the split axis
+  int num_splits = _this->shape()[axis] / size;
+
+  // For each split, accumulate gradients back to the appropriate slice
+  for (int i = 0; i < num_splits; ++i) {
+    if (i < (int)_d_y.size()) {
+      const ::cladtorch::Tensor<T>& split_grad = _d_y[i];
+
+      // Calculate the offset for this split in the original tensor
+      int split_offset = i * size;
+
+      // Calculate slice size for elements after the split axis
+      int slice_size = 1;
+      for (int dim = axis + 1; dim < _this->ndim(); ++dim)
+        slice_size *= _this->shape()[dim];
+
+      // Calculate stride for the split axis
+      int axis_stride = 1;
+      for (int dim = axis + 1; dim < _this->ndim(); ++dim)
+        axis_stride *= _this->shape()[dim];
+
+      // Copy gradients back to the original tensor
+      for (int elem = 0; elem < split_grad.num_elements(); ++elem) {
+        // Calculate multi-dimensional coordinates in the split tensor
+        ::std::vector<int> coords(split_grad.ndim());
+        int temp_idx = elem;
+        for (int dim = split_grad.ndim() - 1; dim >= 0; --dim) {
+          coords[dim] = temp_idx % split_grad.shape()[dim];
+          temp_idx /= split_grad.shape()[dim];
+        }
+
+        // Adjust coordinate for the split axis
+        coords[axis] += split_offset;
+
+        // Calculate flat index in the original tensor
+        int orig_idx = 0;
+        for (int dim = 0; dim < _this->ndim(); ++dim) {
+          int stride = 1;
+          for (int d = dim + 1; d < _this->ndim(); ++d)
+            stride *= _this->shape()[d];
+          orig_idx += coords[dim] * stride;
+        }
+
+        _d_this->data()[orig_idx] += split_grad.data()[elem];
+      }
+    }
+  }
+}
+
+} // namespace class_functions
+} // namespace custom_derivatives
+} // namespace clad
+
+// NOLINTEND(cppcoreguidelines-pro-bounds-*, *-avoid-c-arrays,
+// misc-definitions-in-headers, readability-identifier-naming)
+
+#endif // CLAD_DIFFERENTIATOR_CLADTORCHBUILTINS_H

--- a/include/cladtorch/cladtorch.hpp
+++ b/include/cladtorch/cladtorch.hpp
@@ -1,73 +1,80 @@
-#ifndef CLAD_TENSOR_HPP_DYNAMIC
-#define CLAD_TENSOR_HPP_DYNAMIC
+#ifndef CLADTORCH_CLADTORCH_HPP
+#define CLADTORCH_CLADTORCH_HPP
 
 #include "kernels.hpp" // Include kernel functions for operations
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
-#include <initializer_list> // For at()
 #include <iostream>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
-#define ND __attribute__((annotate("non_differentiable")))
+// #define ND __attribute__((annotate("non_differentiable")))
+#define ND
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-*, *-avoid-c-arrays,
+// cppcoreguidelines-owning-memory)
+
+// Register as a tensor for clad to understand
+namespace clad::tensor_like::cladtorch {
+struct Tensor;
+} // namespace clad::tensor_like::cladtorch
 
 namespace cladtorch {
 // === Dynamic-Shape Tensor Class ===
 template <typename T> class Tensor {
 public:
-  std::vector<int> _shape;
-  std::vector<int> _strides;
-  int _num_elements = 0;
-  T* _data = nullptr;
+  std::vector<int> m_shape;
+  std::vector<int> m_strides;
+  int m_numel = 0;
+  T* m_data = nullptr;
 
 private:
   // Private helper to initialize tensor metadata and allocate memory
   void init_from_shape(const std::vector<int>& shape) {
-    _shape = shape;
-    _num_elements = 1;
+    m_shape = shape;
+    m_numel = 1;
     bool has_zero_dim = false;
-    for (int dim : _shape) {
+    for (int dim : m_shape) {
       if (dim == 0)
         has_zero_dim = true;
-      _num_elements *= dim;
+      m_numel *= dim;
     }
     if (has_zero_dim)
-      _num_elements = 0;
+      m_numel = 0;
 
-    if (_shape.empty()) {
-      _strides.clear();
+    if (m_shape.empty()) {
+      m_strides.clear();
     } else {
-      _strides.resize(_shape.size());
-      _strides.back() = 1;
-      for (long i = _shape.size() - 2; i >= 0; --i)
-        _strides[i] = _strides[i + 1] * _shape[i + 1];
+      m_strides.resize(m_shape.size());
+      m_strides.back() = 1;
+      for (long i = m_shape.size() - 2; i >= 0; --i)
+        m_strides[i] = m_strides[i + 1] * m_shape[i + 1];
     }
-    _data = _num_elements > 0 ? new T[_num_elements] : nullptr;
+    m_data = m_numel > 0 ? new T[m_numel] : nullptr;
   }
 
 public:
   // --- Constructors, Destructor, Assignment ---
 
   // Default constructor: creates an empty tensor.
-  Tensor() : _num_elements(0), _data(nullptr) {}
+  Tensor() : m_data(nullptr) {}
 
   // Shape constructor: creates a tensor with a given shape, zero-initialized.
   explicit Tensor(const std::vector<int>& shape) {
     init_from_shape(shape);
-    if (_data)
-      std::fill(_data, _data + _num_elements, T{});
+    if (m_data)
+      std::fill(m_data, m_data + m_numel, T{});
   }
 
   explicit Tensor(const std::vector<int>& shape, const T* data) {
     init_from_shape(shape);
-    if (!_data) {
-      // If _data is null, tensor is empty, nothing to copy
+    if (!m_data) {
+      // If m_data is null, tensor is empty, nothing to copy
     } else if (data) {
-      std::copy(data, data + _num_elements, _data);
+      std::copy(data, data + m_numel, m_data);
     } else {
-      std::fill(_data, _data + _num_elements, T{});
+      std::fill(m_data, m_data + m_numel, T{});
     }
   }
 
@@ -80,92 +87,93 @@ public:
   // Scalar constructor: creates a 0-dimensional tensor.
   static Tensor<T> new_scalar(T scalar_val) {
     Tensor<T> tensor;
-    tensor._shape = {};
-    tensor._strides = {};
-    tensor._num_elements = 1;
-    tensor._data = new T[1];
-    tensor._data[0] = scalar_val;
+    tensor.m_shape = {};
+    tensor.m_strides = {};
+    tensor.m_numel = 1;
+    tensor.m_data = new T[1];
+    tensor.m_data[0] = scalar_val;
     return tensor;
   }
 
   ~Tensor() {
-    if (_data) {
-      delete[] _data;
-      _data = nullptr;
+    if (m_data) {
+      delete[] m_data;
+      m_data = nullptr;
     }
   }
 
   // Copy constructor
   Tensor(const Tensor& other)
-      : _shape(other._shape), _strides(other._strides),
-        _num_elements(other._num_elements), _data(nullptr) {
-    if (_num_elements > 0) {
-      _data = new T[_num_elements];
-      std::copy(other._data, other._data + _num_elements, _data);
+      : m_shape(other.m_shape), m_strides(other.m_strides),
+        m_numel(other.m_numel), m_data(nullptr) {
+    if (m_numel > 0) {
+      m_data = new T[m_numel];
+      std::copy(other.m_data, other.m_data + m_numel, m_data);
     }
   }
 
   // Copy assignment
   Tensor& operator=(const Tensor& other) {
     if (this != &other) {
-      delete[] _data;
-      _shape = other._shape;
-      _strides = other._strides;
-      _num_elements = other._num_elements;
-      _data = nullptr;
-      if (_num_elements > 0) {
-        _data = new T[_num_elements];
-        std::copy(other._data, other._data + _num_elements, _data);
+      delete[] m_data;
+      m_shape = other.m_shape;
+      m_strides = other.m_strides;
+      m_numel = other.m_numel;
+      m_data = nullptr;
+      if (m_numel > 0) {
+        m_data = new T[m_numel];
+        std::copy(other.m_data, other.m_data + m_numel, m_data);
       }
     }
     return *this;
   }
 
-  // Tensor operator=(Tensor&& other) {
-  //   if (this != &other) {
-  //     delete[] _data;
-  //     _shape = std::move(other._shape);
-  //     _strides = std::move(other._strides);
-  //     _num_elements = other._num_elements;
-  //     _data = other._data;
-  //     other._num_elements = 0;
-  //     other._data = nullptr;
-  //   }
-  //   return *this;
-  // }
+  Tensor& operator=(Tensor&& other) noexcept {
+    if (this != &other) {
+      delete[] m_data;
+      m_shape = std::move(other.m_shape);
+      m_strides = std::move(other.m_strides);
+      m_numel = other.m_numel;
+      m_data = other.m_data;
+      other.m_numel = 0;
+      other.m_data = nullptr;
+    }
+    return *this;
+  }
 
   // Move constructor
   Tensor(Tensor&& other) noexcept
-      : _shape(std::move(other._shape)), _strides(std::move(other._strides)),
-        _num_elements(other._num_elements), _data(other._data) {
-    other._num_elements = 0;
-    other._data = nullptr;
+      : m_shape(std::move(other.m_shape)),
+        m_strides(std::move(other.m_strides)), m_numel(other.m_numel),
+        m_data(other.m_data) {
+    other.m_numel = 0;
+    other.m_data = nullptr;
   }
 
   // Move assignment
   // Tensor& operator=(Tensor&& other) {
   //   if (this != &other) {
-  //     delete[] _data;
-  //     _shape = std::move(other._shape);
-  //     _strides = std::move(other._strides);
-  //     _num_elements = other._num_elements;
-  //     _data = other._data;
-  //     other._num_elements = 0;
-  //     other._data = nullptr;
+  //     delete[] m_data;
+  //     m_shape = std::move(other.m_shape);
+  //     m_strides = std::move(other.m_strides);
+  //     m_numel = other.m_numel;
+  //     m_data = other.m_data;
+  //     other.m_numel = 0;
+  //     other.m_data = nullptr;
   //   }
   //   return *this;
   // }
 
   // --- Accessors & Utilities ---
-  const std::vector<int>& shape() const { return _shape; }
-  int ndim() const { return _shape.size(); }
-  int num_elements() const { return _num_elements; }
+  const std::vector<int>& shape() const { return m_shape; }
+  int ndim() const { return m_shape.size(); }
+  int num_elements() const { return m_numel; }
   ND int size(int dim) const {
-    CLAD_ASSERT(dim < _shape.size(), "Dimension index out of range.");
-    return _shape[dim];
+    // CLAD_ASSERT(dim < m_shape.size(), "Dimension index out of range.");
+    return m_shape[dim];
   }
-  T* data() { return _data; }
-  const T* data() const { return _data; }
+  T* data() { return m_data; }
+  const T* data() const { return m_data; }
 
   // Broadcasting utilities
   static bool can_broadcast_to(const Tensor<T>& from, const Tensor<T>& to) {
@@ -200,9 +208,7 @@ public:
 
       if (dim_a == 1)
         result_shape[max_ndim - 1 - i] = dim_b;
-      else if (dim_b == 1)
-        result_shape[max_ndim - 1 - i] = dim_a;
-      else if (dim_a == dim_b)
+      else if (dim_b == 1 || dim_a == dim_b)
         result_shape[max_ndim - 1 - i] = dim_a;
       else
         CLAD_ASSERT(false, "Shapes are not compatible for broadcasting.");
@@ -217,71 +223,64 @@ public:
     if (ndim() == 0) {
       CLAD_ASSERT(sizeof...(idx_values) == 0,
                   "Do not provide indices for a scalar tensor.");
-      return _data[0];
+      return m_data[0];
     }
 
     int indices[] = {static_cast<int>(idx_values)...};
     int flat_index = 0;
     for (int i = 0; i < ndim(); ++i) {
-      CLAD_ASSERT(indices[i] < _shape[i], "Index out of bounds.");
-      flat_index += indices[i] * _strides[i];
+      CLAD_ASSERT(indices[i] < m_shape[i], "Index out of bounds.");
+      flat_index += indices[i] * m_strides[i];
     }
-    return _data[flat_index];
+    return m_data[flat_index];
   }
 
   template <typename... IdxTypes> const T& at(IdxTypes... idx_values) const {
-    return const_cast<Tensor*>(this)->at(idx_values...);
+    return const_cast<Tensor*>(this)->at(idx_values...); // NOLINT
   }
-
-  // Convenience for scalar tensors
-  // T& scalar() {
-  //   CLAD_ASSERT(ndim() == 0, "scalar() is only for 0-dimension tensors.");
-  //   CLAD_ASSERT(_data != nullptr, "Accessing null data in scalar tensor.");
-  //   return _data[0];
-  // }
 
   const T& scalar() const {
     CLAD_ASSERT(ndim() == 0, "scalar() is only for 0-dimension tensors.");
-    CLAD_ASSERT(_data != nullptr, "Accessing null data in scalar tensor.");
-    return _data[0];
+    CLAD_ASSERT(m_data != nullptr, "Accessing null data in scalar tensor.");
+    return m_data[0];
   }
 
   void fill(T value) {
-    if (_num_elements > 0) {
-      CLAD_ASSERT(_data != nullptr, "Filling null data tensor.");
-      std::fill(_data, _data + _num_elements, value);
+    if (m_numel > 0) {
+      CLAD_ASSERT(m_data != nullptr, "Filling null data tensor.");
+      std::fill(m_data, m_data + m_numel, value);
     }
   }
 
   void print() const {
     std::cout << " (Shape: [";
-    for (int i = 0; i < _shape.size(); ++i)
-      std::cout << _shape[i] << (i == _shape.size() - 1 ? "" : ", ");
-    std::cout << "], NumElements: " << _num_elements << ")" << std::endl;
+    for (int i = 0; i < m_shape.size(); ++i)
+      std::cout << m_shape[i] << (i == m_shape.size() - 1 ? "" : ", ");
+    std::cout << "], NumElements: " << m_numel << ")" << std::endl;
 
-    if (_num_elements == 0) {
+    if (m_numel == 0) {
       std::cout << "(Empty)\n";
       return;
     }
-    CLAD_ASSERT(_data, "Printing null data tensor.");
+    CLAD_ASSERT(m_data, "Printing null data tensor.");
 
     if (ndim() == 0) {
-      std::cout << _data[0] << std::endl;
+      std::cout << m_data[0] << std::endl;
     } else if (ndim() == 1) {
-      for (int i = 0; i < size(0); ++i)
+      for (int i = 0; i < size(/*dim=*/0); ++i)
         std::cout << at(i) << " ";
       std::cout << "\n";
     } else if (ndim() == 2) {
-      for (int i = 0; i < size(0); ++i) {
-        for (int j = 0; j < size(1); ++j)
+      for (int i = 0; i < size(/*dim=*/0); ++i) {
+        for (int j = 0; j < size(/*dim=*/1); ++j)
           std::cout << at(i, j) << " ";
         std::cout << "\n";
       }
     } else {
       std::cout << "[";
-      for (int i = 0; i < std::min((int)10, _num_elements); ++i)
-        std::cout << _data[i] << (i < 9 && i < _num_elements - 1 ? ", " : "");
-      if (_num_elements > 10)
+      for (int i = 0; i < std::min(10, m_numel); ++i)
+        std::cout << m_data[i] << (i < 9 && i < m_numel - 1 ? ", " : "");
+      if (m_numel > 10)
         std::cout << "...";
       std::cout << "]\n";
     }
@@ -289,47 +288,47 @@ public:
 
   // Lookup operation: select slices from this tensor using indices
   template <typename U> Tensor<T> lookup(const Tensor<U>& indices) const {
-    static_assert(std::is_integral_v<U>, "Indices must be integral type.");
+    static_assert(std::is_integral<U>::value, "Indices must be integral type.");
     CLAD_ASSERT(ndim() > 0, "Cannot lookup from a scalar tensor.");
-    CLAD_ASSERT(_data != nullptr, "Cannot lookup from null data tensor.");
+    CLAD_ASSERT(m_data != nullptr, "Cannot lookup from null data tensor.");
 
     // Calculate the size of each slice (everything after the first dimension)
     int slice_size = 1;
     for (int i = 1; i < ndim(); ++i)
-      slice_size *= _shape[i];
+      slice_size *= m_shape[i];
 
     // Create result shape: preserve indices shape and append remaining
     // dimensions
     std::vector<int> result_shape = indices.shape();
     for (int i = 1; i < ndim(); ++i)
-      result_shape.push_back(_shape[i]);
+      result_shape.push_back(m_shape[i]);
 
     Tensor<T> result(result_shape);
 
     if (indices.num_elements() > 0)
-      kernels::lookup_kernel(_data, indices.data(), result.data(),
-                             indices.num_elements(), _shape[0], slice_size);
+      kernels::lookup_kernel(m_data, indices.data(), result.data(),
+                             indices.num_elements(), m_shape[0], slice_size);
 
     return result;
   }
 
   // Layer normalization: normalizes along the last dimension
   Tensor<T> norm() const {
-    static_assert(std::is_same_v<T, float>,
+    static_assert(std::is_same<T, float>::value,
                   "norm() is only supported for float tensors.");
     CLAD_ASSERT(ndim() > 0, "Cannot normalize a scalar tensor.");
-    CLAD_ASSERT(_data != nullptr, "Cannot normalize null data tensor.");
+    CLAD_ASSERT(m_data != nullptr, "Cannot normalize null data tensor.");
 
-    Tensor<T> result(_shape);
+    Tensor<T> result(m_shape);
 
-    if (_num_elements == 0)
+    if (m_numel == 0)
       return result;
 
     // Calculate number of vectors and vector size
-    int vec_size = _shape.back(); // Last dimension
-    int num_vectors = _num_elements / vec_size;
+    int vec_size = m_shape.back(); // Last dimension
+    int num_vectors = m_numel / vec_size;
 
-    kernels::norm_kernel(_data, result.data(), num_vectors, vec_size);
+    kernels::norm_kernel(m_data, result.data(), num_vectors, vec_size);
 
     return result;
   }
@@ -340,42 +339,42 @@ public:
     CLAD_ASSERT(split_axis < ndim(), "Split axis out of bounds.");
     CLAD_ASSERT(new_shape.size() == ndim(),
                 "View shape must have same number of dimensions.");
-    CLAD_ASSERT(_data != nullptr, "Cannot create view of null data tensor.");
+    CLAD_ASSERT(m_data != nullptr, "Cannot create view of null data tensor.");
 
     // Calculate offset for this split
     int split_size = new_shape[split_axis];
     int offset = split_no * split_size;
-    CLAD_ASSERT(offset + split_size <= _shape[split_axis],
+    CLAD_ASSERT(offset + split_size <= m_shape[split_axis],
                 "View extends beyond tensor bounds.");
 
     Tensor<T> result(new_shape);
 
-    if (result._num_elements == 0)
+    if (result.m_numel == 0)
       return result;
 
-    kernels::view_kernel(_data, result.data(), _shape, _strides, new_shape,
-                         result._strides, split_axis, offset);
+    kernels::view_kernel(m_data, result.data(), m_shape, m_strides, new_shape,
+                         result.m_strides, split_axis, offset);
 
     return result;
   }
 
   // Reshape tensor to new dimensions (total number of elements must match)
   Tensor<T> reshape(const std::vector<int>& new_shape) const {
-    CLAD_ASSERT(_data != nullptr, "Cannot reshape null data tensor.");
+    CLAD_ASSERT(m_data != nullptr, "Cannot reshape null data tensor.");
 
     // Calculate total elements in new shape
     int new_elements = 1;
     for (int dim : new_shape)
       new_elements *= dim;
 
-    CLAD_ASSERT(new_elements == _num_elements,
+    CLAD_ASSERT(new_elements == m_numel,
                 "New shape must have same total number of elements.");
 
     Tensor<T> result(new_shape);
 
     // Simple copy since we're just changing the shape interpretation
-    for (int i = 0; i < _num_elements; ++i)
-      result._data[i] = _data[i];
+    for (int i = 0; i < m_numel; ++i)
+      result.m_data[i] = m_data[i];
 
     return result;
   }
@@ -383,23 +382,23 @@ public:
   // Split tensor along specified axis into chunks of given size
   std::vector<Tensor<T>> split(int size, int axis) const {
     CLAD_ASSERT(axis < ndim(), "Split axis out of bounds.");
-    CLAD_ASSERT(_shape[axis] % size == 0,
+    CLAD_ASSERT(m_shape[axis] % size == 0,
                 "Dimension size must be divisible by split size.");
-    CLAD_ASSERT(_data != nullptr, "Cannot split null data tensor.");
+    CLAD_ASSERT(m_data != nullptr, "Cannot split null data tensor.");
 
     std::vector<Tensor<T>> tensors;
 
-    if (_shape[axis] == size) {
+    if (m_shape[axis] == size) {
       // If split size equals dimension size, return copy of this tensor
       tensors.push_back(*this);
       return tensors;
     }
 
     // Create new shape for each split
-    std::vector<int> split_shape = _shape;
+    std::vector<int> split_shape = m_shape;
     split_shape[axis] = size;
 
-    int num_splits = _shape[axis] / size;
+    int num_splits = m_shape[axis] / size;
     for (int i = 0; i < num_splits; ++i)
       tensors.push_back(view(split_shape, axis, i));
 
@@ -410,7 +409,7 @@ public:
   Tensor<T> transpose(int dim0, int dim1) const {
     CLAD_ASSERT(dim0 < ndim() && dim1 < ndim(),
                 "Transpose dimensions out of bounds.");
-    CLAD_ASSERT(_data != nullptr, "Cannot transpose null data tensor.");
+    CLAD_ASSERT(m_data != nullptr, "Cannot transpose null data tensor.");
 
     if (dim0 == dim1) {
       // No-op transpose, return copy
@@ -418,78 +417,77 @@ public:
     }
 
     // Create transposed shape
-    std::vector<int> new_shape = _shape;
+    std::vector<int> new_shape = m_shape;
     std::swap(new_shape[dim0], new_shape[dim1]);
 
     Tensor<T> result(new_shape);
 
-    if (_num_elements == 0)
+    if (m_numel == 0)
       return result;
 
-    kernels::transpose_kernel(_data, result.data(), _shape, _strides,
-                              result._strides, dim0, dim1);
+    kernels::transpose_kernel(m_data, result.data(), m_shape, m_strides,
+                              result.m_strides, dim0, dim1);
 
     return result;
   }
 
   // Broadcast this tensor to the given shape
   Tensor<T> broadcast_to(const std::vector<int>& target_shape) const {
-    CLAD_ASSERT(_data != nullptr || _num_elements == 0,
+    CLAD_ASSERT(m_data != nullptr || m_numel == 0,
                 "Cannot broadcast null data tensor.");
 
     // Check if broadcasting is possible
-    if (_shape.size() > target_shape.size())
+    if (m_shape.size() > target_shape.size())
       CLAD_ASSERT(false, "Cannot broadcast to smaller number of dimensions.");
 
-    int offset = target_shape.size() - _shape.size();
-    for (int i = 0; i < _shape.size(); ++i) {
-      int src_dim = _shape[i];
+    int offset = target_shape.size() - m_shape.size();
+    for (int i = 0; i < m_shape.size(); ++i) {
+      int src_dim = m_shape[i];
       int target_dim = target_shape[i + offset];
       if (src_dim != 1 && src_dim != target_dim)
         CLAD_ASSERT(false, "Incompatible shapes for broadcasting.");
     }
 
     // If shapes are already the same, return a copy
-    if (_shape == target_shape)
+    if (m_shape == target_shape)
       return *this;
 
     Tensor<T> result(target_shape);
 
-    if (result._num_elements == 0 || _num_elements == 0)
+    if (result.m_numel == 0 || m_numel == 0)
       return result;
 
-    kernels::broadcast_kernel(_data, result.data(), _shape, _strides,
-                              target_shape, result._strides);
+    kernels::broadcast_kernel(m_data, result.data(), m_shape, m_strides,
+                              target_shape, result.m_strides);
 
     return result;
   }
 
   // --- Operator Overloads ---
   Tensor& operator+=(const Tensor& other) {
-    if (_shape == other._shape) {
+    if (m_shape == other.m_shape) {
       // Same shape, use optimized kernel
-      kernels::element_wise_add_kernel(_data, other._data, _data,
-                                       _num_elements);
+      kernels::element_wise_add_kernel(m_data, other.m_data, m_data, m_numel);
     } else {
       // Different shapes, need broadcasting
       std::vector<int> result_shape = broadcast_shape(*this, other);
-      CLAD_ASSERT(result_shape == _shape,
+      CLAD_ASSERT(result_shape == m_shape,
                   "In-place addition requires this tensor to have the "
                   "broadcast result shape.");
 
-      Tensor<T> other_broadcast = other.broadcast_to(_shape);
-      kernels::element_wise_add_kernel(_data, other_broadcast._data, _data,
-                                       _num_elements);
+      Tensor<T> other_broadcast = other.broadcast_to(m_shape);
+      kernels::element_wise_add_kernel(m_data, other_broadcast.m_data, m_data,
+                                       m_numel);
     }
     return *this;
   }
 
   Tensor operator+(const Tensor& other) const {
-    if (_shape == other._shape) {
+    if (m_shape == other.m_shape) {
       // Same shape, use optimized path
       Tensor<T> result(*this);
-      kernels::element_wise_add_kernel(_data, other._data, result._data,
-                                       _num_elements);
+      kernels::element_wise_add_kernel(m_data, other.m_data, result.m_data,
+                                       m_numel);
       return result;
     } else {
       // Different shapes, need broadcasting
@@ -499,33 +497,32 @@ public:
       Tensor<T> a_broadcast = this->broadcast_to(result_shape);
       Tensor<T> b_broadcast = other.broadcast_to(result_shape);
 
-      kernels::element_wise_add_kernel(a_broadcast._data, b_broadcast._data,
-                                       result._data, result._num_elements);
+      kernels::element_wise_add_kernel(a_broadcast.m_data, b_broadcast.m_data,
+                                       result.m_data, result.m_numel);
       return result;
     }
   }
 
   Tensor& operator-=(const Tensor& other) {
-    if (_shape == other._shape) {
+    if (m_shape == other.m_shape) {
       // Same shape, use optimized kernel
-      kernels::element_wise_sub_kernel(_data, other._data, _data,
-                                       _num_elements);
+      kernels::element_wise_sub_kernel(m_data, other.m_data, m_data, m_numel);
     } else {
       // Different shapes, need broadcasting
       std::vector<int> result_shape = broadcast_shape(*this, other);
-      CLAD_ASSERT(result_shape == _shape,
+      CLAD_ASSERT(result_shape == m_shape,
                   "In-place subtraction requires this tensor to have the "
                   "broadcast result shape.");
 
-      Tensor<T> other_broadcast = other.broadcast_to(_shape);
-      kernels::element_wise_sub_kernel(_data, other_broadcast._data, _data,
-                                       _num_elements);
+      Tensor<T> other_broadcast = other.broadcast_to(m_shape);
+      kernels::element_wise_sub_kernel(m_data, other_broadcast.m_data, m_data,
+                                       m_numel);
     }
     return *this;
   }
 
   Tensor operator-(const Tensor& other) const {
-    if (_shape == other._shape) {
+    if (m_shape == other.m_shape) {
       // Same shape, use optimized path
       return Tensor(*this) -= other;
     } else {
@@ -536,33 +533,32 @@ public:
       Tensor<T> a_broadcast = this->broadcast_to(result_shape);
       Tensor<T> b_broadcast = other.broadcast_to(result_shape);
 
-      kernels::element_wise_sub_kernel(a_broadcast._data, b_broadcast._data,
-                                       result._data, result._num_elements);
+      kernels::element_wise_sub_kernel(a_broadcast.m_data, b_broadcast.m_data,
+                                       result.m_data, result.m_numel);
       return result;
     }
   }
 
   Tensor& operator*=(const Tensor& other) {
-    if (_shape == other._shape) {
+    if (m_shape == other.m_shape) {
       // Same shape, use optimized kernel
-      kernels::element_wise_mul_kernel(_data, other._data, _data,
-                                       _num_elements);
+      kernels::element_wise_mul_kernel(m_data, other.m_data, m_data, m_numel);
     } else {
       // Different shapes, need broadcasting
       std::vector<int> result_shape = broadcast_shape(*this, other);
-      CLAD_ASSERT(result_shape == _shape,
+      CLAD_ASSERT(result_shape == m_shape,
                   "In-place multiplication requires this tensor to have the "
                   "broadcast result shape.");
 
-      Tensor<T> other_broadcast = other.broadcast_to(_shape);
-      kernels::element_wise_mul_kernel(_data, other_broadcast._data, _data,
-                                       _num_elements);
+      Tensor<T> other_broadcast = other.broadcast_to(m_shape);
+      kernels::element_wise_mul_kernel(m_data, other_broadcast.m_data, m_data,
+                                       m_numel);
     }
     return *this;
   }
 
   Tensor operator*(const Tensor& other) const {
-    if (_shape == other._shape) {
+    if (m_shape == other.m_shape) {
       // Same shape, use optimized path
       return Tensor(*this) *= other;
     } else {
@@ -573,17 +569,17 @@ public:
       Tensor<T> a_broadcast = this->broadcast_to(result_shape);
       Tensor<T> b_broadcast = other.broadcast_to(result_shape);
 
-      kernels::element_wise_mul_kernel(a_broadcast._data, b_broadcast._data,
-                                       result._data, result._num_elements);
+      kernels::element_wise_mul_kernel(a_broadcast.m_data, b_broadcast.m_data,
+                                       result.m_data, result.m_numel);
       return result;
     }
   }
   Tensor operator/(const Tensor& other) const {
-    if (_shape == other._shape) {
+    if (m_shape == other.m_shape) {
       // Same shape, use optimized path
       Tensor<T> result(*this);
-      kernels::element_wise_div_kernel(_data, other._data, result._data,
-                                       result._num_elements);
+      kernels::element_wise_div_kernel(m_data, other.m_data, result.m_data,
+                                       result.m_numel);
       return result;
       // return Tensor(*this) /= other;
     } else {
@@ -594,25 +590,25 @@ public:
       Tensor<T> a_broadcast = this->broadcast_to(result_shape);
       Tensor<T> b_broadcast = other.broadcast_to(result_shape);
 
-      kernels::element_wise_div_kernel(a_broadcast._data, b_broadcast._data,
-                                       result._data, result._num_elements);
+      kernels::element_wise_div_kernel(a_broadcast.m_data, b_broadcast.m_data,
+                                       result.m_data, result.m_numel);
       return result;
     }
   }
   Tensor& operator+=(T scalar) {
-    kernels::scalar_add_kernel(_data, scalar, _data, _num_elements);
+    kernels::scalar_add_kernel(m_data, scalar, m_data, m_numel);
     return *this;
   }
   Tensor operator+(T scalar) const { return Tensor(*this) += scalar; }
 
   Tensor& operator*=(T scalar) {
-    kernels::scalar_mul_kernel(_data, scalar, _data, _num_elements);
+    kernels::scalar_mul_kernel(m_data, scalar, m_data, m_numel);
     return *this;
   }
   Tensor operator*(T scalar) const { return Tensor(*this) *= scalar; }
 
   Tensor& operator/=(T scalar) {
-    kernels::scalar_div_kernel(_data, scalar, _data, _num_elements);
+    kernels::scalar_div_kernel(m_data, scalar, m_data, m_numel);
     return *this;
   }
   Tensor operator/(T scalar) const { return Tensor(*this) /= scalar; }
@@ -649,8 +645,10 @@ template <typename T> Tensor<T> matmul(const Tensor<T>& a, const Tensor<T>& b) {
     CLAD_ASSERT(a_ptr->size(2) == b_ptr->size(1),
                 "Inner dimensions must match for batched matmul (a.shape[2] == "
                 "b.shape[1]).");
-    int B = a_ptr->size(0), R = a_ptr->size(1), C1 = a_ptr->size(2),
-        C2 = b_ptr->size(2);
+    int B = a_ptr->size(0);
+    int R = a_ptr->size(1);
+    int C1 = a_ptr->size(2);
+    int C2 = b_ptr->size(2);
     Tensor<T> result({B, R, C2});
     kernels::batched_mat_mul_kernel(a_ptr->data(), b_ptr->data(), result.data(),
                                     B, R, C1, C2);
@@ -662,7 +660,9 @@ template <typename T> Tensor<T> matmul(const Tensor<T>& a, const Tensor<T>& b) {
     CLAD_ASSERT(
         a.size(1) == b.size(0),
         "Inner dimensions must match for matmul (a.shape[1] == b.shape[0]).");
-    int R = a.size(0), C1 = a.size(1), C2 = b.size(1);
+    int R = a.size(0);
+    int C1 = a.size(1);
+    int C2 = b.size(1);
     Tensor<T> result({R, C2});
     kernels::mat_mul_kernel(a.data(), b.data(), result.data(), R, C1, C2);
     return result;
@@ -675,8 +675,10 @@ template <typename T> Tensor<T> matmul(const Tensor<T>& a, const Tensor<T>& b) {
     CLAD_ASSERT(a.size(2) == b.size(0),
                 "Inner dimensions must match for batched matmul (a.shape[2] == "
                 "b.shape[0]).");
-    int B = a.size(0), seq_len = a.size(1), C = a.size(2),
-        out_features = b.size(1);
+    int B = a.size(0);
+    int seq_len = a.size(1);
+    int C = a.size(2);
+    int out_features = b.size(1);
     Tensor<T> result({B, seq_len, out_features});
 
     // Reshape the 3D input to 2D: (B*seq_len, C)
@@ -701,8 +703,11 @@ template <typename T> Tensor<T> matmul(const Tensor<T>& a, const Tensor<T>& b) {
     CLAD_ASSERT(a.size(3) == b.size(2), "Inner dimensions must match for 4D "
                                         "matmul (a.shape[3] == b.shape[2]).");
 
-    int B = a.size(0), H = a.size(1), T1 = a.size(2), d = a.size(3),
-        T2 = b.size(3);
+    int B = a.size(0);
+    int H = a.size(1);
+    int T1 = a.size(2);
+    int d = a.size(3);
+    int T2 = b.size(3);
     Tensor<T> result({B, H, T1, T2});
 
     // Treat as batched 2D matrix mult: (B*H) batches of (T1, d) x (d, T2)
@@ -712,9 +717,9 @@ template <typename T> Tensor<T> matmul(const Tensor<T>& a, const Tensor<T>& b) {
     int result_matrix_size = T1 * T2;
 
     for (int batch = 0; batch < batch_size; ++batch) {
-      const T* a_batch = a.data() + batch * a_matrix_size;
-      const T* b_batch = b.data() + batch * b_matrix_size;
-      T* result_batch = result.data() + batch * result_matrix_size;
+      const T* a_batch = a.data() + (batch * a_matrix_size);
+      const T* b_batch = b.data() + (batch * b_matrix_size);
+      T* result_batch = result.data() + (batch * result_matrix_size);
       // Use unrolled kernel for better performance
       kernels::mat_mul_kernel(a_batch, b_batch, result_batch, T1, d, T2);
     }
@@ -727,7 +732,8 @@ template <typename T> Tensor<T> matmul(const Tensor<T>& a, const Tensor<T>& b) {
     CLAD_ASSERT(a.size(1) == b.size(0),
                 "Inner dimensions must match for mat-vec mul (a.shape[1] == "
                 "b.shape[0]).");
-    int R = a.size(0), C = a.size(1);
+    int R = a.size(0);
+    int C = a.size(1);
     Tensor<T> result({R});
     kernels::mat_vec_mul_kernel(a.data(), b.data(), result.data(), R, C);
     return result;
@@ -760,8 +766,8 @@ Tensor<T> softmax(const Tensor<T>& input, bool is_casual /* = false */,
 
     for (int batch = 0; batch < batch_size; ++batch) {
       for (int i = 0; i < n; ++i) {
-        const T* logits_slice = input.data() + batch * n * m + i * m;
-        T* probs_slice = result.data() + batch * n * m + i * m;
+        const T* logits_slice = input.data() + (batch * n * m) + (i * m);
+        T* probs_slice = result.data() + (batch * n * m) + (i * m);
         int V = vocab_size > 0 ? vocab_size : m;
         size_t end = i + 1; // Causal: can only attend to positions 0..i
         end = std::min(end, (size_t)V); // Don't exceed vocab size
@@ -771,8 +777,8 @@ Tensor<T> softmax(const Tensor<T>& input, bool is_casual /* = false */,
   } else {
     // Non-causal or 1D tensor: apply softmax normally
     for (int i = 0; i < num_vectors; ++i) {
-      const T* logits_slice = input.data() + i * last_dim;
-      T* probs_slice = result.data() + i * last_dim;
+      const T* logits_slice = input.data() + (i * last_dim);
+      T* probs_slice = result.data() + (i * last_dim);
       int V = vocab_size > 0 ? vocab_size : last_dim;
       size_t end = V;
       kernels::softmax_kernel(logits_slice, probs_slice, last_dim, end,
@@ -797,7 +803,7 @@ Tensor<T> causal_softmax(const Tensor<T>& input, int vocab_size = 0) {
 // const std::vector<int>& targets) {
 template <typename T, typename U>
 Tensor<T> cross_entropy_loss(const Tensor<T>& probs, const Tensor<U>& targets) {
-  static_assert(std::is_integral_v<U>,
+  static_assert(std::is_integral<U>::value,
                 "Targets tensor must contain integral class indices.");
   // CLAD_ASSERT(targets.ndim() == 1, "Targets tensor must be a 1D array");
   // CLAD_ASSERT(probs.ndim() == 2, "Probs tensor must be 2D for batched cross
@@ -814,9 +820,9 @@ Tensor<T> cross_entropy_loss(const Tensor<T>& probs, const Tensor<U>& targets) {
 
   T total_loss = 0;
   for (int i = 0; i < batch_size; ++i) {
-    const T* prob_slice = probs._data + i * num_classes;
+    const T* prob_slice = probs.m_data + (i * num_classes);
     total_loss += kernels::cross_entropy_loss_kernel(
-        prob_slice, targets._data[i], num_classes);
+        prob_slice, targets.m_data[i], num_classes);
   }
   auto ret = Tensor<T>::new_scalar(total_loss / batch_size);
   return ret; // Return mean loss as a scalar tensor
@@ -835,7 +841,7 @@ Tensor<T> cross_entropy_loss(const Tensor<T>& probs, int target_class) {
 template <typename T> Tensor<T> gelu(const Tensor<T>& in) {
   Tensor<T> r(in);
   for (int i = 0; i < in.num_elements(); ++i)
-    r._data[i] = kernels::gelu_kernel(in._data[i]);
+    r.m_data[i] = kernels::gelu_kernel(in.m_data[i]);
   return r;
 }
 
@@ -843,7 +849,7 @@ template <typename T> Tensor<T> gelu(const Tensor<T>& in) {
 template <typename T>
 Tensor<T> linear(const Tensor<T>& input, const Tensor<T>& weight,
                  const Tensor<T>& bias) {
-  static_assert(std::is_same_v<T, float>,
+  static_assert(std::is_same<T, float>::value,
                 "Linear operation currently only supports float tensors");
 
   // Validate input shapes
@@ -883,4 +889,7 @@ Tensor<T> linear(const Tensor<T>& input, const Tensor<T>& weight,
 
 } // namespace cladtorch
 
-#endif // CLAD_TENSOR_HPP_DYNAMIC
+// NOLINTEND(cppcoreguidelines-pro-bounds-*, *-avoid-c-arrays,
+// cppcoreguidelines-owning-memory)
+
+#endif // CLADTORCH_CLADTORCH_HPP

--- a/include/cladtorch/kernels.hpp
+++ b/include/cladtorch/kernels.hpp
@@ -1,6 +1,10 @@
+#ifndef CLADTORCH_KERNELS_HPP
+#define CLADTORCH_KERNELS_HPP
+
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstring>
 #include <vector>
 // #define OMP _OPENMP
 #ifdef OMP
@@ -8,10 +12,15 @@
 #endif
 
 #ifdef __APPLE__
-#include <Accelerate/Accelerate.h> // Imports BLAS symbols on Apple platforms
-#endif // TODO: import BLAS/LAPACK on non-Apple platforms
+#include <Accelerate/Accelerate.h>
+#else
+#include <cblas.h>
+#endif
 
 #define CLAD_ASSERT(condition, message) assert((condition) && message)
+
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-*, *-avoid-c-arrays,
+// modernize-loop-convert)
 
 // === Kernel Functions (Operating on raw pointers) ===
 // These functions are low-level, high-performance routines
@@ -19,9 +28,9 @@
 // independent of how the Tensor class manages its data.
 namespace cladtorch::kernels {
 inline float gelu_kernel(float x) {
-  constexpr float sqrt_2_over_pi = 0.7978845608028654f; // sqrt(2 / pi)
-  return 0.5f * x *
-         (1.0f + std::tanh(sqrt_2_over_pi * (x + 0.044715f * x * x * x)));
+  constexpr float sqrt_2_over_pi = 0.7978845608028654F; // sqrt(2 / pi)
+  return 0.5F * x *
+         (1.0F + std::tanh(sqrt_2_over_pi * (x + 0.044715F * x * x * x)));
 }
 
 inline void softmax_kernel(const float* logits, float* probs, int size, int end,
@@ -30,52 +39,50 @@ inline void softmax_kernel(const float* logits, float* probs, int size, int end,
   CLAD_ASSERT(end > 0, "Softmax kernel requires end > 0");
   CLAD_ASSERT(end <= size, "End index cannot exceed size");
 
-  int V = vocab_size > 0 ? vocab_size : size;
-
   // Find maximum value for numerical stability
-  float maxv = -10000.0f;
-  for (size_t j = 0; j < end; j++)
+  float maxv = -10000.0F;
+  for (int j = 0; j < end; j++)
     maxv = fmaxf(maxv, logits[j]);
 
   // Compute exponentials and sum
-  float sum = 0.0f;
-  for (size_t j = 0; j < end; j++) {
+  float sum = 0.0F;
+  for (int j = 0; j < end; j++) {
     probs[j] = expf(logits[j] - maxv);
     sum += probs[j];
   }
 
   // Normalize probabilities (handle division by zero)
-  if (sum > 0.0f) {
-    float inv_sum = 1.0f / sum;
-    for (size_t j = 0; j < (size_t)end; j++)
+  if (sum > 0.0F) {
+    float inv_sum = 1.0F / sum;
+    for (int j = 0; j < end; j++)
       probs[j] = probs[j] * inv_sum;
   } else {
     // If sum is zero, set uniform distribution over valid range
-    float uniform_prob = 1.0f / end;
-    for (size_t j = 0; j < (size_t)end; j++)
+    float uniform_prob = 1.0F / (float)end;
+    for (int j = 0; j < end; j++)
       probs[j] = uniform_prob;
   }
 
   // [end, V) is padded with 0.0f due to the causal mask
   // [V, m) is padded with 0.0f due to the padded vocab
-  for (size_t j = end; j < size; j++)
-    probs[j] = 0.0f;
+  for (int j = end; j < size; j++)
+    probs[j] = 0.0F;
 }
 
 inline float cross_entropy_loss_kernel(const float* probs, int target_class,
                                        int size) {
   if (target_class < 0 || target_class >= size)
-    return -std::log(1e-9f);
+    return -std::log(1e-9F);
   float prob_at_target = probs[target_class];
-  return -std::log(std::max(prob_at_target, 1e-9f));
+  return -std::log(std::max(prob_at_target, 1e-9F));
 }
 
 inline void mat_vec_mul_kernel(const float* mat, const float* vec,
                                float* result, int rows, int cols) {
   for (int i = 0; i < rows; ++i) {
-    result[i] = 0.0f;
+    result[i] = 0.0F;
     for (int j = 0; j < cols; ++j)
-      result[i] += mat[i * cols + j] * vec[j];
+      result[i] += mat[(i * cols) + j] * vec[j];
   }
 }
 
@@ -85,10 +92,10 @@ inline void mat_mul_kernel_naive(const float* a_data, const float* b_data,
 #pragma omp parallel for
   for (size_t i = 0; i < R; ++i) {
     for (size_t j = 0; j < C2; ++j) {
-      float sum = 0.0f;
+      float sum = 0.0F;
       for (size_t k = 0; k < C1; ++k)
-        sum += a_data[i * C1 + k] * b_data[k * C2 + j];
-      result_data[i * C2 + j] = sum;
+        sum += a_data[(i * C1) + k] * b_data[(k * C2) + j];
+      result_data[(i * C2) + j] = sum;
     }
   }
 }
@@ -102,14 +109,12 @@ inline void mat_mul_kernel_unrolled(const float* a, const float* b, float* out,
   for (size_t r0 = 0; r0 < RT; r0 += UNROLL) {
     for (size_t j = 0; j < C2; ++j) {
       // roll UNROLL outputs into registers
-      float regs[UNROLL];
-      for (int u = 0; u < UNROLL; ++u)
-        regs[u] = 0.0f;
+      float regs[UNROLL] = {};
       // inner "k" loop: load one weight and multiply–accumulate into all regs
       const float* brow = b + j;
       for (size_t k = 0; k < C1; ++k) {
-        float w = *(brow + k * C2);
-        const float* arow = a + (r0 + 0) * C1 + k;
+        float w = *(brow + (k * C2));
+        const float* arow = a + ((r0 + 0) * C1) + k;
         for (int u = 0; u < UNROLL; ++u) {
           regs[u] += *arow * w;
           arow += C1;
@@ -117,7 +122,7 @@ inline void mat_mul_kernel_unrolled(const float* a, const float* b, float* out,
       }
       // write back
       for (int u = 0; u < UNROLL; ++u)
-        out[(r0 + u) * C2 + j] = regs[u];
+        out[((r0 + u) * C2) + j] = regs[u];
     }
   }
 }
@@ -127,8 +132,8 @@ inline void mat_mul_kernel(const float* a, const float* b, float* out, size_t R,
 // Dispatch to unrolled or regular kernel based on R
 #ifdef __APPLE__
   // Use Accelerate framework for unrolled matrix multiplication
-  cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, R, C2, C1, 1.0f, a, C1,
-              b, C2, 0.0f, out, C2);
+  cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, (int)R, (int)C2,
+              (int)C1, 1.0F, a, (int)C1, b, (int)C2, 0.0F, out, (int)C2);
   return;
 #endif
   if (R % UNROLL == 0)
@@ -145,9 +150,9 @@ inline void batched_mat_mul_kernel(const float* a_data, const float* b_data,
   size_t result_batch_stride = R * C2;
 
   for (size_t batch = 0; batch < batch_size; ++batch) {
-    const float* a_batch = a_data + batch * a_batch_stride;
-    const float* b_batch = b_data + batch * b_batch_stride;
-    float* result_batch = result_data + batch * result_batch_stride;
+    const float* a_batch = a_data + (batch * a_batch_stride);
+    const float* b_batch = b_data + (batch * b_batch_stride);
+    float* result_batch = result_data + (batch * result_batch_stride);
     mat_mul_kernel(a_batch, b_batch, result_batch, R, C1, C2);
   }
 }
@@ -169,8 +174,8 @@ inline void linear_kernel_naive(const float* input, const float* weight,
     for (size_t j = 0; j < out_features; ++j) {
       float sum = bias[j]; // Start with bias
       for (size_t k = 0; k < in_features; ++k)
-        sum += input[i * in_features + k] * weight[j * in_features + k];
-      output[i * out_features + j] = sum;
+        sum += input[(i * in_features) + k] * weight[(j * in_features) + k];
+      output[(i * out_features) + j] = sum;
     }
   }
 }
@@ -189,14 +194,14 @@ inline void linear_kernel_unrolled(const T* input, const T* weight,
 
       // Accumulate input * weight for each output feature
       for (size_t k = 0; k < in_features; ++k) {
-        float w = weight[j * in_features + k];
+        float w = weight[(j * in_features) + k];
         for (int u = 0; u < UNROLL; ++u)
-          regs[u] += input[(i0 + u) * in_features + k] * w;
+          regs[u] += input[((i0 + u) * in_features) + k] * w;
       }
 
       // Write back results
       for (int u = 0; u < UNROLL; ++u)
-        output[(i0 + u) * out_features + j] = regs[u];
+        output[((i0 + u) * out_features) + j] = regs[u];
     }
   }
 }
@@ -209,7 +214,7 @@ inline void linear_kernel(const float* input, const float* weight,
 //    output[i, j] = bias[j]
 #pragma omp parallel for
   for (size_t i = 0; i < batch_seq; ++i) {
-    float* out_row = output + i * out_features;
+    float* out_row = output + (i * out_features);
     for (size_t j = 0; j < out_features; ++j)
       out_row[j] = bias[j];
   }
@@ -229,10 +234,10 @@ inline void linear_kernel(const float* input, const float* weight,
       /* transA    */ CblasNoTrans,
       /* transB    */ CblasTrans,
       /* M,N,K     */ (int)batch_seq, (int)out_features, (int)in_features,
-      /* α         */ 1.0f,
+      /* α         */ 1.0F,
       /* A, lda    */ input, (int)in_features,
       /* B, ldb    */ weight, (int)in_features,
-      /* β, C, ldc */ 1.0f, output, (int)out_features);
+      /* β, C, ldc */ 1.0F, output, (int)out_features);
   return;
 #endif
   // Dispatch to unrolled or regular kernel based on batch_seq
@@ -289,8 +294,8 @@ inline void lookup_kernel(const T* src_data, const int* indices, T* dst_data,
     CLAD_ASSERT(idx >= 0 && idx < (int)src_first_dim,
                 "Index out of bounds in lookup.");
 
-    const T* src_slice = src_data + idx * slice_size;
-    T* dst_slice = dst_data + i * slice_size;
+    const T* src_slice = src_data + (idx * slice_size);
+    T* dst_slice = dst_data + (i * slice_size);
 
     for (size_t j = 0; j < slice_size; ++j)
       dst_slice[j] = src_slice[j];
@@ -318,9 +323,9 @@ inline void view_kernel(const T* src_data, T* dst_data,
     size_t src_stride = src_strides[split_axis];
 
     for (size_t i = 0; i < outer_elements; ++i) {
-      const T* src_ptr = src_data + offset * src_stride +
-                         i * src_stride * src_shape[split_axis];
-      T* dst_ptr = dst_data + i * copy_size;
+      const T* src_ptr = src_data + (offset * src_stride) +
+                         (i * src_stride * src_shape[split_axis]);
+      T* dst_ptr = dst_data + (i * copy_size);
       std::memcpy(dst_ptr, src_ptr, copy_size * sizeof(T));
     }
     return;
@@ -380,7 +385,7 @@ inline void transpose_2d_kernel(const T* src_data, T* dst_data, size_t rows,
 
       for (size_t ii = i; ii < max_i; ++ii)
         for (size_t jj = j; jj < max_j; ++jj)
-          dst_data[jj * rows + ii] = src_data[ii * cols + jj];
+          dst_data[(jj * rows) + ii] = src_data[(ii * cols) + jj];
     }
   }
 }
@@ -428,7 +433,7 @@ inline void transpose_2d_kernel<float>(const float* src_data, float* dst_data,
         // Fallback scalar version
         for (size_t ii = i; ii < max_i; ++ii)
           for (size_t jj = j; jj < max_j; ++jj)
-            dst_data[jj * rows + ii] = src_data[ii * cols + jj];
+            dst_data[(jj * rows) + ii] = src_data[(ii * cols) + jj];
       }
     }
   }
@@ -454,8 +459,8 @@ inline void transpose_cache_optimized(const T* src_data, T* dst_data,
         for (size_t jj = j; jj < max_j; ++jj) {
           if (ii < rows && jj < cols && jj < src_row_stride &&
               ii < dst_row_stride) {
-            dst_data[jj * dst_row_stride + ii] =
-                src_data[ii * src_row_stride + jj];
+            dst_data[(jj * dst_row_stride) + ii] =
+                src_data[(ii * src_row_stride) + jj];
           }
         }
       }
@@ -531,9 +536,9 @@ inline void transpose_direct_kernel(const T* src_data, T* dst_data,
         for (size_t ii = i; ii < max_i; ++ii) {
           for (size_t jj = j; jj < max_j; ++jj) {
             size_t src_idx =
-                outer_src_base + ii * src_stride0 + jj * src_stride1;
+                outer_src_base + (ii * src_stride0) + (jj * src_stride1);
             size_t dst_idx =
-                outer_dst_base + jj * dst_stride0 + ii * dst_stride1;
+                outer_dst_base + (jj * dst_stride0) + (ii * dst_stride1);
             dst_data[dst_idx] = src_data[src_idx];
           }
         }
@@ -544,14 +549,9 @@ inline void transpose_direct_kernel(const T* src_data, T* dst_data,
 
 // Performance utilities
 namespace transpose_perf {
-inline size_t calculate_memory_bandwidth(size_t elements, size_t element_size) {
-  return elements * element_size * 2; // read + write
-}
-
 inline bool should_use_parallel(size_t total_elements) {
   return total_elements > 50000; // Threshold for parallel processing
 }
-
 inline bool is_cache_friendly_size(size_t dim0, size_t dim1) {
   return (dim0 * dim1 * sizeof(float)) < (1024 * 1024); // < 1MB
 }
@@ -595,28 +595,30 @@ inline void transpose_kernel(const T* src_data, T* dst_data,
 }
 
 inline float vec_mean_kernel(size_t vec_size, const float* src) {
-  float sum = 0.0f;
+  float sum = 0.0F;
+#pragma omp simd reduction(+ : sum)
   for (size_t i = 0; i < vec_size; i++)
     sum += src[i];
-  return sum / vec_size;
+  return sum / (float)vec_size;
 }
 
 inline float vec_rstd_kernel(size_t vec_size, const float* src, float mean) {
-  float eps = 1e-5f;
-  float sum = 0.0f;
+  float eps = 1e-5F;
+  float sum = 0.0F;
+#pragma omp simd
   for (size_t i = 0; i < vec_size; i++) {
     float diff = src[i] - mean;
     sum += diff * diff;
   }
-  float var = sum / vec_size;
-  return 1.0f / std::sqrt(var + eps);
+  float var = sum / (float)vec_size;
+  return 1.0F / std::sqrt(var + eps);
 }
 
 inline void norm_kernel(const float* src_data, float* dst_data,
                         size_t num_vectors, size_t vec_size) {
   for (size_t idx = 0; idx < num_vectors; ++idx) {
-    const float* vec = src_data + idx * vec_size;
-    float* out = dst_data + idx * vec_size;
+    const float* vec = src_data + (idx * vec_size);
+    float* out = dst_data + (idx * vec_size);
 
     // Calculate the mean and the rstd (without bias correction)
     float mean = vec_mean_kernel(vec_size, vec);
@@ -705,25 +707,26 @@ inline void broadcast_add_kernel(const T* a_data, const T* b_data,
     // Convert flat index to multi-dimensional coordinates
     std::vector<int> coords(result_shape.size());
     size_t temp_idx = result_idx;
-    for (long i = result_shape.size() - 1; i >= 0; --i) {
-      coords[i] = temp_idx % result_shape[i];
+    for (long i = (long)result_shape.size() - 1; i >= 0; --i) {
+      coords[i] = (int)temp_idx % result_shape[i];
       temp_idx /= result_shape[i];
     }
 
     // Get indices for a and b with broadcasting
-    size_t a_idx = 0, b_idx = 0;
+    size_t a_idx = 0;
+    size_t b_idx = 0;
 
     // Map to a coordinates
-    int a_dim = a_shape.size() - 1;
-    for (int coord_dim = coords.size() - 1; coord_dim >= 0 && a_dim >= 0;
+    int a_dim = (int)a_shape.size() - 1;
+    for (int coord_dim = (int)coords.size() - 1; coord_dim >= 0 && a_dim >= 0;
          --coord_dim, --a_dim) {
       int a_coord = (a_shape[a_dim] == 1) ? 0 : coords[coord_dim];
       a_idx += a_coord * a_strides[a_dim];
     }
 
     // Map to b coordinates
-    int b_dim = b_shape.size() - 1;
-    for (int coord_dim = coords.size() - 1; coord_dim >= 0 && b_dim >= 0;
+    int b_dim = (int)b_shape.size() - 1;
+    for (int coord_dim = (int)coords.size() - 1; coord_dim >= 0 && b_dim >= 0;
          --coord_dim, --b_dim) {
       int b_coord = (b_shape[b_dim] == 1) ? 0 : coords[coord_dim];
       b_idx += b_coord * b_strides[b_dim];
@@ -734,3 +737,8 @@ inline void broadcast_add_kernel(const T* a_data, const T* b_data,
 }
 
 } // namespace cladtorch::kernels
+
+// NOLINTEND(cppcoreguidelines-pro-bounds-*, *-avoid-c-arrays,
+// modernize-loop-convert)
+
+#endif // CLADTORCH_KERNELS_HPP


### PR DESCRIPTION
Adds implementation for the tensor header-only library `cladtorch`, and an implementation of the GPT-2 architecture using it. The training loop fine-tunes on the tiny-shakespeare dataset and uses `clad::gradient` for the backpropagation pass.