### PR TITLE
Fix #1551 - Made integer type functions non differentiable

### DIFF
--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -683,6 +683,9 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     return found != m_ActivityRunInfo.VariedS.end();
   }
   bool DiffRequest::shouldHaveAdjoint(const VarDecl* VD) const {
+    // Integer types shouldn't have adjoints.
+    if (VD->getType()->isIntegralOrEnumerationType())
+      return false;
     if (!EnableVariedAnalysis)
       return true;
     return getVariedDecls().find(VD) != getVariedDecls().end();


### PR DESCRIPTION
I added a check for integer type in the function `ShouldHaveAdjoint`. Although I didn't made changes to its overload which checks statements, i.e. `bool DiffRequest::shouldHaveAdjoint(const Stmt* S)`. I think changes to its overload can be made in further commits after discussion from maintainers, (If they don't want any changes for overload, this issue can be closed). 

Here's small change I made : 
```C++
bool DiffRequest::shouldHaveAdjoint(const VarDecl* VD) const {
    // Integer types shouldn't have adjoints.
    if (VD->getType()->isIntegralOrEnumerationType())
      return false;
    if (!EnableVariedAnalysis)
      return true;
    return getVariedDecls().find(VD) != getVariedDecls().end();
  } 
```

For statement overload function I am thinking to implement it somewhat like this : 
(That will be discussed anyway).

```C++
bool DiffRequest::shouldHaveAdjoint(const Stmt* S) const {
  // Proposed Change:
  if (const Expr* E = dyn_cast<Expr>(S)) {
    if (E->getType()->isIntegralOrEnumerationType())
      return false;
  }
  if (!EnableVariedAnalysis)
    return true;
  auto found = m_ActivityRunInfo.VariedS.find(S);
  return found != m_ActivityRunInfo.VariedS.end();
}
```