### PR TITLE
Rework setting the final error.

### DIFF
--- a/include/clad/Differentiator/ErrorEstimator.h
+++ b/include/clad/Differentiator/ErrorEstimator.h
@@ -13,6 +13,7 @@ namespace clang {
 class Stmt;
 class Expr;
 class Decl;
+class DeclRefExpr;
 class VarDecl;
 class ParmVarDecl;
 class FunctionDecl;
@@ -27,9 +28,6 @@ class ErrorEstimationHandler : public ExternalRMVSource {
   // multiple header files. 
   // `Stmts` is originally defined in `VisitorBase`.
   using Stmts = llvm::SmallVector<clang::Stmt*, 16>;
-  /// Reference to the final error parameter in the augumented target
-  /// function.
-  clang::Expr* m_FinalError;
   /// Reference to the return error expression.
   clang::Expr* m_RetErrorExpr;
   /// An instance of the custom error estimation model to be used.
@@ -53,8 +51,7 @@ class ErrorEstimationHandler : public ExternalRMVSource {
 public:
   using direction = rmv::direction;
   ErrorEstimationHandler()
-      : m_FinalError(nullptr), m_RetErrorExpr(nullptr), m_EstModel(nullptr),
-        m_IdxExpr(nullptr) {}
+      : m_RetErrorExpr(nullptr), m_EstModel(nullptr), m_IdxExpr(nullptr) {}
   ~ErrorEstimationHandler() override = default;
 
   /// Function to set the error estimation model currently in use.
@@ -63,8 +60,8 @@ public:
   /// an in-built one (TaylorApprox) or one provided by the user.
   void SetErrorEstimationModel(FPErrorEstimationModel* estModel);
 
-  /// \param[in] finErrExpr The final error expression.
-  void SetFinalErrorExpr(clang::Expr* finErrExpr) { m_FinalError = finErrExpr; }
+  /// Builds a reference to the final error parameter of the function.
+  clang::DeclRefExpr* BuildFinalErrorExpr();
 
   /// Function to build the error statement corresponding
   /// to the function's return statement.
@@ -174,7 +171,6 @@ public:
       llvm::SmallVectorImpl<clang::QualType>& paramTypes) override;
   void ActAfterCreatingDerivedFnParams(
       llvm::SmallVectorImpl<clang::ParmVarDecl*>& params) override;
-  void ActBeforeCreatingDerivedFnBodyScope() override;
   void ActOnEndOfDerivedFnBody() override;
   void ActBeforeDifferentiatingStmtInVisitCompoundStmt() override;
   void ActAfterProcessingStmtInVisitCompoundStmt() override;

--- a/include/clad/Differentiator/ExternalRMVSource.h
+++ b/include/clad/Differentiator/ExternalRMVSource.h
@@ -68,10 +68,6 @@ public:
   virtual void ActAfterCreatingDerivedFnParams(
       llvm::SmallVectorImpl<clang::ParmVarDecl*>& params) {}
 
-  /// This is called just before the scope is created for the derived
-  /// function body.
-  virtual void ActBeforeCreatingDerivedFnBodyScope() {}
-
   /// This is called at the beginning of the derived function body.
   /// \param request differentiation request
   virtual void ActOnStartOfDerivedFnBody(const DiffRequest& request) {}

--- a/include/clad/Differentiator/MultiplexExternalRMVSource.h
+++ b/include/clad/Differentiator/MultiplexExternalRMVSource.h
@@ -5,6 +5,12 @@
 
 #include "llvm/ADT/SmallVector.h"
 
+namespace clang {
+class CallExpr;
+class DeclRefExpr;
+class Expr;
+} // namespace clang
+
 namespace clad {
 struct DiffRequest;
 
@@ -32,7 +38,6 @@ public:
       llvm::SmallVectorImpl<clang::QualType>& paramTypes) override;
   void ActAfterCreatingDerivedFnParams(
       llvm::SmallVectorImpl<clang::ParmVarDecl*>& params) override;
-  void ActBeforeCreatingDerivedFnBodyScope() override;
   void ActOnStartOfDerivedFnBody(const DiffRequest& request) override;
   void ActOnEndOfDerivedFnBody() override;
   void ActBeforeDifferentiatingStmtInVisitCompoundStmt() override;

--- a/lib/Differentiator/MultiplexExternalRMVSource.cpp
+++ b/lib/Differentiator/MultiplexExternalRMVSource.cpp
@@ -61,12 +61,6 @@ void MultiplexExternalRMVSource::ActAfterCreatingDerivedFnParams(
   }
 }
 
-void MultiplexExternalRMVSource::ActBeforeCreatingDerivedFnBodyScope() {
-  for (auto source : m_Sources) {
-    source->ActBeforeCreatingDerivedFnBodyScope();
-  }
-}
-
 void MultiplexExternalRMVSource::ActOnStartOfDerivedFnBody(
     const DiffRequest& request) {
   for (auto source : m_Sources) {

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -332,9 +332,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     m_Derivative->setBody(nullptr);
 
     if (!m_DiffReq.DeclarationOnly) {
-      if (m_ExternalSource)
-        m_ExternalSource->ActBeforeCreatingDerivedFnBodyScope();
-
       // Function body scope.
       beginScope(Scope::FnScope | Scope::DeclScope);
       m_DerivativeFnScope = getCurrentScope();


### PR DESCRIPTION
This patch allows us to drop ActBeforeCreatingDerivedFnBodyScope.