### PR TITLE
Add support for conversion operators

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -379,6 +379,8 @@ namespace clad {
     clang::QualType GetCladMatrixOfType(clang::Sema& S, clang::QualType T);
     /// Create clad::array_ref<T> type.
     clang::QualType GetCladArrayRefOfType(clang::Sema& S, clang::QualType T);
+    /// Returns type clad::Tag<T>
+    clang::QualType GetCladTagOfType(clang::Sema& S, clang::QualType T);
 
     clang::QualType GetParameterDerivativeType(clang::Sema& S, DiffMode Mode,
                                                clang::QualType Type);

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -381,6 +381,8 @@ namespace clad {
     clang::QualType GetCladArrayRefOfType(clang::Sema& S, clang::QualType T);
     /// Returns type clad::Tag<T>
     clang::QualType GetCladTagOfType(clang::Sema& S, clang::QualType T);
+    /// Returns type clad::Tag<T>()
+    clang::Expr* GetCladTagExpr(clang::Sema& S, clang::QualType T);
 
     clang::QualType GetParameterDerivativeType(clang::Sema& S, DiffMode Mode,
                                                clang::QualType Type);

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -590,12 +590,6 @@ namespace clad {
                                  clang::SourceLocation srcLoc);
 
     clang::QualType DetermineCladArrayValueType(clang::QualType T);
-
-    /// Returns clad::Tag template declaration.
-    clang::TemplateDecl* GetCladTag();
-
-    /// Returns type clad::Tag<T>
-    clang::QualType GetCladTagOfType(clang::QualType T);
     /// Find the derived function if present in the DerivedFnCollector.
     ///
     /// \param[in] request The request to find the derived function.
@@ -673,9 +667,6 @@ namespace clad {
                                    clang::Expr*& derivedR);
 
     virtual ~VisitorBase() = 0;
-
-  private:
-    clang::TemplateDecl* m_CladTag = nullptr;
   };
 
   /// A class that generates prettier stack traces when we crash on generating

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -2184,8 +2184,8 @@ clang::Expr* BaseForwardModeVisitor::BuildCustomDerivativeConstructorPFCall(
     llvm::SmallVectorImpl<clang::Expr*>& clonedArgs,
     llvm::SmallVectorImpl<clang::Expr*>& derivedArgs) {
   llvm::SmallVector<Expr*, 4> customPushforwardArgs;
-  QualType CladTagTy =
-      GetCladTagOfType(CE->getType().withoutLocalFastQualifiers());
+  QualType CladTagTy = utils::GetCladTagOfType(
+      m_Sema, CE->getType().withoutLocalFastQualifiers());
   // Builds clad::Tag<T> declaration
   Expr* tagArg =
       m_Sema

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -2184,16 +2184,9 @@ clang::Expr* BaseForwardModeVisitor::BuildCustomDerivativeConstructorPFCall(
     llvm::SmallVectorImpl<clang::Expr*>& clonedArgs,
     llvm::SmallVectorImpl<clang::Expr*>& derivedArgs) {
   llvm::SmallVector<Expr*, 4> customPushforwardArgs;
-  QualType CladTagTy = utils::GetCladTagOfType(
-      m_Sema, CE->getType().withoutLocalFastQualifiers());
-  // Builds clad::Tag<T> declaration
+  // Builds clad::Tag<T>()
   Expr* tagArg =
-      m_Sema
-          .BuildCXXTypeConstructExpr(
-              m_Context.getTrivialTypeSourceInfo(CladTagTy,
-                                                 utils::GetValidSLoc(m_Sema)),
-              noLoc, MultiExprArg{}, noLoc, /*ListInitialization=*/false)
-          .get();
+      utils::GetCladTagExpr(m_Sema, CE->getType().withoutLocalFastQualifiers());
   customPushforwardArgs.push_back(tagArg);
   customPushforwardArgs.append(clonedArgs.begin(), clonedArgs.end());
   customPushforwardArgs.append(derivedArgs.begin(), derivedArgs.end());

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1286,6 +1286,13 @@ namespace clad {
       return C.getFunctionType(dRetTy, FnTypes, EPI);
     }
 
+    QualType GetCladTagOfType(Sema& S, QualType T) {
+      static clang::TemplateDecl* CladTag = nullptr;
+      if (!CladTag)
+        CladTag = utils::LookupTemplateDeclInCladNamespace(S, "Tag");
+      return utils::InstantiateTemplate(S, CladTag, {T});
+    }
+
     bool canUsePushforwardInRevMode(const FunctionDecl* FD) {
       if (FD->getNumParams() != 1 ||
           utils::HasAnyReferenceOrPointerArgument(FD) ||

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1293,6 +1293,17 @@ namespace clad {
       return utils::InstantiateTemplate(S, CladTag, {T});
     }
 
+    Expr* GetCladTagExpr(Sema& S, QualType T) {
+      QualType CladTagTy = utils::GetCladTagOfType(S, T);
+      return S
+          .BuildCXXTypeConstructExpr(S.getASTContext().getTrivialTypeSourceInfo(
+                                         CladTagTy, utils::GetValidSLoc(S)),
+                                     utils::GetValidSLoc(S), MultiExprArg{},
+                                     utils::GetValidSLoc(S),
+                                     /*ListInitialization=*/false)
+          .get();
+    }
+
     bool canUsePushforwardInRevMode(const FunctionDecl* FD) {
       if (FD->getNumParams() != 1 ||
           utils::HasAnyReferenceOrPointerArgument(FD) ||

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -114,6 +114,8 @@ namespace clad {
       default:
         if (isa<CXXConstructorDecl>(FD))
           return "constructor";
+        if (isa<CXXConversionDecl>(FD))
+          return "conversion_operator";
         return FD->getNameAsString();
       }
     }
@@ -1271,6 +1273,12 @@ namespace clad {
       if (forCustomDerv && !thisTy.isNull() && !isa<CXXConstructorDecl>(FD)) {
         FnTypes.insert(FnTypes.begin(), thisTy);
         EPI.TypeQuals.removeConst();
+      }
+
+      if (mode == DiffMode::reverse_mode_forward_pass &&
+          isa<CXXConversionDecl>(FD)) {
+        QualType typeTag = utils::GetCladTagOfType(S, oRetTy);
+        FnTypes.insert(FnTypes.begin(), typeTag);
       }
 
       if (mode == DiffMode::reverse_mode_forward_pass &&

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4693,7 +4693,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     if (auto CD = llvm::dyn_cast<CXXConstructorDecl>(FD)) {
       const RecordDecl* RD = CD->getParent();
-      QualType CladTagTy = GetCladTagOfType(m_Context.getRecordType(RD));
+      QualType CladTagTy =
+          utils::GetCladTagOfType(m_Sema, m_Context.getRecordType(RD));
       Expr* tagArg = m_Sema
                          .BuildCXXTypeConstructExpr(
                              m_Context.getTrivialTypeSourceInfo(

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4693,16 +4693,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     if (auto CD = llvm::dyn_cast<CXXConstructorDecl>(FD)) {
       const RecordDecl* RD = CD->getParent();
-      QualType CladTagTy =
-          utils::GetCladTagOfType(m_Sema, m_Context.getRecordType(RD));
-      Expr* tagArg = m_Sema
-                         .BuildCXXTypeConstructExpr(
-                             m_Context.getTrivialTypeSourceInfo(
-                                 CladTagTy, utils::GetValidSLoc(m_Sema)),
-                             utils::GetValidSLoc(m_Sema), MultiExprArg{},
-                             utils::GetValidSLoc(m_Sema),
-                             /*ListInitialization=*/false)
-                         .get();
+      Expr* tagArg = utils::GetCladTagExpr(m_Sema, m_Context.getRecordType(RD));
       args.push_back(tagArg);
     }
     args.append(primalArgs.begin(), primalArgs.end());

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -821,16 +821,6 @@ namespace clad {
         .get();
   }
 
-  clang::TemplateDecl* VisitorBase::GetCladTag() {
-    if (!m_CladTag)
-      m_CladTag = utils::LookupTemplateDeclInCladNamespace(m_Sema, "Tag");
-    return m_CladTag;
-  }
-
-  clang::QualType VisitorBase::GetCladTagOfType(clang::QualType T) {
-    return utils::InstantiateTemplate(m_Sema, GetCladTag(), {T});
-  }
-
   FunctionDecl*
   VisitorBase::CreateDerivativeOverload(FunctionDecl* derivative) {
     if (!derivative)


### PR DESCRIPTION
We build all names of conversion operators using the prefix `conversion_operator`, for example, `conversion_operator_pullback`. In order to differentiate between conversion operators to different types, we add a `clad::Tag` parameter to the beginning of the signature.

This PR is an alternative approach to #1590.