### PR TITLE
Corrected the wrong scope of the variables declared inside the Lambda function

### DIFF
--- a/test/Regressions/issue-1701.cpp
+++ b/test/Regressions/issue-1701.cpp
@@ -1,0 +1,23 @@
+// RUN: %cladclang -std=c++17 -I%S/../../include %s -o %t
+// RUN: %t | %filecheck_exec %s
+// UNSUPPORTED: clang-10, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16
+#include <cstdio>
+#include "clad/Differentiator/Differentiator.h"
+
+void f2(double i, double j){
+    auto _f = [] () {
+    {
+      double a = 1;
+    }
+  };
+}
+int main(){
+    auto diff=clad::gradient(f2);
+    double di=0,dj=0;
+    double i=7,j=7;
+    diff.execute(i,j,&di,&dj);
+
+    printf("Execution successful\n");
+    // CHECK-EXEC: Execution successful
+    return 0;
+}


### PR DESCRIPTION
Rather than changing the data structure of the m_Globals to stack which has been specified by the author of the issue (since it breaks the memory layout of the class) I have opted to specifically fix the variable scope problem for the Lambda functions only, by swapping the variables  in order to temporarily isolate the lambda variable declaration from the outer function and inject them in the correct scope only.
```cpp
void f2_grad(double i, double j, double *_d_i, double *_d_j) {
    auto _f0 = []() {
        {
            double a = 1;
        }
    };
    auto _d__f = []() {
        double _d_a = 0.;
        double a = 0.;
        {
            a = 1;
        }
        {
        }
    };
}
```
Fixes #1701