### PR TITLE
Fix 1721 const adjoint

### DIFF
--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -12,6 +12,7 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/OperationKinds.h"
+#include "clang/AST/Type.h"
 #include "clang/Basic/LLVM.h"
 
 #include <algorithm>
@@ -145,9 +146,12 @@ ReverseModeForwPassVisitor::BuildParams(DiffParams& diffParams) {
   if (const auto* MD = dyn_cast<CXXMethodDecl>(m_DiffReq.Function)) {
     const CXXRecordDecl* RD = MD->getParent();
     if (MD->isInstance() && !RD->isLambda() && !isa<CXXConstructorDecl>(MD)) {
+      QualType thisDType = derivativeFnType->getParamType(dParamTypesIdx);
+      if (thisDType->isPointerType() &&
+          thisDType->getPointeeType().isConstQualified())
+        thisDType = utils::getNonConstType(thisDType, m_Sema);
       auto* thisDerivativePVD = utils::BuildParmVarDecl(
-          m_Sema, m_Derivative, CreateUniqueIdentifier("_d_this"),
-          derivativeFnType->getParamType(dParamTypesIdx));
+          m_Sema, m_Derivative, CreateUniqueIdentifier("_d_this"), thisDType);
       paramDerivatives.push_back(thisDerivativePVD);
 
       if (thisDerivativePVD->getIdentifier())
@@ -179,6 +183,8 @@ ReverseModeForwPassVisitor::BuildParams(DiffParams& diffParams) {
     if (it != std::end(diffParams)) {
       *it = newPVD;
       QualType dType = derivativeFnType->getParamType(dParamTypesIdx);
+      if (dType->isPointerType() && dType->getPointeeType().isConstQualified())
+        dType = utils::getNonConstType(dType, m_Sema);
       IdentifierInfo* dII =
           CreateUniqueIdentifier("_d_" + newPVD->getNameAsString());
       auto* dPVD = utils::BuildParmVarDecl(m_Sema, m_Derivative, dII, dType,

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2166,7 +2166,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     Expr* OverloadedDerivedFn = nullptr;
     bool hasDynamicNonDiffParams = false;
-    if (!nonDiff) {
+    if (!nonDiff && m_DiffReq.Mode != DiffMode::reverse_mode_forward_pass) {
       // Build the args for the pullback
       llvm::SmallVector<Expr*, 16> pullbackCallArgs = CallArgs;
       if (!(utils::isNonConstReferenceType(returnType) ||

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -1098,7 +1098,7 @@ void inner_function(double *out, bool flag, const double *C) {
    if (flag)
       out[0] = C[0];
 }
-// CHECK: void inner_function_reverse_forw(double *out, bool flag, const double *C, double *_d_out, bool _d_flag, const double *_d_C, clad::restore_tracker &_tracker0) {
+// CHECK: void inner_function_reverse_forw(double *out, bool flag, const double *C, double *_d_out, bool _d_flag, {{(const )?}}double *_d_C, clad::restore_tracker &_tracker0) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         bool _cond0 = flag;
 // CHECK-NEXT:         if (_cond0) {
@@ -1132,7 +1132,7 @@ void fast_interp(double const *coefs, double const *sum_param, double const *dif
   out[0] += x * (diff[0] + x * sum[0]);
 }
 
-// CHECK: void fast_interp_reverse_forw(const double *coefs, const double *sum_param, const double *diff_param, double *out, const double *_d_coefs, const double *_d_sum_param, const double *_d_diff_param, double *_d_out, clad::restore_tracker &_tracker0) {
+// CHECK: void fast_interp_reverse_forw(const double *coefs, const double *sum_param, const double *diff_param, double *out, {{(const )?}}double *_d_coefs, {{(const )?}}double *_d_sum_param, {{(const )?}}double *_d_diff_param, double *_d_out, clad::restore_tracker &_tracker0) {
 // CHECK-NEXT:     const double *_d_sum = _d_sum_param;
 // CHECK-NEXT:     const double *sum0 = sum_param;
 // CHECK-NEXT:     const double *_d_diff = _d_diff_param;
@@ -1193,7 +1193,7 @@ void inner_fn(double const *coefs, double *out) {
   out[0] = b;
 }
 
-// CHECK: void inner_fn_reverse_forw(const double *coefs, double *out, const double *_d_coefs, double *_d_out, clad::restore_tracker &_tracker0) {
+// CHECK: void inner_fn_reverse_forw(const double *coefs, double *out, {{(const )?}}double *_d_coefs, double *_d_out, clad::restore_tracker &_tracker0) {
 // CHECK-NEXT:     double _d_b = 0.;
 // CHECK-NEXT:     double b = iden_func(coefs[0]);
 // CHECK-NEXT:     _tracker0.store(out[0]);

--- a/test/Regressions/issue-1721.cpp
+++ b/test/Regressions/issue-1721.cpp
@@ -1,0 +1,75 @@
+// RUN: %cladclang -std=c++20 -I%S/../../include %s -o %t
+// RUN: %t | %filecheck_exec %s
+// UNSUPPORTED: clang-10, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16
+// XFAIL: valgrind
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <span>
+#include <vector>
+
+#include "clad/Differentiator/Differentiator.h"
+
+// Reproducer from issue #1721 (SOFIE-generated pattern)
+inline void scalar_prod(float* output, int m, const float* a, const float* b) {
+  for (int i = 0; i < m; ++i) {
+    output[i] = a[i] * b[0];
+  }
+}
+
+void inner_func(float const* x, float const* theory_params, float* linear_3) {
+  (void)x;
+  float val_0[5] = {1.F, 1.F, 1.F, 1.F, 1.F};
+  float linear[5] = {0.F, 0.F, 0.F, 0.F, 0.F};
+
+  scalar_prod(linear, 5, val_0, theory_params);
+
+  for (int i = 0; i < 5; ++i) {
+    linear_3[0] += linear[i];
+  }
+}
+
+float my_func(float const* x, float const* theory_params) {
+  float out = 0.F;
+  inner_func(x, theory_params, &out);
+  return out;
+}
+
+int main() {
+  std::vector<float> input1{5.0F, 2.0F, 1.0F, -1.0F, 1.0F};
+  std::vector<float> input2{0.0F};
+
+  auto func = [&](std::span<float> params) {
+    return my_func(input1.data(), params.data());
+  };
+
+  auto numDiff = [&](int i) {
+    const float eps = 1e-4F;
+    std::vector<float> p{input2};
+    p[i] = input2[i] - eps;
+    float funcValDown = func(p);
+    p[i] = input2[i] + eps;
+    float funcValUp = func(p);
+    return (funcValUp - funcValDown) / (2 * eps);
+  };
+
+  for (std::size_t i = 0; i < input2.size(); ++i) {
+    std::cout << i << ":\n";
+    std::cout << " numr : " << numDiff((int)i) << "\n";
+  }
+
+  float grad_output[]{0.F, 0.F, 0.F, 0.F, 0.F};
+  auto g_grad = clad::gradient(my_func, "theory_params");
+  g_grad.execute(input1.data(), input2.data(), grad_output);
+
+  std::fill(std::begin(grad_output), std::end(grad_output), 0.F);
+  g_grad.execute(input1.data(), input2.data(), grad_output);
+
+  std::cout << " clad : " << grad_output[0] << "\n";
+
+  // CHECK-EXEC: 0:
+  // CHECK-EXEC: numr : 5
+  // CHECK-EXEC: clad : 5
+  return 0;
+}


### PR DESCRIPTION
Fixes a regression where reverse_forw could propagate const into adjoint pointer parameters (e.g. const float* _d_b), causing compilation failures for SOFIE-emitted patterns (#1721). The change ensures adjoint pointer params are writable (T*) when used as accumulators. Adds a regression test for #1721 and aligns FileCheck directives with the harness (CHECK-EXEC). ninja check-clad-regressions passes locally.