### PR TITLE
docs/remove-release-notes-placeholder

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -51,8 +51,6 @@ Misc
 Fixed Bugs
 ----------
 
-[XXX](https://github.com/vgvassilev/clad/issues/XXX)
-
  <!---Get release bugs. Check for close, fix, resolve
  git log v2.2..master | grep -i "close" | grep '#' | sed -E 's,.*\#([0-9]*).*,\[\1\]\(https://github.com/vgvassilev/clad/issues/\1\),g' | sort -t'[' -k2,2n
  --->


### PR DESCRIPTION
## Summary

Removes the placeholder bug entry from the "Fixed Bugs" section of
`docs/ReleaseNotes.md`.

The `[XXX](https://github.com/vgvassilev/clad/issues/XXX)` line is a
template stub left over from the release notes scaffolding. It has no
corresponding issue and should not appear in the published release notes.

## Changes

- Removed placeholder `[XXX]` bug entry from `docs/ReleaseNotes.md`
- Removed associated blank line

## Type of change

Documentation-only. No code or behaviour changes.