### PR TITLE
Add Thrust-based demos

### DIFF
--- a/demos/CUDA/LinearRegression.cu
+++ b/demos/CUDA/LinearRegression.cu
@@ -1,0 +1,58 @@
+// A demo of clad's automatic differentiation capabilities on a CUDA Thrust
+// program that computes the loss of a simple linear regression model. The model
+// calculates a prediction `y_pred` as the inner product of features `x` and
+// weights `w`. The loss is the squared error between `y_pred` and a true value
+// `y_true`. The program then computes the gradient of this loss with respect to
+// the weights `w`.
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/ThrustDerivatives.h"
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/inner_product.h>
+
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+double linear_regression_loss(const thrust::device_vector<double>& x,
+                              const thrust::device_vector<double>& w,
+                              double y_true) {
+  double y_pred = thrust::inner_product(x.begin(), x.end(), w.begin(), 0.0);
+  double error = y_pred - y_true;
+  return error * error;
+}
+
+int main() {
+  const int N = 10;
+
+  // Initialize host vectors for features (x) and weights (w)
+  thrust::host_vector<double> h_x(N);
+  std::iota(h_x.begin(), h_x.end(), 1.0); // x = {1, 2, ..., 10}
+
+  thrust::host_vector<double> h_w(N, 0.1); // w = {0.1, 0.1, ..., 0.1}
+
+  const double y_true = 10.0;
+
+  thrust::device_vector<double> x = h_x;
+  thrust::device_vector<double> w = h_w;
+
+  auto loss_grad = clad::gradient(linear_regression_loss);
+
+  thrust::device_vector<double> x_grad(N);
+  thrust::device_vector<double> w_grad(N);
+  double y_true_grad = 0;
+
+  loss_grad.execute(x, w, y_true, &x_grad, &w_grad, &y_true_grad);
+
+  std::cout << "Running linear regression demo." << std::endl;
+
+  thrust::host_vector<double> host_w_gradients = w_grad;
+  std::cout << "Gradients of loss wrt weights (w): ";
+  for (size_t i = 0; i < host_w_gradients.size(); ++i)
+    std::cout << host_w_gradients[i] << " ";
+  std::cout << std::endl;
+
+  return 0;
+}

