### PR TITLE
Add support for passing struct references to the function passed to `clad::differentiate`

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -124,9 +124,11 @@ DerivativeAndOverload BaseForwardModeVisitor::Derive() {
     } else {
       QualType T = m_IndependentVar->getType();
       bool isField = false;
-      if (auto* RD = diffVarInfo.param->getType().getNonReferenceType()->getAsCXXRecordDecl()) {
+      if (auto* RD = diffVarInfo.param->getType()
+                         .getNonReferenceType()
+                         ->getAsCXXRecordDecl()) {
         llvm::SmallVector<llvm::StringRef, 4> ref(diffVarInfo.fields.begin(),
-                                                    diffVarInfo.fields.end());
+                                                  diffVarInfo.fields.end());
         T = utils::ComputeMemExprPathType(m_Sema, RD, ref);
         isField = true;
       }

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -124,9 +124,9 @@ DerivativeAndOverload BaseForwardModeVisitor::Derive() {
     } else {
       QualType T = m_IndependentVar->getType();
       bool isField = false;
-      if (auto* RD = diffVarInfo.param->getType()->getAsCXXRecordDecl()) {
+      if (auto* RD = diffVarInfo.param->getType().getNonReferenceType()->getAsCXXRecordDecl()) {
         llvm::SmallVector<llvm::StringRef, 4> ref(diffVarInfo.fields.begin(),
-                                                  diffVarInfo.fields.end());
+                                                    diffVarInfo.fields.end());
         T = utils::ComputeMemExprPathType(m_Sema, RD, ref);
         isField = true;
       }

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -526,29 +526,18 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
 
         if (!dVarInfo.param->getType().getNonReferenceType()->isRecordType() &&
             !dVarInfo.fields.empty()) {
-          utils::diag(
-              semaRef, DiagnosticsEngine::Error, dArgsL,
-              "fields can only be provided when parameters are of class "
-              "types or are references to class types; "
-              "field information is incorrectly specified in '%0' "
-              "for non-class/non-reference to class type parameter '%1'")
+          utils::diag(semaRef, DiagnosticsEngine::Error, dArgsL,
+                      "fields can only be provided for class type parameters; "
+                      "field information is incorrectly specified in '%0' "
+                      "for non-class type parameter '%1'")
               << diffSpec << pName << dArgsL;
           return;
         }
 
         if (!dVarInfo.fields.empty()) {
-          RecordDecl* RD;
-
-          if (dVarInfo.param->getType()->isRecordType()) {
-            RD = dVarInfo.param->getType()->getAsCXXRecordDecl();
-          } else {
-            assert(dVarInfo.param->getType()->isReferenceType());
-
-            RD = dVarInfo.param->getType()
-                     .getNonReferenceType()
-                     ->getAsCXXRecordDecl();
-          }
-
+          RecordDecl* RD = dVarInfo.param->getType()
+                               .getNonReferenceType()
+                               ->getAsCXXRecordDecl();
           llvm::SmallVector<llvm::StringRef, 4> ref(dVarInfo.fields.begin(),
                                                     dVarInfo.fields.end());
           bool isValid = utils::IsValidMemExprPath(semaRef, RD, ref);

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -526,16 +526,29 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
 
         if (!dVarInfo.param->getType()->isRecordType() &&
             !dVarInfo.fields.empty()) {
-          utils::diag(semaRef, DiagnosticsEngine::Error, dArgsL,
-                      "fields can only be provided for class type parameters; "
-                      "field information is incorrectly specified in '%0' "
-                      "for non-class type parameter '%1'")
-              << diffSpec << pName << dArgsL;
-          return;
+          if (!(dVarInfo.param->getType().getNonReferenceType()->isRecordType())) {
+            utils::diag(semaRef, DiagnosticsEngine::Error, dArgsL,
+                        "fields can only be provided when parameters are of class types or are references to class types; "
+                        "field information is incorrectly specified in '%0' "
+                        "for non-class/non-reference to class type parameter '%1'")
+                << diffSpec << pName << dArgsL;
+            return;
+          }
         }
 
         if (!dVarInfo.fields.empty()) {
-          RecordDecl* RD = dVarInfo.param->getType()->getAsCXXRecordDecl();
+          RecordDecl* RD;
+
+          if (dVarInfo.param->getType()->isRecordType()) {
+            RD = dVarInfo.param->getType()->getAsCXXRecordDecl();
+          } else  {
+            assert(dVarInfo.param->getType()->isReferenceType());
+
+            RD = dVarInfo.param->getType()
+                     .getNonReferenceType()
+                     ->getAsCXXRecordDecl();
+          }
+
           llvm::SmallVector<llvm::StringRef, 4> ref(dVarInfo.fields.begin(),
                                                     dVarInfo.fields.end());
           bool isValid = utils::IsValidMemExprPath(semaRef, RD, ref);

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -526,11 +526,15 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
 
         if (!dVarInfo.param->getType()->isRecordType() &&
             !dVarInfo.fields.empty()) {
-          if (!(dVarInfo.param->getType().getNonReferenceType()->isRecordType())) {
-            utils::diag(semaRef, DiagnosticsEngine::Error, dArgsL,
-                        "fields can only be provided when parameters are of class types or are references to class types; "
-                        "field information is incorrectly specified in '%0' "
-                        "for non-class/non-reference to class type parameter '%1'")
+          if (!(dVarInfo.param->getType()
+                    .getNonReferenceType()
+                    ->isRecordType())) {
+            utils::diag(
+                semaRef, DiagnosticsEngine::Error, dArgsL,
+                "fields can only be provided when parameters are of class "
+                "types or are references to class types; "
+                "field information is incorrectly specified in '%0' "
+                "for non-class/non-reference to class type parameter '%1'")
                 << diffSpec << pName << dArgsL;
             return;
           }
@@ -541,7 +545,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
 
           if (dVarInfo.param->getType()->isRecordType()) {
             RD = dVarInfo.param->getType()->getAsCXXRecordDecl();
-          } else  {
+          } else {
             assert(dVarInfo.param->getType()->isReferenceType());
 
             RD = dVarInfo.param->getType()

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -524,20 +524,16 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
           dVarInfo.fields.push_back(fieldName.str());
         }
 
-        if (!dVarInfo.param->getType()->isRecordType() &&
+        if (!dVarInfo.param->getType().getNonReferenceType()->isRecordType() &&
             !dVarInfo.fields.empty()) {
-          if (!(dVarInfo.param->getType()
-                    .getNonReferenceType()
-                    ->isRecordType())) {
-            utils::diag(
-                semaRef, DiagnosticsEngine::Error, dArgsL,
-                "fields can only be provided when parameters are of class "
-                "types or are references to class types; "
-                "field information is incorrectly specified in '%0' "
-                "for non-class/non-reference to class type parameter '%1'")
-                << diffSpec << pName << dArgsL;
-            return;
-          }
+          utils::diag(
+              semaRef, DiagnosticsEngine::Error, dArgsL,
+              "fields can only be provided when parameters are of class "
+              "types or are references to class types; "
+              "field information is incorrectly specified in '%0' "
+              "for non-class/non-reference to class type parameter '%1'")
+              << diffSpec << pName << dArgsL;
+          return;
         }
 
         if (!dVarInfo.fields.empty()) {

--- a/test/FirstDerivative/DiffInterface.C
+++ b/test/FirstDerivative/DiffInterface.C
@@ -189,7 +189,7 @@ int main () {
   clad::differentiate(fn_with_no_return, "x");
   clad::differentiate(fn_with_no_params); // expected-error {{attempted to differentiate function with no parameters}}
 
-  clad::differentiate(f_2, "x.mem1");                                   // expected-error {{fields can only be provided when parameters are of class types or are references to class types; field information is incorrectly specified in 'x.mem1' for non-class/non-reference to class type parameter 'x'}}
+  clad::differentiate(f_2, "x.mem1");                                   // expected-error {{fields can only be provided for class type parameters; field information is incorrectly specified in 'x.mem1' for non-class type parameter 'x'}}
   clad::differentiate(fn_with_Complex_type_param, "c.real.im");         // expected-error {{path specified by fields in 'c.real.im' is invalid}}
   clad::differentiate(fn_with_ComplexPair_type_param, "cp.c1");         // expected-error {{attempted differentiation w.r.t. parameter 'cp.c1' which is not of real type}}
   clad::differentiate(fn_with_Complex_type_param, "c.getReal");         // expected-error {{path specified by fields in 'c.getReal' is invalid}}

--- a/test/FirstDerivative/DiffInterface.C
+++ b/test/FirstDerivative/DiffInterface.C
@@ -189,7 +189,7 @@ int main () {
   clad::differentiate(fn_with_no_return, "x");
   clad::differentiate(fn_with_no_params); // expected-error {{attempted to differentiate function with no parameters}}
 
-  clad::differentiate(f_2, "x.mem1");                                   // expected-error {{fields can only be provided for class type parameters; field information is incorrectly specified in 'x.mem1' for non-class type parameter 'x'}}
+  clad::differentiate(f_2, "x.mem1");                                   // expected-error {{fields can only be provided when parameters are of class types or are references to class types; field information is incorrectly specified in 'x.mem1' for non-class/non-reference to class type parameter 'x'}}
   clad::differentiate(fn_with_Complex_type_param, "c.real.im");         // expected-error {{path specified by fields in 'c.real.im' is invalid}}
   clad::differentiate(fn_with_ComplexPair_type_param, "cp.c1");         // expected-error {{attempted differentiation w.r.t. parameter 'cp.c1' which is not of real type}}
   clad::differentiate(fn_with_Complex_type_param, "c.getReal");         // expected-error {{path specified by fields in 'c.getReal' is invalid}}

--- a/test/ForwardMode/StructReference.C
+++ b/test/ForwardMode/StructReference.C
@@ -5,8 +5,8 @@
 #include "../TestUtils.h"
 
 struct T {
-    double x;
-    double y;
+    double x{};
+    double y{};
 };
 
 double fn1(T& t) {

--- a/test/ForwardMode/StructReference.C
+++ b/test/ForwardMode/StructReference.C
@@ -5,24 +5,24 @@
 #include "../TestUtils.h"
 
 struct T {
-    double x{};
-    double y{};
+  double x{};
+  double y{};
 };
 
 double fn1(T& t) {
-    return t.x * t.y;
+  return t.x * t.y;
 }
 
 double fn2(T&& t) {
-    return t.x * t.y;
+  return t.x * t.y;
 }
 
 int main() {
-    INIT_DIFFERENTIATE(fn1, "t.x")
-    INIT_DIFFERENTIATE(fn2, "t.y")
+  INIT_DIFFERENTIATE(fn1, "t.x")
+  INIT_DIFFERENTIATE(fn2, "t.y")
 
-    T t{2, 3};
+  T t{2, 3};
 
-    TEST_DIFFERENTIATE(fn1, t); // CHECK-EXEC: {3.00}
-    TEST_DIFFERENTIATE(fn2, T{4, 5}); // CHECK-EXEC: {4.00}
+  TEST_DIFFERENTIATE(fn1, t); // CHECK-EXEC: {3.00}
+  TEST_DIFFERENTIATE(fn2, T{4, 5}); // CHECK-EXEC: {4.00}
   }

--- a/test/ForwardMode/StructReference.C
+++ b/test/ForwardMode/StructReference.C
@@ -1,0 +1,28 @@
+// RUN: %cladclang %s -I%S/../../include -oStructReference.out | %filecheck %s
+// RUN: ./StructReference.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "../TestUtils.h"
+
+struct T {
+    double x;
+    double y;
+};
+
+double fn1(T& t) {
+    return t.x * t.y;
+}
+
+double fn2(T&& t) {
+    return t.x * t.y;
+}
+
+int main() {
+    INIT_DIFFERENTIATE(fn1, "t.x")
+    INIT_DIFFERENTIATE(fn2, "t.y")
+
+    T t{2, 3};
+
+    TEST_DIFFERENTIATE(fn1, t); // CHECK-EXEC: {3.00}
+    TEST_DIFFERENTIATE(fn2, T{4, 5}); // CHECK-EXEC: {4.00}
+  }


### PR DESCRIPTION
Add support for passing struct references to the function passed to `clad::differentiate`

Fixes #696 