### PR TITLE
Do not generate empty pullbacks

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -431,6 +431,8 @@ namespace clad {
     bool isInjective(const clang::Expr* E, clang::AnalysisDeclContext* ADC);
     /// Checks if the return value of the given CallExpr is unused.
     bool hasUnusedReturnValue(clang::ASTContext& C, const clang::CallExpr* CE);
+    /// Returns true if the function is empty
+    bool hasEmptyBody(const clang::FunctionDecl* FD);
     /// For an expr E, decides if we should recompute it or store it.
     /// This is the central point for checkpointing.
     bool ShouldRecompute(const clang::Expr* E, const clang::ASTContext& C);

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -132,17 +132,11 @@ namespace clad {
 
     bool hasEmptyBody(const clang::FunctionDecl* FD) {
       FD = FD->getCanonicalDecl();
-      Stmt* body = FD->getBody();
       if (const FunctionDecl* TIP = FD->getTemplateInstantiationPattern())
-        body = TIP->getBody();
-      while (auto CS = dyn_cast_or_null<CompoundStmt>(body)) {
-        if (CS->size() == 0)
-          return true;
-        if (CS->size() > 1)
-          return false;
-        body = *CS->body_begin();
-      }
-      return false;
+        FD = TIP;
+      if (!FD->hasBody())
+        return false;
+      return utils::unwrapIfSingleStmt(FD->getBody()) == nullptr;
     }
 
     CompoundStmt* PrependAndCreateCompoundStmt(ASTContext& C, Stmt* initial,

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -130,6 +130,21 @@ namespace clad {
       return CS;
     }
 
+    bool hasEmptyBody(const clang::FunctionDecl* FD) {
+      FD = FD->getCanonicalDecl();
+      Stmt* body = FD->getBody();
+      if (const FunctionDecl* TIP = FD->getTemplateInstantiationPattern())
+        body = TIP->getBody();
+      while (auto CS = dyn_cast_or_null<CompoundStmt>(body)) {
+        if (CS->size() == 0)
+          return true;
+        if (CS->size() > 1)
+          return false;
+        body = *CS->body_begin();
+      }
+      return false;
+    }
+
     CompoundStmt* PrependAndCreateCompoundStmt(ASTContext& C, Stmt* initial,
                                                Stmt* S) {
       llvm::SmallVector<Stmt*, 16> block;

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -449,7 +449,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       for (CXXCtorInitializer* CI : CD->inits()) {
         StmtDiff CI_diff = DifferentiateCtorInit(CI, thisObj.getExpr());
         addToCurrentBlock(CI_diff.getStmt(), direction::forward);
-        initsDiff.push_back(CI_diff.getStmt_dx());
+        if (Stmt* unwrappedCIDiff =
+                utils::unwrapIfSingleStmt(CI_diff.getStmt_dx()))
+          initsDiff.push_back(unwrappedCIDiff);
       }
     }
 

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -123,9 +123,7 @@ double fn2(double u, double v) {
 // CHECK-NEXT:      S1 *_this = (S1 *)malloc(sizeof(S1));
 // CHECK-NEXT:      _this->p = x;
 // CHECK-NEXT:      _this->d = 0.;
-// CHECK-NEXT:      {
-// CHECK-NEXT:          _d_this->d = 0.;
-// CHECK-NEXT:      }
+// CHECK-NEXT:      _d_this->d = 0.;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          *_d_x += _d_this->p;
 // CHECK-NEXT:          _d_this->p = 0.;
@@ -138,12 +136,8 @@ double fn2(double u, double v) {
 // CHECK-NEXT:      _this->p = x;
 // CHECK-NEXT:      _this->i = 1.;
 // CHECK-NEXT:      _this->d = 0.;
-// CHECK-NEXT:      {
-// CHECK-NEXT:          _d_this->d = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:      {
-// CHECK-NEXT:          _d_this->i = 0.;
-// CHECK-NEXT:      }
+// CHECK-NEXT:      _d_this->d = 0.;
+// CHECK-NEXT:      _d_this->i = 0.;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          *_d_x += _d_this->p;
 // CHECK-NEXT:          _d_this->p = 0.;
@@ -213,9 +207,7 @@ double fn3(double u, double v) {
 // CHECK-NEXT:        *_d_x += _d_this->p;
 // CHECK-NEXT:        _d_this->p = 0.;
 // CHECK-NEXT:    }
-// CHECK-NEXT:    {
-// CHECK-NEXT:        _d_this->i = 0.;
-// CHECK-NEXT:    }
+// CHECK-NEXT:    _d_this->i = 0.;
 // CHECK-NEXT:}
 
 // CHECK: void fn3_grad(double u, double v, double *_d_u, double *_d_v) {
@@ -257,9 +249,7 @@ double fn4(double i, double j) {
 }
 
 // CHECK: static void constructor_pullback(double px, SimpleFunctions1 *_d_this, double *_d_px) {
-// CHECK-NEXT:      {
-// CHECK-NEXT:          _d_this->y = 0.;
-// CHECK-NEXT:      }
+// CHECK-NEXT:      _d_this->y = 0.;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          *_d_px += _d_this->x;
 // CHECK-NEXT:          _d_this->x = 0.;

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -596,7 +596,6 @@ double fn14(double x, double y) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         emptyFn_pullback(x, y, &*_d_x, &_r0);
 // CHECK-NEXT:         *_d_y += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -587,9 +587,6 @@ double fn6(double u, double v) {
 // CHECK-NEXT:     free(_this);
 // CHECK-NEXT: }
 
-// CHECK: static void constructor_pullback(double &x, SafeTestClass *_d_this, double *_d_x) {
-// CHECK-NEXT: }
-
 // CHECK: void fn6_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:      double &_d_w = *_d_u;
 // CHECK-NEXT:      double &w = u;
@@ -604,10 +601,7 @@ double fn6(double u, double v) {
 // CHECK-NEXT:      SafeTestClass s3(_t3.value);
 // CHECK-NEXT:      SafeTestClass _d_s3 = _t3.adjoint;
 // CHECK-NEXT:      *_d_v += 1;
-// CHECK-NEXT:      {
-// CHECK-NEXT:          w = _t2;
-// CHECK-NEXT:          SafeTestClass::constructor_pullback(w, &_d_s3, &_d_w);
-// CHECK-NEXT:      }
+// CHECK-NEXT:      w = _t2;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;  
 // CHECK-NEXT:          SafeTestClass::constructor_pullback(u, &v, &_d_s2, &_r0, &*_d_v);

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -977,7 +977,6 @@ int main() {
 // CHECK-NEXT:         *_d_e += 5 * _r_d0;
 // CHECK-NEXT:         {{.*}}class_functions::operator_star_pullback(&up, 0., &_d_up);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {{.*}}class_functions::constructor_pullback(p, &_d_up, _d_p);
 // CHECK-NEXT:     *_d_d += *_d_p;
 // CHECK-NEXT: }
 
@@ -1109,23 +1108,20 @@ int main() {
 // CHECK-NEXT:         u += 2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_sum += 1;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         for (; _t0; _t0--) {
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 int _r0 = 0;
-// CHECK-NEXT:                 it = clad::back(_t2);
-// CHECK-NEXT:                 {{.*}}class_functions::operator_plus_plus_pullback(&it, 0, {}, &_d_it, &_r0);
-// CHECK-NEXT:                 clad::pop(_t2);
-// CHECK-NEXT:             }
-// CHECK-NEXT:             u = clad::pop(_t5);
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 double _r_d0 = _d_sum;
-// CHECK-NEXT:                 _d_u += _r_d0 * clad::pop(_t3);
-// CHECK-NEXT:                 {{.*}}::class_functions::operator_star_pullback(&it, u * _r_d0, &_d_it);
-// CHECK-NEXT:                 clad::pop(_t4);
-// CHECK-NEXT:             }
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             int _r0 = 0;
+// CHECK-NEXT:             it = clad::back(_t2);
+// CHECK-NEXT:             {{.*}}class_functions::operator_plus_plus_pullback(&it, 0, {}, &_d_it, &_r0);
+// CHECK-NEXT:             clad::pop(_t2);
 // CHECK-NEXT:         }
-// CHECK-NEXT:         {{.*}}constructor_pullback(start, &_d_it, &(*_d_start));
+// CHECK-NEXT:         u = clad::pop(_t5);
+// CHECK-NEXT:         {
+// CHECK-NEXT:             double _r_d0 = _d_sum;
+// CHECK-NEXT:             _d_u += _r_d0 * clad::pop(_t3);
+// CHECK-NEXT:             {{.*}}::class_functions::operator_star_pullback(&it, u * _r_d0, &_d_it);
+// CHECK-NEXT:             clad::pop(_t4);
+// CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -1215,11 +1211,9 @@ int main() {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         std::shared_ptr<double> _r1 = _t3.adjoint;
 // CHECK-NEXT:         simple_func_pullback(_t3.value, 1, &_r1);
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(x_ptr, &_r1, &_d_x_ptr);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         shared_ptr<{{.*}}double{{.*}}> _r0 = _t1.adjoint;
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(std::move(_t1.value), &_d_x_ptr, &_r0);
 // CHECK-NEXT:         x = _t0;
 // CHECK-NEXT:         clad::custom_derivatives::std::make_shared_pullback(x, _r0, &*_d_x);
 // CHECK-NEXT:     }
@@ -1239,10 +1233,7 @@ int main() {
 // CHECK-NEXT:         _d_x += 2. * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     clad::custom_derivatives::class_functions::operator_star_pullback(&s, _d_x, &_d_s);
-// CHECK-NEXT:     {
-// CHECK-NEXT:         shared_ptr<double> _r0 = _t0.adjoint;
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(std::move(_t0.value), &_d_s, &_r0);
-// CHECK-NEXT:     }
+// CHECK-NEXT:     shared_ptr<double> _r0 = _t0.adjoint;
 // CHECK-NEXT: }
 
 // CHECK: void fn22_grad(double x, double *_d_x) {
@@ -1259,16 +1250,10 @@ int main() {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         std::weak_ptr<double> _r2 = _t5.adjoint;
 // CHECK-NEXT:         weak_fn_pullback(_t5.value, 1, &_r2);
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(w_ptr, &_r2, &_d_w_ptr);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         std::weak_ptr<double> _r1 = _t3.adjoint;
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(std::move(_t3.value), &_d_w_ptr, &_r1);
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(s_ptr, &_r1, &_d_s_ptr);
-// CHECK-NEXT:     }
+// CHECK-NEXT:     std::weak_ptr<double> _r1 = _t3.adjoint;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         shared_ptr<{{.*}}double{{.*}}> _r0 = _t1.adjoint;
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(std::move(_t1.value), &_d_s_ptr, &_r0);
 // CHECK-NEXT:         x = _t0;
 // CHECK-NEXT:         clad::custom_derivatives::std::make_shared_pullback(x, _r0, &*_d_x);
 // CHECK-NEXT:     }

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -843,26 +843,17 @@ int main() {
 // CHECK-NEXT:          {
 // CHECK-NEXT:              double _r_d0 = _d_res;
 // CHECK-NEXT:              *_d_y += _r_d0 * _t4;
-// CHECK-NEXT:              {{.*}}capacity_pullback(&v, y * _r_d0, &_d_v);
 // CHECK-NEXT:              *_d_x += _r_d0 * _t5;
-// CHECK-NEXT:              {{.*}}size_pullback(&v, x * _r_d0, &_d_v);
 // CHECK-NEXT:          }
-// CHECK-NEXT:          {
-// CHECK-NEXT:              v = _t3;
-// CHECK-NEXT:              {{.*}}shrink_to_fit_pullback(&v, &_d_v);
-// CHECK-NEXT:          }
+// CHECK-NEXT:          v = _t3;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              v = _t2;
 // CHECK-NEXT:              {{.*}}push_back_pullback(&v, x, &_d_v, &*_d_x);
 // CHECK-NEXT:          }
-// CHECK-NEXT:          {
-// CHECK-NEXT:              *_d_x += _d_res * _t1;
-// CHECK-NEXT:              {{.*}}capacity_pullback(&v, x * _d_res, &_d_v);
-// CHECK-NEXT:          }
+// CHECK-NEXT:          *_d_x += _d_res * _t1;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}size_type _r0 = {{0U|0UL|0}};
 // CHECK-NEXT:              v = _t0;
-// CHECK-NEXT:              {{.*}}reserve_pullback(&v, 10, &_d_v, &_r0);
 // CHECK-NEXT:          }
 // CHECK-NEXT:      }
 
@@ -1251,7 +1242,6 @@ int main() {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         shared_ptr<double> _r0 = _t0.adjoint;
 // CHECK-NEXT:         clad::custom_derivatives::class_functions::constructor_pullback(std::move(_t0.value), &_d_s, &_r0);
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::lock_pullback(&x_ptr, _r0, &(*_d_x_ptr));
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -997,11 +997,6 @@ constructor_reverse_forw(::clad::ConstructorReverseForwTag<ptrClass>, double* mp
 }
 }}}
 
-// CHECK: static void constructor_pullback(double *mptr, ptrClass *_d_this, double *_d_mptr) {
-// CHECK-NEXT:      {
-// CHECK-NEXT:      }
-// CHECK-NEXT:  }
-
 // CHECK:  clad::ValueAndAdjoint<double &, double &> operator_star_reverse_forw(ptrClass *_d_this) {
 // CHECK-NEXT:      return {*this->ptr, *_d_this->ptr};
 // CHECK-NEXT:  }
@@ -1020,7 +1015,6 @@ double fn26(double x, double y) {
 // CHECK-NEXT:      ptrClass p(_t0.value);
 // CHECK-NEXT:      ptrClass _d_p = _t0.adjoint;
 // CHECK-NEXT:      p.operator_star_pullback(1, &_d_p);
-// CHECK-NEXT:      ptrClass::constructor_pullback(&x, &_d_p, &*_d_x);
 // CHECK-NEXT:  }
 
 struct MyStructWrapper {

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -31,8 +31,8 @@
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/Compatibility.h"
-#include <clad/Differentiator/DiffMode.h>
 
 #include <algorithm>
 #include <cstdlib>  // for getenv
@@ -287,6 +287,11 @@ void InitTimers();
           auto deriveResult = m_DerivativeBuilder->Derive(request);
           DerivativeDecl = cast_or_null<FunctionDecl>(deriveResult.derivative);
           OverloadedDerivativeDecl = deriveResult.overload;
+          // FIXME: Doing this with other function types might lead to
+          // accidental numerical diff.
+          if (isa<CXXConstructorDecl>(FD) &&
+              utils::hasEmptyBody(DerivativeDecl))
+            return nullptr;
           if (DerivativeDecl)
             m_DFC.Add(DerivedFnInfo(request, DerivativeDecl,
                                     OverloadedDerivativeDecl));


### PR DESCRIPTION
Currently, a lot of our pullback calls are done to empty functions. Ideally, we should treat them as non-differentiable, but it is currently impossible to get information before visiting call arguments. In this PR, call exprs to empty function pullbacks are no longer built. Empty constructor pullbacks are never registered and so never used. It wasn't possible to do the same with regular functions because this triggers diagnostics about the function not being differentiated.