### PR TITLE
Add basic forward-mode regression test with <thread> include

### DIFF
--- a/test/ForwardMode/std_thread_basic.C
+++ b/test/ForwardMode/std_thread_basic.C
@@ -1,9 +1,16 @@
-// RUN: %cladclang %s | FileCheck %s
+// RUN: %cladclang %s -I%S/..//../include | FileCheck %s
+
 #include<thread>
+#include "clad/Differentiator/Differentiator.h"
 
 double f(double x){
-      return x * x ; 
+      return x * x; 
 }
 
-// CHECK: return 2 * x; 
+int main() {
+   auto df = clad::differentiate(f, "x");
+   df.execute(3);
+}
+
+// CHECK: return _d_x * x + x * _d_x; 
 


### PR DESCRIPTION
This PR adds a small regression test that verifies Clad's ability to
differentiate a function when the <thread> header is included.

The test ensures that forward-mode differentiation still works correctly
in the presence of C++ concurrency headers.

This is a preparatory step toward supporting automatic differentiation
of C++ concurrency primitives such as std::thread and std::mutex.