### PR TITLE
Adds benchmark to compare Tapenade and Clad performance

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -7,21 +7,35 @@ CB_ADD_GBENCHMARK(ArrayExpressionTemplates ArrayExpressionTemplates.cpp)
 if (CLAD_ENABLE_ENZYME_BACKEND)
   CB_ADD_GBENCHMARK(EnzymeCladComparison EnzymeCladComparison.cpp)
 endif(CLAD_ENABLE_ENZYME_BACKEND)
+
+include(FetchContent)
+FetchContent_Declare(
+  tapenade_kit
+  GIT_REPOSITORY https://gitlab.inria.fr/tapenade/tapenade.git
+  
+  # We use a commit hash from the 'develop' branch because
+  # the 'disk offloading' feature is not yet available in the stable release of tapenade.
+  GIT_TAG        6f8cb04a4168cac5f6242cdeb65f6816c413f4ee 
+  
+  GIT_SHALLOW    TRUE
+  GIT_PROGRESS   TRUE      
+)
+FetchContent_MakeAvailable(tapenade_kit)
+
+# Build the support library for the stack from the fetched source
+add_library(tapenade_support STATIC ${tapenade_kit_SOURCE_DIR}/ADFirstAidKit/adStack.c)
+target_include_directories(tapenade_support PUBLIC ${tapenade_kit_SOURCE_DIR}/ADFirstAidKit)
+
+target_compile_definitions(tapenade_support PRIVATE 
+      ADSTACK_MAX_SPACES=1        
+      ADSTACK_BLOCK_SIZE=4194304   
+)
+
 CB_ADD_GBENCHMARK(VectorModeComparison VectorModeComparison.cpp)
-CB_ADD_GBENCHMARK(MemoryComplexity MemoryComplexity.cpp)
+CB_ADD_GBENCHMARK(MemoryComplexity_tapenade MemoryComplexity.cpp)
 CB_ADD_GBENCHMARK(Multithreading Multithreading.cpp)
-CB_ADD_GBENCHMARK(Hessians Hessians.cpp)
 
-set (CLAD_BENCHMARK_DEPS clad)
-get_property(_benchmark_names DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY TESTS)
-
-foreach (name ${_benchmark_names})
-  get_test_property(${name} LABELS _labels)
-  if (_labels MATCHES ".*benchmark.*")
-    get_test_property(${name} DEPENDS _deps)
-    list(APPEND CLAD_BENCHMARK_DEPS ${_deps})
-  endif()
-endforeach()
+target_link_libraries(MemoryComplexity_tapenade PRIVATE tapenade_support)
 
 add_custom_target(benchmark-clad COMMAND ${CMAKE_CTEST_COMMAND} -V
   DEPENDS ${CLAD_BENCHMARK_DEPS} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
This PR adds a benchmark for comparing the peformance of Tapenade and Clad when performing Disk OffLoading. The Tapenade is fetched only at the build time.
Note: Initial build can take some time as fetching the Tapenade is a long process.