### PR TITLE
Handle self-assignment in ArrayRef::operator=

### DIFF
--- a/include/clad/Differentiator/ArrayRef.h
+++ b/include/clad/Differentiator/ArrayRef.h
@@ -48,6 +48,8 @@ public:
   }
 
   constexpr CUDA_HOST_DEVICE array_ref<T>& operator=(const array_ref<T>& a) {
+    if (this == &a)
+      return *this;
     assert(m_size == a.size());
     for (std::size_t i = 0; i < m_size; ++i)
       m_arr[i] = a[i];


### PR DESCRIPTION
This PR addresses the `bugprone-unhandled-self-assignment` warning flagged by clang-tidy in include/clad/Differentiator/ArrayRef.h
This is a follow-up to the C++11 Compatibility PR #1713 . As requested by @vgvassilev regarding this specific warning: 
> "Can we address such issues in separate PRs?"

**Changes:**
 Added a standard self-assignment check (`if (this == &other) return *this;`) to `operator=`.