### PR TITLE
Generate constructor_reverse_forw automatically

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -429,6 +429,9 @@ namespace clad {
     bool isLinearConstructor(const clang::CXXConstructorDecl* CD,
                              const clang::ASTContext& C);
 
+    bool isElidableConstructor(const clang::CXXConstructorDecl* CD,
+                               const clang::ASTContext& C);
+
     /// Returns true if T allows to edit any memory.
     bool isMemoryType(clang::QualType T);
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -447,8 +447,10 @@ namespace clad {
     ///
     /// \param[in] thisTy `this` type.
     ///
+    /// \param[in] isDerivedThis if true, will build `_d_this`.
+    ///
     /// \returns {_this, free(_this)}
-    StmtDiff BuildThisExpr(clang::QualType thisTy);
+    StmtDiff BuildThisExpr(clang::QualType thisTy, bool isDerivedThis = false);
 
     /// Helper function that checks whether the function to be derived
     /// is meant to be executed only by the GPU

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -466,6 +466,21 @@ size_pushforward(const ::std::array<T, N>* a,
 // vector reverse mode
 // more can be found in tests: test/Gradient/STLCustomDerivatives.C
 
+template <typename T, typename... Args>
+clad::ValueAndAdjoint<::std::vector<T>, ::std::vector<T>>
+constructor_reverse_forw(clad::Tag<::std::vector<T>>,
+                         Args...) elidable_reverse_forw;
+
+template <typename T, typename... Args>
+clad::ValueAndAdjoint<::std::allocator<T>, ::std::allocator<T>>
+constructor_reverse_forw(clad::Tag<::std::allocator<T>>,
+                         Args...) elidable_reverse_forw;
+
+template <typename T, typename U, typename... Args>
+clad::ValueAndAdjoint<::std::pair<T, U>, ::std::pair<T, U>>
+constructor_reverse_forw(clad::Tag<::std::pair<T, U>>,
+                         Args...) elidable_reverse_forw;
+
 template <typename T, typename U, typename pU>
 void push_back_reverse_forw(::std::vector<T>* v, U val, ::std::vector<T>* d_v,
                             pU /*d_val*/) {

--- a/include/clad/Differentiator/ThrustBuiltins.h
+++ b/include/clad/Differentiator/ThrustBuiltins.h
@@ -8,6 +8,8 @@
 
 namespace clad {
 
+#define elidable_reverse_forw __attribute__((annotate("elidable_reverse_forw")))
+
 // zero_init for thrust::device_vector
 template <class T> inline void zero_init(::thrust::device_vector<T>& v) {
   ::thrust::fill(v.begin(), v.end(), T(0)); // NOLINT(misc-include-cleaner)
@@ -16,6 +18,14 @@ template <class T> inline void zero_init(::thrust::device_vector<T>& v) {
 namespace custom_derivatives::class_functions {
 
 // Constructors (reverse mode pullbacks)
+
+template <typename T>
+clad::ValueAndAdjoint<::thrust::device_vector<T>, ::thrust::device_vector<T>>
+constructor_reverse_forw(clad::Tag<::thrust::device_vector<T>>,
+                         typename ::thrust::device_vector<T>::size_type count,
+                         const T& val,
+                         typename ::thrust::device_vector<T>::size_type d_count,
+                         const T& d_val) elidable_reverse_forw;
 
 template <typename T>
 inline void
@@ -28,6 +38,13 @@ constructor_pullback(typename ::thrust::device_vector<T>::size_type count,
     (*d_this)[i] = T(0);
   }
 }
+
+template <typename T>
+clad::ValueAndAdjoint<::thrust::device_vector<T>, ::thrust::device_vector<T>>
+constructor_reverse_forw(clad::Tag<::thrust::device_vector<T>>,
+                         typename ::thrust::device_vector<T>::size_type count,
+                         typename ::thrust::device_vector<T>::size_type d_count)
+    elidable_reverse_forw;
 
 template <typename T>
 inline void

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1456,7 +1456,10 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     forwPassRequest.BaseFunctionName = "constructor";
     forwPassRequest.Mode = DiffMode::reverse_mode_forward_pass;
     forwPassRequest.CallContext = E;
-    if (LookupCustomDerivativeDecl(forwPassRequest))
+    QualType recordTy = CD->getThisType()->getPointeeType();
+    bool elideRevForw =
+        utils::isElidableConstructor(CD, m_Sema.getASTContext());
+    if (LookupCustomDerivativeDecl(forwPassRequest) || !elideRevForw)
       m_DiffRequestGraph.addNode(forwPassRequest, /*isSource=*/true);
 
     // Don't build propagators for calls that do not contribute in
@@ -1488,7 +1491,6 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     if (request.Function->getDefinition())
       request.Function = request.Function->getDefinition();
 
-    QualType recordTy = CD->getThisType()->getPointeeType();
     if (m_Sema.isStdInitializerList(recordTy, /*elemType=*/nullptr))
       return true;
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -466,7 +466,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         StmtDiff CI_diff = DifferentiateCtorInit(CI, thisObj.getExpr());
         addToCurrentBlock(CI_diff.getStmt(), direction::forward);
         if (Stmt* unwrappedCIDiff =
-                utils::unwrapIfSingleStmt(CI_diff.getStmt_dx()))
+                utils::unwrapIfSingleStmt(CI_diff.getRevSweepStmt()))
           initsDiff.push_back(unwrappedCIDiff);
       }
     }
@@ -506,7 +506,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       m_ExternalSource->ActOnEndOfDerivedFnBody();
   }
 
-  StmtDiff ReverseModeVisitor::BuildThisExpr(QualType thisTy) {
+  StmtDiff ReverseModeVisitor::BuildThisExpr(QualType thisTy,
+                                             bool isDerivedThis /*=false*/) {
     // Build `sizeof(T)`
     QualType recordTy = thisTy->getPointeeType();
     TypeSourceInfo* TSI = m_Context.getTrivialTypeSourceInfo(recordTy, noLoc);
@@ -522,12 +523,19 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     init = m_Sema.BuildCStyleCastExpr(noLoc, ptr_TSI, noLoc, init).get();
 
     // Build T* _this = (T*)malloc(sizeof(T));
-    VarDecl* thisDecl = BuildGlobalVarDecl(thisTy, "_this", init);
+    std::string name = isDerivedThis ? "_d_this" : "_this";
+    VarDecl* thisDecl = BuildGlobalVarDecl(thisTy, name, init);
     addToCurrentBlock(BuildDeclStmt(thisDecl), direction::forward);
 
     param[0] = BuildDeclRef(thisDecl);
-    Expr* freeCall = GetFunctionCall("free", "", param);
-    return {BuildDeclRef(thisDecl), freeCall};
+    Expr* setCall = nullptr;
+    if (isDerivedThis) {
+      llvm::SmallVector<Expr*, 3> args = {BuildDeclRef(thisDecl),
+                                          getZeroInit(m_Context.IntTy), size};
+      setCall = GetFunctionCall("memset", "", args);
+    } else
+      setCall = GetFunctionCall("free", "", param);
+    return {BuildDeclRef(thisDecl), setCall};
   }
 
   StmtDiff ReverseModeVisitor::VisitCXXTryStmt(const CXXTryStmt* TS) {
@@ -581,7 +589,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       }
       CompoundStmt* block = endBlock(direction::reverse);
       std::reverse(block->body_begin(), block->body_end());
-      return {initCall, utils::unwrapIfSingleStmt(block)};
+      return {initCall, nullptr, block};
     }
     llvm::StringRef fieldName = CI->getMember()->getName();
     Expr* memberDiff = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
@@ -597,12 +605,17 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     StmtDiff initDiff = Visit(CI->getInit(), memberDiff);
     addToCurrentBlock(initDiff.getStmt_dx(), direction::reverse);
     Stmt* init = nullptr;
+    Stmt* initDx = nullptr;
     if (thisExpr) {
       Expr* member = utils::BuildMemberExpr(m_Sema, getCurrentScope(), thisExpr,
                                             fieldName);
       init = BuildOp(BO_Assign, member, initDiff.getExpr());
+      Expr* memberDx = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                              m_ThisExprDerivative, fieldName);
+      if (!memberDx->getType()->isRealType())
+        initDx = BuildOp(BO_Assign, memberDx, initDiff.getExpr_dx());
     }
-    return {init, endBlock(direction::reverse)};
+    return {init, initDx, endBlock(direction::reverse)};
   }
 
   void ReverseModeVisitor::DifferentiateWithEnzyme() {
@@ -3037,6 +3050,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       else if (!isNonAggrClass)
         assignToZero = BuildOp(BinaryOperatorKind::BO_Assign, declRef,
                                getZeroInit(VDDerivedType));
+      else {
+        StmtDiff pushPop = StoreAndRestore(
+            BuildDeclRef(VDDerived), /*prefix=*/"_t", /*moveToTape=*/true);
+        addToCurrentBlock(pushPop.getStmt(), direction::forward);
+        addToCurrentBlock(pushPop.getStmt_dx(), direction::reverse);
+      }
       if (!keepLocal)
         addToCurrentBlock(assignToZero, direction::reverse);
     }
@@ -3093,38 +3112,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
 
     // Update the initializer
-    if (VDDerived) {
-      if (initDiff.getStmt_dx()) {
-        SetDeclInit(VDDerived, initDiff.getExpr_dx(), isDirectInit);
-      } else if (shouldCopyInitialize) {
-        Expr* copyExpr = BuildDeclRef(VDClone);
-        QualType origTy = VDClone->getType();
-        if (isInsideLoop) {
-          StmtDiff pushPop = StoreAndRestore(
-              BuildDeclRef(VDDerived), /*prefix=*/"_t", /*moveToTape=*/true);
-          addToCurrentBlock(pushPop.getStmt(), direction::forward);
-          addToCurrentBlock(pushPop.getStmt_dx(), direction::reverse);
-        }
-        // if VDClone is volatile, we have to use const_cast to be able to use
-        // most copy constructors.
-        if (origTy.isVolatileQualified()) {
-          Qualifiers quals(origTy.getQualifiers());
-          quals.removeVolatile();
-          QualType castTy = m_Sema.BuildQualifiedType(
-              origTy.getUnqualifiedType(), noLoc, quals);
-          castTy = m_Context.getLValueReferenceType(castTy);
-          SourceRange range = utils::GetValidSRange(m_Sema);
-          copyExpr =
-              m_Sema
-                  .BuildCXXNamedCast(noLoc, tok::kw_const_cast,
-                                     m_Context.getTrivialTypeSourceInfo(
-                                         castTy, utils::GetValidSLoc(m_Sema)),
-                                     copyExpr, range, range)
-                  .get();
-        }
-        SetDeclInit(VDDerived, copyExpr, /*DirectInit=*/true);
-      }
-    }
+    if (VDDerived)
+      SetDeclInit(VDDerived, initDiff.getExpr_dx(), isDirectInit);
 
     // FIXME: Currently, we handle promoteToFnScope for objects in
     // VisitDeclStmts. For other types, we do it in DifferentiateVarDecl. We
@@ -3346,15 +3335,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       addToBlock(BuildDeclStmt(declsToZeroInit), block);
       for (Decl* decl : declsToZeroInit) {
         auto* vDecl = cast<VarDecl>(decl);
-        // Adjoints are initialized with copy-constructors only as a part of
-        // the strategy to maintain the structure of the original variable.
-        // In such cases, we need to zero-initialize the adjoint. e.g.
-        // ```
-        // std::vector<...> v{x, y, z};
-        // std::vector<...> _d_v{v};
-        // clad::zero_init(_d_v); // this line is generated below
-        // ```
-        bool copyInit = false;
         if (Expr* init = vDecl->getInit()) {
           if (promoteToFnScope) {
             auto* declRef = BuildDeclRef(vDecl);
@@ -3363,27 +3343,26 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             SetDeclInit(vDecl, getZeroInit(vDecl->getType()),
                         /*DirectInit=*/true);
           }
-          if (const auto* CE =
-                  dyn_cast<CXXConstructExpr>(init->IgnoreImplicit())) {
-            copyInit = CE && CE->getNumArgs() == 0;
-            if (!copyInit && CE) {
-              if (const auto* DRE =
-                      dyn_cast<DeclRefExpr>(CE->getArg(0)->IgnoreImplicit())) {
-                llvm::StringRef OrigName =
-                    cast<VarDecl>(DRE->getDecl())->getName();
-                std::string CleanName = "_d_" + OrigName.ltrim('_').str();
-                if (cast<VarDecl>(decl)->getNameAsString() == CleanName)
-                  copyInit = true;
-              }
-            }
-          }
+          // if (const auto* CE =
+          //         dyn_cast<CXXConstructExpr>(init->IgnoreImplicit())) {
+          //   copyInit = CE && CE->getNumArgs() == 0;
+          //   if (!copyInit && CE) {
+          //     if (const auto* DRE =
+          //             dyn_cast<DeclRefExpr>(CE->getArg(0)->IgnoreImplicit()))
+          //             {
+          //       llvm::StringRef OrigName =
+          //           cast<VarDecl>(DRE->getDecl())->getName();
+          //       std::string CleanName = "_d_" + OrigName.ltrim('_').str();
+          //       if (cast<VarDecl>(decl)->getNameAsString() == CleanName)
+          //         copyInit = true;
+          //     }
+          //   }
+          // }
         }
-        const auto* VAT =
-            dyn_cast<VariableArrayType>(cast<VarDecl>(decl)->getType());
-        if (copyInit || VAT) {
-          llvm::SmallVector<Expr*, 1> args{BuildDeclRef(vDecl)};
-          if (VAT)
-            args.push_back(Clone(VAT->getSizeExpr()));
+        if (const auto* VAT =
+                dyn_cast<VariableArrayType>(cast<VarDecl>(decl)->getType())) {
+          llvm::SmallVector<Expr*, 2> args{BuildDeclRef(vDecl),
+                                           Clone(VAT->getSizeExpr())};
           Stmt* initCall = GetCladZeroInit(args);
           addToCurrentBlock(initCall, direction::forward);
         }
@@ -3508,7 +3487,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       clonedME = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
                                         baseDiff.getExpr(), fieldName);
     if (clad::utils::hasNonDifferentiableAttribute(ME)) {
-      auto* zero = ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context,
+      auto* zero = ConstantFolder::synthesizeLiteral(ME->getType(), m_Context,
                                                      /*val=*/0);
       return {clonedME, zero};
     }
@@ -4506,6 +4485,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       }
     }
 
