### PR TITLE
Fix range-based loops and add early traverse for regular loops in VA

### DIFF
--- a/lib/Differentiator/ActivityAnalyzer.h
+++ b/lib/Differentiator/ActivityAnalyzer.h
@@ -34,10 +34,10 @@ class VariedAnalyzer : public clang::RecursiveASTVisitor<VariedAnalyzer>,
 
   DiffRequest& m_DiffReq;
   std::set<const clang::Stmt*>& m_ResSet;
-
   void markExpr(const clang::Stmt* S) { m_ResSet.insert(S); }
   void setVaried(const clang::Expr* E, bool isVaried = true);
   void AnalyzeCFGBlock(const clang::CFGBlock& block);
+  void TraverseAllStmtInsideBlock(const clang::CFGBlock& block);
 
 public:
   /// Constructor

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -1,6 +1,6 @@
 // RUN: %cladclang %s -I%S/../../include -oReverseLoops.out 2>&1 | %filecheck %s
 // RUN: ./ReverseLoops.out | %filecheck_exec %s
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oReverseLoops.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -Xclang -plugin-arg-clad -Xclang -enable-va %s -I%S/../../include -oReverseLoops.out
 // RUN: ./ReverseLoops.out | %filecheck_exec %s
 // XFAIL: valgrind
 
@@ -2752,7 +2752,7 @@ int main() {
   TEST_2(fn40, 2, 3); // CHECK-EXEC: {14.00, 0.00}
   TEST_2(fn41, 2, 3); // CHECK-EXEC: {1.00, 0.00}
   
-  auto d_fn42 = clad::gradient(fn42, "0");
+  auto d_fn42 = clad::gradient<clad::opts::disable_va>(fn42, "0");
   float x_ = 2.0f;
   layer l{ .w = {{3}, {4}, {5}, {6}}};
   layer d_l{ .w = {{0}, {0}, {0}, {0}}};


### PR DESCRIPTION
This PR fixes two issues in loop analysis that led to incorrect behavior. First one occured because we used to merge all data into the condition block before traversing a successor block, which could cause problems like entering an infinite loop in cases like:
```cpp
while(b = 1)
  b = x
```
or codition not being the last block to be analyzed. Second thing is that the analysis made assumptions based on block numeration, which do not hold for the range-based loops where the CFG is inverted.

Also, we now run numerical check for Gradient/Loops.C with VA on.