### PR TITLE
Enable TBR in the tests of the produced code

### DIFF
--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -Wno-unused-value -oArrayInputsReverseMode.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -Wno-unused-value -oArrayInputsReverseMode.out 2>&1 | %filecheck %s
 // RUN: ./ArrayInputsReverseMode.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -Wno-unused-value -oArrayInputsReverseMode.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -Wno-unused-value -oArrayInputsReverseMode.out
 // RUN: ./ArrayInputsReverseMode.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
@@ -16,20 +16,17 @@ double addArr(const double *arr, int n) {
 //CHECK: void addArr_pullback(const double *arr, int n, double _d_y, double *_d_arr, int *_d_n) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_ret = 0.;
 //CHECK-NEXT:     double ret = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, ret);
 //CHECK-NEXT:         ret += arr[i];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_ret += _d_y;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             ret = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_ret;
 //CHECK-NEXT:             _d_arr[i] += _r_d0;
 //CHECK-NEXT:         }
@@ -60,7 +57,6 @@ float func(float* a, float* b) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
-//CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
@@ -68,14 +64,12 @@ float func(float* a, float* b) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, a[i]);
 //CHECK-NEXT:         a[i] *= b[i];
-//CHECK-NEXT:         clad::push(_t2, sum);
 //CHECK-NEXT:         sum += a[i];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t2);
 //CHECK-NEXT:             float _r_d1 = _d_sum;
 //CHECK-NEXT:             _d_a[i] += _r_d1;
 //CHECK-NEXT:         }
