### PR TITLE
Don't unnecessarily move loop condition to the loop body

### DIFF
--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -287,21 +287,13 @@ double f9(double x, double const *obs)
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0.;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (loopIdx0 = 0; ; loopIdx0++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(loopIdx0 < 2))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (loopIdx0 = 0; loopIdx0 < 2; loopIdx0++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += std::lgamma(obs[2 + loopIdx0] + 1) + x;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         loopIdx0--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t1);

--- a/test/Analyses/TBR.cpp
+++ b/test/Analyses/TBR.cpp
@@ -19,21 +19,13 @@ double f1(double x) {
 //CHECK-NEXT:     double _d_t = 0.;
 //CHECK-NEXT:     double t = 1;
 //CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-//CHECK-NEXT:         {
-//CHECK-NEXT:             if (!(i < 3))
-//CHECK-NEXT:                 break;
-//CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, t);
 //CHECK-NEXT:         t *= x;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_t += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-//CHECK-NEXT:         {
-//CHECK-NEXT:             if (!_t0)
-//CHECK-NEXT:                 break;
-//CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         t = clad::pop(_t1);
 //CHECK-NEXT:         double _r_d0 = _d_t;
 //CHECK-NEXT:         _d_t = 0.;
@@ -60,11 +52,7 @@ double f2(double val) {
 //CHECK-NEXT:     double _d_res = 0.;
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
-//CHECK-NEXT:     for (i = 1; ; ++i) {
-//CHECK-NEXT:         {
-//CHECK-NEXT:             if (!(i < 5))
-//CHECK-NEXT:                 break;
-//CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 1; i < 5; ++i) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             clad::push(_cond0, i == 3);
@@ -77,11 +65,7 @@ double f2(double val) {
 //CHECK-NEXT:         clad::push(_t1, {{2U|2UL}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_res += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-//CHECK-NEXT:         {
-//CHECK-NEXT:             if (!_t0)
-//CHECK-NEXT:                 break;
-//CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         --i;
 //CHECK-NEXT:         switch (clad::pop(_t1)) {
 //CHECK-NEXT:           case {{2U|2UL}}:

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -20,21 +20,13 @@ double addArr(const double *arr, int n) {
 //CHECK-NEXT:     double _d_ret = 0.;
 //CHECK-NEXT:     double ret = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-//CHECK-NEXT:         {
-//CHECK-NEXT:             if (!(i < n))
-//CHECK-NEXT:                 break;
-//CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, ret);
 //CHECK-NEXT:         ret += arr[i];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_ret += _d_y;
-//CHECK-NEXT:     for (;; _t0--) {
-//CHECK-NEXT:         {
-//CHECK-NEXT:             if (!_t0)
-//CHECK-NEXT:                 break;
-//CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             ret = clad::pop(_t1);
@@ -72,11 +64,7 @@ float func(float* a, float* b) {
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, a[i]);
 //CHECK-NEXT:         a[i] *= b[i];
@@ -84,11 +72,7 @@ float func(float* a, float* b) {
 //CHECK-NEXT:         sum += a[i];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t2);
@@ -127,21 +111,13 @@ float func2(float* a) {
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += helper(a[i]);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         sum = clad::pop(_t1);
 //CHECK-NEXT:         float _r_d0 = _d_sum;
@@ -166,22 +142,14 @@ float func3(float* a, float* b) {
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         clad::push(_t2, a[i]);
 //CHECK-NEXT:         sum += (a[i] += b[i]);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         sum = clad::pop(_t1);
 //CHECK-NEXT:         float _r_d0 = _d_sum;
@@ -210,21 +178,13 @@ double func4(double x) {
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t1);
@@ -271,11 +231,7 @@ double func5(int k) {
 //CHECK-NEXT:     clad::zero_init(_d_arr, n);
 //CHECK-NEXT:     double arr[n];
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, arr[i]);
 //CHECK-NEXT:         arr[i] = k;
@@ -283,21 +239,13 @@ double func5(int k) {
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t2 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i0 = 0; ; i0++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i0 < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i0 = 0; i0 < 3; i0++) {
 //CHECK-NEXT:         _t2++;
 //CHECK-NEXT:         clad::push(_t3, sum);
 //CHECK-NEXT:         sum += addArr(arr, n);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (;; _t2--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t2)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t2; _t2--) {
 //CHECK-NEXT:         i0--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t3);
@@ -307,11 +255,7 @@ double func5(int k) {
 //CHECK-NEXT:             _d_n += _r0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             arr[i] = clad::pop(_t1);
@@ -342,11 +286,7 @@ double func6(double seed) {
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         double (&&_t1)[3] = {seed, seed * i, seed + i};
 //CHECK-NEXT:         clad::push(_t2, arr) , std::move(std::begin(_t1), std::end(_t1), std::begin(arr));
@@ -354,11 +294,7 @@ double func6(double seed) {
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             sum = clad::pop(_t3);
@@ -412,11 +348,7 @@ double func7(double *params) {
 //CHECK-NEXT:     double _d_out = 0.;
 //CHECK-NEXT:     double out = 0.;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 1))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 1; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         double (&&_t1)[1] = {params[0]};
 // CHECK-NEXT:         clad::push(_t2, paramsPrime) , std::move(std::begin(_t1), std::end(_t1), std::begin(paramsPrime));
@@ -424,11 +356,7 @@ double func7(double *params) {
 // CHECK-NEXT:         out = out + inv_square(paramsPrime);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         --i;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             out = clad::pop(_t3);
@@ -529,11 +457,7 @@ double func9(double i, double j) {
 //CHECK-NEXT:     double _d_arr[5] = {0};
 //CHECK-NEXT:     double arr[5] = {};
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (idx = 0; ; ++idx) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(idx < 5))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (idx = 0; idx < 5; ++idx) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, arr[idx]);
 // CHECK-NEXT:         modify(arr[idx], i);
@@ -545,11 +469,7 @@ double func9(double i, double j) {
 // CHECK-NEXT:         _d_arr[3] += 1;
 // CHECK-NEXT:         _d_arr[4] += 1;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         --idx;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             arr[idx] = clad::pop(_t1);
@@ -595,22 +515,14 @@ double func10(double *arr, int n) {
 //CHECK-NEXT:     double _d_res = 0.;
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         clad::push(_t2, arr[i]);
 // CHECK-NEXT:         res += sq(arr[i]);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         --i;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             res = clad::pop(_t1);
@@ -645,11 +557,7 @@ double func11(double seed) {
 // CHECK-NEXT:    double _d_sum = 0.;
 // CHECK-NEXT:    double sum = 0;
 // CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:    for (i = 0; ; i++) {
-// CHECK-NEXT:        {
-// CHECK-NEXT:            if (!(i < 3))
-// CHECK-NEXT:                break;
-// CHECK-NEXT:        }
+// CHECK-NEXT:    for (i = 0; i < 3; i++) {
 // CHECK-NEXT:        _t0++;
 // CHECK-NEXT:        clad::push(_t1, arr[0]);
 // CHECK-NEXT:        arr[0] = seed;
@@ -661,11 +569,7 @@ double func11(double seed) {
 // CHECK-NEXT:        sum += addArr(arr, 3);
 // CHECK-NEXT:    }
 // CHECK-NEXT:    _d_sum += 1;
-// CHECK-NEXT:    for (;; _t0--) {
-// CHECK-NEXT:        {
-// CHECK-NEXT:            if (!_t0)
-// CHECK-NEXT:                break;
-// CHECK-NEXT:        }
+// CHECK-NEXT:    for (; _t0; _t0--) {
 // CHECK-NEXT:        i--;
 // CHECK-NEXT:        {
 // CHECK-NEXT:            sum = clad::pop(_t4);

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -37,11 +37,7 @@ __device__ __host__ double gauss(const double* x, double* p, double sigma, int d
 //CHECK-NEXT:     double _d_t = 0.;
 //CHECK-NEXT:     double t = 0;
 //CHECK-NEXT:     unsigned long _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-//CHECK-NEXT:         {
-//CHECK-NEXT:             if (!(i < dim))
-//CHECK-NEXT:                 break;
-//CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < dim; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, t);
 //CHECK-NEXT:         t += (x[i] - p[i]) * (x[i] - p[i]);
@@ -74,11 +70,7 @@ __device__ __host__ double gauss(const double* x, double* p, double sigma, int d
 //CHECK-NEXT:         _d_sigma += 2 * _r0 * sigma;
 //CHECK-NEXT:         _d_sigma += 2 * sigma * _r0;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     for (;; _t0--) {
-//CHECK-NEXT:         {
-//CHECK-NEXT:             if (!_t0)
-//CHECK-NEXT:                 break;
-//CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         t = clad::pop(_t1);
 //CHECK-NEXT:         double _r_d0 = _d_t;

--- a/test/CUDA/GradientKernels.cu
+++ b/test/CUDA/GradientKernels.cu
@@ -112,11 +112,7 @@ __global__ void add_kernel_4(int *out, int *in, int N) {
 // CHECK-NEXT:         if (_cond0) {
 // CHECK-NEXT:             sum = 0;
 // CHECK-NEXT:             _t0 = 0UL;
-// CHECK-NEXT:             for (i = index0; ; clad::push(_t1, i) , (i += warpSize)) {
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     if (!(i < N))
-// CHECK-NEXT:                         break;
-// CHECK-NEXT:                 }
+// CHECK-NEXT:             for (i = index0; i < N; clad::push(_t1, i) , (i += warpSize)) {
 // CHECK-NEXT:                 _t0++;
 // CHECK-NEXT:                 clad::push(_t2, sum);
 // CHECK-NEXT:                 sum += in[i];
@@ -133,11 +129,7 @@ __global__ void add_kernel_4(int *out, int *in, int N) {
 // CHECK-NEXT:             _d_sum += _r_d2;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             for (;; _t0--) {
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     if (!_t0)
-// CHECK-NEXT:                         break;
-// CHECK-NEXT:                 }
+// CHECK-NEXT:             for (; _t0; _t0--) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     i = clad::pop(_t1);
 // CHECK-NEXT:                     int _r_d0 = _d_i;
@@ -188,11 +180,7 @@ __global__ void add_kernel_5(int *out, int *in, int N) {
 // CHECK-NEXT:             sum = 0;
 // CHECK-NEXT:             totalThreads = blockDim.x * gridDim.x;
 // CHECK-NEXT:             _t0 = 0UL;
-// CHECK-NEXT:             for (i = index0; ; clad::push(_t1, i) , (i += totalThreads)) {
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     if (!(i < N))
-// CHECK-NEXT:                         break;
-// CHECK-NEXT:                 }
+// CHECK-NEXT:             for (i = index0; i < N; clad::push(_t1, i) , (i += totalThreads)) {
 // CHECK-NEXT:                 _t0++;
 // CHECK-NEXT:                 clad::push(_t2, sum);
 // CHECK-NEXT:                 sum += in[i];
@@ -209,11 +197,7 @@ __global__ void add_kernel_5(int *out, int *in, int N) {
 // CHECK-NEXT:             _d_sum += _r_d2;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             for (;; _t0--) {
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     if (!_t0)
-// CHECK-NEXT:                         break;
-// CHECK-NEXT:                 }
+// CHECK-NEXT:             for (; _t0; _t0--) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     i = clad::pop(_t1);
 // CHECK-NEXT:                     int _r_d0 = _d_i;
@@ -524,22 +508,14 @@ double fn_memory(double *out, double *in) {
 //CHECK-NEXT:    double _d_res = 0.;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    unsigned long _t0 = 0UL;
-//CHECK-NEXT:    for (i = 0; ; ++i) {
-//CHECK-NEXT:        {
-//CHECK-NEXT:            if (!(i < 10))
-//CHECK-NEXT:                break;
-//CHECK-NEXT:        }
+//CHECK-NEXT:    for (i = 0; i < 10; ++i) {
 //CHECK-NEXT:        _t0++;
 //CHECK-NEXT:        printf("Writing result of out[%d]\n", i);
 //CHECK-NEXT:        clad::push(_t1, res);
 //CHECK-NEXT:        res += out_host[i];
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_res += 1;
-//CHECK-NEXT:    for (;; _t0--) {
-//CHECK-NEXT:        {
-//CHECK-NEXT:            if (!_t0)
-//CHECK-NEXT:                break;
-//CHECK-NEXT:        }
+//CHECK-NEXT:    for (; _t0; _t0--) {
 //CHECK-NEXT:        --i;
 //CHECK-NEXT:        {
 //CHECK-NEXT:            res = clad::pop(_t1);
@@ -597,11 +573,7 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
 // CHECK-NEXT:         if (_cond0) {
 // CHECK-NEXT:             sum = 0;
 // CHECK-NEXT:             _t0 = 0UL;
-// CHECK-NEXT:             for (i = index0; ; clad::push(_t1, i) , (i += warpSize)) {
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     if (!(i < N))
-// CHECK-NEXT:                         break;
-// CHECK-NEXT:                 }
+// CHECK-NEXT:             for (i = index0; i < N; clad::push(_t1, i) , (i += warpSize)) {
 // CHECK-NEXT:                 _t0++;
 // CHECK-NEXT:                 clad::push(_t2, sum);
 // CHECK-NEXT:                 sum += in[i];
@@ -618,11 +590,7 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
 // CHECK-NEXT:             _d_sum += _r_d2;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             for (;; _t0--) {
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     if (!_t0)
-// CHECK-NEXT:                         break;
-// CHECK-NEXT:                 }
+// CHECK-NEXT:             for (; _t0; _t0--) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     i = clad::pop(_t1);
 // CHECK-NEXT:                     int _r_d0 = _d_i;

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -21,21 +21,13 @@ float func(float* p, int n) {
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += p[i];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});
@@ -71,22 +63,14 @@ float func2(float x) {
 //CHECK-NEXT:     float _d_z = 0.F;
 //CHECK-NEXT:     float z;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 9))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < 9; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, m) , m = x * x;
 //CHECK-NEXT:         clad::push(_t2, z);
 //CHECK-NEXT:         z = m + m;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_z += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_z * z * {{.+}});
@@ -172,11 +156,7 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 10))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < 10; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, x[i]);
 //CHECK-NEXT:         x[i] += y[i];
@@ -184,11 +164,7 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:         sum += x[i];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -21,21 +21,13 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 1; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 1; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += f[i] + f[i - 1];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});
@@ -75,36 +67,20 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, {{0U|0UL|0ULL}});
-//CHECK-NEXT:         for (clad::push(_t2, j) , j = 0; ; j++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(j < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:         for (clad::push(_t2, j) , j = 0; j < n; j++) {
 //CHECK-NEXT:             clad::back(_t1)++;
 //CHECK-NEXT:             clad::push(_t3, sum);
 //CHECK-NEXT:             sum += a[i] * b[j];
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             for (;; clad::back(_t1)--) {
-// CHECK-NEXT:              {
-// CHECK-NEXT:                 if (!clad::back(_t1))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:              }
+//CHECK-NEXT:             for (; clad::back(_t1); clad::back(_t1)--) {
 //CHECK-NEXT:                 j--;
 //CHECK-NEXT:                 _final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:                 sum = clad::pop(_t3);
@@ -148,21 +124,13 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += a[i] / b[i];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -170,11 +170,7 @@ float sum(double* arr, int n) {
 // CHECK-NEXT:     float _d_res = 0.F;
 // CHECK-NEXT:     float res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += arr[i];
@@ -187,11 +183,7 @@ float sum(double* arr, int n) {
 // CHECK-NEXT:         double _r_d1 = _d_arr[0];
 // CHECK-NEXT:         _d_arr[0] += 10 * _r_d1;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         res = clad::pop(_t1);
 // CHECK-NEXT:         float _r_d0 = _d_res;
@@ -234,11 +226,7 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:     double _t0 = res;
 // CHECK-NEXT:     res += sum(arr, n);
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t1 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:     {
-// CHECK-NEXT:          if (!(i < n))
-// CHECK-NEXT:          break;
-// CHECK-NEXT:     }
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t1++;
 // CHECK-NEXT:         clad::push(_t2, arr[i]);
 // CHECK-NEXT:         twice(arr[i]);
@@ -246,11 +234,7 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:         res += arr[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (;; _t1--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t1)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t1; _t1--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t3);
@@ -611,21 +595,13 @@ double fn13(double* x, const double* w) {
 // CHECK-NEXT:     double _d_wCopy[2] = {0};
 // CHECK-NEXT:     double wCopy[2];
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 2))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 2; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, wCopy[i]);
 // CHECK-NEXT:         wCopy[i] = w[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     multiply_pullback(x, wCopy + 1, 1, _d_x, _d_wCopy + 1);
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             wCopy[i] = clad::pop(_t1);

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -655,21 +655,13 @@ float running_sum(float* p, int n) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 1; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 1; i < n; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, p[i]);
 // CHECK-NEXT:         p[i] += p[i - 1];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_p[n - 1] += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             p[i] = clad::pop(_t1);

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -23,21 +23,13 @@ double f1(double x) {
 // CHECK-NEXT:     double _d_t = 0.;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 3; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, t);
 // CHECK-NEXT:         t *= x;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         t = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_t;
@@ -66,35 +58,19 @@ double f2(double x) {
 // CHECK-NEXT:     double _d_t = 0.;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 3; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:        clad::push(_t1, {{0U|0UL|0ULL}});
-// CHECK-NEXT:         for (clad::push(_t2, j) , j = 0; ; j++) {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 if (!(j < 3))
-// CHECK-NEXT:                     break;
-// CHECK-NEXT:             }
+// CHECK-NEXT:         for (clad::push(_t2, j) , j = 0; j < 3; j++) {
 // CHECK-NEXT:             clad::back(_t1)++;
 // CHECK-NEXT:             clad::push(_t3, t);
 // CHECK-NEXT:             t *= x;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
-// CHECK-NEXT:         for (;; clad::back(_t1)--) {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 if (!clad::back(_t1))
-// CHECK-NEXT:                     break;
-// CHECK-NEXT:             }
+// CHECK-NEXT:         for (; clad::back(_t1); clad::back(_t1)--) {
 // CHECK-NEXT:             j--;
 // CHECK-NEXT:             t = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_t;
@@ -128,11 +104,7 @@ double f3(double x) {
 // CHECK-NEXT:     double _d_t = 0.;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 3; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, t);
 // CHECK-NEXT:         t *= x;
@@ -143,11 +115,7 @@ double f3(double x) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (clad::back(_cond0))
@@ -179,20 +147,12 @@ double f4(double x) {
 // CHECK-NEXT:     double _d_t = 0.;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; clad::push(_t1, t) , (t *= x)) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 3; clad::push(_t1, t) , (t *= x)) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         i++;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             t = clad::pop(_t1);
 // CHECK-NEXT:             double _r_d0 = _d_t;
@@ -214,20 +174,12 @@ double f5(double x){
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 10))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 10; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         x++;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_x += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         x--;
 // CHECK-NEXT:     }
@@ -252,22 +204,14 @@ double f_const_local(double x) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, n) , n = x + i;
 // CHECK-NEXT:         clad::push(_t2, res);
 // CHECK-NEXT:         res += x * n;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t2);
@@ -299,21 +243,13 @@ double f_sum(double *p, int n) {
 // CHECK-NEXT:     double _d_s = 0.;
 // CHECK-NEXT:     double s = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < n; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, s);
 // CHECK-NEXT:         s += p[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_s += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         s = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_s;
@@ -341,21 +277,13 @@ double f_sum_squares(double *p, int n) {
 // CHECK-NEXT:     double _d_s = 0.;
 // CHECK-NEXT:     double s = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < n; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, s);
 // CHECK-NEXT:         s += sq(p[i]);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_s += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         s = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_s;
@@ -383,11 +311,7 @@ double f_log_gaus(const double* x, double* p /*means*/, double n, double sigma) 
 // CHECK-NEXT:     double _d_power = 0.;
 // CHECK-NEXT:     double power = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < n; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, power);
 // CHECK-NEXT:         power += sq(x[i] - p[i]);
@@ -429,11 +353,7 @@ double f_log_gaus(const double* x, double* p /*means*/, double n, double sigma) 
 // CHECK-NEXT:         _r2 += 2 * _r1 * sq_pushforward(sigma, 1.).pushforward;
 // CHECK-NEXT:         _d_sigma += _r2;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         power = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_power;
@@ -462,22 +382,14 @@ void f_const_grad(const double, const double, double*, double*);
 // CHECK-NEXT:     int _d_r = 0;
 // CHECK-NEXT:     int r = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < a))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < a; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, sq0) , sq0 = b * b;
 // CHECK-NEXT:         clad::push(_t2, r);
 // CHECK-NEXT:         r += sq0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_r += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             r = clad::pop(_t2);
@@ -518,11 +430,7 @@ double f6 (double i, double j) {
 // CHECK-NEXT:     double _d_a = 0.;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (counter = 0; ; ++counter) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(counter < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (counter = 0; counter < 3; ++counter) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, b) , b = i * i;
 // CHECK-NEXT:         clad::push(_t2, c) , c = j * j;
@@ -532,11 +440,7 @@ double f6 (double i, double j) {
 // CHECK-NEXT:         a += b + c + i;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_a += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --counter;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             a = clad::pop(_t4);
@@ -958,11 +862,7 @@ double fn13(double i, double j) {
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (;; clad::push(_t2, counter) , (counter -= 1)) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(clad::push(_t1, k) , k = counter))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; clad::push(_t1, k) , k = counter; clad::push(_t2, counter) , (counter -= 1)) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t3, k);
 // CHECK-NEXT:         k += i + 2 * j;
@@ -971,11 +871,7 @@ double fn13(double i, double j) {
 // CHECK-NEXT:         res += temp;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 counter = clad::pop(_t2);
@@ -1285,11 +1181,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (ii = 0; ; ++ii) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(ii < counter))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (ii = 0; ii < counter; ++ii) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, ii == 4);
@@ -1318,11 +1210,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:         clad::push(_t2, {{3U|3UL|3ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; ; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; _t0; _t0--) {
 // CHECK-NEXT:         if (_t0 != _numRevIterations0 || (clad::back(_t2) != 1))
 // CHECK-NEXT:          --ii;
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
@@ -1401,11 +1289,7 @@ double fn17(double i, double j) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (ii = 0; ; ++ii) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(ii < counter))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (ii = 0; ii < counter; ++ii) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, jj) , jj = ii;
 // CHECK-NEXT:         {
@@ -1442,11 +1326,7 @@ double fn17(double i, double j) {
 // CHECK-NEXT:         clad::push(_t2, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --ii;
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
 // CHECK-NEXT:           case {{2U|2UL|2ULL}}:
@@ -1529,11 +1409,7 @@ double fn18(double i, double j) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (counter = 0; ; ++counter) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(counter < choice))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (counter = 0; counter < choice; ++counter) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, counter < 2);
@@ -1558,11 +1434,7 @@ double fn18(double i, double j) {
 // CHECK-NEXT:         clad::push(_t2, {{3U|3UL|3ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; ; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; _t0; _t0--) {
 // CHECK-NEXT:         if (_t0 != _numRevIterations0 || (clad::back(_t2) != 2))
 // CHECK-NEXT:          --counter;
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
@@ -1615,11 +1487,7 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         _d_ref = &_d_arr[i];
 // CHECK-NEXT:         clad::push(_t1, _d_ref);
@@ -1628,11 +1496,7 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:         res += *ref;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         _d_ref = clad::pop(_t1);
 // CHECK-NEXT:         {
@@ -1666,22 +1530,14 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:     double _d_interval = 0.;
 // CHECK-NEXT:     double interval = (upper - lower) / num_points;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (x = lower; ; clad::push(_t1, x) , (x += interval)) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(x <= upper))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (x = lower; x <= upper; clad::push(_t1, x) , (x += interval)) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t2, sum);
 // CHECK-NEXT:         sum += x * x * interval;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         for (;; _t0--) {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 if (!_t0)
-// CHECK-NEXT:                     break;
-// CHECK-NEXT:             }
+// CHECK-NEXT:         for (; _t0; _t0--) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 x = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_x;
@@ -1721,22 +1577,14 @@ double fn20(double *arr, int n) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         clad::push(_t2, arr[i]);
 // CHECK-NEXT:         res += (arr[i] *= 5);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t1);
@@ -1770,11 +1618,7 @@ double fn21(double x) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 5))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         double (&&_t1)[3] = {1, x, 2};
 // CHECK-NEXT:         clad::push(_t2, arr) , std::move(std::begin(_t1), std::end(_t1), std::begin(arr)); 
@@ -1782,11 +1626,7 @@ double fn21(double x) {
 // CHECK-NEXT:         res += arr[0] + arr[1];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t3);
@@ -1824,11 +1664,7 @@ double fn22(double param) {
 // CHECK-NEXT:     double _d_out = 0.;
 // CHECK-NEXT:     double out = 0.;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 1))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 1; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         double (&&_t1)[1] = {1.};
 // CHECK-NEXT:         clad::push(_t2, arr) , std::move(std::begin(_t1), std::end(_t1), std::begin(arr));
@@ -1836,11 +1672,7 @@ double fn22(double param) {
 // CHECK-NEXT:         out += arr[0] * param;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             out = clad::pop(_t3);
@@ -1877,9 +1709,7 @@ double fn23(double i, double j) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t1, res);
-// CHECK-NEXT:             }
+// CHECK-NEXT:             clad::push(_t1, res);
 // CHECK-NEXT:             if (!(res = i * j))
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
@@ -1937,9 +1767,7 @@ double fn24(double i, double j) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t1, res);
-// CHECK-NEXT:             }
+// CHECK-NEXT:             clad::push(_t1, res);
 // CHECK-NEXT:             if (!((res += i * j) , c < 3))
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
@@ -1985,9 +1813,7 @@ double fn25(double i, double j) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t1, res);
-// CHECK-NEXT:             }
+// CHECK-NEXT:             clad::push(_t1, res);
 // CHECK-NEXT:             if (!((res += i * j) , c < 3))
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
@@ -2062,9 +1888,7 @@ double fn26(double i, double j) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; clad::push(_t2, res) , (++c , res = 7 * i * j)) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t1, res);
-// CHECK-NEXT:             }
+// CHECK-NEXT:             clad::push(_t1, res);
 // CHECK-NEXT:             if (!(res += i * j))
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
@@ -2135,9 +1959,7 @@ double fn27(double i, double j) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t1, res);
-// CHECK-NEXT:             }
+// CHECK-NEXT:             clad::push(_t1, res);
 // CHECK-NEXT:             if (!(res += i * j))
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
@@ -2206,9 +2028,7 @@ double fn28(double i, double j) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t1, res);
-// CHECK-NEXT:             }
+// CHECK-NEXT:             clad::push(_t1, res);
 // CHECK-NEXT:             if (!((res = i * j) , c < 2))
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
@@ -2257,9 +2077,7 @@ double fn29(double i, double j) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; clad::push(_t2, res) , (++c , res = 3 * i * j)) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 clad::push(_t1, res);
-// CHECK-NEXT:             }
+// CHECK-NEXT:             clad::push(_t1, res);
 // CHECK-NEXT:             if (!(res = i * j , c < 1))
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
@@ -2312,13 +2130,11 @@ double fn30(double i, double j) {
 // CHECK-NEXT:     for (c = 0; ; ++c) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_cond1, (c == 0));
-// CHECK-NEXT:                     if (clad::back(_cond1)) {
-// CHECK-NEXT:                         clad::push(_t1, _cond0);
-// CHECK-NEXT:                         clad::push(_t2, res);
-// CHECK-NEXT:                         _cond0 = (res = i * j);
-// CHECK-NEXT:                     }
+// CHECK-NEXT:                 clad::push(_cond1, (c == 0));
+// CHECK-NEXT:                 if (clad::back(_cond1)) {
+// CHECK-NEXT:                     clad::push(_t1, _cond0);
+// CHECK-NEXT:                     clad::push(_t2, res);
+// CHECK-NEXT:                     _cond0 = (res = i * j);
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             if (!(clad::back(_cond1) && _cond0))
@@ -2436,9 +2252,7 @@ double fn32(double i, double j) {
 //CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:    for (c = 0; ; ++c) {
 //CHECK-NEXT:        {
-//CHECK-NEXT:            {
-//CHECK-NEXT:                clad::push(_t1, res);
-//CHECK-NEXT:            }
+//CHECK-NEXT:            clad::push(_t1, res);
 //CHECK-NEXT:            if (!(res += i * j))
 //CHECK-NEXT:                break;
 //CHECK-NEXT:        }
@@ -2446,9 +2260,7 @@ double fn32(double i, double j) {
 //CHECK-NEXT:        clad::push(_t2, {{0U|0UL|0ULL}});
 //CHECK-NEXT:        for (clad::push(_t3, d) , d = 0; ; ++d) {
 //CHECK-NEXT:            {
-//CHECK-NEXT:                {
-//CHECK-NEXT:                    clad::push(_t4, res);
-//CHECK-NEXT:                }
+//CHECK-NEXT:                clad::push(_t4, res);
 //CHECK-NEXT:                if (!(res += i * j))
 //CHECK-NEXT:                    break;
 //CHECK-NEXT:            }
@@ -2588,9 +2400,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:    for (c = 0; ; ++c) {
 //CHECK-NEXT:        {
-//CHECK-NEXT:            {
-//CHECK-NEXT:                clad::push(_t1, res);
-//CHECK-NEXT:            }
+//CHECK-NEXT:            clad::push(_t1, res);
 //CHECK-NEXT:            if (!(res = i * j))
 //CHECK-NEXT:                break;
 //CHECK-NEXT:        }
@@ -3119,21 +2929,13 @@ double fn39(double x) {
 //CHECK-NEXT:     clad::array<int> range = {1, 2, 3};
 //CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     _d_i = std::begin(_d_range);
-//CHECK-NEXT:     for (i = std::begin(range); ; _d_i++ , i++) {
-//CHECK-NEXT:         {
-//CHECK-NEXT:             if (!(i != std::end(range)))
-//CHECK-NEXT:                 break;
-//CHECK-NEXT:         }
+//CHECK-NEXT:     for (i = std::begin(range); i != std::end(range); _d_i++ , i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, res);
 //CHECK-NEXT:         res += x * *i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_res += 1;
-//CHECK-NEXT:     for (;; _t0--) {
-//CHECK-NEXT:         {
-//CHECK-NEXT:             if (!_t0)
-//CHECK-NEXT:                 break;
-//CHECK-NEXT:         }
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             i--;
 //CHECK-NEXT:             _d_i--;
@@ -3164,11 +2966,7 @@ double fn40(double u, double v) {
 //CHECK-NEXT:    double _d_res = 0.;
 //CHECK-NEXT:    double res = 11 * u;
 //CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL}};
-//CHECK-NEXT:    for (i = 0; ; i++) {
-//CHECK-NEXT:        {
-//CHECK-NEXT:            if (!(i < 3))
-//CHECK-NEXT:                break;
-//CHECK-NEXT:        }
+//CHECK-NEXT:    for (i = 0; i < 3; i++) {
 //CHECK-NEXT:        _t0++;
 //CHECK-NEXT:        clad::push(_t1, res);
 //CHECK-NEXT:        res += u * i;
@@ -3179,11 +2977,7 @@ double fn40(double u, double v) {
 //CHECK-NEXT:        clad::push(_t2, {{2U|2UL}});
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_res += 1;
-//CHECK-NEXT:    for (;; _t0--) {
-//CHECK-NEXT:        {
-//CHECK-NEXT:            if (!_t0)
-//CHECK-NEXT:                break;
-//CHECK-NEXT:        }
+//CHECK-NEXT:    for (; _t0; _t0--) {
 //CHECK-NEXT:        i--;
 //CHECK-NEXT:        switch (clad::pop(_t2)) {
 //CHECK-NEXT:          case {{2U|2UL}}:
@@ -3220,11 +3014,7 @@ double fn41(double u, double v) {
 //CHECK-NEXT:    double _d_res = 0.;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL}};
-//CHECK-NEXT:    for (i = 1; ; i++) {
-//CHECK-NEXT:        {
-//CHECK-NEXT:            if (!(i < 3))
-//CHECK-NEXT:                break;
-//CHECK-NEXT:        }
+//CHECK-NEXT:    for (i = 1; i < 3; i++) {
 //CHECK-NEXT:        _t0++;
 //CHECK-NEXT:        clad::push(_t1, res);
 //CHECK-NEXT:        res += i * u;
@@ -3238,11 +3028,7 @@ double fn41(double u, double v) {
 //CHECK-NEXT:        clad::push(_t2, {{2U|2UL}});
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_res += 1;
-//CHECK-NEXT:    for (unsigned {{int|long}} _numRevIterations0 = _t0; ; _t0--) {
-//CHECK-NEXT:        {
-//CHECK-NEXT:            if (!_t0)
-//CHECK-NEXT:                break;
-//CHECK-NEXT:        }
+//CHECK-NEXT:    for (unsigned {{int|long}} _numRevIterations0 = _t0; _t0; _t0--) {
 //CHECK-NEXT:        if (_t0 != _numRevIterations0 || (clad::back(_t2) != 1))
 //CHECK-NEXT:            i--;
 //CHECK-NEXT:        switch (clad::pop(_t2)) {
@@ -3295,21 +3081,13 @@ float fn42(const layer &l, float x) {
 //CHECK-NEXT:    float _d_x = 0.F;
 //CHECK-NEXT:    float x = inp;
 //CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:    for (i = 0; ; i++) {
-//CHECK-NEXT:        {
-//CHECK-NEXT:            if (!(i < this->w.size()))
-//CHECK-NEXT:                break;
-//CHECK-NEXT:        }
+//CHECK-NEXT:    for (i = 0; i < this->w.size(); i++) {
 //CHECK-NEXT:        _t0++;
 //CHECK-NEXT:        clad::push(_t1, x);
 //CHECK-NEXT:        x = this->w[i].forward(x);
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_x += _d_y;
-//CHECK-NEXT:    for (;; _t0--) {
-//CHECK-NEXT:        {
-//CHECK-NEXT:            if (!_t0)
-//CHECK-NEXT:                break;
-//CHECK-NEXT:        }
+//CHECK-NEXT:    for (; _t0; _t0--) {
 //CHECK-NEXT:        i--;
 //CHECK-NEXT:        {
 //CHECK-NEXT:            x = clad::pop(_t1);

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -159,11 +159,7 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:     double _d_sum = 0.;
 // CHECK-NEXT:     double sum = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < n))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         _d_j = &_d_i;
 // CHECK-NEXT:         clad::push(_t1, _d_j);
@@ -176,11 +172,7 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:         arr = arr + 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_sum += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         size_t *_t2 = clad::pop(_t1);
 // CHECK-NEXT:         {

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -695,11 +695,7 @@ int main() {
 // CHECK-NEXT:        double _d_res = 0.;
 // CHECK-NEXT:        double res = 0;
 // CHECK-NEXT:        unsigned {{long|int}} _t1 = {{0U|0UL}};
-// CHECK-NEXT:        for (i = 0; ; ++i) {
-// CHECK-NEXT:            {
-// CHECK-NEXT:                if (!(i < a.size()))
-// CHECK-NEXT:                    break;
-// CHECK-NEXT:            }
+// CHECK-NEXT:        for (i = 0; i < a.size(); ++i) {
 // CHECK-NEXT:            _t1++;
 // CHECK-NEXT:            clad::push(_t2, res);
 // CHECK-NEXT:            clad::push(_t3, a);
@@ -707,11 +703,7 @@ int main() {
 // CHECK-NEXT:            res += clad::back(_t4).value;
 // CHECK-NEXT:        }
 // CHECK-NEXT:        _d_res += 1;
-// CHECK-NEXT:        for (;; _t1--) {
-// CHECK-NEXT:            {
-// CHECK-NEXT:                if (!_t1)
-// CHECK-NEXT:                    break;
-// CHECK-NEXT:            }
+// CHECK-NEXT:        for (; _t1; _t1--) {
 // CHECK-NEXT:            --i;
 // CHECK-NEXT:            {
 // CHECK-NEXT:                res = clad::pop(_t2);
@@ -882,11 +874,7 @@ int main() {
 // CHECK-NEXT:          {{.*}}vector<double> _d_v = {};
 // CHECK-NEXT:          clad::zero_init(_d_v);
 // CHECK-NEXT:          {{.*}} _t0 = {{0U|0UL|0}};
-// CHECK-NEXT:          for (i = 0; ; ++i) {
-// CHECK-NEXT:              {
-// CHECK-NEXT:                  if (!(i < 3))
-// CHECK-NEXT:                      break;
-// CHECK-NEXT:              }
+// CHECK-NEXT:          for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:              _t0++;
 // CHECK-NEXT:              {{.*}}push(_t1, v);
 // CHECK-NEXT:              {{.*}}push_back_reverse_forw(&v, x, &_d_v, *_d_x);
@@ -894,11 +882,7 @@ int main() {
 // CHECK-NEXT:          double _d_res = 0.;
 // CHECK-NEXT:          double res = 0;
 // CHECK-NEXT:          {{.*}} _t2 = {{0U|0UL|0}};
-// CHECK-NEXT:          for (i0 = 0; ; ++i0) {
-// CHECK-NEXT:              {
-// CHECK-NEXT:                  if (!(i0 < v.size()))
-// CHECK-NEXT:                      break;
-// CHECK-NEXT:              }
+// CHECK-NEXT:          for (i0 = 0; i0 < v.size(); ++i0) {
 // CHECK-NEXT:              _t2++;
 // CHECK-NEXT:              {{.*}}push(_t3, res);
 // CHECK-NEXT:              {{.*}}push(_t4, v);
@@ -938,11 +922,7 @@ int main() {
 // CHECK-NEXT:              v = _t6;
 // CHECK-NEXT:              {{.*}}assign_pullback(&v, 3, 0, &_d_v, &_r1, &_r2);
 // CHECK-NEXT:          }
-// CHECK-NEXT:          for (;; _t2--) {
-// CHECK-NEXT:              {
-// CHECK-NEXT:                  if (!_t2)
-// CHECK-NEXT:                      break;
-// CHECK-NEXT:              }
+// CHECK-NEXT:          for (; _t2; _t2--) {
 // CHECK-NEXT:              --i0;
 // CHECK-NEXT:              {
 // CHECK-NEXT:                  res = {{.*}}pop(_t3);
@@ -955,11 +935,7 @@ int main() {
 // CHECK-NEXT:                  {{.*}}pop(_t5);
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
-// CHECK-NEXT:          for (;; _t0--) {
-// CHECK-NEXT:              {
-// CHECK-NEXT:                  if (!_t0)
-// CHECK-NEXT:                      break;
-// CHECK-NEXT:              }
+// CHECK-NEXT:          for (; _t0; _t0--) {
 // CHECK-NEXT:              --i;
 // CHECK-NEXT:              {
 // CHECK-NEXT:                  v = {{.*}}back(_t1);
@@ -1095,11 +1071,7 @@ int main() {
 // CHECK-NEXT:      {{.*}}allocator_type _d_alloc = {};
 // CHECK-NEXT:      clad::zero_init(_d_alloc);
 // CHECK-NEXT:      unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:      for (i = 0; ; ++i) {
-// CHECK-NEXT:          {
-// CHECK-NEXT:              if (!(i < 3))
-// CHECK-NEXT:                  break;
-// CHECK-NEXT:          }
+// CHECK-NEXT:      for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:          _t0++;
 // CHECK-NEXT:          clad::push(_t1, std::move(_d_ls));
 // CHECK-NEXT:          clad::push(_t2, std::move(ls)) , ls = {u, v}, alloc;
@@ -1117,11 +1089,7 @@ int main() {
 // CHECK-NEXT:          u = clad::back(_t10).value;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      *_d_u += 1;
-// CHECK-NEXT:      for (;; _t0--) {
-// CHECK-NEXT:          {
-// CHECK-NEXT:              if (!_t0)
-// CHECK-NEXT:                  break;
-// CHECK-NEXT:          }
+// CHECK-NEXT:      for (; _t0; _t0--) {
 // CHECK-NEXT:          --i;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              u = clad::pop(_t8);
@@ -1195,11 +1163,7 @@ int main() {
 // CHECK-NEXT:     double _d_prod = 0.;
 // CHECK-NEXT:     double prod = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 3; ; --i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i >= 1))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 3; i >= 1; --i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, std::move(_d_vec));
 // CHECK-NEXT:         clad::push(_t2, std::move(vec)) , vec = i, v + u, alloc;
@@ -1211,11 +1175,7 @@ int main() {
 // CHECK-NEXT:         prod *= clad::back(_t5).value;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_prod += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         ++i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             prod = clad::pop(_t3);
@@ -1260,11 +1220,7 @@ int main() {
 // CHECK-NEXT:     clad::tape<std::vector<double> > _t9 = {};
 // CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t10 = {};
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, std::move(_d_ls));
 // CHECK-NEXT:         clad::push(_t2, std::move(ls)) , ls = {{.*{u, v}.*}};
@@ -1282,11 +1238,7 @@ int main() {
 // CHECK-NEXT:         u = clad::back(_t10).value;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_u += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             u = clad::pop(_t8);
@@ -1339,11 +1291,7 @@ int main() {
 // CHECK-NEXT:     clad::ValueAndAdjoint<{{.*}}> _t1 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<{{.*}}>(), start, (*_d_start));
 // CHECK-NEXT:     it = _t1.value;
 // CHECK-NEXT:     _d_it = _t1.adjoint;
-// CHECK-NEXT:     for (;; clad::push(_t2, it) , {{.*}}class_functions::operator_plus_plus_reverse_forw(&it, 0, &_d_it, 0)) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!operator!=(it, end))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; operator!=(it, end); clad::push(_t2, it) , {{.*}}class_functions::operator_plus_plus_reverse_forw(&it, 0, &_d_it, 0)) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t3, sum);
 // CHECK-NEXT:         clad::push(_t5, {{.*}}class_functions::operator_star_reverse_forw(&it, &_d_it));
@@ -1353,11 +1301,7 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         for (;; _t0--) {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 if (!_t0)
-// CHECK-NEXT:                     break;
-// CHECK-NEXT:             }
+// CHECK-NEXT:         for (; _t0; _t0--) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 int _r0 = 0;
 // CHECK-NEXT:                 it = clad::back(_t2);
@@ -1390,11 +1334,7 @@ int main() {
 // CHECK-NEXT:     Session _d_sess = {{.*}}, nullptr};
 // CHECK-NEXT:     const Session &sess = session[0];
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (id = 0; ; id++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(id < nVals))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (id = 0; id < nVals; id++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, sess.arr[id]);
 // CHECK-NEXT:         sess.arr[id] = tensor_x[id] * tensor_theory_params[0];
@@ -1402,21 +1342,13 @@ int main() {
 // CHECK-NEXT:     float _d_out = 0.F;
 // CHECK-NEXT:     float out = 0.;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t2 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (id0 = 0; ; id0++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(id0 < nVals))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (id0 = 0; id0 < nVals; id0++) {
 // CHECK-NEXT:         _t2++;
 // CHECK-NEXT:         clad::push(_t3, out);
 // CHECK-NEXT:         out += std::exp(-sess.arr[id0]);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
-// CHECK-NEXT:     for (;; _t2--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t2)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t2; _t2--) {
 // CHECK-NEXT:         id0--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             out = clad::pop(_t3);
@@ -1426,11 +1358,7 @@ int main() {
 // CHECK-NEXT:             _d_sess.arr[id0] += -_r0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         id--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             sess.arr[id] = clad::pop(_t1);
@@ -1452,21 +1380,13 @@ int main() {
 // CHECK-NEXT:     float _d_out = 0.F;
 // CHECK-NEXT:     float out = 0.;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (id = 0; ; id++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(id < nVals))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (id = 0; id < nVals; id++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, out);
 // CHECK-NEXT:         out += arr[id] * tensor_theory_params[0];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         id--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             out = clad::pop(_t1);

--- a/test/Gradient/Switch.C
+++ b/test/Gradient/Switch.C
@@ -591,11 +591,7 @@ double fn7(double u, double v) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:     {
-// CHECK-NEXT:          if (!(i < 5))
-// CHECK-NEXT:          break;
-// CHECK-NEXT:     }
+// CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, i)
@@ -632,11 +628,7 @@ double fn7(double u, double v) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             switch (clad::pop(_t2)) {

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -21,21 +21,13 @@ void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a);
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 1; ; i++) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < a))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 1; i < a; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, z);
 // CHECK-NEXT:         z = z * a;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_z += 1;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             z = clad::pop(_t1);

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -61,21 +61,13 @@ double sum(Tangent& t) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 5))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += t.data[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += _d_y;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         res = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_res;
@@ -97,21 +89,13 @@ double sum(double *data) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 5))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += data[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += _d_y;
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         res = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_res;
@@ -329,20 +313,12 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!(i < 5))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, this->data[i]);
 // CHECK-NEXT:         this->data[i] = d;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         this->data[i] = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_this->data[i];
@@ -384,11 +360,7 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (i = 0; ; ++i) {
-// CHECK-NEXT:     {
-// CHECK-NEXT:          if (!(i < 5))
-// CHECK-NEXT:          break;
-// CHECK-NEXT:     }
+// CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += c.real() + 2 * clad::push(_t2, c.imag());
@@ -403,11 +375,7 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:         t = _t4;
 // CHECK-NEXT:         sum_pullback(t, _r_d1, &(*_d_t));
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t1);
@@ -549,21 +517,13 @@ void fn13(double *x, double *y, int size)
 // CHECK-NEXT: Findex p;
 // CHECK-NEXT: unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT: _t1 = p.j;
-// CHECK-NEXT: for (p.j = 0; ; clad::push(_t2, p.j) , (p.j += 1)) {
-// CHECK-NEXT:     {
-// CHECK-NEXT:         if (!(p.j < size))
-// CHECK-NEXT:             break;
-// CHECK-NEXT:     }
+// CHECK-NEXT: for (p.j = 0; p.j < size; clad::push(_t2, p.j) , (p.j += 1)) {
 // CHECK-NEXT:     _t0++;
 // CHECK-NEXT:     clad::push(_t3, y[p.j]);
 // CHECK-NEXT:     y[p.j] = 2. * x[p.j];
 // CHECK-NEXT: }
 // CHECK-NEXT: {
-// CHECK-NEXT:     for (;; _t0--) {
-// CHECK-NEXT:        {
-// CHECK-NEXT:             if (!_t0)
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             p.j = clad::pop(_t2);
 // CHECK-NEXT:             Fint _r_d1 = _d_p.j;

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -111,21 +111,13 @@
 //CHECK_FLOAT_SUM:    float _d_sum = 0.F;
 //CHECK_FLOAT_SUM:    float sum = 0.;
 //CHECK_FLOAT_SUM:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK_FLOAT_SUM:    for (i = 0; ; i++) {
-//CHECK_FLOAT_SUM:        {
-//CHECK_FLOAT_SUM:            if (!(i < n))
-//CHECK_FLOAT_SUM:                break;
-//CHECK_FLOAT_SUM:        }
+//CHECK_FLOAT_SUM:    for (i = 0; i < n; i++) {
 //CHECK_FLOAT_SUM:        _t0++;
 //CHECK_FLOAT_SUM:        clad::push(_t1, sum);
 //CHECK_FLOAT_SUM:        sum = sum + x;
 //CHECK_FLOAT_SUM:    }
 //CHECK_FLOAT_SUM:    _d_sum += 1;
-//CHECK_FLOAT_SUM:    for (;; _t0--) {
-//CHECK_FLOAT_SUM:        {
-//CHECK_FLOAT_SUM:            if (!_t0)
-//CHECK_FLOAT_SUM:                break;
-//CHECK_FLOAT_SUM:        }
+//CHECK_FLOAT_SUM:    for (; _t0; _t0--) {
 //CHECK_FLOAT_SUM:        i--;
 //CHECK_FLOAT_SUM:        {
 //CHECK_FLOAT_SUM:            _final_error += std::abs(_d_sum * sum * 1.1920928955078125E-7);


### PR DESCRIPTION
After the PR #818, we started moving for-loop conditions to the body:
```
for (...; i < n; ...)
```
-->
```
// forward pass
for (...; /*nothing*/; ...) {
    {
        if (!(i < n))
            break;
    }
...
for (; /*nothing*/; --_t0) {
    {
        if (!_t0)
            break;
    }
```
This was done to allow us to insert some statements before the condition (usually pushes in the forward pass and condition derivative stmts in the reverse pass). However, these statements only exist for conditions with differentiable side effects, which represent a small portion of all use cases. This PR turns this behavior off when there's nothing to insert before the condition.