### PR TITLE
Don't copy-initialize reverse_forw diffrequests with pullback diffrequests

### DIFF
--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1374,12 +1374,10 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
 
     if (request.Mode == DiffMode::pullback) {
       DiffRequest forwPassRequest;
-      forwPassRequest = request;
-      forwPassRequest.DVI.clear();
+      forwPassRequest.Function = request.Function;
+      forwPassRequest.BaseFunctionName = request.BaseFunctionName;
       forwPassRequest.Mode = DiffMode::reverse_mode_forward_pass;
-      forwPassRequest.EnableTBRAnalysis = false;
-      forwPassRequest.EnableVariedAnalysis = false;
-      forwPassRequest.EnableUsefulAnalysis = false;
+      forwPassRequest.CallContext = request.CallContext;
       QualType returnType = request->getReturnType();
       if (LookupCustomDerivativeDecl(forwPassRequest) ||
           utils::isMemoryType(returnType) || shouldUseRestoreTracker)


### PR DESCRIPTION
Currently, diffrequests of reverse_forw are copied from those of pullback, and then the necessary fields are reset to other values. The bug in #1565 occurred because custom derivatives from pullbacks were propagated to reverse_forw. In this PR, reverse_forw diffrequests are initialized from scratch, allowing us to explicitly see which fields are initialized.

Fixes #1565.