### PR TITLE
Differentiate method base before its arguments

### DIFF
--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -459,8 +459,8 @@ double fn2(SimpleFunctions& sf, double i) {
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = sf.ref_mem_fn_reverse_forw(i, &(*_d_sf), 0.);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t1.adjoint += 1;
-// CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         sf = _t0;
+// CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         sf.ref_mem_fn_pullback(i, &(*_d_sf), &_r0);
 // CHECK-NEXT:         *_d_i += _r0;
 // CHECK-NEXT:     }
@@ -496,8 +496,8 @@ double fn5(SimpleFunctions& v, double value) {
 // CHECK-NEXT:     v.operator_plus_equal_reverse_forw(value, &(*_d_v), 0.);
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         v = _t0;
+// CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         v.operator_plus_equal_pullback(value, &(*_d_v), &_r0);
 // CHECK-NEXT:         *_d_value += _r0;
 // CHECK-NEXT:     }

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -488,8 +488,8 @@ int main() {
 // CHECK-NEXT:         {{.*}} _r8 = {{0U|0UL}};
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}} _r7 = {{0U|0UL}};
 // CHECK-NEXT:         vec = _t8;
+// CHECK-NEXT:         {{.*}} _r7 = {{0U|0UL}};
 // CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&vec, 2, &_d_vec, &_r7);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -528,8 +528,8 @@ int main() {
 // CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
 // CHECK-NEXT:         vec = _t0;
+// CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
 // CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&vec, 3, &_d_vec, &_r0);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -703,8 +703,8 @@ int main() {
 // CHECK-NEXT:             {{.*size_type|size_t}} _r2 = {{0U|0UL}};
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}} _r0 = 0.;
 // CHECK-NEXT:             a = _t0;
+// CHECK-NEXT:             {{.*}} _r0 = 0.;
 // CHECK-NEXT:             {{.*}}fill_pullback(&a, y + x + x, &_d_a, &_r0);
 // CHECK-NEXT:             *_d_y += _r0;
 // CHECK-NEXT:             *_d_x += _r0;
