### PR TITLE
Support not differentiating w.r.t. const references in reverse mode

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -412,6 +412,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           continue;
         }
         auto VDDerivedType = utils::getNonConstType(paramTy, m_Sema);
+        VDDerivedType = VDDerivedType.getNonReferenceType();
         auto* VDDerived =
             BuildGlobalVarDecl(VDDerivedType, "_d_" + param->getNameAsString(),
                                getZeroInit(VDDerivedType));

--- a/test/Gradient/DiffInterface.C
+++ b/test/Gradient/DiffInterface.C
@@ -73,6 +73,18 @@ double f_1(double x, double y, double z) {
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 
+double f_2 (const double& x, const double& y) {
+   return x + y;
+}
+
+//CHECK:   void f_2_grad_0(const double &x, const double &y, double *_d_x) {
+//CHECK-NEXT:       double _d_y = 0.;
+//CHECK-NEXT:       {
+//CHECK-NEXT:           *_d_x += 1;
+//CHECK-NEXT:           _d_y += 1;
+//CHECK-NEXT:       }
+//CHECK-NEXT:   }
+
 #define TEST(F, ...)                                                           \
   {                                                                            \
     result[0] = 0;                                                             \
@@ -129,6 +141,11 @@ int main () {
        &result[0],
        &result[1],
        &result[2]); // CHECK-EXEC: {0.00, 1.00, 2.00}
+
+  auto f2_dX = clad::gradient(f_2, "0");
+  result[0] = 0;
+  f2_dX.execute(2, 3, &result[0]);
+  printf("{%.2f}\n", result[0]); // CHECK-EXEC: {1.00}
 
   return 0;
 }


### PR DESCRIPTION
This PR fixes issue #1411. If the user doesn't request a derivative w.r.t. a const reference, that derivative will, in theory, not be used. However, in this PR, we still generate it to avoid partial pullbacks.

Fixes #1411.