### PR TITLE
Store adjoints as decls in m_Variables in the reverse mode

### DIFF
--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -172,6 +172,10 @@ protected:
       llvm::SmallVectorImpl<clang::Expr*>& clonedArgs,
       llvm::SmallVectorImpl<clang::Expr*>& derivedArgs);
 
+  /// Map used to keep track of variable declarations and match them
+  /// with their derivatives.
+  std::unordered_map<const clang::ValueDecl*, clang::Expr*> m_Variables;
+
 private:
   /// Prepares the derivative function parameters.
   void

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -14,6 +14,7 @@
 #include "clad/Differentiator/ReverseModeVisitorDirectionKinds.h"
 #include "clad/Differentiator/VisitorBase.h"
 
+#include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
@@ -85,6 +86,9 @@ namespace clad {
     clang::Expr* m_CurrentBreakFlagExpr;
 
     clang::Expr* m_RestoreTracker = nullptr;
+    /// Map used to keep track of variable declarations and match them
+    /// with their derivatives.
+    std::unordered_map<const clang::ValueDecl*, clang::VarDecl*> m_Variables;
 
     unsigned outputArrayCursor = 0;
     unsigned numParams = 0;

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -125,9 +125,6 @@ namespace clad {
     clang::FunctionDecl* m_Derivative;
     /// The differentiation request that is being currently processed.
     const DiffRequest& m_DiffReq;
-    /// Map used to keep track of variable declarations and match them
-    /// with their derivatives.
-    std::unordered_map<const clang::ValueDecl*, clang::Expr*> m_Variables;
     /// Map contains variable declarations replacements. If the original
     /// function contains a declaration which name collides with something
     /// already created inside derivative's body, the declaration is replaced

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -182,17 +182,18 @@ void ErrorEstimationHandler::EmitFinalErrorStmts(
     llvm::SmallVectorImpl<ParmVarDecl*>& params, unsigned numParams) {
   // Emit error variables of parameters at the end.
   for (size_t i = 0; i < numParams; i++) {
-    auto* decl = cast<VarDecl>(params[i]);
+    ParmVarDecl* decl = params[i];
+    Expr* LdiffExpr = m_RMV->BuildDeclRef(m_RMV->m_Variables[decl]);
     if (ShouldEstimateErrorFor(decl)) {
       if (!m_RMV->isArrayOrPointerType(params[i]->getType())) {
+        LdiffExpr = m_RMV->BuildOp(UO_Deref, LdiffExpr);
         auto* paramClone = m_RMV->BuildDeclRef(decl);
         // Finally emit the error.
-        auto* errorExpr = GetError(paramClone, m_RMV->m_Variables[decl],
-                                   params[i]->getNameAsString());
+        auto* errorExpr =
+            GetError(paramClone, LdiffExpr, params[i]->getNameAsString());
         m_RMV->addToCurrentBlock(
             m_RMV->BuildOp(BO_AddAssign, BuildFinalErrorExpr(), errorExpr));
       } else {
-        auto LdiffExpr = m_RMV->m_Variables[decl];
         Expr* size = getSizeExpr(decl);
         VarDecl* idxExprDecl = nullptr;
         // Save our index expression so it can be used later.
@@ -340,7 +341,7 @@ void ErrorEstimationHandler::ActAfterProcessingArraySubscriptExpr(
     if (const auto* DRE =
             dyn_cast<DeclRefExpr>(ASE->getBase()->IgnoreImplicit())) {
       const auto* VD = cast<VarDecl>(DRE->getDecl());
-      Expr* VDdiff = m_RMV->m_Variables[VD];
+      VarDecl* VDdiff = m_RMV->m_Variables[VD];
       // We only need to track sizes for arrays and pointers.
       if (!utils::isArrayOrPointerType(VDdiff->getType()))
         return;

--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -155,7 +155,7 @@ ReverseModeForwPassVisitor::BuildParams(DiffParams& diffParams) {
       if (dPVD->getIdentifier())
         m_Sema.PushOnScopeChains(dPVD, getCurrentScope(),
                                  /*AddToContext=*/false);
-      m_Variables[*it] = BuildDeclRef(dPVD), m_DiffReq->getLocation();
+      m_Variables[*it] = dPVD;
     }
   }
   if (m_DiffReq.UseRestoreTracker) {
@@ -243,7 +243,7 @@ StmtDiff ReverseModeForwPassVisitor::VisitDeclRefExpr(const DeclRefExpr* DRE) {
   auto foundAdjoint = m_Variables.find(decl);
   Expr* adjoint = nullptr;
   if (foundAdjoint != m_Variables.end())
-    adjoint = foundAdjoint->second;
+    adjoint = BuildDeclRef(foundAdjoint->second);
 
   return StmtDiff(clonedDRE, adjoint);
 }
@@ -282,7 +282,7 @@ ReverseModeForwPassVisitor::DifferentiateVarDecl(const clang::VarDecl* VD,
   auto* VDDerived =
       BuildGlobalVarDecl(DerivedType, "_d_" + VD->getNameAsString(),
                          initDiff.getExpr_dx(), VD->isDirectInit());
-  m_Variables.emplace(VDCloned, BuildDeclRef(VDDerived));
+  m_Variables.emplace(VDCloned, VDDerived);
   if ((VD->getDeclName() != VDCloned->getDeclName() ||
        DerivedType != VD->getType()))
     m_DeclReplacements[VD] = VDCloned;

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -443,7 +443,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         auto* VDDerived =
             BuildGlobalVarDecl(VDDerivedType, "_d_" + param->getNameAsString(),
                                initExpr, isDirectInit);
-        m_Variables[param] = BuildDeclRef(VDDerived);
+        m_Variables[param] = VDDerived;
         addToBlock(BuildDeclStmt(VDDerived), m_Globals);
       }
     }
@@ -980,14 +980,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     beginBlock(direction::reverse);
     // Create all declarations needed.
-    DeclRefExpr* beginDeclRef = BuildDeclRef(VisitBegin.getDecl());
-    Expr* d_beginDeclRef = m_Variables[beginDeclRef->getDecl()];
+    DeclRefExpr* beginDeclRef = BuildDeclRef(VisitBegin.getDecl()); //// what
+    Expr* d_beginDeclRef = BuildDeclRef(VisitBegin.getDecl_dx());
     addToCurrentBlock(BuildDeclStmt(VisitRange.getDecl()));
-    if (VisitRange.getDecl_dx())
-      addToCurrentBlock(BuildDeclStmt(VisitRange.getDecl_dx()));
+    addToCurrentBlock(BuildDeclStmt(VisitRange.getDecl_dx()));
     addToCurrentBlock(BuildDeclStmt(VisitBegin.getDecl()));
-    if (VisitBegin.getDecl_dx())
-      addToCurrentBlock(BuildDeclStmt(VisitBegin.getDecl_dx()));
+    addToCurrentBlock(BuildDeclStmt(VisitBegin.getDecl_dx()));
 
     const auto* EndDecl = cast<VarDecl>(FRS->getEndStmt()->getSingleDecl());
     QualType endType = CloneType(EndDecl->getType());
@@ -1024,13 +1022,11 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     StmtDiff storeAdjLoop;
     if (LoopVDDiff.getDecl_dx())
       storeAdjLoop = StoreAndRestore(BuildDeclRef(LoopVDDiff.getDecl_dx()));
-    if (LoopVDDiff.getDecl_dx())
-      addToCurrentBlock(BuildDeclStmt(LoopVDDiff.getDecl_dx()));
+    addToCurrentBlock(BuildDeclStmt(LoopVDDiff.getDecl_dx()));
     Expr* loopInit = LoopVDDiff.getDecl()->getInit();
     SetDeclInit(LoopVDDiff.getDecl(),
                 getZeroInit(LoopVDDiff.getDecl()->getType()));
-    if (LoopVDDiff.getDecl())
-      addToCurrentBlock(BuildDeclStmt(LoopVDDiff.getDecl()));
+    addToCurrentBlock(BuildDeclStmt(LoopVDDiff.getDecl()));
     Expr* assignLoop =
         BuildOp(BO_Assign, BuildDeclRef(LoopVDDiff.getDecl()), loopInit);
 
@@ -1446,8 +1442,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // This case happens when ref-type variables have to become function
       // global. Ref-type declarations cannot be moved to the function global
       // scope because they can't be separated from their inits.
-      if (DRE->getDecl()->getType()->isReferenceType() &&
-          VD->getType()->isPointerType())
+      bool isPromotedToPointer = DRE->getDecl()->getType()->isReferenceType() &&
+                                 VD->getType()->isPointerType();
+      if (isPromotedToPointer)
         clonedDRE = BuildOp(UO_Deref, clonedDRE);
       // Check DeclRefExpr is a reference to an independent variable.
       auto it = m_Variables.find(VD);
@@ -1464,17 +1461,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           if (result.empty())
             return StmtDiff(clonedDRE);
           // Found, return a reference
-          Expr* foundExpr =
-              m_Sema
-                  .BuildDeclarationNameExpr(CXXScopeSpec{}, result,
-                                            /*ADL=*/false)
-                  .get();
-          it = m_Variables.emplace(VD, foundExpr).first;
+          auto* declDiff = cast<VarDecl>(result.getFoundDecl());
+          it = m_Variables.emplace(VD, declDiff).first;
           // On the start of computing every derivative, we have to reset the
           // global adjoint to zero in case it was used by another gradient.
           if (m_DiffReq.Mode == DiffMode::reverse) {
-            Expr* assignToZero = BuildOp(BO_Assign, Clone(foundExpr),
-                                         getZeroInit(foundExpr->getType()));
+            Expr* assignToZero = BuildOp(BO_Assign, BuildDeclRef(declDiff),
+                                         getZeroInit(declDiff->getType()));
             addToBlock(assignToZero, m_Globals);
           }
         } else
@@ -1484,10 +1477,23 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
       if (!it->second)
         return StmtDiff(clonedDRE);
+
+      clang::Expr* dExpr = BuildDeclRef(it->second);
+      // Ensure that parameters passed by value are always dereferenced on use.
+      // For example d_x in f(float x, float *d_x) should be used as (*d_x) to
+      // matching the type of the input x from the original function.
+      if (isa<ParmVarDecl>(VD) && !utils::isArrayOrPointerType(VD->getType()) &&
+          !llvm::is_contained(m_NonIndepParams, VD))
+        isPromotedToPointer = true;
+      if (isPromotedToPointer) {
+        dExpr = BuildOp(UO_Deref, dExpr);
+        if (dExpr->getType()->isRecordType())
+          dExpr = utils::BuildParenExpr(m_Sema, dExpr);
+      }
       // Create the (_d_param[idx] += dfdx) statement.
-      if (Expr* add_assign = BuildDiffIncrement(it->second))
+      if (Expr* add_assign = BuildDiffIncrement(dExpr))
         addToCurrentBlock(add_assign, direction::reverse);
-      return StmtDiff(clonedDRE, it->second);
+      return StmtDiff(clonedDRE, dExpr);
     }
 
     return StmtDiff(clonedDRE);
@@ -2674,7 +2680,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                  m_Globals);
       Expr* condVarRef = BuildDeclRef(condVar);
       Expr* assignExpr = BuildOp(BO_Assign, condVarRef, Clone(R));
-      m_Variables.emplace(condVar, BuildDeclRef(derivedCondVar));
+      m_Variables.emplace(condVar, derivedCondVar);
       auto* IfStmt = clad_compat::IfStmt_Create(
           /*Ctx=*/m_Context, /*IL=*/noLoc, /*IsConstexpr=*/false,
           /*Init=*/nullptr, /*Var=*/nullptr,
@@ -2852,9 +2858,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     VarDecl* VDClone = nullptr;
     Expr* derivedVDE = nullptr;
-    // FIXME: Sometimes, the derivative of `x` is not `_d_x` but `*_d_x`. We
-    // should handle this in VisitDeclRefExpr
-    Expr* valueDx = nullptr;
     if (VDDerived)
       derivedVDE = BuildDeclRef(VDDerived);
 
@@ -2866,11 +2869,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // double* ref;
     // ref = &x;
     if (isRefType && promoteToFnScope) {
-      // FIXME: Add extra parantheses if derived variable pointer is pointing to
-      // a class type object.
       initDiff = {BuildOp(UnaryOperatorKind::UO_AddrOf, initDiff.getExpr()),
                   BuildOp(UnaryOperatorKind::UO_AddrOf, initDiff.getExpr_dx())};
-      valueDx = BuildOp(UnaryOperatorKind::UO_Deref, derivedVDE);
       isPointerType = true;
     }
 
@@ -2941,10 +2941,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       }
     }
 
-    if (!valueDx)
-      valueDx = derivedVDE;
-    if (valueDx)
-      m_Variables.emplace(VDClone, valueDx);
+    m_Variables.emplace(VDClone, VDDerived);
 
     // Check if decl's name is the same as before. The name may be changed
     // if decl name collides with something in the derivative body.
@@ -4613,20 +4610,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       auto* dPVD = utils::BuildParmVarDecl(m_Sema, m_Derivative, II, dPVDTy,
                                            PVD->getStorageClass());
       m_Sema.PushOnScopeChains(dPVD, getCurrentScope(), /*AddToContext=*/false);
-      // Ensure that parameters passed by value are always dereferenced on use.
-      // For example d_x in f(float x, float *d_x) should be used as (*d_x) to
-      // matching the type of the input x from the original function.
-      if (utils::isArrayOrPointerType(oPVD->getType())) {
-        m_Variables[PVD] = BuildDeclRef(dPVD);
-
-      } else {
-        Expr* Deref =
-            BuildOp(UO_Deref, BuildDeclRef(dPVD), oPVD->getLocation());
-        if (dPVDTy->getPointeeType()->isRecordType())
-          Deref = utils::BuildParenExpr(m_Sema, Deref);
-        m_Variables[PVD] = Deref;
-      }
-
+      m_Variables[PVD] = dPVD;
       params.push_back(dPVD);
     }
   }

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -252,6 +252,8 @@ namespace clad {
   }
 
   DeclStmt* VisitorBase::BuildDeclStmt(Decl* D) {
+    if (!D)
+      return nullptr;
     Stmt* DS = m_Sema
                    .ActOnDeclStmt(m_Sema.ConvertDeclToDeclGroup(D),
                                   D->getBeginLoc(), D->getEndLoc())
@@ -267,6 +269,8 @@ namespace clad {
   DeclRefExpr* VisitorBase::BuildDeclRef(DeclaratorDecl* D,
                                          NestedNameSpecifier* NNS /*=nullptr*/,
                                          ExprValueKind VK /*=VK_LValue*/) {
+    if (!D)
+      return nullptr;
     CXXScopeSpec CSS;
     SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
 

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -713,7 +713,7 @@ double f23(double x, double y) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r_d0 = _d_res;
 //CHECK-NEXT:             _d_res = 0.;
-//CHECK-NEXT:             *(std::end(*_d_ref) - 1) += _r_d0;
+//CHECK-NEXT:             *(std::end((*_d_ref)) - 1) += _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {


### PR DESCRIPTION
Currently, we track the correspondance of the original variables and their adjoints in a map `m_Variables` as `x` --> `_d_x`. However, `x` is stored a decl and `_d_x` is stored as an expr. The latter results in us reusing the same `DeclRefExpr` of `_d_x`. Apart from that, it makes it hard to get the actual declaration of `_d_x`.