### PR TITLE
Fix missing struct initialization for structs declared inside loops (#1283)

### DIFF
--- a/demos/BasicUsage.cpp
+++ b/demos/BasicUsage.cpp
@@ -8,7 +8,7 @@
 
 // To run the demo please type:
 // path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
-// path/to/libclad.so  -I../include/ -std=c++17 BasicUsage.cpp
+// path/to/clad.so  -I../include/ -std=c++17 BasicUsage.cpp
 
 // Necessary for clad to work include
 #include "clad/Differentiator/Differentiator.h"

--- a/docs/userDocs/source/user/UsingClad.rst
+++ b/docs/userDocs/source/user/UsingClad.rst
@@ -589,9 +589,91 @@ Currently, class type support have the following limitations:
   non-literal arguments (non-zero derivatives) are not supported.
 - Class cannot have pointer or reference data members.
 
-Class type support is under active development and thus, most of these 
+Class type support is under active development and thus, most of these
 limitations will be removed soon.
 
+The ``non_differentiable`` Attribute
+--------------------------------------
+Clad can automatically differentiate most C++ code, but sometimes certain
+functions, variables, or types should be excluded from differentiation. For
+example, a function that calls an external library with no available source
+code, a buffer parameter used only for scratch storage, or auxiliary state
+that has no meaningful derivative. The ``non_differentiable`` attribute tells
+Clad to skip differentiation for the marked entity and treat its derivative
+contribution as zero.
+To use the attribute, define the following macro::
+  #define non_differentiable __attribute__((annotate("non_differentiable")))
+When Clad encounters a ``non_differentiable`` entity during differentiation, it
+still executes the original code but produces a zero derivative for any
+expression involving that entity.
+**Marking a free function**
+A function marked ``non_differentiable`` will not be differentiated. Calls to
+it inside a differentiated function contribute zero to the derivative::
+  non_differentiable
+  double external_fn(double i, double j) {
+    return i * j;
+  }
+  double my_fn(double i, double j) {
+    // external_fn contributes zero derivative; only i * j is differentiated.
+    return external_fn(i, j) + i * j;
+  }
+**Marking class member fields**
+Individual fields of a class can be marked ``non_differentiable``. Their
+derivative is always treated as zero::
+  class MyClass {
+  public:
+    double x;
+    non_differentiable double y;  // derivative of y is always zero
+    double compute(double i, double j) { return (x + y) * i + i * j * j; }
+  };
+In this example, the derivative of ``y`` is zero, so ``y`` acts as a constant
+during differentiation even though its value participates in the computation.
+**Marking class member functions**
+A member function marked ``non_differentiable`` will not be differentiated.
+Calls to it contribute zero to the derivative::
+  class MyClass {
+  public:
+    double x;
+    non_differentiable double helper(double i, double j) { return i * j; }
+    double compute(double i, double j) { return helper(i, j) + i * j; }
+  };
+Here, ``helper`` contributes zero to the derivative of ``compute``.
+**Marking an entire class**
+When a class is marked ``non_differentiable``, all of its members and methods
+are treated as non-differentiable::
+  class non_differentiable ExternalState {
+  public:
+    double x;
+    double y;
+    double compute(double i, double j) { return (x + y) * i + i * j * j; }
+  };
+  double my_fn(double i, double j) {
+    ExternalState obj(2, 3);
+    // obj.compute() contributes zero derivative; only i * j is differentiated.
+    return obj.compute(i, j) + i * j;
+  }
+.. note::
+   Attempting to directly differentiate a function or method belonging to a
+   class marked ``non_differentiable`` will result in a compilation error.
+**Marking a local variable**
+A local variable marked ``non_differentiable`` is excluded from derivative
+tracking entirely::
+  double my_fn(double i, double j) {
+    non_differentiable double k = i * i * j;
+    return k;  // derivative is zero
+  }
+**Marking a function parameter**
+Parameters can be marked ``non_differentiable`` to exclude them from gradient
+computation. This is especially useful for buffer or scratch parameters that
+would otherwise cause errors during differentiation::
+  float my_fn(float *input, float const *factors,
+              non_differentiable float *buffer) {
+    return input[0] + factors[0] + buffer[0];
+  }
+.. note::
+   The ``non_differentiable`` attribute works with both forward mode
+   (``clad::differentiate``) and reverse mode (``clad::gradient``)
+   differentiation.
 Specifying Custom Derivatives
 -------------------------------
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3287,6 +3287,22 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             }
             inits.push_back(assignment);
             SetDeclInit(decl, getZeroInit(VD->getType()));
