### PR TITLE
Consider unions differentiable.

### DIFF
--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -964,7 +964,7 @@ namespace clad {
       T = T.getNonReferenceType();
       if (T->isEnumeralType())
         return false;
-      if (T->isRealType() || T->isStructureOrClassType())
+      if (T->isRealType() || T->isStructureOrClassType() || T->isUnionType())
         return true;
       if (origType->isPointerType() && T->isVoidType())
         return true;

--- a/test/Regressions/issue-1473.cpp
+++ b/test/Regressions/issue-1473.cpp
@@ -1,0 +1,34 @@
+// RUN: %cladclang -I%S/../../include %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+union b {
+};
+
+b c(int d, int e, int f) {
+  b g;
+  g = {};
+  return g;
+}
+int h;
+void f1(int j) {
+  int d;
+  int f;
+  c(d, h, f);
+}
+
+union U {
+  float f;
+  int i;
+};
+
+double f2(float j) {
+  U u{1.f};
+  u.f = j;
+  return u.f;
+}
+
+int main() {
+   clad::gradient(f1);
+   clad::gradient(f2);
+}


### PR DESCRIPTION
This PR is designed to fix #1473. The core issue here is ``utils::IsDifferentiableType`` that doesn't consider unions differentiable. Making it return ``true`` for unions fixes the crash.

Fixes #1473