### PR TITLE
fix: add TraverseLambdaExpr to VariedAnalyzer and UsefulAnalyzer

### DIFF
--- a/lib/Differentiator/ActivityAnalyzer.cpp
+++ b/lib/Differentiator/ActivityAnalyzer.cpp
@@ -208,6 +208,22 @@ bool VariedAnalyzer::TraverseCXXOperatorCallExpr(
   return false;
 }
 
+bool VariedAnalyzer::TraverseLambdaExpr(clang::LambdaExpr* LE) {
+  // Lambdas introduce a separate scope; analyze captures here and leave the
+  // lambda body to the call operator's own analysis.
+  for (const clang::LambdaCapture& capture : LE->captures()) {
+    if (!capture.capturesVariable())
+      continue;
+    const auto* VD = llvm::dyn_cast<clang::VarDecl>(capture.getCapturedVar());
+    if (!VD)
+      continue;
+    VarData* data = getVarDataFromDecl(VD);
+    if (data && findReq(*data))
+      m_Varied = true;
+  }
+  return false;
+}
+
 bool VariedAnalyzer::TraverseCallExpr(CallExpr* CE) {
   Expr* callee = CE->getCallee();
   if (isa<CXXPseudoDestructorExpr>(callee))

--- a/lib/Differentiator/ActivityAnalyzer.h
+++ b/lib/Differentiator/ActivityAnalyzer.h
@@ -68,6 +68,7 @@ public:
   bool TraverseCompoundAssignOperator(clang::CompoundAssignOperator* CAO);
   bool TraverseInitListExpr(clang::InitListExpr* ILE);
   bool TraverseCXXOperatorCallExpr(clang::CXXOperatorCallExpr* CE);
+  bool TraverseLambdaExpr(clang::LambdaExpr* LE);
   bool TraverseMemberExpr(clang::MemberExpr* ME);
   bool TraverseCXXMemberCallExpr(clang::CXXMemberCallExpr* CE);
   bool TraverseCXXThisExpr(clang::CXXThisExpr* TE);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -6,9 +6,11 @@
 
 #include "clad/Differentiator/ReverseModeVisitor.h"
 
+#include "ActivityAnalyzer.h"
 #include "ConstantFolder.h"
 
 #include "TBRAnalyzer.h"
+#include "UsefulAnalyzer.h"
 #include "clad/Differentiator/DerivativeBuilder.h"
 #include "clad/Differentiator/DiffPlanner.h"
 #include "clad/Differentiator/ErrorEstimator.h"
@@ -1880,6 +1882,27 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     DiffRequest LambdaReq = m_DiffReq;
     LambdaReq.Function = LE->getCallOperator();
     LambdaReq.Functor = LE->getLambdaClass();
+
+    std::unique_ptr<AnalysisDeclContext> LambdaAnalysisDC;
+    if (LambdaReq.EnableVariedAnalysis || LambdaReq.EnableUsefulAnalysis) {
+      clang::CFG::BuildOptions Options;
+      LambdaAnalysisDC = std::make_unique<AnalysisDeclContext>(
+          /*AnalysisDeclContextManager=*/nullptr, LambdaReq.Function, Options);
+
+      if (LambdaReq.EnableVariedAnalysis && LambdaReq->isDefined()) {
+        VariedAnalyzer analyzer(LambdaAnalysisDC.get(), LambdaReq,
+                                LambdaReq.getVariedStmt());
+        analyzer.Analyze();
+      }
+
+      if (LambdaReq.EnableUsefulAnalysis) {
+        UsefulAnalyzer analyzer(LambdaAnalysisDC.get(),
+                                LambdaReq.getUsefulDecls());
+        analyzer.Analyze(LambdaReq.Function);
+      }
+
+      LambdaReq.m_AnalysisDC = LambdaAnalysisDC.get();
+    }
 
     ReverseModeVisitor NestedVisitor(m_Builder, LambdaReq);
     Expr* lambdaE = NestedVisitor.buildDerivedLambda(LE);

--- a/lib/Differentiator/UsefulAnalyzer.cpp
+++ b/lib/Differentiator/UsefulAnalyzer.cpp
@@ -1,4 +1,5 @@
 #include "UsefulAnalyzer.h"
+#include "clang/AST/ExprCXX.h"
 
 using namespace clang;
 

--- a/lib/Differentiator/UsefulAnalyzer.cpp
+++ b/lib/Differentiator/UsefulAnalyzer.cpp
@@ -128,6 +128,12 @@ bool UsefulAnalyzer::VisitReturnStmt(ReturnStmt* RS) {
 
 bool UsefulAnalyzer::VisitCallExpr(CallExpr* CE) { return true; }
 
+bool UsefulAnalyzer::TraverseLambdaExpr(clang::LambdaExpr* LE) {
+  // Lambda bodies are analyzed through their call operators, not as part of
+  // the enclosing function's useful analysis.
+  return false;
+}
+
 bool UsefulAnalyzer::VisitDeclRefExpr(DeclRefExpr* DRE) {
   auto* VD = dyn_cast<VarDecl>(DRE->getDecl());
   if (!VD)

--- a/lib/Differentiator/UsefulAnalyzer.h
+++ b/lib/Differentiator/UsefulAnalyzer.h
@@ -67,6 +67,7 @@ public:
   bool VisitBinaryOperator(clang::BinaryOperator* BinOp);
   bool VisitDeclStmt(clang::DeclStmt* DS);
   bool VisitCallExpr(clang::CallExpr* CE);
+  bool TraverseLambdaExpr(clang::LambdaExpr* LE);
 };
 } // namespace clad
 #endif // CLAD_DIFFERENTIATOR_USEFULANALYZER_H

--- a/lib/Differentiator/UsefulAnalyzer.h
+++ b/lib/Differentiator/UsefulAnalyzer.h
@@ -1,5 +1,6 @@
 #ifndef CLAD_DIFFERENTIATOR_USEFULANALYZER_H
 #define CLAD_DIFFERENTIATOR_USEFULANALYZER_H
+#include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Analysis/CFG.h"
@@ -67,7 +68,7 @@ public:
   bool VisitBinaryOperator(clang::BinaryOperator* BinOp);
   bool VisitDeclStmt(clang::DeclStmt* DS);
   bool VisitCallExpr(clang::CallExpr* CE);
-  bool TraverseLambdaExpr(clang::LambdaExpr* LE);
+  static bool TraverseLambdaExpr(clang::LambdaExpr* LE);
 };
 } // namespace clad
 #endif // CLAD_DIFFERENTIATOR_USEFULANALYZER_H