+          } else if (isInsideLoop) {
+            // If the variable has no initializer but is declared inside a
+            // loop, we still need to store and restore it so it resets to
+            // its zero-initialized state on each iteration.
+            auto* declRef = BuildDeclRef(decl);
+            Expr* assignment =
+                BuildOp(BO_Assign, declRef, getZeroInit(VD->getType()));
+            if (m_DiffReq.shouldBeRecorded(DS)) {
+              auto pushPop = StoreAndRestore(declRef, /*prefix=*/"_t",
+                                             /*moveToTape=*/true);
+              if (pushPop.getExpr() != declRef)
+                addToCurrentBlock(pushPop.getExpr_dx(), direction::reverse);
+              assignment = BuildOp(BO_Comma, pushPop.getExpr(), assignment);
+            }
+            inits.push_back(assignment);
+            SetDeclInit(decl, getZeroInit(VD->getType()));
           }
         }
 

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -2888,6 +2888,60 @@ double fn46(double x, double y) {
 // CHECK-NEXT:         }
 // CHECK-NEXT: }
 
+// Test for issue #1283: struct declared inside loop without initializer
+struct SimpleStruct {
+  double val;
+};
+ 
+double fn47(double a) {
+  double res = 0;
+  for (int i = 0; i < 3; i++) {
+    SimpleStruct s;
+    s.val = a * (i + 1);
+    res += s.val;
+  }
+  return res; // res = a*1 + a*2 + a*3 = 6*a
+}
+ 
+// CHECK: void fn47_grad(double a, double *_d_a) {
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     clad::tape<SimpleStruct> _t1 = {};
+// CHECK-NEXT:     SimpleStruct _d_s = {0.};
+// CHECK-NEXT:     SimpleStruct s = {0.};
+// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double res = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = {{0U|0UL|0ULL}};
+// CHECK-NEXT:     for (i = 0; ; i++) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (!(i < 3))
+// CHECK-NEXT:                 break;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         clad::push(_t1, std::move(s)) , s = {0.};
+// CHECK-NEXT:         s.val = a * (i + 1);
+// CHECK-NEXT:         res += s.val;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     for (;; _t0--) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (!_t0)
+// CHECK-NEXT:                 break;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             _d_s.val += _d_res;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             *_d_a += _d_s.val * (i + 1);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             _d_s = {0.};
+// CHECK-NEXT:             s = clad::pop(_t1);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         i--;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+ 
 #define TEST(F, x) { \
   result[0] = 0; \
   auto F##grad = clad::gradient(F);\
@@ -2997,4 +3051,5 @@ int main() {
   TEST_2(fn44, 2, 3); // CHECK-EXEC: {1.00, 1.00}
   TEST_2(fn45, 1, 0.5); // CHECK-EXEC: {-50.00, 100.00}
   TEST_2(fn46, 1, 0.5); // CHECK-EXEC: {-50.00, 100.00}
+  TEST(fn47, 3); // CHECK-EXEC: {6.00}
 }


### PR DESCRIPTION
**Summary**

This PR fixes issue #1283, where declaring a struct inside a loop without an explicit initializer caused the generated gradient code to produce an invalid empty assignment (s = ;) instead of proper zero-initialization (s = {0.}).
The root cause was in ReverseModeVisitor::VisitDeclStmt, when a variable had no initializer but was declared inside a loop, the code path that handles store-and-restore for loop iterations was never reached. This meant no clad::push/clad::pop pair was emitted with a valid re-initialization value.
The fix adds an else if (isInsideLoop) branch in ReverseModeVisitor.cpp that zero-initializes the struct and correctly emits the store/restore logic, ensuring the variable resets to {0.} on each loop iteration.

**Changes**

lib/Differentiator/ReverseModeVisitor.cpp — Added handling for uninitialized variable declarations inside loops: builds a zero-init assignment and emits StoreAndRestore when the statement should be recorded.
test/Gradient/Loops.C — Added fn47 test case with a SimpleStruct declared inside a loop, verifying both the generated gradient code and the computed derivative (d/da(a + 2a + 3a) = 6).

Test plan

- [ ]  Existing gradient loop tests still pass
- [ ]  New fn47 test validates correct codegen output (CHECK lines) and runtime result ({6.00})
- [ ]  Reproducer from issue #1283 no longer produces s = ;

Fixes vgvassilev/clad#1283