### PR TITLE
Add custom derivative for thrust::reduce

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           build_dir: build
           apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libthrust-dev
-          exclude: "test/*,unittests/*,benchmark/*,demos/*"
+          exclude: "test/*,unittests/*"
           split_workflow: true
           config_file: .clang-tidy
           cmake_command: >

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -34,8 +34,8 @@ jobs:
         id: review
         with:
           build_dir: build
-          apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev
-          exclude: "test/*,unittests/*"
+          apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libthrust-dev
+          exclude: "test/*,unittests/*,benchmark/*,demos/*"
           split_workflow: true
           config_file: .clang-tidy
           cmake_command: >

--- a/include/clad/Differentiator/ThrustDerivatives.h
+++ b/include/clad/Differentiator/ThrustDerivatives.h
@@ -1,0 +1,183 @@
+#ifndef CLAD_DIFFERENTIATOR_THRUSTDERIVATIVES_H
+#define CLAD_DIFFERENTIATOR_THRUSTDERIVATIVES_H
+
+#include <cstddef>
+#include <iterator>
+#include <thrust/count.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/for_each.h>
+#include <thrust/functional.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/reduce.h>
+#include <thrust/transform.h>
+#include <thrust/tuple.h>
+#include <type_traits>
+
+#include "clad/Differentiator/Differentiator.h"
+
+namespace clad::custom_derivatives::thrust {
+
+template <typename Iterator, typename T, typename BinaryOp>
+void reduce_pullback(Iterator first, Iterator last, T init, BinaryOp op,
+                     T d_output, Iterator* d_first, Iterator* d_last, T* d_init,
+                     BinaryOp* d_op) {
+  size_t n = ::thrust::distance(first, last);
+
+  auto d_first_const_ptr = ::thrust::raw_pointer_cast((*d_first).base());
+  auto d_first_ptr = const_cast<T*>(d_first_const_ptr);
+  ::thrust::device_ptr<T> d_first_dev_ptr(d_first_ptr);
+
+  if constexpr (::std::is_same_v<BinaryOp, ::thrust::plus<T>>) {
+    if (d_init)
+      *d_init += d_output;
+
+    struct add_d_output {
+      T d_output;
+      add_d_output(T d) : d_output(d) {}
+      __host__ __device__ void operator()(T& x) const { x += d_output; }
+    };
+
+    if (n > 0) {
+      ::thrust::for_each(d_first_dev_ptr, d_first_dev_ptr + n,
+                         add_d_output(d_output));
+    }
+
+  } else if constexpr (::std::is_same_v<BinaryOp, ::thrust::maximum<T>>) {
+    auto maxValue = ::thrust::reduce(first, last, init, ::thrust::maximum<T>());
+    auto k = (init == maxValue) ? 1 : 0;
+    k += ::thrust::count(first, last, maxValue);
+
+    if (k > 0) {
+      auto gradient = d_output / k;
+      if (d_init && init == maxValue)
+        *d_init += gradient;
+
+      struct max_grad_functor {
+        T max_val, gradient;
+        max_grad_functor(T mv, T g) : max_val(mv), gradient(g) {}
+        __host__ __device__ void
+        operator()(::thrust::tuple<T&, const T&> t) const {
+          if (::thrust::get<1>(t) == max_val)
+            ::thrust::get<0>(t) += gradient;
+        }
+      };
+
+      if (n > 0) {
+        auto iter = ::thrust::make_zip_iterator(
+            ::thrust::make_tuple(d_first_dev_ptr, first));
+        ::thrust::for_each(iter, iter + n,
+                           max_grad_functor(maxValue, gradient));
+      }
+    }
+
+  } else if constexpr (::std::is_same_v<BinaryOp, ::thrust::minimum<T>>) {
+    auto minValue = ::thrust::reduce(first, last, init, ::thrust::minimum<T>());
+    auto k = (init == minValue) ? 1 : 0;
+    k += ::thrust::count(first, last, minValue);
+
+    if (k > 0) {
+      auto gradient = d_output / k;
+      if (d_init && init == minValue)
+        *d_init += gradient;
+
+      struct min_grad_functor {
+        T min_val, gradient;
+        min_grad_functor(T mv, T g) : min_val(mv), gradient(g) {}
+        __host__ __device__ void
+        operator()(::thrust::tuple<T&, const T&> t) const {
+          if (::thrust::get<1>(t) == min_val)
+            ::thrust::get<0>(t) += gradient;
+        }
+      };
+
+      if (n > 0) {
+        auto iter = ::thrust::make_zip_iterator(
+            ::thrust::make_tuple(d_first_dev_ptr, first));
+        ::thrust::for_each(iter, iter + n,
+                           min_grad_functor(minValue, gradient));
+      }
+    }
+
+  } else if constexpr (::std::is_same_v<BinaryOp, ::thrust::multiplies<T>>) {
+    size_t zero_count = ::thrust::count(first, last, 0);
+    bool init_is_zero = (init == 0);
+
+    if (zero_count > 1 || (zero_count == 1 && init_is_zero)) {
+    } else if (zero_count == 1 && !init_is_zero) {
+      struct replace_zero_with_one {
+        __host__ __device__ T operator()(const T& x) const {
+          return (x == 0) ? 1 : x;
+        }
+      };
+      T non_zero_product = ::thrust::reduce(
+          ::thrust::make_transform_iterator(first, replace_zero_with_one()),
+          ::thrust::make_transform_iterator(last, replace_zero_with_one()),
+          init, ::thrust::multiplies<T>());
+
+      struct single_zero_grad_functor {
+        T gradient;
+        single_zero_grad_functor(T g) : gradient(g) {}
+        __host__ __device__ void
+        operator()(::thrust::tuple<T&, const T&> t) const {
+          if (::thrust::get<1>(t) == 0)
+            ::thrust::get<0>(t) += gradient;
+        }
+      };
+      ::thrust::for_each(::thrust::make_zip_iterator(
+                             ::thrust::make_tuple(d_first_dev_ptr, first)),
+                         ::thrust::make_zip_iterator(
+                             ::thrust::make_tuple(d_first_dev_ptr + n, last)),
+                         single_zero_grad_functor(d_output * non_zero_product));
+
+    } else if (zero_count == 0 && init_is_zero) {
+      if (d_init) {
+        T vector_product =
+            ::thrust::reduce(first, last, (T)1, ::thrust::multiplies<T>());
+        *d_init += d_output * vector_product;
+      }
+    } else {
+      auto product =
+          ::thrust::reduce(first, last, init, ::thrust::multiplies<T>());
+
+      if (d_init)
+        *d_init += d_output * product / init;
+
+      struct multiplies_grad_functor {
+        T d_output, product;
+        multiplies_grad_functor(T d, T p) : d_output(d), product(p) {}
+        __host__ __device__ T operator()(const T& d_x, const T& x) const {
+          return d_x + d_output * product / x;
+        }
+      };
+
+      if (n > 0) {
+        ::thrust::transform(d_first_dev_ptr, d_first_dev_ptr + n, first,
+                            d_first_dev_ptr,
+                            multiplies_grad_functor(d_output, product));
+      }
+    }
+
+  } else if constexpr (::std::is_same_v<BinaryOp, ::thrust::bit_and<T>> ||
+                       ::std::is_same_v<BinaryOp, ::thrust::bit_or<T>> ||
+                       ::std::is_same_v<BinaryOp, ::thrust::bit_xor<T>> ||
+                       ::std::is_same_v<BinaryOp, ::thrust::equal_to<T>> ||
+                       ::std::is_same_v<BinaryOp, ::thrust::greater<T>> ||
+                       ::std::is_same_v<BinaryOp, ::thrust::greater_equal<T>> ||
+                       ::std::is_same_v<BinaryOp, ::thrust::less<T>> ||
+                       ::std::is_same_v<BinaryOp, ::thrust::less_equal<T>> ||
+                       ::std::is_same_v<BinaryOp, ::thrust::logical_and<T>> ||
+                       ::std::is_same_v<BinaryOp, ::thrust::logical_or<T>> ||
+                       ::std::is_same_v<BinaryOp, ::thrust::not_equal_to<T>> ||
+                       ::std::is_same_v<BinaryOp, ::thrust::modulus<T>>) {
+  } else {
+    static_assert(::std::is_same_v<T, void>,
+                  "This binary operation is not supported by the custom "
+                  "reduce_pullback.");
+  }
+}
+
+} // namespace clad::custom_derivatives::thrust
+
+#endif // CLAD_DIFFERENTIATOR_THRUSTDERIVATIVES_H

