### PR TITLE
Don't change variable types in reverse_forw.

### DIFF
--- a/include/clad/Differentiator/ReverseModeForwPassVisitor.h
+++ b/include/clad/Differentiator/ReverseModeForwPassVisitor.h
@@ -33,6 +33,9 @@ public:
                                               bool forceStore = false) override;
   StmtDiff StoreAndRestore(clang::Expr* E, llvm::StringRef prefix = "_t",
                            bool moveToTape = false) override;
+  DeclDiff<clang::VarDecl>
+  DifferentiateVarDecl(const clang::VarDecl* VD,
+                       bool keepLocal = false) override;
 
   StmtDiff ProcessSingleStmt(const clang::Stmt* S);
   StmtDiff VisitCompoundStmt(const clang::CompoundStmt* CS) override;

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -426,8 +426,8 @@ namespace clad {
     StmtDiff VisitSwitchStmt(const clang::SwitchStmt* SS);
     StmtDiff VisitCaseStmt(const clang::CaseStmt* CS);
     StmtDiff VisitDefaultStmt(const clang::DefaultStmt* DS);
-    DeclDiff<clang::VarDecl> DifferentiateVarDecl(const clang::VarDecl* VD,
-                                                  bool keepLocal = false);
+    virtual DeclDiff<clang::VarDecl>
+    DifferentiateVarDecl(const clang::VarDecl* VD, bool keepLocal = false);
     StmtDiff DifferentiateCtorInit(clang::CXXCtorInitializer* CI,
                                    clang::Expr* thisExpr);
     StmtDiff VisitSubstNonTypeTemplateParmExpr(


### PR DESCRIPTION
Currently, we keep both cloned and adjoint parameter types in ``reverse_forw`` untouched. However, we strip const off adjoints in the body of ``reverse_forw``. This may cause a mismatch in types like in issue #1573. This PR overrides ``DifferentiateVarDecl`` in ``ReverseModeForwardPassVisitor`` to ensure we use the original type.

Fixes #1573.