### PR TITLE
Fixed nested hessian context loss and reverse mode memory OOB error for nested arrays

### DIFF
--- a/include/clad/Differentiator/ParseDiffArgsTypes.h
+++ b/include/clad/Differentiator/ParseDiffArgsTypes.h
@@ -69,6 +69,8 @@ namespace clad {
     const clang::ValueDecl* param = nullptr;
     /// array index range associated with the parameter.
     IndexInterval paramIndexInterval;
+    /// track the true global capacity across sub-requests
+    std::size_t TotalCapacity = 0;
     /// Nested field information.
     llvm::SmallVector<std::string, 4> fields;
     // FIXME: Add support for differentiating with respect to array fields.

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -26,7 +26,9 @@
 #include "clang/AST/Type.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TokenKinds.h"
+#include "clang/Basic/Version.h"
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Overload.h"
 #include "clang/Sema/Scope.h"
@@ -1117,9 +1119,105 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
     CallArgs.push_back(argDiff.getExpr());
     if (utils::IsDifferentiableType(arg->getType())) {
       Expr* dArg = argDiff.getExpr_dx();
+
+      const Expr* cleanDArg = dArg;
+      bool isZeroDArg = !cleanDArg || clad::utils::IsZeroOrNullValue(cleanDArg);
+
+      if (!isZeroDArg && cleanDArg) {
+        if (const auto* ILE = dyn_cast<InitListExpr>(cleanDArg)) {
+          isZeroDArg = (ILE->getNumInits() == 0) ||
+                       (ILE->getNumInits() == 1 &&
+                        clad::utils::IsZeroOrNullValue(ILE->getInit(0)));
+        }
+      }
+
+      if (isZeroDArg &&
+          (arg->getType()->isPointerType() || arg->getType()->isArrayType())) {
+        const Expr* cleanArg = arg->IgnoreParenImpCasts();
+        if (const auto* DRE = dyn_cast<DeclRefExpr>(cleanArg)) {
+          if (const auto* VD = dyn_cast<VarDecl>(DRE->getDecl())) {
+
+            std::size_t arrSize = 0;
+
+            // Try to get the size from the AST.
+            if (const auto* CAT =
+                    m_Context.getAsConstantArrayType(VD->getType())) {
+              arrSize = CAT->getSize().getZExtValue();
+            }
+            // Otherwise extract the size from DiffRequest using TotalCapacity.
+            else {
+              for (const auto& varInfo : m_DiffReq.DVI) {
+                bool isSameName = false;
+                if (varInfo.param->getIdentifier() && VD->getIdentifier())
+                  isSameName = (varInfo.param->getName() == VD->getName());
+                if (varInfo.param == VD || isSameName) {
+                  if (varInfo.TotalCapacity > 0)
+                    arrSize = varInfo.TotalCapacity;
+                  break;
+                }
+              }
+            }
+
+            // If array size was found construct AST node for arg[k] for all k.
+            if (arrSize > 0) {
+              QualType elemType =
+                  QualType(arg->getType()->getPointeeOrArrayElementType(), 0);
+
+              llvm::APInt sizeAPI(
+                  m_Context.getTypeSize(m_Context.getSizeType()), arrSize);
+              QualType arrType = clad_compat::getConstantArrayType(
+                  m_Context, elemType, sizeAPI, nullptr,
+                  clad_compat::ArraySizeModifier_Normal, 0);
+
+              llvm::SmallVector<Expr*, 4> initExprs;
+              for (std::size_t k = 0; k < arrSize; ++k) {
+                Expr* idxExpr = ConstantFolder::synthesizeLiteral(
+                    m_Context.IntTy, m_Context, k);
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                Expr* safeBase = const_cast<Expr*>(arg->IgnoreParens());
+
+                // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+                Expr* subExpr = new (m_Context)
+                    ArraySubscriptExpr(safeBase, idxExpr, elemType, VK_LValue,
+                                       OK_Ordinary, CE->getBeginLoc());
+
+                StmtDiff subDiff = Visit(subExpr);
+                Expr* subDx = subDiff.getExpr_dx();
+
+                if (!subDx || clad::utils::IsZeroOrNullValue(subDx)) {
+                  Expr* zeroExpr = ConstantFolder::synthesizeLiteral(
+                      elemType, m_Context, /*val=*/0.0);
+                  initExprs.push_back(zeroExpr);
+                } else {
+                  initExprs.push_back(subDx);
+                }
+              }
+
+              // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+              auto* initList = new (m_Context) InitListExpr(
+                  m_Context, CE->getBeginLoc(), initExprs, CE->getEndLoc());
+              initList->setType(arrType);
+
+              TypeSourceInfo* tInfo =
+                  m_Context.getTrivialTypeSourceInfo(arrType);
+
+              // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+              auto* CLE = new (m_Context) CompoundLiteralExpr(
+                  CE->getBeginLoc(), tInfo, arrType, VK_LValue, initList,
+                  /*isFileScope=*/true);
+
+              dArg = m_Sema
+                         .ImpCastExprToType(CLE,
+                                            m_Context.getPointerType(elemType),
+                                            CK_ArrayToPointerDecay)
+                         .get();
+            }
+          }
+        }
+      }
       if (!dArg)
         dArg = getZeroInit(arg->getType());
