### PR TITLE
Fix #1376 - Allow redefining builtin custom derivatives

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -510,6 +510,7 @@ CUDA_HOST_DEVICE ValueAndPushforward<T, dT> exp_pushforward(T x, dT d_x) {
   return {::std::exp(x), ::std::exp(x) * d_x};
 }
 #endif
+
 // pushforward for expf, expl
 template <typename T, typename dT>
 CUDA_HOST_DEVICE ValueAndPushforward<T, dT> expf_pushforward(T x, dT d_x) {

--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -503,11 +503,13 @@ CUDA_HOST_DEVICE void fdiml_pullback(T x, T y, U d_z, T* d_x, T* d_y) {
 // 2. Exponential Functions
 
 // 2.1 exp, expf, expl
+// Allow disabling built-in derivative if user-defined derivative provided.
+#ifndef CLAD_NO_BUILTIN_EXP
 template <typename T, typename dT>
 CUDA_HOST_DEVICE ValueAndPushforward<T, dT> exp_pushforward(T x, dT d_x) {
   return {::std::exp(x), ::std::exp(x) * d_x};
 }
-
+#endif
 // pushforward for expf, expl
 template <typename T, typename dT>
 CUDA_HOST_DEVICE ValueAndPushforward<T, dT> expf_pushforward(T x, dT d_x) {
@@ -1236,7 +1238,9 @@ using std::remainderl_pushforward;
 using std::exp2_pushforward;
 using std::exp2f_pushforward;
 using std::exp2l_pushforward;
-using std::exp_pushforward;
+#ifndef CLAD_NO_BUILTIN_EXP
+using std::exp_pushforward;  //disable built-in exp derivative
+#endif
 using std::expf_pushforward;
 using std::expl_pushforward;
 using std::expm1_pushforward;


### PR DESCRIPTION
I made changes for only one derivative i.e. `exp_pushforward`. Changes for other derivatives can be made after discussing from maintainers. 

Users can redefine builtin derivatives after my changes. 

```
 ~/repos/llvm-project/build/bin/clang++ -std=c++17 -I ./include/ -fplugin=./build/lib/clad.so example.cpp -o example
./example
The code is: 
void differentiable_code_grad(double x, double *_d_x) {
    {
        double _r0 = 0.;
        _r0 += 1 * clad::custom_derivatives::std::exp_pushforward(x, 1.).pushforward;
        *_d_x += _r0;
    }
}
```

#### Changes

Added control macro for the definition of std::exp_pushforward. 
here 
```C++
// 2.1 exp, expf, expl
// Allow disabling built-in derivative if user-defined derivative provided.
#ifndef CLAD_NO_BUILTIN_EXP
template <typename T, typename dT>
CUDA_HOST_DEVICE ValueAndPushforward<T, dT> exp_pushforward(T x, dT d_x) {
  return {::std::exp(x), ::std::exp(x) * d_x};
}
#endif
```

and here:
```C++
#ifndef CLAD_NO_BUILTIN_EXP
using std::exp_pushforward;  //disable built-in exp derivative
#endif
```

Similar macro for all the functions can be used (if maintainers approve).