### PR TITLE
Fix LambdaExpr cloning and add nested request for lambda functions

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -286,6 +286,11 @@ public:
     bool VisitDeclRefExpr(clang::DeclRefExpr* DRE);
     bool VisitCXXConstructExpr(clang::CXXConstructExpr* e);
     bool shouldVisitImplicitCode() const { return true; }
+    /// Here we use TraverseLambdaExpr and not VisitLambdaExpr to ensure the
+    /// new nested DiffRequest is created before the visitor goes to the capture
+    /// or constructor initializers. If we use Visit they would be processed
+    /// under the parent DiffRequest which is not in the lambda scope.
+    bool TraverseLambdaExpr(clang::LambdaExpr* LE);
     bool TraverseFunctionDeclOnce(const clang::FunctionDecl* FD) {
       llvm::SaveAndRestore<bool> Saved(m_IsTraversingTopLevelDecl, false);
       if (m_Traversed.count(FD))

--- a/include/clad/Differentiator/StmtClone.h
+++ b/include/clad/Differentiator/StmtClone.h
@@ -10,11 +10,12 @@
 
 #include "Compatibility.h"
 
-#include "clang/AST/StmtVisitor.h"
+#include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/StmtVisitor.h"
 #include "clang/Basic/Version.h"
-#include "clang/Sema/Sema.h"
 #include "clang/Sema/Scope.h"
+#include "clang/Sema/Sema.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include <unordered_map>
@@ -127,6 +128,7 @@ namespace utils {
     DECLARE_CLONE_FN(CXXScalarValueInitExpr)
     DECLARE_CLONE_FN(ConstantExpr)
     DECLARE_CLONE_FN(ValueStmt)
+    DECLARE_CLONE_FN(LambdaExpr)
 
     clang::Stmt* VisitStmt(clang::Stmt*);
   };

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -329,6 +329,20 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       TraverseDecl(D);
   }
 
