### PR TITLE
Fix #1665 - Don't generate adjoints of counters in weightedSum

### DIFF
--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -61,7 +61,6 @@ static FunctionDecl* DeriveUsingForwardAndReverseMode(
   ReverseModeRequest.EnableUsefulAnalysis = true;
   ReverseModeRequest.EnableTBRAnalysis = true;
 
-
   FunctionDecl* secondDerivative =
       Builder.HandleNestedDiffRequest(ReverseModeRequest);
   return secondDerivative;

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -57,6 +57,10 @@ static FunctionDecl* DeriveUsingForwardAndReverseMode(
   ReverseModeRequest.Function = firstDerivative;
   ReverseModeRequest.Args = ReverseModeArgs;
   ReverseModeRequest.BaseFunctionName = firstDerivative->getNameAsString();
+  ReverseModeRequest.EnableVariedAnalysis = true;
+  ReverseModeRequest.EnableUsefulAnalysis = true;
+  ReverseModeRequest.EnableTBRAnalysis = true;
+
 
   FunctionDecl* secondDerivative =
       Builder.HandleNestedDiffRequest(ReverseModeRequest);

--- a/test/Hessian/LoopAdjoints.C
+++ b/test/Hessian/LoopAdjoints.C
@@ -1,0 +1,21 @@
+// Compile time test for Hessian of weightedSum, kept separate from runtime tests (Hessians.C)
+// RUN: %cladclang -std=c++17 -Xclang -add-plugin -Xclang clad -Xclang -plugin-arg-clad -Xclang \
+// RUN: -fdump-derived-fn %s -I%S/../../include -c -o /dev/null 2>&1 | %filecheck %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+double weightedSum(double* arr, const double* weights) {
+  double sum = 0;
+  for(int i=0; i<10; ++i) {
+    sum += arr[i] * weights[i];
+  }
+  return sum;
+}
+
+// Instantiate Hessian to trigger derivation
+auto h_weightedSum = clad::hessian(weightedSum, "arr[0:10]");
+
+// Verify that the loop index adjoint '_d_i' is NOT created.
+// CHECK: void weightedSum_hessian
+// CHECK-NOT: int _d_i
+// CHECK: }


### PR DESCRIPTION
### Original issue

> When differentiating weightedSum for hessians, we generate adjoints of i, and they are diagnosed as unused even by Clang. This issue comes down to enabling activity analysis for hessians.

When computing hessians, clad generates adjoints for loop indices, e.g. i, this leads to unused variable warnings. 

### What to fix/ Implementation plan

To enable activity analysis during hessian differentiation in clad. The changes will be made in `clad/lib/HessianModeVisitor.cpp`. 

### Changes 

Make following changes to `clad/lib/HessianModeVisitor.cpp`.

```C++
ReverseModeRequest.EnableVariedAnalysis = true;
  ReverseModeRequest.EnableUsefulAnalysis = true;
  ReverseModeRequest.EnableTBRAnalysis = true;
```