--- a/demos/CUDA/ParticleSimulation.cu
+++ b/demos/CUDA/ParticleSimulation.cu
@@ -1,0 +1,91 @@
+// A demo of clad's automatic differentiation capabilities on a CUDA Thrust
+// program that simulates the motion of particles. This program updates the
+// positions of particles over a fixed number of time steps and returns the sum
+// of their final x-positions. It then calculates the gradient of this sum with
+// respect to the initial x-velocities of the particles.
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/ThrustDerivatives.h"
+
+#include <thrust/copy.h>
+#include <thrust/device_vector.h>
+#include <thrust/functional.h>
+#include <thrust/host_vector.h>
+#include <thrust/reduce.h>
+#include <thrust/transform.h>
+
+#include <iostream>
+
+double run_simulation(thrust::device_vector<double>& x,
+                      thrust::device_vector<double>& y,
+                      const thrust::device_vector<double>& vx,
+                      const thrust::device_vector<double>& vy,
+                      const thrust::device_vector<double>& dts,
+                      thrust::device_vector<double>& tmp,
+                      thrust::device_vector<double>& x_buffer,
+                      thrust::device_vector<double>& y_buffer) {
+  const int n_steps = 5;
+
+  for (int i = 0; i < n_steps; ++i) {
+    // Update x-position.
+    thrust::transform(vx.begin(), vx.end(), dts.begin(), tmp.begin(),
+                      thrust::multiplies<double>());
+    thrust::transform(x.begin(), x.end(), tmp.begin(), x_buffer.begin(),
+                      thrust::plus<double>());
+    thrust::copy(x_buffer.begin(), x_buffer.end(), x.begin());
+
+    // Update y-position.
+    thrust::transform(vy.begin(), vy.end(), dts.begin(), tmp.begin(),
+                      thrust::multiplies<double>());
+    thrust::transform(y.begin(), y.end(), tmp.begin(), y_buffer.begin(),
+                      thrust::plus<double>());
+    thrust::copy(y_buffer.begin(), y_buffer.end(), y.begin());
+  }
+
+  // Return the sum of the final x-positions of all particles.
+  return thrust::reduce(x.begin(), x.end(), 0.0);
+}
+
+int main() {
+  const int N = 10;
+  const double dt = 0.1;
+
+  // 1. Set up all vectors in main.
+  thrust::device_vector<double> x(N, 0.0);
+  thrust::device_vector<double> y(N, 0.0);
+  thrust::device_vector<double> vx(N, 2.0);
+  thrust::device_vector<double> vy(N, 1.0);
+  thrust::device_vector<double> dts(N, dt);
+  thrust::device_vector<double> tmp(N);
+  thrust::device_vector<double> x_buffer(N);
+  thrust::device_vector<double> y_buffer(N);
+
+  // 2. Differentiate `run_simulation`.
+  auto run_simulation_grad = clad::gradient(run_simulation);
+
+  // 3. Prepare storage for gradients.
+  thrust::device_vector<double> x_grad(N);
+  thrust::device_vector<double> y_grad(N);
+  thrust::device_vector<double> vx_grad(N);
+  thrust::device_vector<double> vy_grad(N);
+  thrust::device_vector<double> dts_grad(N);
+  thrust::device_vector<double> tmp_grad(N);
+  thrust::device_vector<double> x_buffer_grad(N);
+  thrust::device_vector<double> y_buffer_grad(N);
+
+  // 4. Execute the generated gradient function.
+  run_simulation_grad.execute(x, y, vx, vy, dts, tmp, x_buffer, y_buffer,
+                              &x_grad, &y_grad, &vx_grad, &vy_grad, &dts_grad,
+                              &tmp_grad, &x_buffer_grad, &y_buffer_grad);
+
+  // 5. Print the results.
+  std::cout << "Running particle simulation demo." << std::endl;
+
+  thrust::host_vector<double> host_gradients = vx_grad;
+  std::cout << "Gradients of final x-pos sum wrt initial vx: ";
+  for (size_t i = 0; i < host_gradients.size(); ++i)
+    std::cout << host_gradients[i] << " ";
+  std::cout << std::endl;
+
+  return 0;
+}

--- a/demos/CUDA/VectorAddition.cu
+++ b/demos/CUDA/VectorAddition.cu
@@ -1,0 +1,52 @@
+// A demo of clad's automatic differentiation capabilities on a simple CUDA
+// Thrust program. This program computes the element-wise sum of two vectors `x`
+// and `y`, stores the result in `z`, and returns the sum of `z`'s elements. It
+// then calculates the gradient of this sum with respect to the initial values
+// of `x`.
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/ThrustDerivatives.h"
+
+#include <thrust/device_vector.h>
+#include <thrust/functional.h>
+#include <thrust/host_vector.h>
+#include <thrust/reduce.h>
+#include <thrust/transform.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+double vector_addition(const thrust::device_vector<double>& x,
+                       const thrust::device_vector<double>& y,
+                       thrust::device_vector<double>& z) {
+  thrust::transform(x.begin(), x.end(), y.begin(), z.begin(),
+                    thrust::plus<double>());
+  return thrust::reduce(z.begin(), z.end(), 0.0);
+}
+
+int main() {
+  const int N = 10;
+
+  thrust::device_vector<double> x(N, 1.0);
+  thrust::device_vector<double> y(N, 2.0);
+  thrust::device_vector<double> z(N, 0.0);
+
+  std::cout << "Running vector addition demo." << std::endl;
+
+  auto vector_addition_grad = clad::gradient(vector_addition);
+
+  thrust::device_vector<double> x_grad(N);
+  thrust::device_vector<double> y_grad(N);
+  thrust::device_vector<double> z_grad(N);
+
+  vector_addition_grad.execute(x, y, z, &x_grad, &y_grad, &z_grad);
+
+  thrust::host_vector<double> host_gradients = x_grad;
+  std::cout << "Gradients of sum wrt initial x: ";
+  for (size_t i = 0; i < host_gradients.size(); ++i)
+    std::cout << host_gradients[i] << " ";
+  std::cout << std::endl;
+
+  return 0;
+}

