### PR TITLE
Simplify custom reverse_forw

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -415,6 +415,8 @@ namespace clad {
     /// forward-declared in the `clad::tensor_like` namespace.
     bool isTensorLike(clang::Sema& SemaRef, clang::QualType T);
 
+    bool hasElidableReverseForwAttribute(const clang::Decl* D);
+
     /// Returns true if FD can be differentiated as a pushforward
     /// And be used in the reverse mode.
     bool canUsePushforwardInRevMode(const clang::FunctionDecl* FD);

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -633,10 +633,9 @@ void fill_pullback(::std::array<T, N>* arr,
   }
 }
 template <typename T, ::std::size_t N>
-clad::ValueAndAdjoint<T&, T&>
-back_reverse_forw(::std::array<T, N>* arr, ::std::array<T, N>* d_arr) noexcept {
-  return {arr->back(), d_arr->back()};
-}
+clad::ValueAndAdjoint<T&, T&> elidable_reverse_forw
+back_reverse_forw(::std::array<T, N>* arr, ::std::array<T, N>* d_arr) noexcept;
+
 template <typename T, ::std::size_t N>
 void back_pullback(const ::std::array<T, N>* arr,
                    typename ::std::array<T, N>::value_type d_u,
@@ -646,11 +645,8 @@ void back_pullback(const ::std::array<T, N>* arr,
 template <typename T, ::std::size_t N>
 void back_pullback(::std::array<T, N>* arr, ::std::array<T, N>* d_arr) noexcept;
 template <typename T, ::std::size_t N>
-clad::ValueAndAdjoint<T&, T&>
-front_reverse_forw(::std::array<T, N>* arr,
-                   ::std::array<T, N>* d_arr) noexcept {
-  return {arr->front(), d_arr->front()};
-}
+clad::ValueAndAdjoint<T&, T&> elidable_reverse_forw
+front_reverse_forw(::std::array<T, N>* arr, ::std::array<T, N>* d_arr) noexcept;
 template <typename T, ::std::size_t N>
 void front_pullback(const ::std::array<T, N>* arr,
                     typename ::std::array<T, N>::value_type d_u,

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -597,11 +597,10 @@ void operator_subscript_pullback(::std::array<T, N>* arr,
                                  ::std::array<T, N>* d_arr,
                                  typename ::std::array<T, N>::size_type* d_idx);
 template <typename T, ::std::size_t N>
-clad::ValueAndAdjoint<T&, T&> at_reverse_forw(
+elidable_reverse_forw clad::ValueAndAdjoint<T&, T&> at_reverse_forw(
     ::std::array<T, N>* arr, typename ::std::array<T, N>::size_type idx,
-    ::std::array<T, N>* d_arr, typename ::std::array<T, N>::size_type d_idx) {
-  return {(*arr)[idx], (*d_arr)[idx]};
-}
+    ::std::array<T, N>* d_arr, typename ::std::array<T, N>::size_type d_idx);
+
 template <typename T, ::std::size_t N, typename P>
 void at_pullback(const ::std::array<T, N>* arr,
                  typename ::std::array<T, N>::size_type idx, P d_y,

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -578,11 +578,12 @@ void shrink_to_fit_pullback(::std::vector<T>* /*v*/,
 // array reverse mode
 
 template <typename T, ::std::size_t N>
-clad::ValueAndAdjoint<T&, T&> operator_subscript_reverse_forw(
-    ::std::array<T, N>* arr, typename ::std::array<T, N>::size_type idx,
-    ::std::array<T, N>* d_arr, typename ::std::array<T, N>::size_type d_idx) {
-  return {(*arr)[idx], (*d_arr)[idx]};
-}
+elidable_reverse_forw clad::ValueAndAdjoint<T&, T&>
+operator_subscript_reverse_forw(::std::array<T, N>* arr,
+                                typename ::std::array<T, N>::size_type idx,
+                                ::std::array<T, N>* d_arr,
+                                typename ::std::array<T, N>::size_type d_idx);
+
 template <typename T, ::std::size_t N, typename P>
 void operator_subscript_pullback(
     const ::std::array<T, N>* arr, typename ::std::array<T, N>::size_type idx,

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -867,8 +867,9 @@ constexpr void forward_pullback(T&& t, T dy, T* dt) noexcept {
 
 // std::make_shared<T> custom derivatives...
 template <typename T>
-clad::ValueAndAdjoint<::std::shared_ptr<T>, ::std::shared_ptr<T>>
-make_shared_reverse_forw(T& x, T& dx) {
+elidable_reverse_forw
+    clad::ValueAndAdjoint<::std::shared_ptr<T>, ::std::shared_ptr<T>>
+    make_shared_reverse_forw(T& x, T& dx) {
   return {::std::make_shared<T>(x), ::std::make_shared<T>(dx)};
 }
 

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -501,12 +501,9 @@ void operator_subscript_pullback(::std::vector<T>* vec,
                                  typename ::std::vector<T>::size_type* d_idx);
 
 template <typename T>
-clad::ValueAndAdjoint<T&, T&>
-at_reverse_forw(::std::vector<T>* vec, typename ::std::vector<T>::size_type idx,
-                ::std::vector<T>* d_vec,
-                typename ::std::vector<T>::size_type d_idx) {
-  return {(*vec)[idx], (*d_vec)[idx]};
-}
+clad::ValueAndAdjoint<T&, T&> elidable_reverse_forw at_reverse_forw(
+    ::std::vector<T>* vec, typename ::std::vector<T>::size_type idx,
+    ::std::vector<T>* d_vec, typename ::std::vector<T>::size_type d_idx);
 
 template <typename T, typename P>
 void at_pullback(const ::std::vector<T>* vec,

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -12,6 +12,8 @@
 #include <type_traits>
 #include <vector>
 
+#define elidable_reverse_forw __attribute__((annotate("elidable_reverse_forw")))
+
 namespace clad {
 
 // zero_init specializations
@@ -473,11 +475,11 @@ void push_back_pullback(::std::vector<T>* v, U val, ::std::vector<T>* d_v,
 }
 
 template <typename T>
-clad::ValueAndAdjoint<T&, T&> operator_subscript_reverse_forw(
-    ::std::vector<T>* vec, typename ::std::vector<T>::size_type idx,
-    ::std::vector<T>* d_vec, typename ::std::vector<T>::size_type d_idx) {
-  return {(*vec)[idx], (*d_vec)[idx]};
-}
+elidable_reverse_forw clad::ValueAndAdjoint<T&, T&>
+operator_subscript_reverse_forw(::std::vector<T>* vec,
+                                typename ::std::vector<T>::size_type idx,
+                                ::std::vector<T>* d_vec,
+                                typename ::std::vector<T>::size_type d_idx);
 
 template <typename T, typename P>
 void operator_subscript_pullback(const ::std::vector<T>* vec,

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -687,14 +687,13 @@ void constructor_pullback(T* p, ::std::unique_ptr<T>* dthis, T* dp) noexcept;
 
 // operator* custom derivatives
 template <typename T>
-clad::ValueAndAdjoint<decltype(*(T{}))&, decltype(*(T{}))&>
-operator_star_reverse_forw(
-    const ::std::enable_if_t<helpers::is_std_smart_ptr<T>::value ||
-                                 helpers::is_iterator<T>::value,
-                             T>* u,
-    const T* d_u) {
-  return {**u, **d_u};
-}
+elidable_reverse_forw
+    clad::ValueAndAdjoint<decltype(*(T{}))&, decltype(*(T{}))&>
+    operator_star_reverse_forw(
+        const ::std::enable_if_t<helpers::is_std_smart_ptr<T>::value ||
+                                     helpers::is_iterator<T>::value,
+                                 T>* u,
+        const T* d_u);
 
 // iterator custom derivatives
 template <

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -481,6 +481,11 @@ operator_subscript_reverse_forw(::std::vector<T>* vec,
                                 ::std::vector<T>* d_vec,
                                 typename ::std::vector<T>::size_type d_idx);
 
+template <typename T>
+const elidable_reverse_forw T& operator_subscript_reverse_forw(
+    const ::std::vector<T>* vec, typename ::std::vector<T>::size_type idx,
+    const ::std::vector<T>* d_vec, typename ::std::vector<T>::size_type d_idx);
+
 template <typename T, typename P>
 void operator_subscript_pullback(const ::std::vector<T>* vec,
                                  typename ::std::vector<T>::size_type idx,

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -775,10 +775,8 @@ void constructor_pullback(const U& p, ::std::weak_ptr<T>* dthis,
 
 template <typename T>
 clad::ValueAndAdjoint<::std::shared_ptr<T>, ::std::shared_ptr<T>>
-lock_reverse_forw(const ::std::weak_ptr<T>* p,
-                  const ::std::weak_ptr<T>* dp) noexcept {
-  return {p->lock(), dp->lock()};
-}
+    elidable_reverse_forw lock_reverse_forw(
+        const ::std::weak_ptr<T>* p, const ::std::weak_ptr<T>* dp) noexcept;
 
 template <typename T>
 void lock_pullback(const ::std::weak_ptr<T>* p, ::std::shared_ptr<T> dthis,

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -528,7 +528,7 @@ namespace clad {
     /// perfectly forwarded while calling member functions.
     /// \returns Built call expression
     clang::Expr*
-    BuildCallExprToFunction(clang::FunctionDecl* FD,
+    BuildCallExprToFunction(const clang::FunctionDecl* FD,
                             llvm::MutableArrayRef<clang::Expr*> argExprs,
                             clang::Expr* CUDAExecConfig = nullptr,
                             bool useRefQualifiedThisObj = false);

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -643,6 +643,13 @@ namespace clad {
       return false;
     }
 
+    bool hasElidableReverseForwAttribute(const clang::Decl* D) {
+      for (auto* Attr : D->specific_attrs<clang::AnnotateAttr>())
+        if (Attr->getAnnotation() == "elidable_reverse_forw")
+          return true;
+      return false;
+    }
+
     bool hasNonDifferentiableAttribute(const clang::Expr* E) {
       // Check MemberExpr
       if (const clang::MemberExpr* ME = clang::dyn_cast<clang::MemberExpr>(E)) {

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1831,9 +1831,19 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       return getZeroInit(CE->getType());
     }
 
+    // Lookup a reverse_forw function and build if necessary.
+    DiffRequest calleeFnForwPassReq;
+    calleeFnForwPassReq.Function = FD;
+    calleeFnForwPassReq.Mode = DiffMode::reverse_mode_forward_pass;
+    calleeFnForwPassReq.BaseFunctionName =
+        clad::utils::ComputeEffectiveFnName(FD);
+    FunctionDecl* calleeFnForwPassFD = FindDerivedFunction(calleeFnForwPassReq);
+    bool elideReverseForw =
+        calleeFnForwPassFD &&
+        utils::hasElidableReverseForwAttribute(calleeFnForwPassFD);
+
     // FIXME: consider moving non-diff analysis to DiffPlanner.
     bool nonDiff = clad::utils::hasNonDifferentiableAttribute(CE);
-
     // If the result does not depend on the result of the call, just clone
     // the call and visit arguments (since they may contain side-effects like
     // f(x = y))
@@ -1958,7 +1968,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           DifferentiateCallArg(arg, PVD, PreCallStmts, /*isNonDiff=*/nonDiff,
                                isa<CUDAKernelCallExpr>(CE));
       CallArgs.push_back(argDiff.getExpr());
-      revForwAdjointArgs.push_back(argDiff.getRevSweepAsExpr());
+      if (elideReverseForw && PVD->getType()->isIntegerType())
+        revForwAdjointArgs.push_back(argDiff.getExpr());
+      else
+        revForwAdjointArgs.push_back(argDiff.getRevSweepAsExpr());
       CallArgDx.push_back(argDiff.getExpr_dx());
       if (m_DiffReq.shouldBeRecorded(arg))
         hasStoredParams = true;
@@ -2107,15 +2120,21 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       return StmtDiff(Clone(CE));
 
     Expr* call = nullptr;
-    // Lookup a reverse_forw function and build if necessary.
-    DiffRequest calleeFnForwPassReq;
-    calleeFnForwPassReq.Function = FD;
-    calleeFnForwPassReq.Mode = DiffMode::reverse_mode_forward_pass;
-    calleeFnForwPassReq.BaseFunctionName =
-        clad::utils::ComputeEffectiveFnName(FD);
-    calleeFnForwPassReq.VerboseDiags = true;
+    if (elideReverseForw) {
+      call = BuildCallExprToFunction(FD, CallArgs, CUDAExecConfig);
+      if (MD && MD->isInstance())
+        if (auto* UO = dyn_cast<UnaryOperator>(revForwAdjointArgs[0]))
+          revForwAdjointArgs[0] = UO->getSubExpr();
+      Expr* call_dx =
+          BuildCallExprToFunction(FD, revForwAdjointArgs, CUDAExecConfig);
+      if (Expr* add_assign = BuildDiffIncrement(call_dx)) {
+        Stmts& block = getCurrentBlock(direction::reverse);
+        it = std::begin(block) + insertionPoint;
+        block.insert(it, add_assign);
+      }
+      return {call, call_dx};
+    }
 
-    FunctionDecl* calleeFnForwPassFD = FindDerivedFunction(calleeFnForwPassReq);
     if (calleeFnForwPassFD && !hasDynamicNonDiffParams &&
         (hasStoredParams || needsForwPass)) {
       CallArgs.insert(CallArgs.end(), revForwAdjointArgs.begin(),
@@ -2178,7 +2197,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         Stmts& block = getCurrentBlock(direction::reverse);
         it = std::begin(block) + insertionPoint;
         block.insert(it, add_assign);
-        // addToCurrentBlock(add_assign, direction::reverse);
       }
       return StmtDiff(resValue, resAdjoint);
     } // Recreate the original call expression.
@@ -3031,7 +3049,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     if (stmtDx) {
       if (dxInForward)
         addToCurrentBlock(stmtDx, direction::forward);
-      else
+      else if (!clad_compat::isa_and_nonnull<Expr>(S))
         addToCurrentBlock(stmtDx, direction::reverse);
     }
     CompoundStmt* RCS = endBlock(direction::reverse);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2202,17 +2202,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     } // Recreate the original call expression.
 
     if (const auto* OCE = dyn_cast<CXXOperatorCallExpr>(CE)) {
-      if (OCE->getOperator() == clang::OverloadedOperatorKind::OO_Subscript) {
-        // If the operator is subscript, we should return the adjoint expression
-        auto AdjointCallArgs = CallArgs;
-        Expr* adjointBase = CallArgDx[0];
-        if (auto* UnOp = dyn_cast<UnaryOperator>(adjointBase))
-          adjointBase = UnOp->getSubExpr();
-        AdjointCallArgs[0] = adjointBase;
-        call = BuildOperatorCall(OCE->getOperator(), CallArgs);
-        Expr* call_dx = BuildOperatorCall(OCE->getOperator(), AdjointCallArgs);
-        return StmtDiff(call, call_dx);
-      }
       call = BuildOperatorCall(OCE->getOperator(), CallArgs);
       return StmtDiff(call);
     }

--- a/test/Gradient/Cladtorch.C
+++ b/test/Gradient/Cladtorch.C
@@ -69,8 +69,7 @@ float fn1(
 // CHECK-NEXT:     {{.*}}std::vector<cladtorch::Tensor> v{{.*}}{u, b}{{.*}};
 // CHECK-NEXT:     {{.*}}std::vector<cladtorch::Tensor> _d_v(v);
 // CHECK-NEXT:     clad::zero_init(_d_v);
-// CHECK-NEXT:     clad::ValueAndAdjoint<{{.*}}Tensor &, {{.*}}Tensor &> _t0 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&v, 1, &_d_v, 0);
-// CHECK-NEXT:     _t0.adjoint.data += 1;
+// CHECK-NEXT:     _d_v[1].data += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         clad::array<{{cladtorch::Tensor|std::vector<cladtorch::Tensor, std::allocator<cladtorch::Tensor> >::value_type}}> _r0 = {{2U|2UL}};
 // CHECK:              {{.*}}clad::custom_derivatives::class_functions::constructor_pullback({u, b}, {{.*}}&_d_v, &_r0{{.*}});

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -5,6 +5,7 @@
 // XFAIL: valgrind
 
 #include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
 #include <cmath>
 #include <vector>
 

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -1082,9 +1082,8 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK: void weak_fn_pullback(std::weak_ptr<double> x_ptr, double _d_y, std::weak_ptr<double> *_d_x_ptr) {
-// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t0 = clad::custom_derivatives::class_functions::lock_reverse_forw(&x_ptr, &(*_d_x_ptr));
-// CHECK-NEXT:     std::shared_ptr<double> s = _t0.value;
-// CHECK-NEXT:     std::shared_ptr<double> _d_s = _t0.adjoint;
+// CHECK-NEXT:     std::shared_ptr<double> s = x_ptr.lock();
+// CHECK-NEXT:     std::shared_ptr<double> _d_s = (*_d_x_ptr).lock();
 // CHECK-NEXT:     double _d_x = 0.;
 // CHECK-NEXT:     double x = * s;
 // CHECK-NEXT:     {

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -853,12 +853,11 @@ int main() {
 // CHECK-NEXT:     clad::ValueAndAdjoint< {{.*}}, {{.*}} > _t0 = {{.*}}class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<{{(std::)?}}unique_ptr{{.*}}(), p, _d_p);
 // CHECK-NEXT:     std::unique_ptr{{.*}} up(static_cast<std::unique_ptr{{.*}}(_t0.value));
 // CHECK-NEXT:     std::unique_ptr{{.*}} _d_up = static_cast<std::unique_ptr{{.*}}(_t0.adjoint);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}class_functions::operator_star_reverse_forw(&up, &_d_up);
-// CHECK-NEXT:     _t1.value += 5 * e;
-// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_star_reverse_forw(&up, &_d_up);
-// CHECK-NEXT:     _t2.adjoint += 1;
+// CHECK-NEXT:     double *_t1 = &* up;
+// CHECK-NEXT:     *_t1 += 5 * e;
+// CHECK-NEXT:     * _d_up += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r_d0 = _t1.adjoint;
+// CHECK-NEXT:         double _r_d0 = * _d_up;
 // CHECK-NEXT:         *_d_e += 5 * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_d += *_d_p;
@@ -959,8 +958,7 @@ int main() {
 // CHECK-NEXT:     {{.*}} _d_it{};
 // CHECK-NEXT:     clad::tape<{{.*}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<{{.*}}> _t4 = {};
-// CHECK-NEXT:     clad::tape<int> _t5 = {};
+// CHECK-NEXT:     clad::tape<int> _t4 = {};
 // CHECK-NEXT:     double _d_sum = 0.;
 // CHECK-NEXT:     double sum = 0;
 // CHECK-NEXT:     int _d_u = 0;
@@ -971,9 +969,8 @@ int main() {
 // CHECK-NEXT:     _d_it = _t1.adjoint;
 // CHECK-NEXT:     for (; it != end; clad::push(_t2, it) , {{.*}}class_functions::operator_plus_plus_reverse_forw(&it, 0, &_d_it, 0)) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t4, {{.*}}class_functions::operator_star_reverse_forw(&it, &_d_it));
-// CHECK-NEXT:         sum += u * clad::push(_t3, clad::back(_t4).value);
-// CHECK-NEXT:         clad::push(_t5, u);
+// CHECK-NEXT:         sum += u * clad::push(_t3, * it);
+// CHECK-NEXT:         clad::push(_t4, u);
 // CHECK-NEXT:         u += 2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_sum += 1;
@@ -984,12 +981,11 @@ int main() {
 // CHECK-NEXT:             {{.*}}class_functions::operator_plus_plus_pullback(&it, 0, {}, &_d_it, &_r0);
 // CHECK-NEXT:             clad::pop(_t2);
 // CHECK-NEXT:         }
-// CHECK-NEXT:         u = clad::pop(_t5);
+// CHECK-NEXT:         u = clad::pop(_t4);
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = _d_sum;
 // CHECK-NEXT:             _d_u += _r_d0 * clad::pop(_t3);
-// CHECK-NEXT:             clad::back(_t4).adjoint += u * _r_d0;
-// CHECK-NEXT:             clad::pop(_t4);
+// CHECK-NEXT:             * _d_it += u * _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -1059,15 +1055,14 @@ int main() {
 // CHECK-NEXT: }
 
 // CHECK-NEXT: void simple_func_pullback(std::shared_ptr<double> x_ptr, double _d_y, std::shared_ptr<double> *_d_x_ptr) {
-// CHECK-NEXT:     clad::ValueAndAdjoint<{{.*}} &, {{.*}} &> _t0 = clad::custom_derivatives::class_functions::operator_star_reverse_forw(&x_ptr, &(*_d_x_ptr));
 // CHECK-NEXT:     double _d_x = 0.;
-// CHECK-NEXT:     double x = _t0.value;
+// CHECK-NEXT:     double x = * x_ptr;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_x += _d_y * x;
 // CHECK-NEXT:         _d_x += x * _d_y;
 // CHECK-NEXT:         _d_x += 2. * _d_y;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _t0.adjoint += _d_x;
+// CHECK-NEXT:     * (*_d_x_ptr) += _d_x;
 // CHECK-NEXT: }
 
 // CHECK: void fn21_grad(double x, double *_d_x) {
@@ -1090,15 +1085,14 @@ int main() {
 // CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t0 = clad::custom_derivatives::class_functions::lock_reverse_forw(&x_ptr, &(*_d_x_ptr));
 // CHECK-NEXT:     std::shared_ptr<double> s = _t0.value;
 // CHECK-NEXT:     std::shared_ptr<double> _d_s = _t0.adjoint;
-// CHECK-NEXT:     clad::ValueAndAdjoint<{{.*}} &, {{.*}} &> _t1 = clad::custom_derivatives::class_functions::operator_star_reverse_forw(&s, &_d_s);
 // CHECK-NEXT:     double _d_x = 0.;
-// CHECK-NEXT:     double x = _t1.value;
+// CHECK-NEXT:     double x = * s;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_x += _d_y * x;
 // CHECK-NEXT:         _d_x += x * _d_y;
 // CHECK-NEXT:         _d_x += 2. * _d_y;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _t1.adjoint += _d_x;
+// CHECK-NEXT:     * _d_s += _d_x;
 // CHECK-NEXT: }
 
 // CHECK: void fn22_grad(double x, double *_d_x) {

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -1067,13 +1067,12 @@ int main() {
 
 // CHECK: void fn21_grad(double x, double *_d_x) {
 // CHECK-NEXT:     double _t0 = x;
-// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t1 = clad::custom_derivatives::std::make_shared_reverse_forw(x, *_d_x);
-// CHECK-NEXT:     std::shared_ptr<double> x_ptr = _t1.value;
-// CHECK-NEXT:     std::shared_ptr<double> _d_x_ptr = _t1.adjoint;
-// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t2 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<{{(std::)?}}shared_ptr<double> >(), x_ptr, _d_x_ptr);
+// CHECK-NEXT:     std::shared_ptr<double> x_ptr = std::make_shared(x);
+// CHECK-NEXT:     std::shared_ptr<double> _d_x_ptr = std::make_shared(*_d_x);
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t1 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<{{(std::)?}}shared_ptr<double> >(), x_ptr, _d_x_ptr);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         std::shared_ptr<double> _r0 = _t2.adjoint;
-// CHECK-NEXT:         simple_func_pullback(_t2.value, 1, &_r0);
+// CHECK-NEXT:         std::shared_ptr<double> _r0 = _t1.adjoint;
+// CHECK-NEXT:         simple_func_pullback(_t1.value, 1, &_r0);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         x = _t0;
@@ -1096,16 +1095,15 @@ int main() {
 
 // CHECK: void fn22_grad(double x, double *_d_x) {
 // CHECK-NEXT:     double _t0 = x;
-// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::shared_ptr<double>, ::std::shared_ptr<double> > _t1 = clad::custom_derivatives::std::make_shared_reverse_forw(x, *_d_x);
-// CHECK-NEXT:     std::shared_ptr<double> s_ptr = _t1.value;
-// CHECK-NEXT:     std::shared_ptr<double> _d_s_ptr = _t1.adjoint;
-// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::weak_ptr<double>, ::std::weak_ptr<double> > _t2 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<{{(std::)?}}weak_ptr<double> >(), s_ptr, _d_s_ptr);
-// CHECK-NEXT:     std::weak_ptr<double> w_ptr = _t2.value;
-// CHECK-NEXT:     std::weak_ptr<double> _d_w_ptr = _t2.adjoint;
-// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::weak_ptr<double>, ::std::weak_ptr<double> > _t3 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<{{(std::)?}}weak_ptr<double> >(), w_ptr, _d_w_ptr);
+// CHECK-NEXT:     std::shared_ptr<double> s_ptr = std::make_shared(x);
+// CHECK-NEXT:     std::shared_ptr<double> _d_s_ptr = std::make_shared(*_d_x);
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::weak_ptr<double>, ::std::weak_ptr<double> > _t1 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<{{(std::)?}}weak_ptr<double> >(), s_ptr, _d_s_ptr);
+// CHECK-NEXT:     std::weak_ptr<double> w_ptr = _t1.value;
+// CHECK-NEXT:     std::weak_ptr<double> _d_w_ptr = _t1.adjoint;
+// CHECK-NEXT:     clad::ValueAndAdjoint< ::std::weak_ptr<double>, ::std::weak_ptr<double> > _t2 = clad::custom_derivatives::class_functions::constructor_reverse_forw(clad::ConstructorReverseForwTag<{{(std::)?}}weak_ptr<double> >(), w_ptr, _d_w_ptr);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         std::weak_ptr<double> _r0 = _t3.adjoint;
-// CHECK-NEXT:         weak_fn_pullback(_t3.value, 1, &_r0);
+// CHECK-NEXT:         std::weak_ptr<double> _r0 = _t2.adjoint;
+// CHECK-NEXT:         weak_fn_pullback(_t2.value, 1, &_r0);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         x = _t0;

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -682,7 +682,6 @@ int main() {
 // CHECK-NEXT:          {{.*}}tape<{{.*}}vector<double> > _t1 = {};
 // CHECK-NEXT:          size_t _d_i0 = {{0U|0UL|0}};
 // CHECK-NEXT:          size_t i0 = {{0U|0UL|0}};
-// CHECK-NEXT:          clad::tape<clad::ValueAndAdjoint<double &, double &> > _t3 = {};
 // CHECK-NEXT:          {{.*}}vector<double> v;
 // CHECK-NEXT:          {{.*}}vector<double> _d_v = {};
 // CHECK-NEXT:          clad::zero_init(_d_v);
@@ -697,12 +696,11 @@ int main() {
 // CHECK-NEXT:          {{.*}} _t2 = {{0U|0UL|0}};
 // CHECK-NEXT:          for (i0 = 0; i0 < v.size(); ++i0) {
 // CHECK-NEXT:              _t2++;
-// CHECK-NEXT:              clad::push(_t3, {{.*}}at_reverse_forw(&v, i0, &_d_v, {{0U|0UL|0}}));
-// CHECK-NEXT:              res += clad::back(_t3).value;
+// CHECK-NEXT:              res += v.at(i0);
 // CHECK-NEXT:          }
-// CHECK-NEXT:          {{.*}}vector<double> _t4 = v;
+// CHECK-NEXT:          {{.*}}vector<double> _t3 = v;
 // CHECK-NEXT:          v.assign(3, 0);
-// CHECK-NEXT:          {{.*}}vector<double> _t5 = v;
+// CHECK-NEXT:          {{.*}}vector<double> _t4 = v;
 // CHECK-NEXT:          v.assign(2, y);
 // CHECK-NEXT:          {
 // CHECK-NEXT:              _d_res += 1;
@@ -711,12 +709,12 @@ int main() {
 // CHECK-NEXT:              _d_v[2] += 1;
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              v = _t5;
+// CHECK-NEXT:              v = _t4;
 // CHECK-NEXT:              {{.*size_type|size_t}} _r2 = {{0U|0UL|0}};
 // CHECK-NEXT:              {{.*}}assign_pullback(&v, 2, y, &_d_v, &_r2, &*_d_y);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              v = _t4;
+// CHECK-NEXT:              v = _t3;
 // CHECK-NEXT:              {{.*size_type|size_t}} _r0 = {{0U|0UL|0}};
 // CHECK-NEXT:              {{.*}}value_type _r1 = 0.;
 // CHECK-NEXT:              {{.*}}assign_pullback(&v, 3, 0, &_d_v, &_r0, &_r1);
@@ -725,8 +723,7 @@ int main() {
 // CHECK-NEXT:              --i0;
 // CHECK-NEXT:              {
 // CHECK-NEXT:                  double _r_d0 = _d_res;
-// CHECK-NEXT:                  clad::back(_t3).adjoint += _r_d0;
-// CHECK-NEXT:                  {{.*}}pop(_t3);
+// CHECK-NEXT:                  _d_v.at(i0) += _r_d0;
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
 // CHECK-NEXT:          for (; _t0; _t0--) {

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -589,18 +589,18 @@ int main() {
 // CHECK:     void fn7_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:         std::array<double, 2> _d_a = {{.*}};
 // CHECK-NEXT:         std::array<double, 2> a;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t0 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, 0);
-// CHECK-NEXT:         _t0.value = 5;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, 0);
-// CHECK-NEXT:         _t1.value = y;
+// CHECK-NEXT:         {{.*}}value_type *_t0 = &a[0];
+// CHECK-NEXT:         *_t0 = 5;
+// CHECK-NEXT:         {{.*}}value_type *_t1 = &a[1];
+// CHECK-NEXT:         *_t1 = y;
 // CHECK-NEXT:         std::array<double, 3> _d__b = {{.*}};
 // CHECK-NEXT:         std::array<double, 3> _b0;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&_b0, 0, &_d__b, 0);
-// CHECK-NEXT:         _t2.value = x;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t3 = {{.*}}operator_subscript_reverse_forw(&_b0, 1, &_d__b, 0);
-// CHECK-NEXT:         _t3.value = 0;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t4 = {{.*}}operator_subscript_reverse_forw(&_b0, 2, &_d__b, 0);
-// CHECK-NEXT:         _t4.value = x * x;
+// CHECK-NEXT:         {{.*}}value_type *_t2 = &_b0[0];
+// CHECK-NEXT:         *_t2 = x;
+// CHECK-NEXT:         {{.*}}value_type *_t3 = &_b0[1];
+// CHECK-NEXT:         *_t3 = 0;
+// CHECK-NEXT:         {{.*}}value_type *_t4 = &_b0[2];
+// CHECK-NEXT:         *_t4 = x * x;
 // CHECK-NEXT:         std::array<double, 3> _d_b = {{.*}};
 // CHECK-NEXT:         const std::array<double, 3> b = _b0;
 // CHECK:              clad::ValueAndAdjoint<double &, double &> _t{{7|8}} = {{.*}}back_reverse_forw(&a, &_d_a);
@@ -616,28 +616,28 @@ int main() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {{.*}}constructor_pullback(_b0, &_d_b, &_d__b);
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r_d4 = _t4.adjoint;
-// CHECK-NEXT:             _t4.adjoint = 0.;
+// CHECK-NEXT:             {{.*}}value_type _r_d4 = _d__b[2];
+// CHECK-NEXT:             _d__b[2] = 0.;
 // CHECK-NEXT:             *_d_x += _r_d4 * x;
 // CHECK-NEXT:             *_d_x += x * _r_d4;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r_d3 = _t3.adjoint;
-// CHECK-NEXT:             _t3.adjoint = 0.;
+// CHECK-NEXT:             {{.*}}value_type _r_d3 = _d__b[1];
+// CHECK-NEXT:             _d__b[1] = 0.;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r_d2 = _t2.adjoint;
-// CHECK-NEXT:             _t2.adjoint = 0.;
+// CHECK-NEXT:             {{.*}}value_type _r_d2 = _d__b[0];
+// CHECK-NEXT:             _d__b[0] = 0.;
 // CHECK-NEXT:             *_d_x += _r_d2;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r_d1 = _t1.adjoint;
-// CHECK-NEXT:             _t1.adjoint = 0.;
+// CHECK-NEXT:             {{.*}}value_type _r_d1 = _d_a[1];
+// CHECK-NEXT:             _d_a[1] = 0.;
 // CHECK-NEXT:             *_d_y += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r_d0 = _t0.adjoint;
-// CHECK-NEXT:             _t0.adjoint = 0.;
+// CHECK-NEXT:             {{.*}}value_type _r_d0 = _d_a[0];
+// CHECK-NEXT:             d_a[0] = 0.;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 
@@ -646,11 +646,9 @@ int main() {
 // CHECK-NEXT:         std::array<double, 50> a;
 // CHECK-NEXT:         std::array<double, 50> _t0 = a;
 // CHECK-NEXT:         {{.*}}fill_reverse_forw(&a, y + x + x, &_d_a, 0.);
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 49, &_d_a, 0);
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 3, &_d_a, 0);
 // CHECK-NEXT:         {
-// CHECK-NEXT:             _t1.adjoint += 1;
-// CHECK-NEXT:             _t2.adjoint += 1;
+// CHECK-NEXT:             _d_a[49] += 1;
+// CHECK-NEXT:             _d_a[3] += 1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             a = _t0;
@@ -665,13 +663,12 @@ int main() {
 // CHECK:     void fn9_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:         std::array<double, 2> _d_a = {{.*}};
 // CHECK-NEXT:         std::array<double, 2> a;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t0 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, 0);
-// CHECK-NEXT:         _t0.value = 2 * x;
-// CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&a, 1, &_d_a, 0);
-// CHECK-NEXT:         _t1.adjoint += 1;
+// CHECK-NEXT:         {{.*}}value_type *_t0 = &a[1];
+// CHECK-NEXT:         *_t0 = 2 * x;
+// CHECK-NEXT:         _d_a[1] += 1;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}} _r_d0 = _t0.adjoint;
-// CHECK-NEXT:             _t0.adjoint = 0.;
+// CHECK-NEXT:             {{.*}} _r_d0 = _d_a[1];
+// CHECK-NEXT:             _d_a[1] = 0.;
 // CHECK-NEXT:             *_d_x += 2 * _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -359,11 +359,9 @@ int main() {
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
 // CHECK-NEXT:     std::vector<double> _t1 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, v, &_d_vec, *_d_v);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, 0);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, 0);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _t2.adjoint += 1;
-// CHECK-NEXT:         _t3.adjoint += 1;
+// CHECK-NEXT:         _d_vec[0] += 1;
+// CHECK-NEXT:         _d_vec[1] += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         vec = _t1;
@@ -383,15 +381,12 @@ int main() {
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
 // CHECK-NEXT:     std::vector<double> _t1 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, v, &_d_vec, *_d_v);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, 0);
-// CHECK-NEXT:     double &_d_ref = _t2.adjoint;
-// CHECK-NEXT:     double &ref = _t2.value;
+// CHECK-NEXT:     double &_d_ref = _d_vec[0];
+// CHECK-NEXT:     double &ref = vec[0];
 // CHECK-NEXT:     ref += u;
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, 0);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, 0);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _t3.adjoint += 1;
-// CHECK-NEXT:         _t4.adjoint += 1;
+// CHECK-NEXT:         _d_vec[0] += 1;
+// CHECK-NEXT:         _d_vec[1] += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_ref;
@@ -426,45 +421,35 @@ int main() {
 // CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 3, &_d_vec, 0);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, 0);
-// CHECK-NEXT:         _d_ref0 = &_t1.adjoint;
-// CHECK-NEXT:         ref0 = &_t1.value;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, 0);
-// CHECK-NEXT:         _d_ref1 = &_t2.adjoint;
-// CHECK-NEXT:         ref1 = &_t2.value;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, 0);
-// CHECK-NEXT:         _d_ref2 = &_t3.adjoint;
-// CHECK-NEXT:         ref2 = &_t3.value;
+// CHECK-NEXT:         _d_ref0 = &_d_vec[0];
+// CHECK-NEXT:         ref0 = &vec[0];
+// CHECK-NEXT:         _d_ref1 = &_d_vec[1];
+// CHECK-NEXT:         ref1 = &vec[1];
+// CHECK-NEXT:         _d_ref2 = &_d_vec[2];
+// CHECK-NEXT:         ref2 = &vec[2];
 // CHECK-NEXT:         *ref0 = u;
 // CHECK-NEXT:         *ref1 = v;
 // CHECK-NEXT:         *ref2 = u + v;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, 0);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t5 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, 0);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, 0);
-// CHECK-NEXT:     res = _t4.value + _t5.value + _t6.value;
-// CHECK-NEXT:     std::vector<double> _t7 = vec;
+// CHECK-NEXT:     res = vec[0] + vec[1] + vec[2];
+// CHECK-NEXT:     std::vector<double> _t1 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::clear_reverse_forw(&vec, &_d_vec);
-// CHECK-NEXT:     std::vector<double> _t8 = vec;
+// CHECK-NEXT:     std::vector<double> _t2 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 2, &_d_vec, 0);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t9 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, 0);
-// CHECK-NEXT:         _d_ref00 = &_t9.adjoint;
-// CHECK-NEXT:         ref00 = &_t9.value;
-// CHECK-NEXT:         {{.*}}ValueAndAdjoint<double &, double &> _t10 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, 0);
-// CHECK-NEXT:         _d_ref10 = &_t10.adjoint;
-// CHECK-NEXT:         ref10 = &_t10.value;
+// CHECK-NEXT:         _d_ref00 = &_d_vec[0];
+// CHECK-NEXT:         ref00 = &vec[0];
+// CHECK-NEXT:         _d_ref10 = &_d_vec[1];
+// CHECK-NEXT:         ref10 = &vec[1];
 // CHECK-NEXT:         *ref00 = u;
 // CHECK-NEXT:         *ref10 = u;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t11 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, 0);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t12 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, 0);
-// CHECK-NEXT:     res += _t11.value + _t12.value;
+// CHECK-NEXT:     res += vec[0] + vec[1];
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d6 = _d_res;
-// CHECK-NEXT:         _t11.adjoint += _r_d6;
-// CHECK-NEXT:         _t12.adjoint += _r_d6;
+// CHECK-NEXT:         _d_vec[0] += _r_d6;
+// CHECK-NEXT:         _d_vec[1] += _r_d6;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
@@ -479,20 +464,20 @@ int main() {
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         vec = _t8;
+// CHECK-NEXT:         vec = _t2;
 // CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&vec, 2, &_d_vec, &_r1);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         vec = _t7;
+// CHECK-NEXT:         vec = _t1;
 // CHECK-NEXT:         clad::custom_derivatives::class_functions::clear_pullback(&vec, &_d_vec);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d3 = _d_res;
 // CHECK-NEXT:         _d_res = 0.;
-// CHECK-NEXT:         _t4.adjoint += _r_d3;
-// CHECK-NEXT:         _t5.adjoint += _r_d3;
-// CHECK-NEXT:         _t6.adjoint += _r_d3;
+// CHECK-NEXT:         _d_vec[0] += _r_d3;
+// CHECK-NEXT:         _d_vec[1] += _r_d3;
+// CHECK-NEXT:         _d_vec[2] += _r_d3;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
@@ -530,13 +515,10 @@ int main() {
 // CHECK-NEXT:     std::vector<double> vec(count, u, allocator);
 // CHECK-NEXT:     std::vector<double> _d_vec(vec);
 // CHECK-NEXT:     clad::zero_init(_d_vec);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t0 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 0, &_d_vec, 0);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, 0);
-// CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, 0);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _t0.adjoint += 1;
-// CHECK-NEXT:         _t1.adjoint += 1;
-// CHECK-NEXT:         _t2.adjoint += 1;
+// CHECK-NEXT:         _d_vec[0] += 1;
+// CHECK-NEXT:         _d_vec[1] += 1;
+// CHECK-NEXT:         _d_vec[2] += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
@@ -554,13 +536,12 @@ int main() {
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, x, &_d_a, *_d_x);
 // CHECK-NEXT:          std::vector<double> _t1 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, x, &_d_a, *_d_x);
-// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, 0);
-// CHECK-NEXT:          _t2.value = x * x;
-// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t3 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&a, 1, &_d_a, 0);
-// CHECK-NEXT:          _t3.adjoint += 1;
+// CHECK-NEXT:          {{.*}}value_type *_t2 = &a[1];
+// CHECK-NEXT:          _t2 = x * x;
+// CHECK-NEXT:          _d_a[1] += 1;
 // CHECK-NEXT:          {
-// CHECK-NEXT:              double _r_d0 = _t2.adjoint;
-// CHECK-NEXT:              _t2.adjoint = 0.;
+// CHECK-NEXT:              {{.*}}value_type _r_d0 = _d_a[1];
+// CHECK-NEXT:              _d_a[1] = 0.;
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
 // CHECK-NEXT:          }
@@ -723,14 +704,11 @@ int main() {
 // CHECK-NEXT:          v.assign(3, 0);
 // CHECK-NEXT:          {{.*}}vector<double> _t5 = v;
 // CHECK-NEXT:          v.assign(2, y);
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t6 = {{.*}}operator_subscript_reverse_forw(&v, 0, &_d_v, 0);
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t7 = {{.*}}operator_subscript_reverse_forw(&v, 1, &_d_v, 0);
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t8 = {{.*}}operator_subscript_reverse_forw(&v, 2, &_d_v, 0);
 // CHECK-NEXT:          {
 // CHECK-NEXT:              _d_res += 1;
-// CHECK-NEXT:              _t6.adjoint += 1;
-// CHECK-NEXT:              _t7.adjoint += 1;
-// CHECK-NEXT:              _t8.adjoint += 1;
+// CHECK-NEXT:              _d_v[0] += 1;
+// CHECK-NEXT:              _d_v[1] += 1;
+// CHECK-NEXT:              _d_v[2] += 1;
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              v = _t5;
@@ -797,13 +775,12 @@ int main() {
 // CHECK-NEXT:          clad::zero_init(_d_a);
 // CHECK-NEXT:          std::vector<double> _t0 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, 0, &_d_a, 0);
-// CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, 0);
-// CHECK-NEXT:          _t1.value = x * x;
-// CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&a, 0, &_d_a, 0);
-// CHECK-NEXT:          _t2.adjoint += 1;
+// CHECK-NEXT:          {{.*}}value_type *_t1 = &a[0];
+// CHECK-NEXT:          *_t1 = x * x;
+// CHECK-NEXT:          _d_a[0] += 1;
 // CHECK-NEXT:          {
-// CHECK-NEXT:              double _r_d0 = _t1.adjoint;
-// CHECK-NEXT:              _t1.adjoint = 0{{.*}};
+// CHECK-NEXT:              {{.*}}value_type _r_d0 = _d_a[0];
+// CHECK-NEXT:              _d_a[0] = 0{{.*}};
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
 // CHECK-NEXT:          }
@@ -821,12 +798,10 @@ int main() {
 // CHECK-NEXT:      std::vector<double> ls({u, v}, alloc);
 // CHECK-NEXT:      std::vector<double> _d_ls(ls);
 // CHECK-NEXT:      clad::zero_init(_d_ls);
-// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t0 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, 0);
-// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, 0);
-// CHECK-NEXT:      {{.*}}value_type _t1 = _t2.value;
+// CHECK-NEXT:      {{.*}}value_type _t0 = ls[0];
 // CHECK-NEXT:      {
-// CHECK-NEXT:          _t0.adjoint += 1;
-// CHECK-NEXT:          _t2.adjoint += 2 * -1;
+// CHECK-NEXT:          ls[1] += 1;
+// CHECK-NEXT:          ls[0] += 2 * -1;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          clad::array<{{double|std::vector<double, std::allocator<double> >::value_type}}> _r0 = {{2U|2UL|2ULL}};
@@ -843,9 +818,7 @@ int main() {
 // CHECK-NEXT:      clad::tape<std::vector<double> > _t2 = {};
 // CHECK-NEXT:      std::vector<double> ls = {};
 // CHECK-NEXT:      std::vector<double> _d_ls{};
-// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t3 = {};
-// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t4 = {};
-// CHECK-NEXT:      clad::tape<clad::ValueAndAdjoint<double &, double &> > _t5 = {};
+// CHECK-NEXT:      clad::tape<{{.*}}value_type *> _t3 = {};
 // CHECK-NEXT:      {{.*}}allocator_type alloc;
 // CHECK-NEXT:      {{.*}}allocator_type _d_alloc = {};
 // CHECK-NEXT:      clad::zero_init(_d_alloc);
@@ -856,24 +829,20 @@ int main() {
 // CHECK-NEXT:          clad::push(_t2, std::move(ls)) , ls = {u, v}, alloc;
 // CHECK-NEXT:          _d_ls = ls;
 // CHECK-NEXT:          clad::zero_init(_d_ls);
-// CHECK-NEXT:          clad::push(_t3, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, 0));
-// CHECK-NEXT:          clad::push(_t4, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, 0));
-// CHECK-NEXT:          clad::back(_t3).value += clad::back(_t4).value;
-// CHECK-NEXT:          clad::push(_t5, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, 0));
-// CHECK-NEXT:          u = clad::back(_t5).value;
+// CHECK-NEXT:          clad::push(_t3, &ls[1]);
+// CHECK-NEXT:          *clad::back(_t3) += ls[0];
+// CHECK-NEXT:          u = ls[1];
 // CHECK-NEXT:      }
 // CHECK-NEXT:      *_d_u += 1;
 // CHECK-NEXT:      for (; _t0; _t0--) {
 // CHECK-NEXT:          {
 // CHECK-NEXT:              double _r_d1 = *_d_u;
 // CHECK-NEXT:              *_d_u = 0.;
-// CHECK-NEXT:              clad::back(_t5).adjoint += _r_d1;
-// CHECK-NEXT:              clad::pop(_t5);
+// CHECK-NEXT:              _d_ls[1] += _r_d1;
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              double _r_d0 = clad::back(_t3).adjoint;
-// CHECK-NEXT:              clad::back(_t4).adjoint += _r_d0;
-// CHECK-NEXT:              clad::pop(_t4);
+// CHECK-NEXT:              {{.*}}value_type _r_d0 = _d_ls[1];
+// CHECK-NEXT:              _d_ls[0] += _r_d0;
 // CHECK-NEXT:              clad::pop(_t3);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
@@ -912,7 +881,6 @@ int main() {
 // CHECK-NEXT:     std::vector<double> vec = {};
 // CHECK-NEXT:     std::vector<double> _d_vec{};
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
-// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t4 = {};
 // CHECK-NEXT:     {{.*}}allocator_type alloc;
 // CHECK-NEXT:     {{.*}}allocator_type _d_alloc = {};
 // CHECK-NEXT:     clad::zero_init(_d_alloc);
@@ -926,8 +894,7 @@ int main() {
 // CHECK-NEXT:         _d_vec = vec;
 // CHECK-NEXT:         clad::zero_init(_d_vec);
 // CHECK-NEXT:         clad::push(_t3, prod);
-// CHECK-NEXT:         clad::push(_t4, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&vec, i - 1, &_d_vec, 0));
-// CHECK-NEXT:         prod *= clad::back(_t4).value;
+// CHECK-NEXT:         prod *= vec[i - 1];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_prod += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
@@ -936,9 +903,8 @@ int main() {
 // CHECK-NEXT:             prod = clad::pop(_t3);
 // CHECK-NEXT:             double _r_d0 = _d_prod;
 // CHECK-NEXT:             _d_prod = 0.;
-// CHECK-NEXT:             _d_prod += _r_d0 * clad::back(_t4).value;
-// CHECK-NEXT:             clad::back(_t4).adjoint += prod * _r_d0;
-// CHECK-NEXT:             clad::pop(_t4);
+// CHECK-NEXT:             _d_prod += _r_d0 * vec[i - 1];
+// CHECK-NEXT:             _d_vec[i - 1] += prod * _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*size_type|size_t}} _r0 = 0{{.*}};
@@ -962,9 +928,7 @@ int main() {
 // CHECK-NEXT:     clad::tape<std::vector<double> > _t2 = {};
 // CHECK-NEXT:     std::vector<double> ls = {};
 // CHECK-NEXT:     std::vector<double> _d_ls{};
-// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t3 = {};
-// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t4 = {};
-// CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double &, double &> > _t5 = {};
+// CHECK-NEXT:     clad::tape<value_type *> _t3 = {};
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
 // CHECK-NEXT:     for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:         _t0++;
@@ -972,24 +936,20 @@ int main() {
 // CHECK-NEXT:         clad::push(_t2, std::move(ls)) , ls = {{.*{u, v}.*}};
 // CHECK-NEXT:         _d_ls = ls;
 // CHECK-NEXT:         clad::zero_init(_d_ls);
-// CHECK-NEXT:         clad::push(_t3, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, 0));
-// CHECK-NEXT:         clad::push(_t4, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 0, &_d_ls, 0));
-// CHECK-NEXT:         clad::back(_t3).value += clad::back(_t4).value;
-// CHECK-NEXT:         clad::push(_t5, clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&ls, 1, &_d_ls, 0));
-// CHECK-NEXT:         u = clad::back(_t5).value;
+// CHECK-NEXT:         clad::push(_t3, &ls[1]);
+// CHECK-NEXT:         *clad::back(_t3) += ls[0];
+// CHECK-NEXT:         u = ls[1];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_u += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d1 = *_d_u;
 // CHECK-NEXT:             *_d_u = 0.;
-// CHECK-NEXT:             clad::back(_t5).adjoint += _r_d1;
-// CHECK-NEXT:             clad::pop(_t5);
+// CHECK-NEXT:             _d_ls[1] += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             double _r_d0 = clad::back(_t3).adjoint;
-// CHECK-NEXT:             clad::back(_t4).adjoint += _r_d0;
-// CHECK-NEXT:             clad::pop(_t4);
+// CHECK-NEXT:             {{.*}}value_type _r_d0 = _d_ls[1];
+// CHECK-NEXT:             _d_ls[0] += _r_d0;
 // CHECK-NEXT:             clad::pop(_t3);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -600,14 +600,14 @@ int main() {
 // CHECK-NEXT:         *_t4 = x * x;
 // CHECK-NEXT:         std::array<double, 3> _d_b = {{.*}};
 // CHECK-NEXT:         const std::array<double, 3> b = _b0;
-// CHECK:              clad::ValueAndAdjoint<double &, double &> _t{{7|8}} = {{.*}}back_reverse_forw(&a, &_d_a);
+// CHECK:              {{.*}}value_type _t{{7|8}} = a.back();
 // CHECK-NEXT:         {{.*}}value_type _t6 = b.front();
 // CHECK-NEXT:         {{.*}}value_type _t5 = b.at(2);
 // CHECK-NEXT:         {
-// CHECK-NEXT:             _t{{7|8}}.adjoint += 1 * _t5 * _t6;
-// CHECK:                  {{.*}}front_pullback(&b, _t{{7|8}}.value * 1 * _t5, &_d_b);
+// CHECK-NEXT:             _d_a.back() += 1 * _t5 * _t6;
+// CHECK:                  {{.*}}front_pullback(&b, _t{{7|8}} * 1 * _t5, &_d_b);
 // CHECK-NEXT:             {{.*size_type|size_t}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}at_pullback(&b, 2, _t{{7|8}}.value * _t6 * 1, &_d_b, &_r0);
+// CHECK-NEXT:             {{.*}}at_pullback(&b, 2, _t{{7|8}} * _t6 * 1, &_d_b, &_r0);
 // CHECK-NEXT:             {{.*size_type|size_t}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&b, 1, 1, &_d_b, &_r1);
 // CHECK-NEXT:         }

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -558,7 +558,6 @@ int main() {
 // CHECK:          void fn6_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:        size_t _d_i = {{0U|0UL}};
 // CHECK-NEXT:        size_t i = {{0U|0UL}};
-// CHECK-NEXT:        clad::tape<clad::ValueAndAdjoint<double &, double &> > _t2 = {};
 // CHECK-NEXT:        std::array<double, 3> _d_a = {{.*}};
 // CHECK-NEXT:        std::array<double, 3> a;
 // CHECK-NEXT:        std::array<double, 3> _t0 = a;
@@ -568,16 +567,14 @@ int main() {
 // CHECK-NEXT:        unsigned {{long|int}} _t1 = {{0U|0UL}};
 // CHECK-NEXT:        for (i = 0; i < a.size(); ++i) {
 // CHECK-NEXT:            _t1++;
-// CHECK-NEXT:            clad::push(_t2, {{.*}}at_reverse_forw(&a, i, &_d_a, {{0U|0UL}}));
-// CHECK-NEXT:            res += clad::back(_t2).value;
+// CHECK-NEXT:            res += a.at(i);
 // CHECK-NEXT:        }
 // CHECK-NEXT:        _d_res += 1;
 // CHECK-NEXT:        for (; _t1; _t1--) {
 // CHECK-NEXT:            --i;
 // CHECK-NEXT:            {
 // CHECK-NEXT:                double _r_d0 = _d_res;
-// CHECK-NEXT:                clad::back(_t2).adjoint += _r_d0;
-// CHECK-NEXT:                clad::pop(_t2);
+// CHECK-NEXT:                _d_a.at(i) += _r_d0;
 // CHECK-NEXT:            }
 // CHECK-NEXT:        }
 // CHECK-NEXT:        {


### PR DESCRIPTION
In practice, most ``reverse_forw`` can be expressed as follows:
```
ret_type f(Arg_types...);
```
-->
```
clad::ValueAndAdjoint<ret_type, ret_type> f_reverse_forw(Arg_types, Arg_types) {
    return {f(args...), f(dargs...)};
}
```
If we could insert the value and adjoint of ``f_reverse_forw`` directly into the code, this would not only make the code significantly more readable, but it would also improve performance as ``f_reverse_forw`` always uses temporary variables to store the result (which become tapes inside loops).
The problem is that it's hard to detect such functions, and we cannot do it with automatic analysis yet. However, we can implement it as an alternative option to writing a custom ``reverse_forw``. This is why this PR implements it as a custom attribute ``elidable_reverse_forw``

Note: We can also use it to mark memory functions (``malloc``, ``calloc``, etc.) and ``std::begin``/``std::end``, which have the exact same behaviour and are hard-coded in ``RMV::VisitCallExpr``. We can also replace most of our ``constructor_reverse_forw``.