### PR TITLE
Find used parameter values in nested TBR 

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -421,6 +421,9 @@ namespace clad {
     bool isInjective(const clang::Expr* E, clang::AnalysisDeclContext* ADC);
     /// Checks if the return value of the given CallExpr is unused.
     bool hasUnusedReturnValue(clang::ASTContext& C, const clang::CallExpr* CE);
+    /// For an expr E, decides if we should recompute it or store it.
+    /// This is the central point for checkpointing.
+    bool ShouldRecompute(const clang::Expr* E, const clang::ASTContext& C);
     } // namespace utils
     } // namespace clad
 

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -49,6 +49,7 @@ private:
   mutable struct TbrRunInfo {
     std::set<clang::SourceLocation> ToBeRecorded;
     ParamInfo m_ModifiedParams;
+    ParamInfo m_UsedParams;
     bool HasAnalysisRun = false;
   } m_TbrRunInfo;
 
@@ -199,6 +200,11 @@ public:
   void addFunctionModifiedParams(const clang::FunctionDecl* FD,
                                  const ParamSet& params) {
     m_TbrRunInfo.m_ModifiedParams[FD] = params;
+  }
+  ParamInfo& getUsedParams() const { return m_TbrRunInfo.m_UsedParams; }
+  void addFunctionUsedParams(const clang::FunctionDecl* FD,
+                             const ParamSet& params) {
+    m_TbrRunInfo.m_UsedParams[FD] = params;
   }
   void addVariedDecl(const clang::VarDecl* init) {
     m_ActivityRunInfo.VariedDecls.insert(init);

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -215,10 +215,6 @@ namespace clad {
     /// to avoid recomputiation.
     bool UsefulToStoreGlobal(clang::Expr* E);
 
-    /// For an expr E, decides if we should recompute it or store it.
-    /// This is the central point for checkpointing.
-    bool ShouldRecompute(const clang::Expr* E);
-
     /// Builds a variable declaration and stores it in the function
     /// global scope.
     ///

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -637,7 +637,7 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
         Function->isDefined() && m_AnalysisDC) {
       TimedAnalysisRegion R("TBR " + BaseFunctionName);
       TBRAnalyzer analyzer(m_AnalysisDC, getToBeRecorded(),
-                           &getModifiedParams());
+                           &getModifiedParams(), &getUsedParams());
       analyzer.Analyze(*this);
     }
     auto found = m_TbrRunInfo.ToBeRecorded.find(S->getBeginLoc());
@@ -1295,10 +1295,12 @@ DeclRefExpr* getArgFunction(CallExpr* call, Sema& SemaRef) {
       if (requestTBR) {
         TimedAnalysisRegion R("TBR " + request.BaseFunctionName);
         ParamInfo& modifiedParams = request.getModifiedParams();
+        ParamInfo& usedParams = request.getUsedParams();
         TBRAnalyzer analyzer(request.m_AnalysisDC, request.getToBeRecorded(),
-                             &modifiedParams);
+                             &modifiedParams, &usedParams);
         analyzer.Analyze(request);
         Saved.get()->addFunctionModifiedParams(FD, modifiedParams[FD]);
+        Saved.get()->addFunctionUsedParams(FD, usedParams[FD]);
       }
     }
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2387,7 +2387,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // in the reverse sweep and in RMV::VisitBinaryOperator
       // the order is not reversed.
       beginBlock(direction::reverse);
-      if (!ShouldRecompute(LStored.getExpr()))
+      if (!utils::ShouldRecompute(LStored.getExpr(), m_Context))
         LStored = GlobalStoreAndRef(LStored.getExpr(), /*prefix=*/"_t",
                                     /*force=*/true);
       Stmt* LPop = endBlock(direction::reverse);
@@ -2418,7 +2418,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // in the reverse sweep and in RMV::VisitBinaryOperator
       // the order is not reversed.
       beginBlock(direction::reverse);
-      if (!ShouldRecompute(LStored.getExpr()))
+      if (!utils::ShouldRecompute(LStored.getExpr(), m_Context))
         LStored = GlobalStoreAndRef(LStored.getExpr(), /*prefix=*/"_t",
                                     /*force=*/true);
       Stmt* LPop = endBlock(direction::reverse);
@@ -3312,28 +3312,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     return Visit(EWC->getSubExpr(), dfdx());
   }
 
