### PR TITLE
Wrap argumets when visiting std::forward into std::move

### DIFF
--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -872,14 +872,12 @@ template <typename... Args> auto make_tuple_pushforward(Args... args) noexcept {
 
 // std::forward custom derivatives
 template <class T>
-clad::ValueAndAdjoint<T&&, T&&> forward_reverse_forw(T&& t, T&& dt) {
-  return {::std::forward<T>(t), ::std::forward<T>(dt)};
-}
+clad::ValueAndAdjoint<T&&, T&&>
+    elidable_reverse_forw forward_reverse_forw(T&& t, T&& dt);
 
 template <class T>
-clad::ValueAndAdjoint<T&, T&> forward_reverse_forw(T& t, T& dt) {
-  return {t, dt};
-}
+clad::ValueAndAdjoint<T&, T&> elidable_reverse_forw forward_reverse_forw(T& t,
+                                                                         T& dt);
 
 template <class T>
 constexpr void forward_pullback(T&& t, T dy, T* dt) noexcept {

--- a/lib/Differentiator/ActivityAnalyzer.cpp
+++ b/lib/Differentiator/ActivityAnalyzer.cpp
@@ -128,9 +128,9 @@ void VariedAnalyzer::setVaried(const clang::Expr* E, bool isVaried) {
       if (curBranch.find(iterVD) == curBranch.end()) {
         if (VarData* data = getVarDataFromDecl(iterVD))
           curBranch[iterVD] = data->copy();
-        // else
-        //   // If this variable was not found in predecessors, add it.
-        //   addVar(iterVD);
+        else
+          // If this variable was not found in predecessors, add it.
+          addVar(iterVD);
       }
 
       VarData* data = getVarDataFromDecl(iterVD);

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -36,7 +36,6 @@
 #include "clang/Basic/LLVM.h" // isa, dyn_cast
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TokenKinds.h"
-#include "clang/Basic/Version.h"
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Overload.h"
 #include "clang/Sema/Scope.h"

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -386,22 +386,20 @@ double fn8(double u, double v) {
   return p.first + p.second;
 }
 
-// CHECK: static constexpr void constructor_pullback(double &__{{u1|x}}, double &__{{u2|y}}, std::pair<double, double> *_d_this, double *_d___{{u1|x}}, double *_d___{{u2|y}}) {{.*}}{
-// CHECK-NEXT:      std::pair<double, double> *_this = (std::pair<double, double> *)malloc(sizeof(std::pair<double, double>));
-// CHECK:           clad::ValueAndAdjoint<double &, double &> _t0 = clad::custom_derivatives::std::forward_reverse_forw(__{{u1|x}}, *_d___{{u1|x}}); 
-// CHECK-NEXT:      _this->first = _t0.value;
-// CHECK-NEXT:      clad::ValueAndAdjoint<double &, double &> _t1 = clad::custom_derivatives::std::forward_reverse_forw(__{{u2|y}}, *_d___{{u2|y}});
-// CHECK-NEXT:      _this->second = _t1.value;
-// CHECK:           {
-// CHECK-NEXT:          _t1.adjoint += _d_this->second;
-// CHECK-NEXT:          _d_this->second = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:      {
-// CHECK-NEXT:          _t0.adjoint += _d_this->first;
-// CHECK-NEXT:          _d_this->first = 0.;
-// CHECK-NEXT:      }
-// CHECK-NEXT:      free(_this);
-// CHECK-NEXT:  }
+// CHECK: static constexpr void constructor_pullback(double &__{{u1|x}}, double &__{{u2|y}}, std::pair<double, double> *_d_this, double *_d___{{u1|x}}, double *_d___{{u2|y}}){{.*}}{
+// CHECK-NEXT:     std::pair<double, double> *_this = (std::pair<double, double> *)malloc(sizeof(std::pair<double, double>));
+// CHECK:     _this->first = __{{u1|x}};
+// CHECK-NEXT:     _this->second = __{{u2|y}};
+// CHECK:     {
+// CHECK-NEXT:         *_d___{{u2|y}} += _d_this->second;
+// CHECK-NEXT:         _d_this->second = 0.;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d___{{u1|x}} += _d_this->first;
+// CHECK-NEXT:         _d_this->first = 0.;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     free(_this);
+// CHECK-NEXT: }
 
 // CHECK:  void fn8_grad(double u, double v, double *_d_u, double *_d_v) {
 // CHECK-NEXT:      double _t0 = u;


### PR DESCRIPTION
Previously when differentianting `std::forward` we would always choose one overload:
`ValueAndAdjoint<T&, T&> forward_reverse_forw(T& t, T& dt)`. We want to preserve the value categories of the arguments, so now we wrap them in `std::move` and manually find the right oveload of `forward_reverse_forw`.

Fixes: #1629