### PR TITLE
Simplify assignments with independent RHS/LHS

### DIFF
--- a/demos/ErrorEstimation/CustomModel/README.md
+++ b/demos/ErrorEstimation/CustomModel/README.md
@@ -52,10 +52,9 @@ The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double &
     {
         _final_error += _d_z * z;
         z = _t0;
-        float _r_d0 = _d_z;
+        *_d_x += _d_z;
+        *_d_y += _d_z;
         _d_z = 0;
-        *_d_x += _r_d0;
-        *_d_y += _r_d0;
     }
     _final_error += *_d_x * x;
     _final_error += *_d_y * y;

--- a/demos/ErrorEstimation/PrintModel/README.md
+++ b/demos/ErrorEstimation/PrintModel/README.md
@@ -51,10 +51,9 @@ The code is: void func_grad(float x, float y, float *_d_x, float *_d_y, double &
     {
         _final_error += _d_z * z;
         z = _t0;
-        float _r_d0 = _d_z;
+        *_d_x += _d_z;
+        *_d_y += _d_z;
         _d_z = 0;
-        *_d_x += _r_d0;
-        *_d_y += _r_d0;
     }
     _final_error += *_d_x * x;
     _final_error += *_d_y * y;

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -396,6 +396,8 @@ namespace clad {
 
     bool isCopyable(const clang::CXXRecordDecl* RD);
 
+    bool exprDependsOnVarDecl(const clang::Expr* E, const clang::VarDecl* VD);
+
     bool isLinearConstructor(const clang::CXXConstructorDecl* CD,
                              const clang::ASTContext& C);
 

--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -70,14 +70,12 @@ double f2(double x){
 //CHECK-NEXT:     _d_a += 1;
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         b = _t0;
-//CHECK-NEXT:         double _r_d0 = _d_b;
+//CHECK-NEXT:         *_d_x += _d_b;
 //CHECK-NEXT:         _d_b = 0.;
-//CHECK-NEXT:         *_d_x += _r_d0;
 //CHECK-NEXT:     } else if (!_cond1) {
 //CHECK-NEXT:         g = _t1;
-//CHECK-NEXT:         double _r_d1 = _d_g;
+//CHECK-NEXT:         _d_a += _d_g;
 //CHECK-NEXT:         _d_g = 0.;
-//CHECK-NEXT:         _d_a += _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += _d_a * x;
@@ -126,33 +124,28 @@ double f3(double x){
 //CHECK-NEXT:         {
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 x1 = clad::pop(_t5);
-//CHECK-NEXT:                 double _r_d4 = _d_x1;
+//CHECK-NEXT:                 *_d_x += _d_x1;
 //CHECK-NEXT:                 _d_x1 = 0.;
-//CHECK-NEXT:                 *_d_x += _r_d4;
 //CHECK-NEXT:             }
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 x2 = clad::pop(_t4);
-//CHECK-NEXT:                 double _r_d3 = _d_x2;
+//CHECK-NEXT:                 _d_x1 += _d_x2;
 //CHECK-NEXT:                 _d_x2 = 0.;
-//CHECK-NEXT:                 _d_x1 += _r_d3;
 //CHECK-NEXT:             }
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 x3 = clad::pop(_t3);
-//CHECK-NEXT:                 double _r_d2 = _d_x3;
+//CHECK-NEXT:                 _d_x2 += _d_x3;
 //CHECK-NEXT:                 _d_x3 = 0.;
-//CHECK-NEXT:                 _d_x2 += _r_d2;
 //CHECK-NEXT:             }
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 x4 = clad::pop(_t2);
-//CHECK-NEXT:                 double _r_d1 = _d_x4;
+//CHECK-NEXT:                 _d_x3 += _d_x4;
 //CHECK-NEXT:                 _d_x4 = 0.;
-//CHECK-NEXT:                 _d_x3 += _r_d1;
 //CHECK-NEXT:             }
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 x5 = clad::pop(_t1);
-//CHECK-NEXT:                 double _r_d0 = _d_x5;
+//CHECK-NEXT:                 _d_x4 += _d_x5;
 //CHECK-NEXT:                 _d_x5 = 0.;
-//CHECK-NEXT:                 _d_x4 += _r_d0;
 //CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:         _t0--;

--- a/test/Analyses/TBR.cpp
+++ b/test/Analyses/TBR.cpp
@@ -71,9 +71,8 @@ double f2(double val) {
 //CHECK-NEXT:           case {{2U|2UL}}:
 //CHECK-NEXT:             ;
 //CHECK-NEXT:             {
-//CHECK-NEXT:                 double _r_d0 = _d_res;
-//CHECK-NEXT:                 _d_i += _r_d0 * val;
-//CHECK-NEXT:                 *_d_val += i * _r_d0;
+//CHECK-NEXT:                 _d_i += _d_res * val;
+//CHECK-NEXT:                 *_d_val += i * _d_res;
 //CHECK-NEXT:             }
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 if (clad::back(_cond0))
@@ -128,15 +127,13 @@ double f3(double x){
 //CHECK-NEXT:     _d_res += 1;
 //CHECK-NEXT:     if (!_cond0)
 //CHECK-NEXT:         if (_cond1) {
-//CHECK-NEXT:             double _r_d1 = _d_res;
-//CHECK-NEXT:             _d_i += _r_d1 * x;
-//CHECK-NEXT:             *_d_x += i * _r_d1;
+//CHECK-NEXT:             _d_i += _d_res * x;
+//CHECK-NEXT:             *_d_x += i * _d_res;
 //CHECK-NEXT:         } else if (_cond2)
 //CHECK-NEXT:             i--;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r_d0 = _d_res;
-//CHECK-NEXT:         _d_i += _r_d0 * x;
-//CHECK-NEXT:         *_d_x += i * _r_d0;
+//CHECK-NEXT:         _d_i += _d_res * x;
+//CHECK-NEXT:         *_d_x += i * _d_res;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -201,14 +198,13 @@ double f5(double x, double y) {
 //CHECK-NEXT:     ref -= y;
 //CHECK-NEXT:     _d_ref += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r_d1 = _d_ref;
-//CHECK-NEXT:         *_d_y += -_r_d1;
+//CHECK-NEXT:         double _r_d0 = _d_ref;
+//CHECK-NEXT:         *_d_y += -_r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
-//CHECK-NEXT:         double _r_d0 = *_d_x;
+//CHECK-NEXT:         _d_z += *_d_x;
 //CHECK-NEXT:         *_d_x = 0.;
-//CHECK-NEXT:         _d_z += _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_y += _d_z * ref;

--- a/test/CUDA/GradientKernels.cu
+++ b/test/CUDA/GradientKernels.cu
@@ -124,20 +124,17 @@ __global__ void add_kernel_4(int *out, int *in, int N) {
 // CHECK-NEXT:     if (_cond0) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             out[index0] = _t3;
-// CHECK-NEXT:             int _r_d2 = _d_out[index0];
+// CHECK-NEXT:             int _r_d1 = _d_out[index0];
 // CHECK-NEXT:             _d_out[index0] = 0;
-// CHECK-NEXT:             _d_sum += _r_d2;
+// CHECK-NEXT:             _d_sum += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             for (; _t0; _t0--) {
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     i = clad::pop(_t1);
-// CHECK-NEXT:                     int _r_d0 = _d_i;
-// CHECK-NEXT:                 }
+// CHECK-NEXT:                 i = clad::pop(_t1);
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     sum = clad::pop(_t2);
-// CHECK-NEXT:                     int _r_d1 = _d_sum;
-// CHECK-NEXT:                     atomicAdd(&_d_in[i], _r_d1);
+// CHECK-NEXT:                     int _r_d0 = _d_sum;
+// CHECK-NEXT:                     atomicAdd(&_d_in[i], _r_d0);
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _d_index += _d_i;
@@ -192,21 +189,20 @@ __global__ void add_kernel_5(int *out, int *in, int N) {
 // CHECK-NEXT:     if (_cond0) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             out[index0] = _t3;
-// CHECK-NEXT:             int _r_d2 = _d_out[index0];
+// CHECK-NEXT:             int _r_d1 = _d_out[index0];
 // CHECK-NEXT:             _d_out[index0] = 0;
-// CHECK-NEXT:             _d_sum += _r_d2;
+// CHECK-NEXT:             _d_sum += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             for (; _t0; _t0--) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     i = clad::pop(_t1);
-// CHECK-NEXT:                     int _r_d0 = _d_i;
-// CHECK-NEXT:                     _d_totalThreads += _r_d0;
+// CHECK-NEXT:                     _d_totalThreads += _d_i;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     sum = clad::pop(_t2);
-// CHECK-NEXT:                     int _r_d1 = _d_sum;
-// CHECK-NEXT:                     atomicAdd(&_d_in[i], _r_d1);
+// CHECK-NEXT:                     int _r_d0 = _d_sum;
+// CHECK-NEXT:                     atomicAdd(&_d_in[i], _r_d0);
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _d_index += _d_i;
@@ -585,20 +581,17 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
 // CHECK-NEXT:     if (_cond0) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             out[index0] = _t3;
-// CHECK-NEXT:             int _r_d2 = _d_out[index0];
+// CHECK-NEXT:             int _r_d1 = _d_out[index0];
 // CHECK-NEXT:             _d_out[index0] = 0;
-// CHECK-NEXT:             _d_sum += _r_d2;
+// CHECK-NEXT:             _d_sum += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             for (; _t0; _t0--) {
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     i = clad::pop(_t1);
-// CHECK-NEXT:                     int _r_d0 = _d_i;
-// CHECK-NEXT:                 }
+// CHECK-NEXT:                 i = clad::pop(_t1);
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     sum = clad::pop(_t2);
-// CHECK-NEXT:                     int _r_d1 = _d_sum;
-// CHECK-NEXT:                     atomicAdd(&_d_in[i], _r_d1);
+// CHECK-NEXT:                     int _r_d0 = _d_sum;
+// CHECK-NEXT:                     atomicAdd(&_d_in[i], _r_d0);
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _d_index += _d_i;
@@ -839,22 +832,20 @@ __global__ void injective_reassignment(int *a) {
 // CHECK-NEXT:     a[1] += a[index1];
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a[1] = _t3;
-// CHECK-NEXT:         int _r_d3 = _d_a[1];
-// CHECK-NEXT:         atomicAdd(&_d_a[index1], _r_d3);
+// CHECK-NEXT:         int _r_d1 = _d_a[1];
+// CHECK-NEXT:         atomicAdd(&_d_a[index1], _r_d1);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     if (_cond0) {
 // CHECK-NEXT:         index2 = _t2;
-// CHECK-NEXT:         int _r_d2 = _d_index2;
 // CHECK-NEXT:         _d_index2 = 0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a[1] = _t1;
-// CHECK-NEXT:         int _r_d1 = _d_a[1];
-// CHECK-NEXT:         atomicAdd(&_d_a[index1], _r_d1);
+// CHECK-NEXT:         int _r_d0 = _d_a[1];
+// CHECK-NEXT:         atomicAdd(&_d_a[index1], _r_d0);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         index1 = _t0;
-// CHECK-NEXT:         int _r_d0 = _d_index1;
 // CHECK-NEXT:         _d_index1 = 0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -19,9 +19,8 @@ float func(float x, float y) {
 //CHECK-NEXT:     *_d_y += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t1;
-//CHECK-NEXT:         float _r_d1 = *_d_y;
+//CHECK-NEXT:         *_d_x += *_d_y;
 //CHECK-NEXT:         *_d_y = 0.F;
-//CHECK-NEXT:         *_d_x += _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
@@ -68,9 +67,8 @@ float func3(int x, int y) {
 //CHECK-NEXT:     *_d_y += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
-//CHECK-NEXT:         int _r_d0 = *_d_x;
+//CHECK-NEXT:         *_d_y += *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
-//CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -89,10 +87,9 @@ float func4(float x, float y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
-//CHECK-NEXT:         float _r_d0 = *_d_x;
+//CHECK-NEXT:         _d_z += *_d_x;
+//CHECK-NEXT:         *_d_y += *_d_x;
 //CHECK-NEXT:         *_d_x = 0.F;
-//CHECK-NEXT:         _d_z += _r_d0;
-//CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     *_d_y += _d_z;
 //CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
@@ -114,10 +111,9 @@ float func5(float x, float y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
-//CHECK-NEXT:         float _r_d0 = *_d_x;
+//CHECK-NEXT:         _d_z += *_d_x;
+//CHECK-NEXT:         *_d_y += *_d_x;
 //CHECK-NEXT:         *_d_x = 0.F;
-//CHECK-NEXT:         _d_z += _r_d0;
-//CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
@@ -155,10 +151,9 @@ float func8(int x, int y) {
 //CHECK-NEXT:     *_d_x += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         x = _t0;
-//CHECK-NEXT:         int _r_d0 = *_d_x;
+//CHECK-NEXT:         *_d_y += *_d_x * y;
+//CHECK-NEXT:         *_d_y += y * *_d_x;
 //CHECK-NEXT:         *_d_x = 0;
-//CHECK-NEXT:         *_d_y += _r_d0 * y;
-//CHECK-NEXT:         *_d_y += y * _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -108,10 +108,9 @@ float func3(float x, float y) {
 //CHECK-NEXT:         _d_z += x * _d_t * _t1;
 //CHECK-NEXT:         *_d_y += x * z * _d_t;
 //CHECK-NEXT:         y = _t2;
-//CHECK-NEXT:         float _r_d1 = *_d_y;
+//CHECK-NEXT:         *_d_x += *_d_y;
+//CHECK-NEXT:         *_d_x += *_d_y;
 //CHECK-NEXT:         *_d_y = 0.F;
-//CHECK-NEXT:         *_d_x += _r_d1;
-//CHECK-NEXT:         *_d_x += _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     *_d_y += _d_z;
 //CHECK-NEXT:     {
@@ -164,11 +163,10 @@ float func5(float x, float y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT:         y = _t0;
-//CHECK-NEXT:         float _r_d0 = *_d_y;
-//CHECK-NEXT:         *_d_y = 0.F;
 //CHECK-NEXT:         float _r0 = 0.F;
-//CHECK-NEXT:         _r0 += _r_d0 * clad::custom_derivatives::std::sin_pushforward(x, 1.F).pushforward;
+//CHECK-NEXT:         _r0 += *_d_y * clad::custom_derivatives::std::sin_pushforward(x, 1.F).pushforward;
 //CHECK-NEXT:         *_d_x += _r0;
+//CHECK-NEXT:         *_d_y = 0.F;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
@@ -262,12 +260,11 @@ float func8(float x, float y) {
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         z = _t0;
-//CHECK-NEXT:         float _r_d0 = _d_z;
-//CHECK-NEXT:         _d_z = 0.F;
-//CHECK-NEXT:         *_d_y += _r_d0;
+//CHECK-NEXT:         *_d_y += _d_z;
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _t2 = 0.;
-//CHECK-NEXT:         helper2_pullback(x, _r_d0, &*_d_x, _t2);
+//CHECK-NEXT:         helper2_pullback(x, _d_z, &*_d_x, _t2);
+//CHECK-NEXT:         _d_z = 0.F;
 //CHECK-NEXT:         _final_error += _t2;
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:     }
@@ -294,13 +291,12 @@ float func9(float x, float y) {
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         z = _t3;
-//CHECK-NEXT:         float _r_d0 = _d_z;
 //CHECK-NEXT:         x = _t5;
 //CHECK-NEXT:         double _t6 = 0.;
-//CHECK-NEXT:         helper2_pullback(x, _r_d0 * _t4, &*_d_x, _t6);
+//CHECK-NEXT:         helper2_pullback(x, _d_z * _t4, &*_d_x, _t6);
 //CHECK-NEXT:         y = _t8;
 //CHECK-NEXT:         double _t9 = 0.;
-//CHECK-NEXT:         helper2_pullback(y, _t7 * _r_d0, &*_d_y, _t9);
+//CHECK-NEXT:         helper2_pullback(y, _t7 * _d_z, &*_d_y, _t9);
 //CHECK-NEXT:         _final_error += _t6 + _t9;
 //CHECK-NEXT:         _final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -54,17 +54,15 @@ float func(float x, float y) {
 //CHECK-NEXT:     } else {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             x = _t2;
-//CHECK-NEXT:             float _r_d2 = *_d_x;
+//CHECK-NEXT:             *_d_y += *_d_x;
 //CHECK-NEXT:             *_d_x = 0.F;
-//CHECK-NEXT:             *_d_y += _r_d2;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_temp * temp * {{.+}});
 //CHECK-NEXT:             temp = _t1;
-//CHECK-NEXT:             float _r_d1 = _d_temp;
+//CHECK-NEXT:             *_d_y += _d_temp * y;
+//CHECK-NEXT:             *_d_y += y * _d_temp;
 //CHECK-NEXT:             _d_temp = 0.F;
-//CHECK-NEXT:             *_d_y += _r_d1 * y;
-//CHECK-NEXT:             *_d_y += y * _r_d1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_temp * temp * {{.+}});
@@ -163,14 +161,13 @@ float func4(float x, float y) {
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t0;
-//CHECK-NEXT:         float _r_d0 = *_d_x;
 //CHECK-NEXT:     } else {
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:         x = _t1;
-//CHECK-NEXT:         float _r_d1 = *_d_x;
+//CHECK-NEXT:         float _r_d0 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0.F;
-//CHECK-NEXT:         *_d_x += _r_d1 * x;
-//CHECK-NEXT:         *_d_x += x * _r_d1;
+//CHECK-NEXT:         *_d_x += _r_d0 * x;
+//CHECK-NEXT:         *_d_x += x * _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -75,10 +75,9 @@ float func2(float x) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_z * z * {{.+}});
 //CHECK-NEXT:             z = clad::pop(_t2);
-//CHECK-NEXT:             float _r_d0 = _d_z;
+//CHECK-NEXT:             _d_m += _d_z;
+//CHECK-NEXT:             _d_m += _d_z;
 //CHECK-NEXT:             _d_z = 0.F;
-//CHECK-NEXT:             _d_m += _r_d0;
-//CHECK-NEXT:             _d_m += _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_m * m * {{.+}});
@@ -320,10 +319,9 @@ double func6(double x) {
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         sum = clad::pop(_t1);
-//CHECK-NEXT:         double _r_d0 = _d_sum;
 //CHECK-NEXT:         double _r0 = 0.;
 //CHECK-NEXT:         double _t2 = 0.;
-//CHECK-NEXT:         fun_pullback(x, _r_d0, &_r0, _t2);
+//CHECK-NEXT:         fun_pullback(x, _d_sum, &_r0, _t2);
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:         _final_error += _t2;
 //CHECK-NEXT:     }

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -16,9 +16,8 @@ double f1(double x, double y) {
 //CHECK-NEXT:       x = y;
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d0 = *_d_x;
+//CHECK-NEXT:           *_d_y += *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
-//CHECK-NEXT:           *_d_y += _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -38,9 +37,8 @@ double f2(double x, double y) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:       *_d_x += 1;
 //CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:           double _r_d0 = *_d_x;
+//CHECK-NEXT:           *_d_y += *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
-//CHECK-NEXT:           *_d_y += _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -63,15 +61,13 @@ double f3(double x, double y) {
 //CHECK-NEXT:       *_d_y += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t1;
-//CHECK-NEXT:           double _r_d3 = *_d_x;
+//CHECK-NEXT:           *_d_y += *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
-//CHECK-NEXT:           *_d_y += _r_d3;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d2 = *_d_y;
+//CHECK-NEXT:           *_d_x += *_d_y * x;
+//CHECK-NEXT:           *_d_x += x * *_d_y;
 //CHECK-NEXT:           *_d_y = 0.;
-//CHECK-NEXT:           *_d_x += _r_d2 * x;
-//CHECK-NEXT:           *_d_x += x * _r_d2;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t0;
@@ -98,14 +94,10 @@ double f4(double x, double y) {
 //CHECK-NEXT:       y = x;
 //CHECK-NEXT:       x = 0;
 //CHECK-NEXT:       *_d_y += 1;
+//CHECK-NEXT:       *_d_x = 0.;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d1 = *_d_x;
-//CHECK-NEXT:           *_d_x = 0.;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d0 = *_d_y;
+//CHECK-NEXT:           *_d_x += *_d_y;
 //CHECK-NEXT:           *_d_y = 0.;
-//CHECK-NEXT:           *_d_x += _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -262,38 +254,37 @@ double f7(double x, double y) {
 //CHECK-NEXT:       x = ++t[0];
 //CHECK-NEXT:       _d_t[0] += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d6 = *_d_x;
+//CHECK-NEXT:           double _r_d5 = *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
-//CHECK-NEXT:           _d_t[0] += _r_d6;
+//CHECK-NEXT:           _d_t[0] += _r_d5;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d5 = _d_t[0];
-//CHECK-NEXT:           _d_t[1] += -_r_d5;
+//CHECK-NEXT:           double _r_d4 = _d_t[0];
+//CHECK-NEXT:           _d_t[1] += -_r_d4;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[0] = _t2;
-//CHECK-NEXT:           double _r_d4 = _d_t[0];
+//CHECK-NEXT:           double _r_d3 = _d_t[0];
 //CHECK-NEXT:           _d_t[0] = 0.;
-//CHECK-NEXT:           _d_t[0] += _r_d4 / t[1];
-//CHECK-NEXT:           double _r0 = _r_d4 * -t[0] / (t[1] * t[1]);
+//CHECK-NEXT:           _d_t[0] += _r_d3 / t[1];
+//CHECK-NEXT:           double _r0 = _r_d3 * -t[0] / (t[1] * t[1]);
 //CHECK-NEXT:           _d_t[1] += _r0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t[0] = _t1;
-//CHECK-NEXT:           double _r_d3 = _d_t[0];
+//CHECK-NEXT:           double _r_d2 = _d_t[0];
 //CHECK-NEXT:           _d_t[0] = 0.;
-//CHECK-NEXT:           _d_t[0] += _r_d3 * t[1];
-//CHECK-NEXT:           _d_t[1] += t[0] * _r_d3;
+//CHECK-NEXT:           _d_t[0] += _r_d2 * t[1];
+//CHECK-NEXT:           _d_t[1] += t[0] * _r_d2;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d2 = _d_t[0];
-//CHECK-NEXT:           _d_t[1] += _r_d2;
+//CHECK-NEXT:           double _r_d1 = _d_t[0];
+//CHECK-NEXT:           _d_t[1] += _r_d1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           x = _t0;
-//CHECK-NEXT:           double _r_d1 = *_d_x;
+//CHECK-NEXT:           *_d_y += *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
-//CHECK-NEXT:           *_d_y += _r_d1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       {
 //CHECK-NEXT:           double _r_d0 = _d_t[0];
@@ -388,12 +379,10 @@ double f10(double x, double y) {
 //CHECK-NEXT:       t = x = y;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           double _r_d0 = _d_t;
-//CHECK-NEXT:           _d_t = 0.;
-//CHECK-NEXT:           *_d_x += _r_d0;
-//CHECK-NEXT:           double _r_d1 = *_d_x;
+//CHECK-NEXT:           *_d_x += _d_t;
+//CHECK-NEXT:           *_d_y += *_d_x;
 //CHECK-NEXT:           *_d_x = 0.;
-//CHECK-NEXT:           *_d_y += _r_d1;
+//CHECK-NEXT:           _d_t = 0.;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       *_d_x += _d_t;
 //CHECK-NEXT:   }
@@ -413,12 +402,10 @@ double f11(double x, double y) {
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           t = _t0;
-//CHECK-NEXT:           double _r_d1 = _d_t;
+//CHECK-NEXT:           *_d_y += _d_t;
 //CHECK-NEXT:           _d_t = 0.;
-//CHECK-NEXT:           *_d_y += _r_d1;
-//CHECK-NEXT:           double _r_d0 = _d_t;
+//CHECK-NEXT:           *_d_x += _d_t;
 //CHECK-NEXT:           _d_t = 0.;
-//CHECK-NEXT:           *_d_x += _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       *_d_x += _d_t;
 //CHECK-NEXT:   }
@@ -442,19 +429,17 @@ double f12(double x, double y) {
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_t1 = _t2;
-//CHECK-NEXT:           double _r_d2 = (_cond0 ? _d_t : _d_t);
+//CHECK-NEXT:           double _r_d0 = (_cond0 ? _d_t : _d_t);
 //CHECK-NEXT:           (_cond0 ? _d_t : _d_t) = 0.;
-//CHECK-NEXT:           (_cond0 ? _d_t : _d_t) += _r_d2 * y;
-//CHECK-NEXT:           *_d_y += *_t1 * _r_d2;
+//CHECK-NEXT:           (_cond0 ? _d_t : _d_t) += _r_d0 * y;
+//CHECK-NEXT:           *_d_y += *_t1 * _r_d0;
 //CHECK-NEXT:           if (_cond0) {
 //CHECK-NEXT:               t = _t0;
-//CHECK-NEXT:               double _r_d0 = _d_t;
+//CHECK-NEXT:               *_d_x += _d_t;
 //CHECK-NEXT:               _d_t = 0.;
-//CHECK-NEXT:               *_d_x += _r_d0;
 //CHECK-NEXT:           } else {
-//CHECK-NEXT:               double _r_d1 = _d_t;
+//CHECK-NEXT:               *_d_y += _d_t;
 //CHECK-NEXT:               _d_t = 0.;
-//CHECK-NEXT:               *_d_y += _r_d1;
 //CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -477,9 +462,8 @@ double f13(double x, double y) {
 //CHECK-NEXT:           *_d_x += _d_t * _t0;
 //CHECK-NEXT:           *_d_y += x * _d_t;
 //CHECK-NEXT:           y = _t1;
-//CHECK-NEXT:           double _r_d0 = *_d_y;
+//CHECK-NEXT:           *_d_x += *_d_y;
 //CHECK-NEXT:           *_d_y = 0.;
-//CHECK-NEXT:           *_d_x += _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
@@ -552,20 +536,17 @@ double f15(double i, double j) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         d = _t2;
-// CHECK-NEXT:         double _r_d3 = _d_d;
+// CHECK-NEXT:         double _r_d2 = _d_d;
 // CHECK-NEXT:         _d_d = 0.;
-// CHECK-NEXT:         _d_d += _r_d3 * 3 * j;
-// CHECK-NEXT:         *_d_j += 3 * d * _r_d3;
+// CHECK-NEXT:         _d_d += _r_d2 * 3 * j;
+// CHECK-NEXT:         *_d_j += 3 * d * _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         c = _t1;
-// CHECK-NEXT:         double _r_d2 = _d_c;
-// CHECK-NEXT:         *_d_i += 3 * _r_d2;
+// CHECK-NEXT:         double _r_d1 = _d_c;
+// CHECK-NEXT:         *_d_i += 3 * _r_d1;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         double _r_d1 = _d_b;
-// CHECK-NEXT:         *_d_i += 2 * _r_d1;
-// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_i += 2 * _d_b;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_a;
@@ -617,9 +598,8 @@ double f17(double i, double j, double k) {
 // CHECK-NEXT:     j = 2 * i;
 // CHECK-NEXT:     _d_j += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r_d0 = _d_j;
+// CHECK-NEXT:         *_d_i += 2 * _d_j;
 // CHECK-NEXT:         _d_j = 0.;
-// CHECK-NEXT:         *_d_i += 2 * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -634,15 +614,11 @@ double f18(double i, double j, double k) {
 // CHECK-NEXT:     k = 2 * i + 2 * j;
 // CHECK-NEXT:     k += i;
 // CHECK-NEXT:     _d_k += 1;
+// CHECK-NEXT:     *_d_i += _d_k;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r_d1 = _d_k;
-// CHECK-NEXT:         *_d_i += _r_d1;
-// CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         double _r_d0 = _d_k;
+// CHECK-NEXT:         *_d_i += 2 * _d_k;
+// CHECK-NEXT:         *_d_j += 2 * _d_k;
 // CHECK-NEXT:         _d_k = 0.;
-// CHECK-NEXT:         *_d_i += 2 * _r_d0;
-// CHECK-NEXT:         *_d_j += 2 * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -64,9 +64,8 @@ double fn1(double x, double y) {
 // CHECK-NEXT:          _d_g.y += 1;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
-// CHECK-NEXT:          double _r_d0 = *_d_y;
+// CHECK-NEXT:          *_d_x += *_d_y;
 // CHECK-NEXT:          *_d_y = 0.;
-// CHECK-NEXT:          *_d_x += _r_d0;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
@@ -312,9 +311,8 @@ double fn5(double x, double y) {
 // CHECK-NEXT:          _d_g.y += 1;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
-// CHECK-NEXT:          double _r_d0 = *_d_y;
+// CHECK-NEXT:          *_d_x += *_d_y;
 // CHECK-NEXT:          *_d_y = 0.;
-// CHECK-NEXT:          *_d_x += _r_d0;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -84,18 +84,16 @@ double fn2(double i, double j) {
 // CHECK-NEXT:     temp = modify1(i, j);
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r_d1 = _d_temp;
-// CHECK-NEXT:         _d_temp = 0.;
 // CHECK-NEXT:         i = _t2;
 // CHECK-NEXT:         j = _t3;
-// CHECK-NEXT:         modify1_pullback(i, j, _r_d1, &*_d_i, &*_d_j);
+// CHECK-NEXT:         modify1_pullback(i, j, _d_temp, &*_d_i, &*_d_j);
+// CHECK-NEXT:         _d_temp = 0.;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r_d0 = _d_temp;
-// CHECK-NEXT:         _d_temp = 0.;
 // CHECK-NEXT:         i = _t0;
 // CHECK-NEXT:         j = _t1;
-// CHECK-NEXT:         modify1_pullback(i, j, _r_d0, &*_d_i, &*_d_j);
+// CHECK-NEXT:         modify1_pullback(i, j, _d_temp, &*_d_i, &*_d_j);
+// CHECK-NEXT:         _d_temp = 0.;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -315,7 +313,6 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     double _d_i0 = i;
 // CHECK-NEXT:     _d_i0 += 1;
 // CHECK-NEXT:     *_d_i += _d_y;
-// CHECK-NEXT:     double _r_d0 = _d__d_i;
 // CHECK-NEXT:     *_d_i += _d__d_i;
 // CHECK-NEXT: }
 
@@ -594,8 +591,7 @@ double fn15(double x, double y) {
 //CHECK-NEXT:     *_d_y += 1;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         y = _t0;
-//CHECK-NEXT:         double _r_d0 = *_d_y;
-//CHECK-NEXT:         *_d_x += _r_d0;
+//CHECK-NEXT:         *_d_x += *_d_y;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -138,9 +138,8 @@ double f_div3(double x, double y) {
 //CHECK-NEXT:     double _t0 = (y * y);
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += 1 / _t0;
-//CHECK-NEXT:         double _r_d0 = *_d_x;
+//CHECK-NEXT:         *_d_y += *_d_x;
 //CHECK-NEXT:         *_d_x = 0.;
-//CHECK-NEXT:         *_d_y += _r_d0;
 //CHECK-NEXT:         double _r0 = 1 * -(_t1 / (_t0 * _t0));
 //CHECK-NEXT:         *_d_y += _r0 * y;
 //CHECK-NEXT:         *_d_y += y * _r0;
@@ -898,13 +897,11 @@ double fn_empty_if_else(double x) {
 //CHECK-NEXT:            ;
 //CHECK-NEXT:        else {
 //CHECK-NEXT:            {
-//CHECK-NEXT:                double _r_d1 = _d_res;
+//CHECK-NEXT:                *_d_x += 5 * _d_res;
 //CHECK-NEXT:                _d_res = 0.;
-//CHECK-NEXT:                *_d_x += 5 * _r_d1;
 //CHECK-NEXT:            }
 //CHECK-NEXT:        }
 //CHECK-NEXT:        {
-//CHECK-NEXT:            double _r_d0 = _d_res;
 //CHECK-NEXT:            _d_res = 0.;
 //CHECK-NEXT:        }
 //CHECK-NEXT:    }
@@ -941,17 +938,14 @@ double fn_cond_false(double i, double j) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        if (_cond2) {
 // CHECK-NEXT:            {
-// CHECK-NEXT:                double _r_d1 = _d_res;
+// CHECK-NEXT:                *_d_i += 6 * _d_res * j;
+// CHECK-NEXT:                *_d_j += 6 * i * _d_res;
 // CHECK-NEXT:                _d_res = 0.;
-// CHECK-NEXT:                *_d_i += 6 * _r_d1 * j;
-// CHECK-NEXT:                *_d_j += 6 * i * _r_d1;
 // CHECK-NEXT:            }
 // CHECK-NEXT:        }
 // CHECK-NEXT:        {
-// CHECK-NEXT:            if (_cond1) {
-// CHECK-NEXT:                double _r_d0 = _d_cond0;
+// CHECK-NEXT:            if (_cond1)
 // CHECK-NEXT:                _d_cond0 = 0.;
-// CHECK-NEXT:            }
 // CHECK-NEXT:        }
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -996,36 +990,30 @@ double fn_cond_add_assign(double i, double j) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        if (_cond4) {
 // CHECK-NEXT:            {
-// CHECK-NEXT:                double _r_d5 = _d_res;
-// CHECK-NEXT:                *_d_i += 6 * _r_d5 * j;
-// CHECK-NEXT:                *_d_j += 6 * i * _r_d5;
+// CHECK-NEXT:                *_d_i += 6 * _d_res * j;
+// CHECK-NEXT:                *_d_j += 6 * i * _d_res;
 // CHECK-NEXT:            }
 // CHECK-NEXT:        }
 // CHECK-NEXT:        {
 // CHECK-NEXT:            {
 // CHECK-NEXT:                if (_cond3) {
-// CHECK-NEXT:                    double _r_d3 = _d_cond0;
+// CHECK-NEXT:                    _d_res += _d_cond0;
+// CHECK-NEXT:                    *_d_i += 5 * _d_res * j;
+// CHECK-NEXT:                    *_d_j += 5 * i * _d_res;
 // CHECK-NEXT:                    _d_cond0 = 0.;
-// CHECK-NEXT:                    _d_res += _r_d3;
-// CHECK-NEXT:                    double _r_d4 = _d_res;
-// CHECK-NEXT:                    *_d_i += 5 * _r_d4 * j;
-// CHECK-NEXT:                    *_d_j += 5 * i * _r_d4;
 // CHECK-NEXT:                }
 // CHECK-NEXT:                {
 // CHECK-NEXT:                    {
 // CHECK-NEXT:                        if (_cond2) {
-// CHECK-NEXT:                            double _r_d1 = _d_cond1;
+// CHECK-NEXT:                            _d_res += _d_cond1;
+// CHECK-NEXT:                            *_d_i += 3 * _d_res * j;
+// CHECK-NEXT:                            *_d_j += 3 * i * _d_res;
 // CHECK-NEXT:                            _d_cond1 = 0.;
-// CHECK-NEXT:                            _d_res += _r_d1;
-// CHECK-NEXT:                            double _r_d2 = _d_res;
-// CHECK-NEXT:                            *_d_i += 3 * _r_d2 * j;
-// CHECK-NEXT:                            *_d_j += 3 * i * _r_d2;
 // CHECK-NEXT:                        }
 // CHECK-NEXT:                        {
-// CHECK-NEXT:                            double _r_d0 = _d_res;
+// CHECK-NEXT:                            *_d_i += 2 * _d_res * j;
+// CHECK-NEXT:                            *_d_j += 2 * i * _d_res;
 // CHECK-NEXT:                            _d_res = 0.;
-// CHECK-NEXT:                            *_d_i += 2 * _r_d0 * j;
-// CHECK-NEXT:                            *_d_j += 2 * i * _r_d0;
 // CHECK-NEXT:                        }
 // CHECK-NEXT:                    }
 // CHECK-NEXT:                }
@@ -1118,9 +1106,8 @@ double g(double a, double b) {
 //CHECK-NEXT:     glob1 = b;
 //CHECK-NEXT:     *_d_a += _d_y;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         double _r_d0 = _d_glob1;
+//CHECK-NEXT:         *_d_b += _d_glob1;
 //CHECK-NEXT:         _d_glob1 = 0.;
-//CHECK-NEXT:         *_d_b += _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -196,9 +196,8 @@ double f_const_local(double x) {
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r_d0 = _d_res;
-// CHECK-NEXT:             *_d_x += _r_d0 * n;
-// CHECK-NEXT:             _d_n += x * _r_d0;
+// CHECK-NEXT:             *_d_x += _d_res * n;
+// CHECK-NEXT:             _d_n += x * _d_res;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             *_d_x += _d_n;
@@ -359,10 +358,7 @@ void f_const_grad(const double, const double, double*, double*);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_r += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             int _r_d0 = _d_r;
-// CHECK-NEXT:             _d_sq += _r_d0;
-// CHECK-NEXT:         }
+// CHECK-NEXT:         _d_sq += _d_r;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             *_d_b += _d_sq * b;
 // CHECK-NEXT:             *_d_b += b * _d_sq;
@@ -402,15 +398,11 @@ double f6 (double i, double j) {
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r_d1 = _d_a;
-// CHECK-NEXT:             _d_b += _r_d1;
-// CHECK-NEXT:             _d_c += _r_d1;
-// CHECK-NEXT:             *_d_i += _r_d1;
+// CHECK-NEXT:             _d_b += _d_a;
+// CHECK-NEXT:             _d_c += _d_a;
+// CHECK-NEXT:             *_d_i += _d_a;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         {
-// CHECK-NEXT:             double _r_d0 = _d_b;
-// CHECK-NEXT:             *_d_j += _r_d0;
-// CHECK-NEXT:         }
+// CHECK-NEXT:         *_d_j += _d_b;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             *_d_j += _d_c * j;
 // CHECK-NEXT:             *_d_j += j * _d_c;
@@ -447,10 +439,9 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 double _r_d0 = _d_a;
-// CHECK-NEXT:                 *_d_i += _r_d0 * i;
-// CHECK-NEXT:                 *_d_i += i * _r_d0;
-// CHECK-NEXT:                 *_d_j += _r_d0;
+// CHECK-NEXT:                 *_d_i += _d_a * i;
+// CHECK-NEXT:                 *_d_i += i * _d_a;
+// CHECK-NEXT:                 *_d_j += _d_a;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _t0--;
 // CHECK-NEXT:         }
@@ -489,10 +480,9 @@ double fn8(double i, double j) {
 // CHECK-NEXT:                 do {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             double _r_d0 = _d_a;
-// CHECK-NEXT:                             *_d_i += _r_d0 * i;
-// CHECK-NEXT:                             *_d_i += i * _r_d0;
-// CHECK-NEXT:                             *_d_j += _r_d0;
+// CHECK-NEXT:                             *_d_i += _d_a * i;
+// CHECK-NEXT:                             *_d_i += i * _d_a;
+// CHECK-NEXT:                             *_d_j += _d_a;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     clad::back(_t1)--;
@@ -544,29 +534,23 @@ double fn9(double i, double j) {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                                 {
-// CHECK-NEXT:                                     double _r_d3 = _d_a;
-// CHECK-NEXT:                                     *_d_i += _r_d3 * i;
-// CHECK-NEXT:                                     *_d_i += i * _r_d3;
-// CHECK-NEXT:                                     *_d_j += _r_d3;
+// CHECK-NEXT:                                     *_d_i += _d_a * i;
+// CHECK-NEXT:                                     *_d_i += i * _d_a;
+// CHECK-NEXT:                                     *_d_j += _d_a;
 // CHECK-NEXT:                                 }
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                             clad::back(_t1)--;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     clad::pop(_t1);
 // CHECK-NEXT:                 }
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     int _r_d2 = _d_counter_again;
-// CHECK-NEXT:                     _d_counter_again = 0;
-// CHECK-NEXT:                 }
+// CHECK-NEXT:                 _d_counter_again = 0;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _t0--;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         int _r_d0 = _d_counter;
-// CHECK-NEXT:         _d_counter = 0;
-// CHECK-NEXT:         _d_counter_again += _r_d0;
-// CHECK-NEXT:         int _r_d1 = _d_counter_again;
+// CHECK-NEXT:         _d_counter_again += _d_counter;
 // CHECK-NEXT:         _d_counter_again = 0;
+// CHECK-NEXT:         _d_counter = 0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -600,16 +584,11 @@ double fn10(double i, double j) {
 // CHECK-NEXT:     while (_t0)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 int _r_d2 = _d_counter;
+// CHECK-NEXT:                 _d_b += _d_a;
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     double _r_d1 = _d_a;
-// CHECK-NEXT:                     _d_b += _r_d1;
-// CHECK-NEXT:                 }
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     int _r_d0 = _d_b;
-// CHECK-NEXT:                     *_d_i += _r_d0 * i;
-// CHECK-NEXT:                     *_d_i += i * _r_d0;
-// CHECK-NEXT:                     *_d_j += _r_d0;
+// CHECK-NEXT:                     *_d_i += _d_b * i;
+// CHECK-NEXT:                     *_d_i += i * _d_b;
+// CHECK-NEXT:                     *_d_j += _d_b;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
@@ -644,12 +623,10 @@ double fn11(double i, double j) {
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             int _r_d1 = _d_counter;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 double _r_d0 = _d_a;
-// CHECK-NEXT:                 *_d_i += _r_d0 * i;
-// CHECK-NEXT:                 *_d_i += i * _r_d0;
-// CHECK-NEXT:                 *_d_j += _r_d0;
+// CHECK-NEXT:                 *_d_i += _d_a * i;
+// CHECK-NEXT:                 *_d_i += i * _d_a;
+// CHECK-NEXT:                 *_d_j += _d_a;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _t0--;
@@ -702,26 +679,22 @@ double fn12(double i, double j) {
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     do {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             int _r_d3 = _d_counter;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 do {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             do {
 // CHECK-NEXT:                                 {
-// CHECK-NEXT:                                     double _r_d2 = _d_a;
-// CHECK-NEXT:                                     *_d_j += _r_d2;
+// CHECK-NEXT:                                     *_d_j += _d_a;
 // CHECK-NEXT:                                 }
 // CHECK-NEXT:                                 clad::back(_t2)--;
 // CHECK-NEXT:                             } while (clad::back(_t2));
 // CHECK-NEXT:                             clad::pop(_t2);
 // CHECK-NEXT:                         }
-// CHECK-NEXT:                         int _r_d1 = _d_counter_again;
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             double _r_d0 = _d_a;
-// CHECK-NEXT:                             *_d_i += _r_d0 * i;
-// CHECK-NEXT:                             *_d_i += i * _r_d0;
-// CHECK-NEXT:                             *_d_j += _r_d0;
+// CHECK-NEXT:                             *_d_i += _d_a * i;
+// CHECK-NEXT:                             *_d_i += i * _d_a;
+// CHECK-NEXT:                             *_d_j += _d_a;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     clad::back(_t1)--;
@@ -764,19 +737,14 @@ double fn13(double i, double j) {
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             int _r_d0 = _d_counter;
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 double _r_d2 = _d_res;
-// CHECK-NEXT:                 _d_temp += _r_d2;
-// CHECK-NEXT:             }
+// CHECK-NEXT:             _d_temp += _d_res;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 _d_k += _d_temp;
 // CHECK-NEXT:                 _d_temp = 0.;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 int _r_d1 = _d_k;
-// CHECK-NEXT:                 *_d_i += _r_d1;
-// CHECK-NEXT:                 *_d_j += 2 * _r_d1;
+// CHECK-NEXT:                 *_d_i += _d_k;
+// CHECK-NEXT:                 *_d_j += 2 * _d_k;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
@@ -863,9 +831,8 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                       case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:                         ;
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             double _r_d2 = _d_res;
-// CHECK-NEXT:                             *_d_i += _r_d2 * j;
-// CHECK-NEXT:                             *_d_j += i * _r_d2;
+// CHECK-NEXT:                             *_d_i += _d_res * j;
+// CHECK-NEXT:                             *_d_j += i * _d_res;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     clad::pop(_cond2);
@@ -874,10 +841,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                     if (clad::back(_cond1)) {
 // CHECK-NEXT:                       case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                         ;
-// CHECK-NEXT:                         {
-// CHECK-NEXT:                             double _r_d1 = _d_res;
-// CHECK-NEXT:                             *_d_j += _r_d1;
-// CHECK-NEXT:                         }
+// CHECK-NEXT:                         *_d_j += _d_res;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     clad::pop(_cond1);
 // CHECK-NEXT:                 }
@@ -885,10 +849,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:                     if (clad::back(_cond0)) {
 // CHECK-NEXT:                       case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                         ;
-// CHECK-NEXT:                         {
-// CHECK-NEXT:                             double _r_d0 = _d_res;
-// CHECK-NEXT:                             *_d_i += _r_d0;
-// CHECK-NEXT:                         }
+// CHECK-NEXT:                         *_d_i += _d_res;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     clad::pop(_cond0);
 // CHECK-NEXT:                 }
@@ -980,10 +941,7 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                                 ;
 // CHECK-NEXT:                                 {
 // CHECK-NEXT:                                     if (clad::back(_cond2)) {
-// CHECK-NEXT:                                         {
-// CHECK-NEXT:                                             double _r_d1 = _d_res;
-// CHECK-NEXT:                                             *_d_j += _r_d1;
-// CHECK-NEXT:                                         }
+// CHECK-NEXT:                                         *_d_j += _d_res;
 // CHECK-NEXT:                                     }
 // CHECK-NEXT:                                     clad::pop(_cond2);
 // CHECK-NEXT:                                 }
@@ -991,10 +949,7 @@ double fn15(double i, double j) {
 // CHECK-NEXT:                                     if (clad::back(_cond1)) {
 // CHECK-NEXT:                                       case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                                         ;
-// CHECK-NEXT:                                         {
-// CHECK-NEXT:                                             double _r_d0 = _d_res;
-// CHECK-NEXT:                                             *_d_i += _r_d0;
-// CHECK-NEXT:                                         }
+// CHECK-NEXT:                                         *_d_i += _d_res;
 // CHECK-NEXT:                                     }
 // CHECK-NEXT:                                     clad::pop(_cond1);
 // CHECK-NEXT:                                 }
@@ -1074,18 +1029,14 @@ double fn16(double i, double j) {
 // CHECK-NEXT:           case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 double _r_d2 = _d_res;
-// CHECK-NEXT:                 *_d_i += _r_d2;
-// CHECK-NEXT:                 *_d_j += _r_d2;
+// CHECK-NEXT:                 *_d_i += _d_res;
+// CHECK-NEXT:                 *_d_j += _d_res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 if (clad::back(_cond1)) {
 // CHECK-NEXT:                   case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                     ;
-// CHECK-NEXT:                     {
-// CHECK-NEXT:                         double _r_d1 = _d_res;
-// CHECK-NEXT:                         *_d_i += 2 * _r_d1;
-// CHECK-NEXT:                     }
+// CHECK-NEXT:                     *_d_i += 2 * _d_res;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 clad::pop(_cond1);
 // CHECK-NEXT:             }
@@ -1094,9 +1045,8 @@ double fn16(double i, double j) {
 // CHECK-NEXT:                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         double _r_d0 = _d_res;
-// CHECK-NEXT:                         *_d_i += _r_d0 * j;
-// CHECK-NEXT:                         *_d_j += i * _r_d0;
+// CHECK-NEXT:                         *_d_i += _d_res * j;
+// CHECK-NEXT:                         *_d_j += i * _d_res;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 clad::pop(_cond0);
@@ -1185,20 +1135,18 @@ double fn17(double i, double j) {
 // CHECK-NEXT:                           case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:                             ;
 // CHECK-NEXT:                             {
-// CHECK-NEXT:                                 double _r_d1 = _d_res;
-// CHECK-NEXT:                                 *_d_i += _r_d1 * j * j * i;
-// CHECK-NEXT:                                 *_d_i += i * _r_d1 * j * j;
-// CHECK-NEXT:                                 *_d_j += i * i * _r_d1 * j;
-// CHECK-NEXT:                                 *_d_j += i * i * j * _r_d1;
+// CHECK-NEXT:                                 *_d_i += _d_res * j * j * i;
+// CHECK-NEXT:                                 *_d_i += i * _d_res * j * j;
+// CHECK-NEXT:                                 *_d_j += i * i * _d_res * j;
+// CHECK-NEXT:                                 *_d_j += i * i * j * _d_res;
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                                 if (clad::back(_cond1)) {
 // CHECK-NEXT:                                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                                     ;
 // CHECK-NEXT:                                     {
-// CHECK-NEXT:                                         double _r_d0 = _d_res;
-// CHECK-NEXT:                                         *_d_i += _r_d0 * j;
-// CHECK-NEXT:                                         *_d_j += i * _r_d0;
+// CHECK-NEXT:                                         *_d_i += _d_res * j;
+// CHECK-NEXT:                                         *_d_j += i * _d_res;
 // CHECK-NEXT:                                     }
 // CHECK-NEXT:                                 } else {
 // CHECK-NEXT:                                   case {{2U|2UL|2ULL}}:
@@ -1278,9 +1226,8 @@ double fn18(double i, double j) {
 // CHECK-NEXT:           case {{3U|3UL|3ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             if (clad::back(_cond0)) {
-// CHECK-NEXT:                 double _r_d0 = _d_res;
-// CHECK-NEXT:                 *_d_i += _r_d0;
-// CHECK-NEXT:                 *_d_j += _r_d0;
+// CHECK-NEXT:                 *_d_i += _d_res;
+// CHECK-NEXT:                 *_d_j += _d_res;
 // CHECK-NEXT:             } else {
 // CHECK-NEXT:                 if (clad::back(_cond1))
 // CHECK-NEXT:                   case {{1U|1UL|1ULL}}:
@@ -1289,9 +1236,8 @@ double fn18(double i, double j) {
 // CHECK-NEXT:                   case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         double _r_d1 = _d_res;
-// CHECK-NEXT:                         *_d_i += 2 * _r_d1;
-// CHECK-NEXT:                         *_d_j += 2 * _r_d1;
+// CHECK-NEXT:                         *_d_i += 2 * _d_res;
+// CHECK-NEXT:                         *_d_j += 2 * _d_res;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 clad::pop(_cond1);
@@ -1367,14 +1313,12 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:         for (; _t0; _t0--) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 x = clad::pop(_t1);
-// CHECK-NEXT:                 double _r_d0 = _d_x;
-// CHECK-NEXT:                 _d_interval += _r_d0;
+// CHECK-NEXT:                 _d_interval += _d_x;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 double _r_d1 = _d_sum;
-// CHECK-NEXT:                 _d_x += _r_d1 * interval * x;
-// CHECK-NEXT:                 _d_x += x * _r_d1 * interval;
-// CHECK-NEXT:                 _d_interval += x * x * _r_d1;
+// CHECK-NEXT:                 _d_x += _d_sum * interval * x;
+// CHECK-NEXT:                 _d_x += x * _d_sum * interval;
+// CHECK-NEXT:                 _d_interval += x * x * _d_sum;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:         *_d_lower += _d_x;
@@ -1529,10 +1473,9 @@ double fn23(double i, double j) {
 // CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; ; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0 || (clad::back(_t1) != 1)) {
-// CHECK-NEXT:                 double _r_d0 = _d_res;
+// CHECK-NEXT:                 *_d_i += _d_res * j;
+// CHECK-NEXT:                 *_d_j += i * _d_res;
 // CHECK-NEXT:                 _d_res = 0.;
-// CHECK-NEXT:                 *_d_i += _r_d0 * j;
-// CHECK-NEXT:                 *_d_j += i * _r_d0;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
@@ -1571,9 +1514,8 @@ double fn24(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 _d_res += 0;
-// CHECK-NEXT:                 double _r_d0 = _d_res;
-// CHECK-NEXT:                 *_d_i += _r_d0 * j;
-// CHECK-NEXT:                 *_d_j += i * _r_d0;
+// CHECK-NEXT:                 *_d_i += _d_res * j;
+// CHECK-NEXT:                 *_d_j += i * _d_res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
@@ -1619,9 +1561,8 @@ double fn25(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0 || (clad::back(_t1) != 1)) {
 // CHECK-NEXT:                 _d_res += 0;
-// CHECK-NEXT:                 double _r_d0 = _d_res;
-// CHECK-NEXT:                 *_d_i += _r_d0 * j;
-// CHECK-NEXT:                 *_d_j += i * _r_d0;
+// CHECK-NEXT:                 *_d_i += _d_res * j;
+// CHECK-NEXT:                 *_d_j += i * _d_res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
@@ -1634,10 +1575,9 @@ double fn25(double i, double j) {
 // CHECK-NEXT:                   case {{1U|1UL|1ULL}}:
 // CHECK-NEXT:                     ;
 // CHECK-NEXT:                     {
-// CHECK-NEXT:                         double _r_d1 = _d_res;
+// CHECK-NEXT:                         *_d_i += 8 * _d_res * j;
+// CHECK-NEXT:                         *_d_j += 8 * i * _d_res;
 // CHECK-NEXT:                         _d_res = 0.;
-// CHECK-NEXT:                         *_d_i += 8 * _r_d1 * j;
-// CHECK-NEXT:                         *_d_j += 8 * i * _r_d1;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 clad::pop(_cond0);
@@ -1678,18 +1618,16 @@ double fn26(double i, double j) {
 // CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; ; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0 || (_t0 != _numRevIterations0 || (clad::back(_t1) != 1))) {
-// CHECK-NEXT:                 double _r_d0 = _d_res;
-// CHECK-NEXT:                 *_d_i += _r_d0 * j;
-// CHECK-NEXT:                 *_d_j += i * _r_d0;
+// CHECK-NEXT:                 *_d_i += _d_res * j;
+// CHECK-NEXT:                 *_d_j += i * _d_res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         if (_t0 != _numRevIterations0 || (clad::back(_t1) != 1)) {
-// CHECK-NEXT:             double _r_d1 = _d_res;
+// CHECK-NEXT:             *_d_i += 7 * _d_res * j;
+// CHECK-NEXT:             *_d_j += 7 * i * _d_res;
 // CHECK-NEXT:             _d_res = 0.;
-// CHECK-NEXT:             *_d_i += 7 * _r_d1 * j;
-// CHECK-NEXT:             *_d_j += 7 * i * _r_d1;
 // CHECK-NEXT:             _d_c += 0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         switch (clad::pop(_t1)) {
@@ -1740,9 +1678,8 @@ double fn27(double i, double j) {
 // CHECK-NEXT:     for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; ; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (!_t0 || (_t0 != _numRevIterations0 || (clad::back(_t1) != 1))) {
-// CHECK-NEXT:                 double _r_d0 = _d_res;
-// CHECK-NEXT:                 *_d_i += _r_d0 * j;
-// CHECK-NEXT:                 *_d_j += i * _r_d0;
+// CHECK-NEXT:                 *_d_i += _d_res * j;
+// CHECK-NEXT:                 *_d_j += i * _d_res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
@@ -1753,11 +1690,10 @@ double fn27(double i, double j) {
 // CHECK-NEXT:           case {{2U|2UL|2ULL}}:
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 double _r_d1 = _d_res;
+// CHECK-NEXT:                 _d_c += _d_res * j * i;
+// CHECK-NEXT:                 *_d_i += c * _d_res * j;
+// CHECK-NEXT:                 *_d_j += c * i * _d_res;
 // CHECK-NEXT:                 _d_res = 0.;
-// CHECK-NEXT:                 _d_c += _r_d1 * j * i;
-// CHECK-NEXT:                 *_d_i += c * _r_d1 * j;
-// CHECK-NEXT:                 *_d_j += c * i * _r_d1;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 if (clad::back(_cond0))
@@ -1792,19 +1728,17 @@ double fn28(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 _d_res += 0;
-// CHECK-NEXT:                 double _r_d0 = _d_res;
+// CHECK-NEXT:                 *_d_i += _d_res * j;
+// CHECK-NEXT:                 *_d_j += i * _d_res;
 // CHECK-NEXT:                 _d_res = 0.;
-// CHECK-NEXT:                 *_d_i += _r_d0 * j;
-// CHECK-NEXT:                 *_d_j += i * _r_d0;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r_d1 = _d_res;
+// CHECK-NEXT:             *_d_i += 3 * _d_res * j;
+// CHECK-NEXT:             *_d_j += 3 * i * _d_res;
 // CHECK-NEXT:             _d_res = 0.;
-// CHECK-NEXT:             *_d_i += 3 * _r_d1 * j;
-// CHECK-NEXT:             *_d_j += 3 * i * _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -1829,19 +1763,17 @@ double fn29(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 _d_res += 0;
-// CHECK-NEXT:                 double _r_d0 = _d_res;
+// CHECK-NEXT:                 *_d_i += _d_res * j;
+// CHECK-NEXT:                 *_d_j += i * _d_res;
 // CHECK-NEXT:                 _d_res = 0.;
-// CHECK-NEXT:                 *_d_i += _r_d0 * j;
-// CHECK-NEXT:                 *_d_j += i * _r_d0;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             if (!_t0)
 // CHECK-NEXT:                 break;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r_d1 = _d_res;
+// CHECK-NEXT:             *_d_i += 3 * _d_res * j;
+// CHECK-NEXT:             *_d_j += 3 * i * _d_res;
 // CHECK-NEXT:             _d_res = 0.;
-// CHECK-NEXT:             *_d_i += 3 * _r_d1 * j;
-// CHECK-NEXT:             *_d_j += 3 * i * _r_d1;
 // CHECK-NEXT:             _d_c += 0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
@@ -1880,13 +1812,11 @@ double fn30(double i, double j) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 if (clad::back(_cond1)) {
-// CHECK-NEXT:                     double _r_d0 = _d_cond0;
-// CHECK-NEXT:                     _d_cond0 = 0.;
-// CHECK-NEXT:                     _d_res += _r_d0;
-// CHECK-NEXT:                     double _r_d1 = _d_res;
+// CHECK-NEXT:                     _d_res += _d_cond0;
+// CHECK-NEXT:                     *_d_i += _d_res * j;
+// CHECK-NEXT:                     *_d_j += i * _d_res;
 // CHECK-NEXT:                     _d_res = 0.;
-// CHECK-NEXT:                     *_d_i += _r_d1 * j;
-// CHECK-NEXT:                     *_d_j += i * _r_d1;
+// CHECK-NEXT:                     _d_cond0 = 0.;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 clad::pop(_cond1);
 // CHECK-NEXT:             }
@@ -1916,15 +1846,13 @@ double fn31(double i, double j) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            {
 //CHECK-NEXT:                _d_res += 0;
-//CHECK-NEXT:                double _r_d0 = _d_res;
+//CHECK-NEXT:                *_d_i += 2 * _d_res * j;
+//CHECK-NEXT:                *_d_j += 2 * i * _d_res;
 //CHECK-NEXT:                _d_res = 0.;
-//CHECK-NEXT:                *_d_i += 2 * _r_d0 * j;
-//CHECK-NEXT:                *_d_j += 2 * i * _r_d0;
 //CHECK-NEXT:                _d_res += 0;
-//CHECK-NEXT:                double _r_d1 = _d_res;
+//CHECK-NEXT:                *_d_i += _d_res * j;
+//CHECK-NEXT:                *_d_j += i * _d_res;
 //CHECK-NEXT:                _d_res = 0.;
-//CHECK-NEXT:                *_d_i += _r_d1 * j;
-//CHECK-NEXT:                *_d_j += i * _r_d1;
 //CHECK-NEXT:            }
 //CHECK-NEXT:            if (!_t0)
 //CHECK-NEXT:                break;
@@ -1995,9 +1923,8 @@ double fn32(double i, double j) {
 //CHECK-NEXT:    for (unsigned {{int|long|long long}} _numRevIterations1 = _t0; ; _t0--) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            if (!_t0 || (clad::back(_t3) != 1)) {
-//CHECK-NEXT:                double _r_d0 = _d_res;
-//CHECK-NEXT:                *_d_i += _r_d0 * j;
-//CHECK-NEXT:                *_d_j += i * _r_d0;
+//CHECK-NEXT:                *_d_i += _d_res * j;
+//CHECK-NEXT:                *_d_j += i * _d_res;
 //CHECK-NEXT:            }
 //CHECK-NEXT:            if (!_t0)
 //CHECK-NEXT:                break;
@@ -2010,9 +1937,8 @@ double fn32(double i, double j) {
 //CHECK-NEXT:                  case {{1U|1UL|1ULL}}:
 //CHECK-NEXT:                    ;
 //CHECK-NEXT:                    {
-//CHECK-NEXT:                        double _r_d3 = _d_res;
-//CHECK-NEXT:                        *_d_i += _r_d3 * j;
-//CHECK-NEXT:                        *_d_j += i * _r_d3;
+//CHECK-NEXT:                        *_d_i += _d_res * j;
+//CHECK-NEXT:                        *_d_j += i * _d_res;
 //CHECK-NEXT:                    }
 //CHECK-NEXT:                }
 //CHECK-NEXT:                clad::pop(_cond1);
@@ -2021,9 +1947,8 @@ double fn32(double i, double j) {
 //CHECK-NEXT:                for (unsigned {{int|long|long long}} _numRevIterations0 = clad::back(_t1); ; clad::back(_t1)--) {
 //CHECK-NEXT:                    {
 //CHECK-NEXT:                        if (!clad::back(_t1) || (clad::back(_t2) != 1)) {
-//CHECK-NEXT:                            double _r_d1 = _d_res;
-//CHECK-NEXT:                            *_d_i += _r_d1 * j;
-//CHECK-NEXT:                            *_d_j += i * _r_d1;
+//CHECK-NEXT:                            *_d_i += _d_res * j;
+//CHECK-NEXT:                            *_d_j += i * _d_res;
 //CHECK-NEXT:                        }
 //CHECK-NEXT:                        if (!clad::back(_t1))
 //CHECK-NEXT:                            break;
@@ -2036,9 +1961,8 @@ double fn32(double i, double j) {
 //CHECK-NEXT:                              case {{1U|1UL|1ULL}}:
 //CHECK-NEXT:                                ;
 //CHECK-NEXT:                                {
-//CHECK-NEXT:                                    double _r_d2 = _d_res;
-//CHECK-NEXT:                                    *_d_i += _r_d2 * j;
-//CHECK-NEXT:                                    *_d_j += i * _r_d2;
+//CHECK-NEXT:                                    *_d_i += _d_res * j;
+//CHECK-NEXT:                                    *_d_j += i * _d_res;
 //CHECK-NEXT:                                }
 //CHECK-NEXT:                            }
 //CHECK-NEXT:                            clad::pop(_cond0);
@@ -2118,10 +2042,9 @@ double fn33(double i, double j) {
 //CHECK-NEXT:    for (unsigned {{int|long|long long}} _numRevIterations0 = _t0; ; _t0--) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            if (!_t0 || (clad::back(_t1) != 1 && clad::back(_t1) != 2)) {
-//CHECK-NEXT:                double _r_d0 = _d_res;
+//CHECK-NEXT:                *_d_i += _d_res * j;
+//CHECK-NEXT:                *_d_j += i * _d_res;
 //CHECK-NEXT:                _d_res = 0.;
-//CHECK-NEXT:                *_d_i += _r_d0 * j;
-//CHECK-NEXT:                *_d_j += i * _r_d0;
 //CHECK-NEXT:            }
 //CHECK-NEXT:            if (!_t0)
 //CHECK-NEXT:                break;
@@ -2138,12 +2061,10 @@ double fn33(double i, double j) {
 //CHECK-NEXT:                {
 //CHECK-NEXT:                    {
 //CHECK-NEXT:                        if (clad::back(_cond4)) {
-//CHECK-NEXT:                            double _r_d3 = _d_cond3;
+//CHECK-NEXT:                            _d_res += _d_cond3;
+//CHECK-NEXT:                            *_d_i += _d_res * j;
+//CHECK-NEXT:                            *_d_j += i * _d_res;
 //CHECK-NEXT:                            _d_cond3 = 0.;
-//CHECK-NEXT:                            _d_res += _r_d3;
-//CHECK-NEXT:                            double _r_d4 = _d_res;
-//CHECK-NEXT:                            *_d_i += _r_d4 * j;
-//CHECK-NEXT:                            *_d_j += i * _r_d4;
 //CHECK-NEXT:                        }
 //CHECK-NEXT:                        clad::pop(_cond4);
 //CHECK-NEXT:                    }
@@ -2157,15 +2078,12 @@ double fn33(double i, double j) {
 //CHECK-NEXT:                clad::pop(_cond2);
 //CHECK-NEXT:                {
 //CHECK-NEXT:                    {
-//CHECK-NEXT:                        if (clad::back(_cond1)) {
-//CHECK-NEXT:                            double _r_d2 = _d_cond0;
+//CHECK-NEXT:                        if (clad::back(_cond1))
 //CHECK-NEXT:                            _d_cond0 = 0.;
-//CHECK-NEXT:                        }
 //CHECK-NEXT:                        clad::pop(_cond1);
 //CHECK-NEXT:                        {
-//CHECK-NEXT:                            double _r_d1 = _d_res;
-//CHECK-NEXT:                            *_d_i += _r_d1 * j;
-//CHECK-NEXT:                            *_d_j += i * _r_d1;
+//CHECK-NEXT:                            *_d_i += _d_res * j;
+//CHECK-NEXT:                            *_d_j += i * _d_res;
 //CHECK-NEXT:                        }
 //CHECK-NEXT:                    }
 //CHECK-NEXT:                }
@@ -2429,11 +2347,10 @@ double fn36(double x, double y){
 //CHECK-NEXT:                         ;
 //CHECK-NEXT:                     } else if (1) {
 //CHECK-NEXT:                         {
-//CHECK-NEXT:                             double _r_d0 = _d_sum;
 //CHECK-NEXT:                             double _r0 = 0.;
-//CHECK-NEXT:                             _r0 += _r_d0 * x * clad::custom_derivatives::std::sin_pushforward(i, 1.).pushforward;
+//CHECK-NEXT:                             _r0 += _d_sum * x * clad::custom_derivatives::std::sin_pushforward(i, 1.).pushforward;
 //CHECK-NEXT:                             _d_i += _r0;
-//CHECK-NEXT:                             *_d_x += clad::back(_t2) * _r_d0;
+//CHECK-NEXT:                             *_d_x += clad::back(_t2) * _d_sum;
 //CHECK-NEXT:                             clad::pop(_t2);
 //CHECK-NEXT:                         }
 //CHECK-NEXT:                     }
@@ -2486,8 +2403,7 @@ double fn37(double x, double y) {
 //CHECK-NEXT:                 elem = clad::pop(_t1);
 //CHECK-NEXT:                 _d_elem = clad::pop(_t2);
 //CHECK-NEXT:             }
-//CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             _d_elem += _r_d0;
+//CHECK-NEXT:             _d_elem += _d_sum;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         *_d___begin1 += _d_elem;
 //CHECK-NEXT:     }
@@ -2549,8 +2465,7 @@ double fn38(double x, double y) {
 //CHECK-NEXT:                     elem = clad::pop(_t1);
 //CHECK-NEXT:                     _d_elem = clad::pop(_t2);
 //CHECK-NEXT:                 }
-//CHECK-NEXT:                 double _r_d0 = _d_sum;
-//CHECK-NEXT:                 _d_elem += _r_d0;
+//CHECK-NEXT:                 _d_elem += _d_sum;
 //CHECK-NEXT:             }
 //CHECK-NEXT:             *_d___begin2 += _d_elem;
 //CHECK-NEXT:         }
@@ -2631,9 +2546,8 @@ double fn40(double u, double v) {
 //CHECK-NEXT:          case {{1U|1UL}}:
 //CHECK-NEXT:            ;
 //CHECK-NEXT:            {
-//CHECK-NEXT:                double _r_d0 = _d_res;
-//CHECK-NEXT:                *_d_u += _r_d0 * i;
-//CHECK-NEXT:                _d_i += u * _r_d0;
+//CHECK-NEXT:                *_d_u += _d_res * i;
+//CHECK-NEXT:                _d_i += u * _d_res;
 //CHECK-NEXT:            }
 //CHECK-NEXT:        }
 //CHECK-NEXT:    }
@@ -2684,9 +2598,8 @@ double fn41(double u, double v) {
 //CHECK-NEXT:                clad::pop(_cond0);
 //CHECK-NEXT:            }
 //CHECK-NEXT:            {
-//CHECK-NEXT:                double _r_d0 = _d_res;
-//CHECK-NEXT:                _d_i += _r_d0 * u;
-//CHECK-NEXT:                *_d_u += i * _r_d0;
+//CHECK-NEXT:                _d_i += _d_res * u;
+//CHECK-NEXT:                *_d_u += i * _d_res;
 //CHECK-NEXT:            }
 //CHECK-NEXT:        }
 //CHECK-NEXT:    }

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -1149,10 +1149,7 @@ int main() {
 // CHECK-NEXT:                 {{.*}}class_functions::operator_plus_plus_pullback(&it, 0, {}, &_d_it, &_r0);
 // CHECK-NEXT:                 clad::pop(_t2);
 // CHECK-NEXT:             }
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 u = clad::pop(_t5);
-// CHECK-NEXT:                 int _r_d1 = _d_u;
-// CHECK-NEXT:             }
+// CHECK-NEXT:             u = clad::pop(_t5);
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 double _r_d0 = _d_sum;
 // CHECK-NEXT:                 _d_u += _r_d0 * clad::pop(_t3);

--- a/test/Gradient/Switch.C
+++ b/test/Gradient/Switch.C
@@ -68,11 +68,10 @@ double fn1(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = _t4;
-// CHECK-NEXT:                     double _r_d3 = _d_res;
-// CHECK-NEXT:                     *_d_i += _r_d3 * j * j * i;
-// CHECK-NEXT:                     *_d_i += i * _r_d3 * j * j;
-// CHECK-NEXT:                     *_d_j += i * i * _r_d3 * j;
-// CHECK-NEXT:                     *_d_j += i * i * j * _r_d3;
+// CHECK-NEXT:                     *_d_i += _d_res * j * j * i;
+// CHECK-NEXT:                     *_d_i += i * _d_res * j * j;
+// CHECK-NEXT:                     *_d_j += i * i * _d_res * j;
+// CHECK-NEXT:                     *_d_j += i * i * j * _d_res;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (_cond0 != 0 && _cond0 != 1 && _cond0 != 2)
 // CHECK-NEXT:                     break;
@@ -81,9 +80,8 @@ double fn1(double i, double j) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         res = _t3;
-// CHECK-NEXT:                         double _r_d2 = _d_res;
-// CHECK-NEXT:                         *_d_j += _r_d2 * j;
-// CHECK-NEXT:                         *_d_j += j * _r_d2;
+// CHECK-NEXT:                         *_d_j += _d_res * j;
+// CHECK-NEXT:                         *_d_j += j * _d_res;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     if (2 == _cond0)
 // CHECK-NEXT:                         break;
@@ -92,9 +90,8 @@ double fn1(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = _t2;
-// CHECK-NEXT:                     double _r_d1 = _d_res;
-// CHECK-NEXT:                     *_d_i += _r_d1 * i;
-// CHECK-NEXT:                     *_d_i += i * _r_d1;
+// CHECK-NEXT:                     *_d_i += _d_res * i;
+// CHECK-NEXT:                     *_d_i += i * _d_res;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (1 == _cond0)
 // CHECK-NEXT:                     break;
@@ -104,9 +101,8 @@ double fn1(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = _t0;
-// CHECK-NEXT:                     double _r_d0 = _d_res;
-// CHECK-NEXT:                     *_d_i += _r_d0 * j;
-// CHECK-NEXT:                     *_d_j += i * _r_d0;
+// CHECK-NEXT:                     *_d_i += _d_res * j;
+// CHECK-NEXT:                     *_d_j += i * _d_res;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (0 == _cond0)
 // CHECK-NEXT:                     break;
@@ -188,9 +184,8 @@ double fn2(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = _t6;
-// CHECK-NEXT:                     double _r_d5 = _d_res;
-// CHECK-NEXT:                     *_d_i += _r_d5;
-// CHECK-NEXT:                     *_d_j += _r_d5;
+// CHECK-NEXT:                     *_d_i += _d_res;
+// CHECK-NEXT:                     *_d_j += _d_res;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (_cond0 != 0 && _cond0 != 1 && _cond0 != 2)
 // CHECK-NEXT:                     break;
@@ -200,9 +195,8 @@ double fn2(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = _t5;
-// CHECK-NEXT:                     double _r_d4 = _d_res;
-// CHECK-NEXT:                     *_d_i += _r_d4 * j;
-// CHECK-NEXT:                     *_d_j += i * _r_d4;
+// CHECK-NEXT:                     *_d_i += _d_res * j;
+// CHECK-NEXT:                     *_d_j += i * _d_res;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (2 == _cond0)
 // CHECK-NEXT:                     break;
@@ -210,8 +204,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = _t4;
-// CHECK-NEXT:                     double _r_d3 = _d_res;
-// CHECK-NEXT:                     *_d_j += _r_d3;
+// CHECK-NEXT:                     *_d_j += _d_res;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (1 == _cond0)
 // CHECK-NEXT:                     break;
@@ -221,24 +214,21 @@ double fn2(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = _t2;
-// CHECK-NEXT:                     double _r_d2 = _d_res;
-// CHECK-NEXT:                     *_d_i += _r_d2;
+// CHECK-NEXT:                     *_d_i += _d_res;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (0 == _cond0)
 // CHECK-NEXT:                     break;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 res = _t1;
-// CHECK-NEXT:                 double _r_d1 = _d_res;
-// CHECK-NEXT:                 *_d_i += 50 * _r_d1;
+// CHECK-NEXT:                 *_d_i += 50 * _d_res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 res = _t0;
-// CHECK-NEXT:                 double _r_d0 = _d_res;
-// CHECK-NEXT:                 *_d_i += _r_d0 * j * j * i;
-// CHECK-NEXT:                 *_d_i += i * _r_d0 * j * j;
-// CHECK-NEXT:                 *_d_j += i * i * _r_d0 * j;
-// CHECK-NEXT:                 *_d_j += i * i * j * _r_d0;
+// CHECK-NEXT:                 *_d_i += _d_res * j * j * i;
+// CHECK-NEXT:                 *_d_i += i * _d_res * j * j;
+// CHECK-NEXT:                 *_d_j += i * i * _d_res * j;
+// CHECK-NEXT:                 *_d_j += i * i * j * _d_res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
@@ -319,9 +309,8 @@ double fn3(double i, double j) {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                                 res = clad::pop(_t5);
-// CHECK-NEXT:                                 double _r_d3 = _d_res;
-// CHECK-NEXT:                                 *_d_i += _r_d3;
-// CHECK-NEXT:                                 *_d_j += _r_d3;
+// CHECK-NEXT:                                 *_d_i += _d_res;
+// CHECK-NEXT:                                 *_d_j += _d_res;
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                             if (clad::back(_cond0) != 0 && clad::back(_cond0) != 1 && clad::back(_cond0) != 2)
 // CHECK-NEXT:                                 break;
@@ -329,9 +318,8 @@ double fn3(double i, double j) {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                                 res = clad::pop(_t4);
-// CHECK-NEXT:                                 double _r_d2 = _d_res;
-// CHECK-NEXT:                                 *_d_j += _r_d2 * j;
-// CHECK-NEXT:                                 *_d_j += j * _r_d2;
+// CHECK-NEXT:                                 *_d_j += _d_res * j;
+// CHECK-NEXT:                                 *_d_j += j * _d_res;
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                             if (2 == clad::back(_cond0))
 // CHECK-NEXT:                                 break;
@@ -342,9 +330,8 @@ double fn3(double i, double j) {
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                                 {
 // CHECK-NEXT:                                     res = clad::pop(_t2);
-// CHECK-NEXT:                                     double _r_d1 = _d_res;
-// CHECK-NEXT:                                     *_d_i += _r_d1 * i;
-// CHECK-NEXT:                                     *_d_i += i * _r_d1;
+// CHECK-NEXT:                                     *_d_i += _d_res * i;
+// CHECK-NEXT:                                     *_d_i += i * _d_res;
 // CHECK-NEXT:                                 }
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                             if (1 == clad::back(_cond0))
@@ -353,11 +340,10 @@ double fn3(double i, double j) {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                                 res = clad::pop(_t1);
-// CHECK-NEXT:                                 double _r_d0 = _d_res;
-// CHECK-NEXT:                                 *_d_i += _r_d0 * j * j * i;
-// CHECK-NEXT:                                 *_d_i += i * _r_d0 * j * j;
-// CHECK-NEXT:                                 *_d_j += i * i * _r_d0 * j;
-// CHECK-NEXT:                                 *_d_j += i * i * j * _r_d0;
+// CHECK-NEXT:                                 *_d_i += _d_res * j * j * i;
+// CHECK-NEXT:                                 *_d_i += i * _d_res * j * j;
+// CHECK-NEXT:                                 *_d_j += i * i * _d_res * j;
+// CHECK-NEXT:                                 *_d_j += i * i * j * _d_res;
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                             if (0 == clad::back(_cond0))
 // CHECK-NEXT:                                 break;
@@ -434,9 +420,8 @@ double fn4(double i, double j) {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             res = clad::pop(_t3);
-// CHECK-NEXT:                             double _r_d1 = _d_res;
-// CHECK-NEXT:                             *_d_i += _r_d1 * j;
-// CHECK-NEXT:                             *_d_j += i * _r_d1;
+// CHECK-NEXT:                             *_d_i += _d_res * j;
+// CHECK-NEXT:                             *_d_j += i * _d_res;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     _t2--;
@@ -450,11 +435,10 @@ double fn4(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = _t0;
-// CHECK-NEXT:                     double _r_d0 = _d_res;
-// CHECK-NEXT:                     *_d_i += _r_d0 * j * j * i;
-// CHECK-NEXT:                     *_d_i += i * _r_d0 * j * j;
-// CHECK-NEXT:                     *_d_j += i * i * _r_d0 * j;
-// CHECK-NEXT:                     *_d_j += i * i * j * _r_d0;
+// CHECK-NEXT:                     *_d_i += _d_res * j * j * i;
+// CHECK-NEXT:                     *_d_i += i * _d_res * j * j;
+// CHECK-NEXT:                     *_d_j += i * i * _d_res * j;
+// CHECK-NEXT:                     *_d_j += i * i * j * _d_res;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (0 == 1)
 // CHECK-NEXT:                     break;
@@ -496,9 +480,8 @@ double fn5(double i, double j) {
 // CHECK-NEXT:             ;
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 res = _t0;
-// CHECK-NEXT:                 double _r_d0 = _d_res;
-// CHECK-NEXT:                 *_d_i += _r_d0 * j;
-// CHECK-NEXT:                 *_d_j += i * _r_d0;
+// CHECK-NEXT:                 *_d_i += _d_res * j;
+// CHECK-NEXT:                 *_d_j += i * _d_res;
 // CHECK-NEXT:             }
 // CHECK-NEXT:             if (1 == _cond0)
 // CHECK-NEXT:                 break;
@@ -546,7 +529,6 @@ double fn6(double u, double v) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     temp = _t1;
-// CHECK-NEXT:                     double _r_d1 = _d_temp;
 // CHECK-NEXT:                     _d_temp = 0.;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (true)
@@ -555,10 +537,9 @@ double fn6(double u, double v) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = _t0;
-// CHECK-NEXT:             int _r_d0 = _d_res;
+// CHECK-NEXT:             *_d_u += _d_res * v;
+// CHECK-NEXT:             *_d_v += u * _d_res;
 // CHECK-NEXT:             _d_res = 0;
-// CHECK-NEXT:             *_d_u += _r_d0 * v;
-// CHECK-NEXT:             *_d_v += u * _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -640,8 +621,7 @@ double fn7(double u, double v) {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             res = clad::pop(_t3);
-// CHECK-NEXT:                             double _r_d1 = _d_res;
-// CHECK-NEXT:                             *_d_v += _r_d1;
+// CHECK-NEXT:                             *_d_v += _d_res;
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                         if (clad::back(_cond0) != 0 && clad::back(_cond0) != 1 && clad::back(_cond0) != 2 && clad::back(_cond0) != 3)
 // CHECK-NEXT:                             break;
@@ -656,8 +636,7 @@ double fn7(double u, double v) {
 // CHECK-NEXT:                         {
 // CHECK-NEXT:                             {
 // CHECK-NEXT:                                 res = clad::pop(_t1);
-// CHECK-NEXT:                                 double _r_d0 = _d_res;
-// CHECK-NEXT:                                 *_d_u += _r_d0;
+// CHECK-NEXT:                                 *_d_u += _d_res;
 // CHECK-NEXT:                             }
 // CHECK-NEXT:                             if (2 == clad::back(_cond0))
 // CHECK-NEXT:                                 break;
@@ -762,11 +741,10 @@ double fn24(double x, double y, Op op) {
 // CHECK-NEXT:            {
 // CHECK-NEXT:                {
 // CHECK-NEXT:                    res = _t4;
-// CHECK-NEXT:                    double _r_d3 = _d_res;
-// CHECK-NEXT:                    _d_res = 0.;
-// CHECK-NEXT:                    *_d_x += _r_d3 / y;
-// CHECK-NEXT:                    double _r0 = _r_d3 * -(x / (y * y));
+// CHECK-NEXT:                    *_d_x += _d_res / y;
+// CHECK-NEXT:                    double _r0 = _d_res * -(x / (y * y));
 // CHECK-NEXT:                    _d_y += _r0;
+// CHECK-NEXT:                    _d_res = 0.;
 // CHECK-NEXT:                }
 // CHECK-NEXT:                if (Div == _cond0)
 // CHECK-NEXT:                    break;
@@ -776,10 +754,9 @@ double fn24(double x, double y, Op op) {
 // CHECK-NEXT:            {
 // CHECK-NEXT:                {
 // CHECK-NEXT:                    res = _t3;
-// CHECK-NEXT:                    double _r_d2 = _d_res;
+// CHECK-NEXT:                    *_d_x += _d_res * y;
+// CHECK-NEXT:                    _d_y += x * _d_res;
 // CHECK-NEXT:                    _d_res = 0.;
-// CHECK-NEXT:                    *_d_x += _r_d2 * y;
-// CHECK-NEXT:                    _d_y += x * _r_d2;
 // CHECK-NEXT:                }
 // CHECK-NEXT:                if (Mul == _cond0)
 // CHECK-NEXT:                    break;
@@ -789,10 +766,9 @@ double fn24(double x, double y, Op op) {
 // CHECK-NEXT:            {
 // CHECK-NEXT:                {
 // CHECK-NEXT:                    res = _t2;
-// CHECK-NEXT:                    double _r_d1 = _d_res;
+// CHECK-NEXT:                    *_d_x += _d_res;
+// CHECK-NEXT:                    _d_y += -_d_res;
 // CHECK-NEXT:                    _d_res = 0.;
-// CHECK-NEXT:                    *_d_x += _r_d1;
-// CHECK-NEXT:                    _d_y += -_r_d1;
 // CHECK-NEXT:                }
 // CHECK-NEXT:                if (Sub == _cond0)
 // CHECK-NEXT:                    break;
@@ -802,10 +778,9 @@ double fn24(double x, double y, Op op) {
 // CHECK-NEXT:            {
 // CHECK-NEXT:                {
 // CHECK-NEXT:                    res = _t0;
-// CHECK-NEXT:                    double _r_d0 = _d_res;
+// CHECK-NEXT:                    *_d_x += _d_res;
+// CHECK-NEXT:                    _d_y += _d_res;
 // CHECK-NEXT:                    _d_res = 0.;
-// CHECK-NEXT:                    *_d_x += _r_d0;
-// CHECK-NEXT:                    _d_y += _r_d0;
 // CHECK-NEXT:                }
 // CHECK-NEXT:                if (Add == _cond0)
 // CHECK-NEXT:                    break;

--- a/test/Gradient/SwitchInit.C
+++ b/test/Gradient/SwitchInit.C
@@ -67,11 +67,10 @@ double fn1(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = _t4;
-// CHECK-NEXT:                     double _r_d3 = _d_res;
-// CHECK-NEXT:                     *_d_i += _r_d3 * j * j * i;
-// CHECK-NEXT:                     *_d_i += i * _r_d3 * j * j;
-// CHECK-NEXT:                     *_d_j += i * i * _r_d3 * j;
-// CHECK-NEXT:                     *_d_j += i * i * j * _r_d3;
+// CHECK-NEXT:                     *_d_i += _d_res * j * j * i;
+// CHECK-NEXT:                     *_d_i += i * _d_res * j * j;
+// CHECK-NEXT:                     *_d_j += i * i * _d_res * j;
+// CHECK-NEXT:                     *_d_j += i * i * j * _d_res;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (_cond0 != 0 && _cond0 != 1 && _cond0 != 2)
 // CHECK-NEXT:                     break;
@@ -80,9 +79,8 @@ double fn1(double i, double j) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         res = _t3;
-// CHECK-NEXT:                         double _r_d2 = _d_res;
-// CHECK-NEXT:                         *_d_j += _r_d2 * j;
-// CHECK-NEXT:                         *_d_j += j * _r_d2;
+// CHECK-NEXT:                         *_d_j += _d_res * j;
+// CHECK-NEXT:                         *_d_j += j * _d_res;
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                     if (2 == _cond0)
 // CHECK-NEXT:                         break;
@@ -91,9 +89,8 @@ double fn1(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = _t2;
-// CHECK-NEXT:                     double _r_d1 = _d_res;
-// CHECK-NEXT:                     *_d_i += _r_d1 * i;
-// CHECK-NEXT:                     *_d_i += i * _r_d1;
+// CHECK-NEXT:                     *_d_i += _d_res * i;
+// CHECK-NEXT:                     *_d_i += i * _d_res;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (1 == _cond0)
 // CHECK-NEXT:                     break;
@@ -103,9 +100,8 @@ double fn1(double i, double j) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     res = _t0;
-// CHECK-NEXT:                     double _r_d0 = _d_res;
-// CHECK-NEXT:                     *_d_i += _r_d0 * j;
-// CHECK-NEXT:                     *_d_j += i * _r_d0;
+// CHECK-NEXT:                     *_d_i += _d_res * j;
+// CHECK-NEXT:                     *_d_j += i * _d_res;
 // CHECK-NEXT:                 }
 // CHECK-NEXT:                 if (0 == _cond0)
 // CHECK-NEXT:                     break;

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -481,16 +481,15 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     if (_cond3) {
 // CHECK-NEXT:         derivative = _t2;
-// CHECK-NEXT:         float _r_d1 = _d_derivative;
 // CHECK-NEXT:         float _r4 = 0.F;
 // CHECK-NEXT:         float _r5 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(x, exponent, _r_d1 * d_exponent * _t3, &_r4, &_r5);
+// CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(x, exponent, _d_derivative * d_exponent * _t3, &_r4, &_r5);
 // CHECK-NEXT:         *_d_x += _r4;
 // CHECK-NEXT:         *_d_exponent += _r5;
 // CHECK-NEXT:         float _r6 = 0.F;
-// CHECK-NEXT:         _r6 += _t4 * _r_d1 * d_exponent * clad::custom_derivatives::std::log_pushforward(x, 1.F).pushforward;
+// CHECK-NEXT:         _r6 += _t4 * _d_derivative * d_exponent * clad::custom_derivatives::std::log_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:         *_d_x += _r6;
-// CHECK-NEXT:         *_d_d_exponent += (_t4 * _t3) * _r_d1;
+// CHECK-NEXT:         *_d_d_exponent += (_t4 * _t3) * _d_derivative;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_exponent += _d_derivative * d_x * _t1;
@@ -508,7 +507,6 @@ int main() {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (_cond1) {
 // CHECK-NEXT:                 _cond0 = _t0;
-// CHECK-NEXT:                 double _r_d0 = _d_cond0;
 // CHECK-NEXT:                 _d_cond0 = 0.;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -154,10 +154,9 @@
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    {
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        _final_error += _d_z * z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        z = _t0;
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:        float _r_d0 = _d_z;
+// CHECK_CUSTOM_MODEL_EXEC-NEXT:        *_d_x += _d_z;
+// CHECK_CUSTOM_MODEL_EXEC-NEXT:        *_d_y += _d_z;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:        _d_z = 0.F;
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:        *_d_x += _r_d0;
-// CHECK_CUSTOM_MODEL_EXEC-NEXT:        *_d_y += _r_d0;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    }
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    _final_error += *_d_x * x;
 // CHECK_CUSTOM_MODEL_EXEC-NEXT:    _final_error += *_d_y * y;
@@ -185,10 +184,9 @@
 // CHECK_PRINT_MODEL_EXEC-NEXT:    {
 // CHECK_PRINT_MODEL_EXEC-NEXT:        _final_error += clad::getErrorVal(_d_z, z, "z");
 // CHECK_PRINT_MODEL_EXEC-NEXT:        z = _t0;
-// CHECK_PRINT_MODEL_EXEC-NEXT:        float _r_d0 = _d_z;
+// CHECK_PRINT_MODEL_EXEC-NEXT:        *_d_x += _d_z;
+// CHECK_PRINT_MODEL_EXEC-NEXT:        *_d_y += _d_z;
 // CHECK_PRINT_MODEL_EXEC-NEXT:        _d_z = 0.F;
-// CHECK_PRINT_MODEL_EXEC-NEXT:        *_d_x += _r_d0;
-// CHECK_PRINT_MODEL_EXEC-NEXT:        *_d_y += _r_d0;
 // CHECK_PRINT_MODEL_EXEC-NEXT:    }
 // CHECK_PRINT_MODEL_EXEC-NEXT:    _final_error += clad::getErrorVal(*_d_x, x, "x");
 // CHECK_PRINT_MODEL_EXEC-NEXT:    _final_error += clad::getErrorVal(*_d_y, y, "y");


### PR DESCRIPTION
Currently, we differentiate assignments in the reverse mode as follows:
```
x = y;
...
double _r_d0 = _d_x;
_d_x = 0.;
_d_y += _r_d0;
```
Obviously, in this case, we can simply do
```
_d_y += _d_x;
_d_x = 0.;
```
The current system is motivated by the cases when the LHS and RHS are dependent, for example, if we used this simplified logic for
```
x = x * x;
```
we would get
```
_d_x += x * _d_x;
_d_x += _d_x * x;
_d_x = 0.;
```
which is wrong for many reasons. In order to do this simplification safely, we need to know that setting the derivatives of the RHS will not interfere with setting the derivatives of the LHS. This PR implements a surface-level analysis of assignments. The cases with pointers/arrays/references are ignored for now (meaning the old safe behavior).