### PR TITLE
Disable analyses for dynamically scheduled derivatives

### DIFF
--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -391,6 +391,12 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
     FunctionDecl* derivative = this->FindDerivedFunction(request);
     if (!derivative) {
       alreadyDerived = false;
+      // FIXME: Our analyses are closely tied to the DiffPlanner. Dynamic
+      // derivatives don't have m_AnalysisDC. We should either disable
+      // dynamic scheduling or build m_AnalysisDC here.
+      request.EnableTBRAnalysis = false;
+      request.EnableVariedAnalysis = false;
+      request.EnableUsefulAnalysis = false;
 
       {
         // Store and restore the original function and its order.


### PR DESCRIPTION
After #1456, TBR (as well as other analyses) depend heavily on the DiffPlanner because ``m_AnalysisDC`` is generated there. This is an issue if we're dealing with dynamic derivatives. This has led to issue #1559, where TBR is labeled as enabled but essentially doesn't run (there is no DFC to traverse). Since TBR is technically enabled, but nothing is labeled as to-be-recorded, we don't generate the essential stores.
Of course, disabling analyses for dynamic derivatives is not a perfect solution. We need to decide whether we want to prioritize enabling them or getting rid of dynamic derivatives.

Fixes #1559.