### PR TITLE
Implement Multilayer Disk Offloading feature to the tape.

### DIFF
--- a/benchmark/MemoryComplexity.cpp
+++ b/benchmark/MemoryComplexity.cpp
@@ -1,7 +1,9 @@
 #include "benchmark/benchmark.h"
 
 #include "clad/Differentiator/Differentiator.h"
-
+#include "clad/Differentiator/Tape.h"
+#include <cstddef>
+#include <cstdint>
 namespace {
   struct MemoryManager : public benchmark::MemoryManager {
     size_t cur_num_allocs = 0;
@@ -60,21 +62,29 @@ void operator delete(void* p) noexcept {
   free(p);
 }
 
-template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024>
-void func(clad::tape<T, SBO_SIZE, SLAB_SIZE>& t, T x, int n) {
+template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024,
+          bool DiskOffload = false>
+void func(clad::tape_impl<T, SBO_SIZE, SLAB_SIZE, /*is_Multithread=*/false,
+                          DiskOffload>& t,
+          T x, int n) {
   for (int i = 0; i < n; i++)
-    clad::push<T, SBO_SIZE, SLAB_SIZE>(t, x);
+    clad::push(t, x);
 
-  for (int i = 0; i < n; i++)
-    benchmark::DoNotOptimize(clad::pop<T, SBO_SIZE, SLAB_SIZE>(t));
+  for (int i = 0; i < n; i++) {
+    benchmark::DoNotOptimize(t.back());
+    t.pop_back();
+  }
 }
 
 static void BM_TapeMemory(benchmark::State& state) {
   int block = state.range(0);
   AddBMCounterRAII MemCounters(*mm.get(), state);
   for (auto _ : state) {
-    clad::tape<double> t;
-    func<double>(t, 1, block * 2 + 1);
+    // Explicitly using false for DiskOffload to test baseline
+    clad::tape_impl<double, 64, 1024, /*is_Multithread=*/false,
+                    /*DiskOffload=*/false>
+        t;
+    func<double, 64, 1024, /*DiskOffload=*/false>(t, 1, block * 2 + 1);
   }
 }
 BENCHMARK(BM_TapeMemory)->RangeMultiplier(2)->Range(0, 4096);
@@ -84,8 +94,11 @@ static void BM_TapeMemory_Templated(benchmark::State& state) {
   int block = state.range(0);
   AddBMCounterRAII MemCounters(*mm.get(), state);
   for (auto _ : state) {
-    clad::tape<double, SBO_SIZE, SLAB_SIZE> t;
-    func<double, SBO_SIZE, SLAB_SIZE>(t, 1, block * 2 + 1);
+    clad::tape_impl<double, SBO_SIZE, SLAB_SIZE, /*is_Multithread=*/false,
+                    /*DiskOffload=*/false>
+        t;
+    func<double, SBO_SIZE, SLAB_SIZE, /*DiskOffload=*/false>(t, 1,
+                                                             block * 2 + 1);
   }
 }
 
@@ -98,8 +111,27 @@ static void BM_TapeMemory_Templated(benchmark::State& state) {
 REGISTER_TAPE_BENCHMARK(64, 1024);
 REGISTER_TAPE_BENCHMARK(32, 512);
 
-#include "BenchmarkedFunctions.h"
+// This explicitly tests the case where DiskOffload = true
+template <std::size_t SBO_SIZE, std::size_t SLAB_SIZE>
+static void BM_Multilayer_Storage(benchmark::State& state) {
+  int64_t block = state.range(0);
+  AddBMCounterRAII MemCounters(*mm, state);
+  for (auto _ : state) {
+    // Set DiskOffload = true here
+    clad::tape_impl<double, SBO_SIZE, SLAB_SIZE, /*is_Multithread=*/false,
+                    /*DiskOffload=*/true>
+        t;
+    func<double, SBO_SIZE, SLAB_SIZE, /*DiskOffload=*/true>(t, 1,
+                                                            block * 2 + 1);
+  }
+}
 
+BENCHMARK_TEMPLATE(BM_Multilayer_Storage, 64, 1024)
+    ->RangeMultiplier(2)
+    ->Range(0, 4096)
+    ->Name("BM_Multilayer_Storage/SBO_64_SLAB_1024_DISK");
+
+#include "BenchmarkedFunctions.h"
 static void BM_ReverseGausMemoryP(benchmark::State& state) {
   auto dfdp_grad = clad::gradient(gaus, "p");
   unsigned dim = state.range(0);
@@ -118,5 +150,39 @@ static void BM_ReverseGausMemoryP(benchmark::State& state) {
 }
 BENCHMARK(BM_ReverseGausMemoryP)->RangeMultiplier(2)->Range(0, 4096);
 
-// Define our main.
+const size_t TARGET_ELEMENTS = 20000;
+
+static void BM_CrashTest_OS_Paging(benchmark::State& state) {
+  AddBMCounterRAII MemCounters(*mm, state);
+  for (auto _ : state) {
+    clad::tape_impl<double, 64, 1024, /*is_Multithread=*/false,
+                    /*DiskOffload=*/false>
+        t;
+
+    for (size_t i = 0; i < TARGET_ELEMENTS; ++i) {
+      try {
+        clad::push(t, 1.0);
+      } catch (std::bad_alloc& e) {
+        state.SkipWithError("OS ran out of memory!");
+        break;
+      }
+    }
+  }
+}
+
+BENCHMARK(BM_CrashTest_OS_Paging)->Iterations(1);
+
+static void BM_CrashTest_Clad_Offload(benchmark::State& state) {
+  AddBMCounterRAII MemCounters(*mm, state);
+  for (auto _ : state) {
+    clad::tape_impl<double, 64, 1310720, /*is_Multithread=*/false,
+                    /*DiskOffload=*/true>
+        t;
+
+    for (size_t i = 0; i < TARGET_ELEMENTS; ++i)
+      clad::push(t, 1.0);
+  }
+}
+BENCHMARK(BM_CrashTest_Clad_Offload)->Iterations(1);
+
 BENCHMARK_MAIN();

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -59,90 +59,107 @@ inline CUDA_HOST_DEVICE unsigned int GetLength(const char* code) {
 
 /// Tape type used for storing values in reverse-mode AD inside loops.
 template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024,
-          bool is_multithread = false>
-using tape = tape_impl<T, SBO_SIZE, SLAB_SIZE, is_multithread>;
+          bool is_multithread = false, bool DiskOffload = false>
+using tape = tape_impl<T, SBO_SIZE, SLAB_SIZE, is_multithread, DiskOffload>;
 
 /// Add value to the end of the tape, return the same value.
 template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024,
-          typename... ArgsT>
-CUDA_HOST_DEVICE T& push(tape<T, SBO_SIZE, SLAB_SIZE>& to, ArgsT... val) {
+          bool DiskOffload = false, typename... ArgsT>
+CUDA_HOST_DEVICE T&
+push(tape<T, SBO_SIZE, SLAB_SIZE, /*is_multithread=*/false, DiskOffload>& to,
+     ArgsT... val) {
   to.emplace_back(std::forward<ArgsT>(val)...);
   return to.back();
 }
 
 /// A specialization for C arrays
 template <typename T, typename U, size_t N, std::size_t SBO_SIZE = 64,
-          std::size_t SLAB_SIZE = 1024>
-CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
+          std::size_t SLAB_SIZE = 1024, bool DiskOffload = false>
+CUDA_HOST_DEVICE void
+push(tape<T[N], SBO_SIZE, SLAB_SIZE, /*is_multithread=*/false, DiskOffload>& to,
+     const U& val) {
   to.emplace_back();
   std::copy(std::begin(val), std::end(val), std::begin(to.back()));
 }
 
   /// Remove the last value from the tape, return it.
-  template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024>
-  CUDA_HOST_DEVICE T pop(tape<T, SBO_SIZE, SLAB_SIZE>& to) {
-    T val = std::move(to.back());
-    to.pop_back();
-    return val;
-  }
+template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024,
+          bool DiskOffload = false>
+CUDA_HOST_DEVICE T
+pop(tape<T, SBO_SIZE, SLAB_SIZE, /*is_multithread=*/false, DiskOffload>& to) {
+  T val = std::move(to.back());
+  to.pop_back();
+  return val;
+}
 
   /// A specialization for C arrays
-  template <typename T, std::size_t N, std::size_t SBO_SIZE = 64,
-            std::size_t SLAB_SIZE = 1024>
-  CUDA_HOST_DEVICE void pop(tape<T[N], SBO_SIZE, SLAB_SIZE>& to) {
-    to.pop_back();
-  }
+template <typename T, std::size_t N, std::size_t SBO_SIZE = 64,
+          std::size_t SLAB_SIZE = 1024, bool DiskOffload = false>
+CUDA_HOST_DEVICE void pop(tape<T[N], SBO_SIZE, SLAB_SIZE,
+                               /*is_multithread=*/false, DiskOffload>& to) {
+  to.pop_back();
+}
 
   /// Access return the last value in the tape.
-  template <typename T> CUDA_HOST_DEVICE T& back(tape<T>& of) {
-    return of.back();
-  }
+template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024,
+          bool DiskOffload = false>
+CUDA_HOST_DEVICE T&
+back(tape<T, SBO_SIZE, SLAB_SIZE, /*is_multithread=*/false, DiskOffload>& of) {
+  return of.back();
+}
 
   /// Thread safe tape access functions with mutex locking mechanism
+/// Thread safe tape access functions with mutex locking mechanism
 #ifndef __CUDACC__
-  /// Add value to the end of the tape, return the same value.
-  template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024,
-            typename... ArgsT>
-  T push(tape<T, SBO_SIZE, SLAB_SIZE, /*is_multithreaded=*/true>& to,
-         ArgsT&&... val) {
-    std::lock_guard<std::mutex> lock(to.mutex());
-    to.emplace_back(std::forward<ArgsT>(val)...);
-    return to.back();
-  }
+/// Add value to the end of the tape, return the same value.
+template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024,
+          bool DiskOffload = false, typename... ArgsT>
+T push(tape<T, SBO_SIZE, SLAB_SIZE, /*is_multithreaded=*/true, DiskOffload>& to,
+       ArgsT&&... val) {
+  std::lock_guard<std::mutex> lock(to.mutex());
+  to.emplace_back(std::forward<ArgsT>(val)...);
+  return to.back();
+}
 
   /// A specialization for C arrays
-  template <typename T, typename U, size_t N, std::size_t SBO_SIZE = 64,
-            std::size_t SLAB_SIZE = 1024>
-  void push(tape<T[N], SBO_SIZE, SLAB_SIZE, /*is_multithreaded=*/true>& to,
-            const U& val) {
-    std::lock_guard<std::mutex> lock(to.mutex());
-    to.emplace_back();
-    std::copy(std::begin(val), std::end(val), std::begin(to.back()));
-  }
+template <typename T, typename U, size_t N, std::size_t SBO_SIZE = 64,
+          std::size_t SLAB_SIZE = 1024, bool DiskOffload = false>
+void push(
+    tape<T[N], SBO_SIZE, SLAB_SIZE, /*is_multithreaded=*/true, DiskOffload>& to,
+    const U& val) {
+  std::lock_guard<std::mutex> lock(to.mutex());
+  to.emplace_back();
+  std::copy(std::begin(val), std::end(val), std::begin(to.back()));
+}
 
   /// Remove the last value from the tape, return it.
-  template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024>
-  T pop(tape<T, SBO_SIZE, SLAB_SIZE, /*is_multithreaded=*/true>& to) {
-    std::lock_guard<std::mutex> lock(to.mutex());
-    T val = std::move(to.back());
-    to.pop_back();
-    return val;
-  }
+template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024,
+          bool DiskOffload = false>
+T pop(
+    tape<T, SBO_SIZE, SLAB_SIZE, /*is_multithreaded=*/true, DiskOffload>& to) {
+  std::lock_guard<std::mutex> lock(to.mutex());
+  T val = std::move(to.back());
+  to.pop_back();
+  return val;
+}
 
   /// A specialization for C arrays
-  template <typename T, std::size_t N, std::size_t SBO_SIZE = 64,
-            std::size_t SLAB_SIZE = 1024>
-  void pop(tape<T[N], SBO_SIZE, SLAB_SIZE, /*is_multithreaded=*/true>& to) {
-    std::lock_guard<std::mutex> lock(to.mutex());
-    to.pop_back();
-  }
+template <typename T, std::size_t N, std::size_t SBO_SIZE = 64,
+          std::size_t SLAB_SIZE = 1024, bool DiskOffload = false>
+void pop(tape<T[N], SBO_SIZE, SLAB_SIZE, /*is_multithreaded=*/true,
+              DiskOffload>& to) {
+  std::lock_guard<std::mutex> lock(to.mutex());
+  to.pop_back();
+}
 
   /// Access return the last value in the tape.
-  template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024>
-  T& back(tape<T, SBO_SIZE, SLAB_SIZE, /*is_multithreaded=*/true>& of) {
-    std::lock_guard<std::mutex> lock(of.mutex());
-    return of.back();
-  }
+template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024,
+          bool DiskOffload = false>
+T& back(
+    tape<T, SBO_SIZE, SLAB_SIZE, /*is_multithreaded=*/true, DiskOffload>& of) {
+  std::lock_guard<std::mutex> lock(of.mutex());
+  return of.back();
+}
 #endif
 
   /// The purpose of this function is to initialize adjoints

--- a/include/clad/Differentiator/Tape.h
+++ b/include/clad/Differentiator/Tape.h
@@ -4,10 +4,14 @@
 #include "clad/Differentiator/CladConfig.h"
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
+#include <fstream>
+#include <ios>
 #include <iterator>
 #include <memory>
 #include <new>
+#include <string>
 #include <type_traits>
 #include <utility>
 #ifndef __CUDACC__
@@ -16,8 +20,54 @@
 
 namespace clad {
 
+namespace detail {
+
+/// Manages offloading of data to disk when RAM capacity is exceeded.
+/// Handles files I/O operations for reading and writing slabs.
+template <typename T, std::size_t SLAB_SIZE> struct DiskManager {
+#ifndef __CUDA_ARCH__
+  std::fstream file;
+  std::string filename;
+  DiskManager() {
+    filename = "clad_tape_" + std::to_string((uintptr_t)this) + ".tmp";
+    file.open(filename, std::ios::in | std::ios::out | std::ios::binary |
+                            std::ios::trunc);
+  }
+  ~DiskManager() {
+    if (file.is_open())
+      file.close();
+    std::remove(filename.c_str());
+  }
+  std::size_t write_slab(const T* data) {
+    file.seekp(0, std::ios::end);
+    std::size_t offset = file.tellp();
+    const void* raw_data = static_cast<const void*>(data);
+    file.write(static_cast<const char*>(raw_data), SLAB_SIZE * sizeof(T));
+    return offset;
+  }
+  void read_slab(T* dest, std::size_t offset) {
+    file.seekg(offset, std::ios::beg);
+    void* raw_dest = static_cast<void*>(dest);
+    file.read(static_cast<char*>(raw_dest), SLAB_SIZE * sizeof(T));
+  }
+#else
+  CUDA_HOST_DEVICE DiskManager() {}
+  CUDA_HOST_DEVICE ~DiskManager() {}
+  CUDA_HOST_DEVICE std::size_t write_slab(const T* data) { return 0; }
+  CUDA_HOST_DEVICE void read_slab(T* dest, std::size_t offset) {}
+#endif
+};
+
+struct NoOpMutex {
+  void lock() {}
+  void unlock() {}
+  static bool try_lock() { return true; }
+};
+
+} // namespace detail
+
 template <typename T, std::size_t SBO_SIZE, std::size_t SLAB_SIZE,
-          bool is_multithread>
+          bool is_multithread, bool DiskOffload>
 class tape_impl;
 
 /// A forward iterator for traversing elements in `clad::tape_impl`.
@@ -26,9 +76,10 @@ class tape_impl;
 /// - Increment (`++`)
 /// - Equality and inequality comparisons
 template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024,
-          bool is_multithread = false>
+          bool is_multithread = false, bool DiskOffload = false>
 class tape_iterator {
-  using tape_t = clad::tape_impl<T, SBO_SIZE, SLAB_SIZE, is_multithread>;
+  using tape_t =
+      clad::tape_impl<T, SBO_SIZE, SLAB_SIZE, is_multithread, DiskOffload>;
   tape_t* m_tape;
   std::size_t m_index;
 
@@ -72,55 +123,165 @@ public:
 /// in a static buffer first, then falls back to dynamically allocated linked
 /// slabs if capacity exceeds SBO.
 template <typename T, std::size_t SBO_SIZE = 64, std::size_t SLAB_SIZE = 1024,
-          bool is_multithread = false>
+          bool is_multithread = false, bool DiskOffload = false>
 class tape_impl {
-  /// A block of contiguous storage allocated dynamically when SBO capacity is
-  /// exceeded.
-  struct Slab {
+  /// Storage planning for slabs kept in memory (RAM).
+  /// Provides access to the raw data buffer.
+  struct RAMStorage {
     // std::aligned_storage_t<sizeof(T), alignof(T)> raw_data[SLAB_SIZE];
     // For now use the implementation below as above implementation is not
     // supported by c++11
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     alignas(T) char raw_data[SLAB_SIZE * sizeof(T)];
-    Slab* prev;
-    Slab* next;
-    CUDA_HOST_DEVICE Slab() : prev(nullptr), next(nullptr) {}
+    CUDA_HOST_DEVICE RAMStorage() {}
     CUDA_HOST_DEVICE T* elements() {
-#if __cplusplus >= 201703L
-      return std::launder(reinterpret_cast<T*>(raw_data));
-#else
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
       return reinterpret_cast<T*>(raw_data);
-#endif
     }
   };
 
+  struct DiskStorage {
+    T* data_ptr = nullptr;
+    bool is_on_disk = false;
+    std::size_t disk_offset = 0;
+
+    CUDA_HOST_DEVICE DiskStorage() { allocate(); }
+    CUDA_HOST_DEVICE ~DiskStorage() { deallocate(); }
+
+    DiskStorage(const DiskStorage&) = delete;
+    DiskStorage& operator=(const DiskStorage&) = delete;
+
+    void allocate() {
+      if (!data_ptr)
+        data_ptr = static_cast<T*>(::operator new(SLAB_SIZE * sizeof(T)));
+    }
+    void deallocate() {
+      if (data_ptr) {
+        ::operator delete(data_ptr);
+        data_ptr = nullptr;
+      }
+    }
+    CUDA_HOST_DEVICE T* elements() { return data_ptr; }
+  };
+
+  using SlabBase =
+      typename std::conditional<DiskOffload, DiskStorage, RAMStorage>::type;
+
+public:
+  /// A block of contiguous storage allocated dynamically when SBO capacity is
+  /// exceeded.
+  struct Slab : public SlabBase {
+    Slab* prev;
+    Slab* next;
+    CUDA_HOST_DEVICE Slab() : prev(nullptr), next(nullptr) {}
+  };
+
+private:
   // std::aligned_storage_t<sizeof(T), alignof(T)> m_static_buffer[SBO_SIZE];
   // For now use the implementation below as above implementation is not
   // supported by c++11
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   alignas(T) char m_static_buffer[SBO_SIZE * sizeof(T)];
 
   Slab* m_head = nullptr;
   Slab* m_tail = nullptr;
   std::size_t m_size = 0;
   std::size_t m_capacity = SBO_SIZE;
-
 #ifndef __CUDACC__
   mutable std::mutex m_TapeMutex;
 #endif
+  /// Holds current state related to disk offloading, including the file manager
+  /// and also keep track of active/maximum RAM slabs.
+  struct DiskInfo {
+    std::unique_ptr<detail::DiskManager<T, SLAB_SIZE>> m_DiskManager;
+    std::size_t m_ActiveSlabs = 0;
+    std::size_t m_MaxRamSlabs = 1024;
+    DiskInfo() = default;
+  };
+  struct Empty {};
+
+  using DiskInfoType = std::conditional_t<DiskOffload, DiskInfo, Empty>;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  DiskInfoType m_state;
 
   CUDA_HOST_DEVICE T* sbo_elements() {
 #if __cplusplus >= 201703L
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return std::launder(reinterpret_cast<T*>(m_static_buffer));
 #else
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return reinterpret_cast<T*>(m_static_buffer);
 #endif
   }
 
   CUDA_HOST_DEVICE const T* sbo_elements() const {
 #if __cplusplus >= 201703L
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return std::launder(reinterpret_cast<const T*>(m_static_buffer));
 #else
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return reinterpret_cast<const T*>(m_static_buffer);
 #endif
+  }
+
+  DiskInfo& getDiskInfo() {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return *reinterpret_cast<DiskInfo*>(&m_state);
+  }
+
+  void check_and_evict_impl(std::true_type) {
+    DiskInfo& info = getDiskInfo();
+    if (info.m_ActiveSlabs >= info.m_MaxRamSlabs) {
+      Slab* candidate = m_head;
+      while (candidate && (candidate->is_on_disk || candidate == m_tail))
+        candidate = candidate->next;
+      if (candidate) {
+        if (!info.m_DiskManager)
+          info.m_DiskManager.reset(new detail::DiskManager<T, SLAB_SIZE>());
+        candidate->disk_offset =
+            info.m_DiskManager->write_slab(candidate->elements());
+        // FIXME: We probably should not deallocate the slab but use a pool
+        // where old ones would be recycled.
+        candidate->deallocate();
+        candidate->is_on_disk = true;
+        info.m_ActiveSlabs--;
+      }
+    }
+  }
+
+  void check_and_evict_impl(std::false_type) {}
+
+  void ensure_loaded_impl(Slab* slab, std::true_type) {
+    if (slab && slab->is_on_disk) {
+      DiskInfo& info = getDiskInfo();
+      if (info.m_ActiveSlabs >= info.m_MaxRamSlabs) {
+        Slab* v = m_head;
+        while (v) {
+          if (!v->is_on_disk && v != slab) {
+            v->disk_offset = info.m_DiskManager->write_slab(v->elements());
+            v->deallocate();
+            v->is_on_disk = true;
+            info.m_ActiveSlabs--;
+            break;
+          }
+          v = v->next;
+        }
+      }
+      slab->allocate();
+      info.m_DiskManager->read_slab(slab->elements(), slab->disk_offset);
+      slab->is_on_disk = false;
+      info.m_ActiveSlabs++;
+    }
+  }
+
+  void ensure_loaded_impl(Slab* slab, std::false_type) {}
+
+  void check_and_evict() {
+    check_and_evict_impl(std::integral_constant<bool, DiskOffload>{});
+  }
+
+  void ensure_loaded(Slab* slab) {
+    ensure_loaded_impl(slab, std::integral_constant<bool, DiskOffload>{});
   }
 
 public:
@@ -131,17 +292,24 @@ public:
   using size_type = std::size_t;
   using difference_type = std::ptrdiff_t;
   using value_type = T;
-  using iterator = tape_iterator<T, SBO_SIZE, SLAB_SIZE, is_multithread>;
+  using iterator =
+      tape_iterator<T, SBO_SIZE, SLAB_SIZE, is_multithread, DiskOffload>;
   using const_iterator =
-      tape_iterator<const T, SBO_SIZE, SLAB_SIZE, is_multithread>;
-
+      tape_iterator<const T, SBO_SIZE, SLAB_SIZE, is_multithread, DiskOffload>;
 #ifndef __CUDACC__
-  std::mutex& mutex() const { return m_TapeMutex; }
-#endif
 
+  std::mutex& mutex() const { return m_TapeMutex; }
+
+#endif
   CUDA_HOST_DEVICE tape_impl() = default;
 
   CUDA_HOST_DEVICE ~tape_impl() { clear(); }
+
+  tape_impl(const tape_impl&) = delete;
+  tape_impl& operator=(const tape_impl&) = delete;
+
+  tape_impl(tape_impl&& other) = delete;
+  tape_impl& operator=(tape_impl&& other) = delete;
 
   /// Add new value of type T constructed from args to the end of the tape.
   template <typename... ArgsT>
@@ -155,7 +323,12 @@ public:
       // Allocate new slab if required
       if (!offset) {
         if (m_size == m_capacity) {
+          check_and_evict();
+
           Slab* new_slab = new Slab();
+          if (DiskOffload)
+            getDiskInfo().m_ActiveSlabs++;
+
           if (!m_head)
             m_head = new_slab;
           else {
@@ -171,6 +344,8 @@ public:
       }
 
       // Construct element in-place
+      if (DiskOffload)
+        ensure_loaded(m_tail);
       ::new (const_cast<void*>(static_cast<const volatile void*>(
           m_tail->elements() + offset))) T(std::forward<ArgsT>(args)...);
     }
@@ -197,6 +372,8 @@ public:
     std::size_t index = m_size - 1;
     if (index < SBO_SIZE)
       return *(sbo_elements() + index);
+    if (DiskOffload)
+      ensure_loaded(m_tail);
     index = (index - SBO_SIZE) % SLAB_SIZE;
     return *(m_tail->elements() + index);
   }
@@ -206,6 +383,10 @@ public:
     std::size_t index = m_size - 1;
     if (index < SBO_SIZE)
       return *(sbo_elements() + index);
+    if (DiskOffload) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+      const_cast<tape_impl*>(this)->ensure_loaded(m_tail);
+    }
     index = (index - SBO_SIZE) % SLAB_SIZE;
     return *(m_tail->elements() + index);
   }
@@ -217,7 +398,8 @@ public:
 
   CUDA_HOST_DEVICE const_reference operator[](std::size_t i) const {
     assert(i < m_size);
-    return *at(i);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return *const_cast<tape_impl*>(this)->at(i);
   }
 
   /// Remove the last value from the tape.
@@ -227,6 +409,9 @@ public:
     if (m_size < SBO_SIZE)
       destroy_element(sbo_elements() + m_size);
     else {
+      if (DiskOffload)
+        ensure_loaded(m_tail);
+
       std::size_t offset = (m_size - SBO_SIZE) % SLAB_SIZE;
       destroy_element(m_tail->elements() + offset);
       if (offset == 0) {
@@ -241,10 +426,15 @@ private:
   CUDA_HOST_DEVICE T* at(std::size_t index) {
     if (index < SBO_SIZE)
       return sbo_elements() + index;
+
     Slab* slab = m_head;
     std::size_t idx = (index - SBO_SIZE) / SLAB_SIZE;
     while (idx--)
       slab = slab->next;
+
+    if (DiskOffload)
+      ensure_loaded(slab);
+
     return slab->elements() + ((index - SBO_SIZE) % SLAB_SIZE);
   }
 
@@ -255,6 +445,8 @@ private:
     std::size_t idx = (index - SBO_SIZE) / SLAB_SIZE;
     while (idx--)
       slab = slab->next;
+
+    // Const version cannot ensure loaded if DiskOffload is true
     return slab->elements() + ((index - SBO_SIZE) % SLAB_SIZE);
   }
 
@@ -278,9 +470,25 @@ private:
       destroy(It B, It E) {}
 
   /// Destroys all elements and deallocates slabs
-  void clear() {
+  void clear_impl(std::true_type) {
     std::size_t count = m_size;
+    for (std::size_t i = 0; i < SBO_SIZE && count > 0; ++i, --count)
+      destroy_element(&sbo_elements()[i]);
 
+    Slab* slab = m_head;
+    while (slab) {
+      size_t current_slab_count = (count > SLAB_SIZE) ? SLAB_SIZE : count;
+      count -= current_slab_count;
+      Slab* tmp = slab;
+      slab = slab->next;
+      // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+      delete tmp;
+    }
+    getDiskInfo().m_ActiveSlabs = 0;
+  }
+
+  void clear_impl(std::false_type) {
+    std::size_t count = m_size;
     for (std::size_t i = 0; i < SBO_SIZE && count > 0; ++i, --count)
       destroy_element(&sbo_elements()[i]);
 
@@ -291,9 +499,13 @@ private:
         destroy_element(elems + i);
       Slab* tmp = slab;
       slab = slab->next;
+      // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
       delete tmp;
     }
+  }
 
+  void clear() {
+    clear_impl(std::integral_constant<bool, DiskOffload>{});
     m_head = nullptr;
     m_tail = nullptr;
     m_size = 0;
@@ -301,7 +513,6 @@ private:
   }
 
   template <typename ElTy> void destroy_element(ElTy* elem) { elem->~ElTy(); }
-
   template <typename ElTy, size_t N> void destroy_element(ElTy (*arr)[N]) {
     for (size_t i = 0; i < N; ++i)
       (*arr)[i].~ElTy();


### PR DESCRIPTION
Multilayer Storage feature offloads inactive data to the disk when the RAM gets full enabling differentiation of larger workloads which would otherwise lead to run out of memory errorand its working is similar to the paging in OS, here also the least recently used data is offloaded to the disk and fetched from the disk only when it is needed. Users can opt-in to disk offloading by setting the new template parameter to `true`. 
**Note:** By default the maximum slab size in RAM is set to 1000.