### PR TITLE
Add symbolic derivative for std::expint

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -557,6 +557,51 @@ CUDA_HOST_DEVICE ValueAndPushforward<T, dT> expm1l_pushforward(T x, dT d_x) {
   return expm1_pushforward(x, d_x);
 }
 
+#if __cplusplus >= 201703L
+// 2.4 expint, expintf, expintl
+template <typename T> CUDA_HOST_DEVICE inline T expint_primal(T x) {
+#if defined(__cpp_lib_math_special_funcs) || defined(__STDCPP_MATH_SPEC_FUNCS__)
+  return ::std ::expint(x);
+#else
+  return T(0);
+#endif
+}
+
+template <typename T> CUDA_HOST_DEVICE inline T expintf_primal(T x) {
+#if defined(__cpp_lib_math_special_funcs) || defined(__STDCPP_MATH_SPEC_FUNCS__)
+  return ::std ::expintf(x);
+#else
+  return T(0);
+#endif
+}
+
+template <typename T> CUDA_HOST_DEVICE inline T expintl_primal(T x) {
+#if defined(__cpp_lib_math_special_funcs) || defined(__STDCPP_MATH_SPEC_FUNCS__)
+  return ::std ::expintl(x);
+#else
+  return T(0);
+#endif
+}
+
+template <typename T, typename dT>
+CUDA_HOST_DEVICE ValueAndPushforward<T, dT> expint_pushforward(T x, dT d_x) {
+  return {static_cast<T>(expint_primal(x)),
+          static_cast<dT>((::std ::exp(x) / x) * d_x)};
+}
+
+template <typename T, typename dT>
+CUDA_HOST_DEVICE ValueAndPushforward<T, dT> expintf_pushforward(T x, dT d_x) {
+  return {static_cast<T>(expintf_primal(x)),
+          static_cast<dT>((::std ::exp(x) / x) * d_x)};
+}
+
+template <typename T, typename dT>
+CUDA_HOST_DEVICE ValueAndPushforward<T, dT> expintl_pushforward(T x, dT d_x) {
+  return {static_cast<T>(expintl_primal(x)),
+          static_cast<dT>((::std ::exp(x) / x) * d_x)};
+}
+#endif
+
 // 3. Logarithmic Functions
 
 // 3.1 log, logf, logl
@@ -1351,6 +1396,11 @@ using std::expl_pushforward;
 using std::expm1_pushforward;
 using std::expm1f_pushforward;
 using std::expm1l_pushforward;
+#if __cplusplus >= 201703L
+using std::expint_pushforward;
+using std::expintf_pushforward;
+using std::expintl_pushforward;
+#endif
 
 // 3. Logarithmic Functions
 using std::log10_pushforward;

--- a/test/Features/stl-cmath.cpp
+++ b/test/Features/stl-cmath.cpp
@@ -109,7 +109,7 @@
 // D ellint_1/ f / l           (C++17) incomplete elliptic integral (1st kind)
 // D ellint_2/ f / l           (C++17) incomplete elliptic integral (2nd kind)
 // D ellint_3/ f / l           (C++17) incomplete elliptic integral (3rd kind)
-// D expint/ expintf/ expintl  (C++17) exponential integral
+// DS expint/ expintf/ expintl  (C++17) exponential integral
 // D hermite/ hermitef/ hermitel (C++17) Hermite polynomials
 // D legendre/ legendref/ legendrel (C++17) Legendre polynomials
 // D laguerre/ laguerref/ laguerrel (C++17) Laguerre polynomials
@@ -262,6 +262,12 @@ long double f_fmal(long double x){ return fmal(x,2.0L, 1.0L); }
 DEFINE_FUNCTIONS(exp)   // x in (-inf,+inf)
 DEFINE_FUNCTIONS(exp2)  // x in (-inf,+inf)
 DEFINE_FUNCTIONS(expm1) // x in (-inf,+inf)
+#if __cplusplus >= 201703L && (defined(__cpp_lib_math_special_funcs) || defined(__STDCPP_MATH_SPEC_FUNCS__))
+template <typename T> 
+T f_expint(T x) { return ::std ::expint(x); } // x in (-inf,0) U (0,+inf)
+inline float f_expintf(float x) { return ::std ::expintf(x); }
+inline long double f_expintl(long double x) { return ::std ::expintl(x); }
+#endif
 DEFINE_FUNCTIONS(log)   // x in (0,+inf)
 DEFINE_FUNCTIONS(log10) // x in (0,+inf)
 DEFINE_FUNCTIONS(log2)  // x in (0,+inf)
@@ -323,6 +329,10 @@ int main() {
   CHECK_ALL(exp);
   CHECK_ALL(exp2);
   CHECK_ALL(expm1);
+  #if __cplusplus >= 201703L && (defined(__cpp_lib_math_special_funcs) || defined(__STDCPP_MATH_SPEC_FUNCS__))
+  CHECK_ALL_RANGE(expint, {-2.0, -1.0, -0.5, 0.5, 1.0, 2.0, 3.0});
+  #endif
+
   CHECK_ALL(log);
   CHECK_ALL(log10);
   CHECK_ALL(log2);

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -18,6 +18,16 @@ namespace std {
 #endif
 
 extern "C" int printf(const char* fmt, ...);
+#include <cmath>
+
+#if !defined(__cpp_lib_math_special_functions)
+namespace std {
+  // std::expint mock for osx systems
+  inline double expint(double x) { return 0.0; }
+  inline float expintf(float x) { return 0.0f; }
+  inline long double expintl(long double x) { return 0.0L; }
+}
+#endif
 
 
 namespace N {
@@ -453,6 +463,13 @@ double f_expm1l(double x) { return std::expm1l(x); }
 // CHECK-NEXT:     return _t0.pushforward;
 // CHECK-NEXT: }
 
+double f_expint(double x) { return std::expint(x); }
+// CHECK: double f_expint_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     {{.*}}ValueAndPushforward<double, double> _t0 = {{.*}}expint_pushforward(x, _d_x);
+// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT: }
+
 double f_log1pl(double x) { return std::log1pl(x); }
 // CHECK: double f_log1pl_darg0(double x) {
 // CHECK-NEXT:     double _d_x = 1;
@@ -683,6 +700,9 @@ int main () { //expected-no-diagnostics
 
   auto d_expm1l = clad::differentiate(f_expm1l, 0);
   printf("Result is = %.6f\n", d_expm1l.execute(0.5)); // CHECK-EXEC: Result is = 1.648721
+
+  auto d_expint = clad::differentiate(f_expint, 0);
+  printf("Result is = %.6f\n", d_expint.execute(0.5)); // CHECK-EXEC: Result is = 3.297443
 
   auto d_log1pl = clad::differentiate(f_log1pl, 0);
   printf("Result is = %.6f\n", d_log1pl.execute(0.5)); // CHECK-EXEC: Result is = 0.666667


### PR DESCRIPTION
Fixes #1744 
Implements symbolic derivative support for C++17 `std::expint` function.

The pushforward mode is implemented as `expint_pushforward`. The pullback is auto-synthesized from the pushforward.
Added C++17 guards and tests.