### PR TITLE
Move MacOS x86 runners to MacOS 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,33 +52,33 @@ jobs:
             compiler: clang
             clang-runtime: '21'
 
-          - name: osx13-x86-clang-runtime16
-            os: macos-13
+          - name: osx15-x86-clang-runtime16
+            os: macos-15-intel
             compiler: clang
             clang-runtime: '16'
 
-          - name: osx13-x86-clang-runtime17
-            os: macos-13
+          - name: osx15-x86-clang-runtime17
+            os: macos-15-intel
             compiler: clang
             clang-runtime: '17'
             
-          - name: osx13-x86-clang-runtime18
-            os: macos-13
+          - name: osx15-x86-clang-runtime18
+            os: macos-15-intel
             compiler: clang
             clang-runtime: '18'
 
-          - name: osx13-x86-clang-runtime19
-            os: macos-13
+          - name: osx15-x86-clang-runtime19
+            os: macos-15-intel
             compiler: clang
             clang-runtime: '19'
 
-          - name: osx13-x86-clang-runtime20
-            os: macos-13
+          - name: osx15-x86-clang-runtime20
+            os: macos-15-intel
             compiler: clang
             clang-runtime: '20'
 
-          - name: osx13-x86-clang-runtime21
-            os: macos-13
+          - name: osx15-x86-clang-runtime21
+            os: macos-15-intel
             compiler: clang
             clang-runtime: '21'
 


### PR DESCRIPTION
The MacOS 13 x86 runners have just been deprecated (see https://github.com/actions/runner-images/issues/13046) and a MacOS 15 x86 runner has been created as a replacement (see https://github.com/actions/runner-images/issues/13045). This will be the final MacOS x86 Github runner.