### PR TITLE
Fix reverse-mode scheduling for integral-return helper calls (issue #1793)

### DIFF
--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1191,6 +1191,19 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       if (!utils::hasMemoryTypeParams(FD) && hasPointerOrRefReturn &&
           m_TopMostReq->Mode == DiffMode::reverse)
         nonDiff = true;
+      // Skip reverse-mode scheduling for integral-return helper calls that
+      // cannot accumulate through memory arguments. Keep this narrow to avoid
+      // suppressing diagnostics on variadic/non-helper calls.
+      const bool HasPointerOrReferenceParam = std::any_of(
+          FD->parameters().begin(), FD->parameters().end(),
+          [](const ParmVarDecl* PVD) {
+            QualType ParamType = PVD->getType();
+            return ParamType->isPointerType() || ParamType->isReferenceType();
+          });
+      if (m_TopMostReq->Mode == DiffMode::reverse && !FD->isVariadic() &&
+          HasPointerOrReferenceParam && !utils::hasMemoryTypeParams(FD) &&
+          returnType->isIntegralOrEnumerationType())
+        nonDiff = true;
 
       if (nonDiff && m_TopMostReq->Mode != DiffMode::reverse)
         return true;

--- a/test/Regressions/issue-1793.cpp
+++ b/test/Regressions/issue-1793.cpp
@@ -1,0 +1,34 @@
+// RUN: %cladclang -I%S/../../include %s 2>&1 | %filecheck %s
+
+#include <algorithm>
+#include <cstddef>
+
+#include "clad/Differentiator/Differentiator.h"
+
+unsigned int rawBinNumber(double x, const double* boundaries,
+                          std::size_t nBoundaries) {
+  const double* end = boundaries + nBoundaries;
+  const double* it = std::lower_bound(boundaries, end, x);
+  while (boundaries != it && (end == it || end == it + 1 || x < *it))
+    --it;
+  return it - boundaries;
+}
+
+double roo_codegen_0(double* params, const double* obs, const double* xlArr) {
+  double out = 0.;
+  double t23[5]{1. + params[0], 1. + params[1], 1. + params[2],
+                1. + params[3], 1. + params[4]};
+  for (int i = 0; i < 5; ++i) {
+    const double t215 = t23[rawBinNumber(obs[i], xlArr, 6)];
+    out += t215;
+  }
+  return out;
+}
+
+int main() {
+  auto grad = clad::gradient(roo_codegen_0, "params");
+  (void)grad;
+}
+
+// CHECK: void roo_codegen_0_grad_0(double *params, const double *obs, const double *xlArr, double *_d_params) {
+// CHECK-NOT: rawBinNumber_pullback


### PR DESCRIPTION
This PR : 

- mark nested reverse-mode call requests as non-differentiable when the callee returns an integral/enumeration type and has no memory-type parameters
- avoid scheduling unnecessary pullbacks for helper index functions like the CMS  pattern
- add regression 
- all tests run green locally 


Fixes #1793