### PR TITLE
[CMake] Add fallback hint to find Clang on lib64 systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   # ClangConfig.cmake is not versioned and we will need to work harder to find
   # the correct package.
   if (DEFINED LLVM_VERSION AND NOT DEFINED Clang_DIR)
-    set(extra_hints HINTS ${Clang_DIR} "${LLVM_BINARY_DIR}/lib/cmake/clang" "${LLVM_BINARY_DIR}/cmake")
+    set(extra_hints HINTS ${Clang_DIR} "${LLVM_BINARY_DIR}/lib/cmake/clang" "${LLVM_BINARY_DIR}/cmake" "${LLVM_DIR}/../clang")
     find_package(Clang REQUIRED CONFIG ${extra_hints} NO_DEFAULT_PATH)
   endif()
 


### PR DESCRIPTION
**Problem:**
On systems that default to lib64 for libraries(like Fedora), the build system fails to resolve the `Clang_DIR` even when `LLVM_DIR` was resolved directly(due to `llvm-devel` package directly updating path variables). However `clang-devel` does not automatically expose the path forcing the user to manually find the configs(eg- `/usr/lib64/llvm21/lib64/cmake/clang`)

**Solution:**
Added `${LLVM_DIR}/../clang` to the extra_hints in `find_package(Clang)`. Since LLVM and Clang are typically installed adjacent to each other in the package manager's directory structure, this hint allows CMake to successfully resolve the Clang configuration directory automatically if llvm directory has been resolved, improving the out-of-the-box build experience on these distributions.