+    DiffRequest forwPassReq;
+    forwPassReq.Function = CD;
+    forwPassReq.Mode = DiffMode::reverse_mode_forward_pass;
+    forwPassReq.BaseFunctionName = "constructor";
+    FunctionDecl* constrForw = FindDerivedFunction(forwPassReq);
+    bool elideReverseForw =
+        constrForw && utils::hasElidableReverseForwAttribute(constrForw);
+
     for (std::size_t i = 0, e = CE->getNumArgs(); i != e; ++i) {
       const Expr* arg = CE->getArg(i);
       const ParmVarDecl* PVD = CD->getParamDecl(i);
@@ -4515,7 +4502,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         continue;
       adjointArgs.push_back(argDiff.getExpr_dx());
       primalArgs.push_back(argDiff.getExpr());
-      reverseForwAdjointArgs.push_back(argDiff.getRevSweepAsExpr());
+      if (elideReverseForw && PVD->getType()->isIntegerType())
+        reverseForwAdjointArgs.push_back(argDiff.getExpr());
+      else
+        reverseForwAdjointArgs.push_back(argDiff.getRevSweepAsExpr());
     }
 
     const CXXRecordDecl* RD = CD->getParent();
@@ -4597,13 +4587,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // SomeClass _d_c = _t0.adjoint;
     // SomeClass c = _t0.value;
     // ```