--- a/test/Analyses/UsefulForward.cpp
+++ b/test/Analyses/UsefulForward.cpp
@@ -1,6 +1,7 @@
 // RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oUseful.out 2>&1 | %filecheck %s
 // RUN: ./Useful.out | %filecheck_exec %s
 // RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-ua -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oUseful.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-ua -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oUseful.out 2>&1 | FileCheck --check-prefix=CHECK-LAMBDA-UA %s
 // RUN: ./Useful.out | %filecheck_exec %s
 //CHECK-NOT: {{.*error|warning|note:.*}}
 
@@ -120,6 +121,30 @@ double f6(double x){
 // CHECK-NEXT:    return _d_j;
 // CHECK-NEXT:}
 
+double f7(double i, double j) {
+  auto _f = [](double t, double k) {
+    double a = t * k;
+    return a;
+  };
+  return _f(i + j, i);
+}
+
+// CHECK-LAMBDA-UA-LABEL: inline constexpr clad::ValueAndPushforward<double, double> operator_call_pushforward(double t, double k, double _d_t, double _d_k) const {
+// CHECK-LAMBDA-UA-NEXT:     double _d_a = _d_t * k + t * _d_k;
+// CHECK-LAMBDA-UA-NEXT:     double a = t * k;
+// CHECK-LAMBDA-UA-NEXT:     return {a, _d_a};
+// CHECK-LAMBDA-UA-NEXT: }
+// CHECK-LAMBDA-UA-NEXT: double f7_darg0(double i, double j) {
+// CHECK-LAMBDA-UA-NEXT:     double _d_i = 1;
+// CHECK-LAMBDA-UA-NEXT:     double _d_j = 0;
+// CHECK-LAMBDA-UA-NEXT:     auto _f = [](double t, double k) {
+// CHECK-LAMBDA-UA-NEXT:         double a = t * k;
+// CHECK-LAMBDA-UA-NEXT:         return a;
+// CHECK-LAMBDA-UA-NEXT:     };
+// CHECK-LAMBDA-UA-NEXT:     clad::ValueAndPushforward<double, double> _t0 = _f.operator_call_pushforward(i + j, i, _d_i + _d_j, _d_i);
+// CHECK-LAMBDA-UA-NEXT:     return _t0.pushforward;
+// CHECK-LAMBDA-UA-NEXT: }
+
 int main(){
     INIT_DIFFERENTIATE_UA(f1, "x");
     INIT_DIFFERENTIATE_UA(f2, "x");
@@ -127,6 +152,7 @@ int main(){
     INIT_DIFFERENTIATE_UA(f4, "x");
     INIT_DIFFERENTIATE_UA(f5, "x");
     INIT_DIFFERENTIATE_UA(f6, "x");
+    INIT_DIFFERENTIATE_UA(f7, "i");
 
     TEST_DIFFERENTIATE(f1, 3); // CHECK-EXEC: {1.00}
     TEST_DIFFERENTIATE(f2, 3); // CHECK-EXEC: {1.00}
@@ -134,5 +160,6 @@ int main(){
     TEST_DIFFERENTIATE(f4, 3); // CHECK-EXEC: {0.00}
     TEST_DIFFERENTIATE(f5, 3); // CHECK-EXEC: {1.00}
     TEST_DIFFERENTIATE(f6, 3); // CHECK-EXEC: {10.00}
+    TEST_DIFFERENTIATE(f7, 2, 3); // CHECK-EXEC: {7.00}
     return 0;
 }

--- a/test/Gradient/Lambdas.C
+++ b/test/Gradient/Lambdas.C
@@ -1,5 +1,6 @@
 // RUN: %cladclang %s -I%S/../../include -oLambdas.out 2>&1 | %filecheck %s
 // RUN: ./Lambdas.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -Xclang -plugin-arg-clad -Xclang -enable-va %s -I%S/../../include -oLambdasVA.out 2>&1 | FileCheck --check-prefix=CHECK-VA %s
 // RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr -Xclang -plugin-arg-clad -Xclang -disable-va %s -I%S/../../include -oLambdas.out
 // RUN: ./Lambdas.out | %filecheck_exec %s
 // UNSUPPORTED: clang-11, clang-12, clang-13, clang-14, clang-15, clang-16
@@ -66,6 +67,17 @@ double f2(double i, double j) {
 // CHECK-NEXT:         *_d_i += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
+
+// CHECK-VA-LABEL: void f2_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK-VA:     auto _d__f = [](double t, double k, double _d_y, double *_d_t, double *_d_k) {
+// CHECK-VA-NEXT:         double _d_a = 0.;
+// CHECK-VA-NEXT:         double a = t * k;
+// CHECK-VA-NEXT:         _d_a += _d_y;
+// CHECK-VA-NEXT:         {
+// CHECK-VA-NEXT:             *_d_t += _d_a * k;
+// CHECK-VA-NEXT:             *_d_k += t * _d_a;
+// CHECK-VA-NEXT:         }
+// CHECK-VA-NEXT:     };
 
 double f3(double i, double j) {
   double c = 3.0;


### PR DESCRIPTION
## Problem (Partially addresses #1702)

`VariedAnalyzer` and `UsefulAnalyzer` both use `RecursiveASTVisitor` to walk the CFG of a function being differentiated. Neither had a `TraverseLambdaExpr` override, so when either analyzer encountered a lambda expression (e.g. `auto _f = [](double t, double k) { ... }`), the default traversal walked directly into the lambda body as if it were part of the outer function's scope.

This caused incorrect analysis results because the lambda's own parameters (`t`, `k`) are not in the outer function's varied/useful sets. As a result, variables inside the lambda body (like `double a = t * k`) were never marked as varied, and the generated derivative body for the lambda was incomplete the entire chain rule propagation was silently dropped.

Concretely, with `-enable-va -disable-tbr`, the generated derivative
for:
```cpp
auto _f = [](double t, double k) {
    double a = t * k;
    return a;
};
```

was incorrectly:
```cpp
auto _d__f = [](double t, double k, double _d_y,
                double *_d_t, double *_d_k) {
    double a = t * k;  // no derivative propagation at all
};
```

instead of the correct:
```cpp
auto _d__f = [](double t, double k, double _d_y,
                double *_d_t, double *_d_k) {
    double _d_a = 0.;
    double a = t * k;
    _d_a += _d_y;
    *_d_t += _d_a * k;
    *_d_k += t * _d_a;
};
```

## Fix

Added `TraverseLambdaExpr` to both `VariedAnalyzer` and `UsefulAnalyzer` that returns `false` to stop the default traversal from descending into the lambda body. The lambda body is a separate scope and will be analyzed correctly through its own call operator when it is differentiated.

For `VariedAnalyzer`, the override also inspects the lambda's capture list if any captured variable is already marked as varied in the outer scope, the lambda expression itself is marked as varied.

## Files changed

- `lib/Differentiator/ActivityAnalyzer.h`: declared  `TraverseLambdaExpr` in `VariedAnalyzer`
- `lib/Differentiator/ActivityAnalyzer.cpp`: implemented `VariedAnalyzer::TraverseLambdaExpr`
- `lib/Differentiator/UsefulAnalyzer.h`: declared `TraverseLambdaExpr` in `UsefulAnalyzer`
- `lib/Differentiator/UsefulAnalyzer.cpp`:  implemented `UsefulAnalyzer::TraverseLambdaExpr`

## Known limitations

The full lambda+VA fix in reverse mode also requires addressing the early return at `DiffPlanner.cpp:1172` that was introduced in `f515df3e` and explicitly disables VA for lambda call operators in reverse mode. Removing that early return causes a crash in `ReverseModeVisitor::VisitCallExpr` because the lambda call operator's varied decls are not properly propagated before differentiation runs. That part of the fix requires coordinated changes to `ReverseModeVisitor` and is left for follow-up work.

