### PR TITLE
fix issue #1765 - Resolve valgrind issues for clad on llvm21

### DIFF
--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -464,7 +464,7 @@ void ErrorEstimationHandler::LookupCustomErrorFunction() {
   if (R.empty())
     return;
 
-  FunctionProtoType::ExtProtoInfo EPI;
+  FunctionProtoType::ExtProtoInfo EPI{};
   QualType ConstCharPtr = C.getPointerType(C.getConstType(C.CharTy));
   QualType DoubleTy = C.DoubleTy;
   llvm::SmallVector<QualType, 3> FnTypes = {DoubleTy, DoubleTy, ConstCharPtr};


### PR DESCRIPTION
In lib/Differentiator/ErrorEstimator.cpp, FunctionProtoType::ExtProtoInfo EPI was not initialized, I initialized the object in this PR.
now all fields in ExtProtoInfo are zero initialized.