### PR TITLE
Add support for init lists of different length in clad::move

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -24,6 +24,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstring>
+#include <initializer_list>
 #include <iterator>
 #include <type_traits>
 #include <utility>
@@ -201,18 +202,22 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
   // This function is similar to the iterator-based std::move but is designed to
   // work with CUDA.
   // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+  // An overload to initialize arrays from buffers, e.g., `clad::move(t0, arr)`
   template <class T, size_t N>
-  CUDA_HOST_DEVICE void move(T (&&Input)[N], T* Output) {
-    for (T& elem : Input) {
-      *Output = std::forward<T>(elem);
-      ++Output;
-    }
+  CUDA_HOST_DEVICE void move(T* Input, T (&Output)[N]) {
+    for (size_t i = 0; i < N; ++i)
+      Output[i] = std::move(Input[i]);
   }
 
-  // We cannot use forwarding references
+  // An overload to initialize arrays with init lists, e.g., `clad::move({1, 2},
+  // arr)`
   template <class T, size_t N>
-  CUDA_HOST_DEVICE void move(T (&Input)[N], T* Output) {
-    move(std::move(Input), Output);
+  CUDA_HOST_DEVICE void move(std::initializer_list<T> Input, T (&Output)[N]) {
+    size_t i = 0;
+    for (auto it = Input.begin(); it != Input.end() && i < N; ++it, ++i)
+      Output[i] = *it;
+    for (; i < N; ++i)
+      Output[i] = T();
   }
   // NOLINTEND(cppcoreguidelines-avoid-c-arrays)
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3438,12 +3438,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
   Expr* ReverseModeVisitor::BuildArrayAssignment(Expr* output, Expr* input,
                                                  direction d) {
-    // Build `std::begin(_output)`
-    llvm::SmallVector<Expr*, 1> argOut = {output};
-    Expr* beginOut = GetFunctionCall("begin", "std", argOut);
-
-    // Build `clad::move(_input, std::begin(_output));`
-    llvm::SmallVector<Expr*, 1> moveArgs = {input, beginOut};
+    // Build `clad::move(_input, _output);`
+    llvm::SmallVector<Expr*, 1> moveArgs = {input, output};
     return GetFunctionCall("move", "clad", moveArgs);
   }
 

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -1384,7 +1384,7 @@ double fn21(double x) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::move({1, x, 2}, std::begin(arr));
+// CHECK-NEXT:         clad::move({1, x, 2}, arr);
 // CHECK-NEXT:         res += arr[0] + arr[1];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
@@ -1422,7 +1422,7 @@ double fn22(double param) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
 // CHECK-NEXT:     for (i = 0; i < 1; i++) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, arr) , clad::move({1.}, std::begin(arr));
+// CHECK-NEXT:         clad::push(_t1, arr) , clad::move({1.}, arr);
 // CHECK-NEXT:         out += arr[0] * param;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
@@ -1434,7 +1434,7 @@ double fn22(double param) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::zero_init(_d_arr);
-// CHECK-NEXT:             clad::move(clad::back(_t1), std::begin(arr));
+// CHECK-NEXT:             clad::move(clad::back(_t1), arr);
 // CHECK-NEXT:             clad::pop(_t1);
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }


### PR DESCRIPTION
After #1626, we started initializing arrays inside loops with clad::move. However, since the size of the array was deduced from the size of the init list, this change silently dropped support for decls like `double arr[10] = {0}`.