### PR TITLE
Fix invalid YAML syntax in postci.yml

### DIFF
--- a/.github/workflows/postci.yml
+++ b/.github/workflows/postci.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   knowall:
     runs-on: ubuntu-latest
-    if: ${{ false }} # Disable temporary the workflow.
     if: >
       ${{ github.event.workflow_run.event == 'pull_request'}}
     steps:


### PR DESCRIPTION
The postci.yml workflow currently fails to parse because the if: key is defined twice. This PR removes the confilicting line to 
restore the  workflow functionality.