### PR TITLE
Don't initialize aggregates with getZeroInit in the reverse mode

### DIFF
--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -821,7 +821,7 @@ double fn23(double u, double v) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r_d1 = _d_res;
 // CHECK-NEXT:          _d_res = 0.;
-// CHECK-NEXT:          B _r0 = {0.};
+// CHECK-NEXT:          B _r0 = _d_b;
 // CHECK-NEXT:          double _r1 = 0.;
 // CHECK-NEXT:          add_pullback(b, u, _r_d1, &_r0, &_r1);
 // CHECK-NEXT:          constructor_pullback(b, &_r0, &_d_b);


### PR DESCRIPTION
Currently, we initialize aggregate class types using ``getZeroInit``. This is dangerous for the same reasons described in #1560. This causes bug #1469. Since all constructors of aggregates (default/copy/move) are implicitly generated and are all element-wise, we can safely treat them as list inits, i.e.
```
S{} --> S{}, S{}
S{s} --> S{s}, S{_d_s}
```
We cannot guarantee this with user-provided constructors though, as they can have arbitrary behaviour.

Fixes #1469.