@@ -771,14 +771,14 @@ int main() {
 // CHECK-NEXT:              {{.*size_type|size_t}} _r6 = {{0U|0UL|0}};
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              {{.*size_type|size_t}} _r3 = {{0U|0UL|0}};
 // CHECK-NEXT:              v = _t5;
+// CHECK-NEXT:              {{.*size_type|size_t}} _r3 = {{0U|0UL|0}};
 // CHECK-NEXT:              {{.*}}assign_pullback(&v, 2, y, &_d_v, &_r3, &*_d_y);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
+// CHECK-NEXT:              v = _t4;
 // CHECK-NEXT:              {{.*size_type|size_t}} _r1 = {{0U|0UL|0}};
 // CHECK-NEXT:              {{.*}}value_type _r2 = 0.;
-// CHECK-NEXT:              v = _t4;
 // CHECK-NEXT:              {{.*}}assign_pullback(&v, 3, 0, &_d_v, &_r1, &_r2);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          for (; _t2; _t2--) {
@@ -829,8 +829,8 @@ int main() {
 // CHECK-NEXT:          }
 // CHECK-NEXT:          *_d_x += _d_res * _t1;
 // CHECK-NEXT:          {
-// CHECK-NEXT:              {{.*size_type|size_t}} _r0 = {{0U|0UL|0}};
 // CHECK-NEXT:              v = _t0;
+// CHECK-NEXT:              {{.*size_type|size_t}} _r0 = {{0U|0UL|0}};
 // CHECK-NEXT:          }
 // CHECK-NEXT:      }
 
@@ -855,8 +855,8 @@ int main() {
 // CHECK-NEXT:              {{.*size_type|size_t}} _r1 = 0{{.*}};
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              {{.*}}value_type _r0 = 0.;
 // CHECK-NEXT:              a = _t0;
+// CHECK-NEXT:              {{.*}}value_type _r0 = 0.;
 // CHECK-NEXT:              {{.*}}push_back_pullback(&a, 0{{.*}}, &_d_a, &_r0);
 // CHECK-NEXT:          }
 // CHECK-NEXT:      }
@@ -1085,8 +1085,8 @@ int main() {
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             int _r0 = 0;
 // CHECK-NEXT:             it = clad::back(_t2);
+// CHECK-NEXT:             int _r0 = 0;
 // CHECK-NEXT:             {{.*}}class_functions::operator_plus_plus_pullback(&it, 0, {}, &_d_it, &_r0);
 // CHECK-NEXT:             clad::pop(_t2);
 // CHECK-NEXT:         }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -435,8 +435,8 @@ MyStruct fn12(MyStruct s) {  // expected-warning {{clad::gradient only supports 
 // CHECK-NEXT:     MyStruct _t0 = s;
 // CHECK-NEXT:     s.operator_equal_reverse_forw({2 * s.a, 2 * s.b + 2}, &(*_d_s), {0., 0.});
 // CHECK-NEXT:    {
-// CHECK-NEXT:        MyStruct _r0 = {0., 0.};
 // CHECK-NEXT:        s = _t0;
+// CHECK-NEXT:        MyStruct _r0 = {0., 0.};
 // CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, &(*_d_s), &_r0);
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;
@@ -609,13 +609,13 @@ double fn16(double i, double j) {
 // CHECK-NEXT:    SimpleFunctions1 _d_obj2(obj2);
 // CHECK-NEXT:    clad::zero_init(_d_obj2);
 // CHECK-NEXT:    {
-// CHECK-NEXT:        double _r0 = 0.;
+// CHECK-NEXT:        SimpleFunctions1 _r0 = {};
 // CHECK-NEXT:        double _r1 = 0.;
-// CHECK-NEXT:        SimpleFunctions1 _r2 = {};
-// CHECK-NEXT:        (obj1 + obj2).mem_fn_1_pullback(i, j, 1, &_r2, &_r0, &_r1);
-// CHECK-NEXT:        *_d_i += _r0;
-// CHECK-NEXT:        *_d_j += _r1;
-// CHECK-NEXT:        obj1.operator_plus_pullback(obj2, _r2, &_d_obj1, &_d_obj2);
+// CHECK-NEXT:        double _r2 = 0.;
+// CHECK-NEXT:        (obj1 + obj2).mem_fn_1_pullback(i, j, 1, &_r0, &_r1, &_r2);
+// CHECK-NEXT:        obj1.operator_plus_pullback(obj2, _r0, &_d_obj1, &_d_obj2);
+// CHECK-NEXT:        *_d_i += _r1;
+// CHECK-NEXT:        *_d_j += _r2;
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
 
@@ -698,13 +698,13 @@ double fn19(double i, double j) {
 // CHECK-NEXT:      SimpleFunctions1 _d_sf2(sf2);
 // CHECK-NEXT:      clad::zero_init(_d_sf2);
 // CHECK-NEXT:      {
-// CHECK-NEXT:          double _r2 = 0.;
+// CHECK-NEXT:          SimpleFunctions1 _r2 = {};
 // CHECK-NEXT:          double _r3 = 0.;
-// CHECK-NEXT:          SimpleFunctions1 _r4 = {};
-// CHECK-NEXT:          (sf1 * sf2).mem_fn_pullback(i, j, 1, &_r4, &_r2, &_r3);
-// CHECK-NEXT:          *_d_i += _r2;
-// CHECK-NEXT:          *_d_j += _r3;
-// CHECK-NEXT:          sf1.operator_star_pullback(sf2, _r4, &_d_sf1, &_d_sf2);
+// CHECK-NEXT:          double _r4 = 0.;
+// CHECK-NEXT:          (sf1 * sf2).mem_fn_pullback(i, j, 1, &_r2, &_r3, &_r4);
+// CHECK-NEXT:          sf1.operator_star_pullback(sf2, _r2, &_d_sf1, &_d_sf2);
+// CHECK-NEXT:          *_d_i += _r3;
+// CHECK-NEXT:          *_d_j += _r4;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
@@ -723,8 +723,8 @@ void fn20(MyStruct s) {
 // CHECK-NEXT:     MyStruct _t0 = s;
 // CHECK-NEXT:     s.operator_equal_reverse_forw({2 * s.a, 2 * s.b + 2}, &(*_d_s), {0., 0.});
 // CHECK-NEXT:    {
-// CHECK-NEXT:        MyStruct _r0 = {0., 0.};
 // CHECK-NEXT:        s = _t0;
+// CHECK-NEXT:        MyStruct _r0 = {0., 0.};
 // CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, &(*_d_s), &_r0);
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;
@@ -1014,8 +1014,8 @@ double fn27(double x, double y) {
 // CHECK-NEXT:          _d_s.val.b += s.val.a * 1;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
+// CHECK-NEXT:          s = _t0;  
 // CHECK-NEXT:          MyStructWrapper _r0 = {{.*0., 0..*}};
-// CHECK-NEXT:          s = _t0;
 // CHECK-NEXT:          s.operator_equal_pullback({{.*2 \* y, 3 \* x \+ 2.*}}, &_d_s, &_r0);
 // CHECK-NEXT:          *_d_y += 2 * _r0.val.a;
 // CHECK-NEXT:          *_d_x += 3 * _r0.val.b;


### PR DESCRIPTION
Currently, in ``RMV::VisitCallExpr``, we differentiate the base after the arguments. Our reverse mode differentiation is designed in such a way that expressions should be differentiated in the same order they are executed.