### PR TITLE
Add support for computing Jacobian-Vector Products and Directional Derivatives

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -84,6 +84,7 @@ struct DerivativeAndOverload {
     friend class HessianModeVisitor;
     friend class JacobianModeVisitor;
     friend class ReverseModeForwPassVisitor;
+    friend class JacobianVectorProductModeVisitor;
     clang::Sema& m_Sema;
     plugin::CladPlugin& m_CladPlugin;
     clang::ASTContext& m_Context;

--- a/include/clad/Differentiator/DiffMode.h
+++ b/include/clad/Differentiator/DiffMode.h
@@ -13,7 +13,8 @@ enum class DiffMode {
   hessian,
   hessian_diagonal,
   jacobian,
-  reverse_mode_forward_pass
+  reverse_mode_forward_pass,
+  jacobian_vector_product
 };
 
 /// Convert enum value to string.

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -806,6 +806,18 @@ T& back(
         derivedFn /* will be replaced by Jacobian*/, code, f);
   }
 
+  template <typename F, typename T, size_t N,
+            typename DerivedFnType = JacobianVectorProductDerivedFnTraits_t<
+                remove_reference_and_pointer_t<F>, T, N>>
+  constexpr CladFunction<
+      DerivedFnType> __attribute__((annotate("JVP")))
+  jvp(F&& f, T (&args)[N],
+      DerivedFnType derivedFn = static_cast<DerivedFnType>(nullptr),
+      const char* code = "") {
+    return CladFunction<DerivedFnType>(
+        derivedFn, code);
+  }
+
   template <typename ArgSpec = const char*, typename F,
             typename DerivedFnType = GradientDerivedEstFnTraits_t<F>>
   constexpr CladFunction<DerivedFnType> __attribute__((annotate("E")))

--- a/include/clad/Differentiator/FunctionTraits.h
+++ b/include/clad/Differentiator/FunctionTraits.h
@@ -645,6 +645,20 @@ namespace clad {
     using type = NoFunction*;
   };
 
+  template <typename F, typename NumericType, size_t Size, typename = void>
+  struct JacobianVectorProductDerivedFnTraits {};
+
+  template <typename F, typename NumericType, size_t Size>
+  using JacobianVectorProductDerivedFnTraits_t =
+      typename JacobianVectorProductDerivedFnTraits<F, NumericType, Size>::type;
+
+  template <typename F, typename NumericType, size_t Size>
+  struct JacobianVectorProductDerivedFnTraits<
+      F, NumericType, Size,
+      typename std::enable_if<std::is_function_v<F>>::type> {
+    using type = void (*)(NumericType (&)[Size]);
+  };
+
   template <class T, class = void> struct HessianDerivedFnTraits {};
 
   // HessianDerivedFnTraits is used to deduce type of the derived functions

--- a/include/clad/Differentiator/JacobianVectorProduct.h
+++ b/include/clad/Differentiator/JacobianVectorProduct.h
@@ -1,0 +1,20 @@
+#ifndef CLAD_DIFFERENTIATOR_JACOBIAN_VECTOR_PRODUCT_H
+#define CLAD_DIFFERENTIATOR_JACOBIAN_VECTOR_PRODUCT_H
+
+#include "JacobianModeVisitor.h"
+#include "clad/Differentiator/DerivativeBuilder.h"
+#include <clad/Differentiator/DiffPlanner.h>
+
+using namespace clad;
+
+class clad::JacobianVectorProductModeVisitor : public clad::JacobianModeVisitor {
+  public:
+  JacobianVectorProductModeVisitor(DerivativeBuilder& builder,
+                                   const DiffRequest& request);
+
+  DerivativeAndOverload Derive() override;
+  private:
+  DiffRequest m_ModifiedDiffRequest;
+};
+
+#endif

--- a/include/clad/Differentiator/ParseDiffArgsTypes.h
+++ b/include/clad/Differentiator/ParseDiffArgsTypes.h
@@ -71,6 +71,8 @@ namespace clad {
     IndexInterval paramIndexInterval;
     /// Nested field information.
     llvm::SmallVector<std::string, 4> fields;
+    /// The output parameter to put the result into in case of JVP computation
+    const clang::Expr* jvp_out = nullptr;
     // FIXME: Add support for differentiating with respect to array fields.
     // llvm::SmallVector<IndexInterval> fieldIndexIntervals;
 

--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -60,6 +60,7 @@ llvm_add_library(cladDifferentiator
   DiffPlanner.cpp
   ErrorEstimator.cpp
   JacobianModeVisitor.cpp
+  JacobianVectorProduct.cpp
   HessianModeVisitor.cpp
   MultiplexExternalRMVSource.cpp
   PushForwardModeVisitor.cpp

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -16,6 +16,7 @@
 #include "clad/Differentiator/DynamicGraph.h"
 #include "clad/Differentiator/ErrorEstimator.h"
 #include "clad/Differentiator/HessianModeVisitor.h"
+#include "clad/Differentiator/JacobianVectorProduct.h"
 #include "clad/Differentiator/ParseDiffArgsTypes.h"
 #include "clad/Differentiator/PushForwardModeVisitor.h"
 #include "clad/Differentiator/ReverseModeForwPassVisitor.h"
@@ -606,6 +607,9 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
     } else if (request.Mode == DiffMode::jacobian) {
       JacobianModeVisitor J(*this, request);
       result = J.Derive();
+    } else if (request.Mode == DiffMode::jacobian_vector_product) {
+      JacobianVectorProductModeVisitor JVP(*this, request);
+      result = JVP.Derive();
     } else if (const VarDecl* VD = request.Global) {
       // The request represents a global variable, construct the adjoint and
       // register it.

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -613,6 +613,12 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       }
       return;
     }