+  bool DiffCollector::TraverseLambdaExpr(LambdaExpr* LE) {
+    if (!m_ParentReq)
+      return RecursiveASTVisitor<DiffCollector>::TraverseLambdaExpr(LE);
+    // Create a nested request
+    DiffRequest LambdaReq = *m_ParentReq;
+
+    LambdaReq.Function = LE->getCallOperator();
+    LambdaReq.Functor = LE->getLambdaClass();
+    llvm::SaveAndRestore<DiffRequest*> Saved(m_ParentReq, &LambdaReq);
+    RecursiveASTVisitor<DiffCollector>::TraverseLambdaExpr(LE);
+
+    return true;
+  }
+
   bool DiffCollector::isInInterval(SourceLocation Loc) const {
     const SourceManager &SM = m_Sema.getSourceManager();
     for (size_t i = 0, e = m_Interval.size(); i < e; ++i) {

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1766,10 +1766,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
     llvm::SaveAndRestore<FunctionDecl*> SaveDerivative(m_Derivative);
 
-    // FIXME: Should be easy remove.
-    auto*& FuncRef = const_cast<const FunctionDecl*&>(m_DiffReq.Function);
-
-    llvm::SaveAndRestore<const FunctionDecl*> SaveReq(FuncRef);
     llvm::SaveAndRestore<Scope*> SaveFunctionScope(m_DerivativeFnScope);
     beginScope(Scope::LambdaScope | Scope::DeclScope |
                Scope::FunctionDeclarationScope | Scope::FunctionPrototypeScope);
@@ -1793,8 +1789,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     LSI->Lambda->setDeclContext(DC);
 
     m_Derivative = LSI->CallOperator;
-    // FIXME: Should be easy remove.
-    const_cast<DiffRequest&>(m_DiffReq).Function = LE->getCallOperator();
 
     BuildParams(params, LE);
     m_Derivative->setBody(MakeCompoundStmt({}));
@@ -1883,11 +1877,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   }
 
   StmtDiff ReverseModeVisitor::VisitLambdaExpr(const LambdaExpr* LE) {
-    Expr* lambdaE = buildDerivedLambda(LE);
-    if (!m_Pullback.empty())
-      m_Pullback.pop_back();
-    // FIXME: Clone lambda properly.
-    return {const_cast<Expr*>(cast<Expr>(LE)), lambdaE};
+    DiffRequest LambdaReq = m_DiffReq;
+    LambdaReq.Function = LE->getCallOperator();
+    LambdaReq.Functor = LE->getLambdaClass();
+
+    ReverseModeVisitor NestedVisitor(m_Builder, LambdaReq);
+    Expr* lambdaE = NestedVisitor.buildDerivedLambda(LE);
+
+    return {cast<Expr>(Clone(LE)), lambdaE};
   }
 #endif // CLANG_VERSION_MAJOR
   StmtDiff ReverseModeVisitor::VisitCallExpr(const CallExpr* CE) {

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -350,6 +350,20 @@ Stmt* StmtClone::VisitCallExpr(CallExpr* Node) {
   return result;
 }
 
+Stmt* StmtClone::VisitLambdaExpr(LambdaExpr* Node) {
+  // clone the initialization expressions for the captures
+  llvm::SmallVector<Expr*, 4> clonedCaptureInits;
+  for (Expr* init : Node->capture_inits())
+    clonedCaptureInits.push_back(Clone(init));
+
+  return LambdaExpr::Create(
+      Ctx, Node->getLambdaClass(), Node->getIntroducerRange(),
+      Node->getCaptureDefault(), Node->getCaptureDefaultLoc(),
+      Node->hasExplicitParameters(), Node->hasExplicitResultType(),
+      clonedCaptureInits, Node->getEndLoc(),
+      Node->containsUnexpandedParameterPack());
+}
+
 Stmt* StmtClone::VisitCUDAKernelCallExpr(CUDAKernelCallExpr* Node) {
   llvm::SmallVector<Expr*, 4> clonedArgs;
   for (Expr* arg : Node->arguments())

--- a/test/ForwardMode/Lambdas.C
+++ b/test/ForwardMode/Lambdas.C
@@ -17,6 +17,31 @@ double fn1(double x, double y) {
     return _f(x*x, x+2) + y;
 }
 
+auto fn2_global = [](double _x) {
+    return _x * _x * 3.0;
+};
+
+double fn2(double x) {
+    return fn2_global(x);
+}
+
+double fn3(double x, double y) {
+    auto _f = [](double _x, double _y) {
+        return _x * _x * _y;
+    };
+    return _f(x, y);
+}
+
+double fn4(double x) {
+    auto _f = [](double _x) {
+        auto _g = [](double _y) {
+            return _y + _y;
+        };
+        return _g(_x) * _x;
+    };
+    return _f(x);
+}
+
 int main() {
     auto fn0_dx = clad::differentiate(fn0, 0);
     printf("Result is = %.2f\n", fn0_dx.execute(7)); // CHECK-EXEC: Result is = 14.00
@@ -25,4 +50,16 @@ int main() {
     auto fn1_dx = clad::differentiate(fn1, 0);
     printf("Result is = %.2f\n", fn1_dx.execute(7, 1)); // CHECK-EXEC: Result is = 15.00
     printf("Result is = %.2f\n", fn1_dx.execute(-1, 1)); // CHECK-EXEC: Result is = -1.00
+
+    auto fn2_dx = clad::differentiate(fn2, 0);
+    printf("Result is = %.2f\n", fn2_dx.execute(7)); // CHECK-EXEC: Result is = 42.00
+    printf("Result is = %.2f\n", fn2_dx.execute(-1)); // CHECK-EXEC: Result is = -6.00
+
+    auto fn3_dx = clad::differentiate(fn3, 0);
+    printf("Result is = %.2f\n", fn3_dx.execute(7, 1)); // CHECK-EXEC: Result is = 14.00
+    printf("Result is = %.2f\n", fn3_dx.execute(-1, 1)); // CHECK-EXEC: Result is = -2.00
+
+    auto fn4_dx = clad::differentiate(fn4, 0);
+    printf("Result is = %.2f\n", fn4_dx.execute(7)); // CHECK-EXEC: Result is = 28.00
+    printf("Result is = %.2f\n", fn4_dx.execute(-1)); // CHECK-EXEC: Result is = -4.00
 }

--- a/test/Gradient/Lambdas.C
+++ b/test/Gradient/Lambdas.C
@@ -67,6 +67,111 @@ double f2(double i, double j) {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
+double f3(double i, double j) {
+  double c = 3.0;
+  auto _f = [c] (double t) {
+    return t * t;
+  };
+  return i + _f(j);
+}
+
+// CHECK: void f3_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK-NEXT:     double _d_c = 0.;
+// CHECK-NEXT:     double c = 3.;
+// CHECK-NEXT:     auto _f0 = [c](double t) {
+// CHECK-NEXT:         return t * t;
+// CHECK-NEXT:     };
+// CHECK-NEXT:     auto _d__f = [](double t, double _d_y, double *_d_t) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             *_d_t += _d_y * t;
+// CHECK-NEXT:             *_d_t += t * _d_y;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     };
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_i += 1;
+// CHECK-NEXT:         double _r0 = 0.;
+// CHECK-NEXT:         _d__f(j, 1, &_r0);
+// CHECK-NEXT:         *_d_j += _r0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+double f4(double i, double j) {
+  double c = 3.0;
+  double d = 4.0;
+  auto _f = [c, &d] (double t) {
+    return t * 2.0;
+  };
+  return i + _f(j);
+}
+
+// CHECK: void f4_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK-NEXT:     double _d_c = 0.;
+// CHECK-NEXT:     double c = 3.;
+// CHECK-NEXT:     double _d_d = 0.;
+// CHECK-NEXT:     double d = 4.;
+// CHECK-NEXT:     auto _f0 = [c, &d](double t) {
+// CHECK-NEXT:         return t * 2.;
+// CHECK-NEXT:     };
+// CHECK-NEXT:     auto _d__f = [](double t, double _d_y, double *_d_t) {
+// CHECK-NEXT:         *_d_t += _d_y * 2.;
+// CHECK-NEXT:     };
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_i += 1;
+// CHECK-NEXT:         double _r0 = 0.;
+// CHECK-NEXT:         _d__f(j, 1, &_r0);
+// CHECK-NEXT:         *_d_j += _r0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+const auto _global_f = [](double t) {
+  return t * 3.0 + 1.0;
+};
+
+// CHECK: inline constexpr void operator_call_grad(double t, double *_d_t) const {
+// CHECK-NEXT:     *_d_t += 1 * 3.;
+// CHECK-NEXT: }
+
+double f6(double i) {
+  auto _outer = [](double x) {
+    auto _inner = [](double y) {
+      return y * y;
+    };
+    return _inner(x) + 2.0 * x;
+  };
+  return _outer(i);
+}
+
+// CHECK: void f6_grad(double i, double *_d_i) {
+// CHECK-NEXT:     auto _outer0 = [](double x) {
+// CHECK-NEXT:         auto _inner = [](double y) {
+// CHECK-NEXT:             return y * y;
+// CHECK-NEXT:         };
+// CHECK-NEXT:         return _inner(x) + 2. * x;
+// CHECK-NEXT:     };
+// CHECK-NEXT:     auto _d__outer = [](double x, double _d_y, double *_d_x) {
+// CHECK-NEXT:         auto _inner0 = [](double y) {
+// CHECK-NEXT:             return y * y;
+// CHECK-NEXT:         };
+// CHECK-NEXT:         auto _d__inner = [](double y, double _d_y0, double *_d_y1) {
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 *_d_y1 += _d_y0 * y;
+// CHECK-NEXT:                 *_d_y1 += y * _d_y0;
+// CHECK-NEXT:             }
+// CHECK-NEXT:         };
+// CHECK-NEXT:         {
+// CHECK-NEXT:             double _r0 = 0.;
+// CHECK-NEXT:             _d__inner(x, _d_y, &_r0);
+// CHECK-NEXT:             *_d_x += _r0;
+// CHECK-NEXT:             *_d_x += 2. * _d_y;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     };
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 0.;
+// CHECK-NEXT:         _d__outer(i, 1, &_r0);
+// CHECK-NEXT:         *_d_i += _r0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
 
 int main() {
   auto df1 = clad::gradient(f1);
@@ -78,4 +183,24 @@ int main() {
   di = 0, dj = 0;
   df2.execute(1, 1, &di, &dj);
   printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 3.00 1.00
+
+  auto df3 = clad::gradient(f3);
+  di = 0, dj = 0;
+  df3.execute(1, 2, &di, &dj);
+  printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 1.00 4.00
+
+  auto df4 = clad::gradient(f4);
+  di = 0, dj = 0;
+  df4.execute(1, 2, &di, &dj);
+  printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 1.00 2.00
+
+  auto df5 = clad::gradient(_global_f);
+  double dt = 0; 
+  df5.execute(4, &dt);
+  printf("%.2f\n", dt);                       // CHECK-EXEC: 3.00
+
+  auto df6 = clad::gradient(f6);
+  di = 0;
+  df6.execute(3, &di);
+  printf("%.2f\n", di);                       // CHECK-EXEC: 8.00
 }


### PR DESCRIPTION
`RMV::VisitLambdaExpr` used const_cast on the original LambdaExpr AST node reusing it. This PR Implements `StmtClone::VisitLambdaExpr` to properly clone the node.

`buildDerivedLambda` also used const_cast to mutate the `DiffRequest.Function` pointer. This PR implements a nested DiffRequest for the lambda function. Also adds tests for lambdas in global, function and lambda scope.

Fixes https://github.com/vgvassilev/clad/issues/1699
Fixes https://github.com/vgvassilev/clad/issues/1700