### PR TITLE
Change m_DelayedCalls to std::deque

### DIFF
--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -26,6 +26,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 
+#include <deque>
 #include <map>
 #include <set>
 #include <string>
@@ -147,7 +148,7 @@ struct DifferentiationOptions {
     };
     /// The calls to the main action which clad delayed and will dispatch at
     /// then end of the translation unit.
-    std::vector<DelayedCallInfo> m_DelayedCalls;
+    std::deque<DelayedCallInfo> m_DelayedCalls;
     /// The default clang consumers which are called after clad is done.
     std::unique_ptr<clang::MultiplexConsumer> m_Multiplexer;
 


### PR DESCRIPTION
``m_DelayedCalls`` shouldn't be a ``std::vector`` because we often iterate over it to modify it. In other words, the locations of its elements should ideally remain unchanged. Otherwise, using iterators on it easily leads to accessing deallocated memory.