### PR TITLE
Do not add a pullback parameter for functions with reference return types

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -254,6 +254,8 @@ namespace clad {
     /// `std::move(std::begin(from), std::end(from), std::begin(to));`
     clang::Expr* BuildArrayAssignment(clang::Expr* output, clang::Expr* input,
                                       direction d);
+    /// Builds derivative increments, e.g. ``E += dfdx()``;
+    clang::Expr* BuildDiffIncrement(clang::Expr* E);
 
     //// A type returned by DelayedGlobalStoreAndRef
     /// .Result is a reference to the created (yet uninitialized) global

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -571,18 +571,6 @@ template <typename T>
 void shrink_to_fit_pullback(::std::vector<T>* /*v*/,
                             ::std::vector<T>* /*d_v*/) noexcept {}
 
-template <typename T>
-void capacity_pullback(const ::std::vector<T>* /*v*/,
-                       ::std::vector<T>* /*d_v*/) noexcept {}
-
-template <typename T, typename U>
-void size_pullback(const ::std::vector<T>* /*v*/, U /*d_y*/,
-                   ::std::vector<T>* /*d_v*/) noexcept {}
-
-template <typename T, typename U>
-void capacity_pullback(const ::std::vector<T>* /*v*/, U /*d_y*/,
-                       ::std::vector<T>* /*d_v*/) noexcept {}
-
 // array reverse mode
 
 template <typename T, ::std::size_t N>
@@ -665,9 +653,6 @@ void front_pullback(const ::std::array<T, N>* arr,
                     ::std::array<T, N>* d_arr) {
   (*d_arr)[0] += d_u;
 }
-template <typename T, ::std::size_t N, typename U>
-void size_pullback(const ::std::array<T, N>* /*a*/, U /*d_y*/,
-                   ::std::array<T, N>* /*d_a*/) noexcept {}
 template <typename T, ::std::size_t N>
 void constructor_pullback(const ::std::array<T, N>& arr,
                           ::std::array<T, N>* d_this,
@@ -710,12 +695,6 @@ operator_star_reverse_forw(
     const T* d_u) {
   return {**u, **d_u};
 }
-
-template <typename T>
-::std::enable_if_t<(helpers::is_std_smart_ptr<T>::value ||
-                    helpers::is_iterator<T>::value),
-                   void>
-operator_star_pullback(const T* u, T* d_u) {}
 
 // iterator custom derivatives
 template <
@@ -883,8 +862,6 @@ template <class T>
 clad::ValueAndAdjoint<T&, T&> forward_reverse_forw(T& t, T& dt) {
   return {t, dt};
 }
-
-template <class T> constexpr void forward_pullback(T& t, T* dt) noexcept {}
 
 template <class T>
 constexpr void forward_pullback(T&& t, T dy, T* dt) noexcept {

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -487,13 +487,11 @@ void operator_subscript_pullback(const ::std::vector<T>* vec,
   (*d_vec)[idx] += d_y;
 }
 
-template <typename T, typename P>
+template <typename T>
 void operator_subscript_pullback(::std::vector<T>* vec,
                                  typename ::std::vector<T>::size_type idx,
-                                 P d_y, ::std::vector<T>* d_vec,
-                                 typename ::std::vector<T>::size_type* d_idx) {
-  (*d_vec)[idx] += d_y;
-}
+                                 ::std::vector<T>* d_vec,
+                                 typename ::std::vector<T>::size_type* d_idx) {}
 
 template <typename T>
 clad::ValueAndAdjoint<T&, T&>
@@ -511,13 +509,11 @@ void at_pullback(const ::std::vector<T>* vec,
   (*d_vec)[idx] += d_y;
 }
 
-template <typename T, typename P>
+template <typename T>
 void at_pullback(::std::vector<T>* vec,
-                 typename ::std::vector<T>::size_type idx, P d_y,
+                 typename ::std::vector<T>::size_type idx,
                  ::std::vector<T>* d_vec,
-                 typename ::std::vector<T>::size_type* d_idx) {
-  (*d_vec)[idx] += d_y;
-}
+                 typename ::std::vector<T>::size_type* d_idx) {}
 
 template <typename T, typename U>
 void constructor_pullback(
@@ -602,12 +598,10 @@ void operator_subscript_pullback(
     typename ::std::array<T, N>::size_type* d_idx) {
   (*d_arr)[idx] += d_y;
 }
-template <typename T, ::std::size_t N, typename P>
+template <typename T, ::std::size_t N>
 void operator_subscript_pullback(
-    ::std::array<T, N>* arr, typename ::std::array<T, N>::size_type idx, P d_y,
-    ::std::array<T, N>* d_arr, typename ::std::array<T, N>::size_type* d_idx) {
-  (*d_arr)[idx] += d_y;
-}
+    ::std::array<T, N>* arr, typename ::std::array<T, N>::size_type idx,
+    ::std::array<T, N>* d_arr, typename ::std::array<T, N>::size_type* d_idx) {}
 template <typename T, ::std::size_t N>
 clad::ValueAndAdjoint<T&, T&> at_reverse_forw(
     ::std::array<T, N>* arr, typename ::std::array<T, N>::size_type idx,
@@ -621,13 +615,11 @@ void at_pullback(const ::std::array<T, N>* arr,
                  typename ::std::array<T, N>::size_type* d_idx) {
   (*d_arr)[idx] += d_y;
 }
-template <typename T, ::std::size_t N, typename P>
+template <typename T, ::std::size_t N>
 void at_pullback(::std::array<T, N>* arr,
-                 typename ::std::array<T, N>::size_type idx, P d_y,
+                 typename ::std::array<T, N>::size_type idx,
                  ::std::array<T, N>* d_arr,
-                 typename ::std::array<T, N>::size_type* d_idx) {
-  (*d_arr)[idx] += d_y;
-}
+                 typename ::std::array<T, N>::size_type* d_idx) {}
 template <typename T, ::std::size_t N>
 void fill_reverse_forw(::std::array<T, N>* a,
                        const typename ::std::array<T, N>::value_type& u,
@@ -660,10 +652,7 @@ void back_pullback(const ::std::array<T, N>* arr,
 }
 template <typename T, ::std::size_t N>
 void back_pullback(::std::array<T, N>* arr,
-                   typename ::std::array<T, N>::value_type d_u,
-                   ::std::array<T, N>* d_arr) noexcept {
-  (*d_arr)[d_arr->size() - 1] += d_u;
-}
+                   ::std::array<T, N>* d_arr) noexcept {}
 template <typename T, ::std::size_t N>
 clad::ValueAndAdjoint<T&, T&>
 front_reverse_forw(::std::array<T, N>* arr,
@@ -722,14 +711,11 @@ operator_star_reverse_forw(
   return {**u, **d_u};
 }
 
-template <typename T, typename U>
+template <typename T>
 ::std::enable_if_t<(helpers::is_std_smart_ptr<T>::value ||
-                    helpers::is_iterator<T>::value) &&
-                       ::std::is_arithmetic<U>::value,
+                    helpers::is_iterator<T>::value),
                    void>
-operator_star_pullback(const T* u, U pullback, T* d_u) {
-  **d_u += pullback;
-}
+operator_star_pullback(const T* u, T* d_u) {}
 
 // iterator custom derivatives
 template <
@@ -898,9 +884,7 @@ clad::ValueAndAdjoint<T&, T&> forward_reverse_forw(T& t, T& dt) {
   return {t, dt};
 }
 
-template <class T> constexpr void forward_pullback(T& t, T dy, T* dt) noexcept {
-  *dt += dy;
-}
+template <class T> constexpr void forward_pullback(T& t, T* dt) noexcept {}
 
 template <class T>
 constexpr void forward_pullback(T&& t, T dy, T* dt) noexcept {

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1493,7 +1493,7 @@ namespace clad {
           if (DRE == m_stopE)
             return false;
           if (auto* VD = dyn_cast<VarDecl>(DRE->getDecl())) {
-            if (m_Modifying && VD == m_idxVD) {
+            if (m_Modifying && VD->getName() == m_idxVD->getName()) {
               m_isLive = false;
               return false;
             }

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1192,7 +1192,8 @@ namespace clad {
         // Handle pullbacks
         QualType argTy = oRetTy.getNonReferenceType();
         argTy = utils::getNonConstType(argTy, S);
-        if (!argTy->isVoidType() && !argTy->isPointerType())
+        if (!argTy->isVoidType() && !argTy->isPointerType() &&
+            !utils::isNonConstReferenceType(oRetTy))
           FnTypes.push_back(argTy);
       }
 

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1091,8 +1091,10 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     // ideantical names: `constructor_pullback`, `operator_star_pushforward`,
     // etc. If we turn it on, every such operator will trigger diagnostics
     // because of our STL and Kokkos custom derivatives.
+    // FIXME: Add a way to silence the diagnostics.
     bool enableDiagnostics = !isa<CXXMethodDecl>(request.Function) &&
-                             !request->isOverloadedOperator();
+                             !request->isOverloadedOperator() &&
+                             request.BaseFunctionName != "forward";
     Expr* overload = getOverloadExpr(m_Sema, Name, DC, DerivativeType, callSite,
                                      enableDiagnostics);
     if (!overload && request.Mode == DiffMode::vector_pushforward) {

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -69,7 +69,7 @@ namespace clad {
     if (!S)
       return false;
     if (Expr* E = dyn_cast<Expr>(S)) {
-      if (isUnusedResult(E))
+      if (isUnusedResult(E->IgnoreCasts()))
         return false;
     }
     block.push_back(S);

--- a/test/CUDA/ThrustCopy.cu
+++ b/test/CUDA/ThrustCopy.cu
@@ -44,8 +44,6 @@ void copy_with_return_value_stored(const thrust::device_vector<double>& src,
 // CHECK-NEXT:     thrust::detail::normal_iterator<device_ptr<double> > it = _t0.value;
 // CHECK-NEXT:     thrust::detail::normal_iterator<device_ptr<double> > _d_it = {};
 // CHECK-NEXT:     clad::zero_init(_d_it);
-// CHECK-NEXT:     (void)it;
-// CHECK-NEXT:     (void)_d_it;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         const_iterator _r0 = std::begin((*_d_src));
 // CHECK-NEXT:         const_iterator _r1 = std::end((*_d_src));

--- a/test/Gradient/Cladtorch.C
+++ b/test/Gradient/Cladtorch.C
@@ -72,7 +72,6 @@ float fn1(
 // CHECK-NEXT:     clad::ValueAndAdjoint<{{.*}}Tensor &, {{.*}}Tensor &> _t0 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&v, 1, &_d_v, 0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*size_type|size_t}} _r{{[0|1|2]}} = {{0U|0UL}};
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::operator_subscript_pullback(&v, 1, {}, &_d_v, &{{.*}});
 // CHECK-NEXT:         _t0.adjoint.data += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -397,11 +397,11 @@ double fn8(double u, double v) {
 // CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t1 = clad::custom_derivatives::std::forward_reverse_forw(__{{u2|y}}, *_d___{{u2|y}});
 // CHECK-NEXT:      _this->second = _t1.value;
 // CHECK:           {
-// CHECK-NEXT:          clad::custom_derivatives::std::forward_pullback(__{{u2|y}}, _d_this->second, &*_d___{{u2|y}});
+// CHECK-NEXT:          _t1.adjoint += _d_this->second;
 // CHECK-NEXT:          _d_this->second = 0.;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
-// CHECK-NEXT:          clad::custom_derivatives::std::forward_pullback(__{{u1|x}}, _d_this->first, &*_d___{{u1|x}});
+// CHECK-NEXT:          _t0.adjoint += _d_this->first;
 // CHECK-NEXT:          _d_this->first = 0.;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      free(_this);

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -330,17 +330,15 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     return {i, _d_i};
 // CHECK-NEXT: }
 
-// CHECK: void identity_pullback(double &i, double _d_y, double *_d_i) {
+// CHECK: void identity_pullback(double &i, double *_d_i) {
 // CHECK-NEXT:     MyStruct::myFunction();
 // CHECK-NEXT:     double _d__d_i = 0.;
 // CHECK-NEXT:     double _d_i0 = i;
 // CHECK-NEXT:     _d_i0 += 1;
-// CHECK-NEXT:     *_d_i += _d_y;
 // CHECK-NEXT:     *_d_i += _d__d_i;
 // CHECK-NEXT: }
 
-// CHECK: void custom_identity_pullback(double &i, double _d_y, double *_d_i) {
-// CHECK-NEXT:     *_d_i += _d_y;
+// CHECK: void custom_identity_pullback(double &i, double *_d_i) {
 // CHECK-NEXT: }
 
 // CHECK: void fn7_grad(double i, double j, double *_d_i, double *_d_j) {
@@ -368,9 +366,8 @@ double fn7(double i, double j) {
 // CHECK-NEXT:         double _r_d0 = _d_k;
 // CHECK-NEXT:         *_d_j += 7 * _r_d0;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     custom_identity_pullback(i, 0., &*_d_i);
-// CHECK-NEXT:     identity_pullback(j, 0., &*_d_j);
-// CHECK-NEXT:     identity_pullback(i, 0., &*_d_i);
+// CHECK-NEXT:     identity_pullback(j, &*_d_j);
+// CHECK-NEXT:     identity_pullback(i, &*_d_i);
 // CHECK-NEXT: }
 
 double check_and_return(double x, char c, const char* s) {
@@ -970,12 +967,11 @@ double& nested(double* x, double y) {
 // CHECK-NEXT:     return {x[1], _d_x[1]};
 // CHECK-NEXT: }
 
-// CHECK-NEXT: void nested_pullback(double *x, double y, double _d_y0, double *_d_x, double *_d_y) {
+// CHECK-NEXT: void nested_pullback(double *x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
 // CHECK-NEXT:     mult_reverse_forw(x, y, _d_x, *_d_y, _tracker0);
 // CHECK-NEXT:     clad::restore_tracker _tracker1 = {};
 // CHECK-NEXT:     mult_reverse_forw(x, 3, _d_x, 0, _tracker1);
-// CHECK-NEXT:     _d_x[1] += _d_y0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _tracker1.restore();
 // CHECK-NEXT:         double _r1 = 0.;
@@ -1009,7 +1005,7 @@ double fn28(double u, double v) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         nested_pullback(arr, u, 0., _d_arr, &_r0);
+// CHECK-NEXT:         nested_pullback(arr, u, _d_arr, &_r0);
 // CHECK-NEXT:         *_d_u += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -445,12 +445,11 @@ double fn2(SimpleFunctions& sf, double i) {
 // CHECK-NEXT:     return {this->x, _d_this->x};
 // CHECK-NEXT: }
 
-// CHECK: void ref_mem_fn_pullback(double i, double _d_y, SimpleFunctions *_d_this, double *_d_i) {
+// CHECK: void ref_mem_fn_pullback(double i, SimpleFunctions *_d_this, double *_d_i) {
 // CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x = +i;
 // CHECK-NEXT:     double _t1 = this->x;
 // CHECK-NEXT:     this->x = -i;
-// CHECK-NEXT:     _d_this->x += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         this->x = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_this->x;
@@ -467,10 +466,12 @@ double fn2(SimpleFunctions& sf, double i) {
 
 // CHECK: void fn2_grad(SimpleFunctions &sf, double i, SimpleFunctions *_d_sf, double *_d_i) {
 // CHECK-NEXT:     SimpleFunctions _t0 = sf;
+// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = sf.ref_mem_fn_reverse_forw(i, &(*_d_sf), *_d_i);
 // CHECK-NEXT:     {
+// CHECK-NEXT:         _t1.adjoint += 1;
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         sf = _t0;
-// CHECK-NEXT:         sf.ref_mem_fn_pullback(i, 1, &(*_d_sf), &_r0);
+// CHECK-NEXT:         sf.ref_mem_fn_pullback(i, &(*_d_sf), &_r0);
 // CHECK-NEXT:         *_d_i += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -490,7 +491,7 @@ double fn5(SimpleFunctions& v, double value) {
 // CHECK-NEXT:     return {*this, *_d_this};
 // CHECK-NEXT: }
 
-// CHECK: void operator_plus_equal_pullback(double value, SimpleFunctions _d_y, SimpleFunctions *_d_this, double *_d_value) {
+// CHECK: void operator_plus_equal_pullback(double value, SimpleFunctions *_d_this, double *_d_value) {
 // CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x += value;
 // CHECK-NEXT:     {
@@ -507,7 +508,7 @@ double fn5(SimpleFunctions& v, double value) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         v = _t0;
-// CHECK-NEXT:         v.operator_plus_equal_pullback(value, {}, &(*_d_v), &_r0);
+// CHECK-NEXT:         v.operator_plus_equal_pullback(value, &(*_d_v), &_r0);
 // CHECK-NEXT:         *_d_value += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -522,7 +523,7 @@ double fn4(SimpleFunctions& v) {
 // CHECK-NEXT:     return {*this, *_d_this};
 // CHECK-NEXT: }
 
-// CHECK: void operator_plus_plus_pullback(SimpleFunctions _d_y, SimpleFunctions *_d_this) {
+// CHECK: void operator_plus_plus_pullback(SimpleFunctions *_d_this) {
 // CHECK-NEXT:     double _t0 = this->x;
 // CHECK-NEXT:     this->x += 1.;
 // CHECK-NEXT:     {
@@ -537,7 +538,7 @@ double fn4(SimpleFunctions& v) {
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         v = _t0;
-// CHECK-NEXT:         v.operator_plus_plus_pullback({}, &(*_d_v));
+// CHECK-NEXT:         v.operator_plus_plus_pullback(&(*_d_v));
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -362,10 +362,10 @@ int main() {
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
+// CHECK-NEXT:         _t2.adjoint += 1;
 // CHECK-NEXT:         {{.*size_type|size_t}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r0);
+// CHECK-NEXT:         _t3.adjoint += 1;
 // CHECK-NEXT:         {{.*size_type|size_t}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r1);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         vec = _t1;
@@ -392,19 +392,16 @@ int main() {
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
+// CHECK-NEXT:         _t3.adjoint += 1;
 // CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r1);
+// CHECK-NEXT:         _t4.adjoint += 1;
 // CHECK-NEXT:         {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r2);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_ref;
 // CHECK-NEXT:         *_d_u += _r_d0;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 0., &_d_vec, &_r0);
-// CHECK-NEXT:     }
+// CHECK-NEXT:     {{.*}} _r0 = {{0U|0UL}};
 // CHECK-NEXT:     {
 // CHECK-NEXT:         vec = _t1;
 // CHECK-NEXT:         clad::custom_derivatives::class_functions::push_back_pullback(&vec, v, &_d_vec, &*_d_v);
@@ -471,10 +468,10 @@ int main() {
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d6 = _d_res;
+// CHECK-NEXT:         _t11.adjoint += _r_d6;
 // CHECK-NEXT:         {{.*}} _r10 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, _r_d6, &_d_vec, &_r10);
+// CHECK-NEXT:         _t12.adjoint += _r_d6;
 // CHECK-NEXT:         {{.*}} _r11 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, _r_d6, &_d_vec, &_r11);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
@@ -487,14 +484,8 @@ int main() {
 // CHECK-NEXT:             *_d_ref00 = 0.;
 // CHECK-NEXT:             *_d_u += _r_d4;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}} _r9 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 0., &_d_vec, &_r9);
-// CHECK-NEXT:         }
-// CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}} _r8 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 0., &_d_vec, &_r8);
-// CHECK-NEXT:         }
+// CHECK-NEXT:         {{.*}} _r9 = {{0U|0UL}};
+// CHECK-NEXT:         {{.*}} _r8 = {{0U|0UL}};
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r7 = {{0U|0UL}};
@@ -508,12 +499,12 @@ int main() {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d3 = _d_res;
 // CHECK-NEXT:         _d_res = 0.;
+// CHECK-NEXT:         _t4.adjoint += _r_d3;
 // CHECK-NEXT:         {{.*}} _r4 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 0, _r_d3, &_d_vec, &_r4);
+// CHECK-NEXT:         _t5.adjoint += _r_d3;
 // CHECK-NEXT:         {{.*}} _r5 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 1, _r_d3, &_d_vec, &_r5);
+// CHECK-NEXT:         _t6.adjoint += _r_d3;
 // CHECK-NEXT:         {{.*}} _r6 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::operator_subscript_pullback(&vec, 2, _r_d3, &_d_vec, &_r6);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
@@ -532,18 +523,9 @@ int main() {
 // CHECK-NEXT:             *_d_ref0 = 0.;
 // CHECK-NEXT:             *_d_u += _r_d0;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}} _r3 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 2, 0., &_d_vec, &_r3);
-// CHECK-NEXT:         }
-// CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 1, 0., &_d_vec, &_r2);
-// CHECK-NEXT:         }
-// CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}class_functions::operator_subscript_pullback(&vec, 0, 0., &_d_vec, &_r1);
-// CHECK-NEXT:         }
+// CHECK-NEXT:         {{.*}} _r3 = {{0U|0UL}};
+// CHECK-NEXT:         {{.*}} _r2 = {{0U|0UL}};
+// CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
@@ -567,12 +549,12 @@ int main() {
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, {{0U|0UL|0}});
 // CHECK-NEXT:     {
+// CHECK-NEXT:         _t0.adjoint += 1;
 // CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}operator_subscript_pullback(&vec, 0, 1, &_d_vec, &_r1);
+// CHECK-NEXT:         _t1.adjoint += 1;
 // CHECK-NEXT:         {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}operator_subscript_pullback(&vec, 1, 1, &_d_vec, &_r2);
+// CHECK-NEXT:         _t2.adjoint += 1;
 // CHECK-NEXT:         {{.*}} _r3 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}operator_subscript_pullback(&vec, 2, 1, &_d_vec, &_r3);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
@@ -592,9 +574,10 @@ int main() {
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, x, &_d_a, *_d_x);
 // CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:          _t2.value = x * x;
+// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t3 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&a, 1, &_d_a, 0);
 // CHECK-NEXT:          {
+// CHECK-NEXT:              _t3.adjoint += 1;
 // CHECK-NEXT:              {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 1, 1, &_d_a, &_r1);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              double _r_d0 = _t2.adjoint;
@@ -602,7 +585,6 @@ int main() {
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
 // CHECK-NEXT:              {{.*}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 1, 0., &_d_a, &_r0);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              a = _t1;
@@ -635,8 +617,8 @@ int main() {
 // CHECK-NEXT:            --i;
 // CHECK-NEXT:            {
 // CHECK-NEXT:                double _r_d0 = _d_res;
+// CHECK-NEXT:                clad::back(_t2).adjoint += _r_d0;
 // CHECK-NEXT:                size_t _r0 = {{0U|0UL}};
-// CHECK-NEXT:                {{.*}}at_pullback(&a, i, _r_d0, &_d_a, &_r0);
 // CHECK-NEXT:                _d_i += _r0;
 // CHECK-NEXT:                clad::pop(_t2);
 // CHECK-NEXT:            }
@@ -668,8 +650,8 @@ int main() {
 // CHECK-NEXT:         {{.*}}value_type _t6 = b.front();
 // CHECK-NEXT:         {{.*}}value_type _t5 = b.at(2);
 // CHECK-NEXT:         {
-// CHECK:                  {{.*}}back_pullback(&a, 1 * _t5 * _t6, &_d_a);
-// CHECK-NEXT:             {{.*}}front_pullback(&b, _t{{7|8}}.value * 1 * _t5, &_d_b);
+// CHECK-NEXT:             _t{{7|8}}.adjoint += 1 * _t5 * _t6;
+// CHECK:                  {{.*}}front_pullback(&b, _t{{7|8}}.value * 1 * _t5, &_d_b);
 // CHECK-NEXT:             {{.*size_type|size_t}} _r5 = {{0U|0UL}};
 // CHECK-NEXT:             {{.*}}at_pullback(&b, 2, _t{{7|8}}.value * _t6 * 1, &_d_b, &_r5);
 // CHECK-NEXT:             {{.*size_type|size_t}} _r6 = {{0U|0UL}};
@@ -682,33 +664,28 @@ int main() {
 // CHECK-NEXT:             *_d_x += _r_d4 * x;
 // CHECK-NEXT:             *_d_x += x * _r_d4;
 // CHECK-NEXT:             {{.*size_type|size_t}} _r4 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_b0, 2, 0., &_d__b, &_r4);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d3 = _t3.adjoint;
 // CHECK-NEXT:             _t3.adjoint = 0.;
 // CHECK-NEXT:             {{.*size_type|size_t}} _r3 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_b0, 1, 0., &_d__b, &_r3);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d2 = _t2.adjoint;
 // CHECK-NEXT:             _t2.adjoint = 0.;
 // CHECK-NEXT:             *_d_x += _r_d2;
 // CHECK-NEXT:             {{.*size_type|size_t}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&_b0, 0, 0., &_d__b, &_r2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d1 = _t1.adjoint;
 // CHECK-NEXT:             _t1.adjoint = 0.;
 // CHECK-NEXT:             *_d_y += _r_d1;
 // CHECK-NEXT:             {{.*size_type|size_t}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 1, 0., &_d_a, &_r1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = _t0.adjoint;
 // CHECK-NEXT:             _t0.adjoint = 0.;
 // CHECK-NEXT:             {{.*size_type|size_t}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 0, 0., &_d_a, &_r0);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 
@@ -720,10 +697,10 @@ int main() {
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 49, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 3, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:         {
+// CHECK-NEXT:             _t1.adjoint += 1;
 // CHECK-NEXT:             {{.*size_type|size_t}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 49, 1, &_d_a, &_r1);
+// CHECK-NEXT:             _t2.adjoint += 1;
 // CHECK-NEXT:             {{.*size_type|size_t}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 3, 1, &_d_a, &_r2);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r0 = 0.;
@@ -740,16 +717,16 @@ int main() {
 // CHECK-NEXT:         std::array<double, 2> a;
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t0 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:         _t0.value = 2 * x;
+// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&a, 1, &_d_a, 0);
 // CHECK-NEXT:         {
+// CHECK-NEXT:             _t1.adjoint += 1;
 // CHECK-NEXT:             {{.*size_type|size_t}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 1, 1, &_d_a, &_r1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r_d0 = _t0.adjoint;
 // CHECK-NEXT:             _t0.adjoint = 0.;
 // CHECK-NEXT:             *_d_x += 2 * _r_d0;
 // CHECK-NEXT:             {{.*size_type|size_t}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&a, 1, 0., &_d_a, &_r0);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 
@@ -786,12 +763,12 @@ int main() {
 // CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t8 = {{.*}}operator_subscript_reverse_forw(&v, 2, &_d_v, {{0U|0UL|0}});
 // CHECK-NEXT:          {
 // CHECK-NEXT:              _d_res += 1;
+// CHECK-NEXT:              _t6.adjoint += 1;
 // CHECK-NEXT:              {{.*size_type|size_t}} _r4 = {{0U|0UL|0}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&v, 0, 1, &_d_v, &_r4);
+// CHECK-NEXT:              _t7.adjoint += 1;
 // CHECK-NEXT:              {{.*size_type|size_t}} _r5 = {{0U|0UL|0}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&v, 1, 1, &_d_v, &_r5);
+// CHECK-NEXT:              _t8.adjoint += 1;
 // CHECK-NEXT:              {{.*size_type|size_t}} _r6 = {{0U|0UL|0}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&v, 2, 1, &_d_v, &_r6);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*size_type|size_t}} _r3 = {{0U|0UL|0}};
@@ -808,8 +785,8 @@ int main() {
 // CHECK-NEXT:              --i0;
 // CHECK-NEXT:              {
 // CHECK-NEXT:                  double _r_d0 = _d_res;
+// CHECK-NEXT:                  clad::back(_t3).adjoint += _r_d0;
 // CHECK-NEXT:                  size_t _r0 = {{0U|0UL|0}};
-// CHECK-NEXT:                  {{.*}}at_pullback(&v, i0, _r_d0, &_d_v, &_r0);
 // CHECK-NEXT:                  _d_i0 += _r0;
 // CHECK-NEXT:                  {{.*}}pop(_t3);
 // CHECK-NEXT:              }
@@ -865,9 +842,10 @@ int main() {
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, 0{{.*}}, &_d_a, 0{{.*}});
 // CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, {{0U|0UL|0}});
 // CHECK-NEXT:          _t1.value = x * x;
+// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&a, 0, &_d_a, 0);
 // CHECK-NEXT:          {
+// CHECK-NEXT:              _t2.adjoint += 1;
 // CHECK-NEXT:              {{.*size_type|size_t}} _r2 = 0{{.*}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 0, 1, &_d_a, &_r2);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              double _r_d0 = _t1.adjoint;
@@ -875,7 +853,6 @@ int main() {
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
 // CHECK-NEXT:              {{.*size_type|size_t}} _r1 = 0{{.*}};
-// CHECK-NEXT:              {{.*}}operator_subscript_pullback(&a, 0, 0{{.*}}, &_d_a, &_r1);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              {{.*}}value_type _r0 = 0.;
@@ -895,10 +872,10 @@ int main() {
 // CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, {{0U|0UL|0}});
 // CHECK-NEXT:      {{.*}}value_type _t1 = _t2.value;
 // CHECK-NEXT:      {
+// CHECK-NEXT:          _t0.adjoint += 1;
 // CHECK-NEXT:          {{.*size_type|size_t}} _r1 = 0{{.*}};
-// CHECK-NEXT:          clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, 1, &_d_ls, &_r1);
+// CHECK-NEXT:          _t2.adjoint += 2 * -1;
 // CHECK-NEXT:          {{.*size_type|size_t}} _r2 = 0{{.*}};
-// CHECK-NEXT:          clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 0, 2 * -1, &_d_ls, &_r2);
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          clad::array<{{double|std::vector<double, std::allocator<double> >::value_type}}> _r0 = {{2U|2UL|2ULL}};
@@ -939,17 +916,16 @@ int main() {
 // CHECK-NEXT:          {
 // CHECK-NEXT:              double _r_d1 = *_d_u;
 // CHECK-NEXT:              *_d_u = 0.;
+// CHECK-NEXT:              clad::back(_t5).adjoint += _r_d1;
 // CHECK-NEXT:              {{.*size_type|size_t}} _r3 = 0{{.*}};
-// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, _r_d1, &_d_ls, &_r3);
 // CHECK-NEXT:              clad::pop(_t5);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              double _r_d0 = clad::back(_t3).adjoint;
+// CHECK-NEXT:              clad::back(_t4).adjoint += _r_d0;
 // CHECK-NEXT:              {{.*size_type|size_t}} _r2 = 0{{.*}};
-// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 0, _r_d0, &_d_ls, &_r2);
 // CHECK-NEXT:              clad::pop(_t4);
 // CHECK-NEXT:              {{.*size_type|size_t}} _r1 = 0{{.*}};
-// CHECK-NEXT:              clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, 0., &_d_ls, &_r1);
 // CHECK-NEXT:              clad::pop(_t3);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
@@ -971,7 +947,8 @@ int main() {
 // CHECK-NEXT:     std::unique_ptr{{.*}} _d_up = static_cast<std::unique_ptr{{.*}}(_t0.adjoint);
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}class_functions::operator_star_reverse_forw(&up, &_d_up);
 // CHECK-NEXT:     _t1.value += 5 * e;
-// CHECK-NEXT:     {{.*}}class_functions::operator_star_pullback(&up, 1, &_d_up);
+// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_star_reverse_forw(&up, &_d_up);
+// CHECK-NEXT:     _t2.adjoint += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _t1.adjoint;
 // CHECK-NEXT:         *_d_e += 5 * _r_d0;
@@ -1012,8 +989,8 @@ int main() {
 // CHECK-NEXT:             double _r_d0 = _d_prod;
 // CHECK-NEXT:             _d_prod = 0.;
 // CHECK-NEXT:             _d_prod += _r_d0 * clad::back(_t4).value;
+// CHECK-NEXT:             clad::back(_t4).adjoint += prod * _r_d0;
 // CHECK-NEXT:             {{.*size_type|size_t}} _r2 = 0{{.*}};
-// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&vec, i - 1, prod * _r_d0, &_d_vec, &_r2);
 // CHECK-NEXT:             _d_i += _r2;
 // CHECK-NEXT:             clad::pop(_t4);
 // CHECK-NEXT:         }
@@ -1060,17 +1037,16 @@ int main() {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d1 = *_d_u;
 // CHECK-NEXT:             *_d_u = 0.;
+// CHECK-NEXT:             clad::back(_t5).adjoint += _r_d1;
 // CHECK-NEXT:             {{.*size_type|size_t}} _r{{3|4}} = {{0U|0UL|0ULL}};
-// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, _r_d1, &_d_ls, &_r{{3|4}});
 // CHECK-NEXT:             clad::pop(_t5);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = clad::back(_t3).adjoint;
+// CHECK-NEXT:             clad::back(_t4).adjoint += _r_d0;
 // CHECK-NEXT:             {{.*size_type|size_t}} _r{{2|3}} = {{0U|0UL|0ULL}};
-// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 0, _r_d0, &_d_ls, &_r{{2|3}});
 // CHECK-NEXT:             clad::pop(_t4);
 // CHECK-NEXT:             {{.*size_type|size_t}} _r{{1|2}} = {{0U|0UL|0ULL}};
-// CHECK-NEXT:             clad::custom_derivatives::class_functions::operator_subscript_pullback(&ls, 1, 0., &_d_ls, &_r{{1|2}});
 // CHECK-NEXT:             clad::pop(_t3);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
@@ -1118,7 +1094,7 @@ int main() {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = _d_sum;
 // CHECK-NEXT:             _d_u += _r_d0 * clad::pop(_t3);
-// CHECK-NEXT:             {{.*}}::class_functions::operator_star_pullback(&it, u * _r_d0, &_d_it);
+// CHECK-NEXT:             clad::back(_t4).adjoint += u * _r_d0;
 // CHECK-NEXT:             clad::pop(_t4);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
@@ -1197,7 +1173,7 @@ int main() {
 // CHECK-NEXT:         _d_x += x * _d_y;
 // CHECK-NEXT:         _d_x += 2. * _d_y;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     clad::custom_derivatives::class_functions::operator_star_pullback(&x_ptr, _d_x, &(*_d_x_ptr));
+// CHECK-NEXT:     _t0.adjoint += _d_x;
 // CHECK-NEXT: }
 
 // CHECK: void fn21_grad(double x, double *_d_x) {
@@ -1231,7 +1207,7 @@ int main() {
 // CHECK-NEXT:         _d_x += x * _d_y;
 // CHECK-NEXT:         _d_x += 2. * _d_y;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     clad::custom_derivatives::class_functions::operator_star_pullback(&s, _d_x, &_d_s);
+// CHECK-NEXT:     _t2.adjoint += _d_x;
 // CHECK-NEXT:     shared_ptr<double> _r0 = _t0.adjoint;
 // CHECK-NEXT: }
 

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -412,7 +412,7 @@ MyStruct fn12(MyStruct s) {  // expected-warning {{clad::gradient only supports 
 // CHECK-NEXT:    return {*this, *_d_this};
 // CHECK-NEXT:}
 
-// CHECK: inline constexpr void operator_equal_pullback(MyStruct &&arg, MyStruct _d_y, MyStruct *_d_this, MyStruct *_d_arg) noexcept {
+// CHECK: inline constexpr void operator_equal_pullback(MyStruct &&arg, MyStruct *_d_this, MyStruct *_d_arg) noexcept {
 // CHECK-NEXT:    double _t0 = this->a;
 // CHECK-NEXT:    this->a = static_cast<MyStruct &&>(arg).a;
 // CHECK-NEXT:    double _t1 = this->b;
@@ -437,7 +437,7 @@ MyStruct fn12(MyStruct s) {  // expected-warning {{clad::gradient only supports 
 // CHECK-NEXT:    {
 // CHECK-NEXT:        MyStruct _r0 = {0., 0.};
 // CHECK-NEXT:        s = _t0;
-// CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, {0., 0.}, &(*_d_s), &_r0);
+// CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, &(*_d_s), &_r0);
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;
 // CHECK-NEXT:    }
@@ -725,7 +725,7 @@ void fn20(MyStruct s) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        MyStruct _r0 = {0., 0.};
 // CHECK-NEXT:        s = _t0;
-// CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, {0., 0.}, &(*_d_s), &_r0);
+// CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, &(*_d_s), &_r0);
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;
 // CHECK-NEXT:    }
@@ -1001,8 +1001,7 @@ constructor_reverse_forw(::clad::ConstructorReverseForwTag<ptrClass>, double* mp
 // CHECK-NEXT:      return {*this->ptr, *_d_this->ptr};
 // CHECK-NEXT:  }
 
-// CHECK:  void operator_star_pullback(double _d_y, ptrClass *_d_this) {
-// CHECK-NEXT:      *_d_this->ptr += _d_y;
+// CHECK:  void operator_star_pullback(ptrClass *_d_this) {
 // CHECK-NEXT:  }
 
 double fn26(double x, double y) {
@@ -1014,7 +1013,8 @@ double fn26(double x, double y) {
 // CHECK-NEXT:      ::clad::ValueAndAdjoint<ptrClass, ptrClass> _t0 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<ptrClass>(), &x, &*_d_x);
 // CHECK-NEXT:      ptrClass p(_t0.value);
 // CHECK-NEXT:      ptrClass _d_p = _t0.adjoint;
-// CHECK-NEXT:      p.operator_star_pullback(1, &_d_p);
+// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t1 = p.operator_star_reverse_forw(&_d_p);
+// CHECK-NEXT:      _t1.adjoint += 1;
 // CHECK-NEXT:  }
 
 struct MyStructWrapper {
@@ -1027,12 +1027,12 @@ struct MyStructWrapper {
 // CHECK-NEXT:      return {*this, *_d_this};
 // CHECK-NEXT:  }
 
-// CHECK:  inline constexpr void operator_equal_pullback(MyStructWrapper &&arg, MyStructWrapper _d_y, MyStructWrapper *_d_this, MyStructWrapper *_d_arg) noexcept {
+// CHECK:  inline constexpr void operator_equal_pullback(MyStructWrapper &&arg, MyStructWrapper *_d_this, MyStructWrapper *_d_arg) noexcept {
 // CHECK-NEXT:      MyStruct _t0 = this->val;
 // CHECK-NEXT:      this->val.operator_equal_reverse_forw(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, std::move((*_d_arg).val));
 // CHECK-NEXT:      {
 // CHECK-NEXT:          this->val = _t0;
-// CHECK-NEXT:          this->val.operator_equal_pullback(static_cast<MyStructWrapper &&>(arg).val, {0., 0.}, &_d_this->val, &(*_d_arg).val);
+// CHECK-NEXT:          this->val.operator_equal_pullback(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, &(*_d_arg).val);
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
@@ -1054,7 +1054,7 @@ double fn27(double x, double y) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          MyStructWrapper _r0 = {{.*0., 0..*}};
 // CHECK-NEXT:          s = _t0;
-// CHECK-NEXT:          s.operator_equal_pullback({{.*2 \* y, 3 \* x \+ 2.*}}, {{.*0., 0..*}}, &_d_s, &_r0);
+// CHECK-NEXT:          s.operator_equal_pullback({{.*2 \* y, 3 \* x \+ 2.*}}, &_d_s, &_r0);
 // CHECK-NEXT:          *_d_y += 2 * _r0.val.a;
 // CHECK-NEXT:          *_d_x += 3 * _r0.val.b;
 // CHECK-NEXT:      }


### PR DESCRIPTION
Currently, in the reverse mode, we differentiate functions with reference return types using a pullback parameter, e.g.
```
double& f_ref(double& x) {
    ...
    return x;
}
double z = f_ref(x);
```
-->
```
void f_ref_pullback(double& x, double _d_y, double* _d_x) {
    ...
    *_d_x += _d_y;
}
// forward pass
... _t0 = f_ref_reverse_forw(x, _d_x);
double z = _t0.value;
double _d_z = _t0.adjoint;

// reverse pass
f_ref_pullback(x, _d_z, &_d_x);
```
This is exactly the same approach we use to differentiate functions with by-value returns (except we wouldn't use ``reverse_forw``). This causes problems like described in #1301. The problem with the approach is that we're supposed to use ``+=``/``pullback`` whenever a copy happens. The function ``f_ref`` doesn't copy, it only propagates the address of ``x``. The copying happens when assigning to ``z``, and that's where we should propagate the derivative. We should treat references the same way we would treat pointers:
```
// forward pass
... _t0 = f_ref_reverse_forw(x, _d_x);
double z = _t0.value;
double _d_z = _t0.adjoint;

// reverse pass
_t0.adjoint += _d_z;
// f_ref_pullback(x, &_d_x);      <-- optional, only if the body is not empty
```
Apart from fixing #1301, this change simplifies the generated code, because most functions with reference return types can be divided into 2 categories:
1) Functions that do nothing except return a reference to something. Examples (normally) include ``operator[]``, ``operator*``, ``at``, ``back``, ``front``, and any other "getter-like" functions. In such cases, we don't need the ``pullback`` anymore, only ``reverse_forw``. Note that ``reverse_forw`` is required for reference return type functions anyway. This allowed us to remove/simplify many custom pullbacks.
2) Functions with modifications that support chaining, e.g., ``operator=``, ``operator+=``, ``operator++``, ``operator<<``, etc. In practice, the return values of such functions are mostly discarded. With this new approach, we don't have to zero-initialize the pullback parameter (this is a separate problem we haven't figured out).

Moreover, in case 1, ``reverse_forw`` can often be replaced with a pair of original functions, e.g., ``operator_subscript_reverse_forw(x, i, _d_x, _d_i)`` is mostly just ``{x[i], _d_x[i]}``. If we figure out a way to do this simplification, we could avoid differentiating such functions completely and produce way more efficient and readable code.