### PR TITLE
Add custom derivatives for Thrust prefix sum operations

### DIFF
--- a/include/clad/Differentiator/ThrustDerivatives.h
+++ b/include/clad/Differentiator/ThrustDerivatives.h
@@ -5,12 +5,14 @@
 #include <iterator>
 #include <thrust/count.h>
 #include <thrust/device_ptr.h>
+#include <thrust/fill.h> // NOLINT(misc-include-cleaner)
 // NOLINTNEXTLINE(misc-include-cleaner)
 #include <thrust/device_vector.h>
 #include <thrust/for_each.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/reduce.h>
+#include <thrust/scan.h>
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
 #include <type_traits>
@@ -262,6 +264,148 @@ typename ::std::iterator_traits<Iterator>::value_type
 reduce_reverse_forw(Iterator first, Iterator last, Iterator /*dfirst*/,
                     Iterator /*dlast*/) {
   return ::thrust::reduce(first, last);
+}
+
+template <typename InputIt, typename OutputIt>
+void inclusive_scan_pullback(InputIt first, InputIt last, OutputIt result,
+                             OutputIt d_return, InputIt* d_first,
+                             InputIt* d_last, OutputIt* d_result) {
+  using Value = typename ::std::iterator_traits<InputIt>::value_type;
+  ::thrust::plus<Value> op;
+  ::thrust::plus<Value>* d_op = nullptr;
+  inclusive_scan_pullback(first, last, result, op, d_return, d_first, d_last,
+                          d_result, d_op);
+}
+
+template <typename InputIt, typename OutputIt, typename BinaryOp>
+void inclusive_scan_pullback(InputIt first, InputIt last, OutputIt result,
+                             BinaryOp op, OutputIt d_return, InputIt* d_first,
+                             InputIt* d_last, OutputIt* d_result,
+                             BinaryOp* d_op) {
+  size_t n = ::thrust::distance(first, last);
+
+  if (n == 0)
+    return;
+
+  using ValueConst = typename ::std::iterator_traits<InputIt>::value_type;
+  using Value = ::std::remove_const_t<ValueConst>;
+
+  auto d_src_const_ptr = ::thrust::raw_pointer_cast((*d_first).base());
+  auto d_src_ptr = const_cast<Value*>(d_src_const_ptr);
+  ::thrust::device_ptr<Value> d_src_dev_ptr(d_src_ptr);
+
+  auto d_dst_const_ptr = ::thrust::raw_pointer_cast((*d_result).base());
+  auto d_dst_ptr = const_cast<Value*>(d_dst_const_ptr);
+  ::thrust::device_ptr<Value> d_dst_dev_ptr(d_dst_ptr);
+
+  if constexpr (::std::is_same_v<BinaryOp, ::thrust::plus<Value>>) {
+    ::thrust::device_vector<Value> suffix_sums(n);
+
+    ::thrust::inclusive_scan(::thrust::make_reverse_iterator(d_dst_dev_ptr + n),
+                             ::thrust::make_reverse_iterator(d_dst_dev_ptr),
+                             suffix_sums.begin(), op);
+
+    ::thrust::transform(d_src_dev_ptr, d_src_dev_ptr + n,
+                        ::thrust::make_reverse_iterator(suffix_sums.end()),
+                        d_src_dev_ptr, ::thrust::plus<Value>());
+
+    ::thrust::fill(d_dst_dev_ptr, d_dst_dev_ptr + n, Value(0));
+
+  } else {
+    static_assert(::std::is_same_v<Value, void>,
+                  "This binary operation is not supported by the custom "
+                  "inclusive_scan_pullback.");
+  }
+}
+
+template <typename InputIt, typename OutputIt>
+clad::ValueAndAdjoint<OutputIt, OutputIt>
+inclusive_scan_reverse_forw(InputIt first, InputIt last, OutputIt result,
+                            InputIt, InputIt, OutputIt) {
+  using Value = typename ::std::iterator_traits<InputIt>::value_type;
+  return {
+      ::thrust::inclusive_scan(first, last, result, ::thrust::plus<Value>()),
+      {}};
+}
+
+template <typename InputIt, typename OutputIt, typename BinaryOp>
+clad::ValueAndAdjoint<OutputIt, OutputIt>
+inclusive_scan_reverse_forw(InputIt first, InputIt last, OutputIt result,
+                            BinaryOp op, InputIt, InputIt, OutputIt, BinaryOp) {
+  return {::thrust::inclusive_scan(first, last, result, op), {}};
+}
+
+template <typename InputIt, typename OutputIt, typename T>
+void exclusive_scan_pullback(InputIt first, InputIt last, OutputIt result,
+                             T init, OutputIt d_return, InputIt* d_first,
+                             InputIt* d_last, OutputIt* d_result, T* d_init) {
+  using Value = typename ::std::iterator_traits<InputIt>::value_type;
+  ::thrust::plus<Value> op;
+  ::thrust::plus<Value>* d_op = nullptr;
+  exclusive_scan_pullback(first, last, result, init, op, d_return, d_first,
+                          d_last, d_result, d_init, d_op);
+}
+
+template <typename InputIt, typename OutputIt, typename T, typename BinaryOp>
+void exclusive_scan_pullback(InputIt first, InputIt last, OutputIt result,
+                             T init, BinaryOp op, OutputIt d_return,
+                             InputIt* d_first, InputIt* d_last,
+                             OutputIt* d_result, T* d_init, BinaryOp* d_op) {
+  size_t n = ::thrust::distance(first, last);
+  if (n == 0)
+    return;
+
+  using ValueConst = typename ::std::iterator_traits<InputIt>::value_type;
+  using Value = ::std::remove_const_t<ValueConst>;
+
+  auto d_src_const_ptr = ::thrust::raw_pointer_cast((*d_first).base());
+  auto d_src_ptr = const_cast<Value*>(d_src_const_ptr);
+  ::thrust::device_ptr<Value> d_src_dev_ptr(d_src_ptr);
+
+  auto d_dst_const_ptr = ::thrust::raw_pointer_cast((*d_result).base());
+  auto d_dst_ptr = const_cast<Value*>(d_dst_const_ptr);
+  ::thrust::device_ptr<Value> d_dst_dev_ptr(d_dst_ptr);
+
+  if constexpr (::std::is_same_v<BinaryOp, ::thrust::plus<Value>>) {
+    if (d_init) {
+      *d_init +=
+          ::thrust::reduce(d_dst_dev_ptr, d_dst_dev_ptr + n, Value(0), op);
+    }
+
+    ::thrust::device_vector<Value> suffix_sums(n);
+
+    ::thrust::exclusive_scan(::thrust::make_reverse_iterator(d_dst_dev_ptr + n),
+                             ::thrust::make_reverse_iterator(d_dst_dev_ptr),
+                             suffix_sums.begin(), Value(0), op);
+
+    ::thrust::transform(d_src_dev_ptr, d_src_dev_ptr + n,
+                        ::thrust::make_reverse_iterator(suffix_sums.end()),
+                        d_src_dev_ptr, ::thrust::plus<Value>());
+
+    ::thrust::fill(d_dst_dev_ptr, d_dst_dev_ptr + n, Value(0));
+  } else {
+    static_assert(::std::is_same_v<Value, void>,
+                  "This binary operation is not supported by the custom "
+                  "exclusive_scan_pullback.");
+  }
+}
+
+template <typename InputIt, typename OutputIt, typename T>
+clad::ValueAndAdjoint<OutputIt, OutputIt>
+exclusive_scan_reverse_forw(InputIt first, InputIt last, OutputIt result,
+                            T init, InputIt, InputIt, OutputIt, T) {
+  using Value = typename ::std::iterator_traits<InputIt>::value_type;
+  return {::thrust::exclusive_scan(first, last, result, init,
+                                   ::thrust::plus<Value>()),
+          {}};
+}
+
+template <typename InputIt, typename OutputIt, typename T, typename BinaryOp>
+clad::ValueAndAdjoint<OutputIt, OutputIt>
+exclusive_scan_reverse_forw(InputIt first, InputIt last, OutputIt result,
+                            T init, BinaryOp op, InputIt, InputIt, OutputIt, T,
+                            BinaryOp) {
+  return {::thrust::exclusive_scan(first, last, result, init, op), {}};
 }
 
 template <typename InputIt, typename OutputIt, typename UnaryOp>

