### PR TITLE
Use Memcpy allocation with error handling (Follow-up to PR  #1714)

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -339,16 +339,11 @@ CUDA_HOST_DEVICE void push(tape<T[N], SBO_SIZE, SLAB_SIZE>& to, const U& val) {
 #endif
       size_t length = GetLength(code);
       m_Code = (char*)malloc(length + 1);
-
-      if (m_Code) {
+      if (m_Code)
         memcpy((void*)m_Code, code, length + 1);
-      } else {
-#ifdef __CUDACC__
-        printf("stderr: Error: Failed to allocate memory for m_Code\n");
-#else
+      else
         fprintf(stderr, "Error: Failed to allocate memory for m_Code\n");
-#endif
-      }
+    }
 
     constexpr CUDA_HOST_DEVICE CladFunction(CladFunctionType f,
                                             FunctorType* functor = nullptr,


### PR DESCRIPTION
This is a follow-up to the discussion in PR #1714  regarding C++11 compatibility, as requested by @vgvassilev 

> The memcpy part can go in a separate PR.


**Changes**

1. Replaced Manual Loop: Switched from while (*temp++ = *code++) to std::memcpy optimized copying.
2.Added Error Handling: Introduced a check for malloc failure.