### PR TITLE
Fix error estimator param error

### DIFF
--- a/demos/BasicUsage.cpp
+++ b/demos/BasicUsage.cpp
@@ -8,7 +8,7 @@
 
 // To run the demo please type:
 // path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
-// path/to/libclad.so  -I../include/ -std=c++17 BasicUsage.cpp
+// path/to/clad.so  -I../include/ -std=c++17 BasicUsage.cpp
 
 // Necessary for clad to work include
 #include "clad/Differentiator/Differentiator.h"

--- a/docs/userDocs/source/user/UsingClad.rst
+++ b/docs/userDocs/source/user/UsingClad.rst
@@ -589,9 +589,91 @@ Currently, class type support have the following limitations:
   non-literal arguments (non-zero derivatives) are not supported.
 - Class cannot have pointer or reference data members.
 
-Class type support is under active development and thus, most of these 
+Class type support is under active development and thus, most of these
 limitations will be removed soon.
 
+The ``non_differentiable`` Attribute
+--------------------------------------
+Clad can automatically differentiate most C++ code, but sometimes certain
+functions, variables, or types should be excluded from differentiation. For
+example, a function that calls an external library with no available source
+code, a buffer parameter used only for scratch storage, or auxiliary state
+that has no meaningful derivative. The ``non_differentiable`` attribute tells
+Clad to skip differentiation for the marked entity and treat its derivative
+contribution as zero.
+To use the attribute, define the following macro::
+  #define non_differentiable __attribute__((annotate("non_differentiable")))
+When Clad encounters a ``non_differentiable`` entity during differentiation, it
+still executes the original code but produces a zero derivative for any
+expression involving that entity.
+**Marking a free function**
+A function marked ``non_differentiable`` will not be differentiated. Calls to
+it inside a differentiated function contribute zero to the derivative::
+  non_differentiable
+  double external_fn(double i, double j) {
+    return i * j;
+  }
+  double my_fn(double i, double j) {
+    // external_fn contributes zero derivative; only i * j is differentiated.
+    return external_fn(i, j) + i * j;
+  }
+**Marking class member fields**
+Individual fields of a class can be marked ``non_differentiable``. Their
+derivative is always treated as zero::
+  class MyClass {
+  public:
+    double x;
+    non_differentiable double y;  // derivative of y is always zero
+    double compute(double i, double j) { return (x + y) * i + i * j * j; }
+  };
+In this example, the derivative of ``y`` is zero, so ``y`` acts as a constant
+during differentiation even though its value participates in the computation.
+**Marking class member functions**
+A member function marked ``non_differentiable`` will not be differentiated.
+Calls to it contribute zero to the derivative::
+  class MyClass {
+  public:
+    double x;
+    non_differentiable double helper(double i, double j) { return i * j; }
+    double compute(double i, double j) { return helper(i, j) + i * j; }
+  };
+Here, ``helper`` contributes zero to the derivative of ``compute``.
+**Marking an entire class**
+When a class is marked ``non_differentiable``, all of its members and methods
+are treated as non-differentiable::
+  class non_differentiable ExternalState {
+  public:
+    double x;
+    double y;
+    double compute(double i, double j) { return (x + y) * i + i * j * j; }
+  };
+  double my_fn(double i, double j) {
+    ExternalState obj(2, 3);
+    // obj.compute() contributes zero derivative; only i * j is differentiated.
+    return obj.compute(i, j) + i * j;
+  }
+.. note::
+   Attempting to directly differentiate a function or method belonging to a
+   class marked ``non_differentiable`` will result in a compilation error.
+**Marking a local variable**
+A local variable marked ``non_differentiable`` is excluded from derivative
+tracking entirely::
+  double my_fn(double i, double j) {
+    non_differentiable double k = i * i * j;
+    return k;  // derivative is zero
+  }
+**Marking a function parameter**
+Parameters can be marked ``non_differentiable`` to exclude them from gradient
+computation. This is especially useful for buffer or scratch parameters that
+would otherwise cause errors during differentiation::
+  float my_fn(float *input, float const *factors,
+              non_differentiable float *buffer) {
+    return input[0] + factors[0] + buffer[0];
+  }
+.. note::
+   The ``non_differentiable`` attribute works with both forward mode
+   (``clad::differentiate``) and reverse mode (``clad::gradient``)
+   differentiation.
 Specifying Custom Derivatives
 -------------------------------
 

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -96,13 +96,12 @@ void ErrorEstimationHandler::EmitNestedFunctionParamError(
     llvm::SmallVectorImpl<Expr*>& ArgResult, size_t numArgs) {
   assert(fnDecl && "Must have a value");
   for (size_t i = 0; i < numArgs; i++) {
-    if (!fnDecl->getParamDecl(0)->getType()->isLValueReferenceType())
+    // FIXME: Arguments passed by reference do not have any corresponding
+    // `ArgResultDecl`. Handle arguments passed by reference in error
+    // estimation.
+    QualType paramTy = fnDecl->getParamDecl(i)->getType();
+    if (paramTy->isReferenceType() || utils::isArrayOrPointerType(paramTy))
       continue;
-    // // FIXME: Argument passed by reference do not have any corresponding
-    // // `ArgResultDecl`. Handle arguments passed by reference in error
-    // // estimation.
-    // if (utils::IsReferenceOrPointerType(fnDecl->getParamDecl(i)->getType()))
-    //   continue;
     auto* derefExpr = m_RMV->BuildOp(UO_Deref, ArgResult[i]);
     Expr* errorExpr = AssignError({derivedCallArgs[i], derefExpr},
                                   fnDecl->getNameInfo().getAsString() +

--- a/test/ErrorEstimation/BasicOps.C
+++ b/test/ErrorEstimation/BasicOps.C
@@ -330,6 +330,25 @@ double func10(double x, double y) {
 // CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
 // CHECK-NEXT: }
 
+// Test for EmitNestedFunctionParamError: mixed value and reference params.
+// The fix ensures that error estimation is emitted for value-type params
+// and skipped for reference params.
+double mixed_helper(double x, double& y) { return x * y; }
+
+// CHECK: void mixed_helper_pullback(double x, double &y, double _d_y0, double *_d_x, double *_d_y, double &_final_error) {
+// CHECK:     *_d_x += _d_y0 * y;
+// CHECK:     *_d_y += x * _d_y0;
+// CHECK: }
+
+double func11(double x, double y) {
+  return mixed_helper(x, y);
+}
+
+// CHECK: void func11_grad(double x, double y, double *_d_x, double *_d_y, double &_final_error) {
+// CHECK:     mixed_helper_pullback(x, y, 1, &_r0, {{.*}}_final_error);
+// CHECK:     *_d_x += _r0;
+// CHECK: }
+
 int main() {
   float dx = 0, dy = 0;
   double dxd = 0, dyd = 0;
@@ -363,4 +382,8 @@ int main() {
   
   INIT_ERROR_ESTIMATION(func10);
   TEST_ERROR_ESTIMATION(func10, /*PrecissionType*/float, 8, 5, &dxd, &dyd); // CHECK-EXEC: {240.00}
+
+  dxd = 0; dyd = 0;
+  INIT_ERROR_ESTIMATION(func11);
+  TEST_ERROR_ESTIMATION(func11, /*PrecissionType*/float, 3, 5, &dxd, &dyd); // CHECK-EXEC: {{.+}}
 }


### PR DESCRIPTION
Fix wrong parameter index and inverted condition in EmitNestedFunctionParamError

Two bugs in EmitNestedFunctionParamError:

1. The loop used getParamDecl(0) instead of getParamDecl(i), always
   checking the first parameter regardless of loop iteration.

2. The condition was inverted - it only processed lvalue reference
   params and skipped non-reference ones. This is backwards because
   ArgResult[i] for reference/pointer params is a raw derivative
   expression (not a pointer), while non-reference params have
   ArgResult[i] = &_r (a pointer via UO_AddrOf). Only the latter
   can be correctly dereferenced on line 106.

The fix skips reference and pointer/array params (matching the logic
in ReverseModeVisitor::DifferentiateCallArg where UO_AddrOf is only
applied for plain value-type params) and keeps the FIXME about future
proper handling of reference params in error estimation.