### PR TITLE
Add initial support for nested calls in TBR

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -73,6 +73,8 @@ public:
   clang::Expr* CallContext = nullptr;
   /// Args provided to the call to clad::gradient/differentiate.
   const clang::Expr* Args = nullptr;
+
+  bool RequestTBR = false;
   /// Indexes of global GPU args of function as a subset of Args.
   std::vector<size_t> CUDAGlobalArgsIndexes;
   /// Requested differentiation mode, forward or reverse.
@@ -233,12 +235,14 @@ public:
     ///
     const DiffRequest* m_TopMostReq = nullptr;
 
-    const DiffRequest* m_ParentReq = nullptr;
+    DiffRequest* m_ParentReq = nullptr;
     clang::Sema& m_Sema;
 
     const RequestOptions& m_Options;
 
     llvm::DenseSet<const clang::FunctionDecl*> m_Traversed;
+
+    bool m_TBROnly = false;
 
     bool m_IsTraversingTopLevelDecl = true;
 
@@ -249,6 +253,7 @@ public:
     bool VisitCallExpr(clang::CallExpr* E);
     bool VisitDeclRefExpr(clang::DeclRefExpr* DRE);
     bool VisitCXXConstructExpr(clang::CXXConstructExpr* e);
+    bool shouldVisitImplicitCode() const { return true; }
     bool TraverseFunctionDeclOnce(const clang::FunctionDecl* FD) {
       llvm::SaveAndRestore<bool> Saved(m_IsTraversingTopLevelDecl, false);
       if (m_Traversed.count(FD))

--- a/lib/Differentiator/AnalysisBase.h
+++ b/lib/Differentiator/AnalysisBase.h
@@ -172,6 +172,7 @@ protected:
   std::set<unsigned> m_CFGQueue;
   /// ID of the CFG block being visited.
   unsigned m_CurBlockID{};
+  const clang::FunctionDecl* m_Function = nullptr;
 
   static clang::CFGBlock* getCFGBlockByID(clang::AnalysisDeclContext* ADC,
                                           unsigned ID);
@@ -231,7 +232,7 @@ protected:
   /// Returns the VarsData of the CFG block being visited.
 
   VarsData& getCurBlockVarsData() { return *m_BlockData[m_CurBlockID]; }
-
+  /// Determines the set of all variables that the expression E depends on.
   static void getDependencySet(const clang::Expr* E,
                                std::set<const clang::VarDecl*>& vars);
 };

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1829,7 +1829,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       QualType paramTy = PVD->getType();
       bool passByRef = paramTy->isLValueReferenceType() &&
                        !paramTy.getNonReferenceType().isConstQualified();