-    DiffRequest forwPassReq;
-    forwPassReq.Function = CD;
-    forwPassReq.Mode = DiffMode::reverse_mode_forward_pass;
-    forwPassReq.BaseFunctionName = "constructor";
-    FunctionDecl* constrForw = FindDerivedFunction(forwPassReq);
-    bool elideReverseForw =
-        constrForw && utils::hasElidableReverseForwAttribute(constrForw);
     if (constrForw && !elideReverseForw) {
       reverseForwAdjointArgs.insert(reverseForwAdjointArgs.begin(),
                                     primalArgs.begin(), primalArgs.end());
@@ -4633,25 +4616,20 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       }
       return {val, adjoint};
     }
+    assert((elideReverseForw ||
+            utils::isElidableConstructor(CD, m_Sema.getASTContext())) &&
+           "No reverse_forw for a non-elidable constructor.");
 
     // Aggregate constructors are always element-wise initializers.
-    // This means we can always copy/default initialize the adjoint too.
-    if (RD->isAggregate()) {
-      if (CD->isDefaultConstructor())
-        return {nullptr, getZeroInit(m_Context.getRecordType(RD))};
-      assert(CD->isCopyOrMoveConstructor() &&
-             "unexpected aggregate constructor.");
-      return {primalArgs[0], reverseForwAdjointArgs[0]};
-    }
+    if (RD->isAggregate() && CD->isDefaultConstructor())
+      return {nullptr, getZeroInit(m_Context.getRecordType(RD))};
 
     // `CXXConstructExpr` node will be created automatically by passing these
     // initialiser to higher level `ActOn`/`Build` Sema functions.
     Expr* callClone =
         BuildConstructorCall(m_Sema, CE, primalArgs, m_TrackVarDeclConstructor);
