### PR TITLE
Pass the final error to error estimation pullbacks directly

### DIFF
--- a/include/clad/Differentiator/ErrorEstimator.h
+++ b/include/clad/Differentiator/ErrorEstimator.h
@@ -40,9 +40,9 @@ class ErrorEstimationHandler : public ExternalRMVSource {
   clang::Expr* m_IdxExpr;
   /// A map from var decls to their size variables (e.g. `var_size`).
   std::unordered_map<const clang::VarDecl*, clang::Expr*> m_ArrSizes;
-  /// An expression to match nested function call errors with their
-  /// assignee (if any exists).
-  clang::Expr* m_NestedFuncError = nullptr;
+  // FIXME: Solve this in a more general way.
+  /// A flag signaling if the current error comes from a function call.
+  bool m_ErrorFromFunctionCall = false;
 
   std::stack<bool> m_ShouldEmit;
   ReverseModeVisitor* m_RMV;
@@ -70,9 +70,7 @@ public:
   /// Function to emit error statements into the derivative body.
   ///
   /// \param[in] errorExpr The error expression (LHS) of the variable.
-  /// \param[in] addToTheFront A flag to decide whether the error stmts
-  /// should be added to the beginning of the block or the current position.
-  void AddErrorStmtToBlock(clang::Expr* errorExpr, bool addToTheFront = true);
+  void AddErrorStmtToBlock(clang::Expr* errorExpr);
 
   /// Emit the error estimation related statements that were saved to be
   /// emitted at later points into specific blocks.
@@ -192,8 +190,7 @@ public:
   void ActBeforeFinalizingDifferentiateSingleStmt(const direction& d) override;
   void ActBeforeFinalizingDifferentiateSingleExpr(const direction& d) override;
   void ActBeforeDifferentiatingCallExpr(
-      llvm::SmallVectorImpl<clang::Expr*>& pullbackArgs,
-      llvm::SmallVectorImpl<clang::Stmt*>& ArgDecls, bool hasAssignee) override;
+      llvm::SmallVectorImpl<clang::Expr*>& pullbackArgs) override;
   void ActBeforeFinalizingVisitDeclStmt(
       llvm::SmallVectorImpl<clang::Decl*>& decls,
       llvm::SmallVectorImpl<clang::Decl*>& declsDiff) override;

--- a/include/clad/Differentiator/ExternalRMVSource.h
+++ b/include/clad/Differentiator/ExternalRMVSource.h
@@ -141,8 +141,7 @@ public:
   virtual void ActBeforeFinalizingDifferentiateSingleExpr(const direction& d) {}
 
   virtual void ActBeforeDifferentiatingCallExpr(
-      llvm::SmallVectorImpl<clang::Expr*>& pullbackArgs,
-      llvm::SmallVectorImpl<clang::Stmt*>& ArgDecls, bool hasAssignee) {}
+      llvm::SmallVectorImpl<clang::Expr*>& pullbackArgs) {}
 
   virtual void ActBeforeFinalizingVisitDeclStmt(
       llvm::SmallVectorImpl<clang::Decl*>& decls,

--- a/include/clad/Differentiator/MultiplexExternalRMVSource.h
+++ b/include/clad/Differentiator/MultiplexExternalRMVSource.h
@@ -61,8 +61,7 @@ public:
   void ActBeforeFinalizingDifferentiateSingleStmt(const direction& d) override;
   void ActBeforeFinalizingDifferentiateSingleExpr(const direction& d) override;
   void ActBeforeDifferentiatingCallExpr(
-      llvm::SmallVectorImpl<clang::Expr*>& pullbackArgs,
-      llvm::SmallVectorImpl<clang::Stmt*>& ArgDecls, bool hasAssignee) override;
+      llvm::SmallVectorImpl<clang::Expr*>& pullbackArgs) override;
   void ActBeforeFinalizingVisitDeclStmt(
       llvm::SmallVectorImpl<clang::Decl*>& decls,
       llvm::SmallVectorImpl<clang::Decl*>& declsDiff) override;

