### PR TITLE
Don't store unused return values of reverse_forw

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -9,6 +9,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclarationName.h"
+#include "clang/AST/Expr.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Sema/Ownership.h"
@@ -397,6 +398,9 @@ namespace clad {
     bool isLinearConstructor(const clang::CXXConstructorDecl* CD,
                              const clang::ASTContext& C);
 
+    /// Returns true if T allows to edit any memory.
+    bool isMemoryType(clang::QualType T);
+
     bool IsDifferentiableType(clang::QualType T);
 
     /// Returns true if FD can be differentiated as a pushforward
@@ -412,6 +416,8 @@ namespace clad {
     /// an expression, most likely an index, is injective, meaning no two
     /// threads have the same value.
     bool isInjective(const clang::Expr* E, clang::ASTContext& ctx);
+    /// Checks if the return value of the given CallExpr is unused.
+    bool hasUnusedReturnValue(clang::ASTContext& C, const clang::CallExpr* CE);
     } // namespace utils
     } // namespace clad
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1669,8 +1669,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     QualType returnType = FD->getReturnType();
     // FIXME: Decide this in the diff planner
-    bool needsForwPass = utils::isNonConstReferenceType(returnType) ||
-                         returnType->isPointerType();
+    bool needsForwPass = utils::isMemoryType(returnType);
 
     // FIXME: if the call is non-differentiable but needs a reverse forward
     // call, we still don't need to generate the pullback. The only challenge is
@@ -2120,7 +2119,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                                   CallArgs, Loc, CUDAExecConfig)
                    .get();
       }
-      if (!needsForwPass && !m_TrackVarDeclConstructor)
+      if (!needsForwPass || utils::hasUnusedReturnValue(m_Context, CE))
         return StmtDiff(call);
       Expr* callRes = nullptr;
       if (isInsideLoop)

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -503,7 +503,7 @@ double fn5(SimpleFunctions& v, double value) {
 
 // CHECK: void fn5_grad(SimpleFunctions &v, double value, SimpleFunctions *_d_v, double *_d_value) {
 // CHECK-NEXT:     SimpleFunctions _t0 = v;
-// CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = v.operator_plus_equal_reverse_forw(value, &(*_d_v), 0.);
+// CHECK-NEXT:     v.operator_plus_equal_reverse_forw(value, &(*_d_v), 0.);
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
@@ -534,7 +534,7 @@ double fn4(SimpleFunctions& v) {
 
 // CHECK: void fn4_grad(SimpleFunctions &v, SimpleFunctions *_d_v) {
 // CHECK-NEXT:     SimpleFunctions _t0 = v;
-// CHECK-NEXT:     clad::ValueAndAdjoint<SimpleFunctions &, SimpleFunctions &> _t1 = v.operator_plus_plus_reverse_forw(&(*_d_v));
+// CHECK-NEXT:     v.operator_plus_plus_reverse_forw(&(*_d_v));
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         v = _t0;

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -1137,13 +1137,13 @@ struct MyStructWrapper {
 
 // CHECK:  inline constexpr clad::ValueAndAdjoint<MyStructWrapper &, MyStructWrapper &> operator_equal_reverse_forw(MyStructWrapper &&arg, MyStructWrapper *_d_this, MyStructWrapper &&_d_arg) noexcept {
 // CHECK-NEXT:      MyStruct _t0 = this->val;
-// CHECK-NEXT:      clad::ValueAndAdjoint<MyStruct &, MyStruct &> _t1 = this->val.operator_equal_reverse_forw(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, {0., 0.});
+// CHECK-NEXT:      this->val.operator_equal_reverse_forw(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, {0., 0.});
 // CHECK-NEXT:      return {*this, *_d_this};
 // CHECK-NEXT:  }
 
 // CHECK:  inline constexpr void operator_equal_pullback(MyStructWrapper &&arg, MyStructWrapper _d_y, MyStructWrapper *_d_this, MyStructWrapper *_d_arg) noexcept {
 // CHECK-NEXT:      MyStruct _t0 = this->val;
-// CHECK-NEXT:      clad::ValueAndAdjoint<MyStruct &, MyStruct &> _t1 = this->val.operator_equal_reverse_forw(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, {0., 0.});
+// CHECK-NEXT:      this->val.operator_equal_reverse_forw(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, {0., 0.});
 // CHECK-NEXT:      {
 // CHECK-NEXT:          this->val = _t0;
 // CHECK-NEXT:          this->val.operator_equal_pullback(static_cast<MyStructWrapper &&>(arg).val, {0., 0.}, &_d_this->val, &(*_d_arg).val);


### PR DESCRIPTION
Currently, if we generate a `reverse_forw` of a function call, we store the result unconditionally.
```
ValueAndAdjoint<type, type> _t0 = f_reverse_forw(...);
```
After that, we're supposed to use ``_t0`` as ``_t0.value``/``_t0.adjoint``. However, this never happens if the return value of the original ``f`` was unused. The problem becomes even more critical inside of loops, where the result is pushed on the tape instead. This is an important optimization to efficiently support many member functions and overloaded operators. ``operator=``, ``operator++``, etc., are examples of methods that often have unused return values.
We can check this by analyzing the parent stmts of the call expr: if it's a stmt but not an expr, then the result is not used in a differentiable way. Note that ``VarDecl`` is not a stmt and, therefore, its init WILL be considered used.