-      // FIXME: What happens when dArg is nullptr?
+      // pointer/array arguments are dynamically synthesized above
       diffArgs.push_back(dArg);
     }
   }

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -494,6 +494,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
               return;
             }
             dVarInfo.paramIndexInterval = IndexInterval(index);
+            dVarInfo.TotalCapacity = index + 1;
           } else {
             size_t first, last;
             if (firstStr.getAsInteger(Radix, first) ||
@@ -510,6 +511,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
               return;
             }
             dVarInfo.paramIndexInterval = IndexInterval(first, last);
+            dVarInfo.TotalCapacity = last + 1;
           }
         } else {
           dVarInfo.paramIndexInterval = IndexInterval();
@@ -1367,6 +1369,8 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
               forwRequest.Args = utils::CreateStringLiteral(
                   m_Sema.getASTContext(), independentArgString);
               forwRequest.UpdateDiffParamsInfo(m_Sema);
+              if (!forwRequest.DVI.empty())
+                forwRequest.DVI.back().TotalCapacity = indexInterval.Finish;
               LookupCustomDerivativeDecl(forwRequest);
               m_DiffRequestGraph.addNode(forwRequest, /*isSource=*/true);
             }

--- a/test/Arrays/Arrays.C
+++ b/test/Arrays/Arrays.C
@@ -234,6 +234,23 @@ void f25(double x, const double *y) {
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
+double arr[2] = {4.0, 5.0};
+
+double f_inner(double* p) {
+    return p[0] * p[1];
+}
+
+double f_outer(double x) {
+    return f_inner(arr) * x;
+}
+
+// CHECK: double f_outer_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = f_inner_pushforward(arr, (double{{ *}}[2]){0., 0.});
+// CHECK-NEXT:     double &_t1 = _t0.value;
+// CHECK-NEXT:     return _t0.pushforward * x + _t1 * _d_x;
+// CHECK-NEXT: }
+
 int main () { // expected-no-diagnostics
   auto dsum = clad::differentiate(sum, 0);
   printf("%.2f\n", dsum.execute(11, 12, 13)); // CHECK-EXEC: 1.00
@@ -265,6 +282,11 @@ int main () { // expected-no-diagnostics
                             &const_output_test_result[1]);
   printf("{%.2f, %.2f}\n", const_output_test_result[0],
          const_output_test_result[1]); // CHECK-EXEC: {3.00, 0.00}
+
+    auto d_global = clad::differentiate(f_outer, "x");
+
+    printf("%.2f\n", d_global.execute(5.0));
+    // CHECK-EXEC: 20.00
 
   return 0;
 }

--- a/test/Hessian/NestedArrays.C
+++ b/test/Hessian/NestedArrays.C
@@ -1,0 +1,155 @@
+// RUN: %cladclang %s -I%S/../../include -o NestedArrays.out 2>&1 | %filecheck %s
+// RUN: ./NestedArrays.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include <stdio.h>
+#include <math.h>
+
+double f0_inner(double* params) {
+    return params[0] * params[1] * params[2]
+         + params[3] * params[3]
+         + params[4] * params[0];
+}
+
+double f0_outer(double* params) {
+    return f0_inner(params) + sin(params[2]) - exp(params[4]);
+}
+
+double f1_inner(double* p) {
+    return p[0] * p[1];
+}
+
+double f1_outer(double x, double y) {
+    double arr[2] = {x, y};
+    return f1_inner(arr);
+}
+
+double f2_inner(double* p, double x) {
+    return p[0] * x * x;
+}
+
+double f2_outer(double x) {
+    double arr[2] = {2.0, 3.0};
+    return f2_inner(arr, x);
+}
+
+// CHECK: clad::ValueAndPushforward<double, double> f0_inner_pushforward(double *params, double *_d_params) {
+// CHECK-NEXT:     double {{_t[0-9]+}} = params[0] * params[1];
+// CHECK-NEXT:     return {{{_t[0-9]+}} * params[2] + params[3] * params[3] + params[4] * params[0], (_d_params[0] * params[1] + params[0] * _d_params[1]) * params[2] + {{_t[0-9]+}} * _d_params[2] + _d_params[3] * params[3] + params[3] * _d_params[3] + _d_params[4] * params[0] + params[4] * _d_params[0]};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<double, double> f1_inner_pushforward(double *p, double *_d_p) {
+// CHECK-NEXT:     return {p[0] * p[1], _d_p[0] * p[1] + p[0] * _d_p[1]};
+// CHECK-NEXT: }
+
+// CHECK: clad::ValueAndPushforward<double, double> f2_inner_pushforward(double *p, double x, double *_d_p, double _d_x) {
+// CHECK-NEXT:     double {{_t[0-9]+}} = p[0] * x;
+// CHECK-NEXT:     return {{{_t[0-9]+}} * x, (_d_p[0] * x + p[0] * _d_x) * x + {{_t[0-9]+}} * _d_x};
+// CHECK-NEXT: }
+
+// CHECK: void f0_inner_pushforward_pullback(double *params, double *_d_params, clad::ValueAndPushforward<double, double> _d_y, double *_d_params0, double *_d_d_params) {
+// CHECK-NEXT:     double {{_d_t[0-9]+}} = {{0\.|0\.0|0}};
+// CHECK-NEXT:     double {{_t[0-9]+}} = params[0] * params[1];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {{_d_t[0-9]+}} += _d_y.value * params[2];
+// CHECK-NEXT:         _d_params0[2] += {{_t[0-9]+}} * _d_y.value;
+// CHECK-NEXT:         _d_params0[3] += _d_y.value * params[3];
+// CHECK-NEXT:         _d_params0[3] += params[3] * _d_y.value;
+// CHECK-NEXT:         _d_params0[4] += _d_y.value * params[0];
+// CHECK-NEXT:         _d_params0[0] += params[4] * _d_y.value;
+// CHECK-NEXT:         _d_d_params[0] += _d_y.pushforward * params[2] * params[1];
+// CHECK-NEXT:         _d_params0[1] += _d_params[0] * _d_y.pushforward * params[2];
+// CHECK-NEXT:         _d_params0[0] += _d_y.pushforward * params[2] * _d_params[1];
+// CHECK-NEXT:         _d_d_params[1] += params[0] * _d_y.pushforward * params[2];
+// CHECK-NEXT:         _d_params0[2] += (_d_params[0] * params[1] + params[0] * _d_params[1]) * _d_y.pushforward;
+// CHECK-NEXT:         {{_d_t[0-9]+}} += _d_y.pushforward * _d_params[2];
+// CHECK-NEXT:         _d_d_params[2] += {{_t[0-9]+}} * _d_y.pushforward;
+// CHECK-NEXT:         _d_d_params[3] += _d_y.pushforward * params[3];
+// CHECK-NEXT:         _d_params0[3] += _d_params[3] * _d_y.pushforward;
+// CHECK-NEXT:         _d_params0[3] += _d_y.pushforward * _d_params[3];
+// CHECK-NEXT:         _d_d_params[3] += params[3] * _d_y.pushforward;
+// CHECK-NEXT:         _d_d_params[4] += _d_y.pushforward * params[0];
+// CHECK-NEXT:         _d_params0[0] += _d_params[4] * _d_y.pushforward;
+// CHECK-NEXT:         _d_params0[4] += _d_y.pushforward * _d_params[0];
+// CHECK-NEXT:         _d_d_params[0] += params[4] * _d_y.pushforward;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_params0[0] += {{_d_t[0-9]+}} * params[1];
+// CHECK-NEXT:         _d_params0[1] += params[0] * {{_d_t[0-9]+}};
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: void f1_inner_pushforward_pullback(double *p, double *_d_p, clad::ValueAndPushforward<double, double> _d_y, double *_d_p0, double *_d_d_p) {
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_p0[0] += _d_y.value * p[1];
+// CHECK-NEXT:         _d_p0[1] += p[0] * _d_y.value;
+// CHECK-NEXT:         _d_d_p[0] += _d_y.pushforward * p[1];
+// CHECK-NEXT:         _d_p0[1] += _d_p[0] * _d_y.pushforward;
+// CHECK-NEXT:         _d_p0[0] += _d_y.pushforward * _d_p[1];
+// CHECK-NEXT:         _d_d_p[1] += p[0] * _d_y.pushforward;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK: void f2_inner_pushforward_pullback(double *p, double x, double *_d_p, double _d_x, clad::ValueAndPushforward<double, double> _d_y, double *_d_p0, double *_d_x0, double *_d_d_p, double *_d_d_x) {
+// CHECK-NEXT:     double {{_d_t[0-9]+}} = {{0\.|0\.0|0}};
+// CHECK-NEXT:     double {{_t[0-9]+}} = p[0] * x;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         {{_d_t[0-9]+}} += _d_y.value * x;
+// CHECK-NEXT:         *_d_x0 += {{_t[0-9]+}} * _d_y.value;
+// CHECK-NEXT:         _d_d_p[0] += _d_y.pushforward * x * x;
+// CHECK-NEXT:         *_d_x0 += _d_p[0] * _d_y.pushforward * x;
+// CHECK-NEXT:         _d_p0[0] += _d_y.pushforward * x * _d_x;
+// CHECK-NEXT:         *_d_d_x += p[0] * _d_y.pushforward * x;
+// CHECK-NEXT:         *_d_x0 += (_d_p[0] * x + p[0] * _d_x) * _d_y.pushforward;
+// CHECK-NEXT:         {{_d_t[0-9]+}} += _d_y.pushforward * _d_x;
+// CHECK-NEXT:         *_d_d_x += {{_t[0-9]+}} * _d_y.pushforward;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_p0[0] += {{_d_t[0-9]+}} * x;
+// CHECK-NEXT:         *_d_x0 += p[0] * {{_d_t[0-9]+}};
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+int main() {
+    double p5[5] = {1.5, 2.0, -0.5, 3.0, 1.0};
+    
+    auto h_0 = clad::hessian(f0_outer, "params[0:4]");
+    auto h_1 = clad::hessian(f1_outer);
+    auto h_2 = clad::hessian(f2_outer);
+
+    double H_0[25] = {0};
+    double H_1[4] = {0};
+    double H_2[1] = {0};
+    h_0.execute(p5, H_0);
+    h_1.execute(2.0, 3.0, H_1);
+    h_2.execute(5.0, H_2);
+
+    printf("%.2f\n", H_0[0]);
+    // CHECK-EXEC: 0.00
+    
+    printf("%.2f\n", H_0[1]);
+    // CHECK-EXEC: -0.50
+    
+    printf("%.4f\n", H_0[12]);
+    // CHECK-EXEC: 0.4794
+    
+    printf("%.4f\n", H_0[24]);
+    // CHECK-EXEC: -2.7183
+
+    printf("%.2f\n", H_1[0]);
+    // CHECK-EXEC: 0.00
+
+    printf("%.2f\n", H_1[1]);
+    // CHECK-EXEC: 1.00
+
+    printf("%.2f\n", H_1[2]);
+    // CHECK-EXEC: 1.00
+
+    printf("%.2f\n", H_1[3]);
+    // CHECK-EXEC: 0.00
+
+    printf("%.2f\n", H_2[0]);
+    // CHECK-EXEC: 4.00
+
+    return 0;
+}


### PR DESCRIPTION
This PR resolves the issue where Clad loses the original array dimension during Hessian calculation for nested function calls, which leads to incorrect derivatives as shown in Issue #1737 and causes OOB memory access in the reverse pass . It fixes #1737. 

When `diffplanner` computes `clad::hessian(f, "p[0:4]")`, it generates sub requests for each index. This causes the original array capacity to be lost. The forward pass then uses this wrong capacity to generate an array for this size. The reverse mode then writes cross term adjoints till the original capacity causing OOB errors.

This PR tracks total size through sub requests and generate temporary arrays of correct size. This resolves the OOB errors in the reverse pass. 

Added tests for NestedArrays. 