### PR TITLE
Adds benchmark to compare Tapenade and Clad performance

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -7,6 +7,33 @@ CB_ADD_GBENCHMARK(ArrayExpressionTemplates ArrayExpressionTemplates.cpp)
 if (CLAD_ENABLE_ENZYME_BACKEND)
   CB_ADD_GBENCHMARK(EnzymeCladComparison EnzymeCladComparison.cpp)
 endif(CLAD_ENABLE_ENZYME_BACKEND)
+
+option(CLAD_ENABLE_TAPENADE_BENCHMARK "Enable Tapenade comparison benchmarks" OFF)
+
+if (CLAD_ENABLE_TAPENADE_BENCHMARK)
+  include(FetchContent)
+  FetchContent_Declare(
+    tapenade_kit
+    GIT_REPOSITORY https://gitlab.inria.fr/tapenade/tapenade.git
+    GIT_TAG        develop
+    GIT_SHALLOW    TRUE
+    GIT_PROGRESS   TRUE      
+    GIT_SUBMODULES ""
+  )
+  FetchContent_MakeAvailable(tapenade_kit)
+
+  add_library(tapenade_support STATIC ${tapenade_kit_SOURCE_DIR}/ADFirstAidKit/adStack.c)
+  target_include_directories(tapenade_support PUBLIC ${tapenade_kit_SOURCE_DIR}/ADFirstAidKit)
+
+  target_compile_definitions(tapenade_support PRIVATE 
+      ADSTACK_MAX_SPACES=1        
+      ADSTACK_BLOCK_SIZE=4096    
+  )
+  CB_ADD_GBENCHMARK(TapenadeVsClad TapenadeVsClad.cpp)
+  
+  target_link_libraries(TapenadeVsClad PRIVATE tapenade_support)
+endif()
+
 CB_ADD_GBENCHMARK(VectorModeComparison VectorModeComparison.cpp)
 CB_ADD_GBENCHMARK(MemoryComplexity MemoryComplexity.cpp)
 CB_ADD_GBENCHMARK(Multithreading Multithreading.cpp)

--- a/benchmark/TapenadeVsclad.cpp
+++ b/benchmark/TapenadeVsclad.cpp
@@ -1,0 +1,56 @@
+#include "clad/Differentiator/Tape.h"
+#include <complex.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "benchmark/benchmark.h"
+extern "C" {
+void pushReal8(double x);
+void popReal8(double* x);
+}
+
+static void BM_Tapenade_PushPop(benchmark::State& state) {
+  int n = state.range(0);
+
+  for (auto _ : state) {
+    // 1. Push Loop
+    for (int i = 0; i < n; ++i) {
+      double val = 1.0;
+      pushReal8(val);
+    }
+
+    // 2. Pop Loop
+    for (int i = 0; i < n; ++i) {
+      double val;
+      popReal8(&val);
+      benchmark::DoNotOptimize(val);
+    }
+  }
+}
+
+static void BM_Clad_Disk_PushPop(benchmark::State& state) {
+  int n = state.range(0);
+
+  clad::tape_impl<double, 64, 1024, false, true> t;
+
+  for (auto _ : state) {
+    for (int i = 0; i < n; ++i)
+      t.emplace_back(1.0);
+
+    for (int i = 0; i < n; ++i) {
+      benchmark::DoNotOptimize(t.back());
+      t.pop_back();
+    }
+  }
+}
+
+BENCHMARK(BM_Tapenade_PushPop)
+    ->RangeMultiplier(4)
+    ->Range(1024, 262144)
+    ->Name("Tapenade_Stack");
+
+BENCHMARK(BM_Clad_Disk_PushPop)
+    ->RangeMultiplier(4)
+    ->Range(1024, 262144)
+    ->Name("Clad_Disk_Stack");
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
This PR adds a benchmark for comparing the peformance of Tapenade and Clad when performing Disk OffLoading. The Tapenade is fetched only at the build time and in order to. use it the user have to pass the flag:
``-DCLAD_ENABLE_TAPENADE_BENCHMARK=ON`` 
in the Cmake build.
**Note:** Initial build can take some time as fetching the Tapenade is a long process.