### PR TITLE
Fix ConstantFolder::synthesizeLiteral fallback for unsupported types (Fixes #1073)

### DIFF
--- a/lib/Differentiator/ConstantFolder.cpp
+++ b/lib/Differentiator/ConstantFolder.cpp
@@ -173,7 +173,7 @@ namespace clad {
       Result = clad::synthesizeLiteral(QT, C, APVal);
     } else {
       // Unsupported type: do not silently convert to int
-      return nullptr;
+      Result =  nullptr;
     }
     assert(Result && "Unsupported type passed to ConstantFolder::synthesizeLiteral");
     return Result;

--- a/lib/Differentiator/ConstantFolder.cpp
+++ b/lib/Differentiator/ConstantFolder.cpp
@@ -172,11 +172,10 @@ namespace clad {
       llvm::APFloat APVal(C.getFloatTypeSemantics(QT), val);
       Result = clad::synthesizeLiteral(QT, C, APVal);
     } else {
-      // FIXME: Handle other types, like Complex, Structs, typedefs, etc.
-      // typecasting may be needed right now
-      Result = ConstantFolder::synthesizeLiteral(C.IntTy, C, val);
+      // Unsupported type: do not silently convert to int
+      return nullptr;
     }
-    assert(Result && "Unsupported type for constant folding.");
+    assert(Result && "Unsupported type passed to ConstantFolder::synthesizeLiteral");
     return Result;
   }
 } // end namespace clad


### PR DESCRIPTION
Previously, ConstantFolder::synthesizeLiteral silently synthesized an `int` literal for unsupported types such as structs, classes, and complex types. 
This could lead to invalid ASTs and compilation errors downstream.

This change removes the unsafe fallback and instead fails fast by returning nullptr for unsupported types, making constant folding behavior explicit and correct.

- Handles: Enums, pointers, booleans, integral types, floating-point types
- Unsupported types now return nullptr
- Assertion added to catch unsupported types in debug builds

No behavior is changed for supported types. This is a minimal, safe fix.

