### PR TITLE
Handle complex, array, and record types in ```ConstantFolder::synthesizeLiteral```

### DIFF
--- a/demos/BasicUsage.cpp
+++ b/demos/BasicUsage.cpp
@@ -8,7 +8,7 @@
 
 // To run the demo please type:
 // path/to/clang++  -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang \
-// path/to/libclad.so  -I../include/ -std=c++17 BasicUsage.cpp
+// path/to/clad.so  -I../include/ -std=c++17 BasicUsage.cpp
 
 // Necessary for clad to work include
 #include "clad/Differentiator/Differentiator.h"

--- a/docs/userDocs/source/user/UsingClad.rst
+++ b/docs/userDocs/source/user/UsingClad.rst
@@ -589,9 +589,91 @@ Currently, class type support have the following limitations:
   non-literal arguments (non-zero derivatives) are not supported.
 - Class cannot have pointer or reference data members.
 
-Class type support is under active development and thus, most of these 
+Class type support is under active development and thus, most of these
 limitations will be removed soon.
 
+The ``non_differentiable`` Attribute
+--------------------------------------
+Clad can automatically differentiate most C++ code, but sometimes certain
+functions, variables, or types should be excluded from differentiation. For
+example, a function that calls an external library with no available source
+code, a buffer parameter used only for scratch storage, or auxiliary state
+that has no meaningful derivative. The ``non_differentiable`` attribute tells
+Clad to skip differentiation for the marked entity and treat its derivative
+contribution as zero.
+To use the attribute, define the following macro::
+  #define non_differentiable __attribute__((annotate("non_differentiable")))
+When Clad encounters a ``non_differentiable`` entity during differentiation, it
+still executes the original code but produces a zero derivative for any
+expression involving that entity.
+**Marking a free function**
+A function marked ``non_differentiable`` will not be differentiated. Calls to
+it inside a differentiated function contribute zero to the derivative::
+  non_differentiable
+  double external_fn(double i, double j) {
+    return i * j;
+  }
+  double my_fn(double i, double j) {
+    // external_fn contributes zero derivative; only i * j is differentiated.
+    return external_fn(i, j) + i * j;
+  }
+**Marking class member fields**
+Individual fields of a class can be marked ``non_differentiable``. Their
+derivative is always treated as zero::
+  class MyClass {
+  public:
+    double x;
+    non_differentiable double y;  // derivative of y is always zero
+    double compute(double i, double j) { return (x + y) * i + i * j * j; }
+  };
+In this example, the derivative of ``y`` is zero, so ``y`` acts as a constant
+during differentiation even though its value participates in the computation.
+**Marking class member functions**
+A member function marked ``non_differentiable`` will not be differentiated.
+Calls to it contribute zero to the derivative::
+  class MyClass {
+  public:
+    double x;
+    non_differentiable double helper(double i, double j) { return i * j; }
+    double compute(double i, double j) { return helper(i, j) + i * j; }
+  };
+Here, ``helper`` contributes zero to the derivative of ``compute``.
+**Marking an entire class**
+When a class is marked ``non_differentiable``, all of its members and methods
+are treated as non-differentiable::
+  class non_differentiable ExternalState {
+  public:
+    double x;
+    double y;
+    double compute(double i, double j) { return (x + y) * i + i * j * j; }
+  };
+  double my_fn(double i, double j) {
+    ExternalState obj(2, 3);
+    // obj.compute() contributes zero derivative; only i * j is differentiated.
+    return obj.compute(i, j) + i * j;
+  }
+.. note::
+   Attempting to directly differentiate a function or method belonging to a
+   class marked ``non_differentiable`` will result in a compilation error.
+**Marking a local variable**
+A local variable marked ``non_differentiable`` is excluded from derivative
+tracking entirely::
+  double my_fn(double i, double j) {
+    non_differentiable double k = i * i * j;
+    return k;  // derivative is zero
+  }
+**Marking a function parameter**
+Parameters can be marked ``non_differentiable`` to exclude them from gradient
+computation. This is especially useful for buffer or scratch parameters that
+would otherwise cause errors during differentiation::
+  float my_fn(float *input, float const *factors,
+              non_differentiable float *buffer) {
+    return input[0] + factors[0] + buffer[0];
+  }
+.. note::
+   The ``non_differentiable`` attribute works with both forward mode
+   (``clad::differentiate``) and reverse mode (``clad::gradient``)
+   differentiation.
 Specifying Custom Derivatives
 -------------------------------
 

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -911,8 +911,9 @@ namespace clad {
         return ConstantFolder::synthesizeLiteral(T, S.getASTContext(),
                                                  /*val=*/0);
       if (isa<ConstantArrayType>(T)) {
-        Expr* zero =
-            ConstantFolder::synthesizeLiteral(T, S.getASTContext(), /*val=*/0);
+        // Create a single zero element; C++ zero-initializes remaining elements.
+        Expr* zero = ConstantFolder::synthesizeLiteral(
+            S.getASTContext().IntTy, S.getASTContext(), /*val=*/0);
         return S.ActOnInitList(noLoc, {zero}, noLoc).get();
       }
       if (const auto* RD = T->getAsCXXRecordDecl())

--- a/lib/Differentiator/ConstantFolder.cpp
+++ b/lib/Differentiator/ConstantFolder.cpp
@@ -171,9 +171,50 @@ namespace clad {
     } else if (QT->isRealFloatingType()) {
       llvm::APFloat APVal(C.getFloatTypeSemantics(QT), val);
       Result = clad::synthesizeLiteral(QT, C, APVal);
+    } else if (QT->isComplexType()) {
+      // Handle _Complex types by creating {real, imag} InitListExpr.
+      const auto* CT = QT->castAs<ComplexType>();
+      QualType elemTy = CT->getElementType();
+      Expr* realPart = ConstantFolder::synthesizeLiteral(elemTy, C, val);
+      Expr* imagPart = ConstantFolder::synthesizeLiteral(elemTy, C, /*val=*/0);
+      SourceLocation noLoc;
+      Expr* initExprs[] = {realPart, imagPart};
+      auto* ILE = new (C) InitListExpr(C, noLoc, initExprs, noLoc);
+      ILE->setType(QT);
+      Result = ILE;
+    } else if (QT->isConstantArrayType()) {
+      // Handle constant-size arrays by creating {elem, elem, ...}.
+      const auto* CAT = C.getAsConstantArrayType(QT);
+      QualType elemTy = CAT->getElementType();
+      uint64_t numElems = CAT->getSize().getZExtValue();
+      SourceLocation noLoc;
+      llvm::SmallVector<Expr*, 8> initExprs;
+      for (uint64_t i = 0; i < numElems; ++i)
+        initExprs.push_back(
+            ConstantFolder::synthesizeLiteral(elemTy, C, val));
+      auto* ILE = new (C) InitListExpr(C, noLoc, initExprs, noLoc);
+      ILE->setType(QT);
+      Result = ILE;
+    } else if (QT->isRecordType()) {
+      // Handle struct/class types by initializing each field.
+      const RecordDecl* RD = QT->getAsRecordDecl();
+      if (RD)
+        RD = RD->getDefinition();
+      if (RD) {
+        SourceLocation noLoc;
+        llvm::SmallVector<Expr*, 4> initExprs;
+        for (const FieldDecl* FD : RD->fields())
+          initExprs.push_back(
+              ConstantFolder::synthesizeLiteral(FD->getType(), C, val));
+        auto* ILE = new (C) InitListExpr(C, noLoc, initExprs, noLoc);
+        ILE->setType(QT);
+        Result = ILE;
+      } else {
+        // Forward-declared type with no definition; fall back to zero-init.
+        Result = new (C) ImplicitValueInitExpr(QT);
+      }
     } else {
-      // FIXME: Handle other types, like Complex, Structs, typedefs, etc.
-      // typecasting may be needed right now
+      // Fallback for any remaining unhandled types.
       Result = ConstantFolder::synthesizeLiteral(C.IntTy, C, val);
     }
     assert(Result && "Unsupported type for constant folding.");

--- a/test/FirstDerivative/SynthesizeLiteralTypes.C
+++ b/test/FirstDerivative/SynthesizeLiteralTypes.C
@@ -1,0 +1,109 @@
+// RUN: %cladclang %s -I%S/../../include -oSynthesizeLiteralTypes.out 2>&1 | %filecheck %s
+// RUN: ./SynthesizeLiteralTypes.out | %filecheck_exec %s
+// XFAIL: valgrind
+
+// Tests for improved type handling in ConstantFolder::synthesizeLiteral
+// (issue #1073). Verifies that typedef, struct, and array-containing struct
+// types are handled correctly during differentiation.
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+// Test 1: typedef types
+// Typedefs are resolved via getCanonicalType() in synthesizeLiteral.
+typedef double Real;
+
+Real fn_typedef(Real x, Real y) {
+    return x * y;
+}
+
+// CHECK: Real fn_typedef_darg0(Real x, Real y) {
+// CHECK-NEXT:     Real _d_x = 1;
+// CHECK-NEXT:     Real _d_y = 0;
+// CHECK-NEXT:     return _d_x * y + x * _d_y;
+// CHECK-NEXT: }
+
+// Test 2: nested typedef
+typedef Real MyReal;
+
+MyReal fn_nested_typedef(MyReal x) {
+    return x * x;
+}
+
+// CHECK: MyReal fn_nested_typedef_darg0(MyReal x) {
+// CHECK-NEXT:     MyReal _d_x = 1;
+// CHECK-NEXT:     return _d_x * x + x * _d_x;
+// CHECK-NEXT: }
+
+// Test 3: global struct object with scalar fields
+struct Vec2 {
+    double x, y;
+};
+
+Vec2 globalVec = {3.0, 5.0};
+
+double fn_struct_global(double t) {
+    return globalVec.x * t + globalVec.y;
+}
+
+// CHECK: double fn_struct_global_darg0(double t) {
+// CHECK-NEXT:     double _d_t = 1;
+// CHECK-NEXT:     double &_t0 = globalVec.x;
+// CHECK-NEXT:     return 0. * t + _t0 * _d_t + 0.;
+// CHECK-NEXT: }
+
+// Test 4: struct with array field
+struct ArrayWrapper {
+    double data[3];
+};
+
+ArrayWrapper globalArrWrap = {{1.0, 2.0, 3.0}};
+
+double fn_struct_array_field(double t) {
+    return globalArrWrap.data[0] * t + globalArrWrap.data[2];
+}
+
+// CHECK: double fn_struct_array_field_darg0(double t) {
+// CHECK-NEXT:     double _d_t = 1;
+// CHECK-NEXT:     double &_t0 = globalArrWrap.data[0];
+// CHECK-NEXT:     return 0. * t + _t0 * _d_t + 0.;
+// CHECK-NEXT: }
+
+// Test 5: typedef of struct type
+typedef Vec2 Position;
+
+Position globalPos = {4.0, 6.0};
+
+double fn_typedef_struct(double t) {
+    return globalPos.x * t;
+}
+
+// CHECK: double fn_typedef_struct_darg0(double t) {
+// CHECK-NEXT:     double _d_t = 1;
+// CHECK-NEXT:     double &_t0 = globalPos.x;
+// CHECK-NEXT:     return 0. * t + _t0 * _d_t;
+// CHECK-NEXT: }
+
+int main() {
+    auto d_typedef = clad::differentiate(fn_typedef, "x");
+    printf("typedef: %.2f\n", d_typedef.execute(3.0, 5.0));
+    // CHECK-EXEC: typedef: 5.00
+
+    auto d_nested = clad::differentiate(fn_nested_typedef, "x");
+    printf("nested_typedef: %.2f\n", d_nested.execute(4.0));
+    // CHECK-EXEC: nested_typedef: 8.00
+
+    auto d_struct = clad::differentiate(fn_struct_global, "t");
+    printf("struct_global: %.2f\n", d_struct.execute(2.0));
+    // CHECK-EXEC: struct_global: 3.00
+
+    auto d_arr = clad::differentiate(fn_struct_array_field, "t");
+    printf("struct_array: %.2f\n", d_arr.execute(2.0));
+    // CHECK-EXEC: struct_array: 1.00
+
+    auto d_tds = clad::differentiate(fn_typedef_struct, "t");
+    printf("typedef_struct: %.2f\n", d_tds.execute(2.0));
+    // CHECK-EXEC: typedef_struct: 4.00
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Add support for _Complex types by creating {real, imag} InitListExpr with the real part set to val and imaginary part to 0
- Add support for constant array types by creating per-element InitListExpr with recursive initialization
- Add support for struct/class types by creating per-field InitListExpr with recursive initialization, falling back to ImplicitValueInitExpr for forward-declared types
- Update getZeroInit in CladUtils.cpp to explicitly use IntTy for array zero-initialization, preserving existing {0} output now that synthesizeLiteral handles arrays directly

Previously, synthesizeLiteral fell back to creating an int literal for any type not explicitly handled (integral, floating, boolean, pointer, enum), which caused type mismatches for composite types. Typedefs are already resolved via getCanonicalType() and require no additional handling.

## Fixes #1073 

Test plan

-  Verify new test test/FirstDerivative/SynthesizeLiteralTypes.C passes (typedef, nested typedef, global struct, struct with array field, typedef-of-struct)
-  Verify existing test/FirstDerivative/StructGlobalObjects.C still passes
-  Verify no regressions in gradient tests that use array zero-initialization ({0} pattern)
-  CHECK patterns in the new test may need minor adjustments after a full build