### PR TITLE
Removed unnecessary underscores in generated variable names

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -432,8 +432,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           // If the type is not a tensor, we can use zero initialization.
           initExpr = getZeroInit(VDDerivedType);
         }
+        llvm::StringRef Name = param->getName();
+        std::string CleanName = Name.ltrim('_').str();
         auto* VDDerived =
-            BuildGlobalVarDecl(VDDerivedType, "_d_" + param->getNameAsString(),
+            BuildGlobalVarDecl(VDDerivedType, "_d_" + CleanName,
                                initExpr, isDirectInit);
         m_Variables[param] = BuildDeclRef(VDDerived);
         addToBlock(BuildDeclStmt(VDDerived), m_Globals);
@@ -1489,7 +1491,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       if (it == std::end(m_Variables)) {
         if (VD->isFileVarDecl() && !VD->getType().isConstQualified()) {
           // VD is a global variable, attempt to find its adjoint.
-          std::string nameDiff_str = "_d_" + VD->getNameAsString();
+          llvm::StringRef Name = VD->getName();
+          std::string CleanName = Name.ltrim('_').str();
+          std::string nameDiff_str = "_d_" + CleanName;
           DeclarationName nameDiff = &m_Context.Idents.get(nameDiff_str);
           DeclContext* DC = VD->getDeclContext();
           LookupResult result(m_Sema, nameDiff, noLoc,
@@ -2828,10 +2832,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // Build the adjoint VarDecl
     VarDecl* VDDerived = nullptr;
     if (m_DiffReq.shouldHaveAdjoint(VD) &&
-        !clad::utils::hasNonDifferentiableAttribute(VD))
+        !clad::utils::hasNonDifferentiableAttribute(VD)){
+      llvm::StringRef Name = VD->getName();
+      std::string CleanName = Name.ltrim('_').str();
       VDDerived = BuildGlobalVarDecl(VDDerivedType,
-                                     "_d_" + VD->getNameAsString(), dummyInit);
-
+                                     "_d_" +CleanName, dummyInit);
+      }
     // Differentiate the initializer
     StmtDiff initDiff;
     if (const Expr* init = VD->getInit()) {
@@ -3220,10 +3226,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             copyInit = CE && CE->getNumArgs() == 0;
             if (!copyInit && CE) {
               if (const auto* DRE =
-                      dyn_cast<DeclRefExpr>(CE->getArg(0)->IgnoreImplicit()))
-                if (cast<VarDecl>(decl)->getNameAsString() ==
-                    "_d_" + cast<VarDecl>(DRE->getDecl())->getNameAsString())
-                  copyInit = true;
+                      dyn_cast<DeclRefExpr>(CE->getArg(0)->IgnoreImplicit())){
+                        llvm::StringRef OrigName = cast<VarDecl>(DRE->getDecl())->getName();
+                        std::string CleanName = "_d_" + OrigName.ltrim('_').str();
+                        if (cast<VarDecl>(decl)->getNameAsString() ==CleanName)
+                          copyInit = true;
+                      }
             }
           }
         }
@@ -4632,8 +4640,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         m_NonIndepParams.push_back(PVD);
         continue;
       }
+      llvm::StringRef Name = PVD->getName();
+      std::string CleanName = Name.ltrim('_').str();
       IdentifierInfo* II =
-          CreateUniqueIdentifier("_d_" + PVD->getNameAsString());
+          CreateUniqueIdentifier("_d_" + CleanName);
       QualType dPVDTy = FnType->getParamType(p++);
       auto* dPVD = utils::BuildParmVarDecl(m_Sema, m_Derivative, II, dPVDTy,
                                            PVD->getStorageClass());

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -386,16 +386,17 @@ double fn8(double u, double v) {
   return p.first + p.second;
 }
 
-// CHECK: static constexpr void constructor_pullback(double &__{{u1|x}}, double &__{{u2|y}}, std::pair<double, double> *_d_this, double *_d___{{u1|x}}, double *_d___{{u2|y}}){{.*}}{
+// CHECK: constructor_pullback(double &__{{u1|x}}, double &__{{u2|y}}, std::pair<double, double> *_d_this, double *_d_{{u1|x}}, double *_d_{{u2|y}})
+// CHECK-SAME: {
 // CHECK-NEXT:     std::pair<double, double> *_this = (std::pair<double, double> *)malloc(sizeof(std::pair<double, double>));
 // CHECK:     _this->first = __{{u1|x}};
 // CHECK-NEXT:     _this->second = __{{u2|y}};
 // CHECK:     {
-// CHECK-NEXT:         *_d___{{u2|y}} += _d_this->second;
+// CHECK-NEXT:         *_d_{{u2|y}} += _d_this->second;
 // CHECK-NEXT:         _d_this->second = 0.;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         *_d___{{u1|x}} += _d_this->first;
