### PR TITLE
Move argument differentiation into a separate function

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -482,6 +482,27 @@ namespace clad {
     /// additionally created Stmts, second is a direct result of call to Visit.
     std::pair<StmtDiff, StmtDiff>
     DifferentiateSingleExpr(const clang::Expr* E, clang::Expr* dfdE = nullptr);
+    /// A helper methods to differentiate an argument of a CallExpr or a
+    /// CXXConstructExpr.
+    ///
+    /// \param[in] arg The argument to be differentiated
+    ///
+    /// \param[in] param The corresponding parameter
+    ///
+    /// \param[in] PreCallStmts The block of stmts to be inserted right before
+    /// the pullback call
+    ///
+    /// \param[in] isNonDiff true if the corresponding call is
+    /// non-differentiable
+    ///
+    /// \returns A triplet of differentiated arguments, i.e. ``{<original arg>,
+    /// <arg for pullback>, <reverse_forw arg>}``. In practice, it will look
+    /// somewhat like ``{x, &_r0, _d_x}``.
+    StmtDiff
+    DifferentiateCallArg(const clang::Expr* arg,
+                         const clang::ParmVarDecl* param,
+                         llvm::SmallVectorImpl<clang::Stmt*>& PreCallStmts,
+                         bool isNonDiff, bool isCUDAKernel = false);
     /// Shorthand for warning on differentiation of unsupported operators
     void unsupportedOpWarn(clang::SourceLocation loc,
                            llvm::ArrayRef<llvm::StringRef> args = {}) {

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -64,6 +64,7 @@ namespace clad {
 
     void updateStmt(clang::Stmt* S) { data[1] = S; }
     void updateStmtDx(clang::Stmt* S) { data[0] = S; }
+    void updateRevSweep(clang::Stmt* S) { m_ValueForRevSweep = S; }
     // Stmt_dx goes first!
     std::array<clang::Stmt*, 2>& getBothStmts() { return data; }
 

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -6,6 +6,8 @@
 #include "clad/Differentiator/ReverseModeVisitor.h"
 
 #include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/Basic/LLVM.h"
 
 #include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallVector.h>
@@ -116,8 +118,9 @@ void ErrorEstimationHandler::EmitNestedFunctionParamError(
     // // estimation.
     // if (utils::IsReferenceOrPointerType(fnDecl->getParamDecl(i)->getType()))
     //   continue;
+    auto* UnOp = cast<UnaryOperator>(ArgResult[i]);
     Expr* errorExpr = m_EstModel->AssignError(
-        {derivedCallArgs[i], m_RMV->Clone(ArgResult[i])},
+        {derivedCallArgs[i], m_RMV->Clone(UnOp->getSubExpr())},
         fnDecl->getNameInfo().getAsString() + "_param_" + std::to_string(i));
     Expr* FinalError = BuildFinalErrorExpr();
     Expr* errorStmt = m_RMV->BuildOp(BO_AddAssign, FinalError, errorExpr);

--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -324,7 +324,7 @@ double f10(double x){
 // CHECK-NEXT:     double _d_t[3] = {0};
 // CHECK-NEXT:     double t[3];
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
-// CHECK-NEXT:     f10_1_reverse_forw(x, t, 0., _d_t, _tracker0);
+// CHECK-NEXT:     f10_1_reverse_forw(x, t, *_d_x, _d_t, _tracker0);
 // CHECK-NEXT:     _d_t[0] += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _tracker0.restore();

--- a/test/CUDA/ThrustCopy.cu
+++ b/test/CUDA/ThrustCopy.cu
@@ -25,7 +25,7 @@ void copy(const thrust::device_vector<double>& src,
     thrust::copy(src.begin(), src.end(), dst.begin());
 }
 // CHECK: void copy_grad(const thrust::device_vector<double> &src, thrust::device_vector<double> &dst, thrust::device_vector<double> *_d_src, thrust::device_vector<double> *_d_dst) {
-// CHECK-NEXT:     {{.*}}thrust::copy_reverse_forw(std::begin(src), std::end(src), std::begin(dst), {}, {}, {});
+// CHECK-NEXT:     {{.*}}thrust::copy_reverse_forw(std::begin(src), std::end(src), std::begin(dst), std::begin((*_d_src)), std::end((*_d_src)), std::begin((*_d_dst)));
 // CHECK-NEXT:     {
 // CHECK-NEXT:         const_iterator _r0 = std::begin((*_d_src));
 // CHECK-NEXT:         const_iterator _r1 = std::end((*_d_src));
@@ -40,7 +40,7 @@ void copy_with_return_value_stored(const thrust::device_vector<double>& src,
     (void)it;
 }
 // CHECK: void copy_with_return_value_stored_grad(const thrust::device_vector<double> &src, thrust::device_vector<double> &dst, thrust::device_vector<double> *_d_src, thrust::device_vector<double> *_d_dst) {
-// CHECK-NEXT:     clad::ValueAndAdjoint<{{.*}}> _t0 = {{.*}}thrust::copy_reverse_forw(std::begin(src), std::end(src), std::begin(dst), {}, {}, {});
+// CHECK-NEXT:     clad::ValueAndAdjoint<{{.*}}> _t0 = {{.*}}thrust::copy_reverse_forw(std::begin(src), std::end(src), std::begin(dst), std::begin((*_d_src)), std::end((*_d_src)), std::begin((*_d_dst)));
 // CHECK-NEXT:     thrust::detail::normal_iterator<device_ptr<double> > it = _t0.value;
 // CHECK-NEXT:     thrust::detail::normal_iterator<device_ptr<double> > _d_it = {};
 // CHECK-NEXT:     clad::zero_init(_d_it);

--- a/test/CUDA/ThrustTransform.cu
+++ b/test/CUDA/ThrustTransform.cu
@@ -28,7 +28,7 @@ void transform_negate(const thrust::device_vector<double>& vec, thrust::device_v
     thrust::transform(vec.begin(), vec.end(), output.begin(), thrust::negate<double>());
 }
 // CHECK: void transform_negate_grad(const thrust::device_vector<double> &vec, thrust::device_vector<double> &output, thrust::device_vector<double> *_d_vec, thrust::device_vector<double> *_d_output) {
-// CHECK-NEXT: {{.*}}thrust::transform_reverse_forw(std::begin(vec), std::end(vec), std::begin(output), thrust::negate<double>(), {}, {}, {}, {});
+// CHECK-NEXT: {{.*}}thrust::transform_reverse_forw(std::begin(vec), std::end(vec), std::begin(output), thrust::negate<double>(), std::begin((*_d_vec)), std::end((*_d_vec)), std::begin((*_d_output)), {});
 // CHECK-NEXT: {
 // CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec));
 // CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec));
@@ -42,7 +42,7 @@ void transform_identity(const thrust::device_vector<double>& vec, thrust::device
     thrust::transform(vec.begin(), vec.end(), output.begin(), thrust::identity<double>());
 }
 // CHECK: void transform_identity_grad(const thrust::device_vector<double> &vec, thrust::device_vector<double> &output, thrust::device_vector<double> *_d_vec, thrust::device_vector<double> *_d_output) {
-// CHECK-NEXT: {{.*}}thrust::transform_reverse_forw(std::begin(vec), std::end(vec), std::begin(output), thrust::identity<double>(), {}, {}, {}, {});
+// CHECK-NEXT: {{.*}}thrust::transform_reverse_forw(std::begin(vec), std::end(vec), std::begin(output), thrust::identity<double>(), std::begin((*_d_vec)), std::end((*_d_vec)), std::begin((*_d_output)), {});
 // CHECK-NEXT: {
 // CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec));
 // CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec));
@@ -56,7 +56,7 @@ void transform_plus(const thrust::device_vector<double>& vec1, const thrust::dev
     thrust::transform(vec1.begin(), vec1.end(), vec2.begin(), output.begin(), thrust::plus<double>());
 }
 // CHECK: void transform_plus_grad(const thrust::device_vector<double> &vec1, const thrust::device_vector<double> &vec2, thrust::device_vector<double> &output, thrust::device_vector<double> *_d_vec1, thrust::device_vector<double> *_d_vec2, thrust::device_vector<double> *_d_output) {
-// CHECK-NEXT: {{.*}}thrust::transform_reverse_forw(std::begin(vec1), std::end(vec1), std::begin(vec2), std::begin(output), thrust::plus<double>(), {}, {}, {}, {}, {});
+// CHECK-NEXT: {{.*}}thrust::transform_reverse_forw(std::begin(vec1), std::end(vec1), std::begin(vec2), std::begin(output), thrust::plus<double>(), std::begin((*_d_vec1)), std::end((*_d_vec1)), std::begin((*_d_vec2)), std::begin((*_d_output)), {});
 // CHECK-NEXT: {
 // CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec1));
 // CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec1));
@@ -71,7 +71,7 @@ void transform_minus(const thrust::device_vector<double>& vec1, const thrust::de
     thrust::transform(vec1.begin(), vec1.end(), vec2.begin(), output.begin(), thrust::minus<double>());
 }
 // CHECK: void transform_minus_grad(const thrust::device_vector<double> &vec1, const thrust::device_vector<double> &vec2, thrust::device_vector<double> &output, thrust::device_vector<double> *_d_vec1, thrust::device_vector<double> *_d_vec2, thrust::device_vector<double> *_d_output) {
-// CHECK-NEXT: {{.*}}thrust::transform_reverse_forw(std::begin(vec1), std::end(vec1), std::begin(vec2), std::begin(output), thrust::minus<double>(), {}, {}, {}, {}, {});
+// CHECK-NEXT: {{.*}}thrust::transform_reverse_forw(std::begin(vec1), std::end(vec1), std::begin(vec2), std::begin(output), thrust::minus<double>(), std::begin((*_d_vec1)), std::end((*_d_vec1)), std::begin((*_d_vec2)), std::begin((*_d_output)), {});
 // CHECK-NEXT: {
 // CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec1));
 // CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec1));
@@ -86,7 +86,7 @@ void transform_multiplies(const thrust::device_vector<double>& vec1, const thrus
     thrust::transform(vec1.begin(), vec1.end(), vec2.begin(), output.begin(), thrust::multiplies<double>());
 }
 // CHECK: void transform_multiplies_grad(const thrust::device_vector<double> &vec1, const thrust::device_vector<double> &vec2, thrust::device_vector<double> &output, thrust::device_vector<double> *_d_vec1, thrust::device_vector<double> *_d_vec2, thrust::device_vector<double> *_d_output) {
-// CHECK-NEXT: {{.*}}thrust::transform_reverse_forw(std::begin(vec1), std::end(vec1), std::begin(vec2), std::begin(output), thrust::multiplies<double>(), {}, {}, {}, {}, {});
+// CHECK-NEXT: {{.*}}thrust::transform_reverse_forw(std::begin(vec1), std::end(vec1), std::begin(vec2), std::begin(output), thrust::multiplies<double>(), std::begin((*_d_vec1)), std::end((*_d_vec1)), std::begin((*_d_vec2)), std::begin((*_d_output)), {});
 // CHECK-NEXT: {
 // CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec1));
 // CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec1));
@@ -101,7 +101,7 @@ void transform_divides(const thrust::device_vector<double>& vec1, const thrust::
     thrust::transform(vec1.begin(), vec1.end(), vec2.begin(), output.begin(), thrust::divides<double>());
 }
 // CHECK: void transform_divides_grad(const thrust::device_vector<double> &vec1, const thrust::device_vector<double> &vec2, thrust::device_vector<double> &output, thrust::device_vector<double> *_d_vec1, thrust::device_vector<double> *_d_vec2, thrust::device_vector<double> *_d_output) {
-// CHECK-NEXT: {{.*}}thrust::transform_reverse_forw(std::begin(vec1), std::end(vec1), std::begin(vec2), std::begin(output), thrust::divides<double>(), {}, {}, {}, {}, {});
+// CHECK-NEXT: {{.*}}thrust::transform_reverse_forw(std::begin(vec1), std::end(vec1), std::begin(vec2), std::begin(output), thrust::divides<double>(), std::begin((*_d_vec1)), std::end((*_d_vec1)), std::begin((*_d_vec2)), std::begin((*_d_output)), {});
 // CHECK-NEXT: {
 // CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec1));
 // CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec1));

--- a/test/Gradient/Cladtorch.C
+++ b/test/Gradient/Cladtorch.C
@@ -69,7 +69,7 @@ float fn1(
 // CHECK-NEXT:     {{.*}}std::vector<cladtorch::Tensor> v{{.*}}{u, b}{{.*}};
 // CHECK-NEXT:     {{.*}}std::vector<cladtorch::Tensor> _d_v(v);
 // CHECK-NEXT:     clad::zero_init(_d_v);
-// CHECK-NEXT:     clad::ValueAndAdjoint<Tensor &, Tensor &> _t0 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&v, 1, &_d_v, {{0U|0UL}});
+// CHECK-NEXT:     clad::ValueAndAdjoint<Tensor &, Tensor &> _t0 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&v, 1, &_d_v, 0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}}size_type {{.*}} = {{0U|0UL}};
 // CHECK-NEXT:         clad::custom_derivatives::class_functions::operator_subscript_pullback(&v, 1, {}, &_d_v, &{{.*}});

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -418,6 +418,8 @@ double fn8(double u, double v) {
 // CHECK-NEXT:  }
 
 // CHECK:  void fn8_grad(double u, double v, double *_d_u, double *_d_v) {
+// CHECK-NEXT:      double _t0 = u;
+// CHECK-NEXT:      double _t1 = v;
 // CHECK-NEXT:      std::pair<double, double> p(u, v);
 // CHECK-NEXT:      std::pair<double, double> _d_p(p);
 // CHECK-NEXT:      clad::zero_init(_d_p);
@@ -425,7 +427,11 @@ double fn8(double u, double v) {
 // CHECK-NEXT:          _d_p.first += 1;
 // CHECK-NEXT:          _d_p.second += 1;
 // CHECK-NEXT:      }
-// CHECK-NEXT:      pair::constructor_pullback(u, v, &_d_p, &*_d_u, &*_d_v);
+// CHECK-NEXT:      {
+// CHECK-NEXT:          u = _t0;
+// CHECK-NEXT:          v = _t1;
+// CHECK-NEXT:          pair::constructor_pullback(u, v, &_d_p, &*_d_u, &*_d_v);
+// CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
 int main() {

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -213,7 +213,7 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
-// CHECK-NEXT:     res += sum_reverse_forw(arr, n, _d_arr, 0, _tracker0);
+// CHECK-NEXT:     res += sum_reverse_forw(arr, n, _d_arr, *_d_n, _tracker0);
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
@@ -937,7 +937,7 @@ double fn27(double u, double v) {
 // CHECK-NEXT:     double _d_sum = 0.;
 // CHECK-NEXT:     double sum0 = arr[0] * arr[1] * arr[2];
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
-// CHECK-NEXT:     mult_reverse_forw(arr, u, _d_arr, 0., _tracker0);
+// CHECK-NEXT:     mult_reverse_forw(arr, u, _d_arr, *_d_u, _tracker0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_sum += 1;
 // CHECK-NEXT:         _d_arr[2] += 1;
@@ -966,16 +966,16 @@ double& nested(double* x, double y) {
 }
 
 // CHECK-NEXT: clad::ValueAndAdjoint<double &, double &> nested_reverse_forw(double *x, double y, double *_d_x, double _d_y, clad::restore_tracker &_tracker0) {
-// CHECK-NEXT:     mult_reverse_forw(x, y, _d_x, 0., _tracker0);
-// CHECK-NEXT:     mult_reverse_forw(x, 3, _d_x, 0., _tracker0);
+// CHECK-NEXT:     mult_reverse_forw(x, y, _d_x, _d_y, _tracker0);
+// CHECK-NEXT:     mult_reverse_forw(x, 3, _d_x, 0, _tracker0);
 // CHECK-NEXT:     return {x[1], _d_x[1]};
 // CHECK-NEXT: }
 
 // CHECK-NEXT: void nested_pullback(double *x, double y, double _d_y0, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
-// CHECK-NEXT:     mult_reverse_forw(x, y, _d_x, 0., _tracker0);
+// CHECK-NEXT:     mult_reverse_forw(x, y, _d_x, *_d_y, _tracker0);
 // CHECK-NEXT:     clad::restore_tracker _tracker1 = {};
-// CHECK-NEXT:     mult_reverse_forw(x, 3, _d_x, 0., _tracker1);
+// CHECK-NEXT:     mult_reverse_forw(x, 3, _d_x, 0, _tracker1);
 // CHECK-NEXT:     _d_x[1] += _d_y0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _tracker1.restore();
@@ -1001,7 +1001,7 @@ double fn28(double u, double v) {
 // CHECK-NEXT:     double _d_arr[3] = {0};
 // CHECK-NEXT:     double arr[3] = {u, v, 1};
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
-// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t0 = nested_reverse_forw(arr, u, _d_arr, 0., _tracker0);
+// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t0 = nested_reverse_forw(arr, u, _d_arr, *_d_u, _tracker0);
 // CHECK-NEXT:     double &_d_ref = _t0.adjoint;
 // CHECK-NEXT:     double &ref = _t0.value;
 // CHECK-NEXT:     ref += 2;

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -502,7 +502,7 @@ double fn5(SimpleFunctions& v, double value) {
 
 // CHECK: void fn5_grad(SimpleFunctions &v, double value, SimpleFunctions *_d_v, double *_d_value) {
 // CHECK-NEXT:     SimpleFunctions _t0 = v;
-// CHECK-NEXT:     v.operator_plus_equal_reverse_forw(value, &(*_d_v), 0.);
+// CHECK-NEXT:     v.operator_plus_equal_reverse_forw(value, &(*_d_v), *_d_value);
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
@@ -599,11 +599,15 @@ double fn6(double u, double v) {
 // CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t1 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), u, &v, *_d_u, &*_d_v);
 // CHECK-NEXT:      SafeTestClass s2(_t1.value);
 // CHECK-NEXT:      SafeTestClass _d_s2 = _t1.adjoint;
-// CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t2 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), w, _d_w);
-// CHECK-NEXT:      SafeTestClass s3(_t2.value);
-// CHECK-NEXT:      SafeTestClass _d_s3 = _t2.adjoint;
+// CHECK-NEXT:      double _t2 = w;
+// CHECK-NEXT:      clad::ValueAndAdjoint<SafeTestClass, SafeTestClass> _t3 = {{.*}}constructor_reverse_forw(clad::ConstructorReverseForwTag<SafeTestClass>(), w, _d_w);
+// CHECK-NEXT:      SafeTestClass s3(_t3.value);
+// CHECK-NEXT:      SafeTestClass _d_s3 = _t3.adjoint;
 // CHECK-NEXT:      *_d_v += 1;
-// CHECK-NEXT:      SafeTestClass::constructor_pullback(w, &_d_s3, &_d_w);
+// CHECK-NEXT:      {
+// CHECK-NEXT:          w = _t2;
+// CHECK-NEXT:          SafeTestClass::constructor_pullback(w, &_d_s3, &_d_w);
+// CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;  
 // CHECK-NEXT:          SafeTestClass::constructor_pullback(u, &v, &_d_s2, &_r0, &*_d_v);

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -627,7 +627,7 @@ int main() {
 // CHECK-NEXT:        unsigned {{long|int}} _t1 = {{0U|0UL}};
 // CHECK-NEXT:        for (i = 0; i < a.size(); ++i) {
 // CHECK-NEXT:            _t1++;
-// CHECK-NEXT:            clad::push(_t2, {{.*}}at_reverse_forw(&a, i, &_d_a, {{0U|0UL|0}}));
+// CHECK-NEXT:            clad::push(_t2, {{.*}}at_reverse_forw(&a, i, &_d_a, _d_i));
 // CHECK-NEXT:            res += clad::back(_t2).value;
 // CHECK-NEXT:        }
 // CHECK-NEXT:        _d_res += 1;
@@ -774,7 +774,7 @@ int main() {
 // CHECK-NEXT:          {{.*}} _t2 = {{0U|0UL|0}};
 // CHECK-NEXT:          for (i0 = 0; i0 < v.size(); ++i0) {
 // CHECK-NEXT:              _t2++;
-// CHECK-NEXT:              clad::push(_t3, {{.*}}at_reverse_forw(&v, i0, &_d_v, {{0U|0UL|0}}));
+// CHECK-NEXT:              clad::push(_t3, {{.*}}at_reverse_forw(&v, i0, &_d_v, _d_i0));
 // CHECK-NEXT:              res += clad::back(_t3).value;
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {{.*}}vector<double> _t4 = v;
@@ -871,7 +871,7 @@ int main() {
 // CHECK-NEXT:          std::vector<double> _d_a = {};
 // CHECK-NEXT:          clad::zero_init(_d_a);
 // CHECK-NEXT:          std::vector<double> _t0 = a;
-// CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, 0{{.*}}, &_d_a, 0.);
+// CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, 0{{.*}}, &_d_a, 0{{.*}});
 // CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:          _t1.value = x * x;
 // CHECK-NEXT:          {
@@ -1217,7 +1217,7 @@ int main() {
 // CHECK: void fn21_grad(double x, double *_d_x) {
 // CHECK-NEXT:     double _t0 = x;
 // CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t1 = clad::custom_derivatives::std::make_shared_reverse_forw(x, *_d_x);
-// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t2 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<shared_ptr<double> >(), std::move(_t1.value), _t1.adjoint);
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t2 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<shared_ptr<double> >(), std::move(_t1.value), std::move(_t1.adjoint));
 // CHECK-NEXT:     std::shared_ptr<double> x_ptr = _t2.value;
 // CHECK-NEXT:     std::shared_ptr<double> _d_x_ptr = _t2.adjoint;
 // CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t3 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<shared_ptr<double> >(), x_ptr, _d_x_ptr);
@@ -1236,7 +1236,7 @@ int main() {
 
 // CHECK: void weak_fn_pullback(std::weak_ptr<double> x_ptr, double _d_y, std::weak_ptr<double> *_d_x_ptr) {
 // CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t0 = clad::custom_derivatives::class_functions::lock_reverse_forw(&x_ptr, &(*_d_x_ptr));
-// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t1 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<shared_ptr<double> >(), std::move(_t0.value), _t0.adjoint);
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t1 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<shared_ptr<double> >(), std::move(_t0.value), std::move(_t0.adjoint));
 // CHECK-NEXT:     std::shared_ptr<double> s = _t1.value;
 // CHECK-NEXT:     std::shared_ptr<double> _d_s = _t1.adjoint;
 // CHECK-NEXT:     clad::ValueAndAdjoint<{{.*}} &, {{.*}} &> _t2 = clad::custom_derivatives::class_functions::operator_star_reverse_forw(&s, &_d_s);
@@ -1258,11 +1258,11 @@ int main() {
 // CHECK: void fn22_grad(double x, double *_d_x) {
 // CHECK-NEXT:     double _t0 = x;
 // CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t1 = clad::custom_derivatives::std::make_shared_reverse_forw(x, *_d_x);
-// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t2 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<shared_ptr<double> >(), std::move(_t1.value), _t1.adjoint);
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t2 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<shared_ptr<double> >(), std::move(_t1.value), std::move(_t1.adjoint));
 // CHECK-NEXT:     std::shared_ptr<double> s_ptr = _t2.value;
 // CHECK-NEXT:     std::shared_ptr<double> _d_s_ptr = _t2.adjoint;
 // CHECK-NEXT:     clad::ValueAndAdjoint< ::std::weak_ptr<double>, ::std::weak_ptr<double> > _t3 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<weak_ptr<double> >(), s_ptr, _d_s_ptr);
-// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::weak_ptr<double>, ::std::weak_ptr<double> > _t4 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<weak_ptr<double> >(), std::move(_t3.value), _t3.adjoint);
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::weak_ptr<double>, ::std::weak_ptr<double> > _t4 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<weak_ptr<double> >(), std::move(_t3.value), std::move(_t3.adjoint));
 // CHECK-NEXT:     std::weak_ptr<double> w_ptr = _t4.value;
 // CHECK-NEXT:     std::weak_ptr<double> _d_w_ptr = _t4.adjoint;
 // CHECK-NEXT:     clad::ValueAndAdjoint< ::std::weak_ptr<double>, ::std::weak_ptr<double> > _t5 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<weak_ptr<double> >(), w_ptr, _d_w_ptr);

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -1029,13 +1029,13 @@ struct MyStructWrapper {
 
 // CHECK:  inline constexpr clad::ValueAndAdjoint<MyStructWrapper &, MyStructWrapper &> operator_equal_reverse_forw(MyStructWrapper &&arg, MyStructWrapper *_d_this, MyStructWrapper &&_d_arg) noexcept {
 // CHECK-NEXT:      MyStruct _t0 = this->val;
-// CHECK-NEXT:      this->val.operator_equal_reverse_forw(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, {0., 0.});
+// CHECK-NEXT:      this->val.operator_equal_reverse_forw(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, std::move(_d_arg.val));
 // CHECK-NEXT:      return {*this, *_d_this};
 // CHECK-NEXT:  }
 
 // CHECK:  inline constexpr void operator_equal_pullback(MyStructWrapper &&arg, MyStructWrapper _d_y, MyStructWrapper *_d_this, MyStructWrapper *_d_arg) noexcept {
 // CHECK-NEXT:      MyStruct _t0 = this->val;
-// CHECK-NEXT:      this->val.operator_equal_reverse_forw(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, {0., 0.});
+// CHECK-NEXT:      this->val.operator_equal_reverse_forw(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, std::move((*_d_arg).val));
 // CHECK-NEXT:      {
 // CHECK-NEXT:          this->val = _t0;
 // CHECK-NEXT:          this->val.operator_equal_pullback(static_cast<MyStructWrapper &&>(arg).val, {0., 0.}, &_d_this->val, &(*_d_arg).val);


### PR DESCRIPTION
In the reverse mode, we have quite sophisticated rules about how to differentiate call arguments. This logic should be the same for ``CallExpr`` and ``CXXConstructExpr`` but we repeat it in these functions independently. This leads to frequent confusion, as some features are supported in one but not in the other. Apart from making it harder to add support for new features, it also makes it a lot harder to track them properly. This PR moves function/constructor argument differentiation to a separate function ``DifferentiateCallArg``. It now returns a triplet: ``{<original arg>, <arg for pullback>, <reverse_forw arg>}``. In practice, it will look somewhat like this: ``{x, &_r0, _d_x}``.

Apart from that, it allowed us to move some other argument processing to ``DifferentiateCallArg``. In particular, now ``pullback`` and ``reverse_forw`` arguments are generated inside the function. Before, we used to have more lists of arguments for different stages of processing: ``CallArgs``, ``CallArgDx``, ``DerivedCallArgs``, ``DerivedOutputArgs``, ``pullbackArgs`` (which still doesn't include a list of ``reverse_forw`` args).