### PR TITLE
Replace iterator-based std::move with clad::move

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -197,6 +197,23 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
     for (std::size_t i = 0; i < N; ++i)
       zero_init(x[i]);
   }
+
+  // This function is similar to the iterator-based std::move but is designed to
+  // work with CUDA.
+  // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+  template <class T, size_t N>
+  CUDA_HOST_DEVICE void move(T (&&Input)[N], T* Output) {
+    for (T& elem : Input) {
+      *Output = std::forward<T>(elem);
+      ++Output;
+    }
+  }
+
+  // We cannot use forwarding references
+  template <class T, size_t N>
+  CUDA_HOST_DEVICE void move(T (&Input)[N], T* Output) {
+    move(std::move(Input), Output);
+  }
   // NOLINTEND(cppcoreguidelines-avoid-c-arrays)
 
   /// Pad the args supplied with nullptr(s) or zeros to match the the num of

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3390,25 +3390,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
   Expr* ReverseModeVisitor::BuildArrayAssignment(Expr* output, Expr* input,
                                                  direction d) {
-    // Build `type (&&_t0)[N] = input;`
-    QualType storeTy = input->getType();
-    if (input->isLValue())
-      storeTy = m_Context.getLValueReferenceType(storeTy);
-    else
-      storeTy = m_Context.getRValueReferenceType(storeTy);
-    input = StoreAndRef(input, storeTy, d);
-    llvm::SmallVector<Expr*, 1> argIn = {input};
-    // Build `std::begin(_t0)` and `std::end(_t0)`
-    Expr* beginIn = GetFunctionCall("begin", "std", argIn);
-    Expr* endIn = GetFunctionCall("end", "std", argIn);
-
     // Build `std::begin(_output)`
     llvm::SmallVector<Expr*, 1> argOut = {output};
     Expr* beginOut = GetFunctionCall("begin", "std", argOut);
 
-    // Build `std::move(std::begin(_t0), std::end(_t0), std::begin(_output));`
-    llvm::SmallVector<Expr*, 1> moveArgs = {beginIn, endIn, beginOut};
-    return GetFunctionCall("move", "std", moveArgs);
+    // Build `clad::move(_input, std::begin(_output));`
+    llvm::SmallVector<Expr*, 1> moveArgs = {input, beginOut};
+    return GetFunctionCall("move", "clad", moveArgs);
   }
 
   Expr* ReverseModeVisitor::GlobalStoreAndRef(Expr* E, llvm::StringRef prefix,

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -254,7 +254,7 @@ double func6(double seed) {
 //CHECK: void func6_grad(double seed, double *_d_seed) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     clad::tape<double{{ ?}}[3]> _t2 = {};
+//CHECK-NEXT:     clad::tape<double{{ ?}}[3]> _t1 = {};
 //CHECK-NEXT:     double _d_arr[3] = {0};
 //CHECK-NEXT:     double arr[3] = {0};
 //CHECK-NEXT:     double _d_sum = 0.;
@@ -262,8 +262,7 @@ double func6(double seed) {
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         double (&&_t1)[3] = {seed, seed * i, seed + i};
-//CHECK-NEXT:         clad::push(_t2, arr) , std::move(std::begin(_t1), std::end(_t1), std::begin(arr));
+//CHECK-NEXT:         clad::push(_t1, arr) , clad::move({seed, seed * i, seed + i}, std::begin(arr));
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
@@ -271,8 +270,8 @@ double func6(double seed) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             int _r1 = 0;
-//CHECK-NEXT:             addArr_pullback(arr, 3, _r_d0, _d_arr, &_r1);
+//CHECK-NEXT:             int _r0 = 0;
+//CHECK-NEXT:             addArr_pullback(arr, 3, _r_d0, _d_arr, &_r0);
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             *_d_seed += _d_arr[0];
@@ -281,9 +280,8 @@ double func6(double seed) {
 //CHECK-NEXT:             *_d_seed += _d_arr[2];
 //CHECK-NEXT:             _d_i += _d_arr[2];
 //CHECK-NEXT:             clad::zero_init(_d_arr);
-//CHECK-NEXT:             double &_r0[3] = clad::back(_t2);
-//CHECK-NEXT:             std::move(std::begin(_r0), std::end(_r0), std::begin(arr));
-//CHECK-NEXT:             clad::pop(_t2);
+//CHECK-NEXT:             clad::move(clad::back(_t1), std::begin(arr));
+//CHECK-NEXT:             clad::pop(_t1);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -318,14 +316,13 @@ double func7(double *params) {
 //CHECK-NEXT:     double _d_out = 0.;
 //CHECK-NEXT:     double out = 0.;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
-// CHECK-NEXT:     for (i = 0; i < 1; ++i) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         double (&&_t1)[1] = {params[0]};
-// CHECK-NEXT:         std::move(std::begin(_t1), std::end(_t1), std::begin(paramsPrime));
-// CHECK-NEXT:         out = out + inv_square(paramsPrime);
-// CHECK-NEXT:     }
-// CHECK-NEXT:     _d_out += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (i = 0; i < 1; ++i) {
+//CHECK-NEXT:         _t0++;
+//CHECK-NEXT:         clad::move({params[0]}, std::begin(paramsPrime));
+//CHECK-NEXT:         out = out + inv_square(paramsPrime);
+//CHECK-NEXT:     }
+//CHECK-NEXT:     _d_out += 1;
+//CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r_d0 = _d_out;
 //CHECK-NEXT:             _d_out = 0.;

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -1384,8 +1384,7 @@ double fn21(double x) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         double (&&_t1)[3] = {1, x, 2};
-// CHECK-NEXT:         std::move(std::begin(_t1), std::end(_t1), std::begin(arr));
+// CHECK-NEXT:         clad::move({1, x, 2}, std::begin(arr));
 // CHECK-NEXT:         res += arr[0] + arr[1];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
@@ -1415,7 +1414,7 @@ double fn22(double param) {
 // CHECK: void fn22_grad(double param, double *_d_param) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<double{{ ?}}[1]> _t2 = {};
+// CHECK-NEXT:     clad::tape<double{{ ?}}[1]> _t1 = {};
 // CHECK-NEXT:     double _d_arr[1] = {0};
 // CHECK-NEXT:     double arr[1] = {0};
 // CHECK-NEXT:     double _d_out = 0.;
@@ -1423,8 +1422,7 @@ double fn22(double param) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
 // CHECK-NEXT:     for (i = 0; i < 1; i++) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         double (&&_t1)[1] = {1.};
-// CHECK-NEXT:         clad::push(_t2, arr) , std::move(std::begin(_t1), std::end(_t1), std::begin(arr));
+// CHECK-NEXT:         clad::push(_t1, arr) , clad::move({1.}, std::begin(arr));
 // CHECK-NEXT:         out += arr[0] * param;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
@@ -1436,9 +1434,8 @@ double fn22(double param) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::zero_init(_d_arr);
-// CHECK-NEXT:             double &_r0[1] = clad::back(_t2);
-// CHECK-NEXT:             std::move(std::begin(_r0), std::end(_r0), std::begin(arr));
-// CHECK-NEXT:             clad::pop(_t2);
+// CHECK-NEXT:             clad::move(clad::back(_t1), std::begin(arr));
+// CHECK-NEXT:             clad::pop(_t1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }


### PR DESCRIPTION
We use the iterator-based `std::move` to perform assignments of whole arrays in the reverse mode. This PR reimplements it with `clad::move` to make it compatible with CUDA.

Fixes #1496