### PR TITLE
Test error estimation numerically

### DIFF
--- a/test/ErrorEstimation/Assignments.C
+++ b/test/ErrorEstimation/Assignments.C
@@ -1,7 +1,9 @@
 // RUN: %cladclang -I%S/../../include -oAssignments.out %s 2>&1 | %filecheck %s
-// RUN: ./Assignments.out
+// RUN: ./Assignments.out | %filecheck_exec %s
+// XFAIL: valgrind
 
 #include "clad/Differentiator/Differentiator.h"
+#include "../TestUtils.h"
 
 #include <cmath>
 
@@ -158,12 +160,30 @@ float func8(int x, int y) {
 //CHECK-NEXT: }
 
 int main() {
-  clad::estimate_error(func);
-  clad::estimate_error(func2);
-  clad::estimate_error(func3);
-  clad::estimate_error(func4);
-  clad::estimate_error(func5);
-  clad::estimate_error(func6);
-  clad::estimate_error(func7);
-  clad::estimate_error(func8);
+  int dxi = 0, dyi = 0;
+  float dxf = 0, dyf = 0;
+
+  INIT_ERROR_ESTIMATION(func);
+  TEST_ERROR_ESTIMATION(func, /*PrecissionType*/float, 3, 5, &dxf, &dyf); // CHECK-EXEC: {16.00}
+
+  INIT_ERROR_ESTIMATION(func2);
+  TEST_ERROR_ESTIMATION(func2, /*PrecissionType*/float, -2, 2, &dxf, &dyi); // CHECK-EXEC: {4.00}
+
+  INIT_ERROR_ESTIMATION(func3);
+  TEST_ERROR_ESTIMATION(func3, /*PrecissionType*/float, 8, 4, &dyi, &dyi); // CHECK-EXEC: {0.00}
+  
+  INIT_ERROR_ESTIMATION(func4);
+  TEST_ERROR_ESTIMATION(func4, /*PrecissionType*/float, 0, 9, &dxf, &dyf); // CHECK-EXEC: {36.00}
+  
+  INIT_ERROR_ESTIMATION(func5);
+  TEST_ERROR_ESTIMATION(func5, /*PrecissionType*/float, 5, -7, &dxf, &dyf); // CHECK-EXEC: {56.00}
+  
+  INIT_ERROR_ESTIMATION(func6);
+  TEST_ERROR_ESTIMATION(func6, /*PrecissionType*/float, 3, &dxf); // CHECK-EXEC: {3.00}
+  
+  INIT_ERROR_ESTIMATION(func7);
+  TEST_ERROR_ESTIMATION(func7, /*PrecissionType*/float, 2, 1, &dxf, &dyf); // CHECK-EXEC: {6.00}
+  
+  INIT_ERROR_ESTIMATION(func8);
+  TEST_ERROR_ESTIMATION(func8, /*PrecissionType*/float, -1, 6, &dyi, &dyi); // CHECK-EXEC: {0.00}
 }

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -1,6 +1,9 @@
-// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -Xclang -verify -oBasicOps.out 2>&1 | %filecheck %s
+// RUN: ./BasicOps.out | %filecheck_exec %s
+// XFAIL: valgrind
 
 #include "clad/Differentiator/Differentiator.h"
+#include "../TestUtils.h"
 
 #include <cmath>
 
@@ -328,14 +331,36 @@ double func10(double x, double y) {
 // CHECK-NEXT: }
 
 int main() {
-  clad::estimate_error(func);
-  clad::estimate_error(func2);
-  clad::estimate_error(func3);
-  clad::estimate_error(func4);
-  clad::estimate_error(func5);
-  clad::estimate_error(func6);
-  clad::estimate_error(func7);
-  clad::estimate_error(func8);
-  clad::estimate_error(func9);
-  clad::estimate_error(func10);
+  float dx = 0, dy = 0;
+  double dxd = 0, dyd = 0;
+
+  INIT_ERROR_ESTIMATION(func);
+  TEST_ERROR_ESTIMATION(func, /*PrecissionType*/float, 3, 1, &dx, &dy); // CHECK-EXEC: {76.00}
+  
+  INIT_ERROR_ESTIMATION(func2);
+  TEST_ERROR_ESTIMATION(func2, /*PrecissionType*/float, 4, 9, &dx, &dy); // CHECK-EXEC: {0.32}
+  
+  INIT_ERROR_ESTIMATION(func3);
+  TEST_ERROR_ESTIMATION(func3, /*PrecissionType*/float, 5, 2, &dx, &dy); // CHECK-EXEC: {136.00}
+  
+  INIT_ERROR_ESTIMATION(func4);
+  TEST_ERROR_ESTIMATION(func4, /*PrecissionType*/float, 2, 4, &dx, &dy); // CHECK-EXEC: {124.36}
+  
+  INIT_ERROR_ESTIMATION(func5);
+  TEST_ERROR_ESTIMATION(func5, /*PrecissionType*/float, 1, 4, &dx, &dy); // CHECK-EXEC: {3.03}
+  
+  INIT_ERROR_ESTIMATION(func6);
+  TEST_ERROR_ESTIMATION(func6, /*PrecissionType*/float, 6, -1, &dx, &dy); // CHECK-EXEC: {330.00}
+  
+  INIT_ERROR_ESTIMATION(func7);
+  TEST_ERROR_ESTIMATION(func7, /*PrecissionType*/float, 7, &dx); // CHECK-EXEC: {14.00}
+  
+  INIT_ERROR_ESTIMATION(func8);
+  TEST_ERROR_ESTIMATION(func8, /*PrecissionType*/float, -3, 2, &dx, &dy); // CHECK-EXEC: {47.00}
+  
+  INIT_ERROR_ESTIMATION(func9);
+  TEST_ERROR_ESTIMATION(func9, /*PrecissionType*/float, 0, 5, &dx, &dy); // CHECK-EXEC: {25.00}
+  
+  INIT_ERROR_ESTIMATION(func10);
+  TEST_ERROR_ESTIMATION(func10, /*PrecissionType*/float, 8, 5, &dxd, &dyd); // CHECK-EXEC: {240.00}
 }

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -1,6 +1,9 @@
 // RUN: %cladclang -I%S/../../include -oCondStmts.out %s 2>&1 | %filecheck %s
+// RUN: ./CondStmts.out | %filecheck_exec %s
+// XFAIL: valgrind
 
 #include "clad/Differentiator/Differentiator.h"
+#include "../TestUtils.h"
 
 #include <cmath>
 
@@ -175,8 +178,18 @@ float func4(float x, float y) {
 //CHECK-NEXT: }
 
 int main() {
-  clad::estimate_error(func);
-  clad::estimate_error(func2);
-  clad::estimate_error(func3);
-  clad::estimate_error(func4);
+  float dx = 0, dy = 0;
+  
+  INIT_ERROR_ESTIMATION(func);
+  TEST_ERROR_ESTIMATION(func, /*PrecissionType*/float, 8, 2, &dx, &dy); // CHECK-EXEC: {80.00}
+
+  INIT_ERROR_ESTIMATION(func2);
+  TEST_ERROR_ESTIMATION(func2, /*PrecissionType*/float, 2, &dx); // CHECK-EXEC: {12.00}
+  
+  INIT_ERROR_ESTIMATION(func3);
+  TEST_ERROR_ESTIMATION(func3, /*PrecissionType*/float, 1, 3, &dx, &dy); // CHECK-EXEC: {8.00}
+  
+  INIT_ERROR_ESTIMATION(func4);
+  TEST_ERROR_ESTIMATION(func4, /*PrecissionType*/float, -7, 2, &dx, &dy); // CHECK-EXEC: {0.20}
+  
 }

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -3,6 +3,7 @@
 // XFAIL: valgrind
 
 #include "clad/Differentiator/Differentiator.h"
+#include "../TestUtils.h"
 
 #include <cmath>
 
@@ -155,32 +156,29 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT: }
 
 int main() {
-  auto df = clad::estimate_error(runningSum);
   float arrf[3] = {0.456, 0.77, 0.95};
-  double finalError = 0;
   float darr[3] = {0, 0, 0};
   int dn = 0;
-  df.execute(arrf, 3, darr, &dn, finalError);
-  printf("Result (RS) = {%.2f, %.2f, %.2f} error = %.5f\n", darr[0], darr[1],
-         darr[2], finalError); // CHECK-EXEC: Result (RS) = {1.00, 2.00, 1.00} error = 0.00000
+  INIT_ERROR_ESTIMATION(runningSum);
+  TEST_ERROR_ESTIMATION(runningSum, /*PrecissionType*/float, arrf, 3, darr, &dn); // CHECK-EXEC: {7.12}
+  printf("Result (RS) = {%.2f, %.2f, %.2f}\n", darr[0], darr[1], darr[2]); 
+         // CHECK-EXEC: Result (RS) = {1.00, 2.00, 1.00}
 
-  finalError = 0;
   darr[0] = darr[1] = darr[2] = 0;
   dn = 0;
   float darr2[3] = {0, 0, 0};
-  auto df2 = clad::estimate_error(mulSum);
-  df2.execute(arrf, arrf, 3, darr, darr2, &dn, finalError);
-  printf("Result (MS) = {%.2f, %.2f, %.2f}, {%.2f, %.2f, %.2f}  error = %.5f\n",
-         darr[0], darr[1], darr[2], darr2[0], darr2[1], darr2[2],
-         finalError); // CHECK-EXEC: Result (MS) = {2.18, 2.18, 2.18}, {2.18, 2.18, 2.18}  error = 0.00000
+  INIT_ERROR_ESTIMATION(mulSum);
+  TEST_ERROR_ESTIMATION(mulSum, /*PrecissionType*/float, arrf, arrf, 3, darr, darr2, &dn); // CHECK-EXEC: {28.85}
+  printf("Result (MS) = {%.2f, %.2f, %.2f}, {%.2f, %.2f, %.2f}\n",
+         darr[0], darr[1], darr[2], darr2[0], darr2[1], darr2[2]);
+         // CHECK-EXEC: Result (MS) = {2.18, 2.18, 2.18}, {2.18, 2.18, 2.18}
 
-  finalError = 0;
   darr[0] = darr[1] = darr[2] = 0;
   darr2[0] = darr2[1] = darr2[2] = 0;
   dn = 0;
-  auto df3 = clad::estimate_error(divSum);
-  df3.execute(arrf, arrf, 3, darr, darr2, &dn, finalError);
-  printf("Result (DS) = {%.2f, %.2f, %.2f}, {%.2f, %.2f, %.2f}  error = %.5f\n",
-         darr[0], darr[1], darr[2], darr2[0], darr2[1], darr2[2],
-         finalError); // CHECK-EXEC: Result (DS) = {2.19, 1.30, 1.05}, {-2.19, -1.30, -1.05}  error = 0.00000
+  INIT_ERROR_ESTIMATION(divSum);
+  TEST_ERROR_ESTIMATION(divSum, /*PrecissionType*/float, arrf, arrf, 3, darr, darr2, &dn); // CHECK-EXEC: {12.00}
+  printf("Result (DS) = {%.2f, %.2f, %.2f}, {%.2f, %.2f, %.2f}\n",
+         darr[0], darr[1], darr[2], darr2[0], darr2[1], darr2[2]);
+         // CHECK-EXEC: Result (DS) = {2.19, 1.30, 1.05}, {-2.19, -1.30, -1.05}
 }


### PR DESCRIPTION
Currently, we only check the code produced in error estimation. The produced errors are never checked. This makes it hard to understand whether certain changes break error estimation or not. This PR introduces numerical checks for all error estimation tests.
One of the reasons errors were not tested was that they are usually of order `10^-7`. This is because all errors get multiplied by `std::numeric_limits<float>::epsilon()`, which is equal to `2^-23 = 1.19e-7`. This makes it inconvenient to compare the results with theoretical predictions. This PR adds `TEST_ERROR_ESTIMATION` that normalizes the error by `std::numeric_limits<float>::epsilon()` before printing it. Since dividing by such small numbers could impact precission, the normalization is done as `std::ldexp(error, std::numeric_limits<PrecissionType>::digits - 1)`. `std::ldexp` lets us change the exponent of the float directly, and multiply the number by `2^23` without changing the mantissa. `PrecissionType` is templated so that we can test other floating types in the future.