### PR TITLE
Use Stmt* as identifiers in TBR instead of SourceLocation

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -47,7 +47,7 @@ private:
   /// UsefulToStoreGlobal whether a variable with a given SourceLocation has to
   /// be stored before being changed or not.
   mutable struct TbrRunInfo {
-    std::set<clang::SourceLocation> ToBeRecorded;
+    std::set<const clang::Stmt*> ToBeRecorded;
     ParamInfo m_ModifiedParams;
     ParamInfo m_UsedParams;
     bool HasAnalysisRun = false;
@@ -194,7 +194,7 @@ public:
   std::string ComputeDerivativeName() const;
   bool HasIndependentParameter(const clang::ParmVarDecl* PVD) const;
 
-  std::set<clang::SourceLocation>& getToBeRecorded() const {
+  std::set<const clang::Stmt*>& getToBeRecorded() const {
     m_TbrRunInfo.HasAnalysisRun = true;
     return m_TbrRunInfo.ToBeRecorded;
   }

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -675,7 +675,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
                            &getModifiedParams(), &getUsedParams());
       analyzer.Analyze(*this);
     }
-    auto found = m_TbrRunInfo.ToBeRecorded.find(S->getBeginLoc());
+    auto found = m_TbrRunInfo.ToBeRecorded.find(S);
     return found != m_TbrRunInfo.ToBeRecorded.end();
   }
 

--- a/lib/Differentiator/TBRAnalyzer.h
+++ b/lib/Differentiator/TBRAnalyzer.h
@@ -38,7 +38,7 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer>,
   enum Mode { kMarkingMode = 1, kNonLinearMode = 2 };
   /// Tells if the variable at a given location is required to store. Basically,
   /// is the result of analysis.
-  std::set<clang::SourceLocation>& m_TBRLocs;
+  std::set<const clang::Stmt*>& m_TBRLocs;
   ParamInfo* m_ModifiedParams;
   ParamInfo* m_UsedParams;
 
@@ -50,7 +50,7 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer>,
   std::vector<short> m_BlockPassCounter;
 
   //// Setters
-  /// Marks the SourceLocation of S if it is required to store.
+  /// Marks S if it is required to store.
   /// E could be DeclRefExpr, ArraySubscriptExpr, MemberExpr, or DeclStmt.
   void markLocation(const clang::Stmt* S);
   /// Sets E's corresponding VarData (or all its child nodes) to
@@ -76,7 +76,7 @@ class TBRAnalyzer : public clang::RecursiveASTVisitor<TBRAnalyzer>,
 public:
   /// Constructor
   TBRAnalyzer(clang::AnalysisDeclContext* AnalysisDC,
-              std::set<clang::SourceLocation>& Locs,
+              std::set<const clang::Stmt*>& Locs,
               ParamInfo* ModifiedParams = nullptr,
               ParamInfo* UsedParams = nullptr)
       : AnalysisBase(AnalysisDC), m_TBRLocs(Locs),


### PR DESCRIPTION
Currently, we use ``clang::SourceLocation`` to propagate information from ``TBR`` to ``ReverseModeVisitor``. Source locations are unreliable for a couple of reasons:
1) Some stmts don't have it. For example, if the code is compiler- or clad-generated.
2) Some stmts have the same location. For example,
```
a.getX() = 1;
```
Since ``a`` and ``a.getX()`` have the same location, we cannot differentiate between the information about storing ``a`` in the ``CallExpr`` ``a.getX()`` and about storing ``a.getX()`` in the assignment ``a.getX() = 1``. Storing stmts by pointers allows us to consider these as separate entities.