### PR TITLE
Parallelism in clad::restore_tracker using multithreading

### DIFF
--- a/include/clad/Differentiator/RestoreTracker.h
+++ b/include/clad/Differentiator/RestoreTracker.h
@@ -4,7 +4,9 @@
 #include <cassert>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
 #include <map>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -40,11 +42,38 @@ public:
     m_data.emplace((char*)&val, std::move(buffer));
   }
   // Set all stored addresses to the corresponsing values bitwise.
-  void restore() {
-    for (std::pair<const Address, RawMemory>& pair : m_data) {
-      std::vector<uint8_t>& buffer = pair.second;
-      std::memcpy(pair.first, buffer.data(), buffer.size());
+  template <typename = void> void restore() {
+    size_t total_items = m_data.size();
+    if (total_items == 0)
+      return;
+
+    size_t avail_threads = std::thread::hardware_concurrency();
+    if (avail_threads == 0)
+      avail_threads = 1;
+    std::vector<std::thread> workers;
+    workers.reserve(avail_threads);
+
+    size_t task_per_worker = total_items / avail_threads;
+    size_t left_task = total_items % avail_threads;
+
+    auto block_start = m_data.begin();
+    for (size_t i = 0; i < avail_threads; i++) {
+      size_t curr_block_size = task_per_worker + (i < left_task ? 1 : 0);
+      if (curr_block_size == 0)
+        continue;
+
+      auto block_end = block_start;
+      std::advance(block_end, curr_block_size);
+
+      workers.emplace_back([block_start, block_end]() {
+        for (auto it = block_start; it != block_end; it++)
+          std::memcpy(it->first, it->second.data(), it->second.size());
+      });
+      block_start = block_end;
     }
+    for (auto& t : workers)
+      if (t.joinable())
+        t.join();
     m_data.clear();
   }
 };


### PR DESCRIPTION
Enforced parallelism in restore_tracker by creating safe multi threads to carry out the process of restoring the stored primals without disturbing other threads and i have used async to manage threads automatically without any human intervention
#Fixes 1539