### PR TITLE
Don't create dynamic arrays for static arrays declarations inside loops

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -252,6 +252,11 @@ namespace clad {
                                      llvm::StringRef prefix = "_t",
                                      bool moveToTape = false);
 
+    /// Build element-wise move between 2 arrays, e.g.
+    /// `std::move(std::begin(from), std::end(from), std::begin(to));`
+    clang::Expr* BuildArrayAssignment(clang::Expr* output, clang::Expr* input,
+                                      direction d);
+
     //// A type returned by DelayedGlobalStoreAndRef
     /// .Result is a reference to the created (yet uninitialized) global
     /// variable. When the expression is finally visited and rebuilt, .Finalize

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -476,18 +476,10 @@ namespace clad {
       Expr* Base, const llvm::SmallVectorImpl<clang::Expr*>& Indices) {
     Expr* result = Base;
     SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
-    if (utils::isArrayOrPointerType(Base->getType())) {
-      for (Expr* I : Indices)
-        result =
-            m_Sema.CreateBuiltinArraySubscriptExpr(result, fakeLoc, I, fakeLoc)
-                .get();
-    } else {
-      Expr* idx = Indices.back();
-      result = m_Sema
-                   .ActOnArraySubscriptExpr(getCurrentScope(), Base, fakeLoc,
-                                            idx, fakeLoc)
-                   .get();
-    }
+    for (Expr* I : Indices)
+      result =
+          m_Sema.CreateBuiltinArraySubscriptExpr(result, fakeLoc, I, fakeLoc)
+              .get();
     return result;
   }
 

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -335,10 +335,10 @@ double func6(double seed) {
 //CHECK: void func6_grad(double seed, double *_d_seed) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
+//CHECK-NEXT:     clad::tape<double{{ ?}}[3]> _t2 = {};
 //CHECK-NEXT:     double _d_arr[3] = {0};
-//CHECK-NEXT:     clad::array<double> arr({{3U|3UL|3ULL}});
-//CHECK-NEXT:     clad::tape<double> _t2 = {};
+//CHECK-NEXT:     double arr[3] = {0};
+//CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
@@ -348,8 +348,9 @@ double func6(double seed) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, std::move(arr)) , arr = {seed, seed * i, seed + i};
-//CHECK-NEXT:         clad::push(_t2, sum);
+//CHECK-NEXT:         double (&&_t1)[3] = {seed, seed * i, seed + i};
+//CHECK-NEXT:         clad::push(_t2, arr) , std::move(std::begin(_t1), std::end(_t1), std::begin(arr));
+//CHECK-NEXT:         clad::push(_t3, sum);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
@@ -360,10 +361,10 @@ double func6(double seed) {
 // CHECK-NEXT:         }
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t2);
+//CHECK-NEXT:             sum = clad::pop(_t3);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             int _r0 = 0;
-//CHECK-NEXT:             addArr_pullback(arr, 3, _r_d0, _d_arr, &_r0);
+//CHECK-NEXT:             int _r1 = 0;
+//CHECK-NEXT:             addArr_pullback(arr, 3, _r_d0, _d_arr, &_r1);
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             *_d_seed += _d_arr[0];
@@ -372,7 +373,9 @@ double func6(double seed) {
 //CHECK-NEXT:             *_d_seed += _d_arr[2];
 //CHECK-NEXT:             _d_i += _d_arr[2];
 //CHECK-NEXT:             clad::zero_init(_d_arr);
-//CHECK-NEXT:             arr = clad::pop(_t1);
+//CHECK-NEXT:             double &_r0[3] = clad::back(_t2);
+//CHECK-NEXT:             std::move(std::begin(_r0), std::end(_r0), std::begin(arr));
+//CHECK-NEXT:             clad::pop(_t2);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -402,10 +405,10 @@ double func7(double *params) {
 //CHECK: void func7_grad(double *params, double *_d_params) {
 //CHECK-NEXT:     std::size_t _d_i = {{0U|0UL}};
 //CHECK-NEXT:     std::size_t i = {{0U|0UL}};
-//CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
+//CHECK-NEXT:     clad::tape<double{{ ?}}[1]> _t2 = {};
 //CHECK-NEXT:     double _d_paramsPrime[1] = {0};
-//CHECK-NEXT:     clad::array<double> paramsPrime({{1U|1UL|1ULL}});
-//CHECK-NEXT:     clad::tape<double> _t2 = {};
+//CHECK-NEXT:     double paramsPrime[1] = {0};
+//CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     double _d_out = 0.;
 //CHECK-NEXT:     double out = 0.;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
@@ -415,8 +418,9 @@ double func7(double *params) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, std::move(paramsPrime)) , paramsPrime = {params[0]};
-// CHECK-NEXT:         clad::push(_t2, out);
+// CHECK-NEXT:         double (&&_t1)[1] = {params[0]};
+// CHECK-NEXT:         clad::push(_t2, paramsPrime) , std::move(std::begin(_t1), std::end(_t1), std::begin(paramsPrime));
+// CHECK-NEXT:         clad::push(_t3, out);
 // CHECK-NEXT:         out = out + inv_square(paramsPrime);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