+// CHECK-NEXT:         *_d_{{u1|x}} += _d_this->first;
 // CHECK-NEXT:         _d_this->first = 0.;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     free(_this);

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -332,10 +332,10 @@ double fn7(double i, double j) {
 
 // CHECK: void identity_pullback(double &i, double *_d_i) {
 // CHECK-NEXT:     MyStruct::myFunction();
-// CHECK-NEXT:     double _d__d_i = 0.;
+// CHECK-NEXT:     double _d_d_i = 0.;
 // CHECK-NEXT:     double _d_i0 = i;
 // CHECK-NEXT:     _d_i0 += 1;
-// CHECK-NEXT:     *_d_i += _d__d_i;
+// CHECK-NEXT:     *_d_i += _d_d_i;
 // CHECK-NEXT: }
 
 // CHECK: void custom_identity_pullback(double &i, double *_d_i) {

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -578,7 +578,7 @@ double f_issue138(double x, double y) {
 
 void f_issue138_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK:   void f_issue138_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       double _d__t1 = 0.;
+//CHECK-NEXT:       double _d_t1 = 0.;
 //CHECK-NEXT:       double _t10 = 1;
 //CHECK-NEXT:       {
 //CHECK-NEXT:           *_d_x += 1 * x * x * x;

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -2109,15 +2109,15 @@ double fn34(double x, double y){
 //CHECK-NEXT:     double a[3] = {y, x * y, x * x + y};
 //CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
 //CHECK-NEXT:     double (&__range1)[3] = a;
-//CHECK-NEXT:     double (&_d___range1)[3] = _d_a;
+//CHECK-NEXT:     double (&_d_range1)[3] = _d_a;
 //CHECK-NEXT:     double *__begin1 = __range1;
-//CHECK-NEXT:     double *_d___begin1 = _d___range1;
+//CHECK-NEXT:     double *_d_begin1 = _d_range1;
 //CHECK-NEXT:     double *__end1 = __range1 + {{3|3L}};
 //CHECK-NEXT:     double *_d_i = nullptr;
 //CHECK-NEXT:     double *i = nullptr;
-//CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d___begin1) {
+//CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d_begin1) {
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _d_i = _d___begin1;
+//CHECK-NEXT:             _d_i = _d_begin1;
 //CHECK-NEXT:             i = __begin1;
 //CHECK-NEXT:             clad::push(_t1, i);
 //CHECK-NEXT:             clad::push(_t2, _d_i);
@@ -2129,7 +2129,7 @@ double fn34(double x, double y){
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             {
-//CHECK-NEXT:                 _d___begin1--;
+//CHECK-NEXT:                 _d_begin1--;
 //CHECK-NEXT:                 i = clad::pop(_t1);
 //CHECK-NEXT:                 _d_i = clad::pop(_t2);
 //CHECK-NEXT:             }
@@ -2180,15 +2180,15 @@ double fn35(double x, double y){
 // CHECK-NEXT:     double a[3] = {x, x * y, 0};
 // CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
 // CHECK-NEXT:     double (&__range1)[3] = a;
-// CHECK-NEXT:     double (&_d___range1)[3] = _d_a;
+// CHECK-NEXT:     double (&_d_range1)[3] = _d_a;
 // CHECK-NEXT:     double *__begin1 = __range1;
-// CHECK-NEXT:     double *_d___begin1 = _d___range1;
+// CHECK-NEXT:     double *_d_begin1 = _d_range1;
 // CHECK-NEXT:     double *__end1 = __range1 + {{3|3L}};
 // CHECK-NEXT:     double *_d_i = nullptr;
 // CHECK-NEXT:     double *i = nullptr;
-// CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d___begin1) {
+// CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d_begin1) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             _d_i = _d___begin1;
+// CHECK-NEXT:             _d_i = _d_begin1;
 // CHECK-NEXT:             i = __begin1;
 // CHECK-NEXT:             clad::push(_t5, i);
 // CHECK-NEXT:             clad::push(_t6, _d_i);
@@ -2196,15 +2196,15 @@ double fn35(double x, double y){
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, 0);
 // CHECK-NEXT:         double (&__range2)[3] = a;
-// CHECK-NEXT:         double (&_d___range2)[3] = _d_a;
+// CHECK-NEXT:         double (&_d_range2)[3] = _d_a;
 // CHECK-NEXT:         double *__begin2 = __range2;
-// CHECK-NEXT:         double *_d___begin2 = _d___range2;
+// CHECK-NEXT:         double *_d_begin2 = _d_range2;
 // CHECK-NEXT:         double *__end2 = __range2 + {{3|3L}};
 // CHECK-NEXT:         double *_d_j = nullptr;
 // CHECK-NEXT:         double *j = nullptr;
-// CHECK-NEXT:         for (; __begin2 != __end2; ++__begin2 , ++_d___begin2) {
+// CHECK-NEXT:         for (; __begin2 != __end2; ++__begin2 , ++_d_begin2) {
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 _d_j = _d___begin2;
+// CHECK-NEXT:                 _d_j = _d_begin2;
 // CHECK-NEXT:                 j = __begin2;
 // CHECK-NEXT:                 clad::push(_t3, j);
 // CHECK-NEXT:                 clad::push(_t4, _d_j);
@@ -2231,7 +2231,7 @@ double fn35(double x, double y){
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 _d___begin1--;
+// CHECK-NEXT:                 _d_begin1--;
 // CHECK-NEXT:                 i = clad::pop(_t5);
 // CHECK-NEXT:                 _d_i = clad::pop(_t6);
 // CHECK-NEXT:             }
@@ -2239,7 +2239,7 @@ double fn35(double x, double y){
 // CHECK-NEXT:                 for (; clad::back(_t1); clad::back(_t1)--) {
 // CHECK-NEXT:                     {
 // CHECK-NEXT:                         {
-// CHECK-NEXT:                             _d___begin2--;
+// CHECK-NEXT:                             _d_begin2--;
 // CHECK-NEXT:                             j = clad::pop(_t3);
 // CHECK-NEXT:                             _d_j = clad::pop(_t4);
 // CHECK-NEXT:                         }
@@ -2301,15 +2301,15 @@ double fn36(double x, double y){
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
 //CHECK-NEXT:     double (&__range1)[3] = a;
-//CHECK-NEXT:     double (&_d___range1)[3] = _d_a;
+//CHECK-NEXT:     double (&_d_range1)[3] = _d_a;
 //CHECK-NEXT:     double *__begin1 = __range1;
-//CHECK-NEXT:     double *_d___begin1 = _d___range1;
+//CHECK-NEXT:     double *_d_begin1 = _d_range1;
 //CHECK-NEXT:     double *__end1 = __range1 + {{3|3L}};
 //CHECK-NEXT:     double _d_i = 0.;
 //CHECK-NEXT:     double i = 0.;
-//CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d___begin1) {
+//CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d_begin1) {
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _d_i = *_d___begin1;
+//CHECK-NEXT:             _d_i = *_d_begin1;
 //CHECK-NEXT:             i = *__begin1;
 //CHECK-NEXT:             clad::push(_t3, i);
 //CHECK-NEXT:             clad::push(_t4, _d_i);
@@ -2333,7 +2333,7 @@ double fn36(double x, double y){
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             {
-//CHECK-NEXT:                 _d___begin1--;
+//CHECK-NEXT:                 _d_begin1--;
 //CHECK-NEXT:                 i = clad::pop(_t3);
 //CHECK-NEXT:                 _d_i = clad::pop(_t4);
 //CHECK-NEXT:             }
@@ -2357,7 +2357,7 @@ double fn36(double x, double y){
 //CHECK-NEXT:                 }
 //CHECK-NEXT:             }
 //CHECK-NEXT:         }
-//CHECK-NEXT:         *_d___begin1 += _d_i;
+//CHECK-NEXT:         *_d_begin1 += _d_i;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -2378,15 +2378,15 @@ double fn37(double x, double y) {
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
 //CHECK-NEXT:     double (&__range1)[3] = range;
-//CHECK-NEXT:     double (&_d___range1)[3] = _d_range;
+//CHECK-NEXT:     double (&_d_range1)[3] = _d_range;
 //CHECK-NEXT:     double *__begin1 = __range1;
-//CHECK-NEXT:     double *_d___begin1 = _d___range1;
+//CHECK-NEXT:     double *_d_begin1 = _d_range1;
 //CHECK-NEXT:     double *__end1 = __range1 + {{3|3L}};
 //CHECK-NEXT:     double _d_elem = 0.;
 //CHECK-NEXT:     double elem = 0.;
-//CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d___begin1) {
+//CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d_begin1) {
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _d_elem = *_d___begin1;
+//CHECK-NEXT:             _d_elem = *_d_begin1;
 //CHECK-NEXT:             elem = *__begin1;
 //CHECK-NEXT:             clad::push(_t1, elem);
 //CHECK-NEXT:             clad::push(_t2, _d_elem);
@@ -2398,13 +2398,13 @@ double fn37(double x, double y) {
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             {
-//CHECK-NEXT:                 _d___begin1--;
+//CHECK-NEXT:                 _d_begin1--;
 //CHECK-NEXT:                 elem = clad::pop(_t1);
 //CHECK-NEXT:                 _d_elem = clad::pop(_t2);
 //CHECK-NEXT:             }
 //CHECK-NEXT:             _d_elem += _d_sum;
 //CHECK-NEXT:         }
-//CHECK-NEXT:         *_d___begin1 += _d_elem;
+//CHECK-NEXT:         *_d_begin1 += _d_elem;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += _d_range[0];
@@ -2437,15 +2437,15 @@ double fn38(double x, double y) {
 //CHECK-NEXT:             range = {1., x, 2., y, 3.};
 //CHECK-NEXT:             _t0 = 0;
 //CHECK-NEXT:             clad::array<double> &__range2 = range;
-//CHECK-NEXT:             clad::array<double> &_d___range2 = _d_range;
+//CHECK-NEXT:             clad::array<double> &_d_range2 = _d_range;
 //CHECK-NEXT:             {{const double *\*|const_iterator }}__begin2 = std::begin(__range2);
-//CHECK-NEXT:             double *_d___begin2 = std::begin(_d___range2);
+//CHECK-NEXT:             double *_d_begin2 = std::begin(_d_range2);
 //CHECK-NEXT:             {{const double *\*|const_iterator }}__end2 = std::end(__range2);
 //CHECK-NEXT:             double _d_elem = 0.;
 //CHECK-NEXT:             double elem = 0.;
-//CHECK-NEXT:             for (; __begin2 != __end2; ++__begin2 , ++_d___begin2) {
+//CHECK-NEXT:             for (; __begin2 != __end2; ++__begin2 , ++_d_begin2) {
 //CHECK-NEXT:                 {
-//CHECK-NEXT:                     _d_elem = *_d___begin2;
+//CHECK-NEXT:                     _d_elem = *_d_begin2;
 //CHECK-NEXT:                     elem = *__begin2;
 //CHECK-NEXT:                     clad::push(_t1, elem);
 //CHECK-NEXT:                     clad::push(_t2, _d_elem);
@@ -2460,13 +2460,13 @@ double fn38(double x, double y) {
 //CHECK-NEXT:         for (; _t0; _t0--) {
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 {
-//CHECK-NEXT:                     _d___begin2--;
+//CHECK-NEXT:                     _d_begin2--;
 //CHECK-NEXT:                     elem = clad::pop(_t1);
 //CHECK-NEXT:                     _d_elem = clad::pop(_t2);
 //CHECK-NEXT:                 }
 //CHECK-NEXT:                 _d_elem += _d_sum;
 //CHECK-NEXT:             }
-//CHECK-NEXT:             *_d___begin2 += _d_elem;
+//CHECK-NEXT:             *_d_begin2 += _d_elem;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             *_d_x += _d_range[1];

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -619,7 +619,7 @@ int main() {
 // CHECK-NEXT:         *_t0 = 5;
 // CHECK-NEXT:         {{.*}}value_type *_t1 = &a[1];
 // CHECK-NEXT:         *_t1 = y;
-// CHECK-NEXT:         std::array<double, 3> _d__b = {{.*}};
+// CHECK-NEXT:         std::array<double, 3> _d_b = {{.*}};
 // CHECK-NEXT:         std::array<double, 3> _b0;
 // CHECK-NEXT:         {{.*}}value_type *_t2 = &_b0[0];
 // CHECK-NEXT:         *_t2 = x;
@@ -627,33 +627,33 @@ int main() {
 // CHECK-NEXT:         *_t3 = 0;
 // CHECK-NEXT:         {{.*}}value_type *_t4 = &_b0[2];
 // CHECK-NEXT:         *_t4 = x * x;
-// CHECK-NEXT:         std::array<double, 3> _d_b = {{.*}};
+// CHECK-NEXT:         std::array<double, 3> _d_b0 = {{.*}};
 // CHECK-NEXT:         const std::array<double, 3> b = _b0;
 // CHECK:              {{.*}}value_type _t{{7|8}} = a.back();
 // CHECK-NEXT:         {{.*}}value_type _t6 = b.front();
 // CHECK-NEXT:         {{.*}}value_type _t5 = b.at(2);
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _d_a.back() += 1 * _t5 * _t6;
-// CHECK:                  {{.*}}front_pullback(&b, _t{{7|8}} * 1 * _t5, &_d_b);
+// CHECK:                  {{.*}}front_pullback(&b, _t{{7|8}} * 1 * _t5, &_d_b0);
 // CHECK-NEXT:             {{.*size_type|size_t}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}at_pullback(&b, 2, _t{{7|8}} * _t6 * 1, &_d_b, &_r0);
+// CHECK-NEXT:             {{.*}}at_pullback(&b, 2, _t{{7|8}} * _t6 * 1, &_d_b0, &_r0);
 // CHECK-NEXT:             {{.*size_type|size_t}} _r1 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&b, 1, 1, &_d_b, &_r1);
+// CHECK-NEXT:             {{.*}}operator_subscript_pullback(&b, 1, 1, &_d_b0, &_r1);
 // CHECK-NEXT:         }
-// CHECK-NEXT:         {{.*}}constructor_pullback(_b0, &_d_b, &_d__b);
+// CHECK-NEXT:         {{.*}}constructor_pullback(_b0, &_d_b0, &_d_b);
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}}value_type _r_d4 = _d__b[2];
-// CHECK-NEXT:             _d__b[2] = 0.;
+// CHECK-NEXT:             {{.*}}value_type _r_d4 = _d_b[2];
+// CHECK-NEXT:             _d_b[2] = 0.;
 // CHECK-NEXT:             *_d_x += _r_d4 * x;
 // CHECK-NEXT:             *_d_x += x * _r_d4;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}}value_type _r_d3 = _d__b[1];
-// CHECK-NEXT:             _d__b[1] = 0.;
+// CHECK-NEXT:             {{.*}}value_type _r_d3 = _d_b[1];
+// CHECK-NEXT:             _d_b[1] = 0.;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {{.*}}value_type _r_d2 = _d__b[0];
-// CHECK-NEXT:             _d__b[0] = 0.;
+// CHECK-NEXT:             {{.*}}value_type _r_d2 = _d_b[0];
+// CHECK-NEXT:             _d_b[0] = 0.;
 // CHECK-NEXT:             *_d_x += _r_d2;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -200,141 +200,141 @@ int main() {
 // CHECK: void cos_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
 // CHECK: void f1_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d_d_x = 0.F;
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::sin_pushforward(x, _d_x0);
-// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t1 = {0.F, 0.F};
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d_t1 = {0.F, 0.F};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t10 = clad::custom_derivatives::std::cos_pushforward(x, _d_x0);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d__t0.pushforward += 1;
-// CHECK-NEXT:         _d__t1.pushforward += 1;
+// CHECK-NEXT:         _d_t0.pushforward += 1;
+// CHECK-NEXT:         _d_t1.pushforward += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::cos_pushforward_pullback(x, _d_x0, _d__t1, &_r2, &_r3);
+// CHECK-NEXT:         clad::custom_derivatives::std::cos_pushforward_pullback(x, _d_x0, _d_t1, &_r2, &_r3);
 // CHECK-NEXT:         *_d_x += _r2;
-// CHECK-NEXT:         _d__d_x += _r3;
+// CHECK-NEXT:         _d_d_x += _r3;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::sin_pushforward_pullback(x, _d_x0, _d__t0, &_r0, &_r1);
+// CHECK-NEXT:         clad::custom_derivatives::std::sin_pushforward_pullback(x, _d_x0, _d_t0, &_r0, &_r1);
 // CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         _d__d_x += _r1;
+// CHECK-NEXT:         _d_d_x += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: void exp_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
 // CHECK: void f2_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d_d_x = 0.F;
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::exp_pushforward(x, _d_x0);
-// CHECK-NEXT:     _d__t0.pushforward += 1;
+// CHECK-NEXT:     _d_t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::exp_pushforward_pullback(x, _d_x0, _d__t0, &_r0, &_r1);
+// CHECK-NEXT:         clad::custom_derivatives::std::exp_pushforward_pullback(x, _d_x0, _d_t0, &_r0, &_r1);
 // CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         _d__d_x += _r1;
+// CHECK-NEXT:         _d_d_x += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: void log_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
 // CHECK: void f3_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d_d_x = 0.F;
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::log_pushforward(x, _d_x0);
-// CHECK-NEXT:     _d__t0.pushforward += 1;
+// CHECK-NEXT:     _d_t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::log_pushforward_pullback(x, _d_x0, _d__t0, &_r0, &_r1);
+// CHECK-NEXT:         clad::custom_derivatives::std::log_pushforward_pullback(x, _d_x0, _d_t0, &_r0, &_r1);
 // CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         _d__d_x += _r1;
+// CHECK-NEXT:         _d_d_x += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: void pow_pushforward_pullback(float x, float exponent, float d_x, float d_exponent, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_exponent, float *_d_d_x, float *_d_d_exponent);
 
 // CHECK: void f4_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d_d_x = 0.F;
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
+// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(x, 4.F, _d_x0, 0.F);
-// CHECK-NEXT:     _d__t0.pushforward += 1;
+// CHECK-NEXT:     _d_t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::pow_pushforward_pullback(x, 4.F, _d_x0, 0.F, _d__t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         clad::custom_derivatives::std::pow_pushforward_pullback(x, 4.F, _d_x0, 0.F, _d_t0, &_r0, &_r1, &_r2, &_r3);
 // CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         _d__d_x += _r2;
+// CHECK-NEXT:         _d_d_x += _r2;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: void f5_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d_d_x = 0.F;
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
+// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(2.F, x, 0.F, _d_x0);
-// CHECK-NEXT:     _d__t0.pushforward += 1;
+// CHECK-NEXT:     _d_t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
-// CHECK-NEXT:         {{.*}}pow_pushforward_pullback(2.F, x, 0.F, _d_x0, _d__t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         {{.*}}pow_pushforward_pullback(2.F, x, 0.F, _d_x0, _d_t0, &_r0, &_r1, &_r2, &_r3);
 // CHECK-NEXT:         *_d_x += _r1;
-// CHECK-NEXT:         _d__d_x += _r3;
+// CHECK-NEXT:         _d_d_x += _r3;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: void f6_darg0_grad(float x, float y, float *_d_x, float *_d_y) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d_d_x = 0.F;
 // CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     float _d__d_y = 0.F;
+// CHECK-NEXT:     float _d_d_y = 0.F;
 // CHECK-NEXT:     float _d_y0 = 0;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
+// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(x, y, _d_x0, _d_y0);
-// CHECK-NEXT:     _d__t0.pushforward += 1;
+// CHECK-NEXT:     _d_t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
-// CHECK-NEXT:         {{.*}}pow_pushforward_pullback(x, y, _d_x0, _d_y0, _d__t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         {{.*}}pow_pushforward_pullback(x, y, _d_x0, _d_y0, _d_t0, &_r0, &_r1, &_r2, &_r3);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         *_d_y += _r1;
-// CHECK-NEXT:         _d__d_x += _r2;
-// CHECK-NEXT:         _d__d_y += _r3;
+// CHECK-NEXT:         _d_d_x += _r2;
+// CHECK-NEXT:         _d_d_y += _r3;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: void f6_darg1_grad(float x, float y, float *_d_x, float *_d_y) {
-// CHECK-NEXT:     float _d__d_x = 0.F;
+// CHECK-NEXT:     float _d_d_x = 0.F;
 // CHECK-NEXT:     float _d_x0 = 0;
-// CHECK-NEXT:     float _d__d_y = 0.F;
+// CHECK-NEXT:     float _d_d_y = 0.F;
 // CHECK-NEXT:     float _d_y0 = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d__t0 = {0.F, 0.F};
+// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(x, y, _d_x0, _d_y0);
-// CHECK-NEXT:     _d__t0.pushforward += 1;
+// CHECK-NEXT:     _d_t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
-// CHECK-NEXT:         {{.*}}pow_pushforward_pullback(x, y, _d_x0, _d_y0, _d__t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         {{.*}}pow_pushforward_pullback(x, y, _d_x0, _d_y0, _d_t0, &_r0, &_r1, &_r2, &_r3);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         *_d_y += _r1;
-// CHECK-NEXT:         _d__d_x += _r2;
-// CHECK-NEXT:         _d__d_y += _r3;
+// CHECK-NEXT:         _d_d_x += _r2;
+// CHECK-NEXT:         _d_d_y += _r3;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -211,72 +211,72 @@ int main() {
   TEST2(fn_def_arg, 3, 5);  // CHECK-EXEC: Result is = {0.00, 2.00, 2.00, 0.00}
 
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
-//CHECK-NEXT:    double _d__d_a = 0.;
+//CHECK-NEXT:    double _d_d_a = 0.;
 //CHECK-NEXT:    double _d_a0 = 1;
-//CHECK-NEXT:    double _d__d_b = 0.;
+//CHECK-NEXT:    double _d_d_b = 0.;
 //CHECK-NEXT:    double _d_b0 = 0;
-//CHECK-NEXT:    double _d__t0 = 0.;
+//CHECK-NEXT:    double _d_t0 = 0.;
 //CHECK-NEXT:    double _t00 = a * a;
-//CHECK-NEXT:    double _d__t1 = 0.;
+//CHECK-NEXT:    double _d_t1 = 0.;
 //CHECK-NEXT:    double _t10 = b * b;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        _d__d_a += 1 * a * a;
+//CHECK-NEXT:        _d_d_a += 1 * a * a;
 //CHECK-NEXT:        *_d_a += _d_a0 * 1 * a;
 //CHECK-NEXT:        *_d_a += 1 * a * _d_a0;
-//CHECK-NEXT:        _d__d_a += a * 1 * a;
+//CHECK-NEXT:        _d_d_a += a * 1 * a;
 //CHECK-NEXT:        *_d_a += (_d_a0 * a + a * _d_a0) * 1;
-//CHECK-NEXT:        _d__t0 += 1 * _d_a0;
-//CHECK-NEXT:        _d__d_a += _t00 * 1;
-//CHECK-NEXT:        _d__d_b += 1 * b * b;
+//CHECK-NEXT:        _d_t0 += 1 * _d_a0;
+//CHECK-NEXT:        _d_d_a += _t00 * 1;
+//CHECK-NEXT:        _d_d_b += 1 * b * b;
 //CHECK-NEXT:        *_d_b += _d_b0 * 1 * b;
 //CHECK-NEXT:        *_d_b += 1 * b * _d_b0;
-//CHECK-NEXT:        _d__d_b += b * 1 * b;
+//CHECK-NEXT:        _d_d_b += b * 1 * b;
 //CHECK-NEXT:        *_d_b += (_d_b0 * b + b * _d_b0) * 1;
-//CHECK-NEXT:        _d__t1 += 1 * _d_b0;
-//CHECK-NEXT:        _d__d_b += _t10 * 1;
+//CHECK-NEXT:        _d_t1 += 1 * _d_b0;
+//CHECK-NEXT:        _d_d_b += _t10 * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        *_d_b += _d__t1 * b;
-//CHECK-NEXT:        *_d_b += b * _d__t1;
+//CHECK-NEXT:        *_d_b += _d_t1 * b;
+//CHECK-NEXT:        *_d_b += b * _d_t1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        *_d_a += _d__t0 * a;
-//CHECK-NEXT:        *_d_a += a * _d__t0;
+//CHECK-NEXT:        *_d_a += _d_t0 * a;
+//CHECK-NEXT:        *_d_a += a * _d_t0;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
 //CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg1_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
-//CHECK-NEXT:    double _d__d_a = 0.;
+//CHECK-NEXT:    double _d_d_a = 0.;
 //CHECK-NEXT:    double _d_a0 = 0;
-//CHECK-NEXT:    double _d__d_b = 0.;
+//CHECK-NEXT:    double _d_d_b = 0.;
 //CHECK-NEXT:    double _d_b0 = 1;
-//CHECK-NEXT:    double _d__t0 = 0.;
+//CHECK-NEXT:    double _d_t0 = 0.;
 //CHECK-NEXT:    double _t00 = a * a;
-//CHECK-NEXT:    double _d__t1 = 0.;
+//CHECK-NEXT:    double _d_t1 = 0.;
 //CHECK-NEXT:    double _t10 = b * b;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        _d__d_a += 1 * a * a;
+//CHECK-NEXT:        _d_d_a += 1 * a * a;
 //CHECK-NEXT:        *_d_a += _d_a0 * 1 * a;
 //CHECK-NEXT:        *_d_a += 1 * a * _d_a0;
-//CHECK-NEXT:        _d__d_a += a * 1 * a;
+//CHECK-NEXT:        _d_d_a += a * 1 * a;
 //CHECK-NEXT:        *_d_a += (_d_a0 * a + a * _d_a0) * 1;
-//CHECK-NEXT:        _d__t0 += 1 * _d_a0;
-//CHECK-NEXT:        _d__d_a += _t00 * 1;
-//CHECK-NEXT:        _d__d_b += 1 * b * b;
+//CHECK-NEXT:        _d_t0 += 1 * _d_a0;
+//CHECK-NEXT:        _d_d_a += _t00 * 1;
+//CHECK-NEXT:        _d_d_b += 1 * b * b;
 //CHECK-NEXT:        *_d_b += _d_b0 * 1 * b;
 //CHECK-NEXT:        *_d_b += 1 * b * _d_b0;
-//CHECK-NEXT:        _d__d_b += b * 1 * b;
+//CHECK-NEXT:        _d_d_b += b * 1 * b;
 //CHECK-NEXT:        *_d_b += (_d_b0 * b + b * _d_b0) * 1;
-//CHECK-NEXT:        _d__t1 += 1 * _d_b0;
-//CHECK-NEXT:        _d__d_b += _t10 * 1;
+//CHECK-NEXT:        _d_t1 += 1 * _d_b0;
+//CHECK-NEXT:        _d_d_b += _t10 * 1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        *_d_b += _d__t1 * b;
-//CHECK-NEXT:        *_d_b += b * _d__t1;
+//CHECK-NEXT:        *_d_b += _d_t1 * b;
+//CHECK-NEXT:        *_d_b += b * _d_t1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        *_d_a += _d__t0 * a;
-//CHECK-NEXT:        *_d_a += a * _d__t0;
+//CHECK-NEXT:        *_d_a += _d_t0 * a;
+//CHECK-NEXT:        *_d_a += a * _d_t0;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 }

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -45,76 +45,76 @@ double f2(double x, double y){
 // CHECK-NEXT:     f2_darg1_grad(x, y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
 // CHECK-NEXT: }
 
-// CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1, double *_d__d_x, double *_d__d_y);
+// CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1, double *_d_d_x, double *_d_d_y);
 
 // CHECK: void f2_darg0_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     double _d__d_x = 0.;
+// CHECK-NEXT:     double _d_d_x = 0.;
 // CHECK-NEXT:     double _d_x0 = 1;
-// CHECK-NEXT:     double _d__d_y = 0.;
+// CHECK-NEXT:     double _d_d_y = 0.;
 // CHECK-NEXT:     double _d_y0 = 0;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {0., 0.};
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_t0 = {0., 0.};
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
-// CHECK-NEXT:     double _d__d_ans = 0.;
+// CHECK-NEXT:     double _d_d_ans = 0.;
 // CHECK-NEXT:     double _d_ans = _t00.pushforward;
 // CHECK-NEXT:     double _d_ans0 = 0.;
 // CHECK-NEXT:     double ans = _t00.value;
-// CHECK-NEXT:     _d__d_ans += 1;
-// CHECK-NEXT:     _d__t0.value += _d_ans0;
-// CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
+// CHECK-NEXT:     _d_d_ans += 1;
+// CHECK-NEXT:     _d_t0.value += _d_ans0;
+// CHECK-NEXT:     _d_t0.pushforward += _d_d_ans;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         double _r1 = 0.;
 // CHECK-NEXT:         double _r2 = 0.;
 // CHECK-NEXT:         double _r3 = 0.;
-// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y0, _d__t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y0, _d_t0, &_r0, &_r1, &_r2, &_r3);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         *_d_y += _r1;
-// CHECK-NEXT:         _d__d_x += _r2;
-// CHECK-NEXT:         _d__d_y += _r3;
+// CHECK-NEXT:         _d_d_x += _r2;
+// CHECK-NEXT:         _d_d_y += _r3;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: void f2_darg1_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     double _d__d_x = 0.;
+// CHECK-NEXT:     double _d_d_x = 0.;
 // CHECK-NEXT:     double _d_x0 = 0;
-// CHECK-NEXT:     double _d__d_y = 0.;
+// CHECK-NEXT:     double _d_d_y = 0.;
 // CHECK-NEXT:     double _d_y0 = 1;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d__t0 = {0., 0.};
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_t0 = {0., 0.};
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
-// CHECK-NEXT:     double _d__d_ans = 0.;
+// CHECK-NEXT:     double _d_d_ans = 0.;
 // CHECK-NEXT:     double _d_ans = _t00.pushforward;
 // CHECK-NEXT:     double _d_ans0 = 0.;
 // CHECK-NEXT:     double ans = _t00.value;
-// CHECK-NEXT:     _d__d_ans += 1;
-// CHECK-NEXT:     _d__t0.value += _d_ans0;
-// CHECK-NEXT:     _d__t0.pushforward += _d__d_ans;
+// CHECK-NEXT:     _d_d_ans += 1;
+// CHECK-NEXT:     _d_t0.value += _d_ans0;
+// CHECK-NEXT:     _d_t0.pushforward += _d_d_ans;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         double _r1 = 0.;
 // CHECK-NEXT:         double _r2 = 0.;
 // CHECK-NEXT:         double _r3 = 0.;
-// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y0, _d__t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y0, _d_t0, &_r0, &_r1, &_r2, &_r3);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:         *_d_y += _r1;
-// CHECK-NEXT:         _d__d_x += _r2;
-// CHECK-NEXT:         _d__d_y += _r3;
+// CHECK-NEXT:         _d_d_x += _r2;
+// CHECK-NEXT:         _d_d_y += _r3;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1, double *_d__d_x, double *_d__d_y) {
+// CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1, double *_d_d_x, double *_d_d_y) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_x0 += _d_y0.value * x;
 // CHECK-NEXT:         *_d_x0 += x * _d_y0.value;
 // CHECK-NEXT:         *_d_y1 += _d_y0.value * y;
 // CHECK-NEXT:         *_d_y1 += y * _d_y0.value;
-// CHECK-NEXT:         *_d__d_x += _d_y0.pushforward * x;
+// CHECK-NEXT:         *_d_d_x += _d_y0.pushforward * x;
 // CHECK-NEXT:         *_d_x0 += _d_x * _d_y0.pushforward;
 // CHECK-NEXT:         *_d_x0 += _d_y0.pushforward * _d_x;
-// CHECK-NEXT:         *_d__d_x += x * _d_y0.pushforward;
-// CHECK-NEXT:         *_d__d_y += _d_y0.pushforward * y;
+// CHECK-NEXT:         *_d_d_x += x * _d_y0.pushforward;
+// CHECK-NEXT:         *_d_d_y += _d_y0.pushforward * y;
 // CHECK-NEXT:         *_d_y1 += _d_y * _d_y0.pushforward;
 // CHECK-NEXT:         *_d_y1 += _d_y0.pushforward * _d_y;
-// CHECK-NEXT:         *_d__d_y += y * _d_y0.pushforward;
+// CHECK-NEXT:         *_d_d_y += y * _d_y0.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -30,28 +30,28 @@ double nonMemFn(double i, double j) {
 // CHECK-NEXT: }
 
 // CHECK: void nonMemFn_darg0_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d__d_i = 0.;
+// CHECK-NEXT:     double _d_d_i = 0.;
 // CHECK-NEXT:     double _d_i0 = 1;
-// CHECK-NEXT:     double _d__d_j = 0.;
+// CHECK-NEXT:     double _d_d_j = 0.;
 // CHECK-NEXT:     double _d_j0 = 0;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d__d_i += 1 * j;
+// CHECK-NEXT:         _d_d_i += 1 * j;
 // CHECK-NEXT:         *_d_j += _d_i0 * 1;
 // CHECK-NEXT:         *_d_i += 1 * _d_j0;
-// CHECK-NEXT:         _d__d_j += i * 1;
+// CHECK-NEXT:         _d_d_j += i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: void nonMemFn_darg1_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d__d_i = 0.;
+// CHECK-NEXT:     double _d_d_i = 0.;
 // CHECK-NEXT:     double _d_i0 = 0;
-// CHECK-NEXT:     double _d__d_j = 0.;
+// CHECK-NEXT:     double _d_d_j = 0.;
 // CHECK-NEXT:     double _d_j0 = 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d__d_i += 1 * j;
+// CHECK-NEXT:         _d_d_i += 1 * j;
 // CHECK-NEXT:         *_d_j += _d_i0 * 1;
 // CHECK-NEXT:         *_d_i += 1 * _d_j0;
-// CHECK-NEXT:         _d__d_j += i * 1;
+// CHECK-NEXT:         _d_d_j += i * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 


### PR DESCRIPTION
This PR closes issue #958. I updated the "ReverseModeVisitor.cpp" to strip leading underscores from original variables preventing messy prefixes.
**Ex: `_d___val` -> `_d_val`.**
Also made changes in the regeression test so that they now rely on new clean names.
