### PR TITLE
Avoid early return in RMV::VisitCallExpr

### DIFF
--- a/lib/Differentiator/TBRAnalyzer.cpp
+++ b/lib/Differentiator/TBRAnalyzer.cpp
@@ -409,6 +409,7 @@ bool TBRAnalyzer::TraverseCallExpr(clang::CallExpr* CE) {
   bool hasHiddenParam = (CE->getNumArgs() != FD->getNumParams());
   std::size_t maxParamIdx = FD->getNumParams() - 1;
   setMode(Mode::kMarkingMode | Mode::kNonLinearMode);
+  bool nonDiff = utils::hasNonDifferentiableAttribute(CE);
   for (std::size_t i = hasHiddenParam, e = CE->getNumArgs(); i != e; ++i) {
     clang::Expr* arg = CE->getArg(i);
     const ParmVarDecl* par = nullptr;
@@ -423,6 +424,8 @@ bool TBRAnalyzer::TraverseCallExpr(clang::CallExpr* CE) {
       if (usedParams.find(par) == usedParams.end())
         paramUnused = true;
     }
+    if (nonDiff)
+      paramUnused = true;
     if (paramUnused)
       setMode(/*mode=*/0);
     TraverseStmt(arg);
@@ -459,6 +462,8 @@ bool TBRAnalyzer::TraverseCallExpr(clang::CallExpr* CE) {
       if (usedParams.find(nullptr) == usedParams.end())
         paramUnused = true;
     }
+    if (nonDiff)
+      paramUnused = true;
     if (paramUnused)
       setMode(/*mode=*/0);
     TraverseStmt(base);

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -2650,9 +2650,6 @@ float fn42(const layer &l, float x) {
 //CHECK-NEXT:            float _r_d0 = _d_x;
 //CHECK-NEXT:            _d_x = 0.F;
 //CHECK-NEXT:            this->w[i].forward_pullback(x, _r_d0, &_d_this->w[i], &_d_x);
-//CHECK-NEXT:            size_type _r0 = {{0U|0UL}};
-//CHECK-NEXT:            this->w.operator_subscript_pullback(i, {}, &_d_this->w, &_r0);
-//CHECK-NEXT:            _d_i += _r0;
 //CHECK-NEXT:        }
 //CHECK-NEXT:    }
 //CHECK-NEXT:    *_d_inp += _d_x;

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -235,10 +235,8 @@ int main() {
 
     // CHECK:     void fn_non_diff_param_call_grad(double i, double j, double *_d_i, double *_d_j) {
     // CHECK-NEXT:         SimpleFunctions2 obj1(j, j);
-    // CHECK-NEXT:         SimpleFunctions2 _t0 = obj1;
     // CHECK-NEXT:         {
     // CHECK-NEXT:             double _r0 = 0.;
-    // CHECK-NEXT:             obj1 = _t0;
     // CHECK-NEXT:             fn_non_diff_param_pullback(i, obj1, 1, &_r0);
     // CHECK-NEXT:             *_d_i += _r0;
     // CHECK-NEXT:         }

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -975,7 +975,6 @@ int main() {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _t1.adjoint;
 // CHECK-NEXT:         *_d_e += 5 * _r_d0;
-// CHECK-NEXT:         {{.*}}class_functions::operator_star_pullback(&up, 0., &_d_up);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_d += *_d_p;
 // CHECK-NEXT: }
@@ -1100,7 +1099,7 @@ int main() {
 // CHECK-NEXT:     clad::ValueAndAdjoint<{{.*}}> _t1 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<{{.*}}>(), start, (*_d_start));
 // CHECK-NEXT:     it = _t1.value;
 // CHECK-NEXT:     _d_it = _t1.adjoint;
-// CHECK-NEXT:     for (; operator!=(it, end); clad::push(_t2, it) , {{.*}}class_functions::operator_plus_plus_reverse_forw(&it, 0, &_d_it, 0)) {
+// CHECK-NEXT:     for (; it != end; clad::push(_t2, it) , {{.*}}class_functions::operator_plus_plus_reverse_forw(&it, 0, &_d_it, 0)) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t4, {{.*}}class_functions::operator_star_reverse_forw(&it, &_d_it));
 // CHECK-NEXT:         sum += u * clad::push(_t3, clad::back(_t4).value);


### PR DESCRIPTION
Currently, when we encounter a non-differentiable function in RMV::VisitCallExpr, we do an early return while cloning the original function call. There are 2 disadvantages to doing that:
1) When ``reverse_forw`` was introduced, we started skipping the early return for functions that still required ``reverse_forw``. Because of this, non-differentiable analysis is disabled for some functions.
2) Repeating the code for cloning the function call is a bad practice because we risk not supporting some functions there.