### PR TITLE
Fixes the CI failure caused by fetching the wrong commit hash.

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -16,8 +16,6 @@ FetchContent_Declare(
   # We use a commit hash from the 'develop' branch because
   # the 'disk offloading' feature is not yet available in the stable release of tapenade.
   GIT_TAG        6f8cb04a4168cac5f6242cdeb65f6816c413f4ee 
-  
-  GIT_SHALLOW    TRUE
   GIT_PROGRESS   TRUE      
 )
 FetchContent_MakeAvailable(tapenade_kit)


### PR DESCRIPTION
The CI currently fails with a "fatal: unable to read tree" error when attempting to check out the specific Tapenade commit hash. Because the targeted commit is no longer at the tip of the Tapenade `develop` branch, `GIT_SHALLOW TRUE` (which performs a `--depth 1` clone) fails to download the necessary git history to resolve the hash. So the fix involves disabling git shallow