--- a/lib/Differentiator/MultiplexExternalRMVSource.cpp
+++ b/lib/Differentiator/MultiplexExternalRMVSource.cpp
@@ -179,11 +179,9 @@ void MultiplexExternalRMVSource::ActBeforeFinalizingDifferentiateSingleExpr(
 }
 
 void MultiplexExternalRMVSource::ActBeforeDifferentiatingCallExpr(
-    llvm::SmallVectorImpl<clang::Expr*>& pullbackArgs,
-    llvm::SmallVectorImpl<clang::Stmt*>& ArgDecls, bool hasAssignee) {
+    llvm::SmallVectorImpl<clang::Expr*>& pullbackArgs) {
   for (auto source : m_Sources)
-    source->ActBeforeDifferentiatingCallExpr(pullbackArgs, ArgDecls,
-                                             hasAssignee);
+    source->ActBeforeDifferentiatingCallExpr(pullbackArgs);
 }
 
 void MultiplexExternalRMVSource::ActBeforeFinalizingVisitDeclStmt(

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2062,7 +2062,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                 pullbackRequest.DVI.push_back(PVD);
             }
             m_ExternalSource->ActBeforeDifferentiatingCallExpr(
-                pullbackCallArgs, PreCallStmts, dfdx());
+                pullbackCallArgs);
             pullbackFD =
                 plugin::ProcessDiffRequest(m_CladPlugin, pullbackRequest);
           } else

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -205,11 +205,9 @@ float func6(float x, float y) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0.;
 //CHECK-NEXT:         double _r1 = 0.;
