### PR TITLE
Fix: For issue-1654

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -444,6 +444,11 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
       return static_cast<return_type_t<F>>(0);
     }
 
+    template <typename... Args>
+    constexpr CUDA_HOST_DEVICE auto operator()(Args&&... args) const {
+      return execute(std::forward<Args>(args)...);
+    }
+
     /// Return the string representation for the generated derivative.
     constexpr const char* getCode() const {
       if (m_Code)

--- a/test/Features/DiffInterfaceExec.C
+++ b/test/Features/DiffInterfaceExec.C
@@ -1,0 +1,31 @@
+// RUN: %cladclang -std=c++17 -I%S/../../include %s -o %t
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+double f(double x) {
+  return x * x;
+}
+
+int main() {
+  auto f_diff = clad::differentiate(f);
+  
+  // Test the new operator() syntax
+  double res_diff = f_diff(3.0); 
+  printf("Diff result: %.2f\n", res_diff);
+  // CHECK-EXEC: Diff result: 6.00
+
+  // 2. Test gradient (Reverse Mode)
+  auto f_grad = clad::gradient(f);
+  double x = 4.0;
+  double d_x = 0.0;
+  
+  // Test the new operator() syntax
+  f_grad(x, &d_x);
+  
+  printf("Grad result: %.2f\n", d_x);
+  // CHECK-EXEC: Grad result: 8.00
+
+  return 0;
+}


### PR DESCRIPTION
This PR closes Issue #1654. It implements operator() for the CladFunction class offering users to invoke differentiated functions using natural function call syntax (eg df(x)) and this way is more intutive than the old way i.e. .execute(x).
**Chnages Made:**
1. include/clad/Differentiator/Differentiator.h: Added a template operator() that uses perfect forwarding       (std::forward) to delegate arguments directly to the existing execute() method.
2. test/Regressions/Issue-1654.cpp: Added a regression test verifying that the new operator works correctly for both Forward Mode (clad::differentiate) and Reverse Mode (clad::gradient).
Note: Also performed the llvm lit test on the clad's test suite and it was a success