@@ -107,19 +101,16 @@ float func2(float* a) {
 //CHECK: void func2_grad(float *a, float *_d_a) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += helper(a[i]);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
-//CHECK-NEXT:         sum = clad::pop(_t1);
 //CHECK-NEXT:         float _r_d0 = _d_sum;
 //CHECK-NEXT:         float _r0 = 0.F;
 //CHECK-NEXT:         _r0 += _r_d0 * helper_pushforward(a[i], 1.F).pushforward;
@@ -137,24 +128,18 @@ float func3(float* a, float* b) {
 //CHECK: void func3_grad(float *a, float *b, float *_d_a, float *_d_b) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     clad::tape<float> _t1 = {};
-//CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, sum);
-//CHECK-NEXT:         clad::push(_t2, a[i]);
 //CHECK-NEXT:         sum += (a[i] += b[i]);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
-//CHECK-NEXT:         sum = clad::pop(_t1);
 //CHECK-NEXT:         float _r_d0 = _d_sum;
 //CHECK-NEXT:         _d_a[i] += _r_d0;
-//CHECK-NEXT:         a[i] = clad::pop(_t2);
 //CHECK-NEXT:         float _r_d1 = _d_a[i];
 //CHECK-NEXT:         _d_b[i] += _r_d1;
 //CHECK-NEXT:     }
@@ -172,7 +157,6 @@ double func4(double x) {
 //CHECK: void func4_grad(double x, double *_d_x) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     double arr[3] = {x, 2 * x, x * x};
 //CHECK-NEXT:     double _d_sum = 0.;
@@ -180,14 +164,11 @@ double func4(double x) {
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
 //CHECK-NEXT:             int _r0 = 0;
 //CHECK-NEXT:             addArr_pullback(arr, 3, _r_d0, _d_arr, &_r0);
@@ -221,10 +202,8 @@ double func5(int k) {
 //CHECK: void func5_grad(int k, int *_d_k) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     int _d_i0 = 0;
 //CHECK-NEXT:     int i0 = 0;
-//CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     int _d_n = 0;
 //CHECK-NEXT:     int n = k;
 //CHECK-NEXT:     double _d_arr[n];
@@ -233,22 +212,18 @@ double func5(int k) {
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, arr[i]);
 //CHECK-NEXT:         arr[i] = k;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t2 = {{0U|0UL|0ULL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t1 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i0 = 0; i0 < 3; i0++) {
-//CHECK-NEXT:         _t2++;
-//CHECK-NEXT:         clad::push(_t3, sum);
+//CHECK-NEXT:         _t1++;
 //CHECK-NEXT:         sum += addArr(arr, n);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t2; _t2--) {
-//CHECK-NEXT:         i0--;
+//CHECK-NEXT:     for (; _t1; _t1--) {
 //CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t3);
 //CHECK-NEXT:             double _r_d1 = _d_sum;
 //CHECK-NEXT:             int _r0 = 0;
 //CHECK-NEXT:             addArr_pullback(arr, n, _r_d1, _d_arr, &_r0);
@@ -258,7 +233,6 @@ double func5(int k) {
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             arr[i] = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_arr[i];
 //CHECK-NEXT:             _d_arr[i] = 0.;
 //CHECK-NEXT:             *_d_k += _r_d0;
@@ -282,7 +256,6 @@ double func6(double seed) {
 //CHECK-NEXT:     clad::tape<double{{ ?}}[3]> _t2 = {};
 //CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     double arr[3] = {0};
-//CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
@@ -290,14 +263,12 @@ double func6(double seed) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         double (&&_t1)[3] = {seed, seed * i, seed + i};
 //CHECK-NEXT:         clad::push(_t2, arr) , std::move(std::begin(_t1), std::end(_t1), std::begin(arr));
-//CHECK-NEXT:         clad::push(_t3, sum);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             sum = clad::pop(_t3);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
 //CHECK-NEXT:             int _r1 = 0;
 //CHECK-NEXT:             addArr_pullback(arr, 3, _r_d0, _d_arr, &_r1);
@@ -344,7 +315,6 @@ double func7(double *params) {
 //CHECK-NEXT:     clad::tape<double{{ ?}}[1]> _t2 = {};
 //CHECK-NEXT:     double _d_paramsPrime[1] = {0};
 //CHECK-NEXT:     double paramsPrime[1] = {0};
-//CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     double _d_out = 0.;
 //CHECK-NEXT:     double out = 0.;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
@@ -352,14 +322,11 @@ double func7(double *params) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         double (&&_t1)[1] = {params[0]};
 // CHECK-NEXT:         clad::push(_t2, paramsPrime) , std::move(std::begin(_t1), std::end(_t1), std::begin(paramsPrime));
-// CHECK-NEXT:         clad::push(_t3, out);
 // CHECK-NEXT:         out = out + inv_square(paramsPrime);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-//CHECK-NEXT:         --i;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             out = clad::pop(_t3);
 //CHECK-NEXT:             double _r_d0 = _d_out;
 //CHECK-NEXT:             _d_out = 0.;
 //CHECK-NEXT:             _d_out += _r_d0;
@@ -397,20 +364,17 @@ double func8(double i, double *arr, int n) {
 //CHECK: void func8_grad(double i, double *arr, int n, double *_d_i, double *_d_arr, int *_d_n) {
 //CHECK-NEXT:     double _d_res = 0.;
 //CHECK-NEXT:     double res = 0;
-//CHECK-NEXT:     double _t0 = arr[0];
 //CHECK-NEXT:     arr[0] = 1;
-//CHECK-NEXT:     double _t1 = res;
 //CHECK-NEXT:     res = helper2(i, arr, n);
-//CHECK-NEXT:     double _t2 = arr[0];
+//CHECK-NEXT:     double _t0 = arr[0];
 //CHECK-NEXT:     arr[0] = 5;
 //CHECK-NEXT:     _d_res += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         arr[0] = _t2;
+//CHECK-NEXT:         arr[0] = _t0;
 //CHECK-NEXT:         double _r_d2 = _d_arr[0];
 //CHECK-NEXT:         _d_arr[0] = 0.;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         res = _t1;
 //CHECK-NEXT:         double _r_d1 = _d_res;
 //CHECK-NEXT:         _d_res = 0.;
 //CHECK-NEXT:         double _r0 = 0.;
@@ -420,7 +384,6 @@ double func8(double i, double *arr, int n) {
 //CHECK-NEXT:         *_d_n += _r1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         arr[0] = _t0;
 //CHECK-NEXT:         double _r_d0 = _d_arr[0];
 //CHECK-NEXT:         _d_arr[0] = 0.;
 //CHECK-NEXT:     }
@@ -431,10 +394,8 @@ void modify(double& elem, double val) {
 }
 
 //CHECK: void modify_pullback(double &elem, double val, double *_d_elem, double *_d_val) {
-//CHECK-NEXT:     double _t0 = elem;
 //CHECK-NEXT:     elem = val;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         elem = _t0;
 //CHECK-NEXT:         double _r_d0 = *_d_elem;
 //CHECK-NEXT:         *_d_elem = 0.;
 //CHECK-NEXT:         *_d_val += _r_d0;
@@ -511,23 +472,20 @@ double func10(double *arr, int n) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
-//CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     double _d_res = 0.;
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, res);
-// CHECK-NEXT:         clad::push(_t2, arr[i]);
+// CHECK-NEXT:         clad::push(_t1, arr[i]);
 // CHECK-NEXT:         res += sq(arr[i]);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         --i;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             res = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_res;
-//CHECK-NEXT:             arr[i] = clad::pop(_t2);
+//CHECK-NEXT:             arr[i] = clad::pop(_t1);
 //CHECK-NEXT:             sq_pullback(arr[i], _r_d0, &_d_arr[i]);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
@@ -550,49 +508,37 @@ double func11(double seed) {
 // CHECK-NEXT:    int i = 0;
 // CHECK-NEXT:    double _d_arr[3] = {0};
 // CHECK-NEXT:    double arr[3];
-// CHECK-NEXT:    clad::tape<double> _t1 = {};
-// CHECK-NEXT:    clad::tape<double> _t2 = {};
-// CHECK-NEXT:    clad::tape<double> _t3 = {};
-// CHECK-NEXT:    clad::tape<double> _t4 = {};
 // CHECK-NEXT:    double _d_sum = 0.;
 // CHECK-NEXT:    double sum = 0;
 // CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:    for (i = 0; i < 3; i++) {
 // CHECK-NEXT:        _t0++;
-// CHECK-NEXT:        clad::push(_t1, arr[0]);
 // CHECK-NEXT:        arr[0] = seed;
-// CHECK-NEXT:        clad::push(_t2, arr[1]);
 // CHECK-NEXT:        arr[1] = seed * i;
-// CHECK-NEXT:        clad::push(_t3, arr[2]);
 // CHECK-NEXT:        arr[2] = seed + i;
-// CHECK-NEXT:        clad::push(_t4, sum);
 // CHECK-NEXT:        sum += addArr(arr, 3);
 // CHECK-NEXT:    }
 // CHECK-NEXT:    _d_sum += 1;
 // CHECK-NEXT:    for (; _t0; _t0--) {
 // CHECK-NEXT:        i--;
 // CHECK-NEXT:        {
-// CHECK-NEXT:            sum = clad::pop(_t4);
 // CHECK-NEXT:            double _r_d3 = _d_sum;
 // CHECK-NEXT:            int _r0 = 0;
 // CHECK-NEXT:            addArr_pullback(arr, 3, _r_d3, _d_arr, &_r0);
 // CHECK-NEXT:        }
 // CHECK-NEXT:        {
-// CHECK-NEXT:            arr[2] = clad::pop(_t3);
 // CHECK-NEXT:            double _r_d2 = _d_arr[2];
 // CHECK-NEXT:            _d_arr[2] = 0.;
 // CHECK-NEXT:            *_d_seed += _r_d2;
 // CHECK-NEXT:            _d_i += _r_d2;
 // CHECK-NEXT:        }
 // CHECK-NEXT:        {
-// CHECK-NEXT:            arr[1] = clad::pop(_t2);
 // CHECK-NEXT:            double _r_d1 = _d_arr[1];
 // CHECK-NEXT:            _d_arr[1] = 0.;
 // CHECK-NEXT:            *_d_seed += _r_d1 * i;
 // CHECK-NEXT:            _d_i += seed * _r_d1;
 // CHECK-NEXT:        }
 // CHECK-NEXT:        {
-// CHECK-NEXT:            arr[0] = clad::pop(_t1);
 // CHECK-NEXT:            double _r_d0 = _d_arr[0];
 // CHECK-NEXT:            _d_arr[0] = 0.;
 // CHECK-NEXT:            *_d_seed += _r_d0;

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -1,11 +1,11 @@
 // The Test checks whether a clad gradient can be successfully be generated on
 // the device having all the dependencies also as device functions.
 
-// RUN: %cladclang_cuda -Xclang -plugin-arg-clad -Xclang -disable-tbr -I%S/../../include -fsyntax-only \
+// RUN: %cladclang_cuda -I%S/../../include -fsyntax-only \
 // RUN:     --cuda-gpu-arch=%cudaarch --cuda-path=%cudapath -Xclang -verify \
 // RUN:     %s 2>&1 | %filecheck %s
 //
-// RUN: %cladclang_cuda -Xclang -plugin-arg-clad -Xclang -disable-tbr -I%S/../../include --cuda-gpu-arch=%cudaarch \
+// RUN: %cladclang_cuda -I%S/../../include --cuda-gpu-arch=%cudaarch \
 // RUN:      --cuda-path=%cudapath %cudaldflags -oGradientCuda.out %s
 //
 // RUN: ./GradientCuda.out | %filecheck_exec %s
@@ -33,46 +33,43 @@ __device__ __host__ double gauss(const double* x, double* p, double sigma, int d
 //CHECK-NEXT:     int _d_dim = 0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_t = 0.;
 //CHECK-NEXT:     double t = 0;
 //CHECK-NEXT:     unsigned long _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < dim; i++) {
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, t);
 //CHECK-NEXT:         t += (x[i] - p[i]) * (x[i] - p[i]);
 //CHECK-NEXT:     }
-//CHECK-NEXT:     double _t2 = t;
-//CHECK-NEXT:     double _t3 = (2 * sigma * sigma);
-//CHECK-NEXT:     t = -t / _t3;
-//CHECK-NEXT:     double _t6 = std::pow(2 * 3.1415926535897931, -dim / 2.);
-//CHECK-NEXT:     double _t5 = std::pow(sigma, -0.5);
-//CHECK-NEXT:     double _t4 = std::exp(t);
+//CHECK-NEXT:     double _t1 = t;
+//CHECK-NEXT:     double _t2 = (2 * sigma * sigma);
+//CHECK-NEXT:     t = -t / _t2;
+//CHECK-NEXT:     double _t5 = std::pow(2 * 3.1415926535897931, -dim / 2.);
+//CHECK-NEXT:     double _t4 = std::pow(sigma, -0.5);
+//CHECK-NEXT:     double _t3 = std::exp(t);
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r1 = 0.;
 //CHECK-NEXT:         double _r2 = 0.;
-//CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(2 * 3.1415926535897931, -dim / 2., 1 * _t4 * _t5, &_r1, &_r2);
+//CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(2 * 3.1415926535897931, -dim / 2., 1 * _t3 * _t4, &_r1, &_r2);
 //CHECK-NEXT:         _d_dim += -_r2 / 2.;
 //CHECK-NEXT:         double _r3 = 0.;
 //CHECK-NEXT:         double _r4 = 0.;
-//CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(sigma, -0.5, _t6 * 1 * _t4, &_r3, &_r4);
+//CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(sigma, -0.5, _t5 * 1 * _t3, &_r3, &_r4);
 //CHECK-NEXT:         _d_sigma += _r3;
 //CHECK-NEXT:         double _r5 = 0.;
-//CHECK-NEXT:         _r5 += _t6 * _t5 * 1 * clad::custom_derivatives::std::exp_pushforward(t, 1.).pushforward;
+//CHECK-NEXT:         _r5 += _t5 * _t4 * 1 * clad::custom_derivatives::std::exp_pushforward(t, 1.).pushforward;
 //CHECK-NEXT:         _d_t += _r5;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         t = _t2;
+//CHECK-NEXT:         t = _t1;
 //CHECK-NEXT:         double _r_d1 = _d_t;
 //CHECK-NEXT:         _d_t = 0.;
-//CHECK-NEXT:         _d_t += -_r_d1 / _t3;
-//CHECK-NEXT:         double _r0 = _r_d1 * -(-t / (_t3 * _t3));
+//CHECK-NEXT:         _d_t += -_r_d1 / _t2;
+//CHECK-NEXT:         double _r0 = _r_d1 * -(-t / (_t2 * _t2));
 //CHECK-NEXT:         _d_sigma += 2 * _r0 * sigma;
 //CHECK-NEXT:         _d_sigma += 2 * sigma * _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
-//CHECK-NEXT:         t = clad::pop(_t1);
 //CHECK-NEXT:         double _r_d0 = _d_t;
 //CHECK-NEXT:         _d_p[i] += -_r_d0 * (x[i] - p[i]);
 //CHECK-NEXT:         _d_p[i] += -(x[i] - p[i]) * _r_d0;

--- a/test/Enzyme/DifferentCladEnzymeDerivatives.C
+++ b/test/Enzyme/DifferentCladEnzymeDerivatives.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oDifferentCladEnzymeDerivatives.out | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oDifferentCladEnzymeDerivatives.out | %filecheck %s
 // RUN: ./DifferentCladEnzymeDerivatives.out
 // REQUIRES: Enzyme
 

--- a/test/Enzyme/FunctionPrototypesReverseMode.C
+++ b/test/Enzyme/FunctionPrototypesReverseMode.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oReverseMode.out | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oReverseMode.out | %filecheck %s
 // RUN: ./ReverseMode.out | %filecheck_exec %s
 // REQUIRES: Enzyme
 

--- a/test/Enzyme/GradientsComparisonWithClad.C
+++ b/test/Enzyme/GradientsComparisonWithClad.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s  -I%S/../../include -oEnzymeGradients.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s  -I%S/../../include -oEnzymeGradients.out 2>&1 | %filecheck %s
 // RUN: ./EnzymeGradients.out | %filecheck_exec %s
 // REQUIRES: Enzyme
 

--- a/test/Enzyme/LoopsReverseModeComparisonWithClad.C
+++ b/test/Enzyme/LoopsReverseModeComparisonWithClad.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oEnzymeLoops.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oEnzymeLoops.out 2>&1 | %filecheck %s
 // RUN: ./EnzymeLoops.out | %filecheck_exec %s
 // REQUIRES: Enzyme
 

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -I%S/../../include -oAssignments.out %s 2>&1 | %filecheck %s
+// RUN: %cladclang -I%S/../../include -oAssignments.out %s 2>&1 | %filecheck %s
 // RUN: ./Assignments.out
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1 | %filecheck %s
 
 #include "clad/Differentiator/Differentiator.h"
 

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -I%S/../../include -oCondStmts.out %s 2>&1 | %filecheck %s
+// RUN: %cladclang -I%S/../../include -oCondStmts.out %s 2>&1 | %filecheck %s
 
 #include "clad/Differentiator/Differentiator.h"
 

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -I%S/../../include -oLoopsAndArrays.out %s 2>&1 | %filecheck %s
+// RUN: %cladclang -I%S/../../include -oLoopsAndArrays.out %s 2>&1 | %filecheck %s
 
 #include "clad/Differentiator/Differentiator.h"
 

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oLoopsAndArraysExec.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oLoopsAndArraysExec.out 2>&1 | %filecheck %s
 // RUN: ./LoopsAndArraysExec.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oReverseAssignments.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oReverseAssignments.out 2>&1 | %filecheck %s
 // RUN: ./ReverseAssignments.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oReverseAssignments.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oReverseAssignments.out
 // RUN: ./ReverseAssignments.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
@@ -13,11 +13,9 @@ double f1(double x, double y) {
 }
 
 //CHECK:   void f1_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0 = x;
 //CHECK-NEXT:       x = y;
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           x = _t0;
 //CHECK-NEXT:           double _r_d0 = *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
 //CHECK-NEXT:           *_d_y += _r_d0;
@@ -33,17 +31,13 @@ double f2(double x, double y) {
 
 //CHECK:   void f2_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       bool _cond0;
-//CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           _cond0 = x < y;
-//CHECK-NEXT:           if (_cond0) {
-//CHECK-NEXT:               _t0 = x;
+//CHECK-NEXT:           if (_cond0)
 //CHECK-NEXT:               x = y;
-//CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       *_d_x += 1;
 //CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:           x = _t0;
 //CHECK-NEXT:           double _r_d0 = *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
 //CHECK-NEXT:           *_d_y += _r_d0;
@@ -60,37 +54,33 @@ double f3(double x, double y) {
 }
 
 //CHECK:   void f3_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0 = x;
 //CHECK-NEXT:       x = x;
-//CHECK-NEXT:       double _t1 = x;
+//CHECK-NEXT:       double _t0 = x;
 //CHECK-NEXT:       x = x * x;
-//CHECK-NEXT:       double _t2 = y;
 //CHECK-NEXT:       y = x * x;
-//CHECK-NEXT:       double _t3 = x;
+//CHECK-NEXT:       double _t1 = x;
 //CHECK-NEXT:       x = y;
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           x = _t3;
+//CHECK-NEXT:           x = _t1;
 //CHECK-NEXT:           double _r_d3 = *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
 //CHECK-NEXT:           *_d_y += _r_d3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           y = _t2;
 //CHECK-NEXT:           double _r_d2 = *_d_y;
 //CHECK-NEXT:           *_d_y = 0.;
 //CHECK-NEXT:           *_d_x += _r_d2 * x;
 //CHECK-NEXT:           *_d_x += x * _r_d2;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           x = _t1;
+//CHECK-NEXT:           x = _t0;
 //CHECK-NEXT:           double _r_d1 = *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
 //CHECK-NEXT:           *_d_x += _r_d1 * x;
 //CHECK-NEXT:           *_d_x += x * _r_d1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           x = _t0;
 //CHECK-NEXT:           double _r_d0 = *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
 //CHECK-NEXT:           *_d_x += _r_d0;
@@ -105,18 +95,14 @@ double f4(double x, double y) {
 }
 
 //CHECK:   void f4_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t0 = y;
 //CHECK-NEXT:       y = x;
-//CHECK-NEXT:       double _t1 = x;
 //CHECK-NEXT:       x = 0;
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           x = _t1;
 //CHECK-NEXT:           double _r_d1 = *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           y = _t0;
 //CHECK-NEXT:           double _r_d0 = *_d_y;
 //CHECK-NEXT:           *_d_y = 0.;
 //CHECK-NEXT:           *_d_x += _r_d0;
@@ -139,17 +125,14 @@ double f5(double x, double y) {
 
 //CHECK:   void f5_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       bool _cond0;
-//CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       double _d_z = 0.;
 //CHECK-NEXT:       double z = 0.;
-//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_t = 0.;
 //CHECK-NEXT:       double t = x * x;
 //CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x < 0;
 //CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:           _t0 = t;
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:           goto _label0;
 //CHECK-NEXT:       }
@@ -158,14 +141,12 @@ double f5(double x, double y) {
 //CHECK-NEXT:       _cond1 = y < 0;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           z = t;
-//CHECK-NEXT:           _t1 = t;
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           {
-//CHECK-NEXT:               t = _t1;
 //CHECK-NEXT:               double _r_d1 = _d_t;
 //CHECK-NEXT:               _d_t = 0.;
 //CHECK-NEXT:               _d_t += -_r_d1;
@@ -176,7 +157,6 @@ double f5(double x, double y) {
 //CHECK-NEXT:         _label0:
 //CHECK-NEXT:           _d_t += 1;
 //CHECK-NEXT:           {
-//CHECK-NEXT:               t = _t0;
 //CHECK-NEXT:               double _r_d0 = _d_t;
 //CHECK-NEXT:               _d_t = 0.;
 //CHECK-NEXT:               _d_t += -_r_d0;
@@ -204,17 +184,14 @@ double f6(double x, double y) {
 
 //CHECK:   void f6_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       bool _cond0;
-//CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       bool _cond1;
 //CHECK-NEXT:       double _d_z = 0.;
 //CHECK-NEXT:       double z = 0.;
-//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_t = 0.;
 //CHECK-NEXT:       double t = x * x;
 //CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x < 0;
 //CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:           _t0 = t;
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:           goto _label0;
 //CHECK-NEXT:       }
@@ -223,14 +200,12 @@ double f6(double x, double y) {
 //CHECK-NEXT:       _cond1 = y < 0;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           z = t;
-//CHECK-NEXT:           _t1 = t;
 //CHECK-NEXT:           t = -t;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           {
-//CHECK-NEXT:               t = _t1;
 //CHECK-NEXT:               double _r_d1 = _d_t;
 //CHECK-NEXT:               _d_t = 0.;
 //CHECK-NEXT:               _d_t += -_r_d1;
@@ -241,7 +216,6 @@ double f6(double x, double y) {
 //CHECK-NEXT:         _label0:
 //CHECK-NEXT:           _d_t += 1;
 //CHECK-NEXT:           {
-//CHECK-NEXT:               t = _t0;
 //CHECK-NEXT:               double _r_d0 = _d_t;
 //CHECK-NEXT:               _d_t = 0.;
 //CHECK-NEXT:               _d_t += -_r_d0;
@@ -276,35 +250,28 @@ double f7(double x, double y) {
 //CHECK-NEXT:       t[0]--;
 //CHECK-NEXT:       ++t[0];
 //CHECK-NEXT:       --t[0];
-//CHECK-NEXT:       double _t0 = t[0];
 //CHECK-NEXT:       t[0] = x;
-//CHECK-NEXT:       double _t1 = x;
+//CHECK-NEXT:       double _t0 = x;
 //CHECK-NEXT:       x = y;
-//CHECK-NEXT:       double _t2 = t[0];
 //CHECK-NEXT:       t[0] += t[1];
-//CHECK-NEXT:       double _t3 = t[0];
+//CHECK-NEXT:       double _t1 = t[0];
 //CHECK-NEXT:       t[0] *= t[1];
-//CHECK-NEXT:       double _t4 = t[0];
+//CHECK-NEXT:       double _t2 = t[0];
 //CHECK-NEXT:       t[0] /= t[1];
-//CHECK-NEXT:       double _t5 = t[0];
 //CHECK-NEXT:       t[0] -= t[1];
-//CHECK-NEXT:       double _t6 = x;
 //CHECK-NEXT:       x = ++t[0];
 //CHECK-NEXT:       _d_t[0] += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           x = _t6;
 //CHECK-NEXT:           double _r_d6 = *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
 //CHECK-NEXT:           _d_t[0] += _r_d6;
-//CHECK-NEXT:           --t[0];
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           t[0] = _t5;
 //CHECK-NEXT:           double _r_d5 = _d_t[0];
 //CHECK-NEXT:           _d_t[1] += -_r_d5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           t[0] = _t4;
+//CHECK-NEXT:           t[0] = _t2;
 //CHECK-NEXT:           double _r_d4 = _d_t[0];
 //CHECK-NEXT:           _d_t[0] = 0.;
 //CHECK-NEXT:           _d_t[0] += _r_d4 / t[1];
@@ -312,33 +279,27 @@ double f7(double x, double y) {
 //CHECK-NEXT:           _d_t[1] += _r0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           t[0] = _t3;
+//CHECK-NEXT:           t[0] = _t1;
 //CHECK-NEXT:           double _r_d3 = _d_t[0];
 //CHECK-NEXT:           _d_t[0] = 0.;
 //CHECK-NEXT:           _d_t[0] += _r_d3 * t[1];
 //CHECK-NEXT:           _d_t[1] += t[0] * _r_d3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           t[0] = _t2;
 //CHECK-NEXT:           double _r_d2 = _d_t[0];
 //CHECK-NEXT:           _d_t[1] += _r_d2;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           x = _t1;
+//CHECK-NEXT:           x = _t0;
 //CHECK-NEXT:           double _r_d1 = *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
 //CHECK-NEXT:           *_d_y += _r_d1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           t[0] = _t0;
 //CHECK-NEXT:           double _r_d0 = _d_t[0];
 //CHECK-NEXT:           _d_t[0] = 0.;
 //CHECK-NEXT:           *_d_x += _r_d0;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       ++t[0];
-//CHECK-NEXT:       --t[0];
-//CHECK-NEXT:        t[0]++;
-//CHECK-NEXT:        t[0]--;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += _d_t[1];
 //CHECK-NEXT:           *_d_x += _d_t[2] * x;
@@ -424,16 +385,12 @@ double f10(double x, double y) {
 //CHECK:   void f10_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_t = 0.;
 //CHECK-NEXT:       double t = x;
-//CHECK-NEXT:       double _t0 = t;
-//CHECK-NEXT:       double _t1 = x;
 //CHECK-NEXT:       t = x = y;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           t = _t0;
 //CHECK-NEXT:           double _r_d0 = _d_t;
 //CHECK-NEXT:           _d_t = 0.;
 //CHECK-NEXT:           *_d_x += _r_d0;
-//CHECK-NEXT:           x = _t1;
 //CHECK-NEXT:           double _r_d1 = *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
 //CHECK-NEXT:           *_d_y += _r_d1;
@@ -450,17 +407,15 @@ double f11(double x, double y) {
 //CHECK:   void f11_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _d_t = 0.;
 //CHECK-NEXT:       double t = x;
-//CHECK-NEXT:       double _t0 = t;
 //CHECK-NEXT:       (t = x);
-//CHECK-NEXT:       double _t1 = t;
+//CHECK-NEXT:       double _t0 = t;
 //CHECK-NEXT:       t = y;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           t = _t1;
+//CHECK-NEXT:           t = _t0;
 //CHECK-NEXT:           double _r_d1 = _d_t;
 //CHECK-NEXT:           _d_t = 0.;
 //CHECK-NEXT:           *_d_y += _r_d1;
-//CHECK-NEXT:           t = _t0;
 //CHECK-NEXT:           double _r_d0 = _d_t;
 //CHECK-NEXT:           _d_t = 0.;
 //CHECK-NEXT:           *_d_x += _r_d0;
@@ -476,31 +431,27 @@ double f12(double x, double y) {
 
 //CHECK:   void f12_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _t0;
-//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_t = 0.;
 //CHECK-NEXT:       double t;
 //CHECK-NEXT:       bool _cond0 = x > y;
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:           _t0 = t;
-//CHECK-NEXT:       else
-//CHECK-NEXT:           _t1 = t;
-//CHECK-NEXT:       double *_t2 = &(_cond0 ? (t = x) : (t = y));
-//CHECK-NEXT:       double _t3 = *_t2;
-//CHECK-NEXT:       *_t2 *= y;
+//CHECK-NEXT:       double *_t1 = &(_cond0 ? (t = x) : (t = y));
+//CHECK-NEXT:       double _t2 = *_t1;
+//CHECK-NEXT:       *_t1 *= y;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_t2 = _t3;
+//CHECK-NEXT:           *_t1 = _t2;
 //CHECK-NEXT:           double _r_d2 = (_cond0 ? _d_t : _d_t);
 //CHECK-NEXT:           (_cond0 ? _d_t : _d_t) = 0.;
 //CHECK-NEXT:           (_cond0 ? _d_t : _d_t) += _r_d2 * y;
-//CHECK-NEXT:           *_d_y += *_t2 * _r_d2;
+//CHECK-NEXT:           *_d_y += *_t1 * _r_d2;
 //CHECK-NEXT:           if (_cond0) {
 //CHECK-NEXT:               t = _t0;
 //CHECK-NEXT:               double _r_d0 = _d_t;
 //CHECK-NEXT:               _d_t = 0.;
 //CHECK-NEXT:               *_d_x += _r_d0;
 //CHECK-NEXT:           } else {
-//CHECK-NEXT:               t = _t1;
 //CHECK-NEXT:               double _r_d1 = _d_t;
 //CHECK-NEXT:               _d_t = 0.;
 //CHECK-NEXT:               *_d_y += _r_d1;
@@ -543,27 +494,23 @@ double f14(double i, double j) {
 // CHECK: void f14_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double &_d_a = *_d_i;
 // CHECK-NEXT:     double &a = i;
-// CHECK-NEXT:     double _t0 = a;
 // CHECK-NEXT:     a = 2 * i;
-// CHECK-NEXT:     double _t1 = a;
 // CHECK-NEXT:     a += i;
-// CHECK-NEXT:     double _t2 = a;
+// CHECK-NEXT:     double _t0 = a;
 // CHECK-NEXT:     a *= i;
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         a = _t2;
+// CHECK-NEXT:         a = _t0;
 // CHECK-NEXT:         double _r_d2 = _d_a;
 // CHECK-NEXT:         _d_a = 0.;
 // CHECK-NEXT:         _d_a += _r_d2 * i;
 // CHECK-NEXT:         *_d_i += a * _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         a = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_a;
 // CHECK-NEXT:         *_d_i += _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         a = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_a;
 // CHECK-NEXT:         _d_a = 0.;
 // CHECK-NEXT:         *_d_i += 2 * _r_d0;
@@ -593,11 +540,10 @@ double f15(double i, double j) {
 // CHECK-NEXT:     double &d = j;
 // CHECK-NEXT:     double _t0 = a;
 // CHECK-NEXT:     a *= i;
-// CHECK-NEXT:     double _t1 = b;
 // CHECK-NEXT:     b += 2 * i;
-// CHECK-NEXT:     double _t2 = c;
+// CHECK-NEXT:     double _t1 = c;
 // CHECK-NEXT:     c += 3 * i;
-// CHECK-NEXT:     double _t3 = d;
+// CHECK-NEXT:     double _t2 = d;
 // CHECK-NEXT:     d *= 3 * j;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_a += 1;
@@ -605,19 +551,18 @@ double f15(double i, double j) {
 // CHECK-NEXT:         _d_d += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         d = _t3;
+// CHECK-NEXT:         d = _t2;
 // CHECK-NEXT:         double _r_d3 = _d_d;
 // CHECK-NEXT:         _d_d = 0.;
 // CHECK-NEXT:         _d_d += _r_d3 * 3 * j;
 // CHECK-NEXT:         *_d_j += 3 * d * _r_d3;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         c = _t2;
+// CHECK-NEXT:         c = _t1;
 // CHECK-NEXT:         double _r_d2 = _d_c;
 // CHECK-NEXT:         *_d_i += 3 * _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         b = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_b;
 // CHECK-NEXT:         *_d_i += 2 * _r_d1;
 // CHECK-NEXT:     }
@@ -669,11 +614,9 @@ double f17(double i, double j, double k) {
 // CHECK: void f17_grad_0(double i, double j, double k, double *_d_i) {
 // CHECK-NEXT:     double _d_j = 0.;
 // CHECK-NEXT:     double _d_k = 0.;
-// CHECK-NEXT:     double _t0 = j;
 // CHECK-NEXT:     j = 2 * i;
 // CHECK-NEXT:     _d_j += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         j = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_j;
 // CHECK-NEXT:         _d_j = 0.;
 // CHECK-NEXT:         *_d_i += 2 * _r_d0;
@@ -688,18 +631,14 @@ double f18(double i, double j, double k) {
 
 // CHECK: void f18_grad_0_1(double i, double j, double k, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_k = 0.;
-// CHECK-NEXT:     double _t0 = k;
 // CHECK-NEXT:     k = 2 * i + 2 * j;
-// CHECK-NEXT:     double _t1 = k;
 // CHECK-NEXT:     k += i;
 // CHECK-NEXT:     _d_k += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         k = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_k;
 // CHECK-NEXT:         *_d_i += _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         k = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_k;
 // CHECK-NEXT:         _d_k = 0.;
 // CHECK-NEXT:         *_d_i += 2 * _r_d0;
@@ -733,20 +672,18 @@ double f20(double x, double y) {
 //CHECK: void f20_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     double &_d_r = *_d_x;
 //CHECK-NEXT:     double &r = x;
-//CHECK-NEXT:     double _t0 = r;
 //CHECK-NEXT:     r = 3;
-//CHECK-NEXT:     double _t1 = x;
+//CHECK-NEXT:     double _t0 = x;
 //CHECK-NEXT:     x = r * y;
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         x = _t1;
+//CHECK-NEXT:         x = _t0;
 //CHECK-NEXT:         double _r_d1 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0.;
 //CHECK-NEXT:         _d_r += _r_d1 * y;
 //CHECK-NEXT:         *_d_y += r * _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
-//CHECK-NEXT:         r = _t0;
 //CHECK-NEXT:         double _r_d0 = _d_r;
 //CHECK-NEXT:         _d_r = 0.;
 //CHECK-NEXT:     }
@@ -758,16 +695,13 @@ double f21 (double x, double y) {
 }
 
 //CHECK: void f21_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     double _t0 = y;
 //CHECK-NEXT:     y = (y++ , x);
 //CHECK-NEXT:     *_d_y += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         y = _t0;
 //CHECK-NEXT:         double _r_d0 = *_d_y;
 //CHECK-NEXT:         *_d_y = 0.;
 //CHECK-NEXT:         *_d_x += _r_d0;
 //CHECK-NEXT:         *_d_y += 0;
-//CHECK-NEXT:         y--;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -790,7 +724,6 @@ double f23(double x, double y) {
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     clad::array<double> *_d_ref = nullptr;
 //CHECK-NEXT:     clad::array<double> *ref = {};
-//CHECK-NEXT:     double _t0;
 //CHECK-NEXT:     clad::array<double> _d_list = {{2U|2UL}};
 //CHECK-NEXT:     clad::array<double> list = {1., x + y};
 //CHECK-NEXT:     double _d_res = 0.;
@@ -800,14 +733,12 @@ double f23(double x, double y) {
 //CHECK-NEXT:         if (_cond0) {
 //CHECK-NEXT:             _d_ref = &_d_list;
 //CHECK-NEXT:             ref = &list;
-//CHECK-NEXT:             _t0 = res;
 //CHECK-NEXT:             res = *(std::end(*ref) - 1);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_res += 1;
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         {
-//CHECK-NEXT:             res = _t0;
 //CHECK-NEXT:             double _r_d0 = _d_res;
 //CHECK-NEXT:             _d_res = 0.;
 //CHECK-NEXT:             *(std::end(*_d_ref) - 1) += _r_d0;

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oConstructors.out -Xclang -verify 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oConstructors.out -Xclang -verify 2>&1 | %filecheck %s
 // RUN: ./Constructors.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oConstructors.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oConstructors.out
 // RUN: ./Constructors.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
@@ -30,27 +30,23 @@ double fn1(double x, double y) {
 
 // CHECK:  static void constructor_pullback(double val, argByVal *_d_this, double *_d_val) {
 // CHECK-NEXT:      argByVal *_this = (argByVal *)malloc(sizeof(argByVal));
-// CHECK-NEXT:      double _t0 = _this->x;
 // CHECK-NEXT:      _this->x = val;
-// CHECK-NEXT:      double _t1 = val;
+// CHECK-NEXT:      double _t0 = val;
 // CHECK-NEXT:      val *= val;
-// CHECK-NEXT:      double _t2 = _this->y;
 // CHECK-NEXT:      _this->y = val;
 // CHECK-NEXT:      {
-// CHECK-NEXT:          _this->y = _t2;
 // CHECK-NEXT:          double _r_d2 = _d_this->y;
 // CHECK-NEXT:          _d_this->y = 0.;
 // CHECK-NEXT:          *_d_val += _r_d2;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
-// CHECK-NEXT:          val = _t1;
+// CHECK-NEXT:          val = _t0;
 // CHECK-NEXT:          double _r_d1 = *_d_val;
 // CHECK-NEXT:          *_d_val = 0.;
 // CHECK-NEXT:          *_d_val += _r_d1 * val;
 // CHECK-NEXT:          *_d_val += val * _r_d1;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
-// CHECK-NEXT:          _this->x = _t0;
 // CHECK-NEXT:          double _r_d0 = _d_this->x;
 // CHECK-NEXT:          _d_this->x = 0.;
 // CHECK-NEXT:          *_d_val += _r_d0;
@@ -62,14 +58,12 @@ double fn1(double x, double y) {
 // CHECK-NEXT:      argByVal g(x);
 // CHECK-NEXT:      argByVal _d_g(g);
 // CHECK-NEXT:      clad::zero_init(_d_g);
-// CHECK-NEXT:      double _t0 = y; 
 // CHECK-NEXT:      y = x;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          *_d_y += 1;
 // CHECK-NEXT:          _d_g.y += 1;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
-// CHECK-NEXT:          y = _t0;
 // CHECK-NEXT:          double _r_d0 = *_d_y;
 // CHECK-NEXT:          *_d_y = 0.;
 // CHECK-NEXT:          *_d_x += _r_d0;
@@ -159,10 +153,8 @@ double fn2(double u, double v) {
 
 // CHECK:  static void constructor_pullback(double x, S3 *_d_this, double *_d_x) {
 // CHECK-NEXT:      S3 *_this = (S3 *)malloc(sizeof(S3));
-// CHECK-NEXT:      double _t0 = _this->p;
 // CHECK-NEXT:      _this->p = x * x;
 // CHECK-NEXT:      {
-// CHECK-NEXT:          _this->p = _t0;
 // CHECK-NEXT:          double _r_d0 = _d_this->p;
 // CHECK-NEXT:          _d_this->p = 0.;
 // CHECK-NEXT:          *_d_x += _r_d0 * x;
@@ -314,14 +306,12 @@ double fn5(double x, double y) {
 // CHECK-NEXT:      argByValWrapper g(x);
 // CHECK-NEXT:      argByValWrapper _d_g(g);
 // CHECK-NEXT:      clad::zero_init(_d_g);
-// CHECK-NEXT:      double _t0 = y;
 // CHECK-NEXT:      y = x;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          *_d_y += 1;
 // CHECK-NEXT:          _d_g.y += 1;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
-// CHECK-NEXT:          y = _t0;
 // CHECK-NEXT:          double _r_d0 = *_d_y;
 // CHECK-NEXT:          *_d_y = 0.;
 // CHECK-NEXT:          *_d_x += _r_d0;
@@ -340,10 +330,8 @@ double fn6(double x, double y) {
 
 // CHECK:  static void constructor_pullback(double v, double u, argByValWrapper *_d_this, double *_d_v, double *_d_u) {
 // CHECK-NEXT:      argByValWrapper *_this = new argByValWrapper(v);
-// CHECK-NEXT:      double _t0 = _this->z;
 // CHECK-NEXT:      _this->z = _this->y * u;
 // CHECK-NEXT:      {
-// CHECK-NEXT:          _this->z = _t0;
 // CHECK-NEXT:          double _r_d0 = _d_this->z;
 // CHECK-NEXT:          _d_this->z = 0.;
 // CHECK-NEXT:          _d_this->y += _r_d0 * u;
@@ -379,10 +367,8 @@ double fn7(double x, double y) {
 // CHECK:  static void constructor_pullback(double v, bool arg, argByValWrapper *_d_this, double *_d_v, bool *_d_arg) {
 // CHECK-NEXT:      argByValWrapper *_this = (argByValWrapper *)malloc(sizeof(argByValWrapper));
 // CHECK-NEXT:      new (static_cast<argByVal *>(_this)) argByVal(v);
-// CHECK-NEXT:      double _t0 = _this->z;
 // CHECK-NEXT:      _this->z = _this->x * _this->y;
 // CHECK-NEXT:      {
-// CHECK-NEXT:          _this->z = _t0;
 // CHECK-NEXT:          double _r_d0 = _d_this->z;
 // CHECK-NEXT:          _d_this->z = 0.;
 // CHECK-NEXT:          _d_this->x += _r_d0 * _this->y;

--- a/test/Gradient/DiffInterface.C
+++ b/test/Gradient/DiffInterface.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oGradientDiffInterface.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oGradientDiffInterface.out 2>&1 | %filecheck %s
 // RUN: ./GradientDiffInterface.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oGradientDiffInterface.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oGradientDiffInterface.out
 // RUN: ./GradientDiffInterface.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -1,6 +1,6 @@
-// RUN: %cladnumdiffclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -std=c++17 -Wno-writable-strings %s  -I%S/../../include -oFunctionCalls.out 2>&1 | %filecheck %s
+// RUN: %cladnumdiffclang -std=c++17 -Wno-writable-strings %s  -I%S/../../include -oFunctionCalls.out 2>&1 | %filecheck %s
 // RUN: ./FunctionCalls.out | %filecheck_exec %s
-// RUN: %cladnumdiffclang -std=c++17 -Wno-writable-strings %s  -I%S/../../include -oFunctionCalls.out
+// RUN: %cladnumdiffclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -std=c++17 -Wno-writable-strings %s  -I%S/../../include -oFunctionCalls.out
 // RUN: ./FunctionCalls.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
@@ -47,9 +47,7 @@ double modify1(double& i, double& j) {
 }
 
 // CHECK: void modify1_pullback(double &i, double &j, double _d_y, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0 = i;
 // CHECK-NEXT:     i += j;
-// CHECK-NEXT:     double _t1 = j;
 // CHECK-NEXT:     j += j;
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = i + j;
@@ -59,12 +57,10 @@ double modify1(double& i, double& j) {
 // CHECK-NEXT:         *_d_j += _d_res;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         j = _t1;
 // CHECK-NEXT:         double _r_d1 = *_d_j;
 // CHECK-NEXT:         *_d_j += _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         i = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_i;
 // CHECK-NEXT:         *_d_j += _r_d0;
 // CHECK-NEXT:     }
@@ -80,29 +76,25 @@ double fn2(double i, double j) {
 // CHECK: void fn2_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     double _d_temp = 0.;
 // CHECK-NEXT:     double temp = 0;
-// CHECK-NEXT:     double _t0 = temp;
-// CHECK-NEXT:     double _t1 = i;
-// CHECK-NEXT:     double _t2 = j;
+// CHECK-NEXT:     double _t0 = i;
+// CHECK-NEXT:     double _t1 = j;
 // CHECK-NEXT:     temp = modify1(i, j);
-// CHECK-NEXT:     double _t3 = temp;
-// CHECK-NEXT:     double _t4 = i;
-// CHECK-NEXT:     double _t5 = j;
+// CHECK-NEXT:     double _t2 = i;
+// CHECK-NEXT:     double _t3 = j;
 // CHECK-NEXT:     temp = modify1(i, j);
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         temp = _t3;
 // CHECK-NEXT:         double _r_d1 = _d_temp;
 // CHECK-NEXT:         _d_temp = 0.;
-// CHECK-NEXT:         i = _t4;
-// CHECK-NEXT:         j = _t5;
+// CHECK-NEXT:         i = _t2;
+// CHECK-NEXT:         j = _t3;
 // CHECK-NEXT:         modify1_pullback(i, j, _r_d1, &*_d_i, &*_d_j);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         temp = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_temp;
 // CHECK-NEXT:         _d_temp = 0.;
-// CHECK-NEXT:         i = _t1;
-// CHECK-NEXT:         j = _t2;
+// CHECK-NEXT:         i = _t0;
+// CHECK-NEXT:         j = _t1;
 // CHECK-NEXT:         modify1_pullback(i, j, _r_d0, &*_d_i, &*_d_j);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -113,17 +105,13 @@ void update1(double& i, double& j) {
 }
 
 // CHECK: void update1_pullback(double &i, double &j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0 = i;
 // CHECK-NEXT:     i += j;
-// CHECK-NEXT:     double _t1 = j;
 // CHECK-NEXT:     j += j;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         j = _t1;
 // CHECK-NEXT:         double _r_d1 = *_d_j;
 // CHECK-NEXT:         *_d_j += _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         i = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_i;
 // CHECK-NEXT:         *_d_j += _r_d0;
 // CHECK-NEXT:     }
@@ -166,26 +154,21 @@ float sum(double* arr, int n) {
 // CHECK: void sum_pullback(double *arr, int n, float _d_y, double *_d_arr, int *_d_n) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<float> _t1 = {};
 // CHECK-NEXT:     float _d_res = 0.F;
 // CHECK-NEXT:     float res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += arr[i];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     double _t2 = arr[0];
 // CHECK-NEXT:     arr[0] += 10 * arr[0];
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         arr[0] = _t2;
 // CHECK-NEXT:         double _r_d1 = _d_arr[0];
 // CHECK-NEXT:         _d_arr[0] += 10 * _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
-// CHECK-NEXT:         res = clad::pop(_t1);
 // CHECK-NEXT:         float _r_d0 = _d_res;
 // CHECK-NEXT:         _d_arr[i] += _r_d0;
 // CHECK-NEXT:     }
@@ -196,10 +179,8 @@ void twice(double& d) {
 }
 
 // CHECK: void twice_pullback(double &d, double *_d_d) {
-// CHECK-NEXT:     double _t0 = d;
 // CHECK-NEXT:     d = 2 * d;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         d = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_d;
 // CHECK-NEXT:         *_d_d = 0.;
 // CHECK-NEXT:         *_d_d += 2 * _r_d0;
@@ -219,35 +200,30 @@ double fn4(double* arr, int n) {
 // CHECK: void fn4_grad(double *arr, int n, double *_d_arr, int *_d_n) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     double _t0 = res;
 // CHECK-NEXT:     res += sum(arr, n);
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t1 = {{0U|0UL|0ULL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
-// CHECK-NEXT:         _t1++;
-// CHECK-NEXT:         clad::push(_t2, arr[i]);
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         clad::push(_t1, arr[i]);
 // CHECK-NEXT:         twice(arr[i]);
-// CHECK-NEXT:         clad::push(_t3, res);
 // CHECK-NEXT:         res += arr[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t1; _t1--) {
+// CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             res = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d1 = _d_res;
 // CHECK-NEXT:             _d_arr[i] += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             arr[i] = clad::pop(_t2);
+// CHECK-NEXT:             arr[i] = clad::pop(_t1);
 // CHECK-NEXT:             twice_pullback(arr[i], &_d_arr[i]);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         res = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_res;
 // CHECK-NEXT:         int _r0 = 0;
 // CHECK-NEXT:         sum_pullback(arr, n, _r_d0, _d_arr, &_r0);
@@ -261,10 +237,8 @@ double modify2(double* arr) {
 }
 
 // CHECK: void modify2_pullback(double *arr, double _d_y, double *_d_arr) {
-// CHECK-NEXT:     double _t0 = arr[0];
 // CHECK-NEXT:     arr[0] = 5 * arr[0] + arr[1];
 // CHECK-NEXT:     {
-// CHECK-NEXT:         arr[0] = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_arr[0];
 // CHECK-NEXT:         _d_arr[0] = 0.;
 // CHECK-NEXT:         _d_arr[0] += 5 * _r_d0;
@@ -339,13 +313,9 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     MyStruct::myFunction();
 // CHECK-NEXT:     double _d__d_i = 0.;
 // CHECK-NEXT:     double _d_i0 = i;
-// CHECK-NEXT:     double _t0 = _d_i0;
 // CHECK-NEXT:     _d_i0 += 1;
 // CHECK-NEXT:     *_d_i += _d_y;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         _d_i0 = _t0;
-// CHECK-NEXT:         double _r_d0 = _d__d_i;
-// CHECK-NEXT:     }
+// CHECK-NEXT:     double _r_d0 = _d__d_i;
 // CHECK-NEXT:     *_d_i += _d__d_i;
 // CHECK-NEXT: }
 
@@ -366,9 +336,7 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t5 = {{.*}}custom_derivatives::custom_identity_reverse_forw(i, *_d_i);
 // CHECK-NEXT:     double &_d_temp = _t5.adjoint;
 // CHECK-NEXT:     double &temp = _t5.value;
-// CHECK-NEXT:     double _t6 = k;
 // CHECK-NEXT:     k += 7 * j;
-// CHECK-NEXT:     double _t7 = l;
 // CHECK-NEXT:     l += 9 * i;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += 1;
@@ -376,12 +344,10 @@ double fn7(double i, double j) {
 // CHECK-NEXT:         _d_temp += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         l = _t7;
 // CHECK-NEXT:         double _r_d1 = _d_l;
 // CHECK-NEXT:         *_d_i += 9 * _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         k = _t6;
 // CHECK-NEXT:         double _r_d0 = _d_k;
 // CHECK-NEXT:         *_d_j += 7 * _r_d0;
 // CHECK-NEXT:     }
@@ -410,15 +376,12 @@ double check_and_return(double x, char c, const char* s) {
 // CHECK-NEXT:    double _d_cond0;
 // CHECK-NEXT:    _d_cond0 = 0.;
 // CHECK-NEXT:    bool _cond1;
-// CHECK-NEXT:    bool _t0;
 // CHECK-NEXT:    bool _cond2;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        {
 // CHECK-NEXT:            _cond1 = c == 'a';
-// CHECK-NEXT:            if (_cond1) {
-// CHECK-NEXT:                _t0 = _cond0;
+// CHECK-NEXT:            if (_cond1)
 // CHECK-NEXT:                _cond0 = s[0] == 'a';
-// CHECK-NEXT:            }
 // CHECK-NEXT:        }
 // CHECK-NEXT:        _cond2 = _cond1 && _cond0;
 // CHECK-NEXT:        if (_cond2)
@@ -430,7 +393,6 @@ double check_and_return(double x, char c, const char* s) {
 // CHECK-NEXT:           *_d_x += _d_y;
 // CHECK-NEXT:        {
 // CHECK-NEXT:            if (_cond1) {
-// CHECK-NEXT:                _cond0 = _t0;
 // CHECK-NEXT:                double _r_d0 = _d_cond0;
 // CHECK-NEXT:                _d_cond0 = 0.;
 // CHECK-NEXT:            }
@@ -591,20 +553,17 @@ double fn13(double* x, const double* w) {
 // CHECK: void fn13_grad_0(double *x, const double *w, double *_d_x) {
 // CHECK-NEXT:     std::size_t _d_i = {{0U|0UL}};
 // CHECK-NEXT:     std::size_t i = {{0U|0UL}};
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_wCopy[2] = {0};
 // CHECK-NEXT:     double wCopy[2];
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 2; ++i) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, wCopy[i]);
 // CHECK-NEXT:         wCopy[i] = w[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     multiply_pullback(x, wCopy + 1, 1, _d_x, _d_wCopy + 1);
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             wCopy[i] = clad::pop(_t1);
 // CHECK-NEXT:             double _r_d0 = _d_wCopy[i];
 // CHECK-NEXT:             _d_wCopy[i] = 0.;
 // CHECK-NEXT:         }
@@ -865,10 +824,8 @@ double unused_return(double& x) {
 }
 
 // CHECK:  void unused_return_pullback(double &x, double _d_y, double *_d_x) {
-// CHECK-NEXT:      double _t0 = x;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          *_d_x += _d_y;
-// CHECK-NEXT:          x = _t0;
 // CHECK-NEXT:          double _r_d0 = *_d_x;
 // CHECK-NEXT:          *_d_x = 0.;
 // CHECK-NEXT:          *_d_x += _r_d0 * 2;

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oFunctors.out -Xclang -verify 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oFunctors.out -Xclang -verify 2>&1 | %filecheck %s
 // RUN: ./Functors.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oFunctors.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oFunctors.out
 // RUN: ./Functors.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -1,6 +1,6 @@
-// RUN: %cladnumdiffclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -std=c++17 -I%S/../../include -oGradients.out -Xclang -verify 2>&1 | %filecheck %s
+// RUN: %cladnumdiffclang %s -std=c++17 -I%S/../../include -oGradients.out -Xclang -verify 2>&1 | %filecheck %s
 // RUN: ./Gradients.out | %filecheck_exec %s
-// RUN: %cladnumdiffclang %s  -I%S/../../include -oGradients.out
+// RUN: %cladnumdiffclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s  -I%S/../../include -oGradients.out
 // RUN: ./Gradients.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
@@ -134,16 +134,14 @@ double f_div3(double x, double y) {
 }
 
 //CHECK: void f_div3_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     double _t1 = x;
-//CHECK-NEXT:     double _t2 = (x = y);
+//CHECK-NEXT:     double _t1 = (x = y);
 //CHECK-NEXT:     double _t0 = (y * y);
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += 1 / _t0;
-//CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0.;
 //CHECK-NEXT:         *_d_y += _r_d0;
-//CHECK-NEXT:         double _r0 = 1 * -(_t2 / (_t0 * _t0));
+//CHECK-NEXT:         double _r0 = 1 * -(_t1 / (_t0 * _t0));
 //CHECK-NEXT:         *_d_y += _r0 * y;
 //CHECK-NEXT:         *_d_y += y * _r0;
 //CHECK-NEXT:     }
@@ -253,7 +251,6 @@ double f_cond4(double x, double y) {
 
 //CHECK:   void f_cond4_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       bool _cond0;
-//CHECK-NEXT:       double _t0;
 //CHECK-NEXT:       int _d_i = 0;
 //CHECK-NEXT:       int i = 0;
 //CHECK-NEXT:       double _d_arr[2] = {0};
@@ -261,14 +258,12 @@ double f_cond4(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x > 0;
 //CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:           _t0 = y;
 //CHECK-NEXT:           y = arr[i] * x;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       if (_cond0) {
 //CHECK-NEXT:           {
-//CHECK-NEXT:               y = _t0;
 //CHECK-NEXT:               double _r_d0 = *_d_y;
 //CHECK-NEXT:               *_d_y = 0.;
 //CHECK-NEXT:               _d_arr[i] += _r_d0 * x;
@@ -653,18 +648,15 @@ float running_sum(float* p, int n) {
 // CHECK: void running_sum_grad(float *p, int n, float *_d_p, int *_d_n) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<float> _t1 = {};
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 1; i < n; i++) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, p[i]);
 // CHECK-NEXT:         p[i] += p[i - 1];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_p[n - 1] += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             p[i] = clad::pop(_t1);
 // CHECK-NEXT:             float _r_d0 = _d_p[i];
 // CHECK-NEXT:             _d_p[i - 1] += _r_d0;
 // CHECK-NEXT:         }
@@ -701,7 +693,6 @@ void fn_increment_in_return_grad(double i, double j, double *_d_i, double *_d_j)
 // CHECK-NEXT:     double _t0 = ++i;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += 1 * temp;
-// CHECK-NEXT:         --i;
 // CHECK-NEXT:         _d_temp += _t0 * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_i += _d_temp;
@@ -784,10 +775,8 @@ double fn_cond_side_eff(double x) {
 } // = 2x
 
 //CHECK:         void fn_cond_side_eff_grad(double x, double *_d_x) {
-//CHECK-NEXT:             double _t0;
 //CHECK-NEXT:             bool _cond0;
 //CHECK-NEXT:             {
-//CHECK-NEXT:                 _t0 = x;
 //CHECK-NEXT:                 _cond0 = x += x;
 //CHECK-NEXT:                 if (_cond0) {
 //CHECK-NEXT:                     goto _label0;
@@ -800,7 +789,6 @@ double fn_cond_side_eff(double x) {
 //CHECK-NEXT:                     *_d_x += 1;
 //CHECK-NEXT:                 }
 //CHECK-NEXT:                 {
-//CHECK-NEXT:                     x = _t0;
 //CHECK-NEXT:                     double _r_d0 = *_d_x;
 //CHECK-NEXT:                     *_d_x += _r_d0;
 //CHECK-NEXT:                 }
@@ -893,18 +881,14 @@ double fn_empty_if_else(double x) {
 }
 
 //CHECK: void fn_empty_if_else_grad(double x, double *_d_x) {
-//CHECK-NEXT:    double _t0;
 //CHECK-NEXT:    bool _cond0;
-//CHECK-NEXT:    double _t1;
 //CHECK-NEXT:    double _d_res = 0.;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        _t0 = res;
 //CHECK-NEXT:        _cond0 = (res = 0);
 //CHECK-NEXT:        if (_cond0)
 //CHECK-NEXT:            ;
 //CHECK-NEXT:        else {
-//CHECK-NEXT:            _t1 = res;
 //CHECK-NEXT:            res = 5 * x;
 //CHECK-NEXT:        }
 //CHECK-NEXT:    }
@@ -914,14 +898,12 @@ double fn_empty_if_else(double x) {
 //CHECK-NEXT:            ;
 //CHECK-NEXT:        else {
 //CHECK-NEXT:            {
-//CHECK-NEXT:                res = _t1;
 //CHECK-NEXT:                double _r_d1 = _d_res;
 //CHECK-NEXT:                _d_res = 0.;
 //CHECK-NEXT:                *_d_x += 5 * _r_d1;
 //CHECK-NEXT:            }
 //CHECK-NEXT:        }
 //CHECK-NEXT:        {
-//CHECK-NEXT:            res = _t0;
 //CHECK-NEXT:            double _r_d0 = _d_res;
 //CHECK-NEXT:            _d_res = 0.;
 //CHECK-NEXT:        }
@@ -941,22 +923,17 @@ double fn_cond_false(double i, double j) {
 // CHECK-NEXT:    double _d_cond0;
 // CHECK-NEXT:    _d_cond0 = 0.;
 // CHECK-NEXT:    bool _cond1;
-// CHECK-NEXT:    bool _t0;
 // CHECK-NEXT:    bool _cond2;
-// CHECK-NEXT:    double _t1;
 // CHECK-NEXT:    double _d_res = 0.;
 // CHECK-NEXT:    double res = 0;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        {
 // CHECK-NEXT:            _cond1 = i * j;
-// CHECK-NEXT:            if (_cond1) {
-// CHECK-NEXT:                _t0 = _cond0;
+// CHECK-NEXT:            if (_cond1)
 // CHECK-NEXT:                _cond0 = res > 0;
-// CHECK-NEXT:            }
 // CHECK-NEXT:        }
 // CHECK-NEXT:        _cond2 = _cond1 && _cond0;
 // CHECK-NEXT:        if (_cond2) {
-// CHECK-NEXT:            _t1 = res;
 // CHECK-NEXT:            res = 6 * i * j;
 // CHECK-NEXT:        }
 // CHECK-NEXT:    }
@@ -964,7 +941,6 @@ double fn_cond_false(double i, double j) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        if (_cond2) {
 // CHECK-NEXT:            {
-// CHECK-NEXT:                res = _t1;
 // CHECK-NEXT:                double _r_d1 = _d_res;
 // CHECK-NEXT:                _d_res = 0.;
 // CHECK-NEXT:                *_d_i += 6 * _r_d1 * j;
@@ -973,7 +949,6 @@ double fn_cond_false(double i, double j) {
 // CHECK-NEXT:        }
 // CHECK-NEXT:        {
 // CHECK-NEXT:            if (_cond1) {
-// CHECK-NEXT:                _cond0 = _t0;
 // CHECK-NEXT:                double _r_d0 = _d_cond0;
 // CHECK-NEXT:                _d_cond0 = 0.;
 // CHECK-NEXT:            }
@@ -996,38 +971,24 @@ double fn_cond_add_assign(double i, double j) {
 // CHECK-NEXT:    bool _cond1;
 // CHECK-NEXT:    double _d_cond1;
 // CHECK-NEXT:    _d_cond1 = 0.;
-// CHECK-NEXT:    double _t0;
 // CHECK-NEXT:    bool _cond2;
-// CHECK-NEXT:    bool _t1;
-// CHECK-NEXT:    double _t2;
 // CHECK-NEXT:    bool _cond3;
-// CHECK-NEXT:    bool _t3;
-// CHECK-NEXT:    double _t4;
 // CHECK-NEXT:    bool _cond4;
-// CHECK-NEXT:    double _t5;
 // CHECK-NEXT:    double _d_res = 0.;
 // CHECK-NEXT:    double res = 0;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        {
 // CHECK-NEXT:            {
-// CHECK-NEXT:                _t0 = res;
 // CHECK-NEXT:                _cond2 = (res = 2 * i * j);
-// CHECK-NEXT:                if (_cond2) {
-// CHECK-NEXT:                    _t1 = _cond1;
-// CHECK-NEXT:                    _t2 = res;
+// CHECK-NEXT:                if (_cond2)
 // CHECK-NEXT:                    _cond1 = (res += 3 * i * j);
-// CHECK-NEXT:                }
 // CHECK-NEXT:            }
 // CHECK-NEXT:            _cond3 = _cond2 && _cond1;
-// CHECK-NEXT:            if (_cond3) {
-// CHECK-NEXT:                _t3 = _cond0;
-// CHECK-NEXT:                _t4 = res;
+// CHECK-NEXT:            if (_cond3)
 // CHECK-NEXT:                _cond0 = (res += 5 * i * j);
-// CHECK-NEXT:            }
 // CHECK-NEXT:        }
 // CHECK-NEXT:        _cond4 = _cond3 && _cond0;
 // CHECK-NEXT:        if (_cond4) {
-// CHECK-NEXT:            _t5 = res;
 // CHECK-NEXT:            res += 6 * i * j;
 // CHECK-NEXT:        }
 // CHECK-NEXT:    }
@@ -1035,7 +996,6 @@ double fn_cond_add_assign(double i, double j) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        if (_cond4) {
 // CHECK-NEXT:            {
-// CHECK-NEXT:                res = _t5;
 // CHECK-NEXT:                double _r_d5 = _d_res;
 // CHECK-NEXT:                *_d_i += 6 * _r_d5 * j;
 // CHECK-NEXT:                *_d_j += 6 * i * _r_d5;
@@ -1044,11 +1004,9 @@ double fn_cond_add_assign(double i, double j) {
 // CHECK-NEXT:        {
 // CHECK-NEXT:            {
 // CHECK-NEXT:                if (_cond3) {
-// CHECK-NEXT:                    _cond0 = _t3;
 // CHECK-NEXT:                    double _r_d3 = _d_cond0;
 // CHECK-NEXT:                    _d_cond0 = 0.;
 // CHECK-NEXT:                    _d_res += _r_d3;
-// CHECK-NEXT:                    res = _t4;
 // CHECK-NEXT:                    double _r_d4 = _d_res;
 // CHECK-NEXT:                    *_d_i += 5 * _r_d4 * j;
 // CHECK-NEXT:                    *_d_j += 5 * i * _r_d4;
@@ -1056,17 +1014,14 @@ double fn_cond_add_assign(double i, double j) {
 // CHECK-NEXT:                {
 // CHECK-NEXT:                    {
 // CHECK-NEXT:                        if (_cond2) {
-// CHECK-NEXT:                            _cond1 = _t1;
 // CHECK-NEXT:                            double _r_d1 = _d_cond1;
 // CHECK-NEXT:                            _d_cond1 = 0.;
 // CHECK-NEXT:                            _d_res += _r_d1;
-// CHECK-NEXT:                            res = _t2;
 // CHECK-NEXT:                            double _r_d2 = _d_res;
 // CHECK-NEXT:                            *_d_i += 3 * _r_d2 * j;
 // CHECK-NEXT:                            *_d_j += 3 * i * _r_d2;
 // CHECK-NEXT:                        }
 // CHECK-NEXT:                        {
-// CHECK-NEXT:                            res = _t0;
 // CHECK-NEXT:                            double _r_d0 = _d_res;
 // CHECK-NEXT:                            _d_res = 0.;
 // CHECK-NEXT:                            *_d_i += 2 * _r_d0 * j;
@@ -1160,11 +1115,9 @@ double g(double a, double b) {
 }
 
 //CHECK: void g_pullback(double a, double b, double _d_y, double *_d_a, double *_d_b) {
-//CHECK-NEXT:     double _t0 = glob1;
 //CHECK-NEXT:     glob1 = b;
 //CHECK-NEXT:     *_d_a += _d_y;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         glob1 = _t0;
 //CHECK-NEXT:         double _r_d0 = _d_glob1;
 //CHECK-NEXT:         _d_glob1 = 0.;
 //CHECK-NEXT:         *_d_b += _r_d0;

--- a/test/Gradient/InterfaceCompatibility.c
+++ b/test/Gradient/InterfaceCompatibility.c
@@ -1,6 +1,6 @@
-// RUN: %cladnumdiffclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s  -I%S/../../include -oInterfaceCompatibility.out 2>&1 | %filecheck %s
+// RUN: %cladnumdiffclang %s  -I%S/../../include -oInterfaceCompatibility.out 2>&1 | %filecheck %s
 // RUN: ./InterfaceCompatibility.out | %filecheck_exec %s
-// RUN: %cladnumdiffclang %s  -I%S/../../include -oInterfaceCompatibility.out
+// RUN: %cladnumdiffclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s  -I%S/../../include -oInterfaceCompatibility.out
 // RUN: ./InterfaceCompatibility.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Gradient/Lambdas.C
+++ b/test/Gradient/Lambdas.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oLambdas.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oLambdas.out 2>&1 | %filecheck %s
 // RUN: ./Lambdas.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oLambdas.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oLambdas.out
 // RUN: ./Lambdas.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oReverseLoops.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oReverseLoops.out 2>&1 | %filecheck %s
 // RUN: ./ReverseLoops.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oReverseLoops.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oReverseLoops.out
 // RUN: ./ReverseLoops.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
@@ -30,7 +30,6 @@ double f1(double x) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         i--;
 // CHECK-NEXT:         t = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_t;
 // CHECK-NEXT:         _d_t = 0.;
@@ -69,9 +68,7 @@ double f2(double x) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         i--;
 // CHECK-NEXT:         for (; clad::back(_t1); clad::back(_t1)--) {
-// CHECK-NEXT:             j--;
 // CHECK-NEXT:             t = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_t;
 // CHECK-NEXT:             _d_t = 0.;
@@ -116,7 +113,6 @@ double f3(double x) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (clad::back(_cond0))
 // CHECK-NEXT:               _label0:
@@ -153,14 +149,11 @@ double f4(double x) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             t = clad::pop(_t1);
-// CHECK-NEXT:             double _r_d0 = _d_t;
-// CHECK-NEXT:             _d_t = 0.;
-// CHECK-NEXT:             _d_t += _r_d0 * x;
-// CHECK-NEXT:             *_d_x += t * _r_d0;
-// CHECK-NEXT:         }
-// CHECK-NEXT:         i--;
+// CHECK-NEXT:         t = clad::pop(_t1);
+// CHECK-NEXT:         double _r_d0 = _d_t;
+// CHECK-NEXT:         _d_t = 0.;
+// CHECK-NEXT:         _d_t += _r_d0 * x;
+// CHECK-NEXT:         *_d_x += t * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -179,10 +172,6 @@ double f5(double x){
 // CHECK-NEXT:         x++;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_x += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         i--;
-// CHECK-NEXT:         x--;
-// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 double f_const_local(double x) {
@@ -200,21 +189,17 @@ double f_const_local(double x) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_n = 0.;
 // CHECK-NEXT:     double n = 0.;
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, n) , n = x + i;
-// CHECK-NEXT:         clad::push(_t2, res);
 // CHECK-NEXT:         res += x * n;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             res = clad::pop(_t2);
 // CHECK-NEXT:             double _r_d0 = _d_res;
 // CHECK-NEXT:             *_d_x += _r_d0 * n;
 // CHECK-NEXT:             _d_n += x * _r_d0;
@@ -239,19 +224,16 @@ double f_sum(double *p, int n) {
 // CHECK-NEXT:     int _d_n = 0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_s = 0.;
 // CHECK-NEXT:     double s = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; i++) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, s);
 // CHECK-NEXT:         s += p[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_s += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
-// CHECK-NEXT:         s = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_s;
 // CHECK-NEXT:         _d_p[i] += _r_d0;
 // CHECK-NEXT:     }
@@ -273,19 +255,16 @@ double f_sum_squares(double *p, int n) {
 // CHECK-NEXT:     int _d_n = 0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_s = 0.;
 // CHECK-NEXT:     double s = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; i++) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, s);
 // CHECK-NEXT:         s += sq(p[i]);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_s += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
-// CHECK-NEXT:         s = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_s;
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         _r0 += _r_d0 * sq_pushforward(p[i], 1.).pushforward;
@@ -307,55 +286,52 @@ double f_log_gaus(const double* x, double* p /*means*/, double n, double sigma) 
 // CHECK-NEXT:     double _d_sigma = 0.;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_power = 0.;
 // CHECK-NEXT:     double power = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; i++) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, power);
 // CHECK-NEXT:         power += sq(x[i] - p[i]);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     double _t2 = power;
-// CHECK-NEXT:     double _t4 = sq(sigma);
-// CHECK-NEXT:     double _t3 = (2 * _t4);
-// CHECK-NEXT:     power = -power / _t3;
-// CHECK-NEXT:     double _t7 = std::pow(2 * 3.1415926535897931, n);
-// CHECK-NEXT:     double _t6 = std::sqrt(_t7 * sigma);
-// CHECK-NEXT:     double _t5 = std::exp(power);
+// CHECK-NEXT:     double _t1 = power;
+// CHECK-NEXT:     double _t3 = sq(sigma);
+// CHECK-NEXT:     double _t2 = (2 * _t3);
+// CHECK-NEXT:     power = -power / _t2;
+// CHECK-NEXT:     double _t6 = std::pow(2 * 3.1415926535897931, n);
+// CHECK-NEXT:     double _t5 = std::sqrt(_t6 * sigma);
+// CHECK-NEXT:     double _t4 = std::exp(power);
 // CHECK-NEXT:     double _d_gaus = 0.;
-// CHECK-NEXT:     double gaus = 1. / _t6 * _t5;
+// CHECK-NEXT:     double gaus = 1. / _t5 * _t4;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r8 = 0.;
 // CHECK-NEXT:         _r8 += 1 * clad::custom_derivatives::std::log_pushforward(gaus, 1.).pushforward;
 // CHECK-NEXT:         _d_gaus += _r8;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r3 = _d_gaus * _t5 * -(1. / (_t6 * _t6));
+// CHECK-NEXT:         double _r3 = _d_gaus * _t4 * -(1. / (_t5 * _t5));
 // CHECK-NEXT:         double _r4 = 0.;
-// CHECK-NEXT:         _r4 += _r3 * clad::custom_derivatives::std::sqrt_pushforward(_t7 * sigma, 1.).pushforward;
+// CHECK-NEXT:         _r4 += _r3 * clad::custom_derivatives::std::sqrt_pushforward(_t6 * sigma, 1.).pushforward;
 // CHECK-NEXT:         double _r5 = 0.;
 // CHECK-NEXT:         double _r6 = 0.;
 // CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(2 * 3.1415926535897931, n, _r4 * sigma, &_r5, &_r6);
 // CHECK-NEXT:         _d_n += _r6;
-// CHECK-NEXT:         _d_sigma += _t7 * _r4;
+// CHECK-NEXT:         _d_sigma += _t6 * _r4;
 // CHECK-NEXT:         double _r7 = 0.;
-// CHECK-NEXT:         _r7 += 1. / _t6 * _d_gaus * clad::custom_derivatives::std::exp_pushforward(power, 1.).pushforward;
+// CHECK-NEXT:         _r7 += 1. / _t5 * _d_gaus * clad::custom_derivatives::std::exp_pushforward(power, 1.).pushforward;
 // CHECK-NEXT:         _d_power += _r7;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         power = _t2;
+// CHECK-NEXT:         power = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_power;
 // CHECK-NEXT:         _d_power = 0.;
-// CHECK-NEXT:         _d_power += -_r_d1 / _t3;
-// CHECK-NEXT:         double _r1 = _r_d1 * -(-power / (_t3 * _t3));
+// CHECK-NEXT:         _d_power += -_r_d1 / _t2;
+// CHECK-NEXT:         double _r1 = _r_d1 * -(-power / (_t2 * _t2));
 // CHECK-NEXT:         double _r2 = 0.;
 // CHECK-NEXT:         _r2 += 2 * _r1 * sq_pushforward(sigma, 1.).pushforward;
 // CHECK-NEXT:         _d_sigma += _r2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
-// CHECK-NEXT:         power = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_power;
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         _r0 += _r_d0 * sq_pushforward(x[i] - p[i], 1.).pushforward;
@@ -378,21 +354,17 @@ void f_const_grad(const double, const double, double*, double*);
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_sq = 0;
 // CHECK-NEXT:     int sq0 = 0;
-// CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     int _d_r = 0;
 // CHECK-NEXT:     int r = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < a; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, sq0) , sq0 = b * b;
-// CHECK-NEXT:         clad::push(_t2, r);
 // CHECK-NEXT:         r += sq0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_r += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             r = clad::pop(_t2);
 // CHECK-NEXT:             int _r_d0 = _d_r;
 // CHECK-NEXT:             _d_sq += _r_d0;
 // CHECK-NEXT:         }
@@ -425,8 +397,6 @@ double f6 (double i, double j) {
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_c = 0.;
 // CHECK-NEXT:     double c = 0.;
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     double _d_a = 0.;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
@@ -434,23 +404,18 @@ double f6 (double i, double j) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, b) , b = i * i;
 // CHECK-NEXT:         clad::push(_t2, c) , c = j * j;
-// CHECK-NEXT:         clad::push(_t3, b);
 // CHECK-NEXT:         b += j;
-// CHECK-NEXT:         clad::push(_t4, a);
 // CHECK-NEXT:         a += b + c + i;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --counter;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             a = clad::pop(_t4);
 // CHECK-NEXT:             double _r_d1 = _d_a;
 // CHECK-NEXT:             _d_b += _r_d1;
 // CHECK-NEXT:             _d_c += _r_d1;
 // CHECK-NEXT:             *_d_i += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             b = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_b;
 // CHECK-NEXT:             *_d_j += _r_d0;
 // CHECK-NEXT:         }
@@ -478,7 +443,6 @@ double fn7(double i, double j) {
 }
 
 // CHECK: void fn7_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_a = 0.;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
@@ -487,14 +451,12 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     while (counter--)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
-// CHECK-NEXT:             clad::push(_t1, a);
 // CHECK-NEXT:             a += i * i + j;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 a = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_a;
 // CHECK-NEXT:                 *_d_i += _r_d0 * i;
 // CHECK-NEXT:                 *_d_i += i * _r_d0;
@@ -516,7 +478,6 @@ double fn8(double i, double j) {
 
 // CHECK: void fn8_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_a = 0.;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
@@ -528,7 +489,6 @@ double fn8(double i, double j) {
 // CHECK-NEXT:             clad::push(_t1, {{0U|0UL|0ULL}});
 // CHECK-NEXT:             do {
 // CHECK-NEXT:                 clad::back(_t1)++;
-// CHECK-NEXT:                 clad::push(_t2, a);
 // CHECK-NEXT:                 a += i * i + j;
 // CHECK-NEXT:             } while (--counter);
 // CHECK-NEXT:         }
@@ -539,7 +499,6 @@ double fn8(double i, double j) {
 // CHECK-NEXT:                 do {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             a = clad::pop(_t2);
 // CHECK-NEXT:                             double _r_d0 = _d_a;
 // CHECK-NEXT:                             *_d_i += _r_d0 * i;
 // CHECK-NEXT:                             *_d_i += i * _r_d0;
@@ -568,64 +527,54 @@ double fn9(double i, double j) {
 }
 
 // CHECK: void fn9_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     clad::tape<int> _t3 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t4 = {};
-// CHECK-NEXT:     clad::tape<double> _t5 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     int _d_counter = 0, _d_counter_again = 0;
 // CHECK-NEXT:     int counter, counter_again;
-// CHECK-NEXT:     int _t0 = counter;
-// CHECK-NEXT:     int _t1 = counter_again;
 // CHECK-NEXT:     counter = counter_again = 3;
 // CHECK-NEXT:     double _d_a = 0.;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t2 = {{0U|0UL|0ULL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     while (counter--)
 // CHECK-NEXT:         {
-// CHECK-NEXT:             _t2++;
-// CHECK-NEXT:             clad::push(_t3, counter_again);
+// CHECK-NEXT:             _t0++;
 // CHECK-NEXT:             counter_again = 3;
-// CHECK-NEXT:             clad::push(_t4, {{0U|0UL|0ULL}});
+// CHECK-NEXT:             clad::push(_t1, {{0U|0UL|0ULL}});
 // CHECK-NEXT:             while (counter_again--)
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::back(_t4)++;
-// CHECK-NEXT:                     clad::push(_t5, a);
+// CHECK-NEXT:                     clad::back(_t1)++;
 // CHECK-NEXT:                     a += i * i + j;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     _d_a += 1;
-// CHECK-NEXT:     while (_t2)
+// CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     while (clad::back(_t4))
+// CHECK-NEXT:                     while (clad::back(_t1))
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                                 {
-// CHECK-NEXT:                                     a = clad::pop(_t5);
 // CHECK-NEXT:                                     double _r_d3 = _d_a;
 // CHECK-NEXT:                                     *_d_i += _r_d3 * i;
 // CHECK-NEXT:                                     *_d_i += i * _r_d3;
 // CHECK-NEXT:                                     *_d_j += _r_d3;
 // CHECK-NEXT:                                 }
 // CHECK-NEXT:                             }
-// CHECK-NEXT:                             clad::back(_t4)--;
+// CHECK-NEXT:                             clad::back(_t1)--;
 // CHECK-NEXT:                         }
-// CHECK-NEXT:                     clad::pop(_t4);
+// CHECK-NEXT:                     clad::pop(_t1);
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     counter_again = clad::pop(_t3);
 // CHECK-NEXT:                     int _r_d2 = _d_counter_again;
 // CHECK-NEXT:                     _d_counter_again = 0;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
-// CHECK-NEXT:             _t2--;
+// CHECK-NEXT:             _t0--;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         counter = _t0;
 // CHECK-NEXT:         int _r_d0 = _d_counter;
 // CHECK-NEXT:         _d_counter = 0;
 // CHECK-NEXT:         _d_counter_again += _r_d0;
-// CHECK-NEXT:         counter_again = _t1;
 // CHECK-NEXT:         int _r_d1 = _d_counter_again;
 // CHECK-NEXT:         _d_counter_again = 0;
 // CHECK-NEXT:     }
@@ -646,9 +595,6 @@ double fn10(double i, double j) {
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_b = 0;
 // CHECK-NEXT:     int b = 0;
-// CHECK-NEXT:     clad::tape<int> _t2 = {};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<int> _t4 = {};
 // CHECK-NEXT:     double _d_a = 0.;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
@@ -657,28 +603,20 @@ double fn10(double i, double j) {
 // CHECK-NEXT:     while (clad::push(_t1, b) , b = counter)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t0++;
-// CHECK-NEXT:             clad::push(_t2, b);
 // CHECK-NEXT:             b += i * i + j;
-// CHECK-NEXT:             clad::push(_t3, a);
 // CHECK-NEXT:             a += b;
-// CHECK-NEXT:             clad::push(_t4, counter);
 // CHECK-NEXT:             counter -= 1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
+// CHECK-NEXT:                 int _r_d2 = _d_counter;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     counter = clad::pop(_t4);
-// CHECK-NEXT:                     int _r_d2 = _d_counter;
-// CHECK-NEXT:                 }
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     a = clad::pop(_t3);
 // CHECK-NEXT:                     double _r_d1 = _d_a;
 // CHECK-NEXT:                     _d_b += _r_d1;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     b = clad::pop(_t2);
 // CHECK-NEXT:                     int _r_d0 = _d_b;
 // CHECK-NEXT:                     *_d_i += _r_d0 * i;
 // CHECK-NEXT:                     *_d_i += i * _r_d0;
@@ -705,8 +643,6 @@ double fn11(double i, double j) {
 }
 
 // CHECK: void fn11_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     double _d_a = 0.;
@@ -714,20 +650,14 @@ double fn11(double i, double j) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, a);
 // CHECK-NEXT:         a += i * i + j;
-// CHECK-NEXT:         clad::push(_t2, counter);
 // CHECK-NEXT:         counter -= 1;
 // CHECK-NEXT:     } while (counter);
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         {
+// CHECK-NEXT:             int _r_d1 = _d_counter;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 counter = clad::pop(_t2);
-// CHECK-NEXT:                 int _r_d1 = _d_counter;
-// CHECK-NEXT:             }
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 a = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_a;
 // CHECK-NEXT:                 *_d_i += _r_d0 * i;
 // CHECK-NEXT:                 *_d_i += i * _r_d0;
@@ -760,11 +690,7 @@ double fn12(double i, double j) {
 // CHECK-NEXT:     int _d_counter_again = 0;
 // CHECK-NEXT:     int counter_again = 0;
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<int> _t4 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t5 = {};
-// CHECK-NEXT:     clad::tape<double> _t6 = {};
-// CHECK-NEXT:     clad::tape<int> _t7 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     double _d_a = 0.;
@@ -776,47 +702,35 @@ double fn12(double i, double j) {
 // CHECK-NEXT:         clad::push(_t2, {{0U|0UL|0ULL}});
 // CHECK-NEXT:         do {
 // CHECK-NEXT:             clad::back(_t2)++;
-// CHECK-NEXT:             clad::push(_t3, a);
 // CHECK-NEXT:             a += i * i + j;
-// CHECK-NEXT:             clad::push(_t4, counter_again);
 // CHECK-NEXT:             counter_again -= 1;
-// CHECK-NEXT:             clad::push(_t5, {{0U|0UL|0ULL}});
+// CHECK-NEXT:             clad::push(_t3, {{0U|0UL|0ULL}});
 // CHECK-NEXT:             do {
-// CHECK-NEXT:                 clad::back(_t5)++;
-// CHECK-NEXT:                 clad::push(_t6, a);
+// CHECK-NEXT:                 clad::back(_t3)++;
 // CHECK-NEXT:                 a += j;
 // CHECK-NEXT:             } while (0);
 // CHECK-NEXT:         } while (counter_again);
-// CHECK-NEXT:         clad::push(_t7, counter);
 // CHECK-NEXT:         counter -= 1;
 // CHECK-NEXT:     } while (counter);
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 counter = clad::pop(_t7);
-// CHECK-NEXT:                 int _r_d3 = _d_counter;
-// CHECK-NEXT:             }
+// CHECK-NEXT:             int _r_d3 = _d_counter;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 do {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             do {
 // CHECK-NEXT:                                 {
-// CHECK-NEXT:                                     a = clad::pop(_t6);
 // CHECK-NEXT:                                     double _r_d2 = _d_a;
 // CHECK-NEXT:                                     *_d_j += _r_d2;
 // CHECK-NEXT:                                 }
-// CHECK-NEXT:                                 clad::back(_t5)--;
-// CHECK-NEXT:                             } while (clad::back(_t5));
-// CHECK-NEXT:                             clad::pop(_t5);
+// CHECK-NEXT:                                 clad::back(_t3)--;
+// CHECK-NEXT:                             } while (clad::back(_t3));
+// CHECK-NEXT:                             clad::pop(_t3);
 // CHECK-NEXT:                         }
+// CHECK-NEXT:                         int _r_d1 = _d_counter_again;
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             counter_again = clad::pop(_t4);
-// CHECK-NEXT:                             int _r_d1 = _d_counter_again;
-// CHECK-NEXT:                         }
-// CHECK-NEXT:                         {
-// CHECK-NEXT:                             a = clad::pop(_t3);
 // CHECK-NEXT:                             double _r_d0 = _d_a;
 // CHECK-NEXT:                             *_d_i += _r_d0 * i;
 // CHECK-NEXT:                             *_d_i += i * _r_d0;
@@ -851,44 +765,34 @@ double fn13(double i, double j) {
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     int _d_k = 0;
 // CHECK-NEXT:     int k = 0;
-// CHECK-NEXT:     clad::tape<int> _t2 = {};
-// CHECK-NEXT:     clad::tape<int> _t3 = {};
-// CHECK-NEXT:     clad::tape<double> _t4 = {};
+// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_temp = 0.;
 // CHECK-NEXT:     double temp = 0.;
-// CHECK-NEXT:     clad::tape<double> _t5 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (; clad::push(_t1, k) , k = counter; clad::push(_t2, counter) , (counter -= 1)) {
+// CHECK-NEXT:     for (; clad::push(_t1, k) , k = counter; counter -= 1) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t3, k);
 // CHECK-NEXT:         k += i + 2 * j;
-// CHECK-NEXT:         clad::push(_t4, temp) , temp = k;
-// CHECK-NEXT:         clad::push(_t5, res);
+// CHECK-NEXT:         clad::push(_t2, temp) , temp = k;
 // CHECK-NEXT:         res += temp;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
+// CHECK-NEXT:             int _r_d0 = _d_counter;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 counter = clad::pop(_t2);
-// CHECK-NEXT:                 int _r_d0 = _d_counter;
-// CHECK-NEXT:             }
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 res = clad::pop(_t5);
 // CHECK-NEXT:                 double _r_d2 = _d_res;
 // CHECK-NEXT:                 _d_temp += _r_d2;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 _d_k += _d_temp;
 // CHECK-NEXT:                 _d_temp = 0.;
-// CHECK-NEXT:                 temp = clad::pop(_t4);
+// CHECK-NEXT:                 temp = clad::pop(_t2);
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 k = clad::pop(_t3);
 // CHECK-NEXT:                 int _r_d1 = _d_k;
 // CHECK-NEXT:                 *_d_i += _r_d1;
 // CHECK-NEXT:                 *_d_j += 2 * _r_d1;
@@ -925,12 +829,9 @@ double fn14(double i, double j) {
 
 // CHECK: void fn14_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond2 = {};
-// CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double _d_res = 0.;
@@ -942,10 +843,9 @@ double fn14(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 clad::push(_cond0, choice > 3);
 // CHECK-NEXT:                 if (clad::back(_cond0)) {
-// CHECK-NEXT:                     clad::push(_t1, res);
 // CHECK-NEXT:                     res += i;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         clad::push(_t2, {{1U|1UL|1ULL}});
+// CHECK-NEXT:                         clad::push(_t1, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                         continue;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
@@ -953,10 +853,9 @@ double fn14(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 clad::push(_cond1, choice > 1);
 // CHECK-NEXT:                 if (clad::back(_cond1)) {
-// CHECK-NEXT:                     clad::push(_t3, res);
 // CHECK-NEXT:                     res += j;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         clad::push(_t2, {{2U|2UL|2ULL}});
+// CHECK-NEXT:                         clad::push(_t1, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                         continue;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
@@ -964,20 +863,19 @@ double fn14(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 clad::push(_cond2, choice > 0);
 // CHECK-NEXT:                 if (clad::back(_cond2)) {
-// CHECK-NEXT:                     clad::push(_t4, res);
 // CHECK-NEXT:                     res += i * j;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         clad::push(_t2, {{3U|3UL|3ULL}});
+// CHECK-NEXT:                         clad::push(_t1, {{3U|3UL|3ULL}});
 // CHECK-NEXT:                         continue;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
-// CHECK-NEXT:             clad::push(_t2, {{4U|4UL|4ULL}});
+// CHECK-NEXT:             clad::push(_t1, {{4U|4UL|4ULL}});
 // CHECK-NEXT:         }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
-// CHECK-NEXT:             switch (clad::pop(_t2)) {
+// CHECK-NEXT:             switch (clad::pop(_t1)) {
 // CHECK-NEXT:               case {{4U|4UL|4ULL}}:
 // CHECK-NEXT:                 ;
 // CHECK-NEXT:                 {
@@ -985,7 +883,6 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                       case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:                         ;
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             res = clad::pop(_t4);
 // CHECK-NEXT:                             double _r_d2 = _d_res;
 // CHECK-NEXT:                             *_d_i += _r_d2 * j;
 // CHECK-NEXT:                             *_d_j += i * _r_d2;
@@ -998,7 +895,6 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                       case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                         ;
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             res = clad::pop(_t3);
 // CHECK-NEXT:                             double _r_d1 = _d_res;
 // CHECK-NEXT:                             *_d_j += _r_d1;
 // CHECK-NEXT:                         }
@@ -1010,7 +906,6 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                       case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                         ;
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             res = clad::pop(_t1);
 // CHECK-NEXT:                             double _r_d0 = _d_res;
 // CHECK-NEXT:                             *_d_i += _r_d0;
 // CHECK-NEXT:                         }
@@ -1050,10 +945,8 @@ double fn15(double i, double j) {
 // CHECK-NEXT:     int another_choice = 0;
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
-// CHECK-NEXT:     clad::tape<double> _t4 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t5 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t4 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond2 = {};
-// CHECK-NEXT:     clad::tape<double> _t6 = {};
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double _d_res = 0.;
@@ -1077,10 +970,9 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         clad::push(_cond1, another_choice > 1);
 // CHECK-NEXT:                         if (clad::back(_cond1)) {
-// CHECK-NEXT:                             clad::push(_t4, res);
 // CHECK-NEXT:                             res += i;
 // CHECK-NEXT:                             {
-// CHECK-NEXT:                                 clad::push(_t5, {{1U|1UL|1ULL}});
+// CHECK-NEXT:                                 clad::push(_t4, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                                 continue;
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                         }
@@ -1088,11 +980,10 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         clad::push(_cond2, another_choice > 0);
 // CHECK-NEXT:                         if (clad::back(_cond2)) {
-// CHECK-NEXT:                             clad::push(_t6, res);
 // CHECK-NEXT:                             res += j;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
-// CHECK-NEXT:                     clad::push(_t5, {{2U|2UL|2ULL}});
+// CHECK-NEXT:                     clad::push(_t4, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             clad::push(_t1, {{2U|2UL|2ULL}});
 // CHECK-NEXT:         }
@@ -1105,13 +996,12 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     while (clad::back(_t3))
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             switch (clad::pop(_t5)) {
+// CHECK-NEXT:                             switch (clad::pop(_t4)) {
 // CHECK-NEXT:                               case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                                 ;
 // CHECK-NEXT:                                 {
 // CHECK-NEXT:                                     if (clad::back(_cond2)) {
 // CHECK-NEXT:                                         {
-// CHECK-NEXT:                                             res = clad::pop(_t6);
 // CHECK-NEXT:                                             double _r_d1 = _d_res;
 // CHECK-NEXT:                                             *_d_j += _r_d1;
 // CHECK-NEXT:                                         }
@@ -1123,7 +1013,6 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                                       case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                                         ;
 // CHECK-NEXT:                                         {
-// CHECK-NEXT:                                             res = clad::pop(_t4);
 // CHECK-NEXT:                                             double _r_d0 = _d_res;
 // CHECK-NEXT:                                             *_d_i += _r_d0;
 // CHECK-NEXT:                                         }
@@ -1171,11 +1060,8 @@ double fn16(double i, double j) {
 // CHECK-NEXT:     int _d_ii = 0;
 // CHECK-NEXT:     int ii = 0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 5;
 // CHECK-NEXT:     double _d_res = 0.;
@@ -1186,10 +1072,9 @@ double fn16(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, ii == 4);
 // CHECK-NEXT:             if (clad::back(_cond0)) {
-// CHECK-NEXT:                 clad::push(_t1, res);
 // CHECK-NEXT:                 res += i * j;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_t2, {{1U|1UL|1ULL}});
+// CHECK-NEXT:                     clad::push(_t1, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
@@ -1197,27 +1082,22 @@ double fn16(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond1, ii > 2);
 // CHECK-NEXT:             if (clad::back(_cond1)) {
-// CHECK-NEXT:                 clad::push(_t3, res);
 // CHECK-NEXT:                 res += 2 * i;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_t2, {{2U|2UL|2ULL}});
+// CHECK-NEXT:                     clad::push(_t1, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                     continue;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t4, res);
 // CHECK-NEXT:         res += i + j;
-// CHECK-NEXT:         clad::push(_t2, {{3U|3UL|3ULL}});
+// CHECK-NEXT:         clad::push(_t1, {{3U|3UL|3ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; _t0; _t0--) {
-// CHECK-NEXT:         if (_t0 != _numRevIterations0 || (clad::back(_t2) != 1))
-// CHECK-NEXT:          --ii;
-// CHECK-NEXT:         switch (clad::pop(_t2)) {
+// CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; _t0; _t0--)
+// CHECK-NEXT:         switch (clad::pop(_t1)) {
 // CHECK-NEXT:           case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 res = clad::pop(_t4);
 // CHECK-NEXT:                 double _r_d2 = _d_res;
 // CHECK-NEXT:                 *_d_i += _r_d2;
 // CHECK-NEXT:                 *_d_j += _r_d2;
@@ -1227,7 +1107,6 @@ double fn16(double i, double j) {
 // CHECK-NEXT:                   case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         res = clad::pop(_t3);
 // CHECK-NEXT:                         double _r_d1 = _d_res;
 // CHECK-NEXT:                         *_d_i += 2 * _r_d1;
 // CHECK-NEXT:                     }
@@ -1239,7 +1118,6 @@ double fn16(double i, double j) {
 // CHECK-NEXT:                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         res = clad::pop(_t1);
 // CHECK-NEXT:                         double _r_d0 = _d_res;
 // CHECK-NEXT:                         *_d_i += _r_d0 * j;
 // CHECK-NEXT:                         *_d_j += i * _r_d0;
@@ -1248,7 +1126,6 @@ double fn16(double i, double j) {
 // CHECK-NEXT:                 clad::pop(_cond0);
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 double fn17(double i, double j) {
@@ -1281,9 +1158,7 @@ double fn17(double i, double j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
-// CHECK-NEXT:     clad::tape<double> _t4 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t5 = {};
-// CHECK-NEXT:     clad::tape<double> _t6 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t4 = {};
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 5;
 // CHECK-NEXT:     double _d_res = 0.;
@@ -1306,39 +1181,35 @@ double fn17(double i, double j) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     clad::push(_cond1, jj < 3);
 // CHECK-NEXT:                     if (clad::back(_cond1)) {
-// CHECK-NEXT:                         clad::push(_t4, res);
 // CHECK-NEXT:                         res += i * j;
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             clad::push(_t5, {{1U|1UL|1ULL}});
+// CHECK-NEXT:                             clad::push(_t4, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                             break;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     } else {
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             clad::push(_t5, {{2U|2UL|2ULL}});
+// CHECK-NEXT:                             clad::push(_t4, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                             continue;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 clad::push(_t6, res);
 // CHECK-NEXT:                 res += i * i * j * j;
-// CHECK-NEXT:                 clad::push(_t5, {{3U|3UL|3ULL}});
+// CHECK-NEXT:                 clad::push(_t4, {{3U|3UL|3ULL}});
 // CHECK-NEXT:             }
 // CHECK-NEXT:         clad::push(_t2, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --ii;
+// CHECK-NEXT:     for (; _t0; _t0--)
 // CHECK-NEXT:         switch (clad::pop(_t2)) {
 // CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 while (clad::back(_t3))
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         switch (clad::pop(_t5)) {
+// CHECK-NEXT:                         switch (clad::pop(_t4)) {
 // CHECK-NEXT:                           case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:                             ;
 // CHECK-NEXT:                             {
-// CHECK-NEXT:                                 res = clad::pop(_t6);
 // CHECK-NEXT:                                 double _r_d1 = _d_res;
 // CHECK-NEXT:                                 *_d_i += _r_d1 * j * j * i;
 // CHECK-NEXT:                                 *_d_i += i * _r_d1 * j * j;
@@ -1350,7 +1221,6 @@ double fn17(double i, double j) {
 // CHECK-NEXT:                                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                                     ;
 // CHECK-NEXT:                                     {
-// CHECK-NEXT:                                         res = clad::pop(_t4);
 // CHECK-NEXT:                                         double _r_d0 = _d_res;
 // CHECK-NEXT:                                         *_d_i += _r_d0 * j;
 // CHECK-NEXT:                                         *_d_j += i * _r_d0;
@@ -1378,7 +1248,6 @@ double fn17(double i, double j) {
 // CHECK-NEXT:                 jj = clad::pop(_t1);
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 double fn18(double i, double j) {
@@ -1400,10 +1269,8 @@ double fn18(double i, double j) {
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     int choice = 5;
 // CHECK-NEXT:     double _d_res = 0.;
@@ -1413,35 +1280,30 @@ double fn18(double i, double j) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, counter < 2);
-// CHECK-NEXT:             if (clad::back(_cond0)) {
-// CHECK-NEXT:                 clad::push(_t1, res);
+// CHECK-NEXT:             if (clad::back(_cond0))
 // CHECK-NEXT:                 res += i + j;
-// CHECK-NEXT:             } else {
+// CHECK-NEXT:             else {
 // CHECK-NEXT:                 clad::push(_cond1, counter < 4);
 // CHECK-NEXT:                 if (clad::back(_cond1)) {
-// CHECK-NEXT:                     clad::push(_t2, {{1U|1UL|1ULL}});
+// CHECK-NEXT:                     clad::push(_t1, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                     continue;
 // CHECK-NEXT:                 } else {
-// CHECK-NEXT:                     clad::push(_t3, res);
 // CHECK-NEXT:                     res += 2 * i + 2 * j;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         clad::push(_t2, {{2U|2UL|2ULL}});
+// CHECK-NEXT:                         clad::push(_t1, {{2U|2UL|2ULL}});
 // CHECK-NEXT:                         break;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t2, {{3U|3UL|3ULL}});
+// CHECK-NEXT:         clad::push(_t1, {{3U|3UL|3ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; _t0; _t0--) {
-// CHECK-NEXT:         if (_t0 != _numRevIterations0 || (clad::back(_t2) != 2))
-// CHECK-NEXT:          --counter;
-// CHECK-NEXT:         switch (clad::pop(_t2)) {
+// CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; _t0; _t0--)
+// CHECK-NEXT:         switch (clad::pop(_t1)) {
 // CHECK-NEXT:           case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             if (clad::back(_cond0)) {
-// CHECK-NEXT:                 res = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_res;
 // CHECK-NEXT:                 *_d_i += _r_d0;
 // CHECK-NEXT:                 *_d_j += _r_d0;
@@ -1453,7 +1315,6 @@ double fn18(double i, double j) {
 // CHECK-NEXT:                   case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         res = clad::pop(_t3);
 // CHECK-NEXT:                         double _r_d1 = _d_res;
 // CHECK-NEXT:                         *_d_i += 2 * _r_d1;
 // CHECK-NEXT:                         *_d_j += 2 * _r_d1;
@@ -1463,7 +1324,6 @@ double fn18(double i, double j) {
 // CHECK-NEXT:             }
 // CHECK-NEXT:             clad::pop(_cond0);
 // CHECK-NEXT:         }
-// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 double fn19(double* arr, int n) {
@@ -1483,7 +1343,6 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:     clad::tape<double *> _t2 = {};
 // CHECK-NEXT:     double *_d_ref = nullptr;
 // CHECK-NEXT:     double *ref = {};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
@@ -1492,7 +1351,6 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:         _d_ref = &_d_arr[i];
 // CHECK-NEXT:         clad::push(_t1, _d_ref);
 // CHECK-NEXT:         clad::push(_t2, ref) , ref = &arr[i];
-// CHECK-NEXT:         clad::push(_t3, res);
 // CHECK-NEXT:         res += *ref;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
@@ -1500,7 +1358,6 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         _d_ref = clad::pop(_t1);
 // CHECK-NEXT:         {
-// CHECK-NEXT:             res = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_res;
 // CHECK-NEXT:             *_d_ref += _r_d0;
 // CHECK-NEXT:         }
@@ -1522,7 +1379,6 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:     double _d_x = 0.;
 // CHECK-NEXT:     double x = 0.;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_sum = 0.;
 // CHECK-NEXT:     double sum = 0;
 // CHECK-NEXT:     double _d_num_points = 0.;
@@ -1532,7 +1388,6 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (x = lower; x <= upper; clad::push(_t1, x) , (x += interval)) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t2, sum);
 // CHECK-NEXT:         sum += x * x * interval;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_sum += 1;
@@ -1544,7 +1399,6 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:                 _d_interval += _r_d0;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 sum = clad::pop(_t2);
 // CHECK-NEXT:                 double _r_d1 = _d_sum;
 // CHECK-NEXT:                 _d_x += _r_d1 * interval * x;
 // CHECK-NEXT:                 _d_x += x * _r_d1 * interval;
@@ -1572,25 +1426,19 @@ double fn20(double *arr, int n) {
 // CHECK-NEXT:     int _d_n = 0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, res);
-// CHECK-NEXT:         clad::push(_t2, arr[i]);
 // CHECK-NEXT:         res += (arr[i] *= 5);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             res = clad::pop(_t1);
 // CHECK-NEXT:             double _r_d0 = _d_res;
 // CHECK-NEXT:             _d_arr[i] += _r_d0;
-// CHECK-NEXT:             arr[i] = clad::pop(_t2);
 // CHECK-NEXT:             double _r_d1 = _d_arr[i];
 // CHECK-NEXT:             _d_arr[i] = 0.;
 // CHECK-NEXT:             _d_arr[i] += _r_d1 * 5;
@@ -1614,22 +1462,18 @@ double fn21(double x) {
 // CHECK-NEXT:     clad::tape<double{{ ?}}[3]> _t2 = {};
 // CHECK-NEXT:     double _d_arr[3] = {0};
 // CHECK-NEXT:     double arr[3] = {0};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         double (&&_t1)[3] = {1, x, 2};
-// CHECK-NEXT:         clad::push(_t2, arr) , std::move(std::begin(_t1), std::end(_t1), std::begin(arr)); 
-// CHECK-NEXT:         clad::push(_t3, res);
+// CHECK-NEXT:         clad::push(_t2, arr) , std::move(std::begin(_t1), std::end(_t1), std::begin(arr));
 // CHECK-NEXT:         res += arr[0] + arr[1];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             res = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_res;
 // CHECK-NEXT:             _d_arr[0] += _r_d0;
 // CHECK-NEXT:             _d_arr[1] += _r_d0;
@@ -1660,7 +1504,6 @@ double fn22(double param) {
 // CHECK-NEXT:     clad::tape<double{{ ?}}[1]> _t2 = {};
 // CHECK-NEXT:     double _d_arr[1] = {0};
 // CHECK-NEXT:     double arr[1] = {0};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     double _d_out = 0.;
 // CHECK-NEXT:     double out = 0.;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
@@ -1668,14 +1511,11 @@ double fn22(double param) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         double (&&_t1)[1] = {1.};
 // CHECK-NEXT:         clad::push(_t2, arr) , std::move(std::begin(_t1), std::end(_t1), std::begin(arr));
-// CHECK-NEXT:         clad::push(_t3, out);
 // CHECK-NEXT:         out += arr[0] * param;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             out = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_out;
 // CHECK-NEXT:             _d_arr[0] += _r_d0 * param;
 // CHECK-NEXT:             *_d_param += arr[0] * _r_d0;
@@ -1701,33 +1541,26 @@ double fn23(double i, double j) {
 // CHECK: void fn23_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (c = 0; ; ++c) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             clad::push(_t1, res);
-// CHECK-NEXT:             if (!(res = i * j))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (c = 0; (res = i * j); ++c) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, c == 1);
 // CHECK-NEXT:             if (clad::back(_cond0)) {
-// CHECK-NEXT:                 clad::push(_t2, {{1U|1UL|1ULL}});
+// CHECK-NEXT:                 clad::push(_t1, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t2, {{2U|2UL|2ULL}});
+// CHECK-NEXT:         clad::push(_t1, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; ; _t0--) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0 || (_t0 != _numRevIterations0 || (clad::back(_t2) != 1))) {
-// CHECK-NEXT:                 res = clad::pop(_t1);
+// CHECK-NEXT:             if (!_t0 || (clad::back(_t1) != 1)) {
 // CHECK-NEXT:                 double _r_d0 = _d_res;
 // CHECK-NEXT:                 _d_res = 0.;
 // CHECK-NEXT:                 *_d_i += _r_d0 * j;
@@ -1736,9 +1569,7 @@ double fn23(double i, double j) {
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         if (_t0 != _numRevIterations0 || (clad::back(_t2) != 1))
-// CHECK-NEXT:          --c;
-// CHECK-NEXT:         switch (clad::pop(_t2)) {
+// CHECK-NEXT:         switch (clad::pop(_t1)) {
 // CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
@@ -1761,16 +1592,10 @@ double fn24(double i, double j) {
 // CHECK: void fn24_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (c = 0; ; ++c) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             clad::push(_t1, res);
-// CHECK-NEXT:             if (!((res += i * j) , c < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (c = 0; (res += i * j) , c < 3; ++c) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
@@ -1778,7 +1603,6 @@ double fn24(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 _d_res += 0;
-// CHECK-NEXT:                 res = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_res;
 // CHECK-NEXT:                 *_d_i += _r_d0 * j;
 // CHECK-NEXT:                 *_d_j += i * _r_d0;
@@ -1786,7 +1610,6 @@ double fn24(double i, double j) {
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         --c;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -1804,39 +1627,30 @@ double fn25(double i, double j) {
 // CHECK: void fn25_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (c = 0; ; ++c) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             clad::push(_t1, res);
-// CHECK-NEXT:             if (!((res += i * j) , c < 3))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (c = 0; (res += i * j) , c < 3; ++c) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, c == 1);
 // CHECK-NEXT:             if (clad::back(_cond0)) {
-// CHECK-NEXT:                 clad::push(_t2, res);
 // CHECK-NEXT:                 res = 8 * i * j;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     clad::push(_t3, {{1U|1UL|1ULL}});
+// CHECK-NEXT:                     clad::push(_t1, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t3, {{2U|2UL|2ULL}});
+// CHECK-NEXT:         clad::push(_t1, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; ; _t0--) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0 || (_t0 != _numRevIterations0 || (clad::back(_t3) != 1))) {
+// CHECK-NEXT:             if (!_t0 || (clad::back(_t1) != 1)) {
 // CHECK-NEXT:                 _d_res += 0;
-// CHECK-NEXT:                 res = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_res;
 // CHECK-NEXT:                 *_d_i += _r_d0 * j;
 // CHECK-NEXT:                 *_d_j += i * _r_d0;
@@ -1844,9 +1658,7 @@ double fn25(double i, double j) {
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         if (_t0 != _numRevIterations0 || (clad::back(_t3) != 1))
-// CHECK-NEXT:          --c;
-// CHECK-NEXT:         switch (clad::pop(_t3)) {
+// CHECK-NEXT:         switch (clad::pop(_t1)) {
 // CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
@@ -1854,7 +1666,6 @@ double fn25(double i, double j) {
 // CHECK-NEXT:                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         res = clad::pop(_t2);
 // CHECK-NEXT:                         double _r_d1 = _d_res;
 // CHECK-NEXT:                         _d_res = 0.;
 // CHECK-NEXT:                         *_d_i += 8 * _r_d1 * j;
@@ -1879,34 +1690,26 @@ double fn26(double i, double j) {
 // CHECK: void fn26_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t3 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (c = 0; ; clad::push(_t2, res) , (++c , res = 7 * i * j)) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             clad::push(_t1, res);
-// CHECK-NEXT:             if (!(res += i * j))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (c = 0; (res += i * j); ++c , res = 7 * i * j) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, c == 0);
 // CHECK-NEXT:             if (clad::back(_cond0)) {
-// CHECK-NEXT:                 clad::push(_t3, {{1U|1UL|1ULL}});
+// CHECK-NEXT:                 clad::push(_t1, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t3, {{2U|2UL|2ULL}});
+// CHECK-NEXT:         clad::push(_t1, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; ; _t0--) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0 || (_t0 != _numRevIterations0 || (clad::back(_t3) != 1))) {
-// CHECK-NEXT:                 res = clad::pop(_t1);
+// CHECK-NEXT:             if (!_t0 || (_t0 != _numRevIterations0 || (clad::back(_t1) != 1))) {
 // CHECK-NEXT:                 double _r_d0 = _d_res;
 // CHECK-NEXT:                 *_d_i += _r_d0 * j;
 // CHECK-NEXT:                 *_d_j += i * _r_d0;
@@ -1914,16 +1717,14 @@ double fn26(double i, double j) {
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         if (_t0 != _numRevIterations0 || (clad::back(_t3) != 1)) {
-// CHECK-NEXT:             res = clad::pop(_t2);
+// CHECK-NEXT:         if (_t0 != _numRevIterations0 || (clad::back(_t1) != 1)) {
 // CHECK-NEXT:             double _r_d1 = _d_res;
 // CHECK-NEXT:             _d_res = 0.;
 // CHECK-NEXT:             *_d_i += 7 * _r_d1 * j;
 // CHECK-NEXT:             *_d_j += 7 * i * _r_d1;
 // CHECK-NEXT:             _d_c += 0;
-// CHECK-NEXT:             --c;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         switch (clad::pop(_t3)) {
+// CHECK-NEXT:         switch (clad::pop(_t1)) {
 // CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
@@ -1950,36 +1751,27 @@ double fn27(double i, double j) {
 // CHECK: void fn27_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
-// CHECK-NEXT:     clad::tape<double> _t3 = {};
+// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (c = 0; ; ++c) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             clad::push(_t1, res);
-// CHECK-NEXT:             if (!(res += i * j))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (c = 0; (res += i * j); ++c) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, c == 2);
 // CHECK-NEXT:             if (clad::back(_cond0)) {
-// CHECK-NEXT:                 clad::push(_t2, {{1U|1UL|1ULL}});
+// CHECK-NEXT:                 clad::push(_t1, {{1U|1UL|1ULL}});
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:         clad::push(_t3, res);
 // CHECK-NEXT:         res = c * i * j;
-// CHECK-NEXT:         clad::push(_t2, {{2U|2UL|2ULL}});
+// CHECK-NEXT:         clad::push(_t1, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; ; _t0--) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             if (!_t0 || (_t0 != _numRevIterations0 || (clad::back(_t2) != 1))) {
-// CHECK-NEXT:                 res = clad::pop(_t1);
+// CHECK-NEXT:             if (!_t0 || (_t0 != _numRevIterations0 || (clad::back(_t1) != 1))) {
 // CHECK-NEXT:                 double _r_d0 = _d_res;
 // CHECK-NEXT:                 *_d_i += _r_d0 * j;
 // CHECK-NEXT:                 *_d_j += i * _r_d0;
@@ -1987,13 +1779,12 @@ double fn27(double i, double j) {
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         if (_t0 != _numRevIterations0 || (clad::back(_t2) != 1))
+// CHECK-NEXT:         if (_t0 != _numRevIterations0 || (clad::back(_t1) != 1))
 // CHECK-NEXT:          --c;
-// CHECK-NEXT:         switch (clad::pop(_t2)) {
+// CHECK-NEXT:         switch (clad::pop(_t1)) {
 // CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 res = clad::pop(_t3);
 // CHECK-NEXT:                 double _r_d1 = _d_res;
 // CHECK-NEXT:                 _d_res = 0.;
 // CHECK-NEXT:                 _d_c += _r_d1 * j * i;
@@ -2021,19 +1812,11 @@ double fn28(double i, double j) {
 // CHECK: void fn28_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (c = 0; ; ++c) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             clad::push(_t1, res);
-// CHECK-NEXT:             if (!((res = i * j) , c < 2))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (c = 0; (res = i * j) , c < 2; ++c) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t2, res);
 // CHECK-NEXT:         res = 3 * i * j;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
@@ -2041,7 +1824,6 @@ double fn28(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 _d_res += 0;
-// CHECK-NEXT:                 res = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_res;
 // CHECK-NEXT:                 _d_res = 0.;
 // CHECK-NEXT:                 *_d_i += _r_d0 * j;
@@ -2050,9 +1832,7 @@ double fn28(double i, double j) {
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         --c;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             res = clad::pop(_t2);
 // CHECK-NEXT:             double _r_d1 = _d_res;
 // CHECK-NEXT:             _d_res = 0.;
 // CHECK-NEXT:             *_d_i += 3 * _r_d1 * j;
@@ -2070,17 +1850,10 @@ double fn29(double i, double j) {
 // CHECK: void fn29_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT:     for (c = 0; ; clad::push(_t2, res) , (++c , res = 3 * i * j)) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             clad::push(_t1, res);
-// CHECK-NEXT:             if (!(res = i * j , c < 1))
-// CHECK-NEXT:                 break;
-// CHECK-NEXT:         }
+// CHECK-NEXT:     for (c = 0; res = i * j , c < 1; ++c , res = 3 * i * j) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
@@ -2088,7 +1861,6 @@ double fn29(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 _d_res += 0;
-// CHECK-NEXT:                 res = clad::pop(_t1);
 // CHECK-NEXT:                 double _r_d0 = _d_res;
 // CHECK-NEXT:                 _d_res = 0.;
 // CHECK-NEXT:                 *_d_i += _r_d0 * j;
@@ -2098,13 +1870,11 @@ double fn29(double i, double j) {
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             res = clad::pop(_t2);
 // CHECK-NEXT:             double _r_d1 = _d_res;
 // CHECK-NEXT:             _d_res = 0.;
 // CHECK-NEXT:             *_d_i += 3 * _r_d1 * j;
 // CHECK-NEXT:             *_d_j += 3 * i * _r_d1;
 // CHECK-NEXT:             _d_c += 0;
-// CHECK-NEXT:             --c;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -2122,8 +1892,6 @@ double fn30(double i, double j) {
 // CHECK-NEXT:     double _d_cond0;
 // CHECK-NEXT:     _d_cond0 = 0.;
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
-// CHECK-NEXT:     clad::tape<bool> _t1 = {};
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
@@ -2131,11 +1899,8 @@ double fn30(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 clad::push(_cond1, (c == 0));
-// CHECK-NEXT:                 if (clad::back(_cond1)) {
-// CHECK-NEXT:                     clad::push(_t1, _cond0);
-// CHECK-NEXT:                     clad::push(_t2, res);
+// CHECK-NEXT:                 if (clad::back(_cond1))
 // CHECK-NEXT:                     _cond0 = (res = i * j);
-// CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             if (!(clad::back(_cond1) && _cond0))
 // CHECK-NEXT:                 break;
@@ -2147,11 +1912,9 @@ double fn30(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 if (clad::back(_cond1)) {
-// CHECK-NEXT:                     _cond0 = clad::pop(_t1);
 // CHECK-NEXT:                     double _r_d0 = _d_cond0;
 // CHECK-NEXT:                     _d_cond0 = 0.;
 // CHECK-NEXT:                     _d_res += _r_d0;
-// CHECK-NEXT:                     res = clad::pop(_t2);
 // CHECK-NEXT:                     double _r_d1 = _d_res;
 // CHECK-NEXT:                     _d_res = 0.;
 // CHECK-NEXT:                     *_d_i += _r_d1 * j;
@@ -2162,7 +1925,6 @@ double fn30(double i, double j) {
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         --c;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -2175,20 +1937,10 @@ double fn31(double i, double j) {
 //CHECK:void fn31_grad(double i, double j, double *_d_i, double *_d_j) {
 //CHECK-NEXT:    int _d_c = 0;
 //CHECK-NEXT:    int c = 0;
-//CHECK-NEXT:    clad::tape<double> _t1 = {};
-//CHECK-NEXT:    clad::tape<double> _t2 = {};
 //CHECK-NEXT:    double _d_res = 0.;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:    for (c = 0; ; ++c) {
-//CHECK-NEXT:        {
-//CHECK-NEXT:            {
-//CHECK-NEXT:                clad::push(_t1, res);
-//CHECK-NEXT:                clad::push(_t2, res);
-//CHECK-NEXT:            }
-//CHECK-NEXT:            if (!((res = i * j) , (res = 2 * i * j) , c < 3))
-//CHECK-NEXT:                break;
-//CHECK-NEXT:        }
+//CHECK-NEXT:    for (c = 0; (res = i * j) , (res = 2 * i * j) , c < 3; ++c) {
 //CHECK-NEXT:        _t0++;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_res += 1;
@@ -2196,13 +1948,11 @@ double fn31(double i, double j) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            {
 //CHECK-NEXT:                _d_res += 0;
-//CHECK-NEXT:                res = clad::pop(_t1);
 //CHECK-NEXT:                double _r_d0 = _d_res;
 //CHECK-NEXT:                _d_res = 0.;
 //CHECK-NEXT:                *_d_i += 2 * _r_d0 * j;
 //CHECK-NEXT:                *_d_j += 2 * i * _r_d0;
 //CHECK-NEXT:                _d_res += 0;
-//CHECK-NEXT:                res = clad::pop(_t2);
 //CHECK-NEXT:                double _r_d1 = _d_res;
 //CHECK-NEXT:                _d_res = 0.;
 //CHECK-NEXT:                *_d_i += _r_d1 * j;
@@ -2211,7 +1961,6 @@ double fn31(double i, double j) {
 //CHECK-NEXT:            if (!_t0)
 //CHECK-NEXT:                break;
 //CHECK-NEXT:        }
-//CHECK-NEXT:        --c;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
@@ -2235,67 +1984,50 @@ double fn32(double i, double j) {
 //CHECK:void fn32_grad(double i, double j, double *_d_i, double *_d_j) {
 //CHECK-NEXT:    int _d_c = 0;
 //CHECK-NEXT:    int c = 0;
-//CHECK-NEXT:    clad::tape<double> _t1 = {};
-//CHECK-NEXT:    clad::tape<unsigned {{int|long|long long}}> _t2 = {};
-//CHECK-NEXT:    clad::tape<int> _t3 = {};
+//CHECK-NEXT:    clad::tape<unsigned {{int|long|long long}}> _t1 = {};
+//CHECK-NEXT:    clad::tape<int> _t2 = {};
 //CHECK-NEXT:    int _d_d = 0;
 //CHECK-NEXT:    int d = 0;
-//CHECK-NEXT:    clad::tape<double> _t4 = {};
 //CHECK-NEXT:    clad::tape<bool> _cond0 = {};
-//CHECK-NEXT:    clad::tape<double> _t5 = {};
-//CHECK-NEXT:    clad::tape<unsigned {{int|long|long long}}> _t6 = {};
+//CHECK-NEXT:    clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 //CHECK-NEXT:    clad::tape<bool> _cond1 = {};
-//CHECK-NEXT:    clad::tape<double> _t7 = {};
-//CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t8 = {};
+//CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t4 = {};
 //CHECK-NEXT:    double _d_res = 0.;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:    for (c = 0; ; ++c) {
-//CHECK-NEXT:        {
-//CHECK-NEXT:            clad::push(_t1, res);
-//CHECK-NEXT:            if (!(res += i * j))
-//CHECK-NEXT:                break;
-//CHECK-NEXT:        }
+//CHECK-NEXT:    for (c = 0; (res += i * j); ++c) {
 //CHECK-NEXT:        _t0++;
-//CHECK-NEXT:        clad::push(_t2, {{0U|0UL|0ULL}});
-//CHECK-NEXT:        for (clad::push(_t3, d) , d = 0; ; ++d) {
-//CHECK-NEXT:            {
-//CHECK-NEXT:                clad::push(_t4, res);
-//CHECK-NEXT:                if (!(res += i * j))
-//CHECK-NEXT:                    break;
-//CHECK-NEXT:            }
-//CHECK-NEXT:            clad::back(_t2)++;
+//CHECK-NEXT:        clad::push(_t1, {{0U|0UL|0ULL}});
+//CHECK-NEXT:        for (clad::push(_t2, d) , d = 0; (res += i * j); ++d) {
+//CHECK-NEXT:            clad::back(_t1)++;
 //CHECK-NEXT:            {
 //CHECK-NEXT:                clad::push(_cond0, d == 1);
 //CHECK-NEXT:                if (clad::back(_cond0)) {
-//CHECK-NEXT:                    clad::push(_t5, res);
 //CHECK-NEXT:                    res += i * j;
 //CHECK-NEXT:                    {
-//CHECK-NEXT:                        clad::push(_t6, {{1U|1UL|1ULL}});
+//CHECK-NEXT:                        clad::push(_t3, {{1U|1UL|1ULL}});
 //CHECK-NEXT:                        break;
 //CHECK-NEXT:                    }
 //CHECK-NEXT:                }
 //CHECK-NEXT:            }
-//CHECK-NEXT:            clad::push(_t6, {{2U|2UL|2ULL}});
+//CHECK-NEXT:            clad::push(_t3, {{2U|2UL|2ULL}});
 //CHECK-NEXT:        }
 //CHECK-NEXT:        {
 //CHECK-NEXT:            clad::push(_cond1, c == 1);
 //CHECK-NEXT:            if (clad::back(_cond1)) {
-//CHECK-NEXT:                clad::push(_t7, res);
 //CHECK-NEXT:                res += i * j;
 //CHECK-NEXT:                {
-//CHECK-NEXT:                    clad::push(_t8, {{1U|1UL|1ULL}});
+//CHECK-NEXT:                    clad::push(_t4, {{1U|1UL|1ULL}});
 //CHECK-NEXT:                    break;
 //CHECK-NEXT:                }
 //CHECK-NEXT:            }
 //CHECK-NEXT:        }
-//CHECK-NEXT:        clad::push(_t8, {{2U|2UL|2ULL}});
+//CHECK-NEXT:        clad::push(_t4, {{2U|2UL|2ULL}});
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_res += 1;
 //CHECK-NEXT:    for (unsigned {{int|long|long long}} _numRevIterations1 = _t0; ; _t0--) {
 //CHECK-NEXT:        {
-//CHECK-NEXT:            if (!_t0 || (_t0 != _numRevIterations1 || (clad::back(_t8) != 1))) {
-//CHECK-NEXT:                res = clad::pop(_t1);
+//CHECK-NEXT:            if (!_t0 || (clad::back(_t4) != 1)) {
 //CHECK-NEXT:                double _r_d0 = _d_res;
 //CHECK-NEXT:                *_d_i += _r_d0 * j;
 //CHECK-NEXT:                *_d_j += i * _r_d0;
@@ -2303,9 +2035,7 @@ double fn32(double i, double j) {
 //CHECK-NEXT:            if (!_t0)
 //CHECK-NEXT:                break;
 //CHECK-NEXT:        }
-//CHECK-NEXT:        if (_t0 != _numRevIterations1 || (clad::back(_t8) != 1))
-//CHECK-NEXT:         --c;
-//CHECK-NEXT:        switch (clad::pop(_t8)) {
+//CHECK-NEXT:        switch (clad::pop(_t4)) {
 //CHECK-NEXT:          case {{2U|2UL|2ULL}}:
 //CHECK-NEXT:            ;
 //CHECK-NEXT:            {
@@ -2313,7 +2043,6 @@ double fn32(double i, double j) {
 //CHECK-NEXT:                  case {{1U|1UL|1ULL}}:
 //CHECK-NEXT:                    ;
 //CHECK-NEXT:                    {
-//CHECK-NEXT:                        res = clad::pop(_t7);
 //CHECK-NEXT:                        double _r_d3 = _d_res;
 //CHECK-NEXT:                        *_d_i += _r_d3 * j;
 //CHECK-NEXT:                        *_d_j += i * _r_d3;
@@ -2322,20 +2051,17 @@ double fn32(double i, double j) {
 //CHECK-NEXT:                clad::pop(_cond1);
 //CHECK-NEXT:            }
 //CHECK-NEXT:            {
-//CHECK-NEXT:                for (unsigned {{int|long|long long}} _numRevIterations0 = clad::back(_t2); ; clad::back(_t2)--) {
+//CHECK-NEXT:                for (unsigned {{int|long|long long}} _numRevIterations0 = clad::back(_t1); ; clad::back(_t1)--) {
 //CHECK-NEXT:                    {
-//CHECK-NEXT:                        if (!clad::back(_t2) || (clad::back(_t2) != _numRevIterations0 || (clad::back(_t6) != 1))) {
-//CHECK-NEXT:                            res = clad::pop(_t4);
+//CHECK-NEXT:                        if (!clad::back(_t1) || (clad::back(_t3) != 1)) {
 //CHECK-NEXT:                            double _r_d1 = _d_res;
 //CHECK-NEXT:                            *_d_i += _r_d1 * j;
 //CHECK-NEXT:                            *_d_j += i * _r_d1;
 //CHECK-NEXT:                        }
-//CHECK-NEXT:                        if (!clad::back(_t2))
+//CHECK-NEXT:                        if (!clad::back(_t1))
 //CHECK-NEXT:                            break;
 //CHECK-NEXT:                    }
-//CHECK-NEXT:                    if (clad::back(_t2) != _numRevIterations0 || (clad::back(_t6) != 1))
-//CHECK-NEXT:                     --d;
-//CHECK-NEXT:                    switch (clad::pop(_t6)) {
+//CHECK-NEXT:                    switch (clad::pop(_t3)) {
 //CHECK-NEXT:                      case {{2U|2UL|2ULL}}:
 //CHECK-NEXT:                        ;
 //CHECK-NEXT:                        {
@@ -2343,7 +2069,6 @@ double fn32(double i, double j) {
 //CHECK-NEXT:                              case {{1U|1UL|1ULL}}:
 //CHECK-NEXT:                                ;
 //CHECK-NEXT:                                {
-//CHECK-NEXT:                                    res = clad::pop(_t5);
 //CHECK-NEXT:                                    double _r_d2 = _d_res;
 //CHECK-NEXT:                                    *_d_i += _r_d2 * j;
 //CHECK-NEXT:                                    *_d_j += i * _r_d2;
@@ -2355,9 +2080,9 @@ double fn32(double i, double j) {
 //CHECK-NEXT:                }
 //CHECK-NEXT:                {
 //CHECK-NEXT:                    _d_d = 0;
-//CHECK-NEXT:                    d = clad::pop(_t3);
+//CHECK-NEXT:                    d = clad::pop(_t2);
 //CHECK-NEXT:                }
-//CHECK-NEXT:                clad::pop(_t2);
+//CHECK-NEXT:                clad::pop(_t1);
 //CHECK-NEXT:            }
 //CHECK-NEXT:        }
 //CHECK-NEXT:    }
@@ -2379,45 +2104,32 @@ double fn33(double i, double j) {
 //CHECK: void fn33_grad(double i, double j, double *_d_i, double *_d_j) {
 //CHECK-NEXT:    int _d_c = 0;
 //CHECK-NEXT:    int c = 0;
-//CHECK-NEXT:    clad::tape<double> _t1 = {};
 //CHECK-NEXT:    bool _cond0;
 //CHECK-NEXT:    double _d_cond0;
 //CHECK-NEXT:    _d_cond0 = 0.;
-//CHECK-NEXT:    clad::tape<double> _t2 = {};
 //CHECK-NEXT:    clad::tape<double> _cond1 = {};
-//CHECK-NEXT:    clad::tape<bool> _t3 = {};
 //CHECK-NEXT:    clad::tape<bool> _cond2 = {};
-//CHECK-NEXT:    clad::tape<unsigned {{int|long|long long}}> _t4 = {};
+//CHECK-NEXT:    clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 //CHECK-NEXT:    bool _cond3;
 //CHECK-NEXT:    double _d_cond3;
 //CHECK-NEXT:    _d_cond3 = 0.;
 //CHECK-NEXT:    clad::tape<bool> _cond4 = {};
-//CHECK-NEXT:    clad::tape<bool> _t5 = {};
-//CHECK-NEXT:    clad::tape<double> _t6 = {};
 //CHECK-NEXT:    clad::tape<bool> _cond5 = {};
 //CHECK-NEXT:    double _d_res = 0.;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-//CHECK-NEXT:    for (c = 0; ; ++c) {
-//CHECK-NEXT:        {
-//CHECK-NEXT:            clad::push(_t1, res);
-//CHECK-NEXT:            if (!(res = i * j))
-//CHECK-NEXT:                break;
-//CHECK-NEXT:        }
+//CHECK-NEXT:    for (c = 0; (res = i * j); ++c) {
 //CHECK-NEXT:        _t0++;
 //CHECK-NEXT:        {
 //CHECK-NEXT:            {
-//CHECK-NEXT:                clad::push(_t2, res);
 //CHECK-NEXT:                clad::push(_cond1, (res += i * j));
-//CHECK-NEXT:                if (clad::back(_cond1)) {
-//CHECK-NEXT:                    clad::push(_t3, _cond0);
+//CHECK-NEXT:                if (clad::back(_cond1))
 //CHECK-NEXT:                    _cond0 = (c == 1);
-//CHECK-NEXT:                }
 //CHECK-NEXT:            }
 //CHECK-NEXT:            clad::push(_cond2, clad::back(_cond1) && _cond0);
 //CHECK-NEXT:            if (clad::back(_cond2)) {
 //CHECK-NEXT:                {
-//CHECK-NEXT:                    clad::push(_t4, {{1U|1UL|1ULL}});
+//CHECK-NEXT:                    clad::push(_t1, {{1U|1UL|1ULL}});
 //CHECK-NEXT:                    break;
 //CHECK-NEXT:                }
 //CHECK-NEXT:            }
@@ -2425,27 +2137,23 @@ double fn33(double i, double j) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            {
 //CHECK-NEXT:                clad::push(_cond4, (c == 0));
-//CHECK-NEXT:                if (clad::back(_cond4)) {
-//CHECK-NEXT:                    clad::push(_t5, _cond3);
-//CHECK-NEXT:                    clad::push(_t6, res);
+//CHECK-NEXT:                if (clad::back(_cond4))
 //CHECK-NEXT:                    _cond3 = (res += i * j);
-//CHECK-NEXT:                }
 //CHECK-NEXT:            }
 //CHECK-NEXT:            clad::push(_cond5, clad::back(_cond4) && _cond3);
 //CHECK-NEXT:            if (clad::back(_cond5)) {
 //CHECK-NEXT:                {
-//CHECK-NEXT:                    clad::push(_t4, {{2U|2UL|2ULL}});
+//CHECK-NEXT:                    clad::push(_t1, {{2U|2UL|2ULL}});
 //CHECK-NEXT:                    break;
 //CHECK-NEXT:                }
 //CHECK-NEXT:            }
 //CHECK-NEXT:        }
-//CHECK-NEXT:        clad::push(_t4, {{3U|3UL|3ULL}});
+//CHECK-NEXT:        clad::push(_t1, {{3U|3UL|3ULL}});
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_res += 1;
 //CHECK-NEXT:    for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; ; _t0--) {
 //CHECK-NEXT:        {
-//CHECK-NEXT:            if (!_t0 || (_t0 != _numRevIterations0 || (clad::back(_t4) != 1 && clad::back(_t4) != 2))) {
-//CHECK-NEXT:                res = clad::pop(_t1);
+//CHECK-NEXT:            if (!_t0 || (clad::back(_t1) != 1 && clad::back(_t1) != 2)) {
 //CHECK-NEXT:                double _r_d0 = _d_res;
 //CHECK-NEXT:                _d_res = 0.;
 //CHECK-NEXT:                *_d_i += _r_d0 * j;
@@ -2454,9 +2162,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:            if (!_t0)
 //CHECK-NEXT:                break;
 //CHECK-NEXT:        }
-//CHECK-NEXT:        if (_t0 != _numRevIterations0 || (clad::back(_t4) != 1 && clad::back(_t4) != 2))
-//CHECK-NEXT:         --c;
-//CHECK-NEXT:        switch (clad::pop(_t4)) {
+//CHECK-NEXT:        switch (clad::pop(_t1)) {
 //CHECK-NEXT:          case {{3U|3UL|3ULL}}:
 //CHECK-NEXT:            ;
 //CHECK-NEXT:            {
@@ -2468,11 +2174,9 @@ double fn33(double i, double j) {
 //CHECK-NEXT:                {
 //CHECK-NEXT:                    {
 //CHECK-NEXT:                        if (clad::back(_cond4)) {
-//CHECK-NEXT:                            _cond3 = clad::pop(_t5);
 //CHECK-NEXT:                            double _r_d3 = _d_cond3;
 //CHECK-NEXT:                            _d_cond3 = 0.;
 //CHECK-NEXT:                            _d_res += _r_d3;
-//CHECK-NEXT:                            res = clad::pop(_t6);
 //CHECK-NEXT:                            double _r_d4 = _d_res;
 //CHECK-NEXT:                            *_d_i += _r_d4 * j;
 //CHECK-NEXT:                            *_d_j += i * _r_d4;
@@ -2490,13 +2194,11 @@ double fn33(double i, double j) {
 //CHECK-NEXT:                {
 //CHECK-NEXT:                    {
 //CHECK-NEXT:                        if (clad::back(_cond1)) {
-//CHECK-NEXT:                            _cond0 = clad::pop(_t3);
 //CHECK-NEXT:                            double _r_d2 = _d_cond0;
 //CHECK-NEXT:                            _d_cond0 = 0.;
 //CHECK-NEXT:                        }
 //CHECK-NEXT:                        clad::pop(_cond1);
 //CHECK-NEXT:                        {
-//CHECK-NEXT:                            res = clad::pop(_t2);
 //CHECK-NEXT:                            double _r_d1 = _d_res;
 //CHECK-NEXT:                            *_d_i += _r_d1 * j;
 //CHECK-NEXT:                            *_d_j += i * _r_d1;
@@ -2518,9 +2220,8 @@ double fn34(double x, double y){
 }
 
 //CHECK: void fn34_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     clad::tape<double *> _t1 = {};
 //CHECK-NEXT:     clad::tape<double *> _t2 = {};
-//CHECK-NEXT:     clad::tape<double *> _t3 = {};
 //CHECK-NEXT:     double _d_r = 0.;
 //CHECK-NEXT:     double r = 0;
 //CHECK-NEXT:     double _d_a[3] = {0};
@@ -2537,11 +2238,10 @@ double fn34(double x, double y){
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _d_i = &*_d___begin1;
 //CHECK-NEXT:             i = &*__begin10;
-//CHECK-NEXT:             clad::push(_t2, i);
-//CHECK-NEXT:             clad::push(_t3, _d_i);
+//CHECK-NEXT:             clad::push(_t1, i);
+//CHECK-NEXT:             clad::push(_t2, _d_i);
 //CHECK-NEXT:         }
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, r);
 //CHECK-NEXT:         r += *i * *i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_r += 1;
@@ -2549,11 +2249,10 @@ double fn34(double x, double y){
 //CHECK-NEXT:         {
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 _d___begin1--;
-//CHECK-NEXT:                 i = clad::pop(_t2);
-//CHECK-NEXT:                 _d_i = clad::pop(_t3);
+//CHECK-NEXT:                 i = clad::pop(_t1);
+//CHECK-NEXT:                 _d_i = clad::pop(_t2);
 //CHECK-NEXT:             }
 //CHECK-NEXT:             {
-//CHECK-NEXT:                 r = clad::pop(_t1);
 //CHECK-NEXT:                 double _r_d0 = _d_r;
 //CHECK-NEXT:                 *_d_i += _r_d0 * *i;
 //CHECK-NEXT:                 *_d_i += *i * _r_d0;
@@ -2588,13 +2287,12 @@ double fn35(double x, double y){
 //CHECK: void fn35_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 //CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-//CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     clad::tape<bool> _cond1 = {};
-//CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
+//CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
+//CHECK-NEXT:     clad::tape<double *> _t3 = {};
 //CHECK-NEXT:     clad::tape<double *> _t4 = {};
 //CHECK-NEXT:     clad::tape<double *> _t5 = {};
 //CHECK-NEXT:     clad::tape<double *> _t6 = {};
-//CHECK-NEXT:     clad::tape<double *> _t7 = {};
 //CHECK-NEXT:     double _d_r = 0.;
 //CHECK-NEXT:     double r = 0;
 //CHECK-NEXT:     double _d_a[3] = {0};
@@ -2611,8 +2309,8 @@ double fn35(double x, double y){
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _d_i = &*_d___begin1;
 //CHECK-NEXT:             i = &*__begin10;
-//CHECK-NEXT:             clad::push(_t6, i);
-//CHECK-NEXT:             clad::push(_t7, _d_i);
+//CHECK-NEXT:             clad::push(_t5, i);
+//CHECK-NEXT:             clad::push(_t6, _d_i);
 //CHECK-NEXT:         }
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, {{0U|0UL|0ULL}});
@@ -2627,26 +2325,25 @@ double fn35(double x, double y){
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 _d_j = &*_d___begin2;
 //CHECK-NEXT:                 j = &*__begin20;
-//CHECK-NEXT:                 clad::push(_t4, j);
-//CHECK-NEXT:                 clad::push(_t5, _d_j);
+//CHECK-NEXT:                 clad::push(_t3, j);
+//CHECK-NEXT:                 clad::push(_t4, _d_j);
 //CHECK-NEXT:             }
 //CHECK-NEXT:             clad::back(_t1)++;
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 clad::push(_cond0, r <= x * x);
 //CHECK-NEXT:                 if (clad::back(_cond0)) {
-//CHECK-NEXT:                     clad::push(_t2, r);
 //CHECK-NEXT:                     r += *i * *j;
 //CHECK-NEXT:                 } else {
 //CHECK-NEXT:                     clad::push(_cond1, r > x * x);
 //CHECK-NEXT:                     if (clad::back(_cond1)) {
 //CHECK-NEXT:                         {
-//CHECK-NEXT:                             clad::push(_t3, {{1U|1UL|1ULL}});
+//CHECK-NEXT:                             clad::push(_t2, {{1U|1UL|1ULL}});
 //CHECK-NEXT:                             break;
 //CHECK-NEXT:                         }
 //CHECK-NEXT:                     }
 //CHECK-NEXT:                 }
 //CHECK-NEXT:             }
-//CHECK-NEXT:             clad::push(_t3, {{2U|2UL|2ULL}});
+//CHECK-NEXT:             clad::push(_t2, {{2U|2UL|2ULL}});
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_r += 1;
@@ -2654,24 +2351,23 @@ double fn35(double x, double y){
 //CHECK-NEXT:         {
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 _d___begin1--;
-//CHECK-NEXT:                 i = clad::pop(_t6);
-//CHECK-NEXT:                 _d_i = clad::pop(_t7);
+//CHECK-NEXT:                 i = clad::pop(_t5);
+//CHECK-NEXT:                 _d_i = clad::pop(_t6);
 //CHECK-NEXT:             }
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 for (; clad::back(_t1); clad::back(_t1)--) {
 //CHECK-NEXT:                     {
 //CHECK-NEXT:                         {
 //CHECK-NEXT:                             _d___begin2--;
-//CHECK-NEXT:                             j = clad::pop(_t4);
-//CHECK-NEXT:                             _d_j = clad::pop(_t5);
+//CHECK-NEXT:                             j = clad::pop(_t3);
+//CHECK-NEXT:                             _d_j = clad::pop(_t4);
 //CHECK-NEXT:                         }
-//CHECK-NEXT:                         switch (clad::pop(_t3)) {
+//CHECK-NEXT:                         switch (clad::pop(_t2)) {
 //CHECK-NEXT:                           case {{2U|2UL|2ULL}}:
 //CHECK-NEXT:                             ;
 //CHECK-NEXT:                             {
 //CHECK-NEXT:                                 if (clad::back(_cond0)) {
 //CHECK-NEXT:                                     {
-//CHECK-NEXT:                                         r = clad::pop(_t2);
 //CHECK-NEXT:                                         double _r_d0 = _d_r;
 //CHECK-NEXT:                                         *_d_i += _r_d0 * *j;
 //CHECK-NEXT:                                         *_d_j += *i * _r_d0;
@@ -2718,7 +2414,6 @@ double fn36(double x, double y){
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     clad::tape<double> _t4 = {};
-//CHECK-NEXT:     clad::tape<double> _t5 = {};
 //CHECK-NEXT:     double _d_a[3] = {0};
 //CHECK-NEXT:     double a[3] = {1, 2, 3};
 //CHECK-NEXT:     double _d_sum = 0.;
@@ -2735,8 +2430,8 @@ double fn36(double x, double y){
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _d_i = *_d___begin1;
 //CHECK-NEXT:             i = *__begin10;
-//CHECK-NEXT:             clad::push(_t4, i);
-//CHECK-NEXT:             clad::push(_t5, _d_i);
+//CHECK-NEXT:             clad::push(_t3, i);
+//CHECK-NEXT:             clad::push(_t4, _d_i);
 //CHECK-NEXT:         }
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         {
@@ -2747,9 +2442,8 @@ double fn36(double x, double y){
 //CHECK-NEXT:                     continue;
 //CHECK-NEXT:                 }
 //CHECK-NEXT:             } else if (1) {
-//CHECK-NEXT:                 clad::push(_t2, sum);
-//CHECK-NEXT:                 clad::push(_t3, sin(i));
-//CHECK-NEXT:                 sum += clad::back(_t3) * x;
+//CHECK-NEXT:                 clad::push(_t2, sin(i));
+//CHECK-NEXT:                 sum += clad::back(_t2) * x;
 //CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:         clad::push(_t1, {{2U|2UL|2ULL}});
@@ -2759,8 +2453,8 @@ double fn36(double x, double y){
 //CHECK-NEXT:         {
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 _d___begin1--;
-//CHECK-NEXT:                 i = clad::pop(_t4);
-//CHECK-NEXT:                 _d_i = clad::pop(_t5);
+//CHECK-NEXT:                 i = clad::pop(_t3);
+//CHECK-NEXT:                 _d_i = clad::pop(_t4);
 //CHECK-NEXT:             }
 //CHECK-NEXT:             switch (clad::pop(_t1)) {
 //CHECK-NEXT:               case {{2U|2UL|2ULL}}:
@@ -2771,13 +2465,12 @@ double fn36(double x, double y){
 //CHECK-NEXT:                         ;
 //CHECK-NEXT:                     } else if (1) {
 //CHECK-NEXT:                         {
-//CHECK-NEXT:                             sum = clad::pop(_t2);
 //CHECK-NEXT:                             double _r_d0 = _d_sum;
 //CHECK-NEXT:                             double _r0 = 0.;
 //CHECK-NEXT:                             _r0 += _r_d0 * x * clad::custom_derivatives::std::sin_pushforward(i, 1.).pushforward;
 //CHECK-NEXT:                             _d_i += _r0;
-//CHECK-NEXT:                             *_d_x += clad::back(_t3) * _r_d0;
-//CHECK-NEXT:                             clad::pop(_t3);
+//CHECK-NEXT:                             *_d_x += clad::back(_t2) * _r_d0;
+//CHECK-NEXT:                             clad::pop(_t2);
 //CHECK-NEXT:                         }
 //CHECK-NEXT:                     }
 //CHECK-NEXT:                     clad::pop(_cond0);
@@ -2799,7 +2492,6 @@ double fn37(double x, double y) {
 //CHECK: void fn37_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
-//CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     double _d_range[3] = {0};
 //CHECK-NEXT:     double range[3] = {x, 4., y};
 //CHECK-NEXT:     double _d_sum = 0.;
@@ -2816,11 +2508,10 @@ double fn37(double x, double y) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _d_elem = *_d___begin1;
 //CHECK-NEXT:             elem = *__begin10;
-//CHECK-NEXT:             clad::push(_t2, elem);
-//CHECK-NEXT:             clad::push(_t3, _d_elem);
+//CHECK-NEXT:             clad::push(_t1, elem);
+//CHECK-NEXT:             clad::push(_t2, _d_elem);
 //CHECK-NEXT:         }
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += elem;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
@@ -2828,10 +2519,9 @@ double fn37(double x, double y) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 _d___begin1--;
-//CHECK-NEXT:                 elem = clad::pop(_t2);
-//CHECK-NEXT:                 _d_elem = clad::pop(_t3);
+//CHECK-NEXT:                 elem = clad::pop(_t1);
+//CHECK-NEXT:                 _d_elem = clad::pop(_t2);
 //CHECK-NEXT:             }
-//CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
 //CHECK-NEXT:             _d_elem += _r_d0;
 //CHECK-NEXT:         }
@@ -2860,7 +2550,6 @@ double fn38(double x, double y) {
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
-//CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     {
@@ -2879,11 +2568,10 @@ double fn38(double x, double y) {
 //CHECK-NEXT:                 {
 //CHECK-NEXT:                     _d_elem = *_d___begin2;
 //CHECK-NEXT:                     elem = *__begin20;
-//CHECK-NEXT:                     clad::push(_t2, elem);
-//CHECK-NEXT:                     clad::push(_t3, _d_elem);
+//CHECK-NEXT:                     clad::push(_t1, elem);
+//CHECK-NEXT:                     clad::push(_t2, _d_elem);
 //CHECK-NEXT:                 }
 //CHECK-NEXT:                 _t0++;
-//CHECK-NEXT:                 clad::push(_t1, sum);
 //CHECK-NEXT:                 sum += elem;
 //CHECK-NEXT:             }
 //CHECK-NEXT:         }
@@ -2894,10 +2582,9 @@ double fn38(double x, double y) {
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 {
 //CHECK-NEXT:                     _d___begin2--;
-//CHECK-NEXT:                     elem = clad::pop(_t2);
-//CHECK-NEXT:                     _d_elem = clad::pop(_t3);
+//CHECK-NEXT:                     elem = clad::pop(_t1);
+//CHECK-NEXT:                     _d_elem = clad::pop(_t2);
 //CHECK-NEXT:                 }
-//CHECK-NEXT:                 sum = clad::pop(_t1);
 //CHECK-NEXT:                 double _r_d0 = _d_sum;
 //CHECK-NEXT:                 _d_elem += _r_d0;
 //CHECK-NEXT:             }
@@ -2922,7 +2609,6 @@ double fn39(double x) {
 //CHECK: void fn39_grad(double x, double *_d_x) {
 //CHECK-NEXT:     int *_d_i = nullptr;
 //CHECK-NEXT:     {{const int *\*|const_iterator }}i = nullptr;
-//CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_res = 0.;
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     clad::array<int> _d_range = {{3U|3UL}};
@@ -2931,7 +2617,6 @@ double fn39(double x) {
 //CHECK-NEXT:     _d_i = std::begin(_d_range);
 //CHECK-NEXT:     for (i = std::begin(range); i != std::end(range); _d_i++ , i++) {
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, res);
 //CHECK-NEXT:         res += x * *i;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_res += 1;
@@ -2941,7 +2626,6 @@ double fn39(double x) {
 //CHECK-NEXT:             _d_i--;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
-//CHECK-NEXT:             res = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_res;
 //CHECK-NEXT:             *_d_x += _r_d0 * *i;
 //CHECK-NEXT:             *_d_i += x * _r_d0;
@@ -2961,31 +2645,28 @@ double fn40(double u, double v) {
 // CHECK: void fn40_grad(double u, double v, double *_d_u, double *_d_v) {
 //CHECK-NEXT:    int _d_i = 0;
 //CHECK-NEXT:    int i = 0;
-//CHECK-NEXT:    clad::tape<double> _t1 = {};
-//CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t2 = {};
+//CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t1 = {};
 //CHECK-NEXT:    double _d_res = 0.;
 //CHECK-NEXT:    double res = 11 * u;
 //CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:    for (i = 0; i < 3; i++) {
 //CHECK-NEXT:        _t0++;
-//CHECK-NEXT:        clad::push(_t1, res);
 //CHECK-NEXT:        res += u * i;
 //CHECK-NEXT:        {
-//CHECK-NEXT:            clad::push(_t2, {{1U|1UL}});
+//CHECK-NEXT:            clad::push(_t1, {{1U|1UL}});
 //CHECK-NEXT:            continue;
 //CHECK-NEXT:        }
-//CHECK-NEXT:        clad::push(_t2, {{2U|2UL}});
+//CHECK-NEXT:        clad::push(_t1, {{2U|2UL}});
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_res += 1;
 //CHECK-NEXT:    for (; _t0; _t0--) {
 //CHECK-NEXT:        i--;
-//CHECK-NEXT:        switch (clad::pop(_t2)) {
+//CHECK-NEXT:        switch (clad::pop(_t1)) {
 //CHECK-NEXT:          case {{2U|2UL}}:
 //CHECK-NEXT:            ;
 //CHECK-NEXT:          case {{1U|1UL}}:
 //CHECK-NEXT:            ;
 //CHECK-NEXT:            {
-//CHECK-NEXT:                res = clad::pop(_t1);
 //CHECK-NEXT:                double _r_d0 = _d_res;
 //CHECK-NEXT:                *_d_u += _r_d0 * i;
 //CHECK-NEXT:                _d_i += u * _r_d0;
@@ -3008,30 +2689,28 @@ double fn41(double u, double v) {
 //CHECK: void fn41_grad(double u, double v, double *_d_u, double *_d_v) {
 //CHECK-NEXT:    int _d_i = 0;
 //CHECK-NEXT:    int i = 0;
-//CHECK-NEXT:    clad::tape<double> _t1 = {};
 //CHECK-NEXT:    clad::tape<bool> _cond0 = {};
-//CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t2 = {};
+//CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t1 = {};
 //CHECK-NEXT:    double _d_res = 0.;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:    for (i = 1; i < 3; i++) {
 //CHECK-NEXT:        _t0++;
-//CHECK-NEXT:        clad::push(_t1, res);
 //CHECK-NEXT:        res += i * u;
 //CHECK-NEXT:        {
 //CHECK-NEXT:            clad::push(_cond0, i == 1);
 //CHECK-NEXT:            if (clad::back(_cond0)) {
-//CHECK-NEXT:                clad::push(_t2, {{1U|1UL}});
+//CHECK-NEXT:                clad::push(_t1, {{1U|1UL}});
 //CHECK-NEXT:                break;
 //CHECK-NEXT:           }
 //CHECK-NEXT:        }
-//CHECK-NEXT:        clad::push(_t2, {{2U|2UL}});
+//CHECK-NEXT:        clad::push(_t1, {{2U|2UL}});
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_res += 1;
 //CHECK-NEXT:    for (unsigned {{int|long}} _numRevIterations0 = _t0; _t0; _t0--) {
-//CHECK-NEXT:        if (_t0 != _numRevIterations0 || (clad::back(_t2) != 1))
+//CHECK-NEXT:        if (_t0 != _numRevIterations0 || (clad::back(_t1) != 1))
 //CHECK-NEXT:            i--;
-//CHECK-NEXT:        switch (clad::pop(_t2)) {
+//CHECK-NEXT:        switch (clad::pop(_t1)) {
 //CHECK-NEXT:          case {{2U|2UL}}:
 //CHECK-NEXT:            ;
 //CHECK-NEXT:            {
@@ -3041,7 +2720,6 @@ double fn41(double u, double v) {
 //CHECK-NEXT:                clad::pop(_cond0);
 //CHECK-NEXT:            }
 //CHECK-NEXT:            {
-//CHECK-NEXT:                res = clad::pop(_t1);
 //CHECK-NEXT:                double _r_d0 = _d_res;
 //CHECK-NEXT:                _d_i += _r_d0 * u;
 //CHECK-NEXT:                *_d_u += i * _r_d0;

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -1,16 +1,16 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -fno-exceptions -I%S/../../include -oMemberFunctions.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -fno-exceptions -I%S/../../include -oMemberFunctions.out 2>&1 | %filecheck %s
 // RUN: ./MemberFunctions.out | %filecheck_exec %s
-// RUN: %cladclang %s -fno-exceptions -I%S/../../include -oMemberFunctions.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -fno-exceptions -I%S/../../include -oMemberFunctions.out
 // RUN: ./MemberFunctions.out | %filecheck_exec %s
 
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -std=c++14 %s -fno-exceptions -I%S/../../include -oMemberFunctions-cpp14.out 2>&1 | %filecheck %s
+// RUN: %cladclang -std=c++14 %s -fno-exceptions -I%S/../../include -oMemberFunctions-cpp14.out 2>&1 | %filecheck %s
 // RUN: ./MemberFunctions-cpp14.out | %filecheck_exec %s
-// RUN: %cladclang -std=c++14 %s -fno-exceptions -I%S/../../include -oMemberFunctions-cpp14.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -std=c++14 %s -fno-exceptions -I%S/../../include -oMemberFunctions-cpp14.out
 // RUN: ./MemberFunctions-cpp14.out | %filecheck_exec %s
 
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -std=c++17 %s -fno-exceptions -I%S/../../include -oMemberFunctions-cpp17.out 2>&1 | %filecheck %s
+// RUN: %cladclang -std=c++17 %s -fno-exceptions -I%S/../../include -oMemberFunctions-cpp17.out 2>&1 | %filecheck %s
 // RUN: ./MemberFunctions-cpp17.out | %filecheck_exec %s
-// RUN: %cladclang -std=c++17 %s -fno-exceptions -I%S/../../include -oMemberFunctions-cpp17.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -std=c++17 %s -fno-exceptions -I%S/../../include -oMemberFunctions-cpp17.out
 // RUN: ./MemberFunctions-cpp17.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
@@ -578,10 +578,8 @@ double fn6(double u, double v) {
 
 // CHECK: static void constructor_pullback(double x, double *y, SafeTestClass *_d_this, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     SafeTestClass *_this = (SafeTestClass *)malloc(sizeof(SafeTestClass));
-// CHECK-NEXT:     double _t0 = *y;
 // CHECK-NEXT:     *y = x;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *y = _t0;
 // CHECK-NEXT:         double _r_d0 = *_d_y;
 // CHECK-NEXT:         *_d_y = 0.;
 // CHECK-NEXT:         *_d_x += _r_d0;
@@ -730,17 +728,15 @@ double fn11(double u, double v) {
 // CHECK-NEXT:      A a;
 // CHECK-NEXT:      A _t0 = a;
 // CHECK-NEXT:      a.setData(u);
-// CHECK-NEXT:      double _t1 = res;
 // CHECK-NEXT:      res += a.data * v;
-// CHECK-NEXT:      A _t2 = a;
+// CHECK-NEXT:      A _t1 = a;
 // CHECK-NEXT:      a.increment();
 // CHECK-NEXT:      _d_res += 1;
 // CHECK-NEXT:      {
-// CHECK-NEXT:          a = _t2;
+// CHECK-NEXT:          a = _t1;
 // CHECK-NEXT:          a.increment_pullback(&_d_a);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
-// CHECK-NEXT:          res = _t1;
 // CHECK-NEXT:          double _r_d0 = _d_res;
 // CHECK-NEXT:          _d_a.data += _r_d0 * v;
 // CHECK-NEXT:          *_d_v += a.data * _r_d0;
@@ -761,10 +757,8 @@ struct B {
 };
 
 // CHECK:  void scale_pullback(const float *in, float *out, B *_d_this, float *_d_out) const {
-// CHECK-NEXT:      float _t0 = out[0];
 // CHECK-NEXT:      out[0] = in[0] * this->m;
 // CHECK-NEXT:      {
-// CHECK-NEXT:          out[0] = _t0;
 // CHECK-NEXT:          float _r_d0 = _d_out[0];
 // CHECK-NEXT:          _d_out[0] = 0.F;
 // CHECK-NEXT:          _d_this->m += in[0] * _r_d0;

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -std=c++14 -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oSTLCustomDerivatives.out 2>&1 | %filecheck %s
+// RUN: %cladclang -std=c++14 %s -I%S/../../include -oSTLCustomDerivatives.out 2>&1 | %filecheck %s
 // RUN: ./STLCustomDerivatives.out | %filecheck_exec %s
-// RUN: %cladclang -std=c++14 %s -I%S/../../include -oSTLCustomDerivativesWithTBR.out
+// RUN: %cladclang -std=c++14 -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oSTLCustomDerivativesWithTBR.out
 // RUN: ./STLCustomDerivativesWithTBR.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
@@ -392,22 +392,20 @@ int main() {
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     double &_d_ref = _t3.adjoint;
 // CHECK-NEXT:     double &ref = _t3.value;
-// CHECK-NEXT:     double _t4 = ref;
 // CHECK-NEXT:     ref += u;
-// CHECK-NEXT:     std::vector<double> _t5 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     std::vector<double> _t7 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t8 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     std::vector<double> _t4 = vec;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     std::vector<double> _t6 = vec;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t7 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t5;
+// CHECK-NEXT:         vec = _t4;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r1);
 // CHECK-NEXT:         {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t7;
+// CHECK-NEXT:         vec = _t6;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r2);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         ref = _t4;
 // CHECK-NEXT:         double _r_d0 = _d_ref;
 // CHECK-NEXT:         *_d_u += _r_d0;
 // CHECK-NEXT:     }
@@ -436,17 +434,12 @@ int main() {
 // CHECK-NEXT:     std::vector<double> _t5;
 // CHECK-NEXT:     double *_d_ref2 = nullptr;
 // CHECK-NEXT:     double *ref2 = {};
-// CHECK-NEXT:     double _t7;
-// CHECK-NEXT:     double _t8;
-// CHECK-NEXT:     double _t9;
-// CHECK-NEXT:     std::vector<double> _t19;
+// CHECK-NEXT:     std::vector<double> _t15;
 // CHECK-NEXT:     double *_d_ref00 = nullptr;
 // CHECK-NEXT:     double *ref00 = {};
-// CHECK-NEXT:     std::vector<double> _t21;
+// CHECK-NEXT:     std::vector<double> _t17;
 // CHECK-NEXT:     double *_d_ref10 = nullptr;
 // CHECK-NEXT:     double *ref10 = {};
-// CHECK-NEXT:     double _t23;
-// CHECK-NEXT:     double _t24;
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     std::vector<double> vec;
@@ -467,119 +460,105 @@ int main() {
 // CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:         _d_ref2 = &_t6.adjoint;
 // CHECK-NEXT:         ref2 = &_t6.value;
-// CHECK-NEXT:         _t7 = *ref0;
 // CHECK-NEXT:         *ref0 = u;
-// CHECK-NEXT:         _t8 = *ref1;
 // CHECK-NEXT:         *ref1 = v;
-// CHECK-NEXT:         _t9 = *ref2;
 // CHECK-NEXT:         *ref2 = u + v;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     double _t10 = res;
+// CHECK-NEXT:     std::vector<double> _t7 = vec;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t8 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     std::vector<double> _t9 = vec;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t10 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     std::vector<double> _t11 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t12 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t12 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     res = _t8.value + _t10.value + _t12.value;
 // CHECK-NEXT:     std::vector<double> _t13 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t14 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     std::vector<double> _t15 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t16 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     res = _t12.value + _t14.value + _t16.value;
-// CHECK-NEXT:     std::vector<double> _t17 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::clear_reverse_forw(&vec, &_d_vec);
-// CHECK-NEXT:     std::vector<double> _t18 = vec;
+// CHECK-NEXT:     std::vector<double> _t14 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _t19 = vec;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t20 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:         _d_ref00 = &_t20.adjoint;
-// CHECK-NEXT:         ref00 = &_t20.value;
-// CHECK-NEXT:         _t21 = vec;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t22 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:         _d_ref10 = &_t22.adjoint;
-// CHECK-NEXT:         ref10 = &_t22.value;
-// CHECK-NEXT:         _t23 = *ref00;
+// CHECK-NEXT:         _t15 = vec;
+// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t16 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:         _d_ref00 = &_t16.adjoint;
+// CHECK-NEXT:         ref00 = &_t16.value;
+// CHECK-NEXT:         _t17 = vec;
+// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t18 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:         _d_ref10 = &_t18.adjoint;
+// CHECK-NEXT:         ref10 = &_t18.value;
 // CHECK-NEXT:         *ref00 = u;
-// CHECK-NEXT:         _t24 = *ref10;
 // CHECK-NEXT:         *ref10 = u;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     double _t25 = res;
-// CHECK-NEXT:     std::vector<double> _t26 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t27 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     std::vector<double> _t28 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t29 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     res += _t27.value + _t29.value;
+// CHECK-NEXT:     std::vector<double> _t19 = vec;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t20 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     std::vector<double> _t21 = vec;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t22 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     res += _t20.value + _t22.value;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         res = _t25;
 // CHECK-NEXT:         double _r_d6 = _d_res;
 // CHECK-NEXT:         {{.*}} _r10 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t26;
+// CHECK-NEXT:         vec = _t19;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, _r_d6, &_d_vec, &_r10);
 // CHECK-NEXT:         {{.*}} _r11 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t28;
+// CHECK-NEXT:         vec = _t21;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, _r_d6, &_d_vec, &_r11);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             *ref10 = _t24;
 // CHECK-NEXT:             double _r_d5 = *_d_ref10;
 // CHECK-NEXT:             *_d_ref10 = 0.;
 // CHECK-NEXT:             *_d_u += _r_d5;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             *ref00 = _t23;
 // CHECK-NEXT:             double _r_d4 = *_d_ref00;
 // CHECK-NEXT:             *_d_ref00 = 0.;
 // CHECK-NEXT:             *_d_u += _r_d4;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r9 = {{0U|0UL}};
-// CHECK-NEXT:             vec = _t21;
+// CHECK-NEXT:             vec = _t17;
 // CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 0., &_d_vec, &_r9);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r8 = {{0U|0UL}};
-// CHECK-NEXT:             vec = _t19;
+// CHECK-NEXT:             vec = _t15;
 // CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 0., &_d_vec, &_r8);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r7 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t18;
+// CHECK-NEXT:         vec = _t14;
 // CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&vec, 2, &_d_vec, &_r7);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         vec = _t17;
+// CHECK-NEXT:         vec = _t13;
 // CHECK-NEXT:         clad::custom_derivatives::class_functions::clear_pullback(&vec, &_d_vec);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         res = _t10;
 // CHECK-NEXT:         double _r_d3 = _d_res;
 // CHECK-NEXT:         _d_res = 0.;
 // CHECK-NEXT:         {{.*}} _r4 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t11;
+// CHECK-NEXT:         vec = _t7;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, _r_d3, &_d_vec, &_r4);
 // CHECK-NEXT:         {{.*}} _r5 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t13;
+// CHECK-NEXT:         vec = _t9;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, _r_d3, &_d_vec, &_r5);
 // CHECK-NEXT:         {{.*}} _r6 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t15;
+// CHECK-NEXT:         vec = _t11;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 2, _r_d3, &_d_vec, &_r6);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             *ref2 = _t9;
 // CHECK-NEXT:             double _r_d2 = *_d_ref2;
 // CHECK-NEXT:             *_d_ref2 = 0.;
 // CHECK-NEXT:             *_d_u += _r_d2;
 // CHECK-NEXT:             *_d_v += _r_d2;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             *ref1 = _t8;
 // CHECK-NEXT:             double _r_d1 = *_d_ref1;
 // CHECK-NEXT:             *_d_ref1 = 0.;
 // CHECK-NEXT:             *_d_v += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             *ref0 = _t7;
 // CHECK-NEXT:             double _r_d0 = *_d_ref0;
 // CHECK-NEXT:             *_d_ref0 = 0.;
 // CHECK-NEXT:             *_d_u += _r_d0;
@@ -684,9 +663,8 @@ int main() {
 // CHECK:          void fn6_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:        size_t _d_i = {{0U|0UL}};
 // CHECK-NEXT:        size_t i = {{0U|0UL}};
-// CHECK-NEXT:        clad::tape<double> _t2 = {};
-// CHECK-NEXT:        clad::tape<std::array<double, 3> > _t3 = {};
-// CHECK-NEXT:        clad::tape<clad::ValueAndAdjoint<double &, double &> > _t4 = {};
+// CHECK-NEXT:        clad::tape<std::array<double, 3> > _t2 = {};
+// CHECK-NEXT:        clad::tape<clad::ValueAndAdjoint<double &, double &> > _t3 = {};
 // CHECK-NEXT:        std::array<double, 3> _d_a = {{.*}};
 // CHECK-NEXT:        std::array<double, 3> a;
 // CHECK-NEXT:        std::array<double, 3> _t0 = a;
@@ -696,23 +674,21 @@ int main() {
 // CHECK-NEXT:        unsigned {{long|int}} _t1 = {{0U|0UL}};
 // CHECK-NEXT:        for (i = 0; i < a.size(); ++i) {
 // CHECK-NEXT:            _t1++;
-// CHECK-NEXT:            clad::push(_t2, res);
-// CHECK-NEXT:            clad::push(_t3, a);
-// CHECK-NEXT:            clad::push(_t4, {{.*}}at_reverse_forw(&a, i, &_d_a, {{0U|0UL|0}}));
-// CHECK-NEXT:            res += clad::back(_t4).value;
+// CHECK-NEXT:            clad::push(_t2, a);
+// CHECK-NEXT:            clad::push(_t3, {{.*}}at_reverse_forw(&a, i, &_d_a, {{0U|0UL|0}}));
+// CHECK-NEXT:            res += clad::back(_t3).value;
 // CHECK-NEXT:        }
 // CHECK-NEXT:        _d_res += 1;
 // CHECK-NEXT:        for (; _t1; _t1--) {
 // CHECK-NEXT:            --i;
 // CHECK-NEXT:            {
-// CHECK-NEXT:                res = clad::pop(_t2);
 // CHECK-NEXT:                double _r_d0 = _d_res;
 // CHECK-NEXT:                size_t _r0 = {{0U|0UL}};
-// CHECK-NEXT:                a = clad::back(_t3);
+// CHECK-NEXT:                a = clad::back(_t2);
 // CHECK-NEXT:                {{.*}}at_pullback(&a, i, _r_d0, &_d_a, &_r0);
 // CHECK-NEXT:                _d_i += _r0;
+// CHECK-NEXT:                clad::pop(_t2);
 // CHECK-NEXT:                clad::pop(_t3);
-// CHECK-NEXT:                clad::pop(_t4);
 // CHECK-NEXT:            }
 // CHECK-NEXT:        }
 // CHECK-NEXT:        {
@@ -865,9 +841,8 @@ int main() {
 // CHECK-NEXT:          {{.*}}tape<{{.*}}vector<double> > _t1 = {};
 // CHECK-NEXT:          size_t _d_i0 = {{0U|0UL|0}};
 // CHECK-NEXT:          size_t i0 = {{0U|0UL|0}};
-// CHECK-NEXT:          {{.*}}tape<double> _t3 = {};
-// CHECK-NEXT:          {{.*}}tape<{{.*}}vector<double> > _t4 = {};
-// CHECK-NEXT:          clad::tape<clad::ValueAndAdjoint<double &, double &> > _t5 = {};
+// CHECK-NEXT:          {{.*}}tape<{{.*}}vector<double> > _t3 = {};
+// CHECK-NEXT:          clad::tape<clad::ValueAndAdjoint<double &, double &> > _t4 = {};
 // CHECK-NEXT:          {{.*}}vector<double> v;
 // CHECK-NEXT:          {{.*}}vector<double> _d_v = {};
 // CHECK-NEXT:          clad::zero_init(_d_v);
@@ -882,59 +857,56 @@ int main() {
 // CHECK-NEXT:          {{.*}} _t2 = {{0U|0UL|0}};
 // CHECK-NEXT:          for (i0 = 0; i0 < v.size(); ++i0) {
 // CHECK-NEXT:              _t2++;
-// CHECK-NEXT:              {{.*}}push(_t3, res);
-// CHECK-NEXT:              {{.*}}push(_t4, v);
-// CHECK-NEXT:              clad::push(_t5, {{.*}}at_reverse_forw(&v, i0, &_d_v, {{0U|0UL|0}}));
-// CHECK-NEXT:              res += clad::back(_t5).value;
+// CHECK-NEXT:              {{.*}}push(_t3, v);
+// CHECK-NEXT:              clad::push(_t4, {{.*}}at_reverse_forw(&v, i0, &_d_v, {{0U|0UL|0}}));
+// CHECK-NEXT:              res += clad::back(_t4).value;
 // CHECK-NEXT:          }
-// CHECK-NEXT:          {{.*}}vector<double> _t6 = v;
+// CHECK-NEXT:          {{.*}}vector<double> _t5 = v;
 // CHECK-NEXT:          v.assign(3, 0);
-// CHECK-NEXT:          {{.*}}vector<double> _t7 = v;
+// CHECK-NEXT:          {{.*}}vector<double> _t6 = v;
 // CHECK-NEXT:          v.assign(2, y);
-// CHECK-NEXT:          {{.*}}vector<double> _t8 = v;
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t9 = {{.*}}operator_subscript_reverse_forw(&v, 0, &_d_v, {{0U|0UL|0}});
-// CHECK-NEXT:          {{.*}}vector<double> _t10 = v;
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t11 = {{.*}}operator_subscript_reverse_forw(&v, 1, &_d_v, {{0U|0UL|0}});
-// CHECK-NEXT:          {{.*}}vector<double> _t12 = v;
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t13 = {{.*}}operator_subscript_reverse_forw(&v, 2, &_d_v, {{0U|0UL|0}});
+// CHECK-NEXT:          {{.*}}vector<double> _t7 = v;
+// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t8 = {{.*}}operator_subscript_reverse_forw(&v, 0, &_d_v, {{0U|0UL|0}});
+// CHECK-NEXT:          {{.*}}vector<double> _t9 = v;
+// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t10 = {{.*}}operator_subscript_reverse_forw(&v, 1, &_d_v, {{0U|0UL|0}});
+// CHECK-NEXT:          {{.*}}vector<double> _t11 = v;
+// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t12 = {{.*}}operator_subscript_reverse_forw(&v, 2, &_d_v, {{0U|0UL|0}});
 // CHECK-NEXT:          {
 // CHECK-NEXT:              _d_res += 1;
 // CHECK-NEXT:              {{.*}}size_type _r4 = {{0U|0UL|0}};
-// CHECK-NEXT:              v = _t8;
+// CHECK-NEXT:              v = _t7;
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&v, 0, 1, &_d_v, &_r4);
 // CHECK-NEXT:              {{.*}}size_type _r5 = {{0U|0UL|0}};
-// CHECK-NEXT:              v = _t10;
+// CHECK-NEXT:              v = _t9;
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&v, 1, 1, &_d_v, &_r5);
 // CHECK-NEXT:              {{.*}}size_type _r6 = {{0U|0UL|0}};
-// CHECK-NEXT:              v = _t12;
+// CHECK-NEXT:              v = _t11;
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&v, 2, 1, &_d_v, &_r6);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r3 = {{0U|0UL|0}};
-// CHECK-NEXT:              v = _t7;
+// CHECK-NEXT:              v = _t6;
 // CHECK-NEXT:              {{.*}}assign_pullback(&v, 2, y, &_d_v, &_r3, &*_d_y);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r1 = {{0U|0UL|0}};
 // CHECK-NEXT:              {{.*}}value_type _r2 = 0.;
-// CHECK-NEXT:              v = _t6;
+// CHECK-NEXT:              v = _t5;
 // CHECK-NEXT:              {{.*}}assign_pullback(&v, 3, 0, &_d_v, &_r1, &_r2);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          for (; _t2; _t2--) {
 // CHECK-NEXT:              --i0;
 // CHECK-NEXT:              {
-// CHECK-NEXT:                  res = {{.*}}pop(_t3);
 // CHECK-NEXT:                  double _r_d0 = _d_res;
 // CHECK-NEXT:                  size_t _r0 = {{0U|0UL|0}};
-// CHECK-NEXT:                  v = {{.*}}back(_t4);
+// CHECK-NEXT:                  v = {{.*}}back(_t3);
 // CHECK-NEXT:                  {{.*}}at_pullback(&v, i0, _r_d0, &_d_v, &_r0);
 // CHECK-NEXT:                  _d_i0 += _r0;
+// CHECK-NEXT:                  {{.*}}pop(_t3);
 // CHECK-NEXT:                  {{.*}}pop(_t4);
-// CHECK-NEXT:                  {{.*}}pop(_t5);
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
 // CHECK-NEXT:          for (; _t0; _t0--) {
-// CHECK-NEXT:              --i;
 // CHECK-NEXT:              {
 // CHECK-NEXT:                  v = {{.*}}back(_t1);
 // CHECK-NEXT:                  {{.*}}push_back_pullback(&v, x, &_d_v, &*_d_x);
@@ -956,17 +928,15 @@ int main() {
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&v, x, &_d_v, *_d_x);
 // CHECK-NEXT:          {{.*}}vector<double> _t3 = v;
 // CHECK-NEXT:          v.shrink_to_fit();
-// CHECK-NEXT:          double _t4 = res;
-// CHECK-NEXT:          double _t5 = v.capacity();
-// CHECK-NEXT:          double _t6 = v.size();
-// CHECK-NEXT:          res += y * _t5 + x * _t6;
+// CHECK-NEXT:          double _t4 = v.capacity();
+// CHECK-NEXT:          double _t5 = v.size();
+// CHECK-NEXT:          res += y * _t4 + x * _t5;
 // CHECK-NEXT:          _d_res += 1;
 // CHECK-NEXT:          {
-// CHECK-NEXT:              res = _t4;
 // CHECK-NEXT:              double _r_d0 = _d_res;
-// CHECK-NEXT:              *_d_y += _r_d0 * _t5;
+// CHECK-NEXT:              *_d_y += _r_d0 * _t4;
 // CHECK-NEXT:              {{.*}}capacity_pullback(&v, y * _r_d0, &_d_v);
-// CHECK-NEXT:              *_d_x += _r_d0 * _t6;
+// CHECK-NEXT:              *_d_x += _r_d0 * _t5;
 // CHECK-NEXT:              {{.*}}size_pullback(&v, x * _r_d0, &_d_v);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
@@ -1061,9 +1031,8 @@ int main() {
 // CHECK-NEXT:      clad::tape<double> _t5 = {};
 // CHECK-NEXT:      clad::tape<std::vector<double> > _t6 = {};
 // CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t7 = {};
-// CHECK-NEXT:      clad::tape<double> _t8 = {};
-// CHECK-NEXT:      clad::tape<std::vector<double> > _t9 = {};
-// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t10 = {};
+// CHECK-NEXT:      clad::tape<std::vector<double> > _t8 = {};
+// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t9 = {};
 // CHECK-NEXT:      {{.*}}allocator_type alloc;
 // CHECK-NEXT:      {{.*}}allocator_type _d_alloc = {};
 // CHECK-NEXT:      clad::zero_init(_d_alloc);
@@ -1080,23 +1049,20 @@ int main() {
 // CHECK-NEXT:          clad::push(_t6, ls);
 // CHECK-NEXT:          clad::push(_t7, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}}));
 // CHECK-NEXT:          clad::back(_t4).value += clad::back(_t7).value;
-// CHECK-NEXT:          clad::push(_t8, u);
-// CHECK-NEXT:          clad::push(_t9, ls);
-// CHECK-NEXT:          clad::push(_t10, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
-// CHECK-NEXT:          u = clad::back(_t10).value;
+// CHECK-NEXT:          clad::push(_t8, ls);
+// CHECK-NEXT:          clad::push(_t9, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
+// CHECK-NEXT:          u = clad::back(_t9).value;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      *_d_u += 1;
 // CHECK-NEXT:      for (; _t0; _t0--) {
-// CHECK-NEXT:          --i;
 // CHECK-NEXT:          {
-// CHECK-NEXT:              u = clad::pop(_t8);
 // CHECK-NEXT:              double _r_d1 = *_d_u;
 // CHECK-NEXT:              *_d_u = 0.;
 // CHECK-NEXT:              {{.*}}size_type _r3 = 0{{.*}};
-// CHECK-NEXT:              ls = clad::back(_t9);
+// CHECK-NEXT:              ls = clad::back(_t8);
 // CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, _r_d1, &_d_ls, &_r3);
+// CHECK-NEXT:              clad::pop(_t8);
 // CHECK-NEXT:              clad::pop(_t9);
-// CHECK-NEXT:              clad::pop(_t10);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              clad::back(_t4).value = clad::pop(_t5);
@@ -1212,9 +1178,8 @@ int main() {
 // CHECK-NEXT:     clad::tape<double> _t5 = {};
 // CHECK-NEXT:     clad::tape<std::vector<double> > _t6 = {};
 // CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t7 = {};
-// CHECK-NEXT:     clad::tape<double> _t8 = {};
-// CHECK-NEXT:     clad::tape<std::vector<double> > _t9 = {};
-// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t10 = {};
+// CHECK-NEXT:     clad::tape<std::vector<double> > _t8 = {};
+// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t9 = {};
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:         _t0++;
@@ -1228,23 +1193,20 @@ int main() {
 // CHECK-NEXT:         clad::push(_t6, ls);
 // CHECK-NEXT:         clad::push(_t7, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}}));
 // CHECK-NEXT:         clad::back(_t4).value += clad::back(_t7).value;
-// CHECK-NEXT:         clad::push(_t8, u);
-// CHECK-NEXT:         clad::push(_t9, ls);
-// CHECK-NEXT:         clad::push(_t10, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
-// CHECK-NEXT:         u = clad::back(_t10).value;
+// CHECK-NEXT:         clad::push(_t8, ls);
+// CHECK-NEXT:         clad::push(_t9, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
+// CHECK-NEXT:         u = clad::back(_t9).value;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_u += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             u = clad::pop(_t8);
 // CHECK-NEXT:             double _r_d1 = *_d_u;
 // CHECK-NEXT:             *_d_u = 0.;
 // CHECK-NEXT:             {{.*}}size_type _r{{3|4}} = {{0U|0UL|0ULL}};
-// CHECK-NEXT:             ls = clad::back(_t9);
+// CHECK-NEXT:             ls = clad::back(_t8);
 // CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, _r_d1, &_d_ls, &_r{{3|4}});
+// CHECK-NEXT:             clad::pop(_t8);
 // CHECK-NEXT:             clad::pop(_t9);
-// CHECK-NEXT:             clad::pop(_t10);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::back(_t4).value = clad::pop(_t5);
@@ -1276,9 +1238,8 @@ int main() {
 // CHECK-NEXT:     {{.*}} _d_it{};
 // CHECK-NEXT:     clad::tape<{{.*}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<double> _t4 = {};
-// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<{{.*}}> _t5 = {};
-// CHECK-NEXT:     clad::tape<int> _t6 = {};
+// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<{{.*}}> _t4 = {};
+// CHECK-NEXT:     clad::tape<int> _t5 = {};
 // CHECK-NEXT:     double _d_sum = 0.;
 // CHECK-NEXT:     double sum = 0;
 // CHECK-NEXT:     int _d_u = 0;
@@ -1289,10 +1250,9 @@ int main() {
 // CHECK-NEXT:     _d_it = _t1.adjoint;
 // CHECK-NEXT:     for (; operator!=(it, end); clad::push(_t2, it) , {{.*}}class_functions::operator_plus_plus_reverse_forw(&it, 0, &_d_it, 0)) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t3, sum);
-// CHECK-NEXT:         clad::push(_t5, {{.*}}class_functions::operator_star_reverse_forw(&it, &_d_it));
-// CHECK-NEXT:         sum += u * clad::push(_t4, clad::back(_t5).value);
-// CHECK-NEXT:         clad::push(_t6, u);
+// CHECK-NEXT:         clad::push(_t4, {{.*}}class_functions::operator_star_reverse_forw(&it, &_d_it));
+// CHECK-NEXT:         sum += u * clad::push(_t3, clad::back(_t4).value);
+// CHECK-NEXT:         clad::push(_t5, u);
 // CHECK-NEXT:         u += 2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_sum += 1;
@@ -1305,15 +1265,14 @@ int main() {
 // CHECK-NEXT:                 clad::pop(_t2);
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 u = clad::pop(_t6);
+// CHECK-NEXT:                 u = clad::pop(_t5);
 // CHECK-NEXT:                 int _r_d1 = _d_u;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 sum = clad::pop(_t3);
 // CHECK-NEXT:                 double _r_d0 = _d_sum;
-// CHECK-NEXT:                 _d_u += _r_d0 * clad::pop(_t4);
+// CHECK-NEXT:                 _d_u += _r_d0 * clad::pop(_t3);
 // CHECK-NEXT:                 {{.*}}::class_functions::operator_star_pullback(&it, u * _r_d0, &_d_it);
-// CHECK-NEXT:                 clad::pop(_t5);
+// CHECK-NEXT:                 clad::pop(_t4);
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {{.*}}constructor_pullback(start, &_d_it, &(*_d_start));
@@ -1323,31 +1282,26 @@ int main() {
 // CHECK: void fn18_grad_2(const Session *session, const float *tensor_x, float *tensor_theory_params, float *_d_tensor_theory_params) {
 // CHECK-NEXT:     int _d_id = 0;
 // CHECK-NEXT:     int id = 0;
-// CHECK-NEXT:     clad::tape<float> _t1 = {};
 // CHECK-NEXT:     int _d_id0 = 0;
 // CHECK-NEXT:     int id0 = 0;
-// CHECK-NEXT:     clad::tape<float> _t3 = {};
 // CHECK-NEXT:     Session _d_sess = {{.*}}, nullptr};
 // CHECK-NEXT:     const Session &sess = session[0];
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (id = 0; id < nVals; id++) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, sess.arr[id]);
 // CHECK-NEXT:         sess.arr[id] = tensor_x[id] * tensor_theory_params[0];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     float _d_out = 0.F;
 // CHECK-NEXT:     float out = 0.;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t2 = {{0U|0UL|0ULL}};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t1 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (id0 = 0; id0 < nVals; id0++) {
-// CHECK-NEXT:         _t2++;
-// CHECK-NEXT:         clad::push(_t3, out);
+// CHECK-NEXT:         _t1++;
 // CHECK-NEXT:         out += std::exp(-sess.arr[id0]);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
-// CHECK-NEXT:     for (; _t2; _t2--) {
+// CHECK-NEXT:     for (; _t1; _t1--) {
 // CHECK-NEXT:         id0--;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             out = clad::pop(_t3);
 // CHECK-NEXT:             float _r_d1 = _d_out;
 // CHECK-NEXT:             float _r0 = 0.F;
 // CHECK-NEXT:             _r0 += _r_d1 * clad::custom_derivatives::std::exp_pushforward(-sess.arr[id0], 1.F).pushforward;
@@ -1357,7 +1311,6 @@ int main() {
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         id--;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             sess.arr[id] = clad::pop(_t1);
 // CHECK-NEXT:             float _r_d0 = _d_sess.arr[id];
 // CHECK-NEXT:             _d_sess.arr[id] = 0.F;
 // CHECK-NEXT:             _d_tensor_theory_params[0] += tensor_x[id] * _r_d0;
@@ -1368,7 +1321,6 @@ int main() {
 // CHECK: void fn19_grad_1(const Session *session, float *tensor_theory_params, float *_d_tensor_theory_params) {
 // CHECK-NEXT:     int _d_id = 0;
 // CHECK-NEXT:     int id = 0;
-// CHECK-NEXT:     clad::tape<float> _t1 = {};
 // CHECK-NEXT:     Session _d_sess = {{[{][{][}]}}, nullptr};
 // CHECK-NEXT:     const Session &sess = session[0];
 // CHECK-NEXT:     float *&_d_arr = _d_sess.arr;
@@ -1378,14 +1330,12 @@ int main() {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (id = 0; id < nVals; id++) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, out);
 // CHECK-NEXT:         out += arr[id] * tensor_theory_params[0];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         id--;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             out = clad::pop(_t1);
 // CHECK-NEXT:             float _r_d0 = _d_out;
 // CHECK-NEXT:             _d_arr[id] += _r_d0 * tensor_theory_params[0];
 // CHECK-NEXT:             _d_tensor_theory_params[0] += arr[id] * _r_d0;

--- a/test/Gradient/TemplateFunctors.C
+++ b/test/Gradient/TemplateFunctors.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oTemplateFunctors.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oTemplateFunctors.out 2>&1 | %filecheck %s
 // RUN: ./TemplateFunctors.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oTemplateFunctors.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oTemplateFunctors.out
 // RUN: ./TemplateFunctors.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Gradient/TestAgainstDiff.C
+++ b/test/Gradient/TestAgainstDiff.C
@@ -1,7 +1,7 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oTestAgainstDiff.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oTestAgainstDiff.out 2>&1 | %filecheck %s
 // RUN: ./TestAgainstDiff.out | %filecheck_exec %s
 
-// RUN: %cladclang %s -I%S/../../include -oTestAgainstDiff.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oTestAgainstDiff.out
 // RUN: ./TestAgainstDiff.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -1,6 +1,6 @@
-// RUN: %cladnumdiffclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s  -I%S/../../include -oTestTypeConversion.out 2>&1 | %filecheck %s
+// RUN: %cladnumdiffclang %s  -I%S/../../include -oTestTypeConversion.out 2>&1 | %filecheck %s
 // RUN: ./TestTypeConversion.out | %filecheck_exec %s
-// RUN: %cladnumdiffclang %s  -I%S/../../include -oTestTypeConversion.out
+// RUN: %cladnumdiffclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s  -I%S/../../include -oTestTypeConversion.out
 // RUN: ./TestTypeConversion.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
@@ -28,7 +28,6 @@ void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_z += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             z = clad::pop(_t1);
 // CHECK-NEXT:             float _r_d0 = *_d_z;

--- a/test/Gradient/UnaryMinus.C
+++ b/test/Gradient/UnaryMinus.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oUnaryMinus.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oUnaryMinus.out 2>&1 | %filecheck %s
 // RUN: ./UnaryMinus.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oUnaryMinus.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oUnaryMinus.out
 // RUN: ./UnaryMinus.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oUserDefinedTypes.out -Xclang -verify 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oUserDefinedTypes.out -Xclang -verify 2>&1 | %filecheck %s
 // RUN: ./UserDefinedTypes.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oUserDefinedTypes.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oUserDefinedTypes.out
 // RUN: ./UserDefinedTypes.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
@@ -57,19 +57,16 @@ double sum(Tangent& t) {
 // CHECK: void sum_pullback(Tangent &t, double _d_y, Tangent *_d_t) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += t.data[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
-// CHECK-NEXT:         res = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_res;
 // CHECK-NEXT:         (*_d_t).data[i] += _r_d0;
 // CHECK-NEXT:     }
@@ -85,19 +82,16 @@ double sum(double *data) {
 // CHECK: void sum_pullback(double *data, double _d_y, double *_d_data) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += data[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
-// CHECK-NEXT:         res = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_res;
 // CHECK-NEXT:         _d_data[i] += _r_d0;
 // CHECK-NEXT:     }
@@ -113,11 +107,9 @@ double fn2(Tangent t, double i) {
 // CHECK-NEXT:     Tangent _t0 = t;
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = sum(t);
-// CHECK-NEXT:     double _t1 = res;
 // CHECK-NEXT:     res += sum(t.data) + i + 2 * t.data[0];
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         res = _t1;
 // CHECK-NEXT:         double _r_d0 = _d_res;
 // CHECK-NEXT:         sum_pullback(t.data, _r_d0, (*_d_t).data);
 // CHECK-NEXT:         *_d_i += _r_d0;
@@ -140,24 +132,20 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     Tangent t;
 // CHECK-NEXT:     Tangent _d_t = {};
 // CHECK-NEXT:     clad::zero_init(_d_t);
-// CHECK-NEXT:     double _t0 = t.data[0];
 // CHECK-NEXT:     t.data[0] = 2 * i;
-// CHECK-NEXT:     double _t1 = t.data[1];
 // CHECK-NEXT:     t.data[1] = 5 * i + 3 * j;
-// CHECK-NEXT:     Tangent _t2 = t;
+// CHECK-NEXT:     Tangent _t0 = t;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         t = _t2;
+// CHECK-NEXT:         t = _t0;
 // CHECK-NEXT:         sum_pullback(t, 1, &_d_t);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         t.data[1] = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_t.data[1];
 // CHECK-NEXT:         _d_t.data[1] = 0.;
 // CHECK-NEXT:         *_d_i += 5 * _r_d1;
 // CHECK-NEXT:         *_d_j += 3 * _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         t.data[0] = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_t.data[0];
 // CHECK-NEXT:         _d_t.data[0] = 0.;
 // CHECK-NEXT:         *_d_i += 2 * _r_d0;
@@ -258,12 +246,10 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT:     double _t1 = c.imag();
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = c.real() + 3 * _t1 + 6 * i;
-// CHECK-NEXT:     double _t2 = res;
-// CHECK-NEXT:     double _t3 = c.real();
-// CHECK-NEXT:     res += 4 * _t3;
+// CHECK-NEXT:     double _t2 = c.real();
+// CHECK-NEXT:     res += 4 * _t2;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         res = _t2;
 // CHECK-NEXT:         double _r_d0 = _d_res;
 // CHECK-NEXT:         c.real_pullback(4 * _r_d0, &(*_d_c));
 // CHECK-NEXT:     }
@@ -356,29 +342,23 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, res);
-// CHECK-NEXT:         res += c.real() + 2 * clad::push(_t2, c.imag());
+// CHECK-NEXT:         res += c.real() + 2 * clad::push(_t1, c.imag());
 // CHECK-NEXT:     }
-// CHECK-NEXT:     double _t3 = res;
-// CHECK-NEXT:     Tangent _t4 = t;
+// CHECK-NEXT:     Tangent _t2 = t;
 // CHECK-NEXT:     res += sum(t);
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         res = _t3;
 // CHECK-NEXT:         double _r_d1 = _d_res;
-// CHECK-NEXT:         t = _t4;
+// CHECK-NEXT:         t = _t2;
 // CHECK-NEXT:         sum_pullback(t, _r_d1, &(*_d_t));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             res = clad::pop(_t1);
 // CHECK-NEXT:             double _r_d0 = _d_res;
 // CHECK-NEXT:             c.real_pullback(_r_d0, &(*_d_c));
 // CHECK-NEXT:             c.imag_pullback(2 * _r_d0, &(*_d_c));
@@ -400,13 +380,9 @@ double fn10(double x, double y) {
 // CHECK: void fn10_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     A<double>::PtrType _d_ptr = &*_d_x;
 // CHECK-NEXT:     A<double>::PtrType ptr = &x;
-// CHECK-NEXT:     double _t0 = ptr[0];
 // CHECK-NEXT:     ptr[0] += 6;
 // CHECK-NEXT:     *_d_ptr += 1;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         ptr[0] = _t0;
-// CHECK-NEXT:         double _r_d0 = _d_ptr[0];
-// CHECK-NEXT:     }
+// CHECK-NEXT:     double _r_d0 = _d_ptr[0];
 // CHECK-NEXT: }
 
 double operator+(const double& x, const Tangent& t) {
@@ -430,11 +406,9 @@ double fn11(double x, double y) {
 // CHECK-NEXT:     Tangent t;
 // CHECK-NEXT:     Tangent _d_t = {};
 // CHECK-NEXT:     clad::zero_init(_d_t);
-// CHECK-NEXT:     double _t0 = t.data[0];
 // CHECK-NEXT:     t.data[0] = -y;
 // CHECK-NEXT:     operator_plus_pullback(x, t, 1, &*_d_x, &_d_t);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         t.data[0] = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_t.data[0];
 // CHECK-NEXT:         _d_t.data[0] = 0.;
 // CHECK-NEXT:         *_d_y += -_r_d0;
@@ -510,33 +484,27 @@ void fn13(double *x, double *y, int size)
 
 // CHECK: void fn13_grad_0_1(double *x, double *y, int size, double *_d_x, double *_d_y) {
 // CHECK-NEXT: int _d_size = 0;
-// CHECK-NEXT: Fint _t1;
-// CHECK-NEXT: clad::tape<Fint> _t2 = {};
-// CHECK-NEXT: clad::tape<double> _t3 = {};
+// CHECK-NEXT: clad::tape<Fint> _t1 = {};
 // CHECK-NEXT: Findex _d_p = {};
 // CHECK-NEXT: Findex p;
 // CHECK-NEXT: unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
-// CHECK-NEXT: _t1 = p.j;
-// CHECK-NEXT: for (p.j = 0; p.j < size; clad::push(_t2, p.j) , (p.j += 1)) {
+// CHECK-NEXT: for (p.j = 0; p.j < size; clad::push(_t1, p.j) , (p.j += 1)) {
 // CHECK-NEXT:     _t0++;
-// CHECK-NEXT:     clad::push(_t3, y[p.j]);
 // CHECK-NEXT:     y[p.j] = 2. * x[p.j];
 // CHECK-NEXT: }
 // CHECK-NEXT: {
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             p.j = clad::pop(_t2);
+// CHECK-NEXT:             p.j = clad::pop(_t1);
 // CHECK-NEXT:             Fint _r_d1 = _d_p.j;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             y[p.j] = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d2 = _d_y[p.j];
 // CHECK-NEXT:             _d_y[p.j] = 0.;
 // CHECK-NEXT:             _d_x[p.j] += 2. * _r_d2;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         p.j = _t1;
 // CHECK-NEXT:         Fint _r_d0 = _d_p.j;
 // CHECK-NEXT:        _d_p.j = 0;
 // CHECK-NEXT:     }
@@ -870,15 +838,12 @@ double fn23(double u, double v) {
 // CHECK:  void fn23_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:      B _d_b = {0.};
 // CHECK-NEXT:      B b;
-// CHECK-NEXT:      double _t0 = b.data;
 // CHECK-NEXT:      b.data = v;
 // CHECK-NEXT:      double _d_res = 0.;
 // CHECK-NEXT:      double res = 0;
-// CHECK-NEXT:      double _t1 = res;
 // CHECK-NEXT:      res = add(b, u);
 // CHECK-NEXT:      _d_res += 1;
 // CHECK-NEXT:      {
-// CHECK-NEXT:          res = _t1;
 // CHECK-NEXT:          double _r_d1 = _d_res;
 // CHECK-NEXT:          _d_res = 0.;
 // CHECK-NEXT:          B _r0 = {0.};
@@ -888,7 +853,6 @@ double fn23(double u, double v) {
 // CHECK-NEXT:          *_d_u += _r1;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
-// CHECK-NEXT:          b.data = _t0;
 // CHECK-NEXT:          double _r_d0 = _d_b.data;
 // CHECK-NEXT:          _d_b.data = 0.;
 // CHECK-NEXT:          *_d_v += _r_d0;

--- a/test/Gradient/constexprTest.C
+++ b/test/Gradient/constexprTest.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oconstexprTest.out | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oconstexprTest.out | %filecheck %s
 // RUN: ./constexprTest.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oconstexprTest.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oconstexprTest.out
 // RUN: ./constexprTest.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Hessian/ArrayErrors.C
+++ b/test/Hessian/ArrayErrors.C
@@ -1,4 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1
+// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1
 
 #include "clad/Differentiator/Differentiator.h"
 

--- a/test/Hessian/Arrays.C
+++ b/test/Hessian/Arrays.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oArrays.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oArrays.out 2>&1 | %filecheck %s
 // RUN: ./Arrays.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oArrays.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oArrays.out
 // RUN: ./Arrays.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oHessianBuiltinDerivatives.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oHessianBuiltinDerivatives.out 2>&1 | %filecheck %s
 // RUN: ./HessianBuiltinDerivatives.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oHessianBuiltinDerivatives.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oHessianBuiltinDerivatives.out
 // RUN: ./HessianBuiltinDerivatives.out | %filecheck_exec %s
 
 

--- a/test/Hessian/Functors.C
+++ b/test/Hessian/Functors.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oFunctors.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oFunctors.out 2>&1 | %filecheck %s
 // RUN: ./Functors.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oFunctors.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oFunctors.out
 // RUN: ./Functors.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oHessians.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oHessians.out 2>&1 | %filecheck %s
 // RUN: ./Hessians.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oHessians.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oHessians.out
 // RUN: ./Hessians.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oNestedFunctionCalls.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oNestedFunctionCalls.out 2>&1 | %filecheck %s
 // RUN: ./NestedFunctionCalls.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oNestedFunctionCalls.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oNestedFunctionCalls.out
 // RUN: ./NestedFunctionCalls.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oPointers.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oPointers.out 2>&1 | %filecheck %s
 // RUN: ./Pointers.out | %filecheck_exec %s
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-tbr %s -I%S/../../include -oPointers.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oPointers.out
 // RUN: ./Pointers.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Hessian/TemplateFunctors.C
+++ b/test/Hessian/TemplateFunctors.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oTemplateFunctors.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oTemplateFunctors.out 2>&1 | %filecheck %s
 // RUN: ./TemplateFunctors.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oTemplateFunctors.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oTemplateFunctors.out
 // RUN: ./TemplateFunctors.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Hessian/constexprTest.C
+++ b/test/Hessian/constexprTest.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -std=c++14 -oconstexprTest.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -std=c++14 -oconstexprTest.out 2>&1 | %filecheck %s
 // RUN: ./constexprTest.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -std=c++14 -oconstexprTest.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -std=c++14 -oconstexprTest.out
 // RUN: ./constexprTest.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Hessian/testhessUtility.C
+++ b/test/Hessian/testhessUtility.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -otesthessUtility.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -otesthessUtility.out 2>&1 | %filecheck %s
 // RUN: ./testhessUtility.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -otesthessUtility.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -otesthessUtility.out
 // RUN: ./testhessUtility.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Jacobian/FunctionCalls.C
+++ b/test/Jacobian/FunctionCalls.C
@@ -1,6 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oFunctionCalls.out 2>&1 | %filecheck %s
-// RUN: ./FunctionCalls.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oFunctionCalls.out
+// RUN: %cladclang %s -I%S/../../include -oFunctionCalls.out 2>&1 | %filecheck %s
 // RUN: ./FunctionCalls.out | %filecheck_exec %s
 
 #include <cmath>

--- a/test/Jacobian/Functors.C
+++ b/test/Jacobian/Functors.C
@@ -1,6 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oFunctors.out 2>&1 | %filecheck %s
-// RUN: ./Functors.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oFunctors.out
+// RUN: %cladclang %s -I%S/../../include -oFunctors.out 2>&1 | %filecheck %s
 // RUN: ./Functors.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -1,6 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oJacobian.out 2>&1 | %filecheck %s
-// RUN: ./Jacobian.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oJacobian.out
+// RUN: %cladclang %s -I%S/../../include -oJacobian.out 2>&1 | %filecheck %s
 // RUN: ./Jacobian.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Jacobian/Pointers.C
+++ b/test/Jacobian/Pointers.C
@@ -1,6 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oPointers._clad_out_out 2>&1 | %filecheck %s
-// RUN: ./Pointers._clad_out_out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oPointers._clad_out_out
+// RUN: %cladclang %s -I%S/../../include -oPointers._clad_out_out 2>&1 | %filecheck %s
 // RUN: ./Pointers._clad_out_out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Jacobian/TemplateFunctors.C
+++ b/test/Jacobian/TemplateFunctors.C
@@ -1,6 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oTemplateFunctors.out 2>&1 | %filecheck %s
-// RUN: ./TemplateFunctors.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oTemplateFunctors.out
+// RUN: %cladclang %s -I%S/../../include -oTemplateFunctors.out 2>&1 | %filecheck %s
 // RUN: ./TemplateFunctors.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Jacobian/constexprTest.C
+++ b/test/Jacobian/constexprTest.C
@@ -1,6 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -std=c++14 -oconstexprTest.out 2>&1 | %filecheck %s
-// RUN: ./constexprTest.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -std=c++14 -oconstexprTest.out
+// RUN: %cladclang %s -I%S/../../include -std=c++14 -oconstexprTest.out 2>&1 | %filecheck %s
 // RUN: ./constexprTest.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/Jacobian/testUtility.C
+++ b/test/Jacobian/testUtility.C
@@ -1,6 +1,4 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -otestUtility.out 2>&1 | %filecheck %s
-// RUN: ./testUtility.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -otestUtility.out
+// RUN: %cladclang %s -I%S/../../include -otestUtility.out 2>&1 | %filecheck %s
 // RUN: ./testUtility.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/ROOT/Hessian.C
+++ b/test/ROOT/Hessian.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oHessian.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oHessian.out 2>&1 | %filecheck %s
 // RUN: ./Hessian.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oHessian.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oHessian.out
 // RUN: ./Hessian.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/ROOT/Interface.C
+++ b/test/ROOT/Interface.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oInterface.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oInterface.out 2>&1 | %filecheck %s
 // RUN: ./Interface.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oInterface.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oInterface.out
 // RUN: ./Interface.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oTFormula.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -oTFormula.out 2>&1 | %filecheck %s
 // RUN: ./TFormula.out | %filecheck_exec %s
-// RUN: %cladclang %s -I%S/../../include -oTFormula.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oTFormula.out
 // RUN: ./TFormula.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"

--- a/test/ValidCodeGen/ValidCodeGen.C
+++ b/test/ValidCodeGen/ValidCodeGen.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -std=c++14 -Xclang -verify -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oValidCodeGen.out 2>&1 | %filecheck %s
+// RUN: %cladclang -std=c++14 -Xclang -verify %s -I%S/../../include -oValidCodeGen.out 2>&1 | %filecheck %s
 // RUN: ./ValidCodeGen.out | %filecheck_exec %s
-// RUN: %cladclang -std=c++14 -Xclang -verify %s -I%S/../../include -oValidCodeGenWithTBR.out
+// RUN: %cladclang -std=c++14 -Xclang -verify -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oValidCodeGenWithTBR.out
 // RUN: ./ValidCodeGenWithTBR.out | %filecheck_exec %s
 // CHECK-NOT: {{.*error|warning|note:.*}}
 


### PR DESCRIPTION
Currently, TBR analysis is turned on by default, but it's still manually disabled in the tests. This makes it harder to see what our real produced code looks like. Turning it on in tests will also allow us to see which improvements need to be made on the analysis side.