### PR TITLE
Add support for differentiation of functions using `std::hermite` and its variants

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -1203,7 +1203,7 @@ hermitel_pushforward(unsigned int n, long double x, unsigned int,
 template <typename T, typename U>
 CUDA_HOST_DEVICE void hermite_pullback(unsigned int n, T x, U d_z,
                                        unsigned int*, T* d_x) {
-  *d_x += 2 * n * ::std::hermite(n - 1, x) * d_z;
+  *d_x += 2 * n * clad_hermite_primal(n - 1, x) * d_z;
 }
 
 template <typename T>

--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -1167,10 +1167,26 @@ CUDA_HOST_DEVICE void beta_pullback(T x, T y, U d_z, T* d_x, T* d_y) {
     *d_y += b * (clad_digamma(y) - psi_xy) * d_z;
 }
 
+template <typename T> T clad_hermite_primal(unsigned int n, T x) {
+#if defined(__cpp_lib_math_special_functions)
+  return ::std::hermite(n, x);
+#else
+
+  if (n == 0)
+    return 1;
+  else if (n == 1)
+    return 2 * x;
+  else
+    return (2 * x * clad_hermite_primal(n - 1, x)) -
+           (2 * (n - 1) * clad_hermite_primal(n - 2, x));
+#endif
+}
+
 template <typename T>
 CUDA_HOST_DEVICE ValueAndPushforward<T, T>
 hermite_pushforward(unsigned int n, T x, unsigned int, T d_x) {
-  return {::std::hermite(n, x), 2 * n * ::std::hermite(n - 1, x) * d_x};
+  return {clad_hermite_primal(n, x),
+          2 * n * clad_hermite_primal(n - 1, x) * d_x};
 }
 
 CUDA_HOST_DEVICE inline ValueAndPushforward<float, float>
@@ -1470,17 +1486,14 @@ using std::sqrt_pushforward;
 
 // 7. Special Functions
 #if __cplusplus >= 201703L
-#include <version>
 using std::beta_pullback;
 using std::beta_pushforward;
-#ifdef __cpp_lib_math_special_functions
 using std::hermite_pullback;
 using std::hermite_pushforward;
 using std::hermitef_pullback;
 using std::hermitef_pushforward;
 using std::hermitel_pullback;
 using std::hermitel_pushforward;
-#endif
 #endif
 
 namespace class_functions {

--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -1166,8 +1166,7 @@ CUDA_HOST_DEVICE void beta_pullback(T x, T y, U d_z, T* d_x, T* d_y) {
   if (d_y)
     *d_y += b * (clad_digamma(y) - psi_xy) * d_z;
 }
-#include <version>
-#ifdef __cpp_lib_math_special_functions
+
 template <typename T>
 CUDA_HOST_DEVICE ValueAndPushforward<T, T>
 hermite_pushforward(unsigned int n, T x, unsigned int, T d_x) {
@@ -1202,7 +1201,6 @@ CUDA_HOST_DEVICE void hermitel_pullback(unsigned int n, long double x, T d_z,
                                         unsigned int*, long double* d_x) {
   hermite_pullback(n, x, d_z, nullptr, d_x);
 }
-#endif
 #endif
 
 } // namespace std

--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -1166,6 +1166,43 @@ CUDA_HOST_DEVICE void beta_pullback(T x, T y, U d_z, T* d_x, T* d_y) {
   if (d_y)
     *d_y += b * (clad_digamma(y) - psi_xy) * d_z;
 }
+#include <version>
+#ifdef __cpp_lib_math_special_functions
+template <typename T>
+CUDA_HOST_DEVICE ValueAndPushforward<T, T>
+hermite_pushforward(unsigned int n, T x, unsigned int, T d_x) {
+  return {::std::hermite(n, x), 2 * n * ::std::hermite(n - 1, x) * d_x};
+}
+
+CUDA_HOST_DEVICE inline ValueAndPushforward<float, float>
+hermitef_pushforward(unsigned int n, float x, unsigned int, float d_x) {
+  return hermite_pushforward(n, x, 0, d_x);
+}
+
+CUDA_HOST_DEVICE inline ValueAndPushforward<long double, long double>
+hermitel_pushforward(unsigned int n, long double x, unsigned int,
+                     long double d_x) {
+  return hermite_pushforward(n, x, 0, d_x);
+}
+
+template <typename T, typename U>
+CUDA_HOST_DEVICE void hermite_pullback(unsigned int n, T x, U d_z,
+                                       unsigned int*, T* d_x) {
+  *d_x += 2 * n * ::std::hermite(n - 1, x) * d_z;
+}
+
+template <typename T>
+CUDA_HOST_DEVICE void hermitef_pullback(unsigned int n, float x, T d_z,
+                                        unsigned int*, float* d_x) {
+  hermite_pullback(n, x, d_z, nullptr, d_x);
+}
+
+template <typename T>
+CUDA_HOST_DEVICE void hermitel_pullback(unsigned int n, long double x, T d_z,
+                                        unsigned int*, long double* d_x) {
+  hermite_pullback(n, x, d_z, nullptr, d_x);
+}
+#endif
 #endif
 
 } // namespace std
@@ -1435,8 +1472,17 @@ using std::sqrt_pushforward;
 
 // 7. Special Functions
 #if __cplusplus >= 201703L
+#include <version>
 using std::beta_pullback;
 using std::beta_pushforward;
+#ifdef __cpp_lib_math_special_functions
+using std::hermite_pullback;
+using std::hermite_pushforward;
+using std::hermitef_pullback;
+using std::hermitef_pushforward;
+using std::hermitel_pullback;
+using std::hermitel_pushforward;
+#endif
 #endif
 
 namespace class_functions {

--- a/test/Features/stl-cmath.cpp
+++ b/test/Features/stl-cmath.cpp
@@ -306,6 +306,12 @@ DEFINE_FUNCTIONS(erf)  // x in (-inf,+inf)
 template<typename T> T f_beta(T x){ return std::beta(x,(T)2.0); } // x in (0, +inf)
 inline float f_betaf(float x){ return std::beta(x, 2.0f); }
 inline long double f_betal(long double x){ return std::beta(x, 2.0L); }
+//
+//------------------------ Mathematical special functions ----------------------
+//
+template <typename T> T f_hermite(T x){ return std::hermite(2, x); } // x in (-inf, +inf)
+inline float f_hermitef(float x){ return std::hermitef(2, x); }
+inline long double f_hermitel(long double x){ return std::hermitel(2, x); }
 
 int main() {
   // Absolute value
@@ -365,6 +371,9 @@ int main() {
   // Error / Gamma functions
   CHECK_ALL(erf);
   CHECK_ALL_RANGE(beta, {0.1, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0});
+
+  // Mathematical special functions
+  CHECK_ALL_RANGE(hermite, {-12744.2, -67.23, 1.0, 1.539, 2.012, 3.045, 412.987});
 
   return 0;
 }

--- a/test/Features/stl-cmath.cpp
+++ b/test/Features/stl-cmath.cpp
@@ -309,9 +309,11 @@ inline long double f_betal(long double x){ return std::beta(x, 2.0L); }
 //
 //------------------------ Mathematical special functions ----------------------
 //
+#if __cplusplus >= 201703L && defined(__cpp_lib_math_special_functions)
 template <typename T> T f_hermite(T x){ return std::hermite(2, x); } // x in (-inf, +inf)
 inline float f_hermitef(float x){ return std::hermitef(2, x); }
 inline long double f_hermitel(long double x){ return std::hermitel(2, x); }
+#endif
 
 int main() {
   // Absolute value
@@ -373,7 +375,9 @@ int main() {
   CHECK_ALL_RANGE(beta, {0.1, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0});
 
   // Mathematical special functions
+  #if __cplusplus >= 201703L && defined(__cpp_lib_math_special_functions)
   CHECK_ALL_RANGE(hermite, {-12744.2, -67.23, 1.0, 1.539, 2.012, 3.045, 412.987});
+  #endif
 
   return 0;
 }

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -24,6 +24,10 @@ namespace std {
       return (2 * x * hermite(n - 1, x)) - (2 * (n - 1) * hermite(n - 2, x));
   }
 
+  float hermitef(unsigned int n, float x) { return hermite(n, x); }
+
+  long double hermitel(unsigned int n, long double x) { return hermite(n, x); }
+
 }
 #endif
 

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -14,6 +14,16 @@ namespace std {
   inline double beta(double x, double y) {
     return std::tgamma(x) * std::tgamma(y) / std::tgamma(x + y);
   }
+
+  template <typename T> T hermite(unsigned int n, T x) {
+    if (n == 0)
+      return 1;
+    else if (n == 1)
+      return 2 * x;
+    else
+      return (2 * x * hermite(n - 1, x)) - (2 * (n - 1) * hermite(n - 2, x));
+  }
+
 }
 #endif
 
@@ -335,9 +345,7 @@ extern "C" {
   double f18(double x) { return x * x; }
 }
 
-#if __cplusplus >= 201703L
-#include <version>
-#ifdef __cpp_lib_math_special_functions
+
 double f19(double x) {
   return std::hermite(2, x);
 }
@@ -356,8 +364,6 @@ void f19_grad(double x, double* d_x);
 //CHECK-NEXT:     *_d_x += _r1;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     }
-#endif
-#endif
 
 double f_tan(double x) { return std::tan(x); }
 // CHECK: double f_tan_darg0(double x) {
@@ -660,17 +666,12 @@ int main () { //expected-no-diagnostics
   auto f18_darg0 = clad::differentiate(f18, 0);
   printf("Result is = %f\n", f18_darg0.execute(1)); // CHECK-EXEC: Result is = 2
 
-  #if __cplusplus >= 201703L
-  #include <version>
-  #ifdef __cpp_lib_math_special_functions
   auto f19_darg0 = clad::differentiate(f19, 0);
   printf("Result is = %.6f\n", f19_darg0.execute(3)); // CHECK-EXEC: Result is = 24.000000
 
   INIT_GRADIENT(f19);
 
   TEST_GRADIENT(f19, 1, 3, &d_result[0]); //CHECK-EXEC: {24.00}
-  #endif
-  #endif
 
   auto d_tan = clad::differentiate(f_tan, 0);
   printf("Result is = %.6f\n", d_tan.execute(0.5)); // CHECK-EXEC: Result is = 1.298446

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -335,6 +335,30 @@ extern "C" {
   double f18(double x) { return x * x; }
 }
 
+#if __cplusplus >= 201703L
+#include <version>
+#ifdef __cpp_lib_math_special_functions
+double f19(double x) {
+  return std::hermite(2, x);
+}
+//CHECK: double f19_darg0(double x) {
+//CHECK-NEXT:     double _d_x = 1;
+//CHECK-NEXT:     ValueAndPushforward<double, double> _t0 = clad::custom_derivatives::std::hermite_pushforward(2, x, 0, _d_x);
+//CHECK-NEXT:     return _t0.pushforward;
+//CHECK-NEXT:     }
+
+void f19_grad(double x, double* d_x);
+//CHECK: void f19_grad(double x, double *_d_x) {
+//CHECK-NEXT:     {
+//CHECK-NEXT:     unsigned int _r0 = 0U;
+//CHECK-NEXT:     double _r1 = 0.;
+//CHECK-NEXT:     clad::custom_derivatives::std::hermite_pullback(2, x, 1, &_r0, &_r1);
+//CHECK-NEXT:     *_d_x += _r1;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     }
+#endif
+#endif
+
 double f_tan(double x) { return std::tan(x); }
 // CHECK: double f_tan_darg0(double x) {
 // CHECK-NEXT:     double _d_x = 1;
@@ -635,6 +659,18 @@ int main () { //expected-no-diagnostics
 
   auto f18_darg0 = clad::differentiate(f18, 0);
   printf("Result is = %f\n", f18_darg0.execute(1)); // CHECK-EXEC: Result is = 2
+
+  #if __cplusplus >= 201703L
+  #include <version>
+  #ifdef __cpp_lib_math_special_functions
+  auto f19_darg0 = clad::differentiate(f19, 0);
+  printf("Result is = %.6f\n", f19_darg0.execute(3)); // CHECK-EXEC: Result is = 24.000000
+
+  INIT_GRADIENT(f19);
+
+  TEST_GRADIENT(f19, 1, 3, &d_result[0]); //CHECK-EXEC: {24.00}
+  #endif
+  #endif
 
   auto d_tan = clad::differentiate(f_tan, 0);
   printf("Result is = %.6f\n", d_tan.execute(0.5)); // CHECK-EXEC: Result is = 1.298446


### PR DESCRIPTION
Add support for differentiation of functions using `std::hermite`, `std::hermitef` and `std::hermitel` in both forward and backward modes with tests.