### PR TITLE
Fixed #1654 Add a call operator for CladFunction

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -396,7 +396,7 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
 
     template <typename... Args, class FnType = CladFunctionType>
     typename std::enable_if<!std::is_same<FnType, NoFunction*>::value,
-                            return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
+                            return_type_t<F>> constexpr CUDA_HOST_DEVICE
     execute(Args&&... args) const {
       if (!m_Function)
         return static_cast<return_type_t<F>>(return_type_t<F>());
@@ -419,7 +419,7 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
     /// If not Nofunction*
     template <typename... Args, class FnType = CladFunctionType>
     typename std::enable_if<!std::is_same<FnType, NoFunction*>::value,
-                           return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
+                           return_type_t<F>> constexpr CUDA_HOST_DEVICE
     operator()(Args&&... args) const {
       return execute(std::forward<Args>(args)...);
     }
@@ -450,7 +450,7 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
     /// subsystem.
     template <typename... Args, class FnType = CladFunctionType>
     typename std::enable_if<std::is_same<FnType, NoFunction*>::value,
-                            return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
+                            return_type_t<F>> constexpr CUDA_HOST_DEVICE
     execute(Args&&... args) const {
       return static_cast<return_type_t<F>>(0);
     }
@@ -459,9 +459,9 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
    /// call opreator for Nofunction* case
     template <typename... Args, class FnType = CladFunctionType>
     typename std::enable_if<std::is_same<FnType, NoFunction*>::value,
-                            return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
+                            return_type_t<F>> constexpr CUDA_HOST_DEVICE
     operator()(Args&&... args) const {
-      return return execute(std::forward<Args>(args)...);
+      return execute(std::forward<Args>(args)...);     
     }
 
 


### PR DESCRIPTION
#### Description

I added two new functions with overloaded call operator, that delegates to `execute` internally. This ensures backward compatibility. I can add tests for these new overloads too if maintainers want.

Now we can call CladFunction in a functor-like way. for example : df(x, &dx).

#### Changes

```C++
/// If not Nofunction*
    template <typename... Args, class FnType = CladFunctionType>
    typename std::enable_if<!std::is_same<FnType, NoFunction*>::value,
                           return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
    operator()(Args&&... args) const {
      return execute(std::forward<Args>(args)...);
    }

/// call opreator for Nofunction* case
    template <typename... Args, class FnType = CladFunctionType>
    typename std::enable_if<std::is_same<FnType, NoFunction*>::value,
                            return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
    operator()(Args&&... args) const {
      return return execute(std::forward<Args>(args)...);
    }
```

#### Tests
Codebase is tested and all tests were successful

Extra tests can be added for call operator overloads.