@@ -427,7 +431,7 @@ double func7(double *params) {
 // CHECK-NEXT:         }
 //CHECK-NEXT:         --i;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             out = clad::pop(_t2);
+//CHECK-NEXT:             out = clad::pop(_t3);
 //CHECK-NEXT:             double _r_d0 = _d_out;
 //CHECK-NEXT:             _d_out = 0.;
 //CHECK-NEXT:             _d_out += _r_d0;
@@ -436,7 +440,9 @@ double func7(double *params) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _d_params[0] += _d_paramsPrime[0];
 //CHECK-NEXT:             clad::zero_init(_d_paramsPrime);
-//CHECK-NEXT:             paramsPrime = clad::pop(_t1);
+//CHECK-NEXT:             double &_r0[1] = clad::back(_t2);
+//CHECK-NEXT:             std::move(std::begin(_r0), std::end(_r0), std::begin(paramsPrime));
+//CHECK-NEXT:             clad::pop(_t2);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -631,7 +637,7 @@ double func11(double seed) {
 // CHECK-NEXT:    int _d_i = 0;
 // CHECK-NEXT:    int i = 0;
 // CHECK-NEXT:    double _d_arr[3] = {0};
-// CHECK-NEXT:    clad::array<double> arr({{3U|3UL|3ULL}});
+// CHECK-NEXT:    double arr[3];
 // CHECK-NEXT:    clad::tape<double> _t1 = {};
 // CHECK-NEXT:    clad::tape<double> _t2 = {};
 // CHECK-NEXT:    clad::tape<double> _t3 = {};

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -1763,10 +1763,10 @@ double fn21(double x) {
 // CHECK: void fn21_grad(double x, double *_d_x) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
+// CHECK-NEXT:     clad::tape<double{{ ?}}[3]> _t2 = {};
 // CHECK-NEXT:     double _d_arr[3] = {0};
-// CHECK-NEXT:     clad::array<double> arr({{3U|3UL|3ULL}});
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     double arr[3] = {0};
+// CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
@@ -1776,8 +1776,9 @@ double fn21(double x) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, std::move(arr)) , arr = {1, x, 2};
-// CHECK-NEXT:         clad::push(_t2, res);
+// CHECK-NEXT:         double (&&_t1)[3] = {1, x, 2};
+// CHECK-NEXT:         clad::push(_t2, arr) , std::move(std::begin(_t1), std::end(_t1), std::begin(arr)); 
+// CHECK-NEXT:         clad::push(_t3, res);
 // CHECK-NEXT:         res += arr[0] + arr[1];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
@@ -1788,7 +1789,7 @@ double fn21(double x) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             res = clad::pop(_t2);
+// CHECK-NEXT:             res = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_res;
 // CHECK-NEXT:             _d_arr[0] += _r_d0;
 // CHECK-NEXT:             _d_arr[1] += _r_d0;
@@ -1796,7 +1797,9 @@ double fn21(double x) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             *_d_x += _d_arr[1];
 // CHECK-NEXT:             clad::zero_init(_d_arr);
-// CHECK-NEXT:             arr = clad::pop(_t1);
+// CHECK-NEXT:             double &_r0[3] = clad::back(_t2);
+// CHECK-NEXT:             std::move(std::begin(_r0), std::end(_r0), std::begin(arr));
+// CHECK-NEXT:             clad::pop(_t2); 
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -1814,10 +1817,9 @@ double fn22(double param) {
 // CHECK: void fn22_grad(double param, double *_d_param) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<clad::array<double> > _t1 = {};
+// CHECK-NEXT:     clad::tape<double{{ ?}}[1]> _t2 = {};
 // CHECK-NEXT:     double _d_arr[1] = {0};
-// CHECK-NEXT:     clad::array<double> arr({{1U|1UL|1ULL}});
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     double arr[1] = {0};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_out = 0.;
 // CHECK-NEXT:     double out = 0.;
@@ -1828,10 +1830,10 @@ double fn22(double param) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, std::move(arr)) , arr = {1.};
-// CHECK-NEXT:         clad::push(_t2, out);
-// CHECK-NEXT:         clad::push(_t3, arr[0]);
-// CHECK-NEXT:         out += clad::back(_t3) * param;
+// CHECK-NEXT:         double (&&_t1)[1] = {1.};
+// CHECK-NEXT:         clad::push(_t2, arr) , std::move(std::begin(_t1), std::end(_t1), std::begin(arr));
+// CHECK-NEXT:         clad::push(_t3, out);
+// CHECK-NEXT:         out += arr[0] * param;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
 // CHECK-NEXT:     for (;; _t0--) {
@@ -1841,15 +1843,16 @@ double fn22(double param) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             out = clad::pop(_t2);
+// CHECK-NEXT:             out = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_out;
 // CHECK-NEXT:             _d_arr[0] += _r_d0 * param;
-// CHECK-NEXT:             *_d_param += clad::back(_t3) * _r_d0;
-// CHECK-NEXT:             clad::pop(_t3);
+// CHECK-NEXT:             *_d_param += arr[0] * _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::zero_init(_d_arr);
-// CHECK-NEXT:             arr = clad::pop(_t1);
+// CHECK-NEXT:             double &_r0[1] = clad::back(_t2);
+// CHECK-NEXT:             std::move(std::begin(_r0), std::end(_r0), std::begin(arr));
+// CHECK-NEXT:             clad::pop(_t2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }


### PR DESCRIPTION
This PR fixes #1466. The only reason C arrays were replaced with dynamic ``clad::array`` is that C arrays are non-assignable and hard to handle. This PR creates exceptions in the way our store/restore system works so that such arrays can be handled.