### PR TITLE
fix #1698 - Add a way to specify non-differentiability of pre-existing functions in forward mode

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1193,8 +1193,9 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
       // Request the derivative
       pushforwardFD = FindDerivedFunction(pushforwardFnRequest);
     // Handle void-returning pushforward as non-differentiable
-    // Only if the original function is NOT void (otherwise void return is normal)
-    if (pushforwardFD && pushforwardFD->getReturnType()->isVoidType() && 
+    // Only if the original function is NOT void (otherwise void return is
+    // normal)
+    if (pushforwardFD && pushforwardFD->getReturnType()->isVoidType() &&
         !CE->getType()->isVoidType()) {
       llvm::SmallVector<Expr*, 4> ClonedArgs;
       for (unsigned i = 0, e = CE->getNumArgs(); i < e; ++i)
@@ -1203,7 +1204,7 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
       Expr* Call =
           m_Sema
               .ActOnCallExpr(getCurrentScope(), Clone(CE->getCallee()),
-                            validLoc, ClonedArgs, validLoc, CUDAExecConfig)
+                             validLoc, ClonedArgs, validLoc, CUDAExecConfig)
               .get();
 
       Expr* zero = getZeroInit(Call->getType());

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1192,6 +1192,23 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
     } else
       // Request the derivative
       pushforwardFD = FindDerivedFunction(pushforwardFnRequest);
