### PR TITLE
fix: use adjoint while move it

### DIFF
--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -297,8 +297,14 @@ ReverseModeForwPassVisitor::VisitReturnStmt(const clang::ReturnStmt* RS) {
   SourceLocation validLoc{RS->getBeginLoc()};
   if (!utils::isMemoryType(m_DiffReq->getReturnType()))
     return m_Sema.BuildReturnStmt(validLoc, returnDiff.getExpr()).get();
+  Expr* returnAdjoint = returnDiff.getExpr_dx();
+  // Copy/move constructors can stay on the pre-reverse_forw path and leave
+  // object returns without an explicit adjoint expression. Materialize a zero
+  // adjoint so the ValueAndAdjoint return stays well-formed.
+  if (!returnAdjoint)
+    returnAdjoint = getZeroInit(CloneType(m_DiffReq->getReturnType()));
   llvm::SmallVector<Expr*, 2> returnArgs = {returnDiff.getExpr(),
-                                            returnDiff.getExpr_dx()};
+                                            returnAdjoint};
   Expr* returnInitList =
       m_Sema.ActOnInitList(validLoc, returnArgs, validLoc).get();
   Stmt* newRS = m_Sema.BuildReturnStmt(validLoc, returnInitList).get();

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4669,6 +4669,22 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // SomeClass _d_c = _t0.adjoint;
     // SomeClass c = _t0.value;
     // ```
+    // Copy/move constructors consume their source objects, so replaying them
+    // through constructor_reverse_forw can invalidate the same values that the
+    // pullback still needs to use. Keep them on the pre-9ed0b9e9 path.
+    if (CD->isCopyOrMoveConstructor()) {
+      if (RD->isAggregate())
+        return {primalArgs[0], reverseForwAdjointArgs[0]};
+
+      Expr* callClone = BuildConstructorCall(m_Sema, CE, primalArgs,
+                                             m_TrackVarDeclConstructor);
+      Expr* callDiff = nullptr;
+      if (elideReverseForw)
+        callDiff = BuildConstructorCall(m_Sema, CE, reverseForwAdjointArgs,
+                                        m_TrackVarDeclConstructor);
+      return {callClone, callDiff};
+    }
+
     if (constrForw && !elideReverseForw) {
       reverseForwAdjointArgs.insert(reverseForwAdjointArgs.begin(),
                                     primalArgs.begin(), primalArgs.end());

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1705,14 +1705,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       result.updateRevSweep(argDiff.getExpr_dx());
     else
       result.updateRevSweep(getZeroInit(arg->getType()));
-    if (isNonDiff)
-      result.updateStmtDx(nullptr);
-    QualType paramTy = param->getType();
-    if (Expr* adjointArg = result.getExpr_dx())
-      if (!(isNonDiff || utils::isArrayOrPointerType(paramTy) || isCUDAKernel))
-        result.updateStmtDx(
-            BuildOp(UO_AddrOf, adjointArg, m_DiffReq->getLocation()));
-
     // If a function returns an object by value, there
     // are an implicit move constructor and an implicit
     // cast to XValue. However, when providing arguments,
@@ -1727,6 +1719,15 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       llvm::SmallVector<Expr*, 1> moveArg = {argDiff.getExpr_dx()};
       Expr* moveCall = GetFunctionCall("move", "std", moveArg);
       result.updateRevSweep(moveCall);
+    }
+
+    if (isNonDiff)
+      result.updateStmtDx(nullptr);
+    QualType paramTy = param->getType();
+    if (Expr* adjointArg = result.getExpr_dx()) {
+      if (!(utils::isArrayOrPointerType(paramTy) || isCUDAKernel))
+        result.updateStmtDx(
+            BuildOp(UO_AddrOf, adjointArg, m_DiffReq->getLocation()));
     }
 
     // Save cloned arg in a "global" variable, so that it is accessible from
