### PR TITLE
Find used parameter values in nested TBR

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -419,6 +419,9 @@ namespace clad {
     bool isInjective(const clang::Expr* E, clang::AnalysisDeclContext* ADC);
     /// Checks if the return value of the given CallExpr is unused.
     bool hasUnusedReturnValue(clang::ASTContext& C, const clang::CallExpr* CE);
+    /// For an expr E, decides if we should recompute it or store it.
+    /// This is the central point for checkpointing.
+    bool ShouldRecompute(const clang::Expr* E, const clang::ASTContext& C);
     } // namespace utils
     } // namespace clad
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -215,10 +215,6 @@ namespace clad {
     /// to avoid recomputiation.
     bool UsefulToStoreGlobal(clang::Expr* E);
 
-    /// For an expr E, decides if we should recompute it or store it.
-    /// This is the central point for checkpointing.
-    bool ShouldRecompute(const clang::Expr* E);
-
     /// Builds a variable declaration and stores it in the function
     /// global scope.
     ///

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1466,5 +1466,27 @@ namespace clad {
       } while (E->IgnoreImplicit() != E);
       return false;
     }
+
+    /// Called in ShouldRecompute. In CUDA, to access a current thread/block id
+    /// we use functions that do not change the state of any variable, since no
+    /// point to store the value.
+    static bool isCUDABuiltInIndex(const Expr* E) {
+      const clang::Expr* B = E->IgnoreImplicit();
+      if (const auto* pseudoE = llvm::dyn_cast<PseudoObjectExpr>(B)) {
+        if (const auto* opaqueE =
+                llvm::dyn_cast<OpaqueValueExpr>(pseudoE->getSemanticExpr(0))) {
+          const Expr* innerE = opaqueE->getSourceExpr()->IgnoreImplicit();
+          QualType innerT = innerE->getType();
+          if (innerT.isConstQualified())
+            return true;
+        }
+      }
+      return false;
+    }
+
+    bool ShouldRecompute(const Expr* E, const ASTContext& C) {
+      return !(utils::ContainsFunctionCalls(E) || E->HasSideEffects(C)) ||
+             isCUDABuiltInIndex(E);
+    }
   } // namespace utils
 } // namespace clad

--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -41,6 +41,8 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer>,
   std::set<clang::SourceLocation>& m_TBRLocs;
   std::map<const clang::FunctionDecl*, std::set<const clang::Decl*>>*
       m_ModifiedParams;
+  std::map<const clang::FunctionDecl*, std::set<const clang::Decl*>>*
+      m_UsedParams;
 
   /// Stores modes in a stack (used to retrieve the old mode after entering
   /// a new one).
@@ -80,9 +82,11 @@ public:
   TBRAnalyzer(clang::AnalysisDeclContext* AnalysisDC,
               std::set<clang::SourceLocation>& Locs,
               std::map<const clang::FunctionDecl*,
-                       std::set<const clang::Decl*>>* ModifiedParams = nullptr)
+                       std::set<const clang::Decl*>>* ModifiedParams = nullptr,
+              std::map<const clang::FunctionDecl*,
+                       std::set<const clang::Decl*>>* UsedParams = nullptr)
       : AnalysisBase(AnalysisDC), m_TBRLocs(Locs),
-        m_ModifiedParams(ModifiedParams) {
+        m_ModifiedParams(ModifiedParams), m_UsedParams(UsedParams) {
     m_ModeStack.push_back(0);
   }
 
@@ -112,6 +116,7 @@ public:
   bool TraverseDeclStmt(clang::DeclStmt* DS);
   bool TraverseInitListExpr(clang::InitListExpr* ILE);
   bool TraverseMemberExpr(clang::MemberExpr* ME);
+  bool TraverseReturnStmt(clang::ReturnStmt* RS);
   bool TraverseUnaryOperator(clang::UnaryOperator* UnOp);
 };
 

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -465,7 +465,6 @@ double f13(double x, double y) {
 }
 
 //CHECK:   void f13_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t1 = y;
 //CHECK-NEXT:       double _t0 = (y = x);
 //CHECK-NEXT:       double _d_t = 0.;
 //CHECK-NEXT:       double t = x * _t0;
@@ -476,7 +475,6 @@ double f13(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += _d_t * _t0;
 //CHECK-NEXT:           *_d_y += x * _d_t;
-//CHECK-NEXT:           y = _t1;
 //CHECK-NEXT:           double _r_d0 = *_d_y;
 //CHECK-NEXT:           *_d_y = 0.;
 //CHECK-NEXT:           *_d_x += _r_d0;

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -134,16 +134,14 @@ double f_div3(double x, double y) {
 }
 
 //CHECK: void f_div3_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     double _t1 = x;
-//CHECK-NEXT:     double _t2 = (x = y);
+//CHECK-NEXT:     double _t1 = (x = y);
 //CHECK-NEXT:     double _t0 = (y * y);
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += 1 / _t0;
-//CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0.;
 //CHECK-NEXT:         *_d_y += _r_d0;
-//CHECK-NEXT:         double _r0 = 1 * -(_t2 / (_t0 * _t0));
+//CHECK-NEXT:         double _r0 = 1 * -(_t1 / (_t0 * _t0));
 //CHECK-NEXT:         *_d_y += _r0 * y;
 //CHECK-NEXT:         *_d_y += y * _r0;
 //CHECK-NEXT:     }
@@ -695,7 +693,6 @@ void fn_increment_in_return_grad(double i, double j, double *_d_i, double *_d_j)
 // CHECK-NEXT:     double _t0 = ++i;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += 1 * temp;
-// CHECK-NEXT:         --i;
 // CHECK-NEXT:         _d_temp += _t0 * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_i += _d_temp;

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -134,14 +134,16 @@ double f_div3(double x, double y) {
 }
 
 //CHECK: void f_div3_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     double _t1 = (x = y);
+//CHECK-NEXT:     double _t1 = x;
+//CHECK-NEXT:     double _t2 = (x = y);
 //CHECK-NEXT:     double _t0 = (y * y);
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += 1 / _t0;
+//CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0.;
 //CHECK-NEXT:         *_d_y += _r_d0;
-//CHECK-NEXT:         double _r0 = 1 * -(_t1 / (_t0 * _t0));
+//CHECK-NEXT:         double _r0 = 1 * -(_t2 / (_t0 * _t0));
 //CHECK-NEXT:         *_d_y += _r0 * y;
 //CHECK-NEXT:         *_d_y += y * _r0;
 //CHECK-NEXT:     }
@@ -693,6 +695,7 @@ void fn_increment_in_return_grad(double i, double j, double *_d_i, double *_d_j)
 // CHECK-NEXT:     double _t0 = ++i;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += 1 * temp;
+// CHECK-NEXT:         --i;
 // CHECK-NEXT:         _d_temp += _t0 * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_i += _d_temp;

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -501,12 +501,10 @@ double fn5(SimpleFunctions& v, double value) {
 // CHECK-NEXT: }
 
 // CHECK: void fn5_grad(SimpleFunctions &v, double value, SimpleFunctions *_d_v, double *_d_value) {
-// CHECK-NEXT:     SimpleFunctions _t0 = v;
 // CHECK-NEXT:     v.operator_plus_equal_reverse_forw(value, &(*_d_v), 0.);
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         v = _t0;
 // CHECK-NEXT:         v.operator_plus_equal_pullback(value, {}, &(*_d_v), &_r0);
 // CHECK-NEXT:         *_d_value += _r0;
 // CHECK-NEXT:     }
@@ -532,13 +530,9 @@ double fn4(SimpleFunctions& v) {
 // CHECK-NEXT: }
 
 // CHECK: void fn4_grad(SimpleFunctions &v, SimpleFunctions *_d_v) {
-// CHECK-NEXT:     SimpleFunctions _t0 = v;
 // CHECK-NEXT:     v.operator_plus_plus_reverse_forw(&(*_d_v));
 // CHECK-NEXT:     (*_d_v).x += 1;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         v = _t0;
-// CHECK-NEXT:         v.operator_plus_plus_pullback({}, &(*_d_v));
-// CHECK-NEXT:     }
+// CHECK-NEXT:     v.operator_plus_plus_pullback({}, &(*_d_v));
 // CHECK-NEXT: }
 
 class SafeTestClass {
@@ -726,14 +720,13 @@ double fn11(double u, double v) {
 // CHECK-NEXT:      double res = 0;
 // CHECK-NEXT:      A _d_a = {0.};
 // CHECK-NEXT:      A a;
-// CHECK-NEXT:      A _t0 = a;
 // CHECK-NEXT:      a.setData(u);
 // CHECK-NEXT:      res += a.data * v;
-// CHECK-NEXT:      A _t1 = a;
+// CHECK-NEXT:      A _t0 = a;
 // CHECK-NEXT:      a.increment();
 // CHECK-NEXT:      _d_res += 1;
 // CHECK-NEXT:      {
-// CHECK-NEXT:          a = _t1;
+// CHECK-NEXT:          a = _t0;
 // CHECK-NEXT:          a.increment_pullback(&_d_a);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
@@ -743,7 +736,6 @@ double fn11(double u, double v) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
-// CHECK-NEXT:          a = _t0;
 // CHECK-NEXT:          a.setData_pullback(u, &_d_a, &_r0);
 // CHECK-NEXT:          *_d_u += _r0;
 // CHECK-NEXT:      }

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -354,42 +354,32 @@ int main() {
 // CHECK-NEXT:     std::vector<double> vec;
 // CHECK-NEXT:     std::vector<double> _d_vec = {};
 // CHECK-NEXT:     clad::zero_init(_d_vec);
-// CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
-// CHECK-NEXT:     std::vector<double> _t1 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, v, &_d_vec, *_d_v);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t0 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
 // CHECK-NEXT:         size_type _r0 = {{0U|0UL}};
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r0);
 // CHECK-NEXT:         size_type _r1 = {{0U|0UL}};
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r1);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         vec = _t1;
-// CHECK-NEXT:         {{.*}}class_functions::push_back_pullback(&vec, v, &_d_vec, &*_d_v);
-// CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         vec = _t0;
-// CHECK-NEXT:         {{.*}}class_functions::push_back_pullback(&vec, u, &_d_vec, &*_d_u);
-// CHECK-NEXT:     }
+// CHECK-NEXT:     {{.*}}class_functions::push_back_pullback(&vec, v, &_d_vec, &*_d_v);
+// CHECK-NEXT:     {{.*}}class_functions::push_back_pullback(&vec, u, &_d_vec, &*_d_u);
 // CHECK-NEXT: }
 
 // CHECK-NEXT: void fn2_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:     std::vector<double> vec;
 // CHECK-NEXT:     std::vector<double> _d_vec = {};
 // CHECK-NEXT:     clad::zero_init(_d_vec);
-// CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
-// CHECK-NEXT:     std::vector<double> _t1 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, v, &_d_vec, *_d_v);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     double &_d_ref = _t2.adjoint;
-// CHECK-NEXT:     double &ref = _t2.value;
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t0 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     double &_d_ref = _t0.adjoint;
+// CHECK-NEXT:     double &ref = _t0.value;
 // CHECK-NEXT:     ref += u;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
+// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r1);
@@ -404,14 +394,8 @@ int main() {
 // CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
 // CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 0., &_d_vec, &_r0);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         vec = _t1;
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::push_back_pullback(&vec, v, &_d_vec, &*_d_v);
-// CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         vec = _t0;
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::push_back_pullback(&vec, u, &_d_vec, &*_d_u);
-// CHECK-NEXT:     }
+// CHECK-NEXT:     clad::custom_derivatives::class_functions::push_back_pullback(&vec, v, &_d_vec, &*_d_v);
+// CHECK-NEXT:     clad::custom_derivatives::class_functions::push_back_pullback(&vec, u, &_d_vec, &*_d_u);
 // CHECK-NEXT: }
 
 // CHECK: void fn3_grad(double u, double v, double *_d_u, double *_d_v) {
@@ -585,67 +569,55 @@ int main() {
 // CHECK-NEXT:          std::vector<double> a;
 // CHECK-NEXT:          std::vector<double> _d_a = {};
 // CHECK-NEXT:          clad::zero_init(_d_a);
-// CHECK-NEXT:          std::vector<double> _t0 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, x, &_d_a, *_d_x);
-// CHECK-NEXT:          std::vector<double> _t1 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, x, &_d_a, *_d_x);
-// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
-// CHECK-NEXT:          double _t3 = _t2.value;
-// CHECK-NEXT:          _t2.value = x * x;
+// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t0 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
+// CHECK-NEXT:          double _t1 = _t0.value;
+// CHECK-NEXT:          _t0.value = x * x;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 1, 1, &_d_a, &_r1);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              _t2.value = _t3;
-// CHECK-NEXT:              double _r_d0 = _t2.adjoint;
-// CHECK-NEXT:              _t2.adjoint = 0.;
+// CHECK-NEXT:              _t0.value = _t1;
+// CHECK-NEXT:              double _r_d0 = _t0.adjoint;
+// CHECK-NEXT:              _t0.adjoint = 0.;
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
 // CHECK-NEXT:              {{.*}} _r0 = {{0U|0UL}};
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 1, 0., &_d_a, &_r0);
 // CHECK-NEXT:          }
-// CHECK-NEXT:          {
-// CHECK-NEXT:              a = _t1;
-// CHECK-NEXT:              {{.*}}push_back_pullback(&a, x, &_d_a, &*_d_x);
-// CHECK-NEXT:          }
-// CHECK-NEXT:          {
-// CHECK-NEXT:              a = _t0;
-// CHECK-NEXT:              {{.*}}push_back_pullback(&a, x, &_d_a, &*_d_x);
-// CHECK-NEXT:          }
+// CHECK-NEXT:          {{.*}}push_back_pullback(&a, x, &_d_a, &*_d_x);
+// CHECK-NEXT:          {{.*}}push_back_pullback(&a, x, &_d_a, &*_d_x);
 // CHECK-NEXT:      }
 
 // CHECK:          void fn6_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:        size_t _d_i = {{0U|0UL}};
 // CHECK-NEXT:        size_t i = {{0U|0UL}};
-// CHECK-NEXT:        clad::tape<clad::ValueAndAdjoint<double &, double &> > _t2 = {};
+// CHECK-NEXT:        clad::tape<clad::ValueAndAdjoint<double &, double &> > _t1 = {};
 // CHECK-NEXT:        std::array<double, 3> _d_a = {{.*}};
 // CHECK-NEXT:        std::array<double, 3> a;
-// CHECK-NEXT:        std::array<double, 3> _t0 = a;
 // CHECK-NEXT:        {{.*}}fill_reverse_forw(&a, x, &_d_a, *_d_x);
 // CHECK-NEXT:        double _d_res = 0.;
 // CHECK-NEXT:        double res = 0;
-// CHECK-NEXT:        unsigned {{long|int}} _t1 = {{0U|0UL}};
+// CHECK-NEXT:        unsigned {{long|int}} _t0 = {{0U|0UL}};
 // CHECK-NEXT:        for (i = 0; i < a.size(); ++i) {
-// CHECK-NEXT:            _t1++;
-// CHECK-NEXT:            clad::push(_t2, {{.*}}at_reverse_forw(&a, i, &_d_a, {{0U|0UL|0}}));
-// CHECK-NEXT:            res += clad::back(_t2).value;
+// CHECK-NEXT:            _t0++;
+// CHECK-NEXT:            clad::push(_t1, {{.*}}at_reverse_forw(&a, i, &_d_a, {{0U|0UL|0}}));
+// CHECK-NEXT:            res += clad::back(_t1).value;
 // CHECK-NEXT:        }
 // CHECK-NEXT:        _d_res += 1;
-// CHECK-NEXT:        for (; _t1; _t1--) {
+// CHECK-NEXT:        for (; _t0; _t0--) {
 // CHECK-NEXT:            --i;
 // CHECK-NEXT:            {
 // CHECK-NEXT:                double _r_d0 = _d_res;
 // CHECK-NEXT:                size_t _r0 = {{0U|0UL}};
 // CHECK-NEXT:                {{.*}}at_pullback(&a, i, _r_d0, &_d_a, &_r0);
 // CHECK-NEXT:                _d_i += _r0;
-// CHECK-NEXT:                clad::pop(_t2);
+// CHECK-NEXT:                clad::pop(_t1);
 // CHECK-NEXT:            }
 // CHECK-NEXT:        }
-// CHECK-NEXT:        {
-// CHECK-NEXT:            a = _t0;
-// CHECK-NEXT:            {{.*}}fill_pullback(&a, x, &_d_a, &*_d_x);
-// CHECK-NEXT:        }
+// CHECK-NEXT:        {{.*}}fill_pullback(&a, x, &_d_a, &*_d_x);
 // CHECK-NEXT: }
 
 // CHECK:     void fn7_grad(double x, double y, double *_d_x, double *_d_y) {
@@ -726,10 +698,9 @@ int main() {
 // CHECK:     void fn8_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:         std::array<double, 50> _d_a = {{.*}};
 // CHECK-NEXT:         std::array<double, 50> a;
-// CHECK-NEXT:         std::array<double, 50> _t0 = a;
 // CHECK-NEXT:         {{.*}}fill_reverse_forw(&a, y + x + x, &_d_a, 0.);
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 49, &_d_a, {{0U|0UL|0}});
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 3, &_d_a, {{0U|0UL|0}});
+// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t0 = {{.*}}operator_subscript_reverse_forw(&a, 49, &_d_a, {{0U|0UL|0}});
+// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 3, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}}size_type _r1 = {{0U|0UL}};
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 49, 1, &_d_a, &_r1);
@@ -738,7 +709,6 @@ int main() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r0 = 0.;
-// CHECK-NEXT:             a = _t0;
 // CHECK-NEXT:             {{.*}}fill_pullback(&a, y + x + x, &_d_a, &_r0);
 // CHECK-NEXT:             *_d_y += _r0;
 // CHECK-NEXT:             *_d_x += _r0;
@@ -769,34 +739,32 @@ int main() {
 // CHECK:      void fn10_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:          size_t _d_i = {{0U|0UL|0}};
 // CHECK-NEXT:          size_t i = {{0U|0UL|0}};
-// CHECK-NEXT:          {{.*}}tape<{{.*}}vector<double> > _t1 = {};
 // CHECK-NEXT:          size_t _d_i0 = {{0U|0UL|0}};
 // CHECK-NEXT:          size_t i0 = {{0U|0UL|0}};
-// CHECK-NEXT:          clad::tape<clad::ValueAndAdjoint<double &, double &> > _t3 = {};
+// CHECK-NEXT:          clad::tape<clad::ValueAndAdjoint<double &, double &> > _t2 = {};
 // CHECK-NEXT:          {{.*}}vector<double> v;
 // CHECK-NEXT:          {{.*}}vector<double> _d_v = {};
 // CHECK-NEXT:          clad::zero_init(_d_v);
 // CHECK-NEXT:          {{.*}} _t0 = {{0U|0UL|0}};
 // CHECK-NEXT:          for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:              _t0++;
-// CHECK-NEXT:              {{.*}}push(_t1, v);
 // CHECK-NEXT:              {{.*}}push_back_reverse_forw(&v, x, &_d_v, *_d_x);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          double _d_res = 0.;
 // CHECK-NEXT:          double res = 0;
-// CHECK-NEXT:          {{.*}} _t2 = {{0U|0UL|0}};
+// CHECK-NEXT:          {{.*}} _t1 = {{0U|0UL|0}};
 // CHECK-NEXT:          for (i0 = 0; i0 < v.size(); ++i0) {
-// CHECK-NEXT:              _t2++;
-// CHECK-NEXT:              clad::push(_t3, {{.*}}at_reverse_forw(&v, i0, &_d_v, {{0U|0UL|0}}));
-// CHECK-NEXT:              res += clad::back(_t3).value;
+// CHECK-NEXT:              _t1++;
+// CHECK-NEXT:              clad::push(_t2, {{.*}}at_reverse_forw(&v, i0, &_d_v, {{0U|0UL|0}}));
+// CHECK-NEXT:              res += clad::back(_t2).value;
 // CHECK-NEXT:          }
-// CHECK-NEXT:          {{.*}}vector<double> _t4 = v;
+// CHECK-NEXT:          {{.*}}vector<double> _t3 = v;
 // CHECK-NEXT:          v.assign(3, 0);
-// CHECK-NEXT:          {{.*}}vector<double> _t5 = v;
+// CHECK-NEXT:          {{.*}}vector<double> _t4 = v;
 // CHECK-NEXT:          v.assign(2, y);
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}operator_subscript_reverse_forw(&v, 0, &_d_v, {{0U|0UL|0}});
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t7 = {{.*}}operator_subscript_reverse_forw(&v, 1, &_d_v, {{0U|0UL|0}});
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t8 = {{.*}}operator_subscript_reverse_forw(&v, 2, &_d_v, {{0U|0UL|0}});
+// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}operator_subscript_reverse_forw(&v, 0, &_d_v, {{0U|0UL|0}});
+// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}operator_subscript_reverse_forw(&v, 1, &_d_v, {{0U|0UL|0}});
+// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t7 = {{.*}}operator_subscript_reverse_forw(&v, 2, &_d_v, {{0U|0UL|0}});
 // CHECK-NEXT:          {
 // CHECK-NEXT:              _d_res += 1;
 // CHECK-NEXT:              {{.*}}size_type _r4 = {{0U|0UL|0}};
@@ -808,31 +776,27 @@ int main() {
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r3 = {{0U|0UL|0}};
-// CHECK-NEXT:              v = _t5;
+// CHECK-NEXT:              v = _t4;
 // CHECK-NEXT:              {{.*}}assign_pullback(&v, 2, y, &_d_v, &_r3, &*_d_y);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r1 = {{0U|0UL|0}};
 // CHECK-NEXT:              {{.*}}value_type _r2 = 0.;
-// CHECK-NEXT:              v = _t4;
+// CHECK-NEXT:              v = _t3;
 // CHECK-NEXT:              {{.*}}assign_pullback(&v, 3, 0, &_d_v, &_r1, &_r2);
 // CHECK-NEXT:          }
-// CHECK-NEXT:          for (; _t2; _t2--) {
+// CHECK-NEXT:          for (; _t1; _t1--) {
 // CHECK-NEXT:              --i0;
 // CHECK-NEXT:              {
 // CHECK-NEXT:                  double _r_d0 = _d_res;
 // CHECK-NEXT:                  size_t _r0 = {{0U|0UL|0}};
 // CHECK-NEXT:                  {{.*}}at_pullback(&v, i0, _r_d0, &_d_v, &_r0);
 // CHECK-NEXT:                  _d_i0 += _r0;
-// CHECK-NEXT:                  {{.*}}pop(_t3);
+// CHECK-NEXT:                  {{.*}}pop(_t2);
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
 // CHECK-NEXT:          for (; _t0; _t0--) {
-// CHECK-NEXT:              {
-// CHECK-NEXT:                  v = {{.*}}back(_t1);
-// CHECK-NEXT:                  {{.*}}push_back_pullback(&v, x, &_d_v, &*_d_x);
-// CHECK-NEXT:                  {{.*}}pop(_t1);
-// CHECK-NEXT:              }
+// CHECK-NEXT:              {{.*}}push_back_pullback(&v, x, &_d_v, &*_d_x);
 // CHECK-NEXT:          }
 // CHECK-NEXT:      }
 
@@ -883,19 +847,18 @@ int main() {
 // CHECK-NEXT:          std::vector<double> a;
 // CHECK-NEXT:          std::vector<double> _d_a = {};
 // CHECK-NEXT:          clad::zero_init(_d_a);
-// CHECK-NEXT:          std::vector<double> _t0 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, 0{{.*}}, &_d_a, 0.);
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, {{0U|0UL|0}});
-// CHECK-NEXT:          double _t2 = _t1.value;
-// CHECK-NEXT:          _t1.value = x * x;
+// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t0 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, {{0U|0UL|0}});
+// CHECK-NEXT:          double _t1 = _t0.value;
+// CHECK-NEXT:          _t0.value = x * x;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r2 = 0{{.*}};
 // CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 0, 1, &_d_a, &_r2);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              _t1.value = _t2;
-// CHECK-NEXT:              double _r_d0 = _t1.adjoint;
-// CHECK-NEXT:              _t1.adjoint = 0{{.*}};
+// CHECK-NEXT:              _t0.value = _t1;
+// CHECK-NEXT:              double _r_d0 = _t0.adjoint;
+// CHECK-NEXT:              _t0.adjoint = 0{{.*}};
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
 // CHECK-NEXT:              {{.*}}size_type _r1 = 0{{.*}};
@@ -903,7 +866,6 @@ int main() {
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}value_type _r0 = 0.;
-// CHECK-NEXT:              a = _t0;
 // CHECK-NEXT:              {{.*}}push_back_pullback(&a, 0{{.*}}, &_d_a, &_r0);
 // CHECK-NEXT:          }
 // CHECK-NEXT:      }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -241,13 +241,12 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT: }
 
 // CHECK: void fn6_grad(dcomplex c, double i, dcomplex *_d_c, double *_d_i) {
-// CHECK-NEXT:     dcomplex _t0 = c;
 // CHECK-NEXT:     c.real(5 * i);
-// CHECK-NEXT:     double _t1 = c.imag();
+// CHECK-NEXT:     double _t0 = c.imag();
 // CHECK-NEXT:     double _d_res = 0.;
-// CHECK-NEXT:     double res = c.real() + 3 * _t1 + 6 * i;
-// CHECK-NEXT:     double _t2 = c.real();
-// CHECK-NEXT:     res += 4 * _t2;
+// CHECK-NEXT:     double res = c.real() + 3 * _t0 + 6 * i;
+// CHECK-NEXT:     double _t1 = c.real();
+// CHECK-NEXT:     res += 4 * _t1;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_res;
@@ -260,7 +259,6 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         c = _t0;
 // CHECK-NEXT:         c.real_pullback(5 * i, &(*_d_c), &_r0);
 // CHECK-NEXT:         *_d_i += 5 * _r0;
 // CHECK-NEXT:     }
@@ -273,16 +271,14 @@ double fn7(dcomplex c1, dcomplex c2) {
 
 // CHECK: void fn7_grad(dcomplex c1, dcomplex c2, dcomplex *_d_c1, dcomplex *_d_c2) {
 // CHECK-NEXT:     double _t0 = c2.real();
-// CHECK-NEXT:     dcomplex _t1 = c1;
 // CHECK-NEXT:     c1.real(c2.imag() + 5 * _t0);
-// CHECK-NEXT:     double _t2 = c1.imag();
+// CHECK-NEXT:     double _t1 = c1.imag();
 // CHECK-NEXT:     {
 // CHECK-NEXT:         c1.real_pullback(1, &(*_d_c1));
 // CHECK-NEXT:         c1.imag_pullback(3 * 1, &(*_d_c1));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         c1 = _t1;
 // CHECK-NEXT:         c1.real_pullback(c2.imag() + 5 * _t0, &(*_d_c1), &_r0);
 // CHECK-NEXT:         c2.imag_pullback(_r0, &(*_d_c2));
 // CHECK-NEXT:         c2.real_pullback(5 * _r0, &(*_d_c2));
@@ -314,16 +310,14 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK-NEXT: }
 
 // CHECK: void fn8_grad(Tangent t, dcomplex c, Tangent *_d_t, dcomplex *_d_c) {
-// CHECK-NEXT:     Tangent _t0 = t;
 // CHECK-NEXT:     t.updateTo(c.real());
-// CHECK-NEXT:     Tangent _t1 = t;
+// CHECK-NEXT:     Tangent _t0 = t;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         t = _t1;
+// CHECK-NEXT:         t = _t0;
 // CHECK-NEXT:         sum_pullback(t, 1, &(*_d_t));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         t = _t0;
 // CHECK-NEXT:         t.updateTo_pullback(c.real(), &(*_d_t), &_r0);
 // CHECK-NEXT:         c.real_pullback(_r0, &(*_d_c));
 // CHECK-NEXT:     }
@@ -451,11 +445,9 @@ MyStruct fn12(MyStruct s) {  // expected-warning {{clad::gradient only supports 
 // CHECK-NEXT:}
 
 // CHECK: void fn12_grad(MyStruct s, MyStruct *_d_s) {
-// CHECK-NEXT:     MyStruct _t0 = s;
 // CHECK-NEXT:     s.operator_equal_reverse_forw({2 * s.a, 2 * s.b + 2}, &(*_d_s), {0., 0.});
 // CHECK-NEXT:    {
 // CHECK-NEXT:        MyStruct _r0 = {0., 0.};
-// CHECK-NEXT:        s = _t0;
 // CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, {0., 0.}, &(*_d_s), &_r0);
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;
@@ -739,11 +731,9 @@ void fn20(MyStruct s) {
 }
 
 // CHECK: void fn20_grad(MyStruct s, MyStruct *_d_s) {
-// CHECK-NEXT:     MyStruct _t0 = s;
 // CHECK-NEXT:     s.operator_equal_reverse_forw({2 * s.a, 2 * s.b + 2}, &(*_d_s), {0., 0.});
 // CHECK-NEXT:    {
 // CHECK-NEXT:        MyStruct _r0 = {0., 0.};
-// CHECK-NEXT:        s = _t0;
 // CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, {0., 0.}, &(*_d_s), &_r0);
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -277,7 +277,8 @@ void InitTimers();
       if (request.RequestTBR && request->isDefined() && request.m_AnalysisDC) {
         TimedAnalysisRegion R("TBR " + request.BaseFunctionName);
         TBRAnalyzer analyzer(request.m_AnalysisDC, request.getToBeRecorded(),
-                             &m_ModifiedParams);
+                             &m_TBRAnalysisInfo.m_ModifiedParams,
+                             &m_TBRAnalysisInfo.m_LinearFunctions);
         analyzer.Analyze(request);
         if (request.Mode == DiffMode::unknown)
           return nullptr;

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -104,8 +104,13 @@ struct DifferentiationOptions {
     DerivedFnCollector m_DFC;
     DynamicGraph<DiffRequest> m_DiffRequestGraph;
     OwnedAnalysisContexts m_AllAnalysisDC;
-    std::map<const clang::FunctionDecl*, std::set<const clang::Decl*>>
-        m_ModifiedParams;
+    struct TBRAnalysisInfo {
+      std::map<const clang::FunctionDecl*, std::set<const clang::Decl*>>
+          m_ModifiedParams;
+      std::map<const clang::FunctionDecl*, std::set<const clang::Decl*>>
+          m_LinearFunctions;
+    } m_TBRAnalysisInfo;
+
     enum class CallKind {
       HandleCXXStaticMemberVarInstantiation,
       HandleTopLevelDecl,


### PR DESCRIPTION
After #1490, TBR can detect which parameters have been modified. This PR extends the analysis of the same class of functions to also track whether the function uses the given parameter value, which allows for more optimization in TBR. In particular, now we can avoid storing some arguments even if they are modified. Previously, we assumed that every parameter value was used, which is not true, for example, for most STL methods, e.g., ``push_back``, ``fill``, etc.

During the work on this PR, there occured a bug, the reason for which was that return stmts were not properly visited in TBR. Fixing that caused regressions in some tests, and the goal of the second commit is to deal with those regressions.
The core idea there is that we don't have to store operands if a whole expr is already stored. In particular, we often store LHS/RHS of multiplication/division.