### PR TITLE
Initialize builtin type adjoints with init derivatives

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3312,7 +3312,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   StmtDiff
   ReverseModeVisitor::VisitPseudoObjectExpr(const PseudoObjectExpr* POE) {
     // Used for CUDA Builtins
-    return {Clone(POE), Clone(POE)};
+    return {Clone(POE), getZeroInit(m_Context.IntTy)};
   }
 
   StmtDiff

--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -49,7 +49,7 @@ double f2(double x){
 //CHECK-NEXT:     double _t1;
 //CHECK-NEXT:     double _d_a = 0.;
 //CHECK-NEXT:     double a = x * x;
-//CHECK-NEXT:     double _d_b = 0.;
+//CHECK-NEXT:     double _d_b = 0;
 //CHECK-NEXT:     double b = 1;
 //CHECK-NEXT:     double _d_g = 0.;
 //CHECK-NEXT:     double g;
@@ -102,7 +102,7 @@ double f3(double x){
 //CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     clad::tape<double> _t4 = {};
 //CHECK-NEXT:     clad::tape<double> _t5 = {};
-//CHECK-NEXT:     double _d_x1 = 0., _d_x2 = 0., _d_x3 = 0., _d_x4 = 0., _d_x5 = 0.;
+//CHECK-NEXT:     double _d_x1 = 0., _d_x2 = 0., _d_x3 = 0., _d_x4 = 0., _d_x5 = 0;
 //CHECK-NEXT:     double x1, x2, x3, x4, x5 = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     while (!x3) 
@@ -490,7 +490,7 @@ double f14(double x){
 // CHECK-NEXT:     clad::tape<double> _t7 = {};
 // CHECK-NEXT:     double _d_a = 0., _d_b = 0.;
 // CHECK-NEXT:     double a, b;
-// CHECK-NEXT:     double _d_x1 = 0., _d_x2 = 0., _d_x3 = 0.;
+// CHECK-NEXT:     double _d_x1 = 0, _d_x2 = 0, _d_x3 = 0;
 // CHECK-NEXT:     double x1 = 0, x2 = 0, x3 = 0, x4 = 0;
 // CHECK-NEXT:     int i = 10;
 // CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};

--- a/test/Analyses/TBR.cpp
+++ b/test/Analyses/TBR.cpp
@@ -17,7 +17,7 @@ double f1(double x) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
-//CHECK-NEXT:     double _d_t = 0.;
+//CHECK-NEXT:     double _d_t = 0;
 //CHECK-NEXT:     double t = 1;
 //CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
@@ -50,7 +50,7 @@ double f2(double val) {
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 //CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
-//CHECK-NEXT:     double _d_res = 0.;
+//CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 1; i < 5; ++i) {
@@ -103,11 +103,11 @@ double f3(double x){
 //CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     bool _cond1;
 //CHECK-NEXT:     bool _cond2;
-//CHECK-NEXT:     double _d_i = 0.;
+//CHECK-NEXT:     double _d_i = 0;
 //CHECK-NEXT:     double i = 1;
-//CHECK-NEXT:     double _d_j = 0.;
+//CHECK-NEXT:     double _d_j = 0;
 //CHECK-NEXT:     double j = 0;
-//CHECK-NEXT:     double _d_res = 0.;
+//CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     res += i * x;
 //CHECK-NEXT:     {

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -17,7 +17,7 @@ double addArr(const double *arr, int n) {
 //CHECK: void addArr_pullback(const double *arr, int n, double _d_y, double *_d_arr, int *_d_n) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     double _d_ret = 0.;
+//CHECK-NEXT:     double _d_ret = 0;
 //CHECK-NEXT:     double ret = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
@@ -58,7 +58,7 @@ float func(float* a, float* b) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
-//CHECK-NEXT:     float _d_sum = 0.F;
+//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
@@ -102,7 +102,7 @@ float func2(float* a) {
 //CHECK: void func2_grad(float *a, float *_d_a) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     float _d_sum = 0.F;
+//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
@@ -129,7 +129,7 @@ float func3(float* a, float* b) {
 //CHECK: void func3_grad(float *a, float *b, float *_d_a, float *_d_b) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     float _d_sum = 0.F;
+//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
@@ -160,7 +160,7 @@ double func4(double x) {
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     double arr[3] = {x, 2 * x, x * x};
-//CHECK-NEXT:     double _d_sum = 0.;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
@@ -215,7 +215,7 @@ double func5(int k) {
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         arr[i] = k;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     double _d_sum = 0.;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t1 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i0 = 0; i0 < 3; i0++) {
@@ -257,7 +257,7 @@ double func6(double seed) {
 //CHECK-NEXT:     clad::tape<double{{ ?}}[3]> _t2 = {};
 //CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     double arr[3] = {0};
-//CHECK-NEXT:     double _d_sum = 0.;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
@@ -359,7 +359,7 @@ double func8(double i, double *arr, int n) {
 }
 
 //CHECK: void func8_grad(double i, double *arr, int n, double *_d_i, double *_d_arr, int *_d_n) {
-//CHECK-NEXT:     double _d_res = 0.;
+//CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     arr[0] = 1;
 //CHECK-NEXT:     res = helper2(i, arr, n);
@@ -466,7 +466,7 @@ double func10(double *arr, int n) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
-//CHECK-NEXT:     double _d_res = 0.;
+//CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
@@ -502,7 +502,7 @@ double func11(double seed) {
 // CHECK-NEXT:    int i = 0;
 // CHECK-NEXT:    double _d_arr[3] = {0};
 // CHECK-NEXT:    double arr[3];
-// CHECK-NEXT:    double _d_sum = 0.;
+// CHECK-NEXT:    double _d_sum = 0;
 // CHECK-NEXT:    double sum = 0;
 // CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:    for (i = 0; i < 3; i++) {

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -33,7 +33,7 @@ __device__ __host__ double gauss(const double* x, double* p, double sigma, int d
 //CHECK-NEXT:     int _d_dim = 0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     double _d_t = 0.;
+//CHECK-NEXT:     double _d_t = 0;
 //CHECK-NEXT:     double t = 0;
 //CHECK-NEXT:     unsigned long _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < dim; i++) {

--- a/test/CUDA/GradientKernels.cu
+++ b/test/CUDA/GradientKernels.cu
@@ -39,7 +39,7 @@ __global__ void add_kernel(int *out, int *in) {
 }
 
 // CHECK:    void add_kernel_grad(int *out, int *in, int *_d_out, int *_d_in) {
-//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:     int _d_index = 0;
 //CHECK-NEXT:     int index0 = threadIdx.x;
 //CHECK-NEXT:     int _t0 = out[index0];
 //CHECK-NEXT:     out[index0] += in[index0];
@@ -70,7 +70,7 @@ __global__ void add_kernel_3(int *out, int *in) {
 }
 
 // CHECK:    void add_kernel_3_grad(int *out, int *in, int *_d_out, int *_d_in) {
-//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int _d_index = 0U;
 //CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:    int _t0 = out[index0];
 //CHECK-NEXT:    out[index0] += in[index0];
@@ -105,7 +105,7 @@ __global__ void add_kernel_4(int *out, int *in, int N) {
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     int _t3;
-// CHECK-NEXT:     int _d_index = 0;
+// CHECK-NEXT:     int _d_index = 0U;
 // CHECK-NEXT:     int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _cond0 = index0 < N;
@@ -169,7 +169,7 @@ __global__ void add_kernel_5(int *out, int *in, int N) {
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     int _t3;
-// CHECK-NEXT:     int _d_index = 0;
+// CHECK-NEXT:     int _d_index = 0U;
 // CHECK-NEXT:     int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _cond0 = index0 < N;
@@ -216,7 +216,7 @@ __global__ void add_kernel_6(int *a, int *b) {
 }
 
 //CHECK: void add_kernel_6_grad(int *a, int *b, int *_d_a, int *_d_b) {
-//CHECK-NEXT:     int _d_index = 0;
+//CHECK-NEXT:     int _d_index = 0U;
 //CHECK-NEXT:     int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:     int _t0 = a[index0];
 //CHECK-NEXT:     a[index0] = *b;
@@ -235,7 +235,7 @@ __global__ void add_kernel_7(double *a, double *b) {
 }
 
 // CHECK: void add_kernel_7_grad(double *a, double *b, double *_d_a, double *_d_b) {
-// CHECK-NEXT:     int _d_index = 0;
+// CHECK-NEXT:     int _d_index = 0U;
 // CHECK-NEXT:     int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 // CHECK-NEXT:     double _t0 = a[2 * index0];
 // CHECK-NEXT:     a[2 * index0] = b[0];
@@ -303,7 +303,7 @@ __global__ void dup_kernel_with_device_call_2(double *out, const double *in, dou
 } 
 
 //CHECK: __attribute__((device)) void device_fn_2_pullback_1(const double *in, double val, double _d_y, double *_d_val) {
-//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int _d_index = 0U;
 //CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:    *_d_val += _d_y;
 //CHECK-NEXT:}
@@ -324,7 +324,7 @@ __global__ void dup_kernel_with_device_call_2(double *out, const double *in, dou
 //CHECK-NEXT:}
 
 // CHECK: __attribute__((device)) void device_fn_2_pullback_0(const double *in, double val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int _d_index = 0U;
 //CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _d_in[index0] += _d_y;
@@ -359,7 +359,7 @@ __global__ void kernel_with_device_call_3(double *out, double *in, double *val) 
 } 
 
 // CHECK: __attribute__((device)) void device_fn_3_pullback_0_1(double *in, double *val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int _d_index = 0U;
 //CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _d_in[index0] += _d_y;
@@ -395,7 +395,7 @@ __global__ void kernel_with_nested_device_call(double *out, double *in, double v
 }
 
 // CHECK: __attribute__((device)) void device_fn_4_pullback_0_1(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int _d_index = 0U;
 //CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _d_in[index0] += _d_y;
@@ -434,7 +434,7 @@ __global__ void fn1(double *out, const double *in, double val) {
 }
 
 // CHECK: void fn1_grad_0_2(double *out, const double *in, double val, double *_d_out, double *_d_val) {
-// CHECK-NEXT:     int _d_index = 0;
+// CHECK-NEXT:     int _d_index = 0U;
 // CHECK-NEXT:     int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 // CHECK-NEXT:     double _d_temp = 0.;
 // CHECK-NEXT:     double temp = val;
@@ -501,7 +501,7 @@ double fn_memory(double *out, double *in) {
 //CHECK-NEXT:    memset(_d_out_host, 0, 10 * sizeof(double));
 //CHECK-NEXT:    double *out_host = (double *)malloc(10 * sizeof(double));
 //CHECK-NEXT:    cudaMemcpy(out_host, out, 10 * sizeof(double), cudaMemcpyDeviceToHost);
-//CHECK-NEXT:    double _d_res = 0.;
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    unsigned long _t0 = 0UL;
 //CHECK-NEXT:    for (i = 0; i < 10; ++i) {
@@ -562,7 +562,7 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
 // CHECK-NEXT:     clad::tape<int> _t1 = {};
 // CHECK-NEXT:     clad::tape<int> _t2 = {};
 // CHECK-NEXT:     int _t3;
-// CHECK-NEXT:     int _d_index = 0;
+// CHECK-NEXT:     int _d_index = 0U;
 // CHECK-NEXT:     int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _cond0 = index0 < N;
@@ -662,13 +662,13 @@ __global__ void indices_perm(int *out, int *in) {
 }
 
 // CHECK: void indices_perm_grad(int *out, int *in, int *_d_out, int *_d_in) {
-// CHECK-NEXT:     int _d_index1 = 0;
+// CHECK-NEXT:     int _d_index1 = 0U;
 // CHECK-NEXT:     int index1 = threadIdx.x + blockIdx.x * blockDim.x;
-// CHECK-NEXT:     int _d_index2 = 0;
+// CHECK-NEXT:     int _d_index2 = 0U;
 // CHECK-NEXT:     int index2 = threadIdx.x + blockDim.x * blockIdx.x;
-// CHECK-NEXT:     int _d_index3 = 0;
+// CHECK-NEXT:     int _d_index3 = 0U;
 // CHECK-NEXT:     int index3 = blockIdx.x * blockDim.x + threadIdx.x;
-// CHECK-NEXT:     int _d_index4 = 0;
+// CHECK-NEXT:     int _d_index4 = 0U;
 // CHECK-NEXT:     int index4 = blockDim.x * blockIdx.x + threadIdx.x;
 // CHECK-NEXT:     int _t0 = out[index1];
 // CHECK-NEXT:     out[index1] += in[index1];
@@ -713,7 +713,7 @@ __global__ void indices_lin_comb(int *out, int *in) {
 }
 
 // CHECK: void indices_lin_comb_grad(int *out, int *in, int *_d_out, int *_d_in) {
-// CHECK-NEXT:     int _d_index = 0;
+// CHECK-NEXT:     int _d_index = 0U;
 // CHECK-NEXT:     int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 // CHECK-NEXT:     int _t0 = out[index0];
 // CHECK-NEXT:     out[index0] += in[2 * index0];
@@ -772,7 +772,7 @@ __global__ void kernel_device_injective(int *a) {
 }
 
 // CHECK: __attribute__((device)) void device_injective_index_pullback_0(int *a, int *_d_a) {
-// CHECK-NEXT:     int _d_index1 = 0;
+// CHECK-NEXT:     int _d_index1 = 0U;
 // CHECK-NEXT:     int index1 = threadIdx.x + blockIdx.x * blockDim.x;
 // CHECK-NEXT:     int _d_index2 = 0;
 // CHECK-NEXT:     int index2 = threadIdx.x;
@@ -813,9 +813,9 @@ __global__ void injective_reassignment(int *a) {
 // CHECK: void injective_reassignment_grad(int *a, int *_d_a) {
 // CHECK-NEXT:     bool _cond0;
 // CHECK-NEXT:     int _t2;
-// CHECK-NEXT:     int _d_index1 = 0;
+// CHECK-NEXT:     int _d_index1 = 0U;
 // CHECK-NEXT:     int index1 = threadIdx.x + blockIdx.x * blockDim.x;
-// CHECK-NEXT:     int _d_index2 = 0;
+// CHECK-NEXT:     int _d_index2 = 0U;
 // CHECK-NEXT:     int index2 = threadIdx.x + blockIdx.x * blockDim.x;
 // CHECK-NEXT:     int _t0 = index1;
 // CHECK-NEXT:     index1 = 1;

--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -79,7 +79,7 @@ float func4(float x, float y) {
 }
 
 //CHECK: void func4_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     double _d_z = 0.;
+//CHECK-NEXT:     double _d_z = 0.F;
 //CHECK-NEXT:     double z = y;
 //CHECK-NEXT:     float _t0 = x;
 //CHECK-NEXT:     x = z + y;

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -222,7 +222,7 @@ float func7(float x) {
 }
 
 //CHECK: void func7_grad(float x, float *_d_x, double &_final_error) {
-//CHECK-NEXT:     int _d_z = 0;
+//CHECK-NEXT:     int _d_z = 0.F;
 //CHECK-NEXT:     int z = x;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _d_z += 1;
@@ -280,7 +280,7 @@ float func9(float x, float y) {
 
 //CHECK: void func9_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
 //CHECK-NEXT:     float _t1 = x;
-//CHECK-NEXT:     float _d_z = 0.F;
+//CHECK-NEXT:     float _d_z = 0.;
 //CHECK-NEXT:     float z = helper(x, y) + helper2(x);
 //CHECK-NEXT:     float _t3 = z;
 //CHECK-NEXT:     float _t5 = x;

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -19,7 +19,7 @@ float func(float* p, int n) {
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     unsigned {{int|long}} p_size = {{0U|0UL}};
-//CHECK-NEXT:     float _d_sum = 0.F;
+//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
@@ -153,7 +153,7 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     unsigned {{int|long}} y_size = {{0U|0UL}};
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
-//CHECK-NEXT:     float _d_sum = 0.F;
+//CHECK-NEXT:     float _d_sum = 0;
 //CHECK-NEXT:     float sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < 10; i++) {
@@ -308,7 +308,7 @@ double func6(double x) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
-//CHECK-NEXT:     double _d_sum = 0.;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:     for (i = 1; i < 10; i++) {

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -19,7 +19,7 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     unsigned {{int|long}} f_size = {{0U|0UL}};
-//CHECK-NEXT:     double _d_sum = 0.;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 1; i < n; i++) {
@@ -65,7 +65,7 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     unsigned {{int|long}} b_size = {{0U|0UL}};
 //CHECK-NEXT:     unsigned {{int|long}} a_size = {{0U|0UL}};
-//CHECK-NEXT:     double _d_sum = 0.;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
@@ -122,7 +122,7 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     unsigned {{int|long}} b_size = {{0U|0UL}};
 //CHECK-NEXT:     unsigned {{int|long}} a_size = {{0U|0UL}};
-//CHECK-NEXT:     double _d_sum = 0.;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     for (i = 0; i < n; i++) {

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -698,7 +698,7 @@ double f23(double x, double y) {
 //CHECK-NEXT:     clad::array<double> *ref = {};
 //CHECK-NEXT:     clad::array<double> _d_list = {{2U|2UL}};
 //CHECK-NEXT:     clad::array<double> list = {1., x + y};
-//CHECK-NEXT:     double _d_res = 0.;
+//CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double res = 5;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _cond0 = x > y;

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -26,7 +26,7 @@ double fn1(float i) {
 // CHECK: void fn1_grad(float i, float *_d_i) {
 // CHECK-NEXT:     float _d_res = 0.F;
 // CHECK-NEXT:     float res = A::constantFn(i);
-// CHECK-NEXT:     double _d_a = 0.;
+// CHECK-NEXT:     double _d_a = 0.F;
 // CHECK-NEXT:     double a = res * i;
 // CHECK-NEXT:     _d_a += 1;
 // CHECK-NEXT:     {
@@ -75,7 +75,7 @@ double fn2(double i, double j) {
 }
 
 // CHECK: void fn2_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_temp = 0.;
+// CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double temp = 0;
 // CHECK-NEXT:     double _t0 = i;
 // CHECK-NEXT:     double _t1 = j;
@@ -147,7 +147,7 @@ float sum(double* arr, int n) {
 }
 
 // CHECK: float sum_reverse_forw(double *arr, int n, double *_d_arr, int _d_n, clad::restore_tracker &_tracker0) {
-// CHECK-NEXT:     float _d_res = 0.F;
+// CHECK-NEXT:     float _d_res = 0;
 // CHECK-NEXT:     float res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     int _d_i = 0;
@@ -163,7 +163,7 @@ float sum(double* arr, int n) {
 // CHECK: void sum_pullback(double *arr, int n, float _d_y, double *_d_arr, int *_d_n) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     float _d_res = 0.F;
+// CHECK-NEXT:     float _d_res = 0;
 // CHECK-NEXT:     float res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
@@ -210,7 +210,7 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
 // CHECK-NEXT:     res += sum_reverse_forw(arr, n, _d_arr, 0, _tracker0);

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -578,7 +578,7 @@ double f_issue138(double x, double y) {
 
 void f_issue138_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK:   void f_issue138_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _d__t1 = 0.;
+//CHECK-NEXT:       double _d__t1 = 0;
 //CHECK-NEXT:       double _t10 = 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 1 * x * x * x;
@@ -706,7 +706,7 @@ double fn_template_non_type(double x) {
 }
 
 // CHECK: void fn_template_non_type_grad(double x, double *_d_x) {
-// CHECK-NEXT:     size_t _d_maxN = {{0U|0UL}};
+// CHECK-NEXT:     size_t _d_maxN = 0;
 // CHECK-NEXT:     const size_t maxN = 53;
 // CHECK-NEXT:     bool _cond0 = maxN < {{15U|15UL|15ULL}};
 // CHECK-NEXT:     size_t _d_m = {{0U|0UL}};
@@ -859,7 +859,7 @@ double fn_empty_if_block(double x) {
 
 //CHECK:void fn_empty_if_block_grad(double x, double *_d_x) {
 //CHECK-NEXT:    bool _cond0;
-//CHECK-NEXT:    double _d_res = 0.;
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _cond0 = x > 0;
@@ -882,7 +882,7 @@ double fn_empty_if_else(double x) {
 
 //CHECK: void fn_empty_if_else_grad(double x, double *_d_x) {
 //CHECK-NEXT:    bool _cond0;
-//CHECK-NEXT:    double _d_res = 0.;
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    {
 //CHECK-NEXT:        _cond0 = (res = 0);
@@ -922,7 +922,7 @@ double fn_cond_false(double i, double j) {
 // CHECK-NEXT:    _d_cond0 = 0.;
 // CHECK-NEXT:    bool _cond1;
 // CHECK-NEXT:    bool _cond2;
-// CHECK-NEXT:    double _d_res = 0.;
+// CHECK-NEXT:    double _d_res = 0;
 // CHECK-NEXT:    double res = 0;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        {
@@ -969,7 +969,7 @@ double fn_cond_add_assign(double i, double j) {
 // CHECK-NEXT:    bool _cond2;
 // CHECK-NEXT:    bool _cond3;
 // CHECK-NEXT:    bool _cond4;
-// CHECK-NEXT:    double _d_res = 0.;
+// CHECK-NEXT:    double _d_res = 0;
 // CHECK-NEXT:    double res = 0;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        {

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -21,7 +21,7 @@ double f1(double x) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     double _d_t = 0.;
+// CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 3; i++) {
@@ -54,7 +54,7 @@ double f2(double x) {
 // CHECK-NEXT:     int _d_j = 0;
 // CHECK-NEXT:     int j = 0;
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
-// CHECK-NEXT:     double _d_t = 0.;
+// CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 3; i++) {
@@ -95,7 +95,7 @@ double f3(double x) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
-// CHECK-NEXT:     double _d_t = 0.;
+// CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 3; i++) {
@@ -137,7 +137,7 @@ double f4(double x) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     double _d_t = 0.;
+// CHECK-NEXT:     double _d_t = 0;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 3; clad::push(_t1, t) , (t *= x)) {
@@ -186,7 +186,7 @@ double f_const_local(double x) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_n = 0.;
 // CHECK-NEXT:     double n = 0.;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 3; ++i) {
@@ -220,7 +220,7 @@ double f_sum(double *p, int n) {
 // CHECK-NEXT:     int _d_n = 0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     double _d_s = 0.;
+// CHECK-NEXT:     double _d_s = 0;
 // CHECK-NEXT:     double s = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; i++) {
@@ -251,7 +251,7 @@ double f_sum_squares(double *p, int n) {
 // CHECK-NEXT:     int _d_n = 0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     double _d_s = 0.;
+// CHECK-NEXT:     double _d_s = 0;
 // CHECK-NEXT:     double s = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; i++) {
@@ -282,7 +282,7 @@ double f_log_gaus(const double* x, double* p /*means*/, double n, double sigma) 
 // CHECK-NEXT:     double _d_sigma = 0.;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     double _d_power = 0.;
+// CHECK-NEXT:     double _d_power = 0;
 // CHECK-NEXT:     double power = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; i++) {
@@ -386,7 +386,7 @@ double f6 (double i, double j) {
 // CHECK-NEXT:     double b = 0.;
 // CHECK-NEXT:     double _d_c = 0.;
 // CHECK-NEXT:     double c = 0.;
-// CHECK-NEXT:     double _d_a = 0.;
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (counter = 0; counter < 3; ++counter) {
@@ -426,7 +426,7 @@ double fn7(double i, double j) {
 }
 
 // CHECK: void fn7_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_a = 0.;
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
@@ -460,7 +460,7 @@ double fn8(double i, double j) {
 
 // CHECK: void fn8_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
-// CHECK-NEXT:     double _d_a = 0.;
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
@@ -512,7 +512,7 @@ double fn9(double i, double j) {
 // CHECK-NEXT:     int _d_counter = 0, _d_counter_again = 0;
 // CHECK-NEXT:     int counter, counter_again;
 // CHECK-NEXT:     counter = counter_again = 3;
-// CHECK-NEXT:     double _d_a = 0.;
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     while (counter--)
@@ -569,7 +569,7 @@ double fn10(double i, double j) {
 // CHECK: void fn10_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_b = 0;
 // CHECK-NEXT:     int b = 0;
-// CHECK-NEXT:     double _d_a = 0.;
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
@@ -613,7 +613,7 @@ double fn11(double i, double j) {
 // CHECK: void fn11_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     double _d_a = 0.;
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     do {
@@ -658,7 +658,7 @@ double fn12(double i, double j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
-// CHECK-NEXT:     double _d_a = 0.;
+// CHECK-NEXT:     double _d_a = 0;
 // CHECK-NEXT:     double a = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     do {
@@ -724,7 +724,7 @@ double fn13(double i, double j) {
 // CHECK-NEXT:     int k = 0;
 // CHECK-NEXT:     double _d_temp = 0.;
 // CHECK-NEXT:     double temp = 0.;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 3;
@@ -783,7 +783,7 @@ double fn14(double i, double j) {
 // CHECK-NEXT:     clad::tape<bool> _cond2 = {};
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     int choice = 5;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     while (choice--)
@@ -890,7 +890,7 @@ double fn15(double i, double j) {
 // CHECK-NEXT:     clad::tape<bool> _cond2 = {};
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     int choice = 5;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     while (choice--)
@@ -996,7 +996,7 @@ double fn16(double i, double j) {
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 5;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (ii = 0; ii < counter; ++ii) {
@@ -1087,7 +1087,7 @@ double fn17(double i, double j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 5;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (ii = 0; ii < counter; ++ii) {
@@ -1196,7 +1196,7 @@ double fn18(double i, double j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 // CHECK-NEXT:     int _d_choice = 0;
 // CHECK-NEXT:     int choice = 5;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (counter = 0; counter < choice; ++counter) {
@@ -1263,7 +1263,7 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:     clad::tape<double *> _t1 = {};
 // CHECK-NEXT:     double *_d_ref = nullptr;
 // CHECK-NEXT:     double *ref = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
@@ -1298,9 +1298,9 @@ double f_loop_init_var(double lower, double upper) {
 // CHECK-NEXT:     double _d_x = 0.;
 // CHECK-NEXT:     double x = 0.;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     double _d_sum = 0.;
+// CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = 0;
-// CHECK-NEXT:     double _d_num_points = 0.;
+// CHECK-NEXT:     double _d_num_points = 0;
 // CHECK-NEXT:     double num_points = 10000;
 // CHECK-NEXT:     double _d_interval = 0.;
 // CHECK-NEXT:     double interval = (upper - lower) / num_points;
@@ -1343,7 +1343,7 @@ double fn20(double *arr, int n) {
 // CHECK-NEXT:     int _d_n = 0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
@@ -1378,7 +1378,7 @@ double fn21(double x) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     double _d_arr[3] = {0};
 // CHECK-NEXT:     double arr[3] = {0};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
@@ -1456,7 +1456,7 @@ double fn23(double i, double j) {
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; (res = i * j); ++c) {
@@ -1504,7 +1504,7 @@ double fn24(double i, double j) {
 // CHECK: void fn24_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; (res += i * j) , c < 3; ++c) {
@@ -1540,7 +1540,7 @@ double fn25(double i, double j) {
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; (res += i * j) , c < 3; ++c) {
@@ -1601,7 +1601,7 @@ double fn26(double i, double j) {
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; (res += i * j); ++c , res = 7 * i * j) {
@@ -1660,7 +1660,7 @@ double fn27(double i, double j) {
 // CHECK-NEXT:     int c = 0;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; (res += i * j); ++c) {
@@ -1717,7 +1717,7 @@ double fn28(double i, double j) {
 // CHECK: void fn28_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; (res = i * j) , c < 2; ++c) {
@@ -1753,7 +1753,7 @@ double fn29(double i, double j) {
 // CHECK: void fn29_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     int _d_c = 0;
 // CHECK-NEXT:     int c = 0;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; res = i * j , c < 1; ++c , res = 3 * i * j) {
@@ -1793,7 +1793,7 @@ double fn30(double i, double j) {
 // CHECK-NEXT:     double _d_cond0;
 // CHECK-NEXT:     _d_cond0 = 0.;
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (c = 0; ; ++c) {
@@ -1836,7 +1836,7 @@ double fn31(double i, double j) {
 //CHECK:void fn31_grad(double i, double j, double *_d_i, double *_d_j) {
 //CHECK-NEXT:    int _d_c = 0;
 //CHECK-NEXT:    int c = 0;
-//CHECK-NEXT:    double _d_res = 0.;
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:    for (c = 0; (res = i * j) , (res = 2 * i * j) , c < 3; ++c) {
@@ -1888,7 +1888,7 @@ double fn32(double i, double j) {
 //CHECK-NEXT:    clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 //CHECK-NEXT:    clad::tape<bool> _cond1 = {};
 //CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t3 = {};
-//CHECK-NEXT:    double _d_res = 0.;
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:    for (c = 0; (res += i * j); ++c) {
@@ -2004,7 +2004,7 @@ double fn33(double i, double j) {
 //CHECK-NEXT:    _d_cond3 = 0.;
 //CHECK-NEXT:    clad::tape<bool> _cond4 = {};
 //CHECK-NEXT:    clad::tape<bool> _cond5 = {};
-//CHECK-NEXT:    double _d_res = 0.;
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:    for (c = 0; (res = i * j); ++c) {
@@ -2105,7 +2105,7 @@ double fn34(double x, double y){
 //CHECK: void fn34_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     clad::tape<double *> _t1 = {};
 //CHECK-NEXT:     clad::tape<double *> _t2 = {};
-//CHECK-NEXT:     double _d_r = 0.;
+//CHECK-NEXT:     double _d_r = 0;
 //CHECK-NEXT:     double r = 0;
 //CHECK-NEXT:     double _d_a[3] = {0};
 //CHECK-NEXT:     double a[3] = {y, x * y, x * x + y};
@@ -2176,7 +2176,7 @@ double fn35(double x, double y){
 // CHECK-NEXT:     clad::tape<double *> _t4 = {};
 // CHECK-NEXT:     clad::tape<double *> _t5 = {};
 // CHECK-NEXT:     clad::tape<double *> _t6 = {};
-// CHECK-NEXT:     double _d_r = 0.;
+// CHECK-NEXT:     double _d_r = 0;
 // CHECK-NEXT:     double r = 0;
 // CHECK-NEXT:     double _d_a[3] = {0};
 // CHECK-NEXT:     double a[3] = {x, x * y, 0};
@@ -2299,7 +2299,7 @@ double fn36(double x, double y){
 //CHECK-NEXT:     clad::tape<double> _t4 = {};
 //CHECK-NEXT:     double _d_a[3] = {0};
 //CHECK-NEXT:     double a[3] = {1, 2, 3};
-//CHECK-NEXT:     double _d_sum = 0.;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     double (&__range1)[3] = a;
@@ -2376,7 +2376,7 @@ double fn37(double x, double y) {
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     double _d_range[3] = {0};
 //CHECK-NEXT:     double range[3] = {x, 4., y};
-//CHECK-NEXT:     double _d_sum = 0.;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:     double (&__range1)[3] = range;
@@ -2431,7 +2431,7 @@ double fn38(double x, double y) {
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
-//CHECK-NEXT:     double _d_sum = 0.;
+//CHECK-NEXT:     double _d_sum = 0;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _cond0 = x > 0;
@@ -2489,7 +2489,7 @@ double fn39(double x) {
 //CHECK: void fn39_grad(double x, double *_d_x) {
 //CHECK-NEXT:     int *_d_i = nullptr;
 //CHECK-NEXT:     {{const int *\*|const_iterator }}i = nullptr;
-//CHECK-NEXT:     double _d_res = 0.;
+//CHECK-NEXT:     double _d_res = 0;
 //CHECK-NEXT:     double res = 0;
 //CHECK-NEXT:     clad::array<int> _d_range = {{3U|3UL}};
 //CHECK-NEXT:     clad::array<int> range = {1, 2, 3};
@@ -2570,7 +2570,7 @@ double fn41(double u, double v) {
 //CHECK-NEXT:    int i = 0;
 //CHECK-NEXT:    clad::tape<bool> _cond0 = {};
 //CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t1 = {};
-//CHECK-NEXT:    double _d_res = 0.;
+//CHECK-NEXT:    double _d_res = 0;
 //CHECK-NEXT:    double res = 0;
 //CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL}};
 //CHECK-NEXT:    for (i = 1; i < 3; i++) {
@@ -2708,7 +2708,7 @@ double fn44(double u, double v) {
 //CHECK-NEXT:    int _d_i = 0;
 //CHECK-NEXT:    int i = 0;
 //CHECK-NEXT:    clad::tape<unsigned {{int|long}}> _t1 = {};
-//CHECK-NEXT:    double _d_sum = 0.;
+//CHECK-NEXT:    double _d_sum = 0;
 //CHECK-NEXT:    double sum = 0;
 //CHECK-NEXT:    unsigned {{int|long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK-NEXT:    for (i = 0; i != 1;) {

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -721,7 +721,7 @@ double fn11(double u, double v) {
 }
 
 // CHECK:  void fn11_grad(double u, double v, double *_d_u, double *_d_v) {
-// CHECK-NEXT:      double _d_res = 0.;
+// CHECK-NEXT:      double _d_res = 0;
 // CHECK-NEXT:      double res = 0;
 // CHECK-NEXT:      A _d_a = {0.};
 // CHECK-NEXT:      A a;
@@ -769,7 +769,7 @@ float fn12(const B b, const float* in) {
 }
 
 // CHECK:  void fn12_grad_0(const B b, const float *in, B *_d_b) {
-// CHECK-NEXT:      float _d_res = 0.F;
+// CHECK-NEXT:      float _d_res = 0;
 // CHECK-NEXT:      float res = 0;
 // CHECK-NEXT:      b.scale(in, &res);
 // CHECK-NEXT:      _d_res += 1;

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -124,7 +124,7 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:     size_t *j = nullptr;
 // CHECK-NEXT:     clad::tape<const double *> _t3 = {};
 // CHECK-NEXT:     clad::tape<double *> _t4 = {};
-// CHECK-NEXT:     double _d_sum = 0.;
+// CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -423,7 +423,7 @@ int main() {
 // CHECK-NEXT:     double *ref00 = {};
 // CHECK-NEXT:     double *_d_ref10 = nullptr;
 // CHECK-NEXT:     double *ref10 = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     std::vector<double> vec;
 // CHECK-NEXT:     std::vector<double> _d_vec = {};
@@ -540,7 +540,7 @@ int main() {
 // CHECK-NEXT:     {{.*}}allocator_type allocator;
 // CHECK-NEXT:     {{.*}}allocator_type _d_allocator = {};
 // CHECK-NEXT:     clad::zero_init(_d_allocator);
-// CHECK-NEXT:     {{.*}} _d_count = {{0U|0UL}};
+// CHECK-NEXT:     {{.*}} _d_count = 0;
 // CHECK-NEXT:     {{.*}} count = 3;
 // CHECK-NEXT:     std::vector<double> vec(count, u, allocator);
 // CHECK-NEXT:     std::vector<double> _d_vec(vec);
@@ -604,7 +604,7 @@ int main() {
 // CHECK-NEXT:        std::array<double, 3> a;
 // CHECK-NEXT:        std::array<double, 3> _t0 = a;
 // CHECK-NEXT:        {{.*}}fill_reverse_forw(&a, x, &_d_a, *_d_x);
-// CHECK-NEXT:        double _d_res = 0.;
+// CHECK-NEXT:        double _d_res = 0;
 // CHECK-NEXT:        double res = 0;
 // CHECK-NEXT:        unsigned {{long|int}} _t1 = {{0U|0UL}};
 // CHECK-NEXT:        for (i = 0; i < a.size(); ++i) {
@@ -746,7 +746,7 @@ int main() {
 // CHECK-NEXT:              {{.*}}push(_t1, v);
 // CHECK-NEXT:              {{.*}}push_back_reverse_forw(&v, x, &_d_v, *_d_x);
 // CHECK-NEXT:          }
-// CHECK-NEXT:          double _d_res = 0.;
+// CHECK-NEXT:          double _d_res = 0;
 // CHECK-NEXT:          double res = 0;
 // CHECK-NEXT:          {{.*}} _t2 = {{0U|0UL|0}};
 // CHECK-NEXT:          for (i0 = 0; i0 < v.size(); ++i0) {
@@ -968,7 +968,7 @@ int main() {
 // CHECK-NEXT:     {{.*}}allocator_type alloc;
 // CHECK-NEXT:     {{.*}}allocator_type _d_alloc = {};
 // CHECK-NEXT:     clad::zero_init(_d_alloc);
-// CHECK-NEXT:     double _d_prod = 0.;
+// CHECK-NEXT:     double _d_prod = 0;
 // CHECK-NEXT:     double prod = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 3; i >= 1; --i) {
@@ -1067,7 +1067,7 @@ int main() {
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<{{.*}}> _t4 = {};
 // CHECK-NEXT:     clad::tape<int> _t5 = {};
-// CHECK-NEXT:     double _d_sum = 0.;
+// CHECK-NEXT:     double _d_sum = 0;
 // CHECK-NEXT:     double sum = 0;
 // CHECK-NEXT:     int _d_u = 0;
 // CHECK-NEXT:     int u = 1;
@@ -1112,7 +1112,7 @@ int main() {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         sess.arr[id] = tensor_x[id] * tensor_theory_params[0];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     float _d_out = 0.F;
+// CHECK-NEXT:     float _d_out = 0.;
 // CHECK-NEXT:     float out = 0.;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t1 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (id0 = 0; id0 < nVals; id0++) {
@@ -1146,7 +1146,7 @@ int main() {
 // CHECK-NEXT:     const Session &sess = session[0];
 // CHECK-NEXT:     float *&_d_arr = _d_sess.arr;
 // CHECK-NEXT:     float *const &arr = sess.arr;
-// CHECK-NEXT:     float _d_out = 0.F;
+// CHECK-NEXT:     float _d_out = 0.;
 // CHECK-NEXT:     float out = 0.;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (id = 0; id < nVals; id++) {

--- a/test/Gradient/Switch.C
+++ b/test/Gradient/Switch.C
@@ -25,7 +25,7 @@ double fn1(double i, double j) {
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     double _t3;
 // CHECK-NEXT:     double _t4;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     int _d_count = 0;
 // CHECK-NEXT:     int count = 1;
@@ -136,7 +136,7 @@ double fn2(double i, double j) {
 // CHECK-NEXT:     double _t4;
 // CHECK-NEXT:     double _t5;
 // CHECK-NEXT:     double _t6;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         count = 2;
@@ -258,7 +258,7 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t3 = {};
 // CHECK-NEXT:     clad::tape<double> _t4 = {};
 // CHECK-NEXT:     clad::tape<double> _t5 = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     int _d_counter = 0;
 // CHECK-NEXT:     int counter = 2;
@@ -378,7 +378,7 @@ double fn4(double i, double j) {
 // CHECK-NEXT:     int counter = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t2;
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         switch (1) {
@@ -462,7 +462,7 @@ double fn5(double i, double j) {
 // CHECK-NEXT:     int _cond0;
 // CHECK-NEXT:     double _t0;
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         count = 1;
@@ -507,7 +507,7 @@ double fn6(double u, double v) {
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 // CHECK-NEXT:     int _d_res = 0;
 // CHECK-NEXT:     int res = 0;
-// CHECK-NEXT:     double _d_temp = 0.;
+// CHECK-NEXT:     double _d_temp = 0;
 // CHECK-NEXT:     double temp = 0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t0 = res;
@@ -570,7 +570,7 @@ double fn7(double u, double v) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
@@ -688,7 +688,7 @@ double fn24(double x, double y, Op op) {
 // CHECK-NEXT:    double _t2;
 // CHECK-NEXT:    double _t3;
 // CHECK-NEXT:    double _t4;
-// CHECK-NEXT:    double _d_res = 0.;
+// CHECK-NEXT:    double _d_res = 0;
 // CHECK-NEXT:    double res = 0;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        _cond0 = op;

--- a/test/Gradient/SwitchInit.C
+++ b/test/Gradient/SwitchInit.C
@@ -25,7 +25,7 @@ double fn1(double i, double j) {
 // CHECK-NEXT:     double _t2;
 // CHECK-NEXT:     double _t3;
 // CHECK-NEXT:     double _t4;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         count = 1;

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -58,7 +58,7 @@ double sum(Tangent& t) {
 // CHECK: void sum_pullback(Tangent &t, double _d_y, Tangent *_d_t) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
@@ -83,7 +83,7 @@ double sum(double *data) {
 // CHECK: void sum_pullback(double *data, double _d_y, double *_d_data) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
@@ -325,7 +325,7 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
@@ -814,7 +814,7 @@ double fn23(double u, double v) {
 // CHECK-NEXT:      B _d_b = {0.};
 // CHECK-NEXT:      B b;
 // CHECK-NEXT:      b.data = v;
-// CHECK-NEXT:      double _d_res = 0.;
+// CHECK-NEXT:      double _d_res = 0;
 // CHECK-NEXT:      double res = 0;
 // CHECK-NEXT:      res = add(b, u);
 // CHECK-NEXT:      _d_res += 1;
@@ -1121,14 +1121,14 @@ float fn29(float *input, Session const *session) {
 // CHECK-NEXT:      const Session &sess = session[0];
 // CHECK-NEXT:      float _d_buffer[5] = {0};
 // CHECK-NEXT:      float buffer[5]{0., 0., 0., 0., 0};
-// CHECK-NEXT:      size_t _d_n = {{0U|0UL|0ULL}};
+// CHECK-NEXT:      size_t _d_n = 0;
 // CHECK-NEXT:      const size_t n = 5;
 // CHECK-NEXT:      unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:      for (id = 0; id < n; id++) {
 // CHECK-NEXT:          _t0++;
 // CHECK-NEXT:          buffer[id] = sess.factors[id] * input[id];
 // CHECK-NEXT:      }
-// CHECK-NEXT:      float _d_out = 0.F;
+// CHECK-NEXT:      float _d_out = 0.;
 // CHECK-NEXT:      float out = 0.;
 // CHECK-NEXT:      unsigned {{int|long|long long}} _t1 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:      for (id0 = 0; id0 < n; id0++) {

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -200,7 +200,7 @@ int main() {
 // CHECK: void cos_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
 // CHECK: void f1_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::sin_pushforward(x, _d_x0);
@@ -233,7 +233,7 @@ int main() {
 // CHECK: void exp_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
 // CHECK: void f2_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::exp_pushforward(x, _d_x0);
@@ -252,7 +252,7 @@ int main() {
 // CHECK: void log_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
 // CHECK: void f3_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::log_pushforward(x, _d_x0);
@@ -271,7 +271,7 @@ int main() {
 // CHECK: void pow_pushforward_pullback(float x, float exponent, float d_x, float d_exponent, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_exponent, float *_d_d_x, float *_d_d_exponent);
 
 // CHECK: void f4_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(x, 4.F, _d_x0, 0.F);
@@ -290,7 +290,7 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void f5_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     float _d_x0 = 1;
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(2.F, x, 0.F, _d_x0);
@@ -309,9 +309,9 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void f6_darg0_grad(float x, float y, float *_d_x, float *_d_y) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     float _d__d_y = 0.F;
+// CHECK-NEXT:     float _d__d_y = 0;
 // CHECK-NEXT:     float _d_y0 = 0;
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(x, y, _d_x0, _d_y0);
@@ -332,9 +332,9 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void f6_darg1_grad(float x, float y, float *_d_x, float *_d_y) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d__d_x = 0;
 // CHECK-NEXT:     float _d_x0 = 0;
-// CHECK-NEXT:     float _d__d_y = 0.F;
+// CHECK-NEXT:     float _d__d_y = 0;
 // CHECK-NEXT:     float _d_y0 = 1;
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(x, y, _d_x0, _d_y0);

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -211,9 +211,9 @@ int main() {
   TEST2(fn_def_arg, 3, 5);  // CHECK-EXEC: Result is = {0.00, 2.00, 2.00, 0.00}
 
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
-//CHECK-NEXT:    double _d__d_a = 0.;
+//CHECK-NEXT:    double _d__d_a = 0;
 //CHECK-NEXT:    double _d_a0 = 1;
-//CHECK-NEXT:    double _d__d_b = 0.;
+//CHECK-NEXT:    double _d__d_b = 0;
 //CHECK-NEXT:    double _d_b0 = 0;
 //CHECK-NEXT:    double _d__t0 = 0.;
 //CHECK-NEXT:    double _t00 = a * a;
@@ -246,9 +246,9 @@ int main() {
 //CHECK-NEXT:}
 
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg1_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
-//CHECK-NEXT:    double _d__d_a = 0.;
+//CHECK-NEXT:    double _d__d_a = 0;
 //CHECK-NEXT:    double _d_a0 = 0;
-//CHECK-NEXT:    double _d__d_b = 0.;
+//CHECK-NEXT:    double _d__d_b = 0;
 //CHECK-NEXT:    double _d_b0 = 1;
 //CHECK-NEXT:    double _d__t0 = 0.;
 //CHECK-NEXT:    double _t00 = a * a;

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -48,9 +48,9 @@ double f2(double x, double y){
 // CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1, double *_d__d_x, double *_d__d_y);
 
 // CHECK: void f2_darg0_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     double _d__d_x = 0.;
+// CHECK-NEXT:     double _d__d_x = 0;
 // CHECK-NEXT:     double _d_x0 = 1;
-// CHECK-NEXT:     double _d__d_y = 0.;
+// CHECK-NEXT:     double _d__d_y = 0;
 // CHECK-NEXT:     double _d_y0 = 0;
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {0., 0.};
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
@@ -77,9 +77,9 @@ double f2(double x, double y){
 // CHECK-NEXT: }
 
 // CHECK: void f2_darg1_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     double _d__d_x = 0.;
+// CHECK-NEXT:     double _d__d_x = 0;
 // CHECK-NEXT:     double _d_x0 = 0;
-// CHECK-NEXT:     double _d__d_y = 0.;
+// CHECK-NEXT:     double _d__d_y = 0;
 // CHECK-NEXT:     double _d_y0 = 1;
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {0., 0.};
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -30,9 +30,9 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT: }
 
 // CHECK: void nonMemFn_darg0_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d__d_i = 0.;
+// CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _d_i0 = 1;
-// CHECK-NEXT:     double _d__d_j = 0.;
+// CHECK-NEXT:     double _d__d_j = 0;
 // CHECK-NEXT:     double _d_j0 = 0;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d__d_i += 1 * j;
@@ -43,9 +43,9 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT: }
 
 // CHECK: void nonMemFn_darg1_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d__d_i = 0.;
+// CHECK-NEXT:     double _d__d_i = 0;
 // CHECK-NEXT:     double _d_i0 = 0;
-// CHECK-NEXT:     double _d__d_j = 0.;
+// CHECK-NEXT:     double _d__d_j = 0;
 // CHECK-NEXT:     double _d_j0 = 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d__d_i += 1 * j;

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -109,7 +109,7 @@
 //CHECK_FLOAT_SUM:    unsigned int _d_i = 0U;
 //CHECK_FLOAT_SUM:    unsigned int i = 0U;
 //CHECK_FLOAT_SUM:    clad::tape<float> _t1 = {};
-//CHECK_FLOAT_SUM:    float _d_sum = 0.F;
+//CHECK_FLOAT_SUM:    float _d_sum = 0.;
 //CHECK_FLOAT_SUM:    float sum = 0.;
 //CHECK_FLOAT_SUM:    unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 //CHECK_FLOAT_SUM:    for (i = 0; i < n; i++) {


### PR DESCRIPTION
Currently, when differentiating buitin type variables in the reverse mode, we initialize them using ``getZeroInit()``.
After #1563, differentiating builtin rvalue expression types, like ``1.`` or ``x + y`` (numericals), gives a zero of the corresponding type as the derivative. This means that we can initialize adjoint variables of such types with the derivatives of the original inits. This both makes ``VarDecl`` differentiation more consistent and makes adjoint decls better reflect the original code, for example
```
double prod = 1;
```
used to be differentiated as 
```
double _d_prod = 0.; // zero of the type of the variable
double prod = 1;
```
and now, it's simply
```
double _d_prod = 0; // zero of the same type as the original initializer `1`
double prod = 1;
```