+  if (E->getType().getNonReferenceType()->isArrayType()) {
+    DiffInputVarInfo dVarInfo{};
+    dVarInfo.jvp_out = E;
+    DVI.push_back(dVarInfo);
+    return;
+  }
     // Fail if the argument is not a string or numeric literal.
     utils::diag(semaRef, DiagnosticsEngine::Error, dArgsL,
                 "failed to parse the parameters, must be string or "
@@ -825,6 +831,8 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       request.Mode = DiffMode::jacobian;
     else if (Annotation == "G")
       request.Mode = DiffMode::reverse;
+    else if (Annotation == "JVP")
+      request.Mode = DiffMode::jacobian_vector_product;
     else
       llvm_unreachable("unknown mode");
     if (request.Mode == DiffMode::reverse || request.Mode == DiffMode::hessian)
@@ -1111,7 +1119,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
 
       std::string Annotation = A->getAnnotation().str();
       if (Annotation != "D" && Annotation != "G" && Annotation != "H" &&
-          Annotation != "J" && Annotation != "E")
+          Annotation != "J" && Annotation != "JVP" && Annotation != "E")
         return true;
 
       // A call to clad::differentiate or clad::gradient was not found.
@@ -1206,7 +1214,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       else if (m_TopMostReq->Mode == DiffMode::reverse)
         request.Mode = DiffMode::pullback;
       else if (m_TopMostReq->Mode == DiffMode::vector_forward_mode ||
-               m_TopMostReq->Mode == DiffMode::jacobian ||
+               m_TopMostReq->Mode == DiffMode::jacobian || m_TopMostReq->Mode == DiffMode::jacobian_vector_product ||
                m_TopMostReq->Mode == DiffMode::vector_pushforward) {
         request.Mode = DiffMode::vector_pushforward;
       } else {

--- a/lib/Differentiator/JacobianVectorProduct.cpp
+++ b/lib/Differentiator/JacobianVectorProduct.cpp
@@ -1,0 +1,58 @@
+#include "clad/Differentiator/JacobianVectorProduct.h"
+#include "clad/Differentiator/DerivativeBuilder.h"
+#include "clad/Differentiator/DiffPlanner.h"
+#include <clad/Differentiator/CladUtils.h>
+#include <clad/Differentiator/DiffMode.h>
+#include <clang/AST/Decl.h>
+#include <string>
+#include "./JacobianModeVisitor.h"
+
+using namespace clad;
+using namespace clang;
+
+JacobianVectorProductModeVisitor::JacobianVectorProductModeVisitor(
+    DerivativeBuilder& builder, const DiffRequest& request)
+    : m_ModifiedDiffRequest(request),
+      JacobianModeVisitor(builder, m_ModifiedDiffRequest) {
+  m_ModifiedDiffRequest.Mode = DiffMode::jacobian;
+}
+
+DerivativeAndOverload JacobianVectorProductModeVisitor::Derive() {
+  auto args = m_DiffReq.DVI;
+  SourceLocation loc{m_DiffReq->getLocation()};
+  auto* FD = m_ModifiedDiffRequest.Function;
+
+  auto out = args.back();
+
+  std::string jvp_name = m_DiffReq.BaseFunctionName + std::string{"_jvp"};
+  std::cout << jvp_name << "\n";
+
+  FunctionDecl* jacobian_fn = JacobianModeVisitor::Derive().overload;
+  auto* DC = const_cast<clad_compat::DeclContext*>(m_DiffReq->getDeclContext());
+  IdentifierInfo* II = &m_Context.Idents.get(jvp_name);
+  DeclarationNameInfo name(II, loc);
+  SmallVector<ParmVarDecl*> params{};
+  SmallVector<QualType> types{};
+
+  for (size_t p = 0; p < m_ModifiedDiffRequest.Function->parameters().size() - 1; p++) {
+    params.push_back(m_ModifiedDiffRequest.Function->parameters()[p]);
+    types.push_back(m_ModifiedDiffRequest.Function->parameters()[p]->getType());
+  }
+
+  auto* out_param = utils::BuildParmVarDecl(m_Sema, m_Sema.CurContext, II, m_ModifiedDiffRequest.DVI.back().jvp_out->getType());
+  params.push_back(out_param);
+  types.push_back(out_param->getType());
+
+  auto& C = m_Sema.getASTContext();
+  auto fn_type = C.getFunctionType(C.VoidTy, types, FunctionProtoType::ExtProtoInfo {});
+  FunctionDecl* jvp_fn = FunctionDecl::Create(C, m_Sema.CurContext, noLoc, name, fn_type, nullptr, FD->getStorageClass() CLAD_COMPAT_FunctionDecl_UsesFPIntrin_Param(FD),
+          FD->isInlineSpecified(), FD->hasWrittenPrototype(),
+          FD->getConstexprKind(), CLAD_COMPAT_CLANG21_getTrailingRequiresClause(FD));
+
+  m_Derivative = jvp_fn;
+
+  // TODO
+
+  DerivativeAndOverload d{m_Derivative, nullptr};
+  return d;
+}


### PR DESCRIPTION
**WIP**

Jacobian Vector product allows one to compute the directional derivative along an arbitrary vector, not just the $n$ basis vectors.

The planned approach is to use `JacobianModeVisitor` to derive the jacobian function, wrap the function within another function whose name has the suffix `_jvp` which does the actual JVP computation.