--- a/test/CUDA/RunCudaDemos.C
+++ b/test/CUDA/RunCudaDemos.C
@@ -1,0 +1,49 @@
+// RUN: %cladclang_cuda -I%S/../../include --cuda-gpu-arch=%cudaarch --cuda-path=%cudapath %cudaldflags -o VectorAddition.out %S/../../demos/CUDA/VectorAddition.cu 2>&1 | FileCheck -check-prefix CHECK_VECTOR_ADDITION %s
+// REQUIRES: cuda-runtime
+// CHECK_VECTOR_ADDITION: void vector_addition_grad(const thrust::device_vector<double> &x, const thrust::device_vector<double> &y, thrust::device_vector<double> &z, thrust::device_vector<double> *_d_x, thrust::device_vector<double> *_d_y, thrust::device_vector<double> *_d_z)
+// CHECK_VECTOR_ADDITION: clad::custom_derivatives::thrust::transform_reverse_forw
+// CHECK_VECTOR_ADDITION: clad::custom_derivatives::thrust::reduce_pullback
+// CHECK_VECTOR_ADDITION: clad::custom_derivatives::thrust::transform_pullback
+
+// RUN: ./VectorAddition.out | FileCheck -check-prefix CHECK_VECTOR_ADDITION_EXEC %s
+// CHECK_VECTOR_ADDITION_EXEC: Running vector addition demo.
+// CHECK_VECTOR_ADDITION_EXEC: Gradients of sum wrt initial x: 1 1 1 1 1 1 1 1 1 1 
+
+// RUN: %cladclang_cuda -I%S/../../include --cuda-gpu-arch=%cudaarch --cuda-path=%cudapath %cudaldflags -o ParticleSimulation.out %S/../../demos/CUDA/ParticleSimulation.cu 2>&1 | FileCheck -check-prefix CHECK_PARTICLE_SIMULATION %s
+// CHECK_PARTICLE_SIMULATION: void run_simulation_grad(thrust::device_vector<double> &x, thrust::device_vector<double> &y, const thrust::device_vector<double> &vx, const thrust::device_vector<double> &vy, const thrust::device_vector<double> &dts, thrust::device_vector<double> &tmp, thrust::device_vector<double> &x_buffer, thrust::device_vector<double> &y_buffer, thrust::device_vector<double> *_d_x, thrust::device_vector<double> *_d_y, thrust::device_vector<double> *_d_vx, thrust::device_vector<double> *_d_vy, thrust::device_vector<double> *_d_dts, thrust::device_vector<double> *_d_tmp, thrust::device_vector<double> *_d_x_buffer, thrust::device_vector<double> *_d_y_buffer)
+// CHECK_PARTICLE_SIMULATION: for (i = 0; i < n_steps; ++i)
+// CHECK_PARTICLE_SIMULATION: clad::custom_derivatives::thrust::reduce_pullback
+// CHECK_PARTICLE_SIMULATION: for (; _t0; _t0--)
+// CHECK_PARTICLE_SIMULATION: clad::custom_derivatives::thrust::copy_pullback
+// CHECK_PARTICLE_SIMULATION: clad::custom_derivatives::thrust::transform_pullback
+
+// RUN: ./ParticleSimulation.out | FileCheck -check-prefix CHECK_PARTICLE_SIMULATION_EXEC %s
+// CHECK_PARTICLE_SIMULATION_EXEC: Running particle simulation demo.
+// CHECK_PARTICLE_SIMULATION_EXEC: Gradients of final x-pos sum wrt initial vx: 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5
+
+// RUN: %cladclang_cuda -I%S/../../include --cuda-gpu-arch=%cudaarch --cuda-path=%cudapath %cudaldflags -o LinearRegression.out %S/../../demos/CUDA/LinearRegression.cu 2>&1 | FileCheck -check-prefix CHECK_LINEAR_REGRESSION %s
+// CHECK_LINEAR_REGRESSION: void linear_regression_loss_grad(const thrust::device_vector<double> &x, const thrust::device_vector<double> &w, double y_true, thrust::device_vector<double> *_d_x, thrust::device_vector<double> *_d_w, double *_d_y_true) {
+// CHECK_LINEAR_REGRESSION-NEXT:     double _d_y_pred = 0.;
+// CHECK_LINEAR_REGRESSION-NEXT:     double y_pred = thrust::inner_product(std::begin(x), std::end(x), std::begin(w), 0.);
+// CHECK_LINEAR_REGRESSION-NEXT:     double _d_error = 0.;
+// CHECK_LINEAR_REGRESSION-NEXT:     double error = y_pred - y_true;
+// CHECK_LINEAR_REGRESSION-NEXT:     {
+// CHECK_LINEAR_REGRESSION-NEXT:         _d_error += 1 * error;
+// CHECK_LINEAR_REGRESSION-NEXT:         _d_error += error * 1;
+// CHECK_LINEAR_REGRESSION-NEXT:     }
+// CHECK_LINEAR_REGRESSION-NEXT:     {
+// CHECK_LINEAR_REGRESSION-NEXT:         _d_y_pred += _d_error;
+// CHECK_LINEAR_REGRESSION-NEXT:         *_d_y_true += -_d_error;
+// CHECK_LINEAR_REGRESSION-NEXT:     }
+// CHECK_LINEAR_REGRESSION-NEXT:     {
+// CHECK_LINEAR_REGRESSION-NEXT:         thrust::detail::vector_base<double, thrust::device_allocator<double> >::const_iterator _r0 = std::begin((*_d_x));
+// CHECK_LINEAR_REGRESSION-NEXT:         thrust::detail::vector_base<double, thrust::device_allocator<double> >::const_iterator _r1 = std::end((*_d_x));
+// CHECK_LINEAR_REGRESSION-NEXT:         thrust::detail::vector_base<double, thrust::device_allocator<double> >::const_iterator _r2 = std::begin((*_d_w));
+// CHECK_LINEAR_REGRESSION-NEXT:         double _r3 = 0.;
+// CHECK_LINEAR_REGRESSION-NEXT:         clad::custom_derivatives::thrust::inner_product_pullback(std::begin(x), std::end(x), std::begin(w), 0., _d_y_pred, &_r0, &_r1, &_r2, &_r3);
+// CHECK_LINEAR_REGRESSION-NEXT:     }
+// CHECK_LINEAR_REGRESSION-NEXT: }
+
+// RUN: ./LinearRegression.out | FileCheck -check-prefix CHECK_LINEAR_REGRESSION_EXEC %s
+// CHECK_LINEAR_REGRESSION_EXEC: Running linear regression demo.
+// CHECK_LINEAR_REGRESSION_EXEC: Gradients of loss wrt weights (w): -9 -18 -27 -36 -45 -54 -63 -72 -81 -90


### PR DESCRIPTION
This PR adds three new demos that uses the new Thrust support in clad.

**New Demos:**
*   **`VectorAddition.cu`**: An example that performs element-wise addition of two vectors and calculates the gradient of the sum with respect to one of the inputs. 
*   **`ParticleSimulation.cu`**: A demo that simulates the movement of particles over several time steps. It calculates the gradient of the sum of the final particle positions with respect to their initial velocities.
*   **`LinearRegression.cu`**: Implements a basic linear regression model and computes the gradient of the loss function with respect to the model's weights.

