### PR TITLE
[ci] Remove duplicate builds reduce the pressure on the public infrastructure.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,7 +574,7 @@ jobs:
           ..
         cmake --build . --target sphinx-clad doxygen-clad -- -j4
     - name: Failed job config
-      if: ${{ failure() && runner.os != 'windows' }}
+      if: ${{ failure() && runner.debug && runner.os != 'windows' }}
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: |


### PR DESCRIPTION
The build matrix has grown over time significantly. While it is good to test much of the different compilers we cannot test all possible configurations. The new approach checks if clad works with the last 10 versions of llvm on unix; and the last 5 on osx and windows.

We drop the duplications coming from testing with various compilers which generally makes a little sense because the compilers are larely compatible with each other.