-  /// Called in ShouldRecompute. In CUDA, to access a current thread/block id
-  /// we use functions that do not change the state of any variable, since no
-  /// point to store the value.
-  static bool isCUDABuiltInIndex(const Expr* E) {
-    const clang::Expr* B = E->IgnoreImplicit();
-    if (const auto* pseudoE = llvm::dyn_cast<PseudoObjectExpr>(B)) {
-      if (const auto* opaqueE =
-              llvm::dyn_cast<OpaqueValueExpr>(pseudoE->getSemanticExpr(0))) {
-        const Expr* innerE = opaqueE->getSourceExpr()->IgnoreImplicit();
-        QualType innerT = innerE->getType();
-        if (innerT.isConstQualified())
-          return true;
-      }
-    }
-    return false;
-  }
-
-  bool ReverseModeVisitor::ShouldRecompute(const Expr* E) {
-    return !(utils::ContainsFunctionCalls(E) || E->HasSideEffects(m_Context)) ||
-           isCUDABuiltInIndex(E);
-  }
-
   bool ReverseModeVisitor::UsefulToStoreGlobal(Expr* E) {
     if (!E)
       return false;
@@ -3571,7 +3549,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                                 /*isInsideLoop=*/false,
                                 /*isFnScope=*/false};
     }
