### PR TITLE
Fix checkpoint loop pragma handling in hessian flows (#1736)

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -115,9 +115,10 @@ public:
   /// differentiated, for example, when we are computing higher
   /// order derivatives.
   const clang::CXXRecordDecl* Functor = nullptr;
-  /// Stores loop checkpoint pragma locations, if any.
-  /// The order is reversed to simplify lookups.
-  mutable std::map<clang::SourceLocation, bool, std::greater<>>
+  /// Stores loop checkpoint pragma locations and attached loop locations.
+  /// Key: pragma location; value: attached loop location, if any.
+  /// The key order is reversed to simplify location range lookups.
+  mutable std::map<clang::SourceLocation, clang::SourceLocation, std::greater<>>
       m_CladLoopCheckpoints;
 
   /// Global VarDecl to differentiate, if any.

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -621,11 +621,11 @@ namespace clad {
     /// loop body; otherwise false.
     ///\returns {forward pass statements, reverse pass statements} for the loop
     /// body.
-    StmtDiff DifferentiateLoopBody(const clang::Stmt* body,
-                                   LoopCounter& loopCounter,
-                                   clang::Stmt* condVarDifff = nullptr,
-                                   clang::Stmt* forLoopIncDiff = nullptr,
-                                   bool isForLoop = false);
+    StmtDiff DifferentiateLoopBody(
+        const clang::Stmt* body, LoopCounter& loopCounter,
+        clang::Stmt* condVarDifff = nullptr,
+        clang::Stmt* forLoopIncDiff = nullptr, bool isForLoop = false,
+        clang::SourceLocation loopLoc = clang::SourceLocation());
 
     StmtDiff DifferentiateCanonicalLoop(const clang::ForStmt* S);
 

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -57,6 +57,8 @@ static FunctionDecl* DeriveUsingForwardAndReverseMode(
   ReverseModeRequest.Function = firstDerivative;
   ReverseModeRequest.Args = ReverseModeArgs;
   ReverseModeRequest.BaseFunctionName = firstDerivative->getNameAsString();
+  ReverseModeRequest.m_CladLoopCheckpoints =
+      IndependentArgRequest.m_CladLoopCheckpoints;
 
   FunctionDecl* secondDerivative =
       Builder.HandleNestedDiffRequest(ReverseModeRequest);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1078,7 +1078,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     const Stmt* body = FRS->getBody();
     StmtDiff bodyDiff =
         DifferentiateLoopBody(body, loopCounter, nullptr, nullptr,
-                              /*isForLoop=*/true);
+                              /*isForLoop=*/true, FRS->getForLoc());
 
     activeBreakContHandler->EndCFSwitchStmtScope();
     activeBreakContHandler->UpdateForwAndRevBlocks(bodyDiff);
@@ -1202,10 +1202,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
 
     const Stmt* body = FS->getBody();
-    StmtDiff BodyDiff = DifferentiateLoopBody(body, loopCounter,
-                                              condVarRes.getStmt_dx(),
-                                              incDiff.getStmt_dx(),
-                                              /*isForLoop=*/true);
+    StmtDiff BodyDiff = DifferentiateLoopBody(
+        body, loopCounter, condVarRes.getStmt_dx(), incDiff.getStmt_dx(),
+        /*isForLoop=*/true, FS->getForLoc());
 
     /// FIXME: This part in necessary to replace local variables inside loops
     /// with function globals and replace initializations with assignments.
@@ -3862,8 +3861,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
 
     const Stmt* body = WS->getBody();
-    StmtDiff bodyDiff = DifferentiateLoopBody(body, loopCounter,
-                                              condVarRes.getStmt_dx());
+    StmtDiff bodyDiff =
+        DifferentiateLoopBody(body, loopCounter, condVarRes.getStmt_dx(),
+                              /*forLoopIncDiff=*/nullptr,
+                              /*isForLoop=*/false, WS->getWhileLoc());
     // Create forward-pass `while` loop.
     Stmt* forwardWS =
         m_Sema
@@ -3903,7 +3904,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     Expr* clonedCond = (DS->getCond() ? Clone(DS->getCond()) : nullptr);
 
     const Stmt* body = DS->getBody();
-    StmtDiff bodyDiff = DifferentiateLoopBody(body, loopCounter);
+    StmtDiff bodyDiff =
+        DifferentiateLoopBody(body, loopCounter, /*condVarDiff=*/nullptr,
+                              /*forLoopIncDiff=*/nullptr,
+                              /*isForLoop=*/false, DS->getDoLoc());
 
     // Create forward-pass `do-while` statement.
     Stmt* forwardDS = m_Sema
@@ -4113,34 +4117,33 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     return {endBlock(direction::forward), endBlock(direction::reverse)};
   }
 
-  static bool hasCheckpointingPragma(ASTContext& C, const Stmt* body,
+  static bool hasCheckpointingPragma(ASTContext& C, SourceLocation loopLoc,
                                      const DiffRequest& request) {
-    SourceLocation bodyLoc = body->getBeginLoc();
-    // Find the last pragma location before the loop.
-    // Note: m_CladLoopCheckpoints has reversed order.
-    auto found = request.m_CladLoopCheckpoints.upper_bound(bodyLoc);
-    if (found == request.m_CladLoopCheckpoints.end())
+    if (!loopLoc.isValid())
       return false;
+
     clang::SourceManager& SM = C.getSourceManager();
-    unsigned bodyLine = SM.getPresumedLoc(bodyLoc).getLine();
-    unsigned pragmaLine = SM.getPresumedLoc(found->first).getLine();
-    // Check if the pragma is on the previous line.
-    bool pragmaFound = (bodyLine == pragmaLine + 1);
-    if (pragmaFound)
-      found->second = true;
-    return pragmaFound;
+    SourceLocation expandedLoopLoc = SM.getExpansionLoc(loopLoc);
+    for (const auto& entry : request.m_CladLoopCheckpoints) {
+      if (!entry.second.isValid())
+        continue;
+      if (SM.getExpansionLoc(entry.second) == expandedLoopLoc)
+        return true;
+    }
+    return false;
   }
 
-  StmtDiff ReverseModeVisitor::DifferentiateLoopBody(const Stmt* body,
-                                                     LoopCounter& loopCounter,
-                                                     Stmt* condVarDiff,
-                                                     Stmt* forLoopIncDiff,
-                                                     bool isForLoop) {
+  StmtDiff ReverseModeVisitor::DifferentiateLoopBody(
+      const Stmt* body, LoopCounter& loopCounter, Stmt* condVarDiff,
+      Stmt* forLoopIncDiff, bool isForLoop, SourceLocation loopLoc) {
     // If the user marked this loop with a checkpointing pragma,
     // we should avoid using tapes inside it in favor of recomputations.
     llvm::SaveAndRestore<bool> Saved(isInsideLoop);
     llvm::SaveAndRestore<bool> SavedCP(m_IsInsideCheckpointedLoop);
-    bool shouldCheckpoint = hasCheckpointingPragma(m_Context, body, m_DiffReq);
+    if (!loopLoc.isValid())
+      loopLoc = body->getBeginLoc();
+    bool shouldCheckpoint =
+        hasCheckpointingPragma(m_Context, loopLoc, m_DiffReq);
     if (shouldCheckpoint) {
       isInsideLoop = false;
       m_IsInsideCheckpointedLoop = true;

--- a/test/Diagnostics/LoopCheckpointing.C
+++ b/test/Diagnostics/LoopCheckpointing.C
@@ -7,6 +7,20 @@ double fn_dangling_checkpoint(double x, double y) {
   return x + 1;
 }
 
+double fn_mixed_checkpoint(double x, double y) {
+  #pragma clad checkpoint loop
+  for (int i = 0; i < 2; ++i)
+    x += y;
+
+  #pragma clad checkpoint loop  // expected-error {{'#pragma clad checkpoint loop' is only allowed before a loop}}
+  return x;
+}
+
 int main() {
-    clad::gradient(fn_dangling_checkpoint);
+  // Hits duplicate pragma-diagnosis suppression path.
+  clad::gradient(fn_dangling_checkpoint);
+  clad::hessian(fn_dangling_checkpoint, "x");
+
+  // Hits reverse loop checkpoint scan with one invalid entry in map.
+  clad::gradient(fn_mixed_checkpoint);
 }

--- a/test/Regressions/issue-1736.cpp
+++ b/test/Regressions/issue-1736.cpp
@@ -1,0 +1,32 @@
+// RUN: %cladclang -std=c++20 -I%S/../../include %s -o %t
+// RUN: %t | %filecheck_exec %s
+// UNSUPPORTED: clang-10, clang-11, clang-12, clang-13, clang-14, clang-15, clang-16
+// XFAIL: valgrind
+
+#include <iostream>
+#include "clad/Differentiator/Differentiator.h"
+
+#pragma clad ON
+double f(double* params, const double* obs) {
+  double res = 0.0;
+  const double t1 = params[0] + params[1];
+  #pragma clad checkpoint loop
+  for (int i = 0; i < (int)obs[0]; ++i) {
+    res += t1 * obs[i + 1];
+  }
+  return res;
+}
+
+void request() {
+  clad::gradient(f, "params");
+  clad::hessian(f, "params[0:1]");
+}
+
+#pragma clad OFF
+
+int main() {
+  request();
+  std::cout << "ok\n";
+  // CHECK-EXEC: ok
+  return 0;
+}

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -17,6 +17,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Stmt.h"
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/Basic/LLVM.h" // isa, dyn_cast
 #include "clang/Basic/SourceLocation.h"
@@ -238,6 +239,26 @@ void InitTimers();
       }
     }
 
+    static SourceLocation getAttachedLoopLoc(const FunctionDecl* FD,
+                                             SourceLocation pragmaLoc,
+                                             SourceManager& SM) {
+      const auto* body = cast<CompoundStmt>(FD->getBody());
+
+      const Stmt* nextStmt = nullptr;
+      for (const Stmt* S : body->body()) {
+        SourceLocation beginLoc = S->getBeginLoc();
+        if (!SM.isBeforeInTranslationUnit(pragmaLoc, beginLoc))
+          continue;
+        nextStmt = S;
+        break;
+      }
+
+      if (nextStmt && (isa<ForStmt>(nextStmt) || isa<WhileStmt>(nextStmt) ||
+                       isa<DoStmt>(nextStmt)))
+        return nextStmt->getBeginLoc();
+      return {};
+    }
+
     static void addCladLoopCheckpoints(ASTContext& C, DiffRequest& request) {
       SourceRange range = request->getSourceRange();
       assert(range.isValid());
@@ -248,17 +269,27 @@ void InitTimers();
       auto e = CladLoopCheckpoints.end();
 
       for (; it != e && SM.isBeforeInTranslationUnit(*it, end); ++it)
-        request.m_CladLoopCheckpoints.emplace(*it, false);
+        request.m_CladLoopCheckpoints.emplace(
+            *it, getAttachedLoopLoc(request.Function, *it, SM));
     }
 
     static void diagnoseUnusedPragma(Sema& S, DiffRequest& request) {
+      if (request.Mode != DiffMode::reverse &&
+          request.Mode != DiffMode::pullback)
+        return;
+
+      static std::set<clang::SourceLocation> DiagnosedCladLoopCheckpoints;
       for (const auto& pair : request.m_CladLoopCheckpoints) {
-        if (!pair.second) {
-          unsigned diagID = S.Diags.getCustomDiagID(
-              DiagnosticsEngine::Error,
-              "'#pragma clad checkpoint loop' is only allowed before a loop");
-          S.Diag(pair.first, diagID);
-        }
+        if (pair.second.isValid())
+          continue;
+
+        if (!DiagnosedCladLoopCheckpoints.insert(pair.first).second)
+          continue;
+
+        unsigned diagID = S.Diags.getCustomDiagID(
+            DiagnosticsEngine::Error,
+            "'#pragma clad checkpoint loop' is only allowed before a loop");
+        S.Diag(pair.first, diagID);
       }
     }
 


### PR DESCRIPTION
Fixes false-positive `#pragma clad checkpoint loop` diagnostics in hessian-related flows.

- I added a regression test: `test/Regressions/issue-1736.cpp`
- Also updated `tools/ClangPlugin.cpp` so dangling checkpoint pragma diagnostics are only emitted when appropriate in hessian/relevant flows, avoiding false positives during hessian scheduling

Passed locally:
- `ninja check-clad-regressions`
- `ninja check-clad-diagnostics`
- `lit -sv build/test`
- `lit -sv build/test/Regressions/issue-1736.cpp`