@@ -1973,7 +1974,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     bool shouldWrapInStdMove = false;
     bool isCastSem = false;
     if (clang::AnalysisDeclContext::isInStdNamespace(FD) &&
-        FDName == "forward") {
+        (FDName == "forward" || FDName == "move")) {
       isCastSem = true;
       if (!FD->getReturnType()->isLValueReferenceType())
         shouldWrapInStdMove = true;

--- a/test/Gradient/Cladtorch.C
+++ b/test/Gradient/Cladtorch.C
@@ -72,9 +72,9 @@ float fn1(
 // CHECK-NEXT:     anon_namespace _d_z = {0.F};
 // CHECK-NEXT:     not_found::Tensor _d_w = {0.F};
 // CHECK-NEXT:     {{.*}}cladtorch::Tensor b = t;
-// CHECK-NEXT:     {{.*}}cladtorch::Tensor _d_b = (*_d_t);
+// CHECK-NEXT:     {{.*}}cladtorch::Tensor _d_b;
 // CHECK-NEXT:     {{.*}}std::vector<cladtorch::Tensor> v{{.*}}{u, b}{{.*}};
-// CHECK-NEXT:     {{.*}}std::vector<cladtorch::Tensor> _d_v{{.*}}{_d_u, _d_b}{{.*}};
+// CHECK-NEXT:     {{.*}}std::vector<cladtorch::Tensor> _d_v{{.*}};
 // CHECK-NEXT:     _d_v[1].data += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         clad::array<{{cladtorch::Tensor|std::vector<cladtorch::Tensor, std::allocator<cladtorch::Tensor> >::value_type}}> _r0 = {{2U|2UL}};

--- a/test/Gradient/Functors.C
+++ b/test/Gradient/Functors.C
@@ -286,7 +286,7 @@ int main() {
   // CHECK-NEXT:     Experiment E(3, 5);
   // CHECK-NEXT:     Experiment _d_E(0, 0);
   // CHECK-NEXT:     {
-  // CHECK-NEXT:         Experiment _r0 = _d_E;
+  // CHECK-NEXT:         Experiment _r0 = {};
   // CHECK-NEXT:         double _r1 = 0.;
   // CHECK-NEXT:         double _r2 = 0.;
   // CHECK-NEXT:         FunctorAsArg_pullback(E, i, j, 1, &_r0, &_r1, &_r2);

--- a/test/Gradient/ImplicitMoveReturn.C
+++ b/test/Gradient/ImplicitMoveReturn.C
@@ -1,6 +1,6 @@
-// RUN: %cladclang -Wno-nontrivial-memcall %s -I%S/../../include -oImplicitMoveReturn.out 2>&1 | %filecheck %s
+// RUN: %cladclang -Wno-unknown-warning-option -Wno-nontrivial-memcall -Wno-nontrivial-memaccess %s -I%S/../../include -oImplicitMoveReturn.out 2>&1 | %filecheck %s
 // RUN: ./ImplicitMoveReturn.out
-// RUN: %cladclang -Wno-nontrivial-memcall -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oImplicitMoveReturn.out 2>&1 | %filecheck %s
+// RUN: %cladclang -Wno-unknown-warning-option -Wno-nontrivial-memcall -Wno-nontrivial-memaccess -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oImplicitMoveReturn.out 2>&1 | %filecheck %s
 // RUN: ./ImplicitMoveReturn.out
 // XFAIL: valgrind
 

--- a/test/Gradient/ImplicitMoveReturn.C
+++ b/test/Gradient/ImplicitMoveReturn.C
@@ -2,8 +2,6 @@
 // RUN: ./ImplicitMoveReturn.out
 // RUN: %cladclang -Wno-unknown-warning-option -Wno-nontrivial-memcall -Wno-nontrivial-memaccess -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oImplicitMoveReturn.out 2>&1 | %filecheck %s
 // RUN: ./ImplicitMoveReturn.out
-// XFAIL: valgrind
-
 #include "clad/Differentiator/Differentiator.h"
 
 struct S {

--- a/test/Gradient/ImplicitMoveReturn.C
+++ b/test/Gradient/ImplicitMoveReturn.C
@@ -1,0 +1,46 @@
+// RUN: %cladclang -Wno-nontrivial-memcall %s -I%S/../../include -oImplicitMoveReturn.out 2>&1 | %filecheck %s
+// RUN: ./ImplicitMoveReturn.out
+// RUN: %cladclang -Wno-nontrivial-memcall -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oImplicitMoveReturn.out 2>&1 | %filecheck %s
+// RUN: ./ImplicitMoveReturn.out
+// XFAIL: valgrind
+
+#include "clad/Differentiator/Differentiator.h"
+
+struct S {
+  double x;
+  S() : x(0) {}
+  S(double px) : x(px) {}
+  S(const S&) = default;
+  S(S&& other) noexcept : x(other.x) { other.x = 0; }
+
+  S operator+(const S& other) const {
+    S res(x + other.x);
+    return res;
+  }
+};
+
+struct M {
+  S f(const S& a, const S& b) const {
+    auto t = a + b;
+    return t;
+  }
+};
+
+double loss(const M& m, const S& a, const S& b) {
+  auto y = m.f(a, b);
+  return y.x;
+}
+
+// CHECK: void f_pullback(const S &a, const S &b, S _d_y, M *_d_this, S *_d_a, S *_d_b) const {
+// CHECK-NEXT:     S t = a + b;
+// CHECK-NEXT:     S _d_t;
+// CHECK-NOT:     S::constructor_reverse_forw
+// CHECK-NEXT:     S::constructor_pullback(std::move(t), &_d_y, &_d_t);
+// CHECK-NEXT:     a.operator_plus_pullback(b, _d_t, _d_a, _d_b);
+// CHECK-NEXT: }
+
+int main() {
+  auto grad = clad::gradient(loss, "1");
+  (void)grad;
+  return 0;
+}

--- a/test/Gradient/MoveCtorReturnExpr.C
+++ b/test/Gradient/MoveCtorReturnExpr.C
@@ -2,8 +2,6 @@
 // RUN: ./MoveCtorReturnExpr.out
 // RUN: %cladclang -Wno-unknown-warning-option -Wno-nontrivial-memcall -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oMoveCtorReturnExpr.out 2>&1 | %filecheck %s
 // RUN: ./MoveCtorReturnExpr.out
-// XFAIL: valgrind
-
 #include "clad/Differentiator/Differentiator.h"
 #include <utility>
 

--- a/test/Gradient/MoveCtorReturnExpr.C
+++ b/test/Gradient/MoveCtorReturnExpr.C
@@ -6,12 +6,16 @@
 #include <utility>
 
 struct S {
+  double x;
   double* p;
-  S() : p(nullptr) {}
-  S(double* pp) : p(pp) {}
+  S() : x(0), p(nullptr) {}
+  S(double px) : x(px), p(nullptr) {}
   S(const S&) = default;
   S& operator=(const S&) = default;
-  S(S&& other) noexcept : p(other.p) { other.p = nullptr; }
+  S(S&& other) noexcept : x(other.x), p(other.p) {
+    other.x = 0;
+    other.p = nullptr;
+  }
 };
 
 struct M {
@@ -19,8 +23,8 @@ struct M {
 };
 
 double loss(const M& m, double x) {
-  auto y = m.g(S(&x));
-  return *y.p;
+  auto y = m.g(S(x));
+  return y.x;
 }
 
 // CHECK: clad::ValueAndAdjoint<S, S> g_reverse_forw(S v, M *_d_this, S _d_v, clad::restore_tracker &_tracker0) const {

--- a/test/Gradient/MoveCtorReturnExpr.C
+++ b/test/Gradient/MoveCtorReturnExpr.C
@@ -1,0 +1,44 @@
+// RUN: %cladclang -Wno-unknown-warning-option -Wno-nontrivial-memcall %s -I%S/../../include -oMoveCtorReturnExpr.out 2>&1 | %filecheck %s
+// RUN: ./MoveCtorReturnExpr.out
+// RUN: %cladclang -Wno-unknown-warning-option -Wno-nontrivial-memcall -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oMoveCtorReturnExpr.out 2>&1 | %filecheck %s
+// RUN: ./MoveCtorReturnExpr.out
+// XFAIL: valgrind
+
+#include "clad/Differentiator/Differentiator.h"
+#include <utility>
+
+struct S {
+  double* p;
+  S() : p(nullptr) {}
+  S(double* pp) : p(pp) {}
+  S(const S&) = default;
+  S& operator=(const S&) = default;
+  S(S&& other) noexcept : p(other.p) { other.p = nullptr; }
+};
+
+struct M {
+  S g(S v) const { return S(std::move(v)); }
+};
+
+double loss(const M& m, double x) {
+  auto y = m.g(S(&x));
+  return *y.p;
+}
+
+// CHECK: clad::ValueAndAdjoint<S, S> g_reverse_forw(S v, M *_d_this, S _d_v, clad::restore_tracker &_tracker0) const {
+// CHECK-NEXT:     return {S(std::move(v)), {}};
+// CHECK-NEXT: }
+
+// CHECK: void g_pullback(S v, S _d_y, M *_d_this, S *_d_v) const {
+// CHECK-NEXT:     S _t0 = v;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         S::constructor_pullback(std::move(v), &_d_y, _d_v);
+// CHECK-NEXT:         v = _t0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+int main() {
+  auto grad = clad::gradient(loss, "x");
+  (void)grad;
+  return 0;
+}


### PR DESCRIPTION
I have currently implemented a fix with maximum compatibility by creating a copy. However, xvalues are still being used within the function; this incorrect usage of rvalues is a systemic issue throughout the entire workflow.

It appears that Clad is not correctly perceiving the move operation, which prevents the proper transformation of the adjoint. This suggests a potential design conflict between the semantics of a 'move' and the requirements of automatic differentiation