### PR TITLE
Find pullback before differentiating args in RMV::VisitCallExpr

### DIFF
--- a/test/Gradient/Cladtorch.C
+++ b/test/Gradient/Cladtorch.C
@@ -70,10 +70,7 @@ float fn1(
 // CHECK-NEXT:     {{.*}}std::vector<cladtorch::Tensor> _d_v(v);
 // CHECK-NEXT:     clad::zero_init(_d_v);
 // CHECK-NEXT:     clad::ValueAndAdjoint<{{.*}}Tensor &, {{.*}}Tensor &> _t0 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&v, 1, &_d_v, 0);
-// CHECK-NEXT:     {
-// CHECK-NEXT:         {{.*size_type|size_t}} _r{{[0|1|2]}} = {{0U|0UL}};
-// CHECK-NEXT:         _t0.adjoint.data += 1;
-// CHECK-NEXT:     }
+// CHECK-NEXT:     _t0.adjoint.data += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         clad::array<{{cladtorch::Tensor|std::vector<cladtorch::Tensor, std::allocator<cladtorch::Tensor> >::value_type}}> _r0 = {{2U|2UL}};
 // CHECK:              {{.*}}clad::custom_derivatives::class_functions::constructor_pullback({u, b}, {{.*}}&_d_v, &_r0{{.*}});

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -591,10 +591,6 @@ double fn14(double x, double y) {
 // CHECK-NEXT:         *_d_x += 1;
 // CHECK-NEXT:         *_d_y += 1;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         *_d_y += _r0;
-// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 double fn15(double x, double y) {

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -363,9 +363,7 @@ int main() {
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t3 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, 0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t2.adjoint += 1;
-// CHECK-NEXT:         {{.*size_type|size_t}} _r0 = {{0U|0UL}};
 // CHECK-NEXT:         _t3.adjoint += 1;
-// CHECK-NEXT:         {{.*size_type|size_t}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         vec = _t1;
@@ -393,15 +391,12 @@ int main() {
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t4 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 1, &_d_vec, 0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t3.adjoint += 1;
-// CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:         _t4.adjoint += 1;
-// CHECK-NEXT:         {{.*}} _r2 = {{0U|0UL}};
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_ref;
 // CHECK-NEXT:         *_d_u += _r_d0;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {{.*}} _r0 = {{0U|0UL}};
 // CHECK-NEXT:     {
 // CHECK-NEXT:         vec = _t1;
 // CHECK-NEXT:         clad::custom_derivatives::class_functions::push_back_pullback(&vec, v, &_d_vec, &*_d_v);
@@ -469,9 +464,7 @@ int main() {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d6 = _d_res;
 // CHECK-NEXT:         _t11.adjoint += _r_d6;
-// CHECK-NEXT:         {{.*}} _r10 = {{0U|0UL}};
 // CHECK-NEXT:         _t12.adjoint += _r_d6;
-// CHECK-NEXT:         {{.*}} _r11 = {{0U|0UL}};
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
@@ -484,13 +477,11 @@ int main() {
 // CHECK-NEXT:             *_d_ref00 = 0.;
 // CHECK-NEXT:             *_d_u += _r_d4;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         {{.*}} _r9 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}} _r8 = {{0U|0UL}};
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         vec = _t8;
-// CHECK-NEXT:         {{.*}} _r7 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&vec, 2, &_d_vec, &_r7);
+// CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
+// CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&vec, 2, &_d_vec, &_r1);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         vec = _t7;
@@ -500,11 +491,8 @@ int main() {
 // CHECK-NEXT:         double _r_d3 = _d_res;
 // CHECK-NEXT:         _d_res = 0.;
 // CHECK-NEXT:         _t4.adjoint += _r_d3;
-// CHECK-NEXT:         {{.*}} _r4 = {{0U|0UL}};
 // CHECK-NEXT:         _t5.adjoint += _r_d3;
-// CHECK-NEXT:         {{.*}} _r5 = {{0U|0UL}};
 // CHECK-NEXT:         _t6.adjoint += _r_d3;
-// CHECK-NEXT:         {{.*}} _r6 = {{0U|0UL}};
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
@@ -523,9 +511,6 @@ int main() {
 // CHECK-NEXT:             *_d_ref0 = 0.;
 // CHECK-NEXT:             *_d_u += _r_d0;
 // CHECK-NEXT:         }
-// CHECK-NEXT:         {{.*}} _r3 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}} _r2 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         vec = _t0;
@@ -550,11 +535,8 @@ int main() {
 // CHECK-NEXT:     {{.*}}ValueAndAdjoint<double &, double &> _t2 = {{.*}}class_functions::operator_subscript_reverse_forw(&vec, 2, &_d_vec, 0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t0.adjoint += 1;
-// CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:         _t1.adjoint += 1;
-// CHECK-NEXT:         {{.*}} _r2 = {{0U|0UL}};
 // CHECK-NEXT:         _t2.adjoint += 1;
-// CHECK-NEXT:         {{.*}} _r3 = {{0U|0UL}};
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
@@ -575,16 +557,12 @@ int main() {
 // CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, 0);
 // CHECK-NEXT:          _t2.value = x * x;
 // CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t3 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&a, 1, &_d_a, 0);
-// CHECK-NEXT:          {
-// CHECK-NEXT:              _t3.adjoint += 1;
-// CHECK-NEXT:              {{.*}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:          }
+// CHECK-NEXT:          _t3.adjoint += 1;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              double _r_d0 = _t2.adjoint;
 // CHECK-NEXT:              _t2.adjoint = 0.;
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
-// CHECK-NEXT:              {{.*}} _r0 = {{0U|0UL}};
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              a = _t1;
@@ -618,8 +596,6 @@ int main() {
 // CHECK-NEXT:            {
 // CHECK-NEXT:                double _r_d0 = _d_res;
 // CHECK-NEXT:                clad::back(_t2).adjoint += _r_d0;
-// CHECK-NEXT:                size_t _r0 = {{0U|0UL}};
-// CHECK-NEXT:                _d_i += _r0;
 // CHECK-NEXT:                clad::pop(_t2);
 // CHECK-NEXT:            }
 // CHECK-NEXT:        }
@@ -652,10 +628,10 @@ int main() {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t{{7|8}}.adjoint += 1 * _t5 * _t6;
 // CHECK:                  {{.*}}front_pullback(&b, _t{{7|8}}.value * 1 * _t5, &_d_b);
-// CHECK-NEXT:             {{.*size_type|size_t}} _r5 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}at_pullback(&b, 2, _t{{7|8}}.value * _t6 * 1, &_d_b, &_r5);
-// CHECK-NEXT:             {{.*size_type|size_t}} _r6 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&b, 1, 1, &_d_b, &_r6);
+// CHECK-NEXT:             {{.*size_type|size_t}} _r0 = {{0U|0UL}};
+// CHECK-NEXT:             {{.*}}at_pullback(&b, 2, _t{{7|8}}.value * _t6 * 1, &_d_b, &_r0);
+// CHECK-NEXT:             {{.*size_type|size_t}} _r1 = {{0U|0UL}};
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&b, 1, 1, &_d_b, &_r1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {{.*}}constructor_pullback(_b0, &_d_b, &_d__b);
 // CHECK-NEXT:         {
@@ -663,29 +639,24 @@ int main() {
 // CHECK-NEXT:             _t4.adjoint = 0.;
 // CHECK-NEXT:             *_d_x += _r_d4 * x;
 // CHECK-NEXT:             *_d_x += x * _r_d4;
-// CHECK-NEXT:             {{.*size_type|size_t}} _r4 = {{0U|0UL}};
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d3 = _t3.adjoint;
 // CHECK-NEXT:             _t3.adjoint = 0.;
-// CHECK-NEXT:             {{.*size_type|size_t}} _r3 = {{0U|0UL}};
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d2 = _t2.adjoint;
 // CHECK-NEXT:             _t2.adjoint = 0.;
 // CHECK-NEXT:             *_d_x += _r_d2;
-// CHECK-NEXT:             {{.*size_type|size_t}} _r2 = {{0U|0UL}};
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d1 = _t1.adjoint;
 // CHECK-NEXT:             _t1.adjoint = 0.;
 // CHECK-NEXT:             *_d_y += _r_d1;
-// CHECK-NEXT:             {{.*size_type|size_t}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = _t0.adjoint;
 // CHECK-NEXT:             _t0.adjoint = 0.;
-// CHECK-NEXT:             {{.*size_type|size_t}} _r0 = {{0U|0UL}};
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 
@@ -698,9 +669,7 @@ int main() {
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}operator_subscript_reverse_forw(&a, 3, &_d_a, 0);
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _t1.adjoint += 1;
-// CHECK-NEXT:             {{.*size_type|size_t}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:             _t2.adjoint += 1;
-// CHECK-NEXT:             {{.*size_type|size_t}} _r2 = {{0U|0UL}};
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             a = _t0;
@@ -718,15 +687,11 @@ int main() {
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t0 = {{.*}}operator_subscript_reverse_forw(&a, 1, &_d_a, 0);
 // CHECK-NEXT:         _t0.value = 2 * x;
 // CHECK-NEXT:         clad::ValueAndAdjoint<double &, double &> _t1 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&a, 1, &_d_a, 0);
-// CHECK-NEXT:         {
-// CHECK-NEXT:             _t1.adjoint += 1;
-// CHECK-NEXT:             {{.*size_type|size_t}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:         }
+// CHECK-NEXT:         _t1.adjoint += 1;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {{.*}} _r_d0 = _t0.adjoint;
 // CHECK-NEXT:             _t0.adjoint = 0.;
 // CHECK-NEXT:             *_d_x += 2 * _r_d0;
-// CHECK-NEXT:             {{.*size_type|size_t}} _r0 = {{0U|0UL}};
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 
@@ -764,30 +729,25 @@ int main() {
 // CHECK-NEXT:          {
 // CHECK-NEXT:              _d_res += 1;
 // CHECK-NEXT:              _t6.adjoint += 1;
-// CHECK-NEXT:              {{.*size_type|size_t}} _r4 = {{0U|0UL|0}};
 // CHECK-NEXT:              _t7.adjoint += 1;
-// CHECK-NEXT:              {{.*size_type|size_t}} _r5 = {{0U|0UL|0}};
 // CHECK-NEXT:              _t8.adjoint += 1;
-// CHECK-NEXT:              {{.*size_type|size_t}} _r6 = {{0U|0UL|0}};
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              v = _t5;
-// CHECK-NEXT:              {{.*size_type|size_t}} _r3 = {{0U|0UL|0}};
-// CHECK-NEXT:              {{.*}}assign_pullback(&v, 2, y, &_d_v, &_r3, &*_d_y);
+// CHECK-NEXT:              {{.*size_type|size_t}} _r2 = {{0U|0UL|0}};
+// CHECK-NEXT:              {{.*}}assign_pullback(&v, 2, y, &_d_v, &_r2, &*_d_y);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              v = _t4;
-// CHECK-NEXT:              {{.*size_type|size_t}} _r1 = {{0U|0UL|0}};
-// CHECK-NEXT:              {{.*}}value_type _r2 = 0.;
-// CHECK-NEXT:              {{.*}}assign_pullback(&v, 3, 0, &_d_v, &_r1, &_r2);
+// CHECK-NEXT:              {{.*size_type|size_t}} _r0 = {{0U|0UL|0}};
+// CHECK-NEXT:              {{.*}}value_type _r1 = 0.;
+// CHECK-NEXT:              {{.*}}assign_pullback(&v, 3, 0, &_d_v, &_r0, &_r1);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          for (; _t2; _t2--) {
 // CHECK-NEXT:              --i0;
 // CHECK-NEXT:              {
 // CHECK-NEXT:                  double _r_d0 = _d_res;
 // CHECK-NEXT:                  clad::back(_t3).adjoint += _r_d0;
-// CHECK-NEXT:                  size_t _r0 = {{0U|0UL|0}};
-// CHECK-NEXT:                  _d_i0 += _r0;
 // CHECK-NEXT:                  {{.*}}pop(_t3);
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -828,10 +788,7 @@ int main() {
 // CHECK-NEXT:              {{.*}}push_back_pullback(&v, x, &_d_v, &*_d_x);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          *_d_x += _d_res * _t1;
-// CHECK-NEXT:          {
-// CHECK-NEXT:              v = _t0;
-// CHECK-NEXT:              {{.*size_type|size_t}} _r0 = {{0U|0UL|0}};
-// CHECK-NEXT:          }
+// CHECK-NEXT:          v = _t0;
 // CHECK-NEXT:      }
 
 // CHECK:      void fn12_grad(double x, double y, double *_d_x, double *_d_y) {
@@ -843,16 +800,12 @@ int main() {
 // CHECK-NEXT:          {{.*}}ValueAndAdjoint<double &, double &> _t1 = {{.*}}operator_subscript_reverse_forw(&a, 0, &_d_a, 0);
 // CHECK-NEXT:          _t1.value = x * x;
 // CHECK-NEXT:          clad::ValueAndAdjoint<double &, double &> _t2 = clad::custom_derivatives::class_functions::operator_subscript_reverse_forw(&a, 0, &_d_a, 0);
-// CHECK-NEXT:          {
-// CHECK-NEXT:              _t2.adjoint += 1;
-// CHECK-NEXT:              {{.*size_type|size_t}} _r2 = 0{{.*}};
-// CHECK-NEXT:          }
+// CHECK-NEXT:          _t2.adjoint += 1;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              double _r_d0 = _t1.adjoint;
 // CHECK-NEXT:              _t1.adjoint = 0{{.*}};
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
-// CHECK-NEXT:              {{.*size_type|size_t}} _r1 = 0{{.*}};
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              a = _t0;
@@ -873,9 +826,7 @@ int main() {
 // CHECK-NEXT:      {{.*}}value_type _t1 = _t2.value;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          _t0.adjoint += 1;
-// CHECK-NEXT:          {{.*size_type|size_t}} _r1 = 0{{.*}};
 // CHECK-NEXT:          _t2.adjoint += 2 * -1;
-// CHECK-NEXT:          {{.*size_type|size_t}} _r2 = 0{{.*}};
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          clad::array<{{double|std::vector<double, std::allocator<double> >::value_type}}> _r0 = {{2U|2UL|2ULL}};
@@ -917,15 +868,12 @@ int main() {
 // CHECK-NEXT:              double _r_d1 = *_d_u;
 // CHECK-NEXT:              *_d_u = 0.;
 // CHECK-NEXT:              clad::back(_t5).adjoint += _r_d1;
-// CHECK-NEXT:              {{.*size_type|size_t}} _r3 = 0{{.*}};
 // CHECK-NEXT:              clad::pop(_t5);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              double _r_d0 = clad::back(_t3).adjoint;
 // CHECK-NEXT:              clad::back(_t4).adjoint += _r_d0;
-// CHECK-NEXT:              {{.*size_type|size_t}} _r2 = 0{{.*}};
 // CHECK-NEXT:              clad::pop(_t4);
-// CHECK-NEXT:              {{.*size_type|size_t}} _r1 = 0{{.*}};
 // CHECK-NEXT:              clad::pop(_t3);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
@@ -990,8 +938,6 @@ int main() {
 // CHECK-NEXT:             _d_prod = 0.;
 // CHECK-NEXT:             _d_prod += _r_d0 * clad::back(_t4).value;
 // CHECK-NEXT:             clad::back(_t4).adjoint += prod * _r_d0;
-// CHECK-NEXT:             {{.*size_type|size_t}} _r2 = 0{{.*}};
-// CHECK-NEXT:             _d_i += _r2;
 // CHECK-NEXT:             clad::pop(_t4);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
@@ -1038,15 +984,12 @@ int main() {
 // CHECK-NEXT:             double _r_d1 = *_d_u;
 // CHECK-NEXT:             *_d_u = 0.;
 // CHECK-NEXT:             clad::back(_t5).adjoint += _r_d1;
-// CHECK-NEXT:             {{.*size_type|size_t}} _r{{3|4}} = {{0U|0UL|0ULL}};
 // CHECK-NEXT:             clad::pop(_t5);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = clad::back(_t3).adjoint;
 // CHECK-NEXT:             clad::back(_t4).adjoint += _r_d0;
-// CHECK-NEXT:             {{.*size_type|size_t}} _r{{2|3}} = {{0U|0UL|0ULL}};
 // CHECK-NEXT:             clad::pop(_t4);
-// CHECK-NEXT:             {{.*size_type|size_t}} _r{{1|2}} = {{0U|0UL|0ULL}};
 // CHECK-NEXT:             clad::pop(_t3);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {


### PR DESCRIPTION
Currently, in ``RMV::VisitCallExpr``, we first differentiate all of the arguments, and then we use this information to build a request and find a matching derivative. This is a problem because we get some information about the non-differentiability of the function too late. Therefore, we cannot use it to simplify the differentiation of arguments. The only reason we cannot get the derivative sooner is dynamic derivatives. This PR moves the lookup earlier, but for dynamic derivatives, we update diff params later and, if necessary, perform the dynamic differentiation.