-    Expr* callDiff = nullptr;
-    if (elideReverseForw)
-      callDiff = BuildConstructorCall(m_Sema, CE, reverseForwAdjointArgs,
-                                      m_TrackVarDeclConstructor);
+    Expr* callDiff = BuildConstructorCall(m_Sema, CE, reverseForwAdjointArgs,
+                                          m_TrackVarDeclConstructor);
     return {callClone, callDiff};
   }
 

--- a/test/Gradient/Cladtorch.C
+++ b/test/Gradient/Cladtorch.C
@@ -57,6 +57,14 @@ float fn1(
   std::vector<cladtorch::Tensor> v{{u, b}};
   return v[1].data;
 }
+
+// CHECK: static inline constexpr void constructor_pullback(const {{.*}}Tensor &arg, cladtorch::Tensor *_d_this, {{.*}}Tensor *_d_arg) noexcept {
+// CHECK-NEXT:     {
+// CHECK-NEXT:         (*_d_arg).data += _d_this->data;
+// CHECK-NEXT:         _d_this->data = 0.F;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
 // CHECK: void fn1_grad_0(const cladtorch::Tensor &t, const cladtorch::Tensor &u, no_namespace o, decltype(anon) a, {{.*}}anon_namespace z, not_found::Tensor w, cladtorch::Tensor *_d_t) {
 // CHECK-NEXT:     {{.*}}cladtorch::Tensor _d_u(u);
 // CHECK-NEXT:     no_namespace _d_o = {0.F};
