### PR TITLE
Don't generate pullbacks of static methods with non-diff args.

### DIFF
--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1177,7 +1177,8 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       if (clad::utils::hasNonDifferentiableAttribute(E))
         nonDiff = true;
 
-      if (const CXXMethodDecl* MD = dyn_cast<CXXMethodDecl>(FD)) {
+      const auto* MD = dyn_cast<CXXMethodDecl>(FD);
+      if (MD) {
         const CXXRecordDecl* CD = MD->getParent();
         if (clad::utils::hasNonDifferentiableAttribute(CD))
           nonDiff = true;
@@ -1188,7 +1189,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
                                    returnType->isPointerType();
       // Don't build propagators for calls that do not contribute in
       // differentiable way to the result.
-      if (!isa<CXXMethodDecl>(FD) && !hasPointerOrRefReturn &&
+      if (!(MD && MD->isInstance()) && !hasPointerOrRefReturn &&
           allArgumentsAreLiterals(E->arguments(), m_ParentReq))
         nonDiff = true;
       // In the reverse mode, such functions don't have dfdx()

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -1156,6 +1156,31 @@ double f_static_assert(double x, double y) {
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
+double f_infinity(double x, double y) {
+  constexpr double inf = std::numeric_limits<double>::infinity();
+  if (x < inf)
+    return y;
+  return x + y;
+}
+
+//CHECK: void f_infinity_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK-NEXT:     bool _cond0;
+//CHECK-NEXT:     double _d_inf = 0.;
+//CHECK-NEXT:     const double inf = std::numeric_limits<double>::infinity();
+//CHECK-NEXT:     {
+//CHECK-NEXT:         _cond0 = x < inf;
+//CHECK-NEXT:         if (_cond0)
+//CHECK-NEXT:             goto _label0;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     {
+//CHECK-NEXT:         *_d_x += 1;
+//CHECK-NEXT:         *_d_y += 1;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     if (_cond0)
+//CHECK-NEXT:       _label0:
+//CHECK-NEXT:         *_d_y += 1;
+//CHECK-NEXT: }
+
 #define TEST(F, x, y)                                                          \
   {                                                                            \
     result[0] = 0;                                                             \
@@ -1259,4 +1284,7 @@ int main() {
 
   INIT_GRADIENT(f_static_assert);
   TEST_GRADIENT(f_static_assert, /*numOfDerivativeArgs=*/2, -3, 4, &d_i, &d_j);  // CHECK-EXEC: {1.00, 1.00}
+
+  INIT_GRADIENT(f_infinity);
+  TEST_GRADIENT(f_infinity, /*numOfDerivativeArgs=*/2, -3, 4, &d_i, &d_j);  // CHECK-EXEC: {0.00, 1.00}
 }


### PR DESCRIPTION
In #1550, non-diff handling in the DiffPlanner was refactored. One of the ways to deduce non-differentiability of a function was to check that it has no varied (non-constant) arguments. It was also checked whether the function is not a method. However, after the change, we started also skipping static methods. This caused a crash in #1557 with the function `std::numeric_limits<double>::infinity()`.

Fixes #1557