-//CHECK-NEXT:         double _t0 = 0.;
-//CHECK-NEXT:         helper_pullback(x, y, _d_z, &_r0, &_r1, _t0);
+//CHECK-NEXT:         helper_pullback(x, y, _d_z, &_r0, &_r1, _final_error);
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:         *_d_y += _r1;
-//CHECK-NEXT:         _final_error += _t0;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
@@ -262,10 +260,8 @@ float func8(float x, float y) {
 //CHECK-NEXT:         z = _t0;
 //CHECK-NEXT:         *_d_y += _d_z;
 //CHECK-NEXT:         x = _t1;
-//CHECK-NEXT:         double _t2 = 0.;
-//CHECK-NEXT:         helper2_pullback(x, _d_z, _d_x, _t2);
+//CHECK-NEXT:         helper2_pullback(x, _d_z, _d_x, _final_error);
 //CHECK-NEXT:         _d_z = 0.F;
-//CHECK-NEXT:         _final_error += _t2;
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
@@ -279,44 +275,57 @@ float func9(float x, float y) {
 }
 
 //CHECK: void func9_grad(float x, float y, float *_d_x, float *_d_y, double &_final_error) {
-//CHECK-NEXT:     float _t1 = x;
+//CHECK-NEXT:     float _t0 = x;
 //CHECK-NEXT:     float _d_z = 0.F;
 //CHECK-NEXT:     float z = helper(x, y) + helper2(x);
-//CHECK-NEXT:     float _t3 = z;
-//CHECK-NEXT:     float _t5 = x;
-//CHECK-NEXT:     double _t7 = helper2(x);
-//CHECK-NEXT:     float _t8 = y;
-//CHECK-NEXT:     double _t4 = helper2(y);
-//CHECK-NEXT:     z += _t7 * _t4;
+//CHECK-NEXT:     float _t1 = z;
+//CHECK-NEXT:     float _t3 = x;
+//CHECK-NEXT:     double _t4 = helper2(x);
+//CHECK-NEXT:     float _t5 = y;
+//CHECK-NEXT:     double _t2 = helper2(y);
+//CHECK-NEXT:     z += _t4 * _t2;
 //CHECK-NEXT:     _d_z += 1;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         z = _t3;
-//CHECK-NEXT:         x = _t5;
-//CHECK-NEXT:         double _t6 = 0.;
-//CHECK-NEXT:         helper2_pullback(x, _d_z * _t4, _d_x, _t6);
-//CHECK-NEXT:         y = _t8;
-//CHECK-NEXT:         double _t9 = 0.;
-//CHECK-NEXT:         helper2_pullback(y, _t7 * _d_z, _d_y, _t9);
-//CHECK-NEXT:         _final_error += _t6 + _t9;
+//CHECK-NEXT:         z = _t1;
+//CHECK-NEXT:         x = _t3;
+//CHECK-NEXT:         helper2_pullback(x, _d_z * _t2, _d_x, _final_error);
+//CHECK-NEXT:         y = _t5;
+//CHECK-NEXT:         helper2_pullback(y, _t4 * _d_z, _d_y, _final_error);
 //CHECK-NEXT:         _final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = 0.;
 //CHECK-NEXT:         double _r1 = 0.;
-//CHECK-NEXT:         double _t0 = 0.;
-//CHECK-NEXT:         helper_pullback(x, y, _d_z, &_r0, &_r1, _t0);
+//CHECK-NEXT:         helper_pullback(x, y, _d_z, &_r0, &_r1, _final_error);
 //CHECK-NEXT:         *_d_x += _r0;
 //CHECK-NEXT:         *_d_y += _r1;
-//CHECK-NEXT:         x = _t1;
-//CHECK-NEXT:         double _t2 = 0.;
-//CHECK-NEXT:         helper2_pullback(x, _d_z, _d_x, _t2);
-//CHECK-NEXT:         _final_error += _t0 + _t2;
+//CHECK-NEXT:         x = _t0;
+//CHECK-NEXT:         helper2_pullback(x, _d_z, _d_x, _final_error);
 //CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
 //CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
 //CHECK-NEXT: }
+
+double func10(double x, double y) {
+    return helper(x, y);
+}
+
+// CHECK: void func10_grad(double x, double y, double *_d_x, double *_d_y, double &_final_error) {
+// CHECK-NEXT:     double _ret_value0 = 0.;
+// CHECK-NEXT:     _ret_value0 = helper(x, y);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 0.;
+// CHECK-NEXT:         double _r1 = 0.;
+// CHECK-NEXT:         helper_pullback(x, y, 1, &_r0, &_r1, _final_error);
+// CHECK-NEXT:         *_d_x += _r0;
+// CHECK-NEXT:         *_d_y += _r1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
+// CHECK-NEXT:     _final_error += std::abs(*_d_y * y * {{.+}});
+// CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+// CHECK-NEXT: }
 
 int main() {
   clad::estimate_error(func);
@@ -328,4 +337,5 @@ int main() {
   clad::estimate_error(func7);
   clad::estimate_error(func8);
   clad::estimate_error(func9);
+  clad::estimate_error(func10);
 }

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -321,10 +321,8 @@ double func6(double x) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         sum = clad::pop(_t1);
 //CHECK-NEXT:         double _r0 = 0.;
-//CHECK-NEXT:         double _t2 = 0.;
-//CHECK-NEXT:         fun_pullback(x, _d_sum, &_r0, _t2);
+//CHECK-NEXT:         fun_pullback(x, _d_sum, &_r0, _final_error);
 //CHECK-NEXT:         *_d_x += _r0;
-//CHECK-NEXT:         _final_error += _t2;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});


### PR DESCRIPTION
Currently, in error estimation, we accumulate errors of a nested function into a separate variable, which we then add to the final error. For example
```
double _t0 = 0.;
helper_pullback(..., _t0);
_final_error += _t0;
```
However, the only thing we do with `_final_error` and `_t0` is add partial errors to them. It doesn't matter if we first add it to the temporary `_t0` or to `_final_error` directly, i.e.
```
helper_pullback(..., _final_error);
```
Moreover, currently, having a call expression outside a binary operator results in its error `_t0` being ignored. For example
```
double f(double x, double y) {
    return helper(x, y);
}
```
Always produces zero error. This PR removes such temporaries.
Fixes #427.