@@ -64,11 +72,9 @@ float fn1(
 // CHECK-NEXT:     anon_namespace _d_z = {0.F};
 // CHECK-NEXT:     not_found::Tensor _d_w = {0.F};
 // CHECK-NEXT:     {{.*}}cladtorch::Tensor b = t;
-// CHECK-NEXT:     {{.*}}cladtorch::Tensor _d_b(b);
-// CHECK-NEXT:     clad::zero_init(_d_b);
+// CHECK-NEXT:     {{.*}}cladtorch::Tensor _d_b = (*_d_t);
 // CHECK-NEXT:     {{.*}}std::vector<cladtorch::Tensor> v{{.*}}{u, b}{{.*}};
-// CHECK-NEXT:     {{.*}}std::vector<cladtorch::Tensor> _d_v(v);
-// CHECK-NEXT:     clad::zero_init(_d_v);
+// CHECK-NEXT:     {{.*}}std::vector<cladtorch::Tensor> _d_v{{.*}}{_d_u, _d_b}{{.*}};
 // CHECK-NEXT:     _d_v[1].data += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         clad::array<{{cladtorch::Tensor|std::vector<cladtorch::Tensor, std::allocator<cladtorch::Tensor> >::value_type}}> _r0 = {{2U|2UL}};

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -228,8 +228,7 @@ int main() {
 
   // CHECK: void CallFunctor_grad(double i, double j, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     Experiment E(3, 5);
-  // CHECK-NEXT:     Experiment _d_E(E);
-  // CHECK-NEXT:     clad::zero_init(_d_E);
+  // CHECK-NEXT:     Experiment _d_E(0, 0);
   // CHECK-NEXT:     {
   // CHECK-NEXT:         double _r0 = 0.;
   // CHECK-NEXT:         double _r1 = 0.;
@@ -285,10 +284,9 @@ int main() {
 
   // CHECK: void FunctorAsArgWrapper_grad(double i, double j, double *_d_i, double *_d_j) {
   // CHECK-NEXT:     Experiment E(3, 5);
-  // CHECK-NEXT:     Experiment _d_E(E);
-  // CHECK-NEXT:     clad::zero_init(_d_E);
+  // CHECK-NEXT:     Experiment _d_E(0, 0);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         Experiment _r0 = {};
+  // CHECK-NEXT:         Experiment _r0 = _d_E;
   // CHECK-NEXT:         double _r1 = 0.;
   // CHECK-NEXT:         double _r2 = 0.;
   // CHECK-NEXT:         FunctorAsArg_pullback(E, i, j, 1, &_r0, &_r1, &_r2);

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -913,8 +913,7 @@ int main() {
 // CHECK-NEXT:     double _d_x = 0.;
 // CHECK-NEXT:     double _d_y = 0.;
 // CHECK-NEXT:     SimpleFunctions sf(x, y);
-// CHECK-NEXT:     SimpleFunctions _d_sf(sf);
-// CHECK-NEXT:     clad::zero_init(_d_sf);
+// CHECK-NEXT:     SimpleFunctions _d_sf(0., 0.);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r2 = 0.;
 // CHECK-NEXT:         double _r3 = 0.;

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -169,6 +169,7 @@ int main() {
   TEST_FUNC(fn_non_diff_call, 3, 5) // CHECK-EXEC: 5.00 3.00
 
   TEST_FUNC(fn_non_diff_param_call, 3, 5) // CHECK-EXEC: 1.00 0.00
+
     // CHECK: void mem_fn_1_pullback(double i, double j, double _d_y, SimpleFunctions1 *_d_this, double *_d_i, double *_d_j) {
     // CHECK-NEXT:     {
     // CHECK-NEXT:         _d_this->x += _d_y * i;
@@ -181,8 +182,7 @@ int main() {
 
     // CHECK: void fn_s1_mem_fn_grad(double i, double j, double *_d_i, double *_d_j) {
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
-    // CHECK-NEXT:     SimpleFunctions1 _d_obj(obj);
-    // CHECK-NEXT:     clad::zero_init(_d_obj);
+    // CHECK-NEXT:     SimpleFunctions1 _d_obj(0, 0);
     // CHECK-NEXT:     {
     // CHECK-NEXT:         double _r0 = 0.;
     // CHECK-NEXT:         double _r1 = 0.;
@@ -196,8 +196,7 @@ int main() {
     
     // CHECK: void fn_s1_field_grad(double i, double j, double *_d_i, double *_d_j) {
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
-    // CHECK-NEXT:     SimpleFunctions1 _d_obj(obj);
-    // CHECK-NEXT:     clad::zero_init(_d_obj);
+    // CHECK-NEXT:     SimpleFunctions1 _d_obj(0, 0);
     // CHECK-NEXT:     {
     // CHECK-NEXT:         _d_obj.x += 1 * obj.y;
     // CHECK-NEXT:         *_d_i += 1 * j;
@@ -207,8 +206,7 @@ int main() {
     
     // CHECK: void fn_s1_field_pointer_grad(double i, double j, double *_d_i, double *_d_j) {
     // CHECK-NEXT:     SimpleFunctions1 obj(2, 3);
-    // CHECK-NEXT:     SimpleFunctions1 _d_obj(obj);
-    // CHECK-NEXT:     clad::zero_init(_d_obj);
+    // CHECK-NEXT:     SimpleFunctions1 _d_obj(0, 0);
     // CHECK-NEXT:     {
     // CHECK-NEXT:         *_d_obj.x_pointer += 1 * *obj.y_pointer;
     // CHECK-NEXT:         *_d_i += 1 * j;

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -383,7 +383,6 @@ int main() {
 // CHECK: void fn1_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:     std::vector<double> vec;
 // CHECK-NEXT:     std::vector<double> _d_vec;
-// CHECK-NEXT:     clad::zero_init(_d_vec);
 // CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
 // CHECK-NEXT:     std::vector<double> _t1 = vec;
@@ -405,7 +404,6 @@ int main() {
 // CHECK-NEXT: void fn2_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:     std::vector<double> vec;
 // CHECK-NEXT:     std::vector<double> _d_vec;
-// CHECK-NEXT:     clad::zero_init(_d_vec);
 // CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, u, &_d_vec, *_d_u);
 // CHECK-NEXT:     std::vector<double> _t1 = vec;
@@ -446,7 +444,6 @@ int main() {
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     std::vector<double> vec;
 // CHECK-NEXT:     std::vector<double> _d_vec;
-// CHECK-NEXT:     clad::zero_init(_d_vec);
 // CHECK-NEXT:     std::vector<double> _t0 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 3, &_d_vec, 0);
 // CHECK-NEXT:     {
@@ -538,12 +535,10 @@ int main() {
 // CHECK-NEXT:     double res = u;
 // CHECK-NEXT:     {{.*}}allocator_type allocator;
 // CHECK-NEXT:     {{.*}}allocator_type _d_allocator;
-// CHECK-NEXT:     clad::zero_init(_d_allocator);
 // CHECK-NEXT:     {{.*}} _d_count = {{0U|0UL}};
 // CHECK-NEXT:     {{.*}} count = 3;
 // CHECK-NEXT:     std::vector<double> vec(count, u, allocator);
-// CHECK-NEXT:     std::vector<double> _d_vec(vec);
-// CHECK-NEXT:     clad::zero_init(_d_vec);
+// CHECK-NEXT:     std::vector<double> _d_vec(count, *_d_u, _d_allocator);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_vec[0] += 1;
 // CHECK-NEXT:         _d_vec[1] += 1;
@@ -560,7 +555,6 @@ int main() {
 // CHECK:      void fn5_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:          std::vector<double> a;
 // CHECK-NEXT:          std::vector<double> _d_a;
-// CHECK-NEXT:          clad::zero_init(_d_a);
 // CHECK-NEXT:          std::vector<double> _t0 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, x, &_d_a, *_d_x);
 // CHECK-NEXT:          std::vector<double> _t1 = a;
@@ -707,7 +701,6 @@ int main() {
 // CHECK-NEXT:          size_t i0 = {{0U|0UL|0}};
 // CHECK-NEXT:          {{.*}}vector<double> v;
 // CHECK-NEXT:          {{.*}}vector<double> _d_v;
-// CHECK-NEXT:          clad::zero_init(_d_v);
 // CHECK-NEXT:          {{.*}} _t0 = {{0U|0UL|0}};
 // CHECK-NEXT:          for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:              _t0++;
@@ -761,7 +754,6 @@ int main() {
 // CHECK:      void fn11_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:          {{.*}}vector<double> v;
 // CHECK-NEXT:          {{.*}}vector<double> _d_v;
-// CHECK-NEXT:          clad::zero_init(_d_v);
 // CHECK-NEXT:          {{.*}}vector<double> _t0 = v;
 // CHECK-NEXT:          {{.*}}reserve_reverse_forw(&v, 10, &_d_v, 0);
 // CHECK-NEXT:          double _t1 = v.capacity();
@@ -792,7 +784,6 @@ int main() {
 // CHECK:      void fn12_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:          std::vector<double> a;
 // CHECK-NEXT:          std::vector<double> _d_a;
-// CHECK-NEXT:          clad::zero_init(_d_a);
 // CHECK-NEXT:          std::vector<double> _t0 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, 0, &_d_a, 0);
 // CHECK-NEXT:          {{.*}}value_type *_t1 = &a[0];
@@ -814,10 +805,8 @@ int main() {
 // CHECK:      void fn13_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:      std::vector<double>::allocator_type alloc;
 // CHECK-NEXT:      std::vector<double>::allocator_type _d_alloc;
-// CHECK-NEXT:      clad::zero_init(_d_alloc);
 // CHECK-NEXT:      std::vector<double> ls({u, v}, alloc);
-// CHECK-NEXT:      std::vector<double> _d_ls(ls);
-// CHECK-NEXT:      clad::zero_init(_d_ls);
+// CHECK-NEXT:      std::vector<double> _d_ls({0., 0.}, _d_alloc);
 // CHECK-NEXT:      {{.*}}value_type _t0 = ls[0];
 // CHECK-NEXT:      {
 // CHECK-NEXT:          ls[1] += 1;
@@ -841,14 +830,12 @@ int main() {
 // CHECK-NEXT:      clad::tape<{{.*}}value_type *> _t3 = {};
 // CHECK-NEXT:      {{.*}}allocator_type alloc;
 // CHECK-NEXT:      {{.*}}allocator_type _d_alloc;
-// CHECK-NEXT:      clad::zero_init(_d_alloc);
 // CHECK-NEXT:      unsigned {{int|long|long long}} _t0 = 0;
 // CHECK-NEXT:      for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:          _t0++;
 // CHECK-NEXT:          clad::push(_t1, std::move(_d_ls));
 // CHECK-NEXT:          clad::push(_t2, std::move(ls)) , ls = {u, v}, alloc;
-// CHECK-NEXT:          _d_ls = ls;
-// CHECK-NEXT:          clad::zero_init(_d_ls);
+// CHECK-NEXT:          _d_ls = {0., 0.}, _d_alloc;
 // CHECK-NEXT:          clad::push(_t3, &ls[1]);
 // CHECK-NEXT:          *clad::back(_t3) += ls[0];
 // CHECK-NEXT:          u = ls[1];
@@ -901,7 +888,6 @@ int main() {
 // CHECK-NEXT:     clad::tape<double> _t3 = {};
 // CHECK-NEXT:     {{.*}}allocator_type alloc;
 // CHECK-NEXT:     {{.*}}allocator_type _d_alloc;
-// CHECK-NEXT:     clad::zero_init(_d_alloc);
 // CHECK-NEXT:     double _d_prod = 0.;
 // CHECK-NEXT:     double prod = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
@@ -909,8 +895,7 @@ int main() {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, std::move(_d_vec));
 // CHECK-NEXT:         clad::push(_t2, std::move(vec)) , vec = i, v + u, alloc;
-// CHECK-NEXT:         _d_vec = vec;
-// CHECK-NEXT:         clad::zero_init(_d_vec);
+// CHECK-NEXT:         _d_vec = i, 0., _d_alloc;
 // CHECK-NEXT:         clad::push(_t3, prod);
 // CHECK-NEXT:         prod *= vec[i - 1];
 // CHECK-NEXT:     }
@@ -952,8 +937,7 @@ int main() {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, std::move(_d_ls));
 // CHECK-NEXT:         clad::push(_t2, std::move(ls)) , ls = {{.*{u, v}.*}};
-// CHECK-NEXT:         _d_ls = ls;
-// CHECK-NEXT:         clad::zero_init(_d_ls);
+// CHECK-NEXT:         _d_ls = {{.*}}{0., 0.}{{.*}};
 // CHECK-NEXT:         clad::push(_t3, &ls[1]);
 // CHECK-NEXT:         *clad::back(_t3) += ls[0];
 // CHECK-NEXT:         u = ls[1];
@@ -1165,8 +1149,7 @@ int main() {
 // CHECK: void fn24_grad(double x, double *_d_x) {
 // CHECK-NEXT:    double _t0 = x;
 // CHECK-NEXT:    std::pair<double, double> p(x, 1);
-// CHECK-NEXT:    std::pair<double, double> _d_p(p);
-// CHECK-NEXT:    clad::zero_init(_d_p);
+// CHECK-NEXT:    std::pair<double, double> _d_p(*_d_x, 0);
 // CHECK-NEXT:    _d_p.first += 1;
 // CHECK-NEXT:    {
 // CHECK-NEXT:        x = _t0;

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -128,7 +128,6 @@ double fn3(double i, double j) {
 // CHECK: void fn3_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     Tangent t;
 // CHECK-NEXT:     Tangent _d_t;
-// CHECK-NEXT:     clad::zero_init(_d_t);
 // CHECK-NEXT:     t.data[0] = 2 * i;
 // CHECK-NEXT:     t.data[1] = 5 * i + 3 * j;
 // CHECK-NEXT:     sum_pullback(t, 1, &_d_t);
@@ -153,11 +152,9 @@ double fn4(double i, double j) {
 
 // CHECK: void fn4_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:     pairdd p(1, 3);
-// CHECK-NEXT:     pairdd _d_p(p);
-// CHECK-NEXT:     clad::zero_init(_d_p);
+// CHECK-NEXT:     pairdd _d_p(0, 0);
 // CHECK-NEXT:     pairdd q{7, 5};
-// CHECK-NEXT:     pairdd _d_q(q);
-// CHECK-NEXT:     clad::zero_init(_d_q);
+// CHECK-NEXT:     pairdd _d_q{0, 0};
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_p.first += 1 * i;
 // CHECK-NEXT:         *_d_i += p.first * 1;
@@ -386,7 +383,6 @@ double fn11(double x, double y) {
 // CHECK: void fn11_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     Tangent t;
 // CHECK-NEXT:     Tangent _d_t;
-// CHECK-NEXT:     clad::zero_init(_d_t);
 // CHECK-NEXT:     t.data[0] = -y;
 // CHECK-NEXT:     operator_plus_pullback(x, t, 1, _d_x, &_d_t);
 // CHECK-NEXT:     {
@@ -583,8 +579,7 @@ public:
 
 // CHECK:  void operator_plus_pullback(const SimpleFunctions1 &other, SimpleFunctions1 _d_y, SimpleFunctions1 *_d_this, SimpleFunctions1 *_d_other) const {
 // CHECK-NEXT:      SimpleFunctions1 res(this->x + other.x, this->y + other.y);
-// CHECK-NEXT:      SimpleFunctions1 _d_res(res);
-// CHECK-NEXT:      clad::zero_init(_d_res);
+// CHECK-NEXT:      SimpleFunctions1 _d_res(0., 0.);
 // CHECK-NEXT:      SimpleFunctions1::constructor_pullback(std::move(res), &_d_y, &_d_res);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
@@ -605,11 +600,9 @@ double fn16(double i, double j) {
 
 // CHECK: void fn16_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:    SimpleFunctions1 obj1(2, 3);
-// CHECK-NEXT:    SimpleFunctions1 _d_obj1(obj1);
-// CHECK-NEXT:    clad::zero_init(_d_obj1);
+// CHECK-NEXT:    SimpleFunctions1 _d_obj1(0, 0);
 // CHECK-NEXT:    SimpleFunctions1 obj2(3, 5);
-// CHECK-NEXT:    SimpleFunctions1 _d_obj2(obj2);
-// CHECK-NEXT:    clad::zero_init(_d_obj2);
+// CHECK-NEXT:    SimpleFunctions1 _d_obj2(0, 0);
 // CHECK-NEXT:    {
 // CHECK-NEXT:        SimpleFunctions1 _r0 = {};
 // CHECK-NEXT:        double _r1 = 0.;
@@ -638,8 +631,7 @@ double fn17(double i, double j) {
 
 // CHECK: void fn17_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:    SimpleFunctions1 sf(3, 5);
-// CHECK-NEXT:    SimpleFunctions1 _d_sf(sf);
-// CHECK-NEXT:    clad::zero_init(_d_sf);
+// CHECK-NEXT:    SimpleFunctions1 _d_sf(0, 0);
 // CHECK-NEXT:    {
 // CHECK-NEXT:        double _r0 = 0.;
 // CHECK-NEXT:        double _r1 = 0.;
@@ -656,8 +648,7 @@ double fn18(double i, double j) {
 
 // CHECK:  void fn18_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:      SimpleFunctions1 sf(3 * i, 5 * j);
-// CHECK-NEXT:      SimpleFunctions1 _d_sf(sf);
-// CHECK-NEXT:      clad::zero_init(_d_sf);
+// CHECK-NEXT:      SimpleFunctions1 _d_sf(0., 0.);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r2 = 0.;
 // CHECK-NEXT:          double _r3 = 0.;
@@ -694,11 +685,9 @@ double fn19(double i, double j) {
 
 // CHECK:  void fn19_grad(double i, double j, double *_d_i, double *_d_j) {
 // CHECK-NEXT:      SimpleFunctions1 sf1(3, 5);
-// CHECK-NEXT:      SimpleFunctions1 _d_sf1(sf1);
-// CHECK-NEXT:      clad::zero_init(_d_sf1);
+// CHECK-NEXT:      SimpleFunctions1 _d_sf1(0, 0);
 // CHECK-NEXT:      SimpleFunctions1 sf2(i, j);
-// CHECK-NEXT:      SimpleFunctions1 _d_sf2(sf2);
-// CHECK-NEXT:      clad::zero_init(_d_sf2);
+// CHECK-NEXT:      SimpleFunctions1 _d_sf2(0., 0.);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          SimpleFunctions1 _r2 = {};
 // CHECK-NEXT:          double _r3 = 0.;
@@ -776,8 +765,7 @@ double fn22(double x){
 
 // CHECK:  void fn22_grad(double x, double *_d_x) {
 // CHECK-NEXT:      StructNoDefConstr t(0);
-// CHECK-NEXT:      StructNoDefConstr _d_t(t);
-// CHECK-NEXT:      clad::zero_init(_d_t);
+// CHECK-NEXT:      StructNoDefConstr _d_t(0);
 // CHECK-NEXT:      *_d_x += 1;
 // CHECK-NEXT:  }
 
@@ -886,8 +874,7 @@ double fn24(double x, double y) {
 
 // CHECK:  void fn24_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      Vector3 v(x, x, y);
-// CHECK-NEXT:      Vector3 _d_v(v);
-// CHECK-NEXT:      clad::zero_init(_d_v);
+// CHECK-NEXT:      Vector3 _d_v(0., 0., 0.);
 // CHECK-NEXT:      Vector3 w = 2 * v;
 // CHECK-NEXT:      Vector3 _d_w;
 // CHECK-NEXT:      _d_w.x += 1;
@@ -926,8 +913,7 @@ double fn25(double x, double y) {
 
 // CHECK:  void fn25_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      Vector3 v{x, x, y};
-// CHECK-NEXT:      Vector3 _d_v(v);
-// CHECK-NEXT:      clad::zero_init(_d_v);
+// CHECK-NEXT:      Vector3 _d_v{0., 0., 0.};
 // CHECK-NEXT:      Vector3 w = - v;
 // CHECK-NEXT:      Vector3 _d_w;
 // CHECK-NEXT:      _d_w.x += 1;
@@ -1042,7 +1028,7 @@ double fn28(double x, double y) {
 // CHECK-NEXT:      double z = vecSum({x, y, x});
 // CHECK-NEXT:      _d_z += 1;
 // CHECK-NEXT:      {
-// CHECK-NEXT:          Vector3 _r0 = {};
+// CHECK-NEXT:          Vector3 _r0 = {0., 0., 0.};
 // CHECK-NEXT:          vecSum_pullback({x, y, x}, _d_z, &_r0);
 // CHECK-NEXT:          double _r1 = 0.;
 // CHECK-NEXT:          double _r2 = 0.;
@@ -1329,8 +1315,7 @@ double fn36(double x, size_t n){
 // CHECK:  void fn36_grad_0(double x, size_t n, double *_d_x) {
 // CHECK-NEXT:      size_t _d_n = {{0U|0UL|0ULL}};
 // CHECK-NEXT:      PrivClass E(n);
-// CHECK-NEXT:      PrivClass _d_E(E);
-// CHECK-NEXT:      clad::zero_init(_d_E);
+// CHECK-NEXT:      PrivClass _d_E(0{{.*}});
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r1 = 0.;
 // CHECK-NEXT:          E.multiply_pullback(x, 1, &_d_E, &_r1);


### PR DESCRIPTION
This PR adds support for automatic constructor_reverse_forw. This solves the problem described in detail in issue #1577. By default, we generate constructor_reverse_forw for every constructor, which is the option that works in the general case. If possible, we detect that the constructor is elidable and simplify the code (the user can do it manually by adding the `elidable_reverse_forw` to the custom derivative).

Fixes #1577.