--- a/test/CUDA/ThrustReduce.cu
+++ b/test/CUDA/ThrustReduce.cu
@@ -1,0 +1,161 @@
+// RUN: %cladclang_cuda -I%S/../../include --cuda-path=%cudapath \
+// RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oThrustReduce.out \
+// RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
+//
+// RUN: ./ThrustReduce.out | %filecheck_exec %s
+//
+// REQUIRES: cuda-runtime
+//
+// expected-no-diagnostics
+
+#include <iostream>
+#include <vector>
+#include <iomanip>
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/ThrustDerivatives.h"
+#include "../TestUtils.h"
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/copy.h>
+#include <thrust/functional.h>
+#include <thrust/memory.h>
+#include <thrust/reduce.h>
+
+
+double sum_array(const thrust::device_vector<double>& vec) {
+    return thrust::reduce(vec.begin(), vec.end(), 0.0, thrust::plus<double>());
+}
+// CHECK: void sum_array_grad(const thrust::device_vector<double> &vec, thrust::device_vector<double> *_d_vec) {
+// CHECK-NEXT: {
+// CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec));
+// CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec));
+// CHECK-NEXT:     double _r2 = 0.;
+// CHECK-NEXT:     thrust::plus<double> _r3 = {};
+// CHECK-NEXT:     clad::custom_derivatives::thrust::reduce_pullback(std::begin(vec), std::end(vec), 0., thrust::plus<double>(), 1, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+double max_array(const thrust::device_vector<double>& vec) {
+    return thrust::reduce(vec.begin(), vec.end(), 0.0, thrust::maximum<double>());
+}
+// CHECK: void max_array_grad(const thrust::device_vector<double> &vec, thrust::device_vector<double> *_d_vec) {
+// CHECK-NEXT: {
+// CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec));
+// CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec));
+// CHECK-NEXT:     double _r2 = 0.;
+// CHECK-NEXT:     thrust::maximum<double> _r3 = {};
+// CHECK-NEXT:     clad::custom_derivatives::thrust::reduce_pullback(std::begin(vec), std::end(vec), 0., thrust::maximum<double>(), 1, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+double min_array(const thrust::device_vector<double>& vec) {
+    return thrust::reduce(vec.begin(), vec.end(), 100.0, thrust::minimum<double>());
+}
+// CHECK: void min_array_grad(const thrust::device_vector<double> &vec, thrust::device_vector<double> *_d_vec) {
+// CHECK-NEXT: {
+// CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec));
+// CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec));
+// CHECK-NEXT:     double _r2 = 0.;
+// CHECK-NEXT:     thrust::minimum<double> _r3 = {};
+// CHECK-NEXT:     clad::custom_derivatives::thrust::reduce_pullback(std::begin(vec), std::end(vec), 100., thrust::minimum<double>(), 1, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+double product_array(const thrust::device_vector<double>& vec) {
+    return thrust::reduce(vec.begin(), vec.end(), 1.0, thrust::multiplies<double>());
+}
+// CHECK: void product_array_grad(const thrust::device_vector<double> &vec, thrust::device_vector<double> *_d_vec) {
+// CHECK-NEXT: {
+// CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec));
+// CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec));
+// CHECK-NEXT:     double _r2 = 0.;
+// CHECK-NEXT:     thrust::multiplies<double> _r3 = {};
+// CHECK-NEXT:     clad::custom_derivatives::thrust::reduce_pullback(std::begin(vec), std::end(vec), 1., thrust::multiplies<double>(), 1, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+double product_array_init_zero(const thrust::device_vector<double>& vec) {
+    return thrust::reduce(vec.begin(), vec.end(), 0.0, thrust::multiplies<double>());
+}
+// CHECK: void product_array_init_zero_grad(const thrust::device_vector<double> &vec, thrust::device_vector<double> *_d_vec) {
+// CHECK-NEXT: {
+// CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec));
+// CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec));
+// CHECK-NEXT:     double _r2 = 0.;
+// CHECK-NEXT:     thrust::multiplies<double> _r3 = {};
+// CHECK-NEXT:     clad::custom_derivatives::thrust::reduce_pullback(std::begin(vec), std::end(vec), 0., thrust::multiplies<double>(), 1, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+
+int main() {
+    // --- Standard Tests ---
+    std::vector<double> host_input = {10.0, 5.0, 2.0, 20.0};
+    thrust::device_vector<double> device_input = host_input;
+
+    // Test Summation
+    INIT_GRADIENT(sum_array);
+    thrust::device_vector<double> sum_gradients(host_input.size());
+    sum_array_grad.execute(device_input, &sum_gradients);
+    thrust::host_vector<double> host_sum_gradients = sum_gradients;
+    printf("Sum Gradients: %.3f %.3f %.3f %.3f\n", host_sum_gradients[0], host_sum_gradients[1], host_sum_gradients[2], host_sum_gradients[3]);
+    // CHECK-EXEC: Sum Gradients: 1.000 1.000 1.000 1.000
+
+    // Test Maximum
+    INIT_GRADIENT(max_array);
+    thrust::device_vector<double> max_gradients(host_input.size());
+    max_array_grad.execute(device_input, &max_gradients);
+    thrust::host_vector<double> host_max_gradients = max_gradients;
+    printf("Max Gradients: %.3f %.3f %.3f %.3f\n", host_max_gradients[0], host_max_gradients[1], host_max_gradients[2], host_max_gradients[3]);
+    // CHECK-EXEC: Max Gradients: 0.000 0.000 0.000 1.000
+
+    // Test Minimum
+    INIT_GRADIENT(min_array);
+    thrust::device_vector<double> min_gradients(host_input.size());
+    min_array_grad.execute(device_input, &min_gradients);
+    thrust::host_vector<double> host_min_gradients = min_gradients;
+    printf("Min Gradients: %.3f %.3f %.3f %.3f\n", host_min_gradients[0], host_min_gradients[1], host_min_gradients[2], host_min_gradients[3]);
+    // CHECK-EXEC: Min Gradients: 0.000 0.000 1.000 0.000
+
+    // Test Product (No Zeros)
+    INIT_GRADIENT(product_array);
+    thrust::device_vector<double> product_gradients(host_input.size());
+    product_array_grad.execute(device_input, &product_gradients);
+    thrust::host_vector<double> host_product_gradients = product_gradients;
+    printf("Product Gradients (No Zeros): %.3f %.3f %.3f %.3f\n", host_product_gradients[0], host_product_gradients[1], host_product_gradients[2], host_product_gradients[3]);
+    // CHECK-EXEC: Product Gradients (No Zeros): 200.000 400.000 1000.000 100.000
+
+    // --- Robust Product Tests ---
+    
+    // Test case 1: One zero in the input vector
+    std::vector<double> host_input_one_zero = {10.0, 5.0, 0.0, 20.0};
+    thrust::device_vector<double> device_input_one_zero = host_input_one_zero;
+    thrust::device_vector<double> p_grads_one_zero(host_input_one_zero.size());
+    product_array_grad.execute(device_input_one_zero, &p_grads_one_zero);
+    thrust::host_vector<double> h_p_grads_one_zero = p_grads_one_zero;
+    printf("Product Gradients (One Zero): %.3f %.3f %.3f %.3f\n", h_p_grads_one_zero[0], h_p_grads_one_zero[1], h_p_grads_one_zero[2], h_p_grads_one_zero[3]);
+    // CHECK-EXEC: Product Gradients (One Zero): 0.000 0.000 1000.000 0.000
+
+    // Test case 2: Multiple zeros in the input vector
+    std::vector<double> host_input_multi_zero = {10.0, 0.0, 2.0, 0.0};
+    thrust::device_vector<double> device_input_multi_zero = host_input_multi_zero;
+    thrust::device_vector<double> p_grads_multi_zero(host_input_multi_zero.size());
+    product_array_grad.execute(device_input_multi_zero, &p_grads_multi_zero);
+    thrust::host_vector<double> h_p_grads_multi_zero = p_grads_multi_zero;
+    printf("Product Gradients (Multiple Zeros): %.3f %.3f %.3f %.3f\n", h_p_grads_multi_zero[0], h_p_grads_multi_zero[1], h_p_grads_multi_zero[2], h_p_grads_multi_zero[3]);
+    // CHECK-EXEC: Product Gradients (Multiple Zeros): 0.000 0.000 0.000 0.000
+
+    // Test case 3: Initial value is zero
+    INIT_GRADIENT(product_array_init_zero);
+    std::vector<double> host_input_for_init_zero = {10.0, 5.0, 2.0, 20.0};
+    thrust::device_vector<double> device_input_for_init_zero = host_input_for_init_zero;
+    thrust::device_vector<double> p_grads_init_zero(host_input_for_init_zero.size());
+    product_array_init_zero_grad.execute(device_input_for_init_zero, &p_grads_init_zero);
+    thrust::host_vector<double> h_p_grads_init_zero = p_grads_init_zero;
+    printf("Product Gradients (Init is Zero): %.3f %.3f %.3f %.3f\n", h_p_grads_init_zero[0], h_p_grads_init_zero[1], h_p_grads_init_zero[2], h_p_grads_init_zero[3]);
+    // CHECK-EXEC: Product Gradients (Init is Zero): 0.000 0.000 0.000 0.000
+
+    return 0;
+} 


### PR DESCRIPTION
This PR adds a custom derivative for thrust::reduce to support reverse-mode automatic differentiation of common parallel reduction patterns in Thrust.

Current supported operators: 

- plus
- maximum
- minimum
- multiplies