### PR TITLE
Remove unary operators that cancel eath other

### DIFF
--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -7,6 +7,7 @@
 
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/OperationKinds.h"
 #include "clang/Basic/LLVM.h"
 
 #include <llvm/ADT/STLExtras.h>
@@ -118,9 +119,9 @@ void ErrorEstimationHandler::EmitNestedFunctionParamError(
     // // estimation.
     // if (utils::IsReferenceOrPointerType(fnDecl->getParamDecl(i)->getType()))
     //   continue;
-    auto* UnOp = cast<UnaryOperator>(ArgResult[i]);
+    auto* derefExpr = m_RMV->BuildOp(UO_Deref, ArgResult[i]);
     Expr* errorExpr = m_EstModel->AssignError(
-        {derivedCallArgs[i], m_RMV->Clone(UnOp->getSubExpr())},
+        {derivedCallArgs[i], derefExpr},
         fnDecl->getNameInfo().getAsString() + "_param_" + std::to_string(i));
     Expr* FinalError = BuildFinalErrorExpr();
     Expr* errorStmt = m_RMV->BuildOp(BO_AddAssign, FinalError, errorExpr);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2036,9 +2036,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     Expr* call = nullptr;
     if (elideReverseForw) {
       call = BuildCallExprToFunction(FD, CallArgs, CUDAExecConfig);
-      if (MD && MD->isInstance())
-        if (auto* UO = dyn_cast<UnaryOperator>(revForwAdjointArgs[0]))
-          revForwAdjointArgs[0] = UO->getSubExpr();
+      if (MD && MD->isInstance()) {
+        revForwAdjointArgs[0] = BuildOp(UO_Deref, revForwAdjointArgs[0]);
+        if (isa<UnaryOperator>(revForwAdjointArgs[0]))
+          revForwAdjointArgs[0] =
+              utils::BuildParenExpr(m_Sema, revForwAdjointArgs[0]);
+      }
       Expr* call_dx =
           BuildCallExprToFunction(FD, revForwAdjointArgs, CUDAExecConfig);
       if (Expr* add_assign = BuildDiffIncrement(call_dx)) {

--- a/test/CUDA/ThrustTransform.cu
+++ b/test/CUDA/ThrustTransform.cu
@@ -146,7 +146,7 @@ void apply_affine(const thrust::device_vector<double>& v,
 // CHECK-NEXT:     {{.*}}iterator _r2 = std::begin((*_d_out));
 // CHECK-NEXT:     Affine _r3 = (*_d_op);
 // CHECK-NEXT:     clad::custom_derivatives::thrust::transform_pullback(std::begin(v), std::end(v), std::begin(out), op, {}, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:     Affine::constructor_pullback(op, &_r3, &(*_d_op));
+// CHECK-NEXT:     Affine::constructor_pullback(op, &_r3, _d_op);
 // CHECK-NEXT: }
 // CHECK-NEXT: }
 
@@ -175,7 +175,7 @@ void apply_spb(const thrust::device_vector<double>& v,
 // CHECK-NEXT:     {{.*}}iterator _r2 = std::begin((*_d_out));
 // CHECK-NEXT:     SquarePlusBias _r3 = (*_d_op);
 // CHECK-NEXT:     clad::custom_derivatives::thrust::transform_pullback(std::begin(v), std::end(v), std::begin(out), op, {}, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:     SquarePlusBias::constructor_pullback(op, &_r3, &(*_d_op));
+// CHECK-NEXT:     SquarePlusBias::constructor_pullback(op, &_r3, _d_op);
 // CHECK-NEXT: }
 // CHECK-NEXT: }
 
@@ -208,7 +208,7 @@ void apply_bilinear(const thrust::device_vector<double>& v1,
 // CHECK-NEXT:     {{.*}}iterator _r3 = std::begin((*_d_out));
 // CHECK-NEXT:     Bilinear _r4 = (*_d_op);
 // CHECK-NEXT:     clad::custom_derivatives::thrust::transform_pullback(std::begin(v1), std::end(v1), std::begin(v2), std::begin(out), op, {}, &_r0, &_r1, &_r2, &_r3, &_r4);
-// CHECK-NEXT:     Bilinear::constructor_pullback(op, &_r4, &(*_d_op));
+// CHECK-NEXT:     Bilinear::constructor_pullback(op, &_r4, _d_op);
 // CHECK-NEXT: }
 // CHECK-NEXT: }
 
@@ -244,7 +244,7 @@ void apply_mix(const thrust::device_vector<double>& v1,
 // CHECK-NEXT:     {{.*}}iterator _r3 = std::begin((*_d_out));
 // CHECK-NEXT:     MixOp _r4 = (*_d_op);
 // CHECK-NEXT:     clad::custom_derivatives::thrust::transform_pullback(std::begin(v1), std::end(v1), std::begin(v2), std::begin(out), op, {}, &_r0, &_r1, &_r2, &_r3, &_r4);
-// CHECK-NEXT:     MixOp::constructor_pullback(op, &_r4, &(*_d_op));
+// CHECK-NEXT:     MixOp::constructor_pullback(op, &_r4, _d_op);
 // CHECK-NEXT: }
 // CHECK-NEXT: }
 

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -263,7 +263,7 @@ float func8(float x, float y) {
 //CHECK-NEXT:         *_d_y += _d_z;
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _t2 = 0.;
-//CHECK-NEXT:         helper2_pullback(x, _d_z, &*_d_x, _t2);
+//CHECK-NEXT:         helper2_pullback(x, _d_z, _d_x, _t2);
 //CHECK-NEXT:         _d_z = 0.F;
 //CHECK-NEXT:         _final_error += _t2;
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
@@ -293,10 +293,10 @@ float func9(float x, float y) {
 //CHECK-NEXT:         z = _t3;
 //CHECK-NEXT:         x = _t5;
 //CHECK-NEXT:         double _t6 = 0.;
-//CHECK-NEXT:         helper2_pullback(x, _d_z * _t4, &*_d_x, _t6);
+//CHECK-NEXT:         helper2_pullback(x, _d_z * _t4, _d_x, _t6);
 //CHECK-NEXT:         y = _t8;
 //CHECK-NEXT:         double _t9 = 0.;
-//CHECK-NEXT:         helper2_pullback(y, _t7 * _d_z, &*_d_y, _t9);
+//CHECK-NEXT:         helper2_pullback(y, _t7 * _d_z, _d_y, _t9);
 //CHECK-NEXT:         _final_error += _t6 + _t9;
 //CHECK-NEXT:         _final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
@@ -310,7 +310,7 @@ float func9(float x, float y) {
 //CHECK-NEXT:         *_d_y += _r1;
 //CHECK-NEXT:         x = _t1;
 //CHECK-NEXT:         double _t2 = 0.;
-//CHECK-NEXT:         helper2_pullback(x, _d_z, &*_d_x, _t2);
+//CHECK-NEXT:         helper2_pullback(x, _d_z, _d_x, _t2);
 //CHECK-NEXT:         _final_error += _t0 + _t2;
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:     }

--- a/test/ForwardMode/Pointer.C
+++ b/test/ForwardMode/Pointer.C
@@ -34,7 +34,7 @@ double fn2(double i, double j) {
 // CHECK: double fn2_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     return *&_d_i * *&*&j + *&i * *&*&_d_j;
+// CHECK-NEXT:     return _d_i * j + i * _d_j;
 // CHECK-NEXT: }
 
 double fn3(double i, double j) {

--- a/test/Gradient/Cladtorch.C
+++ b/test/Gradient/Cladtorch.C
@@ -76,7 +76,7 @@ float fn1(
 // CHECK-NEXT:         Tensor::constructor_pullback(u, &_r0[0], &_d_u);
 // CHECK-NEXT:         Tensor::constructor_pullback(b, &_r0[1], &_d_b);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     Tensor::constructor_pullback(t, &_d_b, &(*_d_t));
+// CHECK-NEXT:     Tensor::constructor_pullback(t, &_d_b, _d_t);
 // CHECK-NEXT: }
 
 int main() {

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -283,7 +283,7 @@ double fn5(double x, double y) {
 // CHECK:  static void constructor_pullback(double v, argByValWrapper *_d_this, double *_d_v) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
-// CHECK-NEXT:          argByVal::constructor_pullback(v, &*_d_this, &_r0);
+// CHECK-NEXT:          argByVal::constructor_pullback(v, _d_this, &_r0);
 // CHECK-NEXT:          *_d_v += _r0;
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
@@ -324,7 +324,7 @@ double fn6(double x, double y) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
-// CHECK-NEXT:          argByValWrapper::constructor_pullback(v, &*_d_this, &_r0);
+// CHECK-NEXT:          argByValWrapper::constructor_pullback(v, _d_this, &_r0);
 // CHECK-NEXT:          *_d_v += _r0;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      free(_this);
@@ -361,7 +361,7 @@ double fn7(double x, double y) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
-// CHECK-NEXT:          argByVal::constructor_pullback(v, &*_d_this, &_r0);
+// CHECK-NEXT:          argByVal::constructor_pullback(v, _d_this, &_r0);
 // CHECK-NEXT:          *_d_v += _r0;
 // CHECK-NEXT:      }
 // CHECK-NEXT:      free(_this);
@@ -416,7 +416,7 @@ double fn8(double u, double v) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          u = _t0;
 // CHECK-NEXT:          v = _t1;
-// CHECK-NEXT:          std::pair<double, double>::constructor_pullback(u, v, &_d_p, &*_d_u, &*_d_v);
+// CHECK-NEXT:          std::pair<double, double>::constructor_pullback(u, v, &_d_p, _d_u, _d_v);
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -87,13 +87,13 @@ double fn2(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         i = _t2;
 // CHECK-NEXT:         j = _t3;
-// CHECK-NEXT:         modify1_pullback(i, j, _d_temp, &*_d_i, &*_d_j);
+// CHECK-NEXT:         modify1_pullback(i, j, _d_temp, _d_i, _d_j);
 // CHECK-NEXT:         _d_temp = 0.;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         i = _t0;
 // CHECK-NEXT:         j = _t1;
-// CHECK-NEXT:         modify1_pullback(i, j, _d_temp, &*_d_i, &*_d_j);
+// CHECK-NEXT:         modify1_pullback(i, j, _d_temp, _d_i, _d_j);
 // CHECK-NEXT:         _d_temp = 0.;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -130,11 +130,11 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     *_d_i += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         j = _t1;
-// CHECK-NEXT:         update1_pullback(i, j, &*_d_i, &*_d_j);
+// CHECK-NEXT:         update1_pullback(i, j, _d_i, _d_j);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         j = _t0;
-// CHECK-NEXT:         update1_pullback(i, j, &*_d_i, &*_d_j);
+// CHECK-NEXT:         update1_pullback(i, j, _d_i, _d_j);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -366,8 +366,8 @@ double fn7(double i, double j) {
 // CHECK-NEXT:         double _r_d0 = _d_k;
 // CHECK-NEXT:         *_d_j += 7 * _r_d0;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     identity_pullback(j, &*_d_j);
-// CHECK-NEXT:     identity_pullback(i, &*_d_i);
+// CHECK-NEXT:     identity_pullback(j, _d_j);
+// CHECK-NEXT:     identity_pullback(i, _d_i);
 // CHECK-NEXT: }
 
 double check_and_return(double x, char c, const char* s) {
@@ -441,7 +441,7 @@ double fn9(double x, double y) {
 // CHECK:void fn9_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        double _r0 = 0.;
-// CHECK-NEXT:        custom_max_pullback(x * y, y, 1, &_r0, &*_d_y);
+// CHECK-NEXT:        custom_max_pullback(x * y, y, 1, &_r0, _d_y);
 // CHECK-NEXT:        *_d_x += _r0 * y;
 // CHECK-NEXT:        *_d_y += x * _r0;
 // CHECK-NEXT:    }
@@ -519,7 +519,7 @@ double fn11(double x, double y) {
 }
 
 // CHECK: void fn11_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:    clad::custom_derivatives::n1::sum_pullback(x, y, 1, &*_d_x, &*_d_y);
+// CHECK-NEXT:    clad::custom_derivatives::n1::sum_pullback(x, y, 1, _d_x, _d_y);
 // CHECK-NEXT: }
 
 double do_nothing(double* u, double* v, double* w) {
@@ -535,7 +535,7 @@ double fn12(double x, double y) {
 }
 
 // CHECK: void fn12_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     do_nothing_pullback(&x, nullptr, 0, 1, &*_d_x, nullptr, 0);
+// CHECK-NEXT:     do_nothing_pullback(&x, nullptr, 0, 1, _d_x, nullptr, 0);
 // CHECK-NEXT: }
 
 double multiply(double* a, double* b) {
@@ -683,7 +683,7 @@ double fn17 (double x, const double* y) {
 //CHECK-NEXT:         double _r_d1 = *_d_x;
 //CHECK-NEXT:         *_d_x = 0.;
 //CHECK-NEXT:         double _r1 = 0.;
-//CHECK-NEXT:         add_pullback(x, &x, _r_d1, &_r1, &*_d_x);
+//CHECK-NEXT:         add_pullback(x, &x, _r_d1, &_r1, _d_x);
 //CHECK-NEXT:         *_d_x += _r1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
@@ -770,7 +770,7 @@ double fn21(double x) {
 }
 
 // CHECK: void fn21_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double *_d_ptr = &*_d_x;
+// CHECK-NEXT:     double *_d_ptr = _d_x;
 // CHECK-NEXT:     double *ptr = &x;
 // CHECK-NEXT:     ptrRef_pullback(ptr, 1, &_d_ptr);
 // CHECK-NEXT: }
@@ -837,7 +837,7 @@ double fn24(double x) {
 // CHECK-NEXT:      *_d_x += 1;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          x = _t0;
-// CHECK-NEXT:          unused_return_pullback(x, 0., &*_d_x);
+// CHECK-NEXT:          unused_return_pullback(x, 0., _d_x);
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
  

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -248,7 +248,7 @@ int main() {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0.;
   // CHECK-NEXT:         double _r1 = 0.;
-  // CHECK-NEXT:         fn.operator_call_pullback(i, j, 1, &(*_d_fn), &_r0, &_r1);
+  // CHECK-NEXT:         fn.operator_call_pullback(i, j, 1, _d_fn, &_r0, &_r1);
   // CHECK-NEXT:         *_d_i += _r0;
   // CHECK-NEXT:         *_d_j += _r1;
   // CHECK-NEXT:     }
@@ -265,7 +265,7 @@ int main() {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0.;
   // CHECK-NEXT:         double _r1 = 0.;
-  // CHECK-NEXT:         fn.operator_call_pullback(i, j, _d_y, &(*_d_fn), &_r0, &_r1);
+  // CHECK-NEXT:         fn.operator_call_pullback(i, j, _d_y, _d_fn, &_r0, &_r1);
   // CHECK-NEXT:         *_d_i += _r0;
   // CHECK-NEXT:         *_d_j += _r1;
   // CHECK-NEXT:     }

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -1078,9 +1078,9 @@ double f_ref_in_rhs(double x, double y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _cond0 = x != 55;
 //CHECK-NEXT:         if (_cond0) {
-//CHECK-NEXT:             _d_ref_x = &*_d_x;
+//CHECK-NEXT:             _d_ref_x = _d_x;
 //CHECK-NEXT:             ref_x = &x;
-//CHECK-NEXT:             _d_ref_y = &*_d_y;
+//CHECK-NEXT:             _d_ref_y = _d_y;
 //CHECK-NEXT:             ref_y = &y;
 //CHECK-NEXT:             goto _label0;
 //CHECK-NEXT:         }

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -2120,8 +2120,8 @@ double fn34(double x, double y){
 //CHECK-NEXT:     double *i = nullptr;
 //CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d___begin1) {
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _d_i = &*_d___begin1;
-//CHECK-NEXT:             i = &*__begin1;
+//CHECK-NEXT:             _d_i = _d___begin1;
+//CHECK-NEXT:             i = __begin1;
 //CHECK-NEXT:             clad::push(_t1, i);
 //CHECK-NEXT:             clad::push(_t2, _d_i);
 //CHECK-NEXT:         }
@@ -2191,8 +2191,8 @@ double fn35(double x, double y){
 // CHECK-NEXT:     double *i = nullptr;
 // CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d___begin1) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             _d_i = &*_d___begin1;
-// CHECK-NEXT:             i = &*__begin1;
+// CHECK-NEXT:             _d_i = _d___begin1;
+// CHECK-NEXT:             i = __begin1;
 // CHECK-NEXT:             clad::push(_t5, i);
 // CHECK-NEXT:             clad::push(_t6, _d_i);
 // CHECK-NEXT:         }
@@ -2207,8 +2207,8 @@ double fn35(double x, double y){
 // CHECK-NEXT:         double *j = nullptr;
 // CHECK-NEXT:         for (; __begin2 != __end2; ++__begin2 , ++_d___begin2) {
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 _d_j = &*_d___begin2;
-// CHECK-NEXT:                 j = &*__begin2;
+// CHECK-NEXT:                 _d_j = _d___begin2;
+// CHECK-NEXT:                 j = __begin2;
 // CHECK-NEXT:                 clad::push(_t3, j);
 // CHECK-NEXT:                 clad::push(_t4, _d_j);
 // CHECK-NEXT:             }

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -458,12 +458,12 @@ double fn2(SimpleFunctions& sf, double i) {
 
 // CHECK: void fn2_grad(SimpleFunctions &sf, double i, SimpleFunctions *_d_sf, double *_d_i) {
 // CHECK-NEXT:     SimpleFunctions _t0 = sf;
-// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = sf.ref_mem_fn_reverse_forw(i, &(*_d_sf), 0.);
+// CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t1 = sf.ref_mem_fn_reverse_forw(i, _d_sf, 0.);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t1.adjoint += 1;
 // CHECK-NEXT:         sf = _t0;
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         sf.ref_mem_fn_pullback(i, &(*_d_sf), &_r0);
+// CHECK-NEXT:         sf.ref_mem_fn_pullback(i, _d_sf, &_r0);
 // CHECK-NEXT:         *_d_i += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -495,12 +495,12 @@ double fn5(SimpleFunctions& v, double value) {
 
 // CHECK: void fn5_grad(SimpleFunctions &v, double value, SimpleFunctions *_d_v, double *_d_value) {
 // CHECK-NEXT:     SimpleFunctions _t0 = v;
-// CHECK-NEXT:     v.operator_plus_equal_reverse_forw(value, &(*_d_v), 0.);
+// CHECK-NEXT:     v.operator_plus_equal_reverse_forw(value, _d_v, 0.);
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         v = _t0;
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         v.operator_plus_equal_pullback(value, &(*_d_v), &_r0);
+// CHECK-NEXT:         v.operator_plus_equal_pullback(value, _d_v, &_r0);
 // CHECK-NEXT:         *_d_value += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -526,11 +526,11 @@ double fn4(SimpleFunctions& v) {
 
 // CHECK: void fn4_grad(SimpleFunctions &v, SimpleFunctions *_d_v) {
 // CHECK-NEXT:     SimpleFunctions _t0 = v;
-// CHECK-NEXT:     v.operator_plus_plus_reverse_forw(&(*_d_v));
+// CHECK-NEXT:     v.operator_plus_plus_reverse_forw(_d_v);
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         v = _t0;
-// CHECK-NEXT:         v.operator_plus_plus_pullback(&(*_d_v));
+// CHECK-NEXT:         v.operator_plus_plus_pullback(_d_v);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -585,7 +585,7 @@ double fn6(double u, double v) {
 // CHECK-NEXT:      SafeTestClass s1(_t0.value);
 // CHECK-NEXT:      SafeTestClass _d_s1(_t0.adjoint);
 // CHECK-NEXT:      SafeTestClass s2(u, &v);
-// CHECK-NEXT:      SafeTestClass _d_s2(0., &*_d_v);
+// CHECK-NEXT:      SafeTestClass _d_s2(0., _d_v);
 // CHECK-NEXT:      double _t1 = w;
 // CHECK-NEXT:      SafeTestClass s3(w);
 // CHECK-NEXT:      SafeTestClass _d_s3(_d_w);
@@ -593,7 +593,7 @@ double fn6(double u, double v) {
 // CHECK-NEXT:      w = _t1;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;  
-// CHECK-NEXT:          SafeTestClass::constructor_pullback(u, &v, &_d_s2, &_r0, &*_d_v);
+// CHECK-NEXT:          SafeTestClass::constructor_pullback(u, &v, &_d_s2, &_r0, _d_v);
 // CHECK-NEXT:          *_d_u += _r0;
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
@@ -668,7 +668,7 @@ double fn10(double x, double y) {
 // CHECK-NEXT:          S _r0 = {0., false};
 // CHECK-NEXT:          ((s - 4 * x) - y).getVal_pullback(1, &_r0);
 // CHECK-NEXT:          S _r1 = {0., false};
-// CHECK-NEXT:          (s - 4 * x).operator_minus_pullback(y, _r0, &_r1, &*_d_y);
+// CHECK-NEXT:          (s - 4 * x).operator_minus_pullback(y, _r0, &_r1, _d_y);
 // CHECK-NEXT:          double _r2 = 0.;
 // CHECK-NEXT:          s.operator_minus_pullback(4 * x, _r1, &_d_s, &_r2);
 // CHECK-NEXT:          *_d_x += 4 * _r2;
@@ -761,7 +761,7 @@ float fn12(const B b, const float* in) {
 // CHECK-NEXT:      float res = 0;
 // CHECK-NEXT:      b.scale(in, &res);
 // CHECK-NEXT:      _d_res += 1;
-// CHECK-NEXT:      b.scale_pullback(in, &res, &(*_d_b), &_d_res);
+// CHECK-NEXT:      b.scale_pullback(in, &res, _d_b, &_d_res);
 // CHECK-NEXT:  }
 
 int main() {

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -23,7 +23,7 @@ double minimalPointer(double x) {
 }
 
 // CHECK: void minimalPointer_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double *_d_p = &*_d_x;
+// CHECK-NEXT:     double *_d_p = _d_x;
 // CHECK-NEXT:     double *const p = &x;
 // CHECK-NEXT:     double _t0 = *p;
 // CHECK-NEXT:     *p = *p * *p;
@@ -434,7 +434,7 @@ double listInitPtrFn (double x, double y) {
 }
 
 // CHECK:  void listInitPtrFn_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:      double *_d_ptr{&*_d_x};
+// CHECK-NEXT:      double *_d_ptr{_d_x};
 // CHECK-NEXT:      double *ptr{&x};
 // CHECK-NEXT:      *ptr += y;
 // CHECK-NEXT:      *_d_ptr += 1;

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -382,11 +382,11 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         vec = _t1;
-// CHECK-NEXT:         {{.*}}class_functions::push_back_pullback(&vec, v, &_d_vec, &*_d_v);
+// CHECK-NEXT:         {{.*}}class_functions::push_back_pullback(&vec, v, &_d_vec, _d_v);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         vec = _t0;
-// CHECK-NEXT:         {{.*}}class_functions::push_back_pullback(&vec, u, &_d_vec, &*_d_u);
+// CHECK-NEXT:         {{.*}}class_functions::push_back_pullback(&vec, u, &_d_vec, _d_u);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -411,11 +411,11 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         vec = _t1;
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::push_back_pullback(&vec, v, &_d_vec, &*_d_v);
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::push_back_pullback(&vec, v, &_d_vec, _d_v);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         vec = _t0;
-// CHECK-NEXT:         clad::custom_derivatives::class_functions::push_back_pullback(&vec, u, &_d_vec, &*_d_u);
+// CHECK-NEXT:         clad::custom_derivatives::class_functions::push_back_pullback(&vec, u, &_d_vec, _d_u);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -539,7 +539,7 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{.*}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:         {{.*}}constructor_pullback(count, u, allocator, &_d_vec, &_r0, &*_d_u, &_d_allocator);
+// CHECK-NEXT:         {{.*}}constructor_pullback(count, u, allocator, &_d_vec, &_r0, _d_u, &_d_allocator);
 // CHECK-NEXT:         _d_count += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_u += _d_res;
@@ -564,11 +564,11 @@ int main() {
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              a = _t1;
-// CHECK-NEXT:              {{.*}}push_back_pullback(&a, x, &_d_a, &*_d_x);
+// CHECK-NEXT:              {{.*}}push_back_pullback(&a, x, &_d_a, _d_x);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              a = _t0;
-// CHECK-NEXT:              {{.*}}push_back_pullback(&a, x, &_d_a, &*_d_x);
+// CHECK-NEXT:              {{.*}}push_back_pullback(&a, x, &_d_a, _d_x);
 // CHECK-NEXT:          }
 // CHECK-NEXT:      }
 
@@ -596,7 +596,7 @@ int main() {
 // CHECK-NEXT:        }
 // CHECK-NEXT:        {
 // CHECK-NEXT:            a = _t0;
-// CHECK-NEXT:            {{.*}}fill_pullback(&a, x, &_d_a, &*_d_x);
+// CHECK-NEXT:            {{.*}}fill_pullback(&a, x, &_d_a, _d_x);
 // CHECK-NEXT:        }
 // CHECK-NEXT: }
 
@@ -722,7 +722,7 @@ int main() {
 // CHECK-NEXT:          {
 // CHECK-NEXT:              v = _t4;
 // CHECK-NEXT:              {{.*size_type|size_t}} _r2 = {{0U|0UL|0}};
-// CHECK-NEXT:              {{.*}}assign_pullback(&v, 2, y, &_d_v, &_r2, &*_d_y);
+// CHECK-NEXT:              {{.*}}assign_pullback(&v, 2, y, &_d_v, &_r2, _d_y);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              v = _t3;
@@ -740,7 +740,7 @@ int main() {
 // CHECK-NEXT:          for (; _t0; _t0--) {
 // CHECK-NEXT:              {
 // CHECK-NEXT:                  v = {{.*}}back(_t1);
-// CHECK-NEXT:                  {{.*}}push_back_pullback(&v, x, &_d_v, &*_d_x);
+// CHECK-NEXT:                  {{.*}}push_back_pullback(&v, x, &_d_v, _d_x);
 // CHECK-NEXT:                  {{.*}}pop(_t1);
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -771,7 +771,7 @@ int main() {
 // CHECK-NEXT:          v = _t3;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              v = _t2;
-// CHECK-NEXT:              {{.*}}push_back_pullback(&v, x, &_d_v, &*_d_x);
+// CHECK-NEXT:              {{.*}}push_back_pullback(&v, x, &_d_v, _d_x);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          *_d_x += _d_res * _t1;
 // CHECK-NEXT:          v = _t0;
@@ -1080,7 +1080,7 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         x = _t0;
-// CHECK-NEXT:         clad::custom_derivatives::std::make_shared_pullback(x, _d_x_ptr, &*_d_x);
+// CHECK-NEXT:         clad::custom_derivatives::std::make_shared_pullback(x, _d_x_ptr, _d_x);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -1109,7 +1109,7 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         x = _t0;
-// CHECK-NEXT:         clad::custom_derivatives::std::make_shared_pullback(x, _d_s_ptr, &*_d_x);
+// CHECK-NEXT:         clad::custom_derivatives::std::make_shared_pullback(x, _d_s_ptr, _d_x);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -115,7 +115,7 @@ double fn2(Tangent t, double i) {
 // CHECK-NEXT:         *_d_i += _r_d0;
 // CHECK-NEXT:         (*_d_t).data[0] += 2 * _r_d0;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     sum_pullback(t, _d_res, &(*_d_t));
+// CHECK-NEXT:     sum_pullback(t, _d_res, _d_t);
 // CHECK-NEXT: }
 
 double fn3(double i, double j) {
@@ -200,7 +200,7 @@ double fn5(const Tangent& t, double i) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         double _r1 = 0.;
-// CHECK-NEXT:         t.someMemFn2_pullback(i, i, 1, &(*_d_t), &_r0, &_r1);
+// CHECK-NEXT:         t.someMemFn2_pullback(i, i, 1, _d_t, &_r0, &_r1);
 // CHECK-NEXT:         *_d_i += _r0;
 // CHECK-NEXT:         *_d_i += _r1;
 // CHECK-NEXT:     }
@@ -243,16 +243,16 @@ double fn6(dcomplex c, double i) {
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         c.real_pullback(4 * _r_d0, &(*_d_c));
+// CHECK-NEXT:         c.real_pullback(4 * _r_d0, _d_c);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         c.real_pullback(_d_res, &(*_d_c));
-// CHECK-NEXT:         c.imag_pullback(3 * _d_res, &(*_d_c));
+// CHECK-NEXT:         c.real_pullback(_d_res, _d_c);
+// CHECK-NEXT:         c.imag_pullback(3 * _d_res, _d_c);
 // CHECK-NEXT:         *_d_i += 6 * _d_res;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         c.real_pullback(5 * i, &(*_d_c), &_r0);
+// CHECK-NEXT:         c.real_pullback(5 * i, _d_c, &_r0);
 // CHECK-NEXT:         *_d_i += 5 * _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -267,14 +267,14 @@ double fn7(dcomplex c1, dcomplex c2) {
 // CHECK-NEXT:     c1.real(c2.imag() + 5 * _t0);
 // CHECK-NEXT:     double _t1 = c1.imag();
 // CHECK-NEXT:     {
-// CHECK-NEXT:         c1.real_pullback(1, &(*_d_c1));
-// CHECK-NEXT:         c1.imag_pullback(3 * 1, &(*_d_c1));
+// CHECK-NEXT:         c1.real_pullback(1, _d_c1);
+// CHECK-NEXT:         c1.imag_pullback(3 * 1, _d_c1);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         c1.real_pullback(c2.imag() + 5 * _t0, &(*_d_c1), &_r0);
-// CHECK-NEXT:         c2.imag_pullback(_r0, &(*_d_c2));
-// CHECK-NEXT:         c2.real_pullback(5 * _r0, &(*_d_c2));
+// CHECK-NEXT:         c1.real_pullback(c2.imag() + 5 * _t0, _d_c1, &_r0);
+// CHECK-NEXT:         c2.imag_pullback(_r0, _d_c2);
+// CHECK-NEXT:         c2.real_pullback(5 * _r0, _d_c2);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -304,11 +304,11 @@ double fn8(Tangent t, dcomplex c) {
 
 // CHECK: void fn8_grad(Tangent t, dcomplex c, Tangent *_d_t, dcomplex *_d_c) {
 // CHECK-NEXT:     t.updateTo(c.real());
-// CHECK-NEXT:     sum_pullback(t, 1, &(*_d_t));
+// CHECK-NEXT:     sum_pullback(t, 1, _d_t);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         t.updateTo_pullback(c.real(), &(*_d_t), &_r0);
-// CHECK-NEXT:         c.real_pullback(_r0, &(*_d_c));
+// CHECK-NEXT:         t.updateTo_pullback(c.real(), _d_t, &_r0);
+// CHECK-NEXT:         c.real_pullback(_r0, _d_c);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -336,13 +336,13 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d1 = _d_res;
-// CHECK-NEXT:         sum_pullback(t, _r_d1, &(*_d_t));
+// CHECK-NEXT:         sum_pullback(t, _r_d1, _d_t);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = _d_res;
-// CHECK-NEXT:             c.real_pullback(_r_d0, &(*_d_c));
-// CHECK-NEXT:             c.imag_pullback(2 * _r_d0, &(*_d_c));
+// CHECK-NEXT:             c.real_pullback(_r_d0, _d_c);
+// CHECK-NEXT:             c.imag_pullback(2 * _r_d0, _d_c);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -359,7 +359,7 @@ double fn10(double x, double y) {
 }
 
 // CHECK: void fn10_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     A<double>::PtrType _d_ptr = &*_d_x;
+// CHECK-NEXT:     A<double>::PtrType _d_ptr = _d_x;
 // CHECK-NEXT:     A<double>::PtrType ptr = &x;
 // CHECK-NEXT:     ptr[0] += 6;
 // CHECK-NEXT:     *_d_ptr += 1;
@@ -388,7 +388,7 @@ double fn11(double x, double y) {
 // CHECK-NEXT:     Tangent _d_t;
 // CHECK-NEXT:     clad::zero_init(_d_t);
 // CHECK-NEXT:     t.data[0] = -y;
-// CHECK-NEXT:     operator_plus_pullback(x, t, 1, &*_d_x, &_d_t);
+// CHECK-NEXT:     operator_plus_pullback(x, t, 1, _d_x, &_d_t);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_t.data[0];
 // CHECK-NEXT:         _d_t.data[0] = 0.;
@@ -433,11 +433,11 @@ MyStruct fn12(MyStruct s) {  // expected-warning {{clad::gradient only supports 
 
 // CHECK: void fn12_grad(MyStruct s, MyStruct *_d_s) {
 // CHECK-NEXT:     MyStruct _t0 = s;
-// CHECK-NEXT:     s.operator_equal_reverse_forw({2 * s.a, 2 * s.b + 2}, &(*_d_s), {0., 0.});
+// CHECK-NEXT:     s.operator_equal_reverse_forw({2 * s.a, 2 * s.b + 2}, _d_s, {0., 0.});
 // CHECK-NEXT:    {
 // CHECK-NEXT:        s = _t0;
 // CHECK-NEXT:        MyStruct _r0 = {0., 0.};
-// CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, &(*_d_s), &_r0);
+// CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, _d_s, &_r0);
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;
 // CHECK-NEXT:    }
@@ -721,11 +721,11 @@ void fn20(MyStruct s) {
 
 // CHECK: void fn20_grad(MyStruct s, MyStruct *_d_s) {
 // CHECK-NEXT:     MyStruct _t0 = s;
-// CHECK-NEXT:     s.operator_equal_reverse_forw({2 * s.a, 2 * s.b + 2}, &(*_d_s), {0., 0.});
+// CHECK-NEXT:     s.operator_equal_reverse_forw({2 * s.a, 2 * s.b + 2}, _d_s, {0., 0.});
 // CHECK-NEXT:    {
 // CHECK-NEXT:        s = _t0;
 // CHECK-NEXT:        MyStruct _r0 = {0., 0.};
-// CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, &(*_d_s), &_r0);
+// CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, _d_s, &_r0);
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;
 // CHECK-NEXT:    }
@@ -971,7 +971,7 @@ double fn26(double x, double y) {
 
 // CHECK:  void fn26_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      ptrClass p(&x);
-// CHECK-NEXT:      ptrClass _d_p(&*_d_x);
+// CHECK-NEXT:      ptrClass _d_p(_d_x);
 // CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t0 = p.operator_star_reverse_forw(&_d_p);
 // CHECK-NEXT:      _t0.adjoint += 1;
 // CHECK-NEXT:  }
@@ -1153,7 +1153,7 @@ double fn31(double x, double y) {
 }
 
 // CHECK:  void fn31_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:      PtrAndValAggr _d_s = {0., &*_d_y};
+// CHECK-NEXT:      PtrAndValAggr _d_s = {0., _d_y};
 // CHECK-NEXT:      PtrAndValAggr s = {x, &y};
 // CHECK-NEXT:      {
 // CHECK-NEXT:          _d_s.x += 1;
@@ -1169,7 +1169,7 @@ double fn32(double x, double y) {
 
 // CHECK:  void fn32_grad(double x, double y, double *_d_x, double *_d_y) {
 //// Note: {{ is represented with {{[{][{]}} because of regex
-// CHECK-NEXT:      PtrAndValAggr _d_s[2] = {{[{][{]}}0., &*_d_x}, {0., &*_d_y{{[}][}]}};
+// CHECK-NEXT:      PtrAndValAggr _d_s[2] = {{[{][{]}}0., _d_x}, {0., _d_y{{[}][}]}};
 // CHECK-NEXT:      PtrAndValAggr s[2] = {{[{][{]}}x, &x}, {y, &y{{[}][}]}};
 // CHECK-NEXT:      {
 // CHECK-NEXT:          _d_s[0].x += 1;


### PR DESCRIPTION
We often automatically generate expressions like `&*_d_x`. Removing this is a trivial optimization we can do when building unary operators.