-      if (passByRef) {
+      if (passByRef && m_DiffReq.shouldBeRecorded(arg)) {
         StmtDiff pushPop = StoreAndRestore(argDiff.getExpr());
         addToCurrentBlock(pushPop.getStmt());
         PreCallStmts.push_back(pushPop.getStmt_dx());
@@ -1875,7 +1875,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         if (baseTy->isPointerType())
           baseTy = baseTy->getPointeeType();
         CXXRecordDecl* baseRD = baseTy->getAsCXXRecordDecl();
-        if (isPassedByRef && !MD->isConst() && utils::isCopyable(baseRD)) {
+        if (isPassedByRef && !MD->isConst() && utils::isCopyable(baseRD) &&
+            m_DiffReq.shouldBeRecorded(baseOriginalE)) {
           Expr* baseDiffStore =
               GlobalStoreAndRef(baseDiff.getExpr(), "_t", /*force=*/true);
           Expr* assign = BuildOp(BO_Assign, baseDiff.getExpr(), baseDiffStore);

--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -15,6 +15,7 @@
 #include "clad/Differentiator/DiffPlanner.h"
 
 #include <map>
+#include <set>
 #include <unordered_map>
 
 namespace clad {
@@ -38,6 +39,8 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer>,
   /// Tells if the variable at a given location is required to store. Basically,
   /// is the result of analysis.
   std::set<clang::SourceLocation>& m_TBRLocs;
+  std::map<const clang::FunctionDecl*, std::set<const clang::Decl*>>*
+      m_ModifiedParams;
 
   /// Stores modes in a stack (used to retrieve the old mode after entering
   /// a new one).
@@ -75,8 +78,11 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer>,
 public:
   /// Constructor
   TBRAnalyzer(clang::AnalysisDeclContext* AnalysisDC,
-              std::set<clang::SourceLocation>& Locs)
-      : AnalysisBase(AnalysisDC), m_TBRLocs(Locs) {
+              std::set<clang::SourceLocation>& Locs,
+              std::map<const clang::FunctionDecl*,
+                       std::set<const clang::Decl*>>* ModifiedParams = nullptr)
+      : AnalysisBase(AnalysisDC), m_TBRLocs(Locs),
+        m_ModifiedParams(ModifiedParams) {
     m_ModeStack.push_back(0);
   }
 

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -403,20 +403,16 @@ double fn8(double u, double v) {
 
 // CHECK: static constexpr void constructor_pullback(double &__{{u1|x}}, double &__{{u2|y}}, std::pair<double, double> *_d_this, double *_d___{{u1|x}}, double *_d___{{u2|y}}) {{.*}}{
 // CHECK-NEXT:      std::pair<double, double> *_this = (std::pair<double, double> *)malloc(sizeof(std::pair<double, double>));
-// CHECK:           double _t0 = __{{u1|x}};
-// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t1 = clad::custom_derivatives::std::forward_reverse_forw(__{{u1|x}}, *_d___{{u1|x}}); 
-// CHECK-NEXT:      _this->first = _t1.value;
-// CHECK-NEXT:      double _t2 = __{{u2|y}};
-// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t3 = clad::custom_derivatives::std::forward_reverse_forw(__{{u2|y}}, *_d___{{u2|y}});
-// CHECK-NEXT:      _this->second = _t3.value;
+// CHECK:           clad::ValueAndAdjoint<double &, double &> _t0 = clad::custom_derivatives::std::forward_reverse_forw(__{{u1|x}}, *_d___{{u1|x}}); 
+// CHECK-NEXT:      _this->first = _t0.value;
+// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t1 = clad::custom_derivatives::std::forward_reverse_forw(__{{u2|y}}, *_d___{{u2|y}});
+// CHECK-NEXT:      _this->second = _t1.value;
 // CHECK:           {
 // CHECK-NEXT:          clad::custom_derivatives::std::forward_pullback(__{{u2|y}}, _d_this->second, &*_d___{{u2|y}});
-// CHECK-NEXT:          __{{u2|y}} = _t2;
 // CHECK-NEXT:          _d_this->second = 0.;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          clad::custom_derivatives::std::forward_pullback(__{{u1|x}}, _d_this->first, &*_d___{{u1|x}});
-// CHECK-NEXT:          __{{u1|x}} = _t0;
 // CHECK-NEXT:          _d_this->first = 0.;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      free(_this);

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -324,18 +324,15 @@ double fn7(double i, double j) {
 // CHECK-NEXT: }
 
 // CHECK: void fn7_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _t0 = i;
-// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = identity_reverse_forw(i, *_d_i);
-// CHECK-NEXT:     double &_d_k = _t1.adjoint;
-// CHECK-NEXT:     double &k = _t1.value;
-// CHECK-NEXT:     double _t2 = j;
-// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t3 = identity_reverse_forw(j, *_d_j);
-// CHECK-NEXT:     double &_d_l = _t3.adjoint;
-// CHECK-NEXT:     double &l = _t3.value;
-// CHECK-NEXT:     double _t4 = i;
-// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t5 = {{.*}}custom_derivatives::custom_identity_reverse_forw(i, *_d_i);
-// CHECK-NEXT:     double &_d_temp = _t5.adjoint;
-// CHECK-NEXT:     double &temp = _t5.value;
+// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t0 = identity_reverse_forw(i, *_d_i);
+// CHECK-NEXT:     double &_d_k = _t0.adjoint;
+// CHECK-NEXT:     double &k = _t0.value;
+// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = identity_reverse_forw(j, *_d_j);
+// CHECK-NEXT:     double &_d_l = _t1.adjoint;
+// CHECK-NEXT:     double &l = _t1.value;
+// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}custom_derivatives::custom_identity_reverse_forw(i, *_d_i);
+// CHECK-NEXT:     double &_d_temp = _t2.adjoint;
+// CHECK-NEXT:     double &temp = _t2.value;
 // CHECK-NEXT:     k += 7 * j;
 // CHECK-NEXT:     l += 9 * i;
 // CHECK-NEXT:     {
@@ -351,18 +348,9 @@ double fn7(double i, double j) {
 // CHECK-NEXT:         double _r_d0 = _d_k;
 // CHECK-NEXT:         *_d_j += 7 * _r_d0;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         i = _t4;
-// CHECK-NEXT:         custom_identity_pullback(i, 0., &*_d_i);
-// CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         j = _t2;
-// CHECK-NEXT:         identity_pullback(j, 0., &*_d_j);
-// CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         i = _t0;
-// CHECK-NEXT:         identity_pullback(i, 0., &*_d_i);
-// CHECK-NEXT:     }
+// CHECK-NEXT:     custom_identity_pullback(i, 0., &*_d_i);
+// CHECK-NEXT:     identity_pullback(j, 0., &*_d_j);
+// CHECK-NEXT:     identity_pullback(i, 0., &*_d_i);
 // CHECK-NEXT: }
 
 double check_and_return(double x, char c, const char* s) {

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -229,11 +229,9 @@ int main() {
   // CHECK-NEXT:     Experiment E(3, 5);
   // CHECK-NEXT:     Experiment _d_E(E);
   // CHECK-NEXT:     clad::zero_init(_d_E);
-  // CHECK-NEXT:     Experiment _t0 = E;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0.;
   // CHECK-NEXT:         double _r1 = 0.;
-  // CHECK-NEXT:         E = _t0;
   // CHECK-NEXT:         E.operator_call_pullback(i, j, 1, &_d_E, &_r0, &_r1);
   // CHECK-NEXT:         *_d_i += _r0;
   // CHECK-NEXT:         *_d_j += _r1;
@@ -247,11 +245,9 @@ int main() {
   printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 27.00 21.00
 
   // CHECK: void FunctorAsArg_grad(Experiment fn, double i, double j, Experiment *_d_fn, double *_d_i, double *_d_j) {
-  // CHECK-NEXT:     Experiment _t0 = fn;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0.;
   // CHECK-NEXT:         double _r1 = 0.;
-  // CHECK-NEXT:         fn = _t0;
   // CHECK-NEXT:         fn.operator_call_pullback(i, j, 1, &(*_d_fn), &_r0, &_r1);
   // CHECK-NEXT:         *_d_i += _r0;
   // CHECK-NEXT:         *_d_j += _r1;
@@ -266,11 +262,9 @@ int main() {
   printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 27.00 21.00
 
   // CHECK: void FunctorAsArg_pullback(Experiment fn, double i, double j, double _d_y, Experiment *_d_fn, double *_d_i, double *_d_j) {
-  // CHECK-NEXT:     Experiment _t0 = fn;
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0.;
   // CHECK-NEXT:         double _r1 = 0.;
-  // CHECK-NEXT:         fn = _t0;
   // CHECK-NEXT:         fn.operator_call_pullback(i, j, _d_y, &(*_d_fn), &_r0, &_r1);
   // CHECK-NEXT:         *_d_i += _r0;
   // CHECK-NEXT:         *_d_j += _r1;

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -921,11 +921,9 @@ int main() {
 // CHECK-NEXT:     SimpleFunctions sf(x, y);
 // CHECK-NEXT:     SimpleFunctions _d_sf(sf);
 // CHECK-NEXT:     clad::zero_init(_d_sf);
-// CHECK-NEXT:     SimpleFunctions _t0 = sf;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r2 = 0.;
 // CHECK-NEXT:         double _r3 = 0.;
-// CHECK-NEXT:         sf = _t0;
 // CHECK-NEXT:         sf.mem_fn_pullback(i, j, 1, &_d_sf, &_r2, &_r3);
 // CHECK-NEXT:         *_d_i += _r2;
 // CHECK-NEXT:         *_d_j += _r3;

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -358,16 +358,12 @@ int main() {
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
 // CHECK-NEXT:     std::vector<double> _t1 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, v, &_d_vec, *_d_v);
-// CHECK-NEXT:     std::vector<double> _t2 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     std::vector<double> _t4 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
 // CHECK-NEXT:         size_type _r0 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t2;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r0);
 // CHECK-NEXT:         size_type _r1 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t4;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r1);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -388,21 +384,16 @@ int main() {
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
 // CHECK-NEXT:     std::vector<double> _t1 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, v, &_d_vec, *_d_v);
-// CHECK-NEXT:     std::vector<double> _t2 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     double &_d_ref = _t3.adjoint;
-// CHECK-NEXT:     double &ref = _t3.value;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     double &_d_ref = _t2.adjoint;
+// CHECK-NEXT:     double &ref = _t2.value;
 // CHECK-NEXT:     ref += u;
-// CHECK-NEXT:     std::vector<double> _t4 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     std::vector<double> _t6 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t7 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t4;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r1);
 // CHECK-NEXT:         {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t6;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r2);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -411,7 +402,6 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t2;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 0., &_d_vec, &_r0);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -425,19 +415,14 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void fn3_grad(double u, double v, double *_d_u, double *_d_v) {
-// CHECK-NEXT:     std::vector<double> _t1;
 // CHECK-NEXT:     double *_d_ref0 = nullptr;
 // CHECK-NEXT:     double *ref0 = {};
-// CHECK-NEXT:     std::vector<double> _t3;
 // CHECK-NEXT:     double *_d_ref1 = nullptr;
 // CHECK-NEXT:     double *ref1 = {};
-// CHECK-NEXT:     std::vector<double> _t5;
 // CHECK-NEXT:     double *_d_ref2 = nullptr;
 // CHECK-NEXT:     double *ref2 = {};
-// CHECK-NEXT:     std::vector<double> _t15;
 // CHECK-NEXT:     double *_d_ref00 = nullptr;
 // CHECK-NEXT:     double *ref00 = {};
-// CHECK-NEXT:     std::vector<double> _t17;
 // CHECK-NEXT:     double *_d_ref10 = nullptr;
 // CHECK-NEXT:     double *ref10 = {};
 // CHECK-NEXT:     double _d_res = 0.;
@@ -448,58 +433,46 @@ int main() {
 // CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 3, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _t1 = vec;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:         _d_ref0 = &_t2.adjoint;
-// CHECK-NEXT:         ref0 = &_t2.value;
-// CHECK-NEXT:         _t3 = vec;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:         _d_ref1 = &_t4.adjoint;
-// CHECK-NEXT:         ref1 = &_t4.value;
-// CHECK-NEXT:         _t5 = vec;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:         _d_ref2 = &_t6.adjoint;
-// CHECK-NEXT:         ref2 = &_t6.value;
+// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:         _d_ref0 = &_t1.adjoint;
+// CHECK-NEXT:         ref0 = &_t1.value;
+// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:         _d_ref1 = &_t2.adjoint;
+// CHECK-NEXT:         ref1 = &_t2.value;
+// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:         _d_ref2 = &_t3.adjoint;
+// CHECK-NEXT:         ref2 = &_t3.value;
 // CHECK-NEXT:         *ref0 = u;
 // CHECK-NEXT:         *ref1 = v;
 // CHECK-NEXT:         *ref2 = u + v;
 // CHECK-NEXT:     }
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     res = _t4.value + _t5.value + _t6.value;
 // CHECK-NEXT:     std::vector<double> _t7 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t8 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     std::vector<double> _t9 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t10 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     std::vector<double> _t11 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t12 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     res = _t8.value + _t10.value + _t12.value;
-// CHECK-NEXT:     std::vector<double> _t13 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::clear_reverse_forw(&vec, &_d_vec);
-// CHECK-NEXT:     std::vector<double> _t14 = vec;
+// CHECK-NEXT:     std::vector<double> _t8 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _t15 = vec;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t16 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:         _d_ref00 = &_t16.adjoint;
-// CHECK-NEXT:         ref00 = &_t16.value;
-// CHECK-NEXT:         _t17 = vec;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t18 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:         _d_ref10 = &_t18.adjoint;
-// CHECK-NEXT:         ref10 = &_t18.value;
+// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t9 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:         _d_ref00 = &_t9.adjoint;
+// CHECK-NEXT:         ref00 = &_t9.value;
+// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t10 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:         _d_ref10 = &_t10.adjoint;
+// CHECK-NEXT:         ref10 = &_t10.value;
 // CHECK-NEXT:         *ref00 = u;
 // CHECK-NEXT:         *ref10 = u;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     std::vector<double> _t19 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t20 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     std::vector<double> _t21 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t22 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     res += _t20.value + _t22.value;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t11 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t12 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     res += _t11.value + _t12.value;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d6 = _d_res;
 // CHECK-NEXT:         {{.*}} _r10 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t19;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, _r_d6, &_d_vec, &_r10);
 // CHECK-NEXT:         {{.*}} _r11 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t21;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, _r_d6, &_d_vec, &_r11);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -515,35 +488,30 @@ int main() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r9 = {{0U|0UL}};
-// CHECK-NEXT:             vec = _t17;
 // CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 0., &_d_vec, &_r9);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r8 = {{0U|0UL}};
-// CHECK-NEXT:             vec = _t15;
 // CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 0., &_d_vec, &_r8);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r7 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t14;
+// CHECK-NEXT:         vec = _t8;
 // CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&vec, 2, &_d_vec, &_r7);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         vec = _t13;
+// CHECK-NEXT:         vec = _t7;
 // CHECK-NEXT:         clad::custom_derivatives::class_functions::clear_pullback(&vec, &_d_vec);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d3 = _d_res;
 // CHECK-NEXT:         _d_res = 0.;
 // CHECK-NEXT:         {{.*}} _r4 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t7;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, _r_d3, &_d_vec, &_r4);
 // CHECK-NEXT:         {{.*}} _r5 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t9;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, _r_d3, &_d_vec, &_r5);
 // CHECK-NEXT:         {{.*}} _r6 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t11;
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 2, _r_d3, &_d_vec, &_r6);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -565,17 +533,14 @@ int main() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r3 = {{0U|0UL}};
-// CHECK-NEXT:             vec = _t5;
 // CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 2, 0., &_d_vec, &_r3);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:             vec = _t3;
 // CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 0., &_d_vec, &_r2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:             vec = _t1;
 // CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 0., &_d_vec, &_r1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
@@ -597,21 +562,15 @@ int main() {
 // CHECK-NEXT:     std::vector<double> vec(count, u, allocator);
 // CHECK-NEXT:     std::vector<double> _d_vec(vec);
 // CHECK-NEXT:     clad::zero_init(_d_vec);
-// CHECK-NEXT:     std::vector<double> _t0 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     std::vector<double> _t2 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     std::vector<double> _t4 = vec;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t0 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t0;
 // CHECK-NEXT:         {{.*}}operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r1);
 // CHECK-NEXT:         {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t2;
 // CHECK-NEXT:         {{.*}}operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r2);
 // CHECK-NEXT:         {{.*}} _r3 = {{0U|0UL}};
-// CHECK-NEXT:         vec = _t4;
 // CHECK-NEXT:         {{.*}}operator_subscript_pullback(&vec, 2, 1, &_d_vec, &_r3);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -630,24 +589,20 @@ int main() {
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, x, &_d_a, *_d_x);
 // CHECK-NEXT:          std::vector<double> _t1 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, x, &_d_a, *_d_x);
-// CHECK-NEXT:          std::vector<double> _t2 = a;
-// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t3 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
-// CHECK-NEXT:          double _t4 = _t3.value;
-// CHECK-NEXT:          _t3.value = x * x;
-// CHECK-NEXT:          std::vector<double> _t5 = a;
+// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
+// CHECK-NEXT:          double _t3 = _t2.value;
+// CHECK-NEXT:          _t2.value = x * x;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:              a = _t5;
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 1, 1, &_d_a, &_r1);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              _t3.value = _t4;
-// CHECK-NEXT:              double _r_d0 = _t3.adjoint;
-// CHECK-NEXT:              _t3.adjoint = 0.;
+// CHECK-NEXT:              _t2.value = _t3;
+// CHECK-NEXT:              double _r_d0 = _t2.adjoint;
+// CHECK-NEXT:              _t2.adjoint = 0.;
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
 // CHECK-NEXT:              {{.*}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:              a = _t2;
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 1, 0., &_d_a, &_r0);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
@@ -663,8 +618,7 @@ int main() {
 // CHECK:          void fn6_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:        size_t _d_i = {{0U|0UL}};
 // CHECK-NEXT:        size_t i = {{0U|0UL}};
-// CHECK-NEXT:        clad::tape<std::array<double, 3> > _t2 = {};
-// CHECK-NEXT:        clad::tape<clad::ValueAndAdjoint<double &, double &> > _t3 = {};
+// CHECK-NEXT:        clad::tape<clad::ValueAndAdjoint<double &, double &> > _t2 = {};
 // CHECK-NEXT:        std::array<double, 3> _d_a = {{.*}};
 // CHECK-NEXT:        std::array<double, 3> a;
 // CHECK-NEXT:        std::array<double, 3> _t0 = a;
@@ -674,9 +628,8 @@ int main() {
 // CHECK-NEXT:        unsigned {{long|int}} _t1 = {{0U|0UL}};
 // CHECK-NEXT:        for (i = 0; i < a.size(); ++i) {
 // CHECK-NEXT:            _t1++;
-// CHECK-NEXT:            clad::push(_t2, a);
-// CHECK-NEXT:            clad::push(_t3, {{.*}}at_reverse_forw(&a, i, &_d_a, {{0U|0UL|0}}));
-// CHECK-NEXT:            res += clad::back(_t3).value;
+// CHECK-NEXT:            clad::push(_t2, {{.*}}at_reverse_forw(&a, i, &_d_a, {{0U|0UL|0}}));
+// CHECK-NEXT:            res += clad::back(_t2).value;
 // CHECK-NEXT:        }
 // CHECK-NEXT:        _d_res += 1;
 // CHECK-NEXT:        for (; _t1; _t1--) {
@@ -684,11 +637,9 @@ int main() {
 // CHECK-NEXT:            {
 // CHECK-NEXT:                double _r_d0 = _d_res;
 // CHECK-NEXT:                size_t _r0 = {{0U|0UL}};
-// CHECK-NEXT:                a = clad::back(_t2);
 // CHECK-NEXT:                {{.*}}at_pullback(&a, i, _r_d0, &_d_a, &_r0);
 // CHECK-NEXT:                _d_i += _r0;
 // CHECK-NEXT:                clad::pop(_t2);
-// CHECK-NEXT:                clad::pop(_t3);
 // CHECK-NEXT:            }
 // CHECK-NEXT:        }
 // CHECK-NEXT:        {
@@ -700,86 +651,74 @@ int main() {
 // CHECK:     void fn7_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:         std::array<double, 2> _d_a = {{.*}};
 // CHECK-NEXT:         std::array<double, 2> a;
-// CHECK-NEXT:         std::array<double, 2> _t0 = a;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, {{0U|0UL|0}});
-// CHECK-NEXT:         double _t2 = _t1.value;
-// CHECK-NEXT:         _t1.value = 5;
-// CHECK-NEXT:         std::array<double, 2> _t3 = a;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t4 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
-// CHECK-NEXT:         double _t5 = _t4.value;
-// CHECK-NEXT:         _t4.value = y;
+// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t0 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, {{0U|0UL|0}});
+// CHECK-NEXT:         double _t1 = _t0.value;
+// CHECK-NEXT:         _t0.value = 5;
+// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
+// CHECK-NEXT:         double _t3 = _t2.value;
+// CHECK-NEXT:         _t2.value = y;
 // CHECK-NEXT:         std::array<double, 3> _d__b = {{.*}};
 // CHECK-NEXT:         std::array<double, 3> _b0;
-// CHECK-NEXT:         std::array<double, 3> _t6 = _b0;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t7 = {{.*}}operator_subscript_reverse_forw(&_b0, 0, &_d__b, {{0U|0UL|0}});
-// CHECK-NEXT:         double _t8 = _t7.value;
-// CHECK-NEXT:         _t7.value = x;
-// CHECK-NEXT:         std::array<double, 3> _t9 = _b0;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t10 = {{.*}}operator_subscript_reverse_forw(&_b0, 1, &_d__b, {{0U|0UL|0}});
-// CHECK-NEXT:         double _t11 = _t10.value;
-// CHECK-NEXT:         _t10.value = 0;
-// CHECK-NEXT:         std::array<double, 3> _t12 = _b0;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t13 = {{.*}}operator_subscript_reverse_forw(&_b0, 2, &_d__b, {{0U|0UL|0}});
-// CHECK-NEXT:         double _t14 = _t13.value;
-// CHECK-NEXT:         _t13.value = x * x;
+// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t4 = {{.*}}operator_subscript_reverse_forw(&_b0, 0, &_d__b, {{0U|0UL|0}});
+// CHECK-NEXT:         double _t5 = _t4.value;
+// CHECK-NEXT:         _t4.value = x;
+// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t6 = {{.*}}operator_subscript_reverse_forw(&_b0, 1, &_d__b, {{0U|0UL|0}});
+// CHECK-NEXT:         double _t7 = _t6.value;
+// CHECK-NEXT:         _t6.value = 0;
+// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t8 = {{.*}}operator_subscript_reverse_forw(&_b0, 2, &_d__b, {{0U|0UL|0}});
+// CHECK-NEXT:         double _t9 = _t8.value;
+// CHECK-NEXT:         _t8.value = x * x;
 // CHECK-NEXT:         std::array<double, 3> _d_b = {{.*}};
 // CHECK-NEXT:         const std::array<double, 3> b = _b0;
-// CHECK-NEXT:         std::array<double, 2> _t17 = a;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t18 = {{.*}}back_reverse_forw(&a, &_d_a);
-// CHECK-NEXT:         {{.*}}value_type _t16 = b.front();
-// CHECK-NEXT:         {{.*}}value_type _t15 = b.at(2);
+// CHECK:              clad::ValueAndAdjoint<double &, double &> _t{{12|13}} = {{.*}}back_reverse_forw(&a, &_d_a);
+// CHECK-NEXT:         {{.*}}value_type _t11 = b.front();
+// CHECK-NEXT:         {{.*}}value_type _t10 = b.at(2);
 // CHECK-NEXT:         {
-// CHECK-NEXT:             a = _t17;
-// CHECK-NEXT:             {{.*}}back_pullback(&a, 1 * _t15 * _t16, &_d_a);
-// CHECK-NEXT:             {{.*}}front_pullback(&b, _t18.value * 1 * _t15, &_d_b);
+// CHECK:                  {{.*}}back_pullback(&a, 1 * _t10 * _t11, &_d_a);
+// CHECK-NEXT:             {{.*}}front_pullback(&b, _t{{12|13}}.value * 1 * _t10, &_d_b);
 // CHECK-NEXT:             {{.*}}size_type _r5 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}at_pullback(&b, 2, _t18.value * _t16 * 1, &_d_b, &_r5);
+// CHECK-NEXT:             {{.*}}at_pullback(&b, 2, _t{{12|13}}.value * _t11 * 1, &_d_b, &_r5);
 // CHECK-NEXT:             {{.*}}size_type _r6 = {{0U|0UL}};
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&b, 1, 1, &_d_b, &_r6);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {{.*}}constructor_pullback(_b0, &_d_b, &_d__b);
 // CHECK-NEXT:         {
-// CHECK-NEXT:             _t13.value = _t14;
-// CHECK-NEXT:             double _r_d4 = _t13.adjoint;
-// CHECK-NEXT:             _t13.adjoint = 0.;
+// CHECK-NEXT:             _t8.value = _t9;
+// CHECK-NEXT:             double _r_d4 = _t8.adjoint;
+// CHECK-NEXT:             _t8.adjoint = 0.;
 // CHECK-NEXT:             *_d_x += _r_d4 * x;
 // CHECK-NEXT:             *_d_x += x * _r_d4;
 // CHECK-NEXT:             {{.*}}size_type _r4 = {{0U|0UL}};
-// CHECK-NEXT:             _b0 = _t12;
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_b0, 2, 0., &_d__b, &_r4);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             _t10.value = _t11;
-// CHECK-NEXT:             double _r_d3 = _t10.adjoint;
-// CHECK-NEXT:             _t10.adjoint = 0.;
+// CHECK-NEXT:             _t6.value = _t7;
+// CHECK-NEXT:             double _r_d3 = _t6.adjoint;
+// CHECK-NEXT:             _t6.adjoint = 0.;
 // CHECK-NEXT:             {{.*}}size_type _r3 = {{0U|0UL}};
-// CHECK-NEXT:             _b0 = _t9;
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_b0, 1, 0., &_d__b, &_r3);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             _t7.value = _t8;
-// CHECK-NEXT:             double _r_d2 = _t7.adjoint;
-// CHECK-NEXT:             _t7.adjoint = 0.;
+// CHECK-NEXT:             _t4.value = _t5;
+// CHECK-NEXT:             double _r_d2 = _t4.adjoint;
+// CHECK-NEXT:             _t4.adjoint = 0.;
 // CHECK-NEXT:             *_d_x += _r_d2;
 // CHECK-NEXT:             {{.*}}size_type _r2 = {{0U|0UL}};
-// CHECK-NEXT:             _b0 = _t6;
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_b0, 0, 0., &_d__b, &_r2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             _t4.value = _t5;
-// CHECK-NEXT:             double _r_d1 = _t4.adjoint;
-// CHECK-NEXT:             _t4.adjoint = 0.;
+// CHECK-NEXT:             _t2.value = _t3;
+// CHECK-NEXT:             double _r_d1 = _t2.adjoint;
+// CHECK-NEXT:             _t2.adjoint = 0.;
 // CHECK-NEXT:             *_d_y += _r_d1;
 // CHECK-NEXT:             {{.*}}size_type _r1 = {{0U|0UL}};
-// CHECK-NEXT:             a = _t3;
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 1, 0., &_d_a, &_r1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             _t1.value = _t2;
-// CHECK-NEXT:             double _r_d0 = _t1.adjoint;
-// CHECK-NEXT:             _t1.adjoint = 0.;
+// CHECK-NEXT:             _t0.value = _t1;
+// CHECK-NEXT:             double _r_d0 = _t0.adjoint;
+// CHECK-NEXT:             _t0.adjoint = 0.;
 // CHECK-NEXT:             {{.*}}size_type _r0 = {{0U|0UL}};
-// CHECK-NEXT:             a = _t0;
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 0, 0., &_d_a, &_r0);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
@@ -789,16 +728,12 @@ int main() {
 // CHECK-NEXT:         std::array<double, 50> a;
 // CHECK-NEXT:         std::array<double, 50> _t0 = a;
 // CHECK-NEXT:         {{.*}}fill_reverse_forw(&a, y + x + x, &_d_a, 0.);
-// CHECK-NEXT:         std::array<double, 50> _t1 = a;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 49, &_d_a, {{0U|0UL|0}});
-// CHECK-NEXT:         std::array<double, 50> _t3 = a;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t4 = {{.*}}operator_subscript_reverse_forw(&a, 3, &_d_a, {{0U|0UL|0}});
+// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 49, &_d_a, {{0U|0UL|0}});
+// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 3, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}}size_type _r1 = {{0U|0UL}};
-// CHECK-NEXT:             a = _t1;
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 49, 1, &_d_a, &_r1);
 // CHECK-NEXT:             {{.*}}size_type _r2 = {{0U|0UL}};
-// CHECK-NEXT:             a = _t3;
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 3, 1, &_d_a, &_r2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
@@ -814,23 +749,19 @@ int main() {
 // CHECK:     void fn9_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:         std::array<double, 2> _d_a = {{.*}};
 // CHECK-NEXT:         std::array<double, 2> a;
-// CHECK-NEXT:         std::array<double, 2> _t0 = a;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
-// CHECK-NEXT:         {{.*}} _t2 = _t1.value;
-// CHECK-NEXT:         _t1.value = 2 * x;
-// CHECK-NEXT:         std::array<double, 2> _t3 = a;
+// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t0 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
+// CHECK-NEXT:         {{.*}} _t1 = _t0.value;
+// CHECK-NEXT:         _t0.value = 2 * x;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}}size_type _r1 = {{0U|0UL}};
-// CHECK-NEXT:             a = _t3;
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 1, 1, &_d_a, &_r1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             _t1.value = _t2;
-// CHECK-NEXT:             {{.*}} _r_d0 = _t1.adjoint;
-// CHECK-NEXT:             _t1.adjoint = 0.;
+// CHECK-NEXT:             _t0.value = _t1;
+// CHECK-NEXT:             {{.*}} _r_d0 = _t0.adjoint;
+// CHECK-NEXT:             _t0.adjoint = 0.;
 // CHECK-NEXT:             *_d_x += 2 * _r_d0;
 // CHECK-NEXT:             {{.*}}size_type _r0 = {{0U|0UL}};
-// CHECK-NEXT:             a = _t0;
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 1, 0., &_d_a, &_r0);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
@@ -841,8 +772,7 @@ int main() {
 // CHECK-NEXT:          {{.*}}tape<{{.*}}vector<double> > _t1 = {};
 // CHECK-NEXT:          size_t _d_i0 = {{0U|0UL|0}};
 // CHECK-NEXT:          size_t i0 = {{0U|0UL|0}};
-// CHECK-NEXT:          {{.*}}tape<{{.*}}vector<double> > _t3 = {};
-// CHECK-NEXT:          clad::tape<clad::ValueAndAdjoint<double &, double &> > _t4 = {};
+// CHECK-NEXT:          clad::tape<clad::ValueAndAdjoint<double &, double &> > _t3 = {};
 // CHECK-NEXT:          {{.*}}vector<double> v;
 // CHECK-NEXT:          {{.*}}vector<double> _d_v = {};
 // CHECK-NEXT:          clad::zero_init(_d_v);
@@ -857,41 +787,34 @@ int main() {
 // CHECK-NEXT:          {{.*}} _t2 = {{0U|0UL|0}};
 // CHECK-NEXT:          for (i0 = 0; i0 < v.size(); ++i0) {
 // CHECK-NEXT:              _t2++;
-// CHECK-NEXT:              {{.*}}push(_t3, v);
-// CHECK-NEXT:              clad::push(_t4, {{.*}}at_reverse_forw(&v, i0, &_d_v, {{0U|0UL|0}}));
-// CHECK-NEXT:              res += clad::back(_t4).value;
+// CHECK-NEXT:              clad::push(_t3, {{.*}}at_reverse_forw(&v, i0, &_d_v, {{0U|0UL|0}}));
+// CHECK-NEXT:              res += clad::back(_t3).value;
 // CHECK-NEXT:          }
-// CHECK-NEXT:          {{.*}}vector<double> _t5 = v;
+// CHECK-NEXT:          {{.*}}vector<double> _t4 = v;
 // CHECK-NEXT:          v.assign(3, 0);
-// CHECK-NEXT:          {{.*}}vector<double> _t6 = v;
+// CHECK-NEXT:          {{.*}}vector<double> _t5 = v;
 // CHECK-NEXT:          v.assign(2, y);
-// CHECK-NEXT:          {{.*}}vector<double> _t7 = v;
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t8 = {{.*}}operator_subscript_reverse_forw(&v, 0, &_d_v, {{0U|0UL|0}});
-// CHECK-NEXT:          {{.*}}vector<double> _t9 = v;
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t10 = {{.*}}operator_subscript_reverse_forw(&v, 1, &_d_v, {{0U|0UL|0}});
-// CHECK-NEXT:          {{.*}}vector<double> _t11 = v;
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t12 = {{.*}}operator_subscript_reverse_forw(&v, 2, &_d_v, {{0U|0UL|0}});
+// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}operator_subscript_reverse_forw(&v, 0, &_d_v, {{0U|0UL|0}});
+// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t7 = {{.*}}operator_subscript_reverse_forw(&v, 1, &_d_v, {{0U|0UL|0}});
+// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t8 = {{.*}}operator_subscript_reverse_forw(&v, 2, &_d_v, {{0U|0UL|0}});
 // CHECK-NEXT:          {
 // CHECK-NEXT:              _d_res += 1;
 // CHECK-NEXT:              {{.*}}size_type _r4 = {{0U|0UL|0}};
-// CHECK-NEXT:              v = _t7;
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&v, 0, 1, &_d_v, &_r4);
 // CHECK-NEXT:              {{.*}}size_type _r5 = {{0U|0UL|0}};
-// CHECK-NEXT:              v = _t9;
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&v, 1, 1, &_d_v, &_r5);
 // CHECK-NEXT:              {{.*}}size_type _r6 = {{0U|0UL|0}};
-// CHECK-NEXT:              v = _t11;
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&v, 2, 1, &_d_v, &_r6);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r3 = {{0U|0UL|0}};
-// CHECK-NEXT:              v = _t6;
+// CHECK-NEXT:              v = _t5;
 // CHECK-NEXT:              {{.*}}assign_pullback(&v, 2, y, &_d_v, &_r3, &*_d_y);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r1 = {{0U|0UL|0}};
 // CHECK-NEXT:              {{.*}}value_type _r2 = 0.;
-// CHECK-NEXT:              v = _t5;
+// CHECK-NEXT:              v = _t4;
 // CHECK-NEXT:              {{.*}}assign_pullback(&v, 3, 0, &_d_v, &_r1, &_r2);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          for (; _t2; _t2--) {
@@ -899,11 +822,9 @@ int main() {
 // CHECK-NEXT:              {
 // CHECK-NEXT:                  double _r_d0 = _d_res;
 // CHECK-NEXT:                  size_t _r0 = {{0U|0UL|0}};
-// CHECK-NEXT:                  v = {{.*}}back(_t3);
 // CHECK-NEXT:                  {{.*}}at_pullback(&v, i0, _r_d0, &_d_v, &_r0);
 // CHECK-NEXT:                  _d_i0 += _r0;
 // CHECK-NEXT:                  {{.*}}pop(_t3);
-// CHECK-NEXT:                  {{.*}}pop(_t4);
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
 // CHECK-NEXT:          for (; _t0; _t0--) {
@@ -964,24 +885,20 @@ int main() {
 // CHECK-NEXT:          clad::zero_init(_d_a);
 // CHECK-NEXT:          std::vector<double> _t0 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, 0{{.*}}, &_d_a, 0.);
-// CHECK-NEXT:          std::vector<double> _t1 = a;
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, {{0U|0UL|0}});
-// CHECK-NEXT:          double _t3 = _t2.value;
-// CHECK-NEXT:          _t2.value = x * x;
-// CHECK-NEXT:          std::vector<double> _t4 = a;
+// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, {{0U|0UL|0}});
+// CHECK-NEXT:          double _t2 = _t1.value;
+// CHECK-NEXT:          _t1.value = x * x;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r2 = 0{{.*}};
-// CHECK-NEXT:              a = _t4;
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 0, 1, &_d_a, &_r2);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              _t2.value = _t3;
-// CHECK-NEXT:              double _r_d0 = _t2.adjoint;
-// CHECK-NEXT:              _t2.adjoint = 0{{.*}};
+// CHECK-NEXT:              _t1.value = _t2;
+// CHECK-NEXT:              double _r_d0 = _t1.adjoint;
+// CHECK-NEXT:              _t1.adjoint = 0{{.*}};
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
 // CHECK-NEXT:              {{.*}}size_type _r1 = 0{{.*}};
-// CHECK-NEXT:              a = _t1;
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 0, 0{{.*}}, &_d_a, &_r1);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
@@ -998,17 +915,13 @@ int main() {
 // CHECK-NEXT:      std::vector<double> ls({u, v}, alloc);
 // CHECK-NEXT:      std::vector<double> _d_ls(ls);
 // CHECK-NEXT:      clad::zero_init(_d_ls);
-// CHECK-NEXT:      std::vector<double> _t0 = ls;
-// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t1 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}});
-// CHECK-NEXT:      std::vector<double> _t3 = ls;
-// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t4 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}});
-// CHECK-NEXT:      {{.*}}value_type _t2 = _t4.value;
+// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t0 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}});
+// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}});
+// CHECK-NEXT:      {{.*}}value_type _t1 = _t2.value;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          {{.*}}size_type _r1 = 0{{.*}};
-// CHECK-NEXT:          ls = _t0;
 // CHECK-NEXT:          clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, 1, &_d_ls, &_r1);
 // CHECK-NEXT:          {{.*}}size_type _r2 = 0{{.*}};
-// CHECK-NEXT:          ls = _t3;
 // CHECK-NEXT:          clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 0, 2 * -1, &_d_ls, &_r2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
@@ -1026,13 +939,10 @@ int main() {
 // CHECK-NEXT:      clad::tape<std::vector<double> > _t2 = {};
 // CHECK-NEXT:      std::vector<double> ls = {};
 // CHECK-NEXT:      std::vector<double> _d_ls{};
-// CHECK-NEXT:      clad::tape<std::vector<double> > _t3 = {};
-// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t4 = {};
-// CHECK-NEXT:      clad::tape<double> _t5 = {};
-// CHECK-NEXT:      clad::tape<std::vector<double> > _t6 = {};
-// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t7 = {};
-// CHECK-NEXT:      clad::tape<std::vector<double> > _t8 = {};
-// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t9 = {};
+// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t3 = {};
+// CHECK-NEXT:      clad::tape<double> _t4 = {};
+// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t5 = {};
+// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t6 = {};
 // CHECK-NEXT:      {{.*}}allocator_type alloc;
 // CHECK-NEXT:      {{.*}}allocator_type _d_alloc = {};
 // CHECK-NEXT:      clad::zero_init(_d_alloc);
@@ -1043,15 +953,12 @@ int main() {
 // CHECK-NEXT:          clad::push(_t2, std::move(ls)) , ls = {u, v}, alloc;
 // CHECK-NEXT:          _d_ls = ls;
 // CHECK-NEXT:          clad::zero_init(_d_ls);
-// CHECK-NEXT:          clad::push(_t3, ls);
-// CHECK-NEXT:          clad::push(_t4, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
-// CHECK-NEXT:          clad::push(_t5, clad::back(_t4).value); 
-// CHECK-NEXT:          clad::push(_t6, ls);
-// CHECK-NEXT:          clad::push(_t7, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}}));
-// CHECK-NEXT:          clad::back(_t4).value += clad::back(_t7).value;
-// CHECK-NEXT:          clad::push(_t8, ls);
-// CHECK-NEXT:          clad::push(_t9, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
-// CHECK-NEXT:          u = clad::back(_t9).value;
+// CHECK-NEXT:          clad::push(_t3, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
+// CHECK-NEXT:          clad::push(_t4, clad::back(_t3).value);
+// CHECK-NEXT:          clad::push(_t5, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}}));
+// CHECK-NEXT:          clad::back(_t3).value += clad::back(_t5).value;
+// CHECK-NEXT:          clad::push(_t6, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
+// CHECK-NEXT:          u = clad::back(_t6).value;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      *_d_u += 1;
 // CHECK-NEXT:      for (; _t0; _t0--) {
@@ -1059,24 +966,18 @@ int main() {
 // CHECK-NEXT:              double _r_d1 = *_d_u;
 // CHECK-NEXT:              *_d_u = 0.;
 // CHECK-NEXT:              {{.*}}size_type _r3 = 0{{.*}};
-// CHECK-NEXT:              ls = clad::back(_t8);
 // CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, _r_d1, &_d_ls, &_r3);
-// CHECK-NEXT:              clad::pop(_t8);
-// CHECK-NEXT:              clad::pop(_t9);
+// CHECK-NEXT:              clad::pop(_t6);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              clad::back(_t4).value = clad::pop(_t5);
-// CHECK-NEXT:              double _r_d0 = clad::back(_t4).adjoint;
+// CHECK-NEXT:              clad::back(_t3).value = clad::pop(_t4);
+// CHECK-NEXT:              double _r_d0 = clad::back(_t3).adjoint;
 // CHECK-NEXT:              {{.*}}size_type _r2 = 0{{.*}};
-// CHECK-NEXT:              ls = clad::back(_t6);
 // CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 0, _r_d0, &_d_ls, &_r2);
-// CHECK-NEXT:              clad::pop(_t6);
-// CHECK-NEXT:              clad::pop(_t7);
+// CHECK-NEXT:              clad::pop(_t5);
 // CHECK-NEXT:              {{.*}}size_type _r1 = 0{{.*}};
-// CHECK-NEXT:              ls = clad::back(_t3);
 // CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, 0., &_d_ls, &_r1);
 // CHECK-NEXT:              clad::pop(_t3);
-// CHECK-NEXT:              clad::pop(_t4);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              clad::array<double> _r0 = {{2U|2UL|2ULL}};
@@ -1117,8 +1018,7 @@ int main() {
 // CHECK-NEXT:     std::vector<double> vec = {};
 // CHECK-NEXT:     std::vector<double> _d_vec{};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<std::vector<double> > _t4 = {};
-// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t5 = {};
+// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t4 = {};
 // CHECK-NEXT:     {{.*}}allocator_type alloc;
 // CHECK-NEXT:     {{.*}}allocator_type _d_alloc = {};
 // CHECK-NEXT:     clad::zero_init(_d_alloc);
@@ -1132,9 +1032,8 @@ int main() {
 // CHECK-NEXT:         _d_vec = vec;
 // CHECK-NEXT:         clad::zero_init(_d_vec);
 // CHECK-NEXT:         clad::push(_t3, prod);
-// CHECK-NEXT:         clad::push(_t4, vec);
-// CHECK-NEXT:         clad::push(_t5, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&vec, i - 1, &_d_vec, {{0U|0UL|0}}));
-// CHECK-NEXT:         prod *= clad::back(_t5).value;
+// CHECK-NEXT:         clad::push(_t4, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&vec, i - 1, &_d_vec, {{0U|0UL|0}}));
+// CHECK-NEXT:         prod *= clad::back(_t4).value;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_prod += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
@@ -1143,13 +1042,11 @@ int main() {
 // CHECK-NEXT:             prod = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_prod;
 // CHECK-NEXT:             _d_prod = 0.;
-// CHECK-NEXT:             _d_prod += _r_d0 * clad::back(_t5).value;
+// CHECK-NEXT:             _d_prod += _r_d0 * clad::back(_t4).value;
 // CHECK-NEXT:             {{.*}}size_type _r2 = 0{{.*}};
-// CHECK-NEXT:             vec = clad::back(_t4);
 // CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&vec, i - 1, prod * _r_d0, &_d_vec, &_r2);
 // CHECK-NEXT:             _d_i += _r2;
 // CHECK-NEXT:             clad::pop(_t4);
-// CHECK-NEXT:             clad::pop(_t5);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}}size_type _r0 = 0{{.*}};
@@ -1173,13 +1070,10 @@ int main() {
 // CHECK-NEXT:     clad::tape<std::vector<double> > _t2 = {};
 // CHECK-NEXT:     std::vector<double> ls = {};
 // CHECK-NEXT:     std::vector<double> _d_ls{};
-// CHECK-NEXT:     clad::tape<std::vector<double> > _t3 = {};
-// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t4 = {};
-// CHECK-NEXT:     clad::tape<double> _t5 = {};
-// CHECK-NEXT:     clad::tape<std::vector<double> > _t6 = {};
-// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t7 = {};
-// CHECK-NEXT:     clad::tape<std::vector<double> > _t8 = {};
-// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t9 = {};
+// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t3 = {};
+// CHECK-NEXT:     clad::tape<double> _t4 = {};
+// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t5 = {};
+// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t6 = {};
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:         _t0++;
@@ -1187,15 +1081,12 @@ int main() {
 // CHECK-NEXT:         clad::push(_t2, std::move(ls)) , ls = {{.*{u, v}.*}};
 // CHECK-NEXT:         _d_ls = ls;
 // CHECK-NEXT:         clad::zero_init(_d_ls);
-// CHECK-NEXT:         clad::push(_t3, ls);
-// CHECK-NEXT:         clad::push(_t4, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
-// CHECK-NEXT:         clad::push(_t5, clad::back(_t4).value);
-// CHECK-NEXT:         clad::push(_t6, ls);
-// CHECK-NEXT:         clad::push(_t7, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}}));
-// CHECK-NEXT:         clad::back(_t4).value += clad::back(_t7).value;
-// CHECK-NEXT:         clad::push(_t8, ls);
-// CHECK-NEXT:         clad::push(_t9, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
-// CHECK-NEXT:         u = clad::back(_t9).value;
+// CHECK-NEXT:         clad::push(_t3, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
+// CHECK-NEXT:         clad::push(_t4, clad::back(_t3).value);
+// CHECK-NEXT:         clad::push(_t5, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}}));
+// CHECK-NEXT:         clad::back(_t3).value += clad::back(_t5).value;
+// CHECK-NEXT:         clad::push(_t6, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, {{0U|0UL|0}}));
+// CHECK-NEXT:         u = clad::back(_t6).value;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_u += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
@@ -1203,24 +1094,18 @@ int main() {
 // CHECK-NEXT:             double _r_d1 = *_d_u;
 // CHECK-NEXT:             *_d_u = 0.;
 // CHECK-NEXT:             {{.*}}size_type _r{{3|4}} = {{0U|0UL|0ULL}};
-// CHECK-NEXT:             ls = clad::back(_t8);
 // CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, _r_d1, &_d_ls, &_r{{3|4}});
-// CHECK-NEXT:             clad::pop(_t8);
-// CHECK-NEXT:             clad::pop(_t9);
+// CHECK-NEXT:             clad::pop(_t6);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             clad::back(_t4).value = clad::pop(_t5);
-// CHECK-NEXT:             double _r_d0 = clad::back(_t4).adjoint;
+// CHECK-NEXT:             clad::back(_t3).value = clad::pop(_t4);
+// CHECK-NEXT:             double _r_d0 = clad::back(_t3).adjoint;
 // CHECK-NEXT:             {{.*}}size_type _r{{2|3}} = {{0U|0UL|0ULL}};
-// CHECK-NEXT:             ls = clad::back(_t6);
 // CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 0, _r_d0, &_d_ls, &_r{{2|3}});
-// CHECK-NEXT:             clad::pop(_t6);
-// CHECK-NEXT:             clad::pop(_t7);
+// CHECK-NEXT:             clad::pop(_t5);
 // CHECK-NEXT:             {{.*}}size_type _r{{1|2}} = {{0U|0UL|0ULL}};
-// CHECK-NEXT:             ls = clad::back(_t3);
 // CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, 0., &_d_ls, &_r{{1|2}});
 // CHECK-NEXT:             clad::pop(_t3);
-// CHECK-NEXT:             clad::pop(_t4);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::array<double> _r0 = {{2U|2UL|2ULL}};

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -657,11 +657,9 @@ double fn17(double i, double j) {
 // CHECK-NEXT:    SimpleFunctions1 sf(3, 5);
 // CHECK-NEXT:    SimpleFunctions1 _d_sf(sf);
 // CHECK-NEXT:    clad::zero_init(_d_sf);
-// CHECK-NEXT:    SimpleFunctions1 _t0 = sf;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        double _r0 = 0.;
 // CHECK-NEXT:        double _r1 = 0.;
-// CHECK-NEXT:        sf = _t0;
 // CHECK-NEXT:        sf.mem_fn_pullback(i, j, 1, &_d_sf, &_r0, &_r1);
 // CHECK-NEXT:        *_d_i += _r0;
 // CHECK-NEXT:        *_d_j += _r1;
@@ -677,11 +675,9 @@ double fn18(double i, double j) {
 // CHECK-NEXT:      SimpleFunctions1 sf(3 * i, 5 * j);
 // CHECK-NEXT:      SimpleFunctions1 _d_sf(sf);
 // CHECK-NEXT:      clad::zero_init(_d_sf);
-// CHECK-NEXT:      SimpleFunctions1 _t0 = sf;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r2 = 0.;
 // CHECK-NEXT:          double _r3 = 0.;
-// CHECK-NEXT:          sf = _t0;
 // CHECK-NEXT:          sf.mem_fn_pullback(i, j, 1, &_d_sf, &_r2, &_r3);
 // CHECK-NEXT:          *_d_i += _r2;
 // CHECK-NEXT:          *_d_j += _r3;
@@ -773,7 +769,6 @@ double fn21(double x, double y) {
 // CHECK:  void fn21_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      Identity _d_di = {};
 // CHECK-NEXT:      Identity di{};
-// CHECK-NEXT:      Identity _t0 = di;
 // CHECK-NEXT:      double _d_val = 0.;
 // CHECK-NEXT:      double val = di(x);
 // CHECK-NEXT:      {
@@ -782,7 +777,6 @@ double fn21(double x, double y) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
-// CHECK-NEXT:          di = _t0;
 // CHECK-NEXT:          di.operator_call_pullback(x, _d_val, &_d_di, &_r0);
 // CHECK-NEXT:          *_d_x += _r0;
 // CHECK-NEXT:      }
@@ -984,7 +978,6 @@ double fn25(double x, double y) {
 // CHECK-NEXT:      Vector3 v{x, x, y};
 // CHECK-NEXT:      Vector3 _d_v(v);
 // CHECK-NEXT:      clad::zero_init(_d_v);
-// CHECK-NEXT:      Vector3 _t0 = v;
 // CHECK-NEXT:      Vector3 w = - v;
 // CHECK-NEXT:      Vector3 _d_w(w);
 // CHECK-NEXT:      clad::zero_init(_d_w);
@@ -992,7 +985,6 @@ double fn25(double x, double y) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          Vector3 _r3 = {};
 // CHECK-NEXT:          Vector3::constructor_pullback(- v, &_d_w, &_r3);
-// CHECK-NEXT:          v = _t0;
 // CHECK-NEXT:          v.operator_minus_pullback(_r3, &_d_v);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
@@ -1046,11 +1038,7 @@ double fn26(double x, double y) {
 // CHECK-NEXT:      ::clad::ValueAndAdjoint<ptrClass, ptrClass> _t0 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<ptrClass>(), &x, &*_d_x);
 // CHECK-NEXT:      ptrClass p(_t0.value);
 // CHECK-NEXT:      ptrClass _d_p = _t0.adjoint;
-// CHECK-NEXT:      ptrClass _t1 = p;
-// CHECK-NEXT:      {
-// CHECK-NEXT:          p = _t1;
-// CHECK-NEXT:          p.operator_star_pullback(1, &_d_p);
-// CHECK-NEXT:      }
+// CHECK-NEXT:      p.operator_star_pullback(1, &_d_p);
 // CHECK-NEXT:      ptrClass::constructor_pullback(&x, &_d_p, &*_d_x);
 // CHECK-NEXT:  }
 

--- a/test/Misc/CrashDiags.cpp
+++ b/test/Misc/CrashDiags.cpp
@@ -16,7 +16,7 @@ int main() {
 #endif
 }
 
-// CHECK: Building code for '<double fn1(double x)>[name=fn1, order=1, mode={{.*}}, args='', tbr]'
+// CHECK: Building code for '<double fn1(double x)>[name=fn1, order=1, mode={{.*}}, args=''
 // CHECK-NEXT: While visiting <CompoundStmt> [ '
 // CHECK: --- Begin Stmt Dump ---
 // CHECK return x * x + 3 * x + 5;

--- a/test/Misc/TimingsReport.C
+++ b/test/Misc/TimingsReport.C
@@ -22,7 +22,7 @@
 // CHECK_STATS-NEXT: <double global_fn(double x)>[name=global_fn, order=1, mode=reverse, args='']: #8 (source), (unprocessed)
 // CHECK_STATS-NEXT: <constexpr double constexpr_fn(double x, double y)>[name=constexpr_fn, order=1, mode=reverse, args='']: #9 (source), (unprocessed)
 
-// CHECK_STATS_TBR: <double test1(double x, double y)>[name=test1, order=1, mode=forward, args='"x"', tbr]: #1 (source), (unprocessed)
+// CHECK_STATS_TBR: <double test2(double a, double b)>[name=test2, order=1, mode=reverse, args='', tbr]: #3 (source), (unprocessed)
 
 #ifdef GLOBAL
 double g = 3.14; // expected-warning {{The gradient utilizes a global variable 'g'}}

--- a/test/ValidCodeGen/ValidCodeGen.C
+++ b/test/ValidCodeGen/ValidCodeGen.C
@@ -68,13 +68,11 @@ int main() {
 //CHECK:     void fn2_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:         TN::Test2<double> _d_t = {};
 //CHECK-NEXT:         TN::Test2<double> t;
-//CHECK-NEXT:         TN::Test2<double> _t0 = t;
 //CHECK-NEXT:         double _d_q = 0.;
 //CHECK-NEXT:         double q = t[x];
 //CHECK-NEXT:         _d_q += 1;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r0 = 0.;
-//CHECK-NEXT:             t = _t0;
 //CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&t, x, _d_q, &_d_t, &_r0);
 //CHECK-NEXT:             *_d_x += _r0;
 //CHECK-NEXT:         }

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -12,6 +12,7 @@
 #include "clad/Differentiator/Sins.h"
 #include "clad/Differentiator/Timers.h"
 #include "clad/Differentiator/Version.h"
+#include "../lib/Differentiator/TBRAnalyzer.h"
 
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
@@ -30,6 +31,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include "clad/Differentiator/Compatibility.h"
+#include <clad/Differentiator/DiffMode.h>
 
 #include <algorithm>
 #include <cstdlib>  // for getenv
@@ -271,6 +273,14 @@ void InitTimers();
       // If enabled, set the proper fields in derivative builder.
       if (m_DO.PrintNumDiffErrorInfo) {
         m_DerivativeBuilder->setNumDiffErrDiag(true);
+      }
+      if (request.RequestTBR && request->isDefined() && request.m_AnalysisDC) {
+        TimedAnalysisRegion R("TBR " + request.BaseFunctionName);
+        TBRAnalyzer analyzer(request.m_AnalysisDC, request.getToBeRecorded(),
+                             &m_ModifiedParams);
+        analyzer.Analyze(request);
+        if (request.Mode == DiffMode::unknown)
+          return nullptr;
       }
 
       FunctionDecl* DerivativeDecl = nullptr;

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -20,11 +20,14 @@
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "clang/Frontend/MultiplexConsumer.h"
 #include "clang/Sema/SemaConsumer.h"
+#include <clang/AST/DeclBase.h>
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 
+#include <map>
+#include <set>
 #include <string>
 
 namespace clang {
@@ -101,6 +104,8 @@ struct DifferentiationOptions {
     DerivedFnCollector m_DFC;
     DynamicGraph<DiffRequest> m_DiffRequestGraph;
     OwnedAnalysisContexts m_AllAnalysisDC;
+    std::map<const clang::FunctionDecl*, std::set<const clang::Decl*>>
+        m_ModifiedParams;
     enum class CallKind {
       HandleCXXStaticMemberVarInstantiation,
       HandleTopLevelDecl,


### PR DESCRIPTION
Currently, whenever a call argument has a type that allows for modification (e.g., a non-constant reference), TBR assumes it's modified. We can make TBR work between functions and propagate this information. This leads to optimization for OOP, as most operations there involve method calls and not built-in operators that TBR can currently work with.
The current implementation only tracks modification and not whether the method uses the value of the arg. As a result, we still store all modified arguments. When we also start tracking usage of the arguments, we'll be able to remove even more tapes.