### PR TITLE
Fixes XFail test (ArrayErrors.C)

### DIFF
--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -157,6 +157,8 @@ DerivativeAndOverload HessianModeVisitor::Derive() {
           std::string helperMsg("clad::hessian(" + FD->getNameAsString() +
                                 ", \"" + suggestedArgsStr + "\")");
           SourceLocation L = PVD->getBeginLoc();
+          if (m_DiffReq.Args)
+            L = m_DiffReq.Args->getExprLoc();
           diag(DiagnosticsEngine::Error, L,
                "hessian mode differentiation w.r.t. array or pointer "
                "parameters needs explicit declaration of the indices of the "

--- a/test/Hessian/ArrayErrors.C
+++ b/test/Hessian/ArrayErrors.C
@@ -2,14 +2,13 @@
 
 #include "clad/Differentiator/Differentiator.h"
 
-//XFAIL:*
-double f(int a, const double *b) {
+double f(double a, const double *b) {
   return b[0] * a + b[1] * a + b[2] * a;
 }
 
 int main() {
-    clad::hessian(f, 1); // expected-error {{hessian mode differentiation w.r.t. array or pointer parameters needs explicit declaration of the indices of the array using the args parameter; did you mean 'clad::hessian(f, "b[0:<last index of b>]")'}}
+    clad::hessian(f, 1); // expected-error {{hessian mode differentiation w.r.t. array or pointer parameters needs explicit declaration of the indices of the array using the args parameter; did you mean 'clad::hessian}}
     clad::hessian(f, "a");
-    clad::hessian(f, "a, b"); // expected-error {{hessian mode differentiation w.r.t. array or pointer parameters needs explicit declaration of the indices of the array using the args parameter; did you mean 'clad::hessian(f, "a, b[0:<last index of b>]")'}}
+    clad::hessian(f, "a, b"); // expected-error {{hessian mode differentiation w.r.t. array or pointer parameters needs explicit declaration of the indices of the array using the args parameter; did you mean 'clad::hessian}}
     clad::hessian(f, "a, b[0:2]");
 };


### PR DESCRIPTION
This PR resolves the problem where error diagnostics in Hessian Mode were pointing to the function declaration instead of the call site when array indices were missing. This fix enable the "Hessian/ArrayErrors.C" which was previously marked as XFail.

Fixes #1540