### PR TITLE
Rework lambdas in Clad

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -22,10 +22,10 @@
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/Version.h"
 #include "clang/Sema/Sema.h"
-
-#include <llvm/ADT/ArrayRef.h>
-#include <llvm/ADT/SmallVector.h>
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
 
 #include <array>
 #include <limits>
@@ -90,7 +90,7 @@ namespace clad {
 
     unsigned outputArrayCursor = 0;
     unsigned numParams = 0;
-    clang::Expr* m_Pullback = nullptr;
+    llvm::SmallVector<clang::Expr*, 1> m_Pullback;
     const char* funcPostfix() const {
       if (m_DiffReq.Mode == DiffMode::jacobian)
         return "_jac";
@@ -386,6 +386,10 @@ namespace clad {
     StmtDiff VisitForStmt(const clang::ForStmt* FS);
     StmtDiff VisitIfStmt(const clang::IfStmt* If);
     StmtDiff VisitImplicitCastExpr(const clang::ImplicitCastExpr* ICE);
+
+#if CLANG_VERSION_MAJOR > 16
+    StmtDiff VisitLambdaExpr(const clang::LambdaExpr* LE);
+#endif // CLANG_VERSION_MAJOR
     StmtDiff
     VisitCXXFunctionalCastExpr(const clang::CXXFunctionalCastExpr* FCE);
     StmtDiff VisitCStyleCastExpr(const clang::CStyleCastExpr* CSCE);
@@ -696,8 +700,21 @@ namespace clad {
     ///\paramp[in] source An external RMV source
     void AddExternalSource(ExternalRMVSource& source);
 
+    clang::QualType GetLambdaDerivativeType(const clang::LambdaExpr* LE) {
+      clang::FunctionDecl* FD = LE->getCallOperator();
+      llvm::SmallVector<const clang::ValueDecl*, 4> diffParams{};
+      for (const auto* param : FD->parameters())
+        diffParams.push_back(param);
+
+      return utils::GetDerivativeType(m_Sema, FD, DiffMode::pullback,
+                                      diffParams,
+                                      /*forCustomDerv=*/false,
+                                      /*shouldUseRestoreTracker=*/false);
+    }
+    clang::Expr* buildDerivedLambda(const clang::LambdaExpr* LE);
     /// Builds and returns the sequence of derived function parameters.
-    void BuildParams(llvm::SmallVectorImpl<clang::ParmVarDecl*>& params);
+    void BuildParams(llvm::SmallVectorImpl<clang::ParmVarDecl*>& params,
+                     const clang::LambdaExpr* LE = nullptr);
 
     /// Stores data required for differentiating a switch statement.
     struct SwitchStmtInfo {

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1155,8 +1155,11 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
 
       const auto* MD = dyn_cast<CXXMethodDecl>(FD);
       if (MD) {
-        if (isLambdaCallOperator(MD))
+        if (isLambdaCallOperator(MD) &&
+            m_TopMostReq->Mode == DiffMode::reverse) {
           request.EnableVariedAnalysis = false;
+          return true;
+        }
         const CXXRecordDecl* CD = MD->getParent();
         if (clad::utils::hasNonDifferentiableAttribute(CD))
           nonDiff = true;

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -20,6 +20,8 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTLambda.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/DeclarationName.h"
@@ -30,17 +32,22 @@
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/Type.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
+#include "clang/Basic/ExceptionSpecificationType.h"
 #include "clang/Basic/LLVM.h" // for clang::isa
+#include "clang/Basic/Lambda.h"
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/TokenKinds.h"
 #include "clang/Basic/TypeTraits.h"
 #include "clang/Basic/Version.h"
+#include "clang/Sema/DeclSpec.h"
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Overload.h"
 #include "clang/Sema/Ownership.h"
+#include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/Scope.h"
+#include "clang/Sema/ScopeInfo.h"
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/SemaInternal.h"
 #include "clang/Sema/Template.h"
@@ -265,9 +272,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // added by the plugins yet.
     if (m_DiffReq.Mode == DiffMode::reverse) {
       if (returnTy->isRealType())
-        m_Pullback =
-            ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context,
-                                              /*val=*/1);
+        m_Pullback.push_back(ConstantFolder::synthesizeLiteral(m_Context.IntTy,
+                                                               m_Context,
+                                                               /*val=*/1));
       else if (!returnTy->isVoidType()) {
         diag(DiagnosticsEngine::Warning, m_DiffReq.Function->getBeginLoc(),
              "clad::gradient only supports differentiation functions of real "
@@ -1313,7 +1320,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       return {nullptr, nullptr};
     const Expr* value = RS->getRetValue();
     QualType type = value->getType();
-    auto* dfdf = m_Pullback;
+    Expr* dfdf = nullptr;
+    if (!m_Pullback.empty())
+      dfdf = m_Pullback.back();
     if (dfdf && (isa<FloatingLiteral>(dfdf) || isa<IntegerLiteral>(dfdf)) &&
         type->isScalarType()) {
       ExprResult tmp = dfdf;
@@ -1469,17 +1478,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // Check if referenced Decl was "replaced" with another identifier inside
     // the derivative
     if (auto* VD = dyn_cast<VarDecl>(cast<DeclRefExpr>(clonedDRE)->getDecl())) {
-      // If current context is different than the context of the original
-      // declaration (e.g. we are inside lambda), rebuild the DeclRefExpr
-      // with Sema::BuildDeclRefExpr. This is required in some cases, e.g.
-      // Sema::BuildDeclRefExpr is responsible for adding captured fields
-      // to the underlying struct of a lambda.
-      if (VD->getDeclContext() != m_Sema.CurContext) {
-        auto* ccDRE = dyn_cast<DeclRefExpr>(clonedDRE);
-        NestedNameSpecifier* NNS = DRE->getQualifier();
-        auto* referencedDecl = cast<VarDecl>(ccDRE->getDecl());
-        clonedDRE = BuildDeclRef(referencedDecl, NNS, DRE->getValueKind());
-      }
       // This case happens when ref-type variables have to become function
       // global. Ref-type declarations cannot be moved to the function global
       // scope because they can't be separated from their inits.
@@ -1732,6 +1730,132 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     return result;
   }
 
+#if CLANG_VERSION_MAJOR > 16
+  clang::Expr* ReverseModeVisitor::buildDerivedLambda(const LambdaExpr* LE) {
+    LambdaIntroducer Intro;
+    Intro.Default = LCD_None;
+    Intro.Range.setBegin(noLoc);
+    Intro.Range.setEnd(noLoc);
+    AttributeFactory AttrFactory;
+    const DeclSpec DS(AttrFactory);
+    Declarator D(DS, clang::ParsedAttributesView::none(),
+                 clang::DeclaratorContext::LambdaExpr);
+
+    QualType dFnType = GetLambdaDerivativeType(LE);
+
+    auto* DC =
+        const_cast<DeclContext*>(LE->getCallOperator()->getDeclContext());
+    llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
+    llvm::SaveAndRestore<FunctionDecl*> SaveDerivative(m_Derivative);
+
+    // FIXME: Should be easy remove.
+    auto*& FuncRef = const_cast<const FunctionDecl*&>(m_DiffReq.Function);
+
+    llvm::SaveAndRestore<const FunctionDecl*> SaveReq(FuncRef);
+    llvm::SaveAndRestore<Scope*> SaveFunctionScope(m_DerivativeFnScope);
+    beginScope(Scope::LambdaScope | Scope::DeclScope |
+               Scope::FunctionDeclarationScope | Scope::FunctionPrototypeScope);
+
+    m_Sema.PushLambdaScope();
+    m_Sema.ActOnLambdaExpressionAfterIntroducer(Intro, getCurrentScope());
+
+    beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
+               Scope::DeclScope);
+
+    llvm::SmallVector<DeclaratorChunk::ParamInfo> ParamInfoLambda;
+    llvm::SmallVector<ParmVarDecl*, 8> params;
+
+    m_Sema.ActOnLambdaClosureQualifiers(Intro, noLoc);
+
+    sema::LambdaScopeInfo* LSI = m_Sema.getCurLambda();
+    LSI->CallOperator->setType(dFnType);
+
+    m_Sema.PushDeclContext(getCurrentScope(), LSI->CallOperator);
+
+    LSI->Lambda->setDeclContext(DC);
+
+    m_Derivative = LSI->CallOperator;
+    // FIXME: Should be easy remove.
+    const_cast<DiffRequest&>(m_DiffReq).Function = LE->getCallOperator();
+
+    BuildParams(params, LE);
+    m_Derivative->setBody(MakeCompoundStmt({}));
+
+    m_Sema.PopDeclContext();
+
+    for (auto* PVD : params)
+      ParamInfoLambda.emplace_back(PVD->getIdentifier(), PVD->getLocation(),
+                                   PVD, nullptr);
+    D.AddTypeInfo(DeclaratorChunk::getFunction(
+                      /*hasProto=*/true,
+                      /*isAmbiguous=*/false,
+                      /*LParenLoc=*/noLoc,
+                      /*Params=*/ParamInfoLambda.data(),
+                      /*NumParams=*/ParamInfoLambda.size(),
+                      /*EllipsisLoc=*/SourceLocation(),
+                      /*RParenLoc=*/noLoc,
+                      /*RefQualifierIsLValueRef=*/true,
+                      /*RefQualifierLoc=*/SourceLocation(),
+                      /*MutableLoc=*/SourceLocation(),
+                      /*ESpecType=*/EST_None,
+                      /*ESpecRange=*/SourceRange(),
+                      /*Exceptions=*/nullptr,
+                      /*ExceptionRanges=*/nullptr,
+                      /*NumExceptions=*/0,
+                      /*NoexceptExpr=*/nullptr,
+                      /*ExceptionSpecTokens=*/nullptr,
+                      /*DeclsInPrototype=*/{},
+                      /*LocalRangeBegin=*/noLoc,
+                      /*LocalRangeEnd=*/noLoc,
+                      /*Declarator=*/D,
+                      /*TrailingReturnType=*/ParsedType(),
+                      /*TrailingReturnTypeLoc=*/SourceLocation()),
+                  /*EndLoc=*/SourceLocation());
+
+    m_Sema.ActOnLambdaClosureParameters(getCurrentScope(), ParamInfoLambda);
+
+    beginScope(Scope::BlockScope | Scope::FnScope | Scope::DeclScope |
+               Scope::CompoundStmtScope);
+
+    m_Sema.ActOnStartOfLambdaDefinition(
+        Intro, D,
+        clad_compat::Sema_ActOnStartOfLambdaDefinition_ScopeOrDeclSpec(
+            getCurrentScope(), DS));
+
+    m_DerivativeFnScope = getCurrentScope();
+    beginBlock();
+
+    // FIXME: Fix m_Globals being emmitted to the outer function.
+    StmtDiff BodyDiff = Visit(LE->getCallOperator()->getBody());
+    for (auto* S : cast<CompoundStmt>(BodyDiff.getStmt())->body())
+      addToCurrentBlock(S);
+    for (auto* S : cast<CompoundStmt>(BodyDiff.getStmt_dx())->body())
+      addToCurrentBlock(S);
+
+    CompoundStmt* DerivedBody = endBlock();
+
+    Expr* lambda =
+        m_Sema
+            .ActOnLambdaExpr(
+                noLoc,
+                DerivedBody /*,*/
+                    CLAD_COMPAT_CLANG17_ActOnLambdaExpr_getCurrentScope_ExtraParam(
+                        *this))
+            .get();
+
+    endScope();
+    endScope();
+    endScope();
+    return lambda;
+  }
+
+  StmtDiff ReverseModeVisitor::VisitLambdaExpr(const LambdaExpr* LE) {
+    Expr* lambdaE = buildDerivedLambda(LE);
+    m_Pullback.pop_back();
+    // FIXME: Clone lambda properly.
+    return {const_cast<Expr*>(cast<Expr>(LE)), lambdaE};
+  }
+#endif // CLANG_VERSION_MAJOR
   StmtDiff ReverseModeVisitor::VisitCallExpr(const CallExpr* CE) {
     // FIXME: Add general support for non-direct calls
     const Expr* callee = CE->getCallee();
@@ -1743,6 +1867,37 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     if (!FD) {
       diagUnsupportedIndirectCalls(CE);
       return StmtDiff(Clone(CE));
+    }
+
+    const auto* MD = dyn_cast<CXXMethodDecl>(FD);
+    Expr* LambdaCallOpExpr = nullptr;
+    if (MD) {
+      if (isLambdaCallOperator(MD)) {
+        const auto* CallE = CE->getArg(0)->IgnoreParenImpCasts();
+        // FIXME: Handle direct calls when we properly clone lambdas.
+        if (isa<LambdaExpr>(CallE)) {
+          SourceLocation L = CallE->getBeginLoc();
+          diag(DiagnosticsEngine::Warning, L,
+               "direct lambda calls are not supported, ignored")
+              << L;
+          return getZeroInit(CE->getType());
+        }
+
+        if (const auto* DRE = llvm::dyn_cast<DeclRefExpr>(CallE)) {
+          const auto* VD = dyn_cast<VarDecl>(DRE->getDecl());
+          for (auto* D : m_Derivative->decls())
+            if (auto* lookupVD = dyn_cast<VarDecl>(D))
+              if (lookupVD->getNameAsString() ==
+                  "_d_" + VD->getNameAsString()) {
+                CXXScopeSpec SS;
+                LambdaCallOpExpr = DeclRefExpr::Create(
+                    m_Context, NestedNameSpecifierLoc(), SourceLocation(),
+                    lookupVD,
+                    /*RefersToEnclosingVariableOrCapture=*/false, noLoc,
+                    lookupVD->getType(), VK_LValue);
+              }
+        }
+      }
     }
 
     // FIXME: Revisit this when variadic functions are supported.
@@ -1799,24 +1954,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     llvm::SmallVector<Expr*, 16> CallArgDx{};
 
     // Determine the base of the call if any.
-    const auto* MD = dyn_cast<CXXMethodDecl>(FD);
     const Expr* baseOriginalE = nullptr;
     if (MD && MD->isInstance()) {
       if (const auto* MCE = dyn_cast<CXXMemberCallExpr>(CE))
         baseOriginalE = MCE->getImplicitObjectArgument();
       else if (const auto* OCE = dyn_cast<CXXOperatorCallExpr>(CE))
         baseOriginalE = OCE->getArg(0);
-    }
-
-    // FIXME: Add support for lambdas used directly, e.g.
-    // [](){return 12.;}()
-    if (MD && isLambdaCallOperator(MD) &&
-        !isa<DeclRefExpr>(baseOriginalE->IgnoreImplicit())) {
-      SourceLocation L = baseOriginalE->getBeginLoc();
-      diag(DiagnosticsEngine::Warning, L,
-           "direct lambda calls are not supported, ignored")
-          << L;
-      return getZeroInit(CE->getType());
     }
 
     // Lookup a reverse_forw function and build if necessary.
@@ -1926,10 +2069,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     /// Add base derivative expression in the derived call output args list if
     /// `CE` is a call to an instance member function.
-    if (MD) {
-      if (isLambdaCallOperator(MD)) {
-        CallArgs.push_back(Clone(baseOriginalE));
-      } else if (MD->isInstance()) {
+    if (MD && !isLambdaCallOperator(MD)) {
+      if (MD->isInstance()) {
         // The differentiation result of implicit `this` object.
         StmtDiff baseDiff;
         bool isPassedByRef = utils::IsReferenceOrPointerArg(baseOriginalE);
@@ -2057,6 +2198,16 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           m_ExternalSource->ActBeforeDifferentiatingCallExpr(pullbackCallArgs);
         OverloadedDerivedFn = BuildCallExprToFunction(
             pullbackFD, pullbackCallArgs, CUDAExecConfig);
+      } else if (MD && isLambdaCallOperator(MD)) {
+        OverloadedDerivedFn =
+            m_Sema
+                .ActOnCallExpr(
+                    getCurrentScope(),
+                    /*Fn=*/LambdaCallOpExpr,
+                    /*LParenLoc=*/noLoc,
+                    /*ArgExprs=*/llvm::MutableArrayRef<Expr*>(pullbackCallArgs),
+                    /*RParenLoc=*/m_DiffReq->getLocation(), CUDAExecConfig)
+                .get();
       } else if (utils::IsRealFunction(FD)) {
         // FIXME: Add support for reference arguments to the numerical diff. If
         // it already correctly support reference arguments then confirm the
@@ -2108,7 +2259,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       it++;
     }
 
-    if (isa<CUDAKernelCallExpr>(CE))
+    if (isa<CUDAKernelCallExpr>(CE) || (MD && isLambdaCallOperator(MD)))
       return StmtDiff(Clone(CE));
 
     Expr* call = nullptr;
@@ -2788,7 +2939,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         VD->getInit() && isa<CXXConstructExpr>(VD->getInit()->IgnoreImplicit());
     const CXXRecordDecl* RD = VD->getType()->getAsCXXRecordDecl();
     bool isNonAggrClass = RD && !RD->isAggregate();
-
+    bool isLambdaDS = llvm::isa_and_nonnull<LambdaExpr>(VD->getInit());
     // We initialize adjoints with original variables as part of
     // the strategy to maintain the structure of the original variable.
     // After that, we'll zero-initialize the adjoint. e.g.
@@ -2829,11 +2980,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     VarDecl* VDDerived = nullptr;
     if (m_DiffReq.shouldHaveAdjoint(VD) &&
         !clad::utils::hasNonDifferentiableAttribute(VD)) {
-      llvm::StringRef Name = VD->getName();
-      std::string CleanName = Name.ltrim('_').str();
-      VDDerived =
-          BuildGlobalVarDecl(VDDerivedType, "_d_" + CleanName, dummyInit);
+      if (!isLambdaDS) {
+        llvm::StringRef Name = VD->getName();
+        std::string CleanName = Name.ltrim('_').str();
+        VDDerived =
+            BuildGlobalVarDecl(VDDerivedType, "_d_" + CleanName, dummyInit);
+      }
     }
+
     // Differentiate the initializer
     StmtDiff initDiff;
     if (const Expr* init = VD->getInit()) {
@@ -2846,8 +3000,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       llvm::SaveAndRestore<bool> saveTrackVarDecl(m_TrackVarDeclConstructor,
                                                   true);
       initDiff = Visit(init, derivedE);
-    }
 
+      if (isLambdaDS) {
+        QualType AutoQT = m_Context.getAutoDeductType();
+        VDDerived = BuildGlobalVarDecl(
+            AutoQT, "_d_" + VD->getNameAsString(), initDiff.getExpr_dx(), false,
+            m_Context.getTrivialTypeSourceInfo(AutoQT, noLoc));
+      }
+    }
     // If we are differentiating `VarDecl` corresponding to a local variable
     // inside a loop, then we need to reset it to 0 at each iteration.
     //
@@ -2905,9 +3065,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       isPointerType = true;
     }
 
-    VDClone = BuildGlobalVarDecl(VDCloneType, VD->getNameAsString(),
-                                 initDiff.getExpr(), VD->isDirectInit());
-
+    if (isLambdaDS)
+      VDCloneType = m_Context.getAutoDeductType();
+    VDClone = BuildGlobalVarDecl(
+        VDCloneType, VD->getNameAsString(), initDiff.getExpr(),
+        VD->isDirectInit(),
+        isLambdaDS ? m_Context.getTrivialTypeSourceInfo(VDCloneType, noLoc)
+                   : nullptr);
     // The choice of isDirectInit is mostly stylistic.
     bool isDirectInit = VD->isDirectInit() && (!RD || isNonAggrClass);
     if (VDDerivedType->isBuiltinType() || !VD->getInit()) {
@@ -3057,30 +3221,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     bool promoteToFnScope =
         !getCurrentScope()->isFunctionScope() &&
         m_DiffReq.Mode != DiffMode::reverse_mode_forward_pass;
-
-    // If the DeclStmt is not empty, check the first declaration in case it is a
-    // lambda function. This case it is treated separately for now and we don't
-    // create a variable for its derivative.
-    const auto* declsBegin = DS->decls().begin();
-    if (declsBegin != DS->decls().end() && isa<VarDecl>(*declsBegin)) {
-      auto* VD = dyn_cast<VarDecl>(*declsBegin);
-      QualType QT = VD->getType();
-      if (QT->isPointerType())
-        QT = QT->getPointeeType();
-
-      auto* typeDecl = QT->getAsCXXRecordDecl();
-      // We should also simply copy the original lambda. The differentiation
-      // of lambdas is happening in the `VisitCallExpr`. For now, only the
-      // declarations with lambda expressions without captures are supported.
-      if (typeDecl && typeDecl->isLambda()) {
-        for (auto* D : DS->decls())
-          if (auto* VD = dyn_cast<VarDecl>(D))
-            decls.push_back(VD);
-        Stmt* DSClone = BuildDeclStmt(decls);
-        return StmtDiff(DSClone, nullptr);
-      }
-    }
-
     // For each variable declaration v, create another declaration _d_v to
     // store derivatives for potential reassignments. E.g.
     // double y = x;
@@ -4542,8 +4682,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   }
 
   void
-  ReverseModeVisitor::BuildParams(llvm::SmallVectorImpl<ParmVarDecl*>& params) {
+  ReverseModeVisitor::BuildParams(llvm::SmallVectorImpl<ParmVarDecl*>& params,
+                                  const LambdaExpr* LE) {
     const FunctionDecl* FD = m_DiffReq.Function;
+    if (LE)
+      FD = LE->getCallOperator();
+
     for (ParmVarDecl* PVD : FD->parameters()) {
       IdentifierInfo* PVDII = PVD->getIdentifier();
       // Implicitly created special member functions have no parameter names.
@@ -4563,7 +4707,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     bool HasRet = false;
     QualType dRetTy = FD->getReturnType().getNonReferenceType();
     dRetTy = utils::getNonConstType(dRetTy, m_Sema);
-    if (m_DiffReq.Mode == DiffMode::pullback && !dRetTy->isVoidType() &&
+    if ((m_DiffReq.Mode == DiffMode::pullback || LE) && !dRetTy->isVoidType() &&
         !dRetTy->isPointerType() &&
         !utils::isNonConstReferenceType(FD->getReturnType())) {
       auto paramNameExists = [&params](llvm::StringRef name) {
@@ -4591,7 +4735,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                                /*AddToContext=*/false);
 
       params.push_back(retPVD);
-      m_Pullback = BuildDeclRef(retPVD);
+      m_Pullback.push_back(BuildDeclRef(retPVD));
       HasRet = true;
     }
 
@@ -4614,6 +4758,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
 
     const auto* FnType = cast<FunctionProtoType>(m_Derivative->getType());
+    if (LE)
+      FnType = cast<FunctionProtoType>(GetLambdaDerivativeType(LE));
+
     for (size_t i = 0, s = params.size(), p = s; i < s - HasThis - HasRet;
          ++i) {
       const ParmVarDecl* oPVD = FD->getParamDecl(i);
@@ -4633,7 +4780,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       }
 
       const ParmVarDecl* PVD = params[i];
-      if (!IsSelected) {
+      if (!LE && !IsSelected) {
         m_NonIndepParams.push_back(PVD);
         continue;
       }

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -159,7 +159,7 @@ namespace clad {
     SetDeclInit(VD, Init, DirectInit);
     m_Sema.FinalizeDeclaration(VD);
     // Add the identifier to the scope and IdResolver
-    m_Sema.PushOnScopeChains(VD, Scope, /*AddToContext*/ false);
+    m_Sema.PushOnScopeChains(VD, Scope);
     return VD;
   }
 

--- a/test/Gradient/Lambdas.C
+++ b/test/Gradient/Lambdas.C
@@ -1,7 +1,8 @@
 // RUN: %cladclang %s -I%S/../../include -oLambdas.out 2>&1 | %filecheck %s
 // RUN: ./Lambdas.out | %filecheck_exec %s
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -Xclang -plugin-arg-clad -Xclang -enable-va %s -I%S/../../include -oLambdas.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -Xclang -plugin-arg-clad -Xclang -disable-va %s -I%S/../../include -oLambdas.out
 // RUN: ./Lambdas.out | %filecheck_exec %s
+// UNSUPPORTED: clang-11, clang-12, clang-13, clang-14, clang-15, clang-16
 
 #include "clad/Differentiator/Differentiator.h"
 
@@ -12,56 +13,59 @@ double f1(double i, double j) {
   return i + _f(j);
 }
 
-// CHECK:     inline constexpr void operator_call_pullback(double t, double _d_y, double *_d_t) const {
+// CHECK: void f1_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK-NEXT:     auto _f0 = [](double t) {
+// CHECK-NEXT:         return t * t + 1.;
+// CHECK-NEXT:     };
+// CHECK-NEXT:     auto _d__f = [](double t, double _d_y, double *_d_t) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             *_d_t += _d_y * t;
 // CHECK-NEXT:             *_d_t += t * _d_y;
 // CHECK-NEXT:         }
+// CHECK-NEXT:     };
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_i += 1;
+// CHECK-NEXT:         double _r0 = 0.;
+// CHECK-NEXT:         _d__f(j, 1, &_r0);
+// CHECK-NEXT:         *_d_j += _r0;
 // CHECK-NEXT:     }
-
-// CHECK:     void f1_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:         auto _f = []{{ ?}}(double t) {
-// CHECK-NEXT:             return t * t + 1.;
-// CHECK-NEXT:         }{{;?}}
-// CHECK:         {
-// CHECK-NEXT:             *_d_i += 1;
-// CHECK-NEXT:             double _r0 = 0.;
-// CHECK-NEXT:             _f.operator_call_pullback(j, 1, &_r0);
-// CHECK-NEXT:             *_d_j += _r0;
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
 double f2(double i, double j) {
   auto _f = [] (double t, double k) {
-    return t + k;
+    double a = t*k;
+    return a;
   };
   double x = _f(i + j, i);
   return x;
 }
 
-// CHECK:     inline constexpr void operator_call_pullback(double t, double k, double _d_y, double *_d_t, double *_d_k) const {
+// CHECK: void f2_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK-NEXT:     auto _f0 = [](double t, double k) {
+// CHECK-NEXT:         double a = t * k;
+// CHECK-NEXT:         return a;
+// CHECK-NEXT:     };
+// CHECK-NEXT:     auto _d__f = [](double t, double k, double _d_y, double *_d_t, double *_d_k) {
+// CHECK-NEXT:         double _d_a = 0.;
+// CHECK-NEXT:         double a = t * k;
+// CHECK-NEXT:         _d_a += _d_y;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             *_d_t += _d_y;
-// CHECK-NEXT:             *_d_k += _d_y;
+// CHECK-NEXT:             *_d_t += _d_a * k;
+// CHECK-NEXT:             *_d_k += t * _d_a;
 // CHECK-NEXT:         }
+// CHECK-NEXT:     };
+// CHECK-NEXT:     double _d_x = 0.;
+// CHECK-NEXT:     double x = _f0(i + j, i);
+// CHECK-NEXT:     _d_x += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 0.;
+// CHECK-NEXT:         double _r1 = 0.;
+// CHECK-NEXT:         _d__f(i + j, i, _d_x, &_r0, &_r1);
+// CHECK-NEXT:         *_d_i += _r0;
+// CHECK-NEXT:         *_d_j += _r0;
+// CHECK-NEXT:         *_d_i += _r1;
 // CHECK-NEXT:     }
-
-// CHECK:     void f2_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:             auto _f = []{{ ?}}(double t, double k) {
-// CHECK-NEXT:                 return t + k;
-// CHECK-NEXT:             }{{;?}}
-// CHECK:        double _d_x = 0.;
-// CHECK-NEXT:             double x = _f(i + j, i);
-// CHECK-NEXT:             _d_x += 1;
-// CHECK-NEXT:             {
-// CHECK-NEXT:                 double _r0 = 0.;
-// CHECK-NEXT:                 double _r1 = 0.;
-// CHECK-NEXT:                 _f.operator_call_pullback(i + j, i, _d_x, &_r0, &_r1);
-// CHECK-NEXT:                 *_d_i += _r0;
-// CHECK-NEXT:                 *_d_j += _r0;
-// CHECK-NEXT:                 *_d_i += _r1;
-// CHECK-NEXT:             }
-// CHECK-NEXT:         }
+// CHECK-NEXT: }
 
 
 int main() {
@@ -72,6 +76,6 @@ int main() {
 
   auto df2 = clad::gradient(f2);
   di = 0, dj = 0;
-  df2.execute(3, 4, &di, &dj);
-  printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 2.00 1.00
+  df2.execute(1, 1, &di, &dj);
+  printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 3.00 1.00
 }


### PR DESCRIPTION
This PR adds basic support for lambda pullbacks inside derived functions. It is not complete and still requires some work, but implements core features.

TODO list:
- Fix clang version API mismatch.
- Make m_Globals emit to the lambda not to the outer function.
- Replace const_cast inside of RMV::VisitLambdaExpr with proper lambda cloning.
- Remove const_cast of a DiffRequest inside of buildLambda.
- Probably rework how we fill the body of a lambda inside buildLambda.
- Fix VA from failing.
- Address minor issues left as comments. 