### PR TITLE
Only use the reverse mode in error estimation

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1985,6 +1985,15 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // Derivative was not found, request differentiation
       if (!pullbackFD) {
         if (m_ExternalSource) {
+          if (!asGrad) {
+            asGrad = true;
+            pullbackRequest.Mode = DiffMode::pullback;
+            pullbackCallArgs = DerivedCallArgs;
+            pullbackCallArgs.insert(pullbackCallArgs.begin() + CE->getNumArgs(),
+                                    pullback);
+            for (const ParmVarDecl* PVD : FD->parameters())
+              pullbackRequest.DVI.push_back(PVD);
+          }
           m_ExternalSource->ActBeforeDifferentiatingCallExpr(
               pullbackCallArgs, PreCallStmts, dfdx());
           pullbackFD =

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -310,7 +310,7 @@ double func6(double x) {
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned long _t0 = 0UL;
+//CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 1; i < 10; i++) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -282,10 +282,60 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
 //CHECK-NEXT: }
 
+double fun(double x) {
+    return x*x;
+}
+
+//CHECK: void fun_pullback(double x, double _d_y, double *_d_x, double &_final_error) {
+//CHECK-NEXT:     double _ret_value0 = 0.;
+//CHECK-NEXT:     _ret_value0 = x * x;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         *_d_x += _d_y * x;
+//CHECK-NEXT:         *_d_x += x * _d_y;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT: }
+
+double func6(double x) {
+  double sum = 0;
+  for (int i = 1; i < 10; i++)
+    sum += fun(x);
+  return sum;
+}
+
+//CHECK: void func6_grad(double x, double *_d_x, double &_final_error) {
+//CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
+//CHECK-NEXT:     clad::tape<double> _t1 = {};
+//CHECK-NEXT:     double _d_sum = 0.;
+//CHECK-NEXT:     double sum = 0;
+//CHECK-NEXT:     unsigned long _t0 = 0UL;
+//CHECK-NEXT:     for (i = 1; i < 10; i++) {
+//CHECK-NEXT:         _t0++;
+//CHECK-NEXT:         clad::push(_t1, sum);
+//CHECK-NEXT:         sum += fun(x);
+//CHECK-NEXT:     }
+//CHECK-NEXT:     _d_sum += 1;
+//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:         i--;
+//CHECK-NEXT:         sum = clad::pop(_t1);
+//CHECK-NEXT:         double _r_d0 = _d_sum;
+//CHECK-NEXT:         double _r0 = 0.;
+//CHECK-NEXT:         double _t2 = 0.;
+//CHECK-NEXT:         fun_pullback(x, _r_d0, &_r0, _t2);
+//CHECK-NEXT:         *_d_x += _r0;
+//CHECK-NEXT:         _final_error += _t2;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     _final_error += std::abs(_d_sum * sum * {{.+}});
+//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT: }
+
 int main() {
   clad::estimate_error(func);
   clad::estimate_error(func2);
   clad::estimate_error(func3);
   clad::estimate_error(func4);
   clad::estimate_error(func5);
+  clad::estimate_error(func6);
 }


### PR DESCRIPTION
We sometimes use pushforwards in the reverse mode for simplicity/efficiency. To be precise, when a nested non-member function has only one numerical by-value parameter, then we are safe to replace the pullback with a pushforward, even in the reverse mode. However, the approach only works to compute the gradient, in error estimation, we need only pullbacks. Issue #1498 occurs because Clad attempts to pass the additional ``_final_error`` arg to a pushforward.
Fixes #1498.