### PR TITLE
Fix #1539 Use parallelism in clad::restore_tracker 

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -413,17 +413,6 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
 #endif
     }
 
-    /// call overload for 'execute' function, that can be called as functor.
-    /// Delegates to execute for backward compatibility.
-
-    /// If not Nofunction*
-    template <typename... Args, class FnType = CladFunctionType>
-    typename std::enable_if<!std::is_same<FnType, NoFunction*>::value,
-                           return_type_t<F>> constexpr CUDA_HOST_DEVICE
-    operator()(Args&&... args) const {
-      return execute(std::forward<Args>(args)...);
-    }
-
 #ifdef __CUDACC__
     template <typename... Args, class FnType = CladFunctionType>
     typename std::enable_if<!std::is_same<FnType, NoFunction*>::value,

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -396,7 +396,7 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
 
     template <typename... Args, class FnType = CladFunctionType>
     typename std::enable_if<!std::is_same<FnType, NoFunction*>::value,
-                            return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
+                            return_type_t<F>> constexpr CUDA_HOST_DEVICE
     execute(Args&&... args) const {
       if (!m_Function)
         return static_cast<return_type_t<F>>(return_type_t<F>());
@@ -419,7 +419,7 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
     /// If not Nofunction*
     template <typename... Args, class FnType = CladFunctionType>
     typename std::enable_if<!std::is_same<FnType, NoFunction*>::value,
-                           return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
+                           return_type_t<F>> constexpr CUDA_HOST_DEVICE
     operator()(Args&&... args) const {
       return execute(std::forward<Args>(args)...);
     }
@@ -450,7 +450,7 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
     /// subsystem.
     template <typename... Args, class FnType = CladFunctionType>
     typename std::enable_if<std::is_same<FnType, NoFunction*>::value,
-                            return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
+                            return_type_t<F>> constexpr CUDA_HOST_DEVICE
     execute(Args&&... args) const {
       return static_cast<return_type_t<F>>(0);
     }
@@ -459,9 +459,9 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
    /// call opreator for Nofunction* case
     template <typename... Args, class FnType = CladFunctionType>
     typename std::enable_if<std::is_same<FnType, NoFunction*>::value,
-                            return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
+                            return_type_t<F>> constexpr CUDA_HOST_DEVICE
     operator()(Args&&... args) const {
-      return return execute(std::forward<Args>(args)...);
+      return execute(std::forward<Args>(args)...);     
     }
 
 

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -413,6 +413,17 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
 #endif
     }
 
+    /// call overload for 'execute' function, that can be called as functor.
+    /// Delegates to execute for backward compatibility.
+
+    /// If not Nofunction*
+    template <typename... Args, class FnType = CladFunctionType>
+    typename std::enable_if<!std::is_same<FnType, NoFunction*>::value,
+                           return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
+    operator()(Args&&... args) const {
+      return execute(std::forward<Args>(args)...);
+    }
+
 #ifdef __CUDACC__
     template <typename... Args, class FnType = CladFunctionType>
     typename std::enable_if<!std::is_same<FnType, NoFunction*>::value,
@@ -443,6 +454,17 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
     execute(Args&&... args) const {
       return static_cast<return_type_t<F>>(0);
     }
+
+    
+   /// call opreator for Nofunction* case
+    template <typename... Args, class FnType = CladFunctionType>
+    typename std::enable_if<std::is_same<FnType, NoFunction*>::value,
+                            return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
+    operator()(Args&&... args) const {
+      return execute(std::forward<Args>(args)...);
+    }
+
+
 
     /// Return the string representation for the generated derivative.
     constexpr const char* getCode() const {

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -461,7 +461,7 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
     typename std::enable_if<std::is_same<FnType, NoFunction*>::value,
                             return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
     operator()(Args&&... args) const {
-      return execute(std::forward<Args>(args)...);
+      return return execute(std::forward<Args>(args)...);
     }
 
 

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -396,7 +396,7 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
 
     template <typename... Args, class FnType = CladFunctionType>
     typename std::enable_if<!std::is_same<FnType, NoFunction*>::value,
-                            return_type_t<F>> constexpr CUDA_HOST_DEVICE
+                            return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
     execute(Args&&... args) const {
       if (!m_Function)
         return static_cast<return_type_t<F>>(return_type_t<F>());
@@ -439,7 +439,7 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
     /// subsystem.
     template <typename... Args, class FnType = CladFunctionType>
     typename std::enable_if<std::is_same<FnType, NoFunction*>::value,
-                            return_type_t<F>> constexpr CUDA_HOST_DEVICE
+                            return_type_t<F>>::type constexpr CUDA_HOST_DEVICE
     execute(Args&&... args) const {
       return static_cast<return_type_t<F>>(0);
     }

--- a/include/clad/Differentiator/RestoreTracker.h
+++ b/include/clad/Differentiator/RestoreTracker.h
@@ -43,25 +43,26 @@ public:
   }
   // Set all stored addresses to the corresponsing values bitwise.
   void restore() {
-    // Copy pointers to a vector for efficient parallel iteration
+    // store the map to a vector of pointers for efficient execution
     std::vector<std::pair<Address, RawMemory*>> work;
     work.reserve(m_data.size());
     for (auto& kv : m_data) {
         work.emplace_back(kv.first, &kv.second);
     }
 
-    // Parallel restore
+    // Parallel restore 
     std::for_each(std::execution::par, work.begin(), work.end(),
         [](auto& entry) {
-            Address addr = entry.first;
-            RawMemory* buf = entry.second;
-            std::memcpy(addr, buf->data(), buf->size());
+            std::memcpy(
+                entry.first,
+                entry.second->data(),
+                entry.second->size()
+            );
         }
     );
-
-    // Clear the map
     m_data.clear();
   }
+
 };
 } // namespace clad
 

--- a/include/clad/Differentiator/RestoreTracker.h
+++ b/include/clad/Differentiator/RestoreTracker.h
@@ -58,6 +58,8 @@ public:
             std::memcpy(addr, buf->data(), buf->size());
         }
     );
+
+    // Clear the map
     m_data.clear();
   }
 };


### PR DESCRIPTION
#### Description

This PR fixes issue #1539. 
I have used c++ 17 feature `std::execution::par` to make execution of loop parellel. For efficient execution of threads I have used separate array. This was existing function so no tests were written.

#### Any external dependency introduced?

I have used standard c++ includes so no new dependency