### PR TITLE
Refactor nested TBR

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -38,6 +38,8 @@ class Type;
 namespace clad {
 using OwnedAnalysisContexts =
     llvm::SmallVector<std::unique_ptr<clang::AnalysisDeclContext>, 4>;
+using ParamSet = std::set<const clang::ParmVarDecl*>;
+using ParamInfo = std::map<const clang::FunctionDecl*, ParamSet>;
 /// A struct containing information about request to differentiate a function.
 struct DiffRequest {
 private:
@@ -46,8 +48,7 @@ private:
   /// be stored before being changed or not.
   mutable struct TbrRunInfo {
     std::set<clang::SourceLocation> ToBeRecorded;
-    std::map<const clang::FunctionDecl*, std::set<const clang::Decl*>>
-        m_ModifiedParams;
+    ParamInfo m_ModifiedParams;
     bool HasAnalysisRun = false;
   } m_TbrRunInfo;
 
@@ -194,12 +195,9 @@ public:
     m_TbrRunInfo.HasAnalysisRun = true;
     return m_TbrRunInfo.ToBeRecorded;
   }
-  std::map<const clang::FunctionDecl*, std::set<const clang::Decl*>>&
-  getModifiedParams() const {
-    return m_TbrRunInfo.m_ModifiedParams;
-  }
+  ParamInfo& getModifiedParams() const { return m_TbrRunInfo.m_ModifiedParams; }
   void addFunctionModifiedParams(const clang::FunctionDecl* FD,
-                                 const std::set<const clang::Decl*>& params) {
+                                 const ParamSet& params) {
     m_TbrRunInfo.m_ModifiedParams[FD] = params;
   }
   void addVariedDecl(const clang::VarDecl* init) {

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1300,7 +1300,7 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
 
       if (requestTBR) {
         TimedAnalysisRegion R("TBR " + request.BaseFunctionName);
-        auto& modifiedParams = request.getModifiedParams();
+        ParamInfo& modifiedParams = request.getModifiedParams();
         TBRAnalyzer analyzer(request.m_AnalysisDC, request.getToBeRecorded(),
                              &modifiedParams);
         analyzer.Analyze(request);

--- a/lib/Differentiator/TBRAnalyzer.cpp
+++ b/lib/Differentiator/TBRAnalyzer.cpp
@@ -64,7 +64,7 @@ void TBRAnalyzer::setIsRequired(const clang::Expr* E, bool isReq) {
   auto& curBranch = getCurBlockVarsData();
   for (const VarDecl* iterVD : vars) {
     if (m_ModifiedParams && !isReq && (!iterVD || isa<ParmVarDecl>(iterVD)))
-      (*m_ModifiedParams)[m_Function].insert(iterVD);
+      (*m_ModifiedParams)[m_Function].insert(cast_or_null<ParmVarDecl>(iterVD));
     if (isReq || sequenceFound) {
       if (curBranch.find(iterVD) == curBranch.end()) {
         if (VarData* data = getVarDataFromDecl(iterVD))
@@ -367,9 +367,11 @@ bool TBRAnalyzer::TraverseUnaryOperator(clang::UnaryOperator* UnOp) {
     if (m_ModifiedParams) {
       std::set<const clang::VarDecl*> vars;
       getDependencySet(E, vars);
-      for (const VarDecl* VD : vars)
-        if (!VD || isa<ParmVarDecl>(VD))
-          (*m_ModifiedParams)[m_Function].insert(VD);
+      for (const VarDecl* VD : vars) {
+        const auto* PVD = dyn_cast_or_null<ParmVarDecl>(VD);
+        if (!VD || PVD)
+          (*m_ModifiedParams)[m_Function].insert(PVD);
+      }
     }
   }
   // FIXME: Ideally, `__real` and `__imag` operators should be treated as member

--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -39,8 +39,7 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer>,
   /// Tells if the variable at a given location is required to store. Basically,
   /// is the result of analysis.
   std::set<clang::SourceLocation>& m_TBRLocs;
-  std::map<const clang::FunctionDecl*, std::set<const clang::Decl*>>*
-      m_ModifiedParams;
+  ParamInfo* m_ModifiedParams;
 
   /// Stores modes in a stack (used to retrieve the old mode after entering
   /// a new one).
@@ -79,8 +78,7 @@ public:
   /// Constructor
   TBRAnalyzer(clang::AnalysisDeclContext* AnalysisDC,
               std::set<clang::SourceLocation>& Locs,
-              std::map<const clang::FunctionDecl*,
-                       std::set<const clang::Decl*>>* ModifiedParams = nullptr)
+              ParamInfo* ModifiedParams = nullptr)
       : AnalysisBase(AnalysisDC), m_TBRLocs(Locs),
         m_ModifiedParams(ModifiedParams) {
     m_ModeStack.push_back(0);

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -274,14 +274,6 @@ void InitTimers();
       if (m_DO.PrintNumDiffErrorInfo) {
         m_DerivativeBuilder->setNumDiffErrDiag(true);
       }
-      if (request.RequestTBR && request->isDefined() && request.m_AnalysisDC) {
-        TimedAnalysisRegion R("TBR " + request.BaseFunctionName);
-        TBRAnalyzer analyzer(request.m_AnalysisDC, request.getToBeRecorded(),
-                             &m_ModifiedParams);
-        analyzer.Analyze(request);
-        if (request.Mode == DiffMode::unknown)
-          return nullptr;
-      }
 
       FunctionDecl* DerivativeDecl = nullptr;
       bool alreadyDerived = false;

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -104,8 +104,6 @@ struct DifferentiationOptions {
     DerivedFnCollector m_DFC;
     DynamicGraph<DiffRequest> m_DiffRequestGraph;
     OwnedAnalysisContexts m_AllAnalysisDC;
-    std::map<const clang::FunctionDecl*, std::set<const clang::Decl*>>
-        m_ModifiedParams;
     enum class CallKind {
       HandleCXXStaticMemberVarInstantiation,
       HandleTopLevelDecl,


### PR DESCRIPTION
After #1490, there have been concerns about how nested TBR was implemented. This PR moves the information about modified parameters from the ``ClangPlugin`` to ``DiffRequest`` (each one only has the necessary information), removes the state variable ``m_TBROnly`` in the ``DiffPlanner``, and removes the field ``RequestTBR`` from ``DiffRequest``.

Fixes #1497.