### PR TITLE
Improve consistency using high-level interfaces.

### DIFF
--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -236,14 +236,8 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
     CXXScopeSpec CSS;
     utils::BuildNNS(SemaRef, replacementFD->getDeclContext(), CSS,
                     /*addGlobalNS=*/true);
-    // Expr* Arg = SemaRef.BuildDeclRefExpr(replacementFD,
-    // replacementFD->getType(),
-    //                                             VK, noLoc, &CSS);
-    Expr* Arg = DeclRefExpr::Create(
-        C, CSS.getWithLocInContext(C), noLoc, replacementFD,
-        /*RefersToEnclosingVariableOrCapture=*/false,
-        replacementFD->getNameInfo(), replacementFD->getType(), VK);
-
+    Expr* Arg = SemaRef.BuildDeclRefExpr(
+        replacementFD, replacementFD->getType(), VK, noLoc, &CSS);
     // Add the "&" operator
     Arg = SemaRef
               .BuildUnaryOp(/*Scope=*/nullptr, noLoc,

--- a/test/ForwardMode/ConstevalTest.C
+++ b/test/ForwardMode/ConstevalTest.C
@@ -1,6 +1,6 @@
 // RUN: %cladclang %s -I%S/../../include -std=c++23 -oConstevalTest.out | %filecheck %s
 // RUN: ./ConstevalTest.out | %filecheck_exec %s
-// UNSUPPORTED: clang-8, clang-9, clang-10, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16
+// UNSUPPORTED: clang-10, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16
 
 #include "clad/Differentiator/Differentiator.h"
 

--- a/test/ForwardMode/ConstexprTest.C
+++ b/test/ForwardMode/ConstexprTest.C
@@ -1,6 +1,6 @@
 // RUN: %cladclang %s -I%S/../../include -std=c++23 -oConstexprTest.out | %filecheck %s
 // RUN: ./ConstexprTest.out | %filecheck_exec %s
-// UNSUPPORTED: clang-8, clang-9, clang-10, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16
+// UNSUPPORTED: clang-10, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16
 
 #include "clad/Differentiator/Differentiator.h"
 


### PR DESCRIPTION
This patch adds a call to Sema::BuildDeclRefExpr which in turn marks expressions as referenced. Then we need to push new constant evaluation context because clang was able to find that inconsistency. The new context is pushed by Sema::ActOnFinishFunctionBody but we cannot call its friend ActOnFinishFunctionBody because it uncovers another inconsistency with the way we generate goto statements.

Overall this patch makes consteval function treated as they should be as far as clang's internal data structures are concerned.