+    // Handle void-returning pushforward as non-differentiable
+    // Only if the original function is NOT void (otherwise void return is normal)
+    if (pushforwardFD && pushforwardFD->getReturnType()->isVoidType() && 
+        !CE->getType()->isVoidType()) {
+      llvm::SmallVector<Expr*, 4> ClonedArgs;
+      for (unsigned i = 0, e = CE->getNumArgs(); i < e; ++i)
+        ClonedArgs.push_back(Clone(CE->getArg(i)));
+
+      Expr* Call =
+          m_Sema
+              .ActOnCallExpr(getCurrentScope(), Clone(CE->getCallee()),
+                            validLoc, ClonedArgs, validLoc, CUDAExecConfig)
+              .get();
+
+      Expr* zero = getZeroInit(Call->getType());
+      return StmtDiff(Call, zero);
+    }
     if (pushforwardFD) {
       if (Expr* baseE = baseDiff.getExpr())
         pushforwardFnArgs.insert(pushforwardFnArgs.begin(), baseE);

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1015,17 +1015,17 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     // Manual check for void-returning overload (Void Pushforward feature)
     if (R.Mode == DiffMode::forward || R.Mode == DiffMode::pushforward) {
       const auto* FTP = dTy->getAs<FunctionProtoType>();
-      
+
       for (LookupResult::iterator I = Found.begin(), E = Found.end(); I != E;
            ++I) {
         auto* FD = dyn_cast<FunctionDecl>(I.getDecl());
         if (!FD)
           continue;
-        
+
         // Custom derivative must return void
         if (!FD->getReturnType()->isVoidType())
           continue;
-        
+
         // Parameter count must match
         if (FD->getNumParams() != FTP->getNumParams())
           continue;

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1016,30 +1016,35 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     if (R.Mode == DiffMode::forward || R.Mode == DiffMode::pushforward) {
       const auto* FTP = dTy->getAs<FunctionProtoType>();
       
-      for (LookupResult::iterator I = Found.begin(), E = Found.end(); I != E; ++I) {
+      for (LookupResult::iterator I = Found.begin(), E = Found.end(); I != E;
+           ++I) {
         auto* FD = dyn_cast<FunctionDecl>(I.getDecl());
-        if (!FD) continue;
+        if (!FD)
+          continue;
         
         // Custom derivative must return void
-        if (!FD->getReturnType()->isVoidType()) continue;
+        if (!FD->getReturnType()->isVoidType())
+          continue;
         
         // Parameter count must match
-        if (FD->getNumParams() != FTP->getNumParams()) continue;
+        if (FD->getNumParams() != FTP->getNumParams())
+          continue;
 
         // Parameter types must match (using canonical types)
         bool paramsMatch = true;
         for (unsigned i = 0; i < FD->getNumParams(); ++i) {
-          QualType candParamTy = FD->getParamDecl(i)->getType().getCanonicalType();
+          QualType candParamTy =
+              FD->getParamDecl(i)->getType().getCanonicalType();
           QualType reqParamTy = FTP->getParamType(i).getCanonicalType();
           if (candParamTy != reqParamTy) {
-             paramsMatch = false;
-             break;
+            paramsMatch = false;
+            break;
           }
         }
         
         if (paramsMatch) {
-            CXXScopeSpec SS;
-            return S.BuildDeclarationNameExpr(SS, Found, /*ADL=*/false).get();
+          CXXScopeSpec SS;
+          return S.BuildDeclarationNameExpr(SS, Found, /*ADL=*/false).get();
         }
       }
     }

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1012,6 +1012,38 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
             utils::MatchOverloadType(S, dTy, Found, FailedCandidates))
       return overload;
 
+    // Manual check for void-returning overload (Void Pushforward feature)
+    if (R.Mode == DiffMode::forward || R.Mode == DiffMode::pushforward) {
+      const auto* FTP = dTy->getAs<FunctionProtoType>();
+      
+      for (LookupResult::iterator I = Found.begin(), E = Found.end(); I != E; ++I) {
+        FunctionDecl* FD = dyn_cast<FunctionDecl>(I.getDecl());
+        if (!FD) continue;
+        
+        // Custom derivative must return void
+        if (!FD->getReturnType()->isVoidType()) continue;
+        
+        // Parameter count must match
+        if (FD->getNumParams() != FTP->getNumParams()) continue;
+
+        // Parameter types must match (using canonical types)
+        bool paramsMatch = true;
+        for (unsigned i = 0; i < FD->getNumParams(); ++i) {
+          QualType candParamTy = FD->getParamDecl(i)->getType().getCanonicalType();
+          QualType reqParamTy = FTP->getParamType(i).getCanonicalType();
+          if (candParamTy != reqParamTy) {
+             paramsMatch = false;
+             break;
+          }
+        }
+        
+        if (paramsMatch) {
+            CXXScopeSpec SS;
+            return S.BuildDeclarationNameExpr(SS, Found, /*ADL=*/false).get();
+        }
+      }
+    }
+
     if (!enableDiagnostics)
       return nullptr;
 

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1017,7 +1017,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       const auto* FTP = dTy->getAs<FunctionProtoType>();
       
       for (LookupResult::iterator I = Found.begin(), E = Found.end(); I != E; ++I) {
-        FunctionDecl* FD = dyn_cast<FunctionDecl>(I.getDecl());
+        auto* FD = dyn_cast<FunctionDecl>(I.getDecl());
         if (!FD) continue;
         
         // Custom derivative must return void

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1041,7 +1041,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
             break;
           }
         }
-        
+
         if (paramsMatch) {
           CXXScopeSpec SS;
           return S.BuildDeclarationNameExpr(SS, Found, /*ADL=*/false).get();

--- a/test/ForwardMode/VoidPushforward.C
+++ b/test/ForwardMode/VoidPushforward.C
@@ -1,0 +1,47 @@
+// RUN: %cladclang -std=c++17 %s -I%S/../../include -DCLAD_NO_NUM_DIFF -oVoidPushforward.out 2>&1 | %filecheck %s
+// RUN: ./VoidPushforward.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include <iostream>
+
+extern "C" int printf(const char* fmt, ...);
+
+// Global Function Test
+double global_fn(double x) {
+  return x * x * x; // Derivative would normally be 3*x^2
+}
+
+// Custom derivative definitions for the feature to work
+namespace clad {
+namespace custom_derivatives {
+// Void pushforward -> signals non-differentiable
+void global_fn_pushforward(double, double) {}
+}
+}
+
+double test_global(double x) {
+  // Clad treats global_fn as non-differentiable -> derivative 0
+  return global_fn(x) + x;
+}
+
+// Execution Wrapper
+#define TEST_FUNC(name, arg)                                  \
+  do {                                                        \
+    auto d_##name = clad::differentiate(name, "x");           \
+    printf("d_" #name "(%.0f) = %.2f\n", arg, d_##name.execute(arg)); \
+  } while(0)
+
+int main() {
+  // Expected: 0 + 1 = 1.00
+  TEST_FUNC(test_global, 2.0); // CHECK-EXEC: d_test_global(2) = 1.00
+  return 0;
+}
+
+// Verification of generated code
+
+// CHECK-LABEL: double test_global_darg0(double x) {
+// CHECK:       double _d_x = 1;
+// Primal call optimized away as it's pure and unused
+// CHECK-NOT:   global_fn(x)
+// CHECK:       return 0. + _d_x;
+// CHECK-NEXT: }


### PR DESCRIPTION
This PR adds support for void pushforward functions in forward mode. When a pushforward function returns void, it signals that the original function is non-differentiable. Clad will now treat such functions as constant (derivative = 0) while still calling the original function.

Changes include updates in `DiffPlanner.cpp` and `BaseForwardModeVisitor` to handle void pushforwards correctly. I have added a new test (ForwardMode/VoidPushforward.C) to verify this behavior.