--- a/test/CUDA/ThrustScan.cu
+++ b/test/CUDA/ThrustScan.cu
@@ -1,0 +1,85 @@
+// RUN: %cladclang_cuda -I%S/../../include --cuda-path=%cudapath \
+// RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oThrustScan.out \
+// RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
+//
+// RUN: ./ThrustScan.out | %filecheck_exec %s
+//
+// REQUIRES: cuda-runtime
+//
+// expected-no-diagnostics
+
+#include <iostream>
+#include <vector>
+#include <iomanip>
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/ThrustDerivatives.h"
+#include "../TestUtils.h"
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/copy.h>
+#include <thrust/functional.h>
+#include <thrust/memory.h>
+#include <thrust/scan.h>
+
+void inclusive_scan_plus(const thrust::device_vector<double>& vec, thrust::device_vector<double>& output) {
+    thrust::inclusive_scan(vec.begin(), vec.end(), output.begin(), thrust::plus<double>());
+}
+// CHECK: void inclusive_scan_plus_grad(const thrust::device_vector<double> &vec, thrust::device_vector<double> &output, thrust::device_vector<double> *_d_vec, thrust::device_vector<double> *_d_output) {
+// CHECK-NEXT: {{.*}}thrust::inclusive_scan_reverse_forw(std::begin(vec), std::end(vec), std::begin(output), thrust::plus<double>(), std::begin((*_d_vec)), std::end((*_d_vec)), std::begin((*_d_output)), {});
+// CHECK-NEXT: {
+// CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec));
+// CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec));
+// CHECK-NEXT:     iterator _r2 = std::begin((*_d_output));
+// CHECK-NEXT:     thrust::plus<double> _r3 = {};
+// CHECK-NEXT:     clad::custom_derivatives::thrust::inclusive_scan_pullback(std::begin(vec), std::end(vec), std::begin(output), thrust::plus<double>(), {}, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+void exclusive_scan_plus(const thrust::device_vector<double>& vec, thrust::device_vector<double>& output, double init) {
+    thrust::exclusive_scan(vec.begin(), vec.end(), output.begin(), init, thrust::plus<double>());
+}
+// CHECK: void exclusive_scan_plus_grad(const thrust::device_vector<double> &vec, thrust::device_vector<double> &output, double init, thrust::device_vector<double> *_d_vec, thrust::device_vector<double> *_d_output, double *_d_init) {
+// CHECK-NEXT: {{.*}}thrust::exclusive_scan_reverse_forw(std::begin(vec), std::end(vec), std::begin(output), init, thrust::plus<double>(), std::begin((*_d_vec)), std::end((*_d_vec)), std::begin((*_d_output)), 0., {});
+// CHECK-NEXT: {
+// CHECK-NEXT:     const_iterator _r0 = std::begin((*_d_vec));
+// CHECK-NEXT:     const_iterator _r1 = std::end((*_d_vec));
+// CHECK-NEXT:     iterator _r2 = std::begin((*_d_output));
+// CHECK-NEXT:     double _r3 = 0.;
+// CHECK-NEXT:     thrust::plus<double> _r4 = {};
+// CHECK-NEXT:     clad::custom_derivatives::thrust::exclusive_scan_pullback(std::begin(vec), std::end(vec), std::begin(output), init, thrust::plus<double>(), {}, &_r0, &_r1, &_r2, &_r3, &_r4);
+// CHECK-NEXT:     *_d_init += _r3;
+// CHECK-NEXT: }
+// CHECK-NEXT: }
+
+int main() {
+    std::vector<double> host_input = {1.0, 2.0, 3.0, 4.0};
+    thrust::device_vector<double> device_input = host_input;
+    thrust::device_vector<double> device_output(host_input.size());
+
+    thrust::device_vector<double> d_output(host_input.size());
+    thrust::fill(d_output.begin(), d_output.end(), 1.0);
+
+    // Test Inclusive Scan
+    INIT_GRADIENT(inclusive_scan_plus);
+    thrust::device_vector<double> d_input_inclusive(host_input.size());
+    inclusive_scan_plus_grad.execute(device_input, device_output, &d_input_inclusive, &d_output);
+    thrust::host_vector<double> host_d_input_inclusive = d_input_inclusive;
+    printf("Inclusive Scan Gradients: %.3f %.3f %.3f %.3f\n", host_d_input_inclusive[0], host_d_input_inclusive[1], host_d_input_inclusive[2], host_d_input_inclusive[3]);
+    // CHECK-EXEC: Inclusive Scan Gradients: 4.000 3.000 2.000 1.000
+
+    // Test Exclusive Scan
+    thrust::fill(d_output.begin(), d_output.end(), 1.0);
+    INIT_GRADIENT(exclusive_scan_plus);
+    thrust::device_vector<double> d_input_exclusive(host_input.size());
+    double d_init_exclusive = 1.0;
+    exclusive_scan_plus_grad.execute(device_input, device_output, 0.0, &d_input_exclusive, &d_output, &d_init_exclusive);
+    thrust::host_vector<double> host_d_input_exclusive = d_input_exclusive;
+    printf("Exclusive Scan Gradients: %.3f %.3f %.3f %.3f\n", host_d_input_exclusive[0], host_d_input_exclusive[1], host_d_input_exclusive[2], host_d_input_exclusive[3]);
+    // CHECK-EXEC: Exclusive Scan Gradients: 3.000 2.000 1.000 0.000
+    printf("Exclusive Scan Init Gradient: %.3f\n", d_init_exclusive);
+    // CHECK-EXEC: Exclusive Scan Init Gradient: 5.000
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds custom derivatives for `thrust::inclusive_scan` and `thrust::exclusive_scan` to support reverse-mode automatic differentiation of common parallel scan patterns in Thrust.
