### PR TITLE
Add support for matrix multiplication

### DIFF
--- a/include/clad/Differentiator/Matrix.h
+++ b/include/clad/Differentiator/Matrix.h
@@ -5,7 +5,10 @@
 #include "clad/Differentiator/CladConfig.h"
 
 #include <cassert>
+#include <cblas.h>
 #include <initializer_list>
+#include <openblas_config.h>
+#include <stdexcept>
 #include <type_traits>
 
 /// Implementing a matrix class using clad::array for storing the data.
@@ -165,6 +168,28 @@ public:
     matrix res(mat.m_rows, mat.m_cols);
     res.m_data = val - mat.m_data;
     return res;
+  }
+
+  CUDA_HOST_DEVICE matrix<T> matmul(const matrix<T>& other) {
+    if (!std::is_floating_point_v<float> && !std::is_floating_point_v<double>)
+      throw std::runtime_error{
+          "Error: Matrix multiplication can only be performed between matrices "
+          "with floating point values"};
+
+    if (this->cols() != other.rows())
+      throw std::runtime_error{
+          "Error: Invalid sizes for matrix multiplication"};
+
+    matrix<T> prod{this->rows(), other.cols()};
+
+    cblas_dgemm(CBLAS_ORDER::CblasRowMajor, CBLAS_TRANSPOSE::CblasNoTrans,
+                CBLAS_TRANSPOSE::CblasNoTrans, this->rows(), other.cols(),
+                this->cols(), 1, reinterpret_cast<double*>(this->m_data.ptr()),
+                this->cols(), reinterpret_cast<double*>(other.m_data.ptr()),
+                other.cols(), 1, reinterpret_cast<double*>(prod.m_data.ptr()),
+                prod.cols());
+
+    return prod;
   }
 }; // class matrix
 

--- a/include/clad/Differentiator/Matrix.h
+++ b/include/clad/Differentiator/Matrix.h
@@ -5,9 +5,12 @@
 #include "clad/Differentiator/CladConfig.h"
 
 #include <cassert>
+#ifdef __APPLE__
+#include <Accelerate/Accelerate.h>
+#else
 #include <cblas.h>
+#endif
 #include <initializer_list>
-#include <openblas_config.h>
 #include <stdexcept>
 #include <type_traits>
 

--- a/include/clad/Differentiator/Matrix.h
+++ b/include/clad/Differentiator/Matrix.h
@@ -171,23 +171,36 @@ public:
   }
 
   CUDA_HOST_DEVICE matrix<T> matmul(const matrix<T>& other) {
-    if (!std::is_floating_point_v<float> && !std::is_floating_point_v<double>)
-      throw std::runtime_error{
-          "Error: Matrix multiplication can only be performed between matrices "
-          "with floating point values"};
-
     if (this->cols() != other.rows())
       throw std::runtime_error{
           "Error: Invalid sizes for matrix multiplication"};
 
     matrix<T> prod{this->rows(), other.cols()};
 
-    cblas_dgemm(CBLAS_ORDER::CblasRowMajor, CBLAS_TRANSPOSE::CblasNoTrans,
-                CBLAS_TRANSPOSE::CblasNoTrans, this->rows(), other.cols(),
-                this->cols(), 1, reinterpret_cast<double*>(this->m_data.ptr()),
-                this->cols(), reinterpret_cast<double*>(other.m_data.ptr()),
-                other.cols(), 1, reinterpret_cast<double*>(prod.m_data.ptr()),
-                prod.cols());
+    if (std::is_floating_point_v<T>) {
+      if (sizeof(T) == sizeof(double))
+        // The reinterpret_cast in both branches is safe because they exist
+        // only to satisfy the compiler
+        cblas_dgemm(CBLAS_ORDER::CblasRowMajor, CBLAS_TRANSPOSE::CblasNoTrans,
+                    CBLAS_TRANSPOSE::CblasNoTrans, this->rows(), other.cols(),
+                    this->cols(), 1,
+                    reinterpret_cast<double*>(this->m_data.ptr()), this->cols(),
+                    reinterpret_cast<double*>(other.m_data.ptr()), other.cols(),
+                    1, reinterpret_cast<double*>(prod.m_data.ptr()),
+                    prod.cols());
+
+      else if (sizeof(T) == sizeof(float))
+        cblas_sgemm(CBLAS_ORDER::CblasRowMajor, CBLAS_TRANSPOSE::CblasNoTrans,
+                    CBLAS_TRANSPOSE::CblasNoTrans, this->rows(), other.cols(),
+                    this->cols(), 1,
+                    reinterpret_cast<float*>(this->m_data.ptr()), this->cols(),
+                    reinterpret_cast<float*>(other.m_data.ptr()), other.cols(),
+                    1, reinterpret_cast<float*>(prod.m_data.ptr()),
+                    prod.cols());
+    } else
+      throw std::runtime_error{
+          "Error: Matrix multiplication can only be performed between matrices "
+          "with floating point values"};
 
     return prod;
   }

--- a/test/Misc/CladMatrix.C
+++ b/test/Misc/CladMatrix.C
@@ -1,7 +1,10 @@
-// RUN: %cladclang %s -I%S/../../include -oCladMatrix.out 2>&1
+// RUN: %cladclang %s -I%S/../../include -oCladMatrix.out -lblas 2>&1
 // RUN: ./CladMatrix.out | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
+#include <clad/Differentiator/Matrix.h>
+#include <cstddef>
+#include <cstdio>
 
 int main() {
   clad::matrix<int> test_mat(2, 2);
@@ -168,4 +171,38 @@ int main() {
   // CHECK-EXEC: 2, 0 : 0
   // CHECK-EXEC: 2, 1 : 0
   // CHECK-EXEC: 2, 2 : 0
+
+  clad::matrix<double> test4_mat{2, 3};
+  clad::matrix<double> test5_mat{3, 4};
+
+  test4_mat[0][0] = 1;
+  test4_mat[0][1] = 2;
+  test4_mat[0][2] = 3;
+  test4_mat[1][0] = 4;
+  test4_mat[1][1] = 5;
+  test4_mat[1][2] = 6;
+
+  test5_mat[0][0] = 7;
+  test5_mat[0][1] = 8;
+  test5_mat[0][2] = 9;
+  test5_mat[0][3] = 10;
+  test5_mat[1][0] = 11;
+  test5_mat[1][1] = 12;
+  test5_mat[1][2] = 13;
+  test5_mat[1][3] = 14;
+  test5_mat[2][0] = 15;
+  test5_mat[2][1] = 16;
+  test5_mat[2][2] = 17;
+  test5_mat[2][3] = 18;
+
+  auto test1_prod = test4_mat.matmul(test5_mat);
+
+  for (size_t i = 0; i < test1_prod.rows(); i++) {
+    for (size_t j = 0; j < test1_prod.cols(); j++)
+      printf("%.1f ", test1_prod[i][j]);
+    printf("\n");
+  }
+
+  // CHECK-EXEC: 74.0 80.0 86.0 92.0
+  // CHECK-EXEC: 173.0 188.0 203.0 218.0
 }


### PR DESCRIPTION
Matrix-Matrix product can be used to computer the Jacobian-Vector Products and directional derivatives. The vector can be expressed as a $n \times 1$ matrix for a jacobian matrix of size $m \times n$. This is also planned to be used in #1780. 