### PR TITLE
Fixes the adjoint initialization for all copyable record types

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -5,7 +5,6 @@
 //------------------------------------------------------------------------------
 
 #include "clad/Differentiator/ReverseModeVisitor.h"
-
 #include "ConstantFolder.h"
 
 #include "TBRAnalyzer.h"
@@ -430,8 +429,16 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         // be used for the adjoint as well.
         const CXXRecordDecl* RD = VDDerivedType->getAsCXXRecordDecl();
         bool isNonAggrClass = RD && !RD->isAggregate();
+        auto hasDangerousFields = [](const CXXRecordDecl* Record) {
+          bool result = false;
+          for (const clang::FieldDecl* FD : Record->fields())
+            result = result || FD->getType()->isPointerType() ||
+                     FD->getType()->isReferenceType();
+          return result;
+        };
         bool isDirectInit = false;
-        if (isNonAggrClass && utils::isCopyable(RD)) {
+        if (isNonAggrClass && utils::isCopyable(RD) &&
+            !hasDangerousFields(RD)) {
           ParmVarDecl* newFuncParam = nullptr;
           for (auto* p : m_Derivative->parameters()) {
             if (p->getName() == param->getName()) {

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -475,6 +475,15 @@ double nestedStruct(double x) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
+struct StructWithPtr {
+  double* ptr;
+};
+double pointerAliasing(double x) {
+  StructWithPtr s{&x};
+  return s.ptr[0] * 3.0; 
+}
+
+
 #define NON_MEM_FN_TEST(var)\
 res[0]=0;\
 var.execute(5,res);\
@@ -595,4 +604,9 @@ int main() {
 
   auto d_nestedStruct = clad::gradient(nestedStruct);
   NON_MEM_FN_TEST(d_nestedStruct); // CHECK-EXEC: 1.00
+
+  auto d_ptrAliasing = clad::gradient(pointerAliasing);
+  double d_x_1750 = 0;
+  d_ptrAliasing.execute(5.0, &d_x_1750);
+  printf("%.2f\n", d_x_1750); // CHECK-EXEC: 3.00
 }


### PR DESCRIPTION
Commit [a1f9b9d](https://github.com/vgvassilev/clad/commit/a1f9b9d636659c8d2495fc488baa9e36c4d50fc8) broadened the adjoint initialization scope to all non aggregate copyable records. If a utility struct (like Session in the reproducer) contains a raw pointer, the newly instantiated adjoint variable shares the exact same memory address as the forward variable. Now during the reverese pass when the adjoint is Zeored out it overwrites the forward data too. So, the fix includes blocking copy init for the records containing the raw pointers or the references.
Fixes #1750