-    if (!forceStore && ShouldRecompute(E)) {
+    if (!forceStore && utils::ShouldRecompute(E, m_Context)) {
       // The value of the literal has no. It's given a very particular value for
       // easier debugging.
       Expr* PH = ConstantFolder::synthesizeLiteral(E->getType(), m_Context,

--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -110,6 +110,7 @@ public:
   bool TraverseDeclStmt(clang::DeclStmt* DS);
   bool TraverseInitListExpr(clang::InitListExpr* ILE);
   bool TraverseMemberExpr(clang::MemberExpr* ME);
+  bool TraverseReturnStmt(clang::ReturnStmt* RS);
   bool TraverseUnaryOperator(clang::UnaryOperator* UnOp);
 };
 

--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -40,6 +40,7 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer>,
   /// is the result of analysis.
   std::set<clang::SourceLocation>& m_TBRLocs;
   ParamInfo* m_ModifiedParams;
+  ParamInfo* m_UsedParams;
 
   /// Stores modes in a stack (used to retrieve the old mode after entering
   /// a new one).
@@ -78,9 +79,10 @@ public:
   /// Constructor
   TBRAnalyzer(clang::AnalysisDeclContext* AnalysisDC,
               std::set<clang::SourceLocation>& Locs,
-              ParamInfo* ModifiedParams = nullptr)
+              ParamInfo* ModifiedParams = nullptr,
+              ParamInfo* UsedParams = nullptr)
       : AnalysisBase(AnalysisDC), m_TBRLocs(Locs),
-        m_ModifiedParams(ModifiedParams) {
+        m_ModifiedParams(ModifiedParams), m_UsedParams(UsedParams) {
     m_ModeStack.push_back(0);
   }
 
@@ -104,6 +106,7 @@ public:
   bool TraverseConditionalOperator(clang::ConditionalOperator* CO);
   bool TraverseCompoundAssignOperator(clang::CompoundAssignOperator* BinOp);
   bool TraverseCXXConstructExpr(clang::CXXConstructExpr* CE);
+  bool TraverseCXXThisExpr(clang::CXXThisExpr* TE);
   bool TraverseCXXMemberCallExpr(clang::CXXMemberCallExpr* CE);
   bool TraverseCXXOperatorCallExpr(clang::CXXOperatorCallExpr* CE);
   bool TraverseDeclRefExpr(clang::DeclRefExpr* DRE);

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -450,7 +450,6 @@ double f13(double x, double y) {
 }
 
 //CHECK:   void f13_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _t1 = y;
 //CHECK-NEXT:       double _t0 = (y = x);
 //CHECK-NEXT:       double _d_t = 0.;
 //CHECK-NEXT:       double t = x * _t0;
@@ -461,7 +460,6 @@ double f13(double x, double y) {
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += _d_t * _t0;
 //CHECK-NEXT:           *_d_y += x * _d_t;
-//CHECK-NEXT:           y = _t1;
 //CHECK-NEXT:           *_d_x += *_d_y;
 //CHECK-NEXT:           *_d_y = 0.;
 //CHECK-NEXT:       }

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -726,14 +726,13 @@ double fn11(double u, double v) {
 // CHECK-NEXT:      double res = 0;
 // CHECK-NEXT:      A _d_a = {0.};
 // CHECK-NEXT:      A a;
-// CHECK-NEXT:      A _t0 = a;
 // CHECK-NEXT:      a.setData(u);
 // CHECK-NEXT:      res += a.data * v;
-// CHECK-NEXT:      A _t1 = a;
+// CHECK-NEXT:      A _t0 = a;
 // CHECK-NEXT:      a.increment();
 // CHECK-NEXT:      _d_res += 1;
 // CHECK-NEXT:      {
-// CHECK-NEXT:          a = _t1;
+// CHECK-NEXT:          a = _t0;
 // CHECK-NEXT:          a.increment_pullback(&_d_a);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
@@ -743,7 +742,6 @@ double fn11(double u, double v) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
-// CHECK-NEXT:          a = _t0;
 // CHECK-NEXT:          a.setData_pullback(u, &_d_a, &_r0);
 // CHECK-NEXT:          *_d_u += _r0;
 // CHECK-NEXT:      }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -241,13 +241,12 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT: }
 
 // CHECK: void fn6_grad(dcomplex c, double i, dcomplex *_d_c, double *_d_i) {
-// CHECK-NEXT:     dcomplex _t0 = c;
 // CHECK-NEXT:     c.real(5 * i);
-// CHECK-NEXT:     double _t1 = c.imag();
+// CHECK-NEXT:     double _t0 = c.imag();
 // CHECK-NEXT:     double _d_res = 0.;
-// CHECK-NEXT:     double res = c.real() + 3 * _t1 + 6 * i;
-// CHECK-NEXT:     double _t2 = c.real();
-// CHECK-NEXT:     res += 4 * _t2;
+// CHECK-NEXT:     double res = c.real() + 3 * _t0 + 6 * i;
+// CHECK-NEXT:     double _t1 = c.real();
+// CHECK-NEXT:     res += 4 * _t1;
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_res;
@@ -260,7 +259,6 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         c = _t0;
 // CHECK-NEXT:         c.real_pullback(5 * i, &(*_d_c), &_r0);
 // CHECK-NEXT:         *_d_i += 5 * _r0;
 // CHECK-NEXT:     }
@@ -273,16 +271,14 @@ double fn7(dcomplex c1, dcomplex c2) {
 
 // CHECK: void fn7_grad(dcomplex c1, dcomplex c2, dcomplex *_d_c1, dcomplex *_d_c2) {
 // CHECK-NEXT:     double _t0 = c2.real();
-// CHECK-NEXT:     dcomplex _t1 = c1;
 // CHECK-NEXT:     c1.real(c2.imag() + 5 * _t0);
-// CHECK-NEXT:     double _t2 = c1.imag();
+// CHECK-NEXT:     double _t1 = c1.imag();
 // CHECK-NEXT:     {
 // CHECK-NEXT:         c1.real_pullback(1, &(*_d_c1));
 // CHECK-NEXT:         c1.imag_pullback(3 * 1, &(*_d_c1));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         c1 = _t1;
 // CHECK-NEXT:         c1.real_pullback(c2.imag() + 5 * _t0, &(*_d_c1), &_r0);
 // CHECK-NEXT:         c2.imag_pullback(_r0, &(*_d_c2));
 // CHECK-NEXT:         c2.real_pullback(5 * _r0, &(*_d_c2));
@@ -314,16 +310,14 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK-NEXT: }
 
 // CHECK: void fn8_grad(Tangent t, dcomplex c, Tangent *_d_t, dcomplex *_d_c) {
-// CHECK-NEXT:     Tangent _t0 = t;
 // CHECK-NEXT:     t.updateTo(c.real());
-// CHECK-NEXT:     Tangent _t1 = t;
+// CHECK-NEXT:     Tangent _t0 = t;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         t = _t1;
+// CHECK-NEXT:         t = _t0;
 // CHECK-NEXT:         sum_pullback(t, 1, &(*_d_t));
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         t = _t0;
 // CHECK-NEXT:         t.updateTo_pullback(c.real(), &(*_d_t), &_r0);
 // CHECK-NEXT:         c.real_pullback(_r0, &(*_d_c));
 // CHECK-NEXT:     }


### PR DESCRIPTION
After #1490, TBR can detect which parameters have been modified. This PR extends the analysis of the same class of functions to also track whether the function uses the given parameter value, which allows for more optimization in TBR. In particular, now we can avoid storing some arguments even if they are modified.

This PR is a less powerful version of #1506 that works consistently across all platforms. To get the benefits from STL, we need to improve the system of nested TBR to analyze which fields of objects are modified/used. However, even in its current form, this PR is sufficient to unblock #1445. 

During the work on this PR, there occured a bug, the reason for which was that return stmts were not properly visited in TBR. Fixing that caused regressions in some tests, and the goal of the second commit is to deal with those regressions.
The core idea there is that we don't have to store operands if a whole expr is already stored. In particular, we often store the LHS/RHS of multiplication/division.