### PR TITLE
Store Thrust sort_by_key permutation on restore_tracker (#1694)

### DIFF
--- a/include/clad/Differentiator/DerivedFnInfo.h
+++ b/include/clad/Differentiator/DerivedFnInfo.h
@@ -19,6 +19,7 @@ struct DerivedFnInfo {
   std::vector<size_t> m_CUDAGlobalArgsIndexes;
   bool m_UsesEnzyme = false;
   bool m_DeclarationOnly = false;
+  bool m_UseRestoreTracker = false;
 
   DerivedFnInfo() = default;
   DerivedFnInfo(const DiffRequest& request, clang::FunctionDecl* derivedFn,

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -186,7 +186,8 @@ public:
            EnableUsefulAnalysis == other.EnableUsefulAnalysis &&
            DVI == other.DVI && use_enzyme == other.use_enzyme &&
            DeclarationOnly == other.DeclarationOnly && Global == other.Global &&
-           CUDAGlobalArgsIndexes == other.CUDAGlobalArgsIndexes;
+           CUDAGlobalArgsIndexes == other.CUDAGlobalArgsIndexes &&
+           UseRestoreTracker == other.UseRestoreTracker;
   }
 
   const clang::FunctionDecl* operator->() const { return Function; }

--- a/include/clad/Differentiator/RestoreTracker.h
+++ b/include/clad/Differentiator/RestoreTracker.h
@@ -8,6 +8,10 @@
 #include <utility>
 #include <vector>
 
+#ifdef __CUDACC__
+#include <thrust/device_vector.h>
+#endif
+
 namespace clad {
 
 /// This class is used for bitwise storing/restoring variables.
@@ -24,6 +28,12 @@ class restore_tracker {
   using RawMemory = std::vector<uint8_t>;
   using Address = char*;
   std::map<const Address, RawMemory> m_data;
+
+#ifdef __CUDACC__
+  /// LIFO stack of sort permutations for thrust::sort_by_key AD, scoped to
+  /// this tracker instance (replaces a process-wide static stack).
+  ::std::vector<::thrust::device_vector<::std::size_t>> m_thrustSortByKeyPerm{};
+#endif
 
 public:
   // Store the value and the address of `val`.
@@ -47,6 +57,22 @@ public:
     }
     m_data.clear();
   }
+
+#ifdef __CUDACC__
+  void push_thrust_sort_by_key_perm(
+      ::thrust::device_vector<::std::size_t>&& permutation) {
+    m_thrustSortByKeyPerm.push_back(::std::move(permutation));
+  }
+
+  ::thrust::device_vector<::std::size_t> pop_thrust_sort_by_key_perm() {
+    assert(!m_thrustSortByKeyPerm.empty() &&
+           "pop_thrust_sort_by_key_perm: empty permutation stack");
+    ::thrust::device_vector<::std::size_t> top =
+        ::std::move(m_thrustSortByKeyPerm.back());
+    m_thrustSortByKeyPerm.pop_back();
+    return top;
+  }
+#endif
 };
 } // namespace clad
 

--- a/include/clad/Differentiator/ThrustDerivatives.h
+++ b/include/clad/Differentiator/ThrustDerivatives.h
@@ -1,6 +1,8 @@
 #ifndef CLAD_DIFFERENTIATOR_THRUSTDERIVATIVES_H
 #define CLAD_DIFFERENTIATOR_THRUSTDERIVATIVES_H
 
+#include "clad/Differentiator/RestoreTracker.h"
+
 #include <cstddef>
 #include <iterator>
 #include <thrust/adjacent_difference.h>
@@ -1232,18 +1234,11 @@ adjacent_difference_reverse_forw(InputIt first, InputIt last, OutputIt result,
   return {::thrust::adjacent_difference(first, last, result, op), {}};
 }
 
-namespace detail {
-inline ::std::vector<::thrust::device_vector<::std::size_t>>&
-permutation_stack() {
-  static ::std::vector<::thrust::device_vector<::std::size_t>> stack;
-  return stack;
-}
-} // namespace detail
-
 template <typename KeyIterator, typename ValueIterator>
 void sort_by_key_reverse_forw(KeyIterator keys_first, KeyIterator keys_last,
                               ValueIterator values_first, KeyIterator,
-                              KeyIterator, ValueIterator) {
+                              KeyIterator, ValueIterator,
+                              ::clad::restore_tracker& tracker) {
   const ::std::size_t n = ::thrust::distance(keys_first, keys_last);
   if (n > 0) {
     ::thrust::device_vector<::std::size_t> perm(n);
@@ -1255,7 +1250,7 @@ void sort_by_key_reverse_forw(KeyIterator keys_first, KeyIterator keys_last,
       }
     };
     ::thrust::sort(perm.begin(), perm.end(), index_comp_less{keys_first});
-    detail::permutation_stack().push_back(::std::move(perm));
+    tracker.push_thrust_sort_by_key_perm(::std::move(perm));
   }
   ::thrust::sort_by_key(keys_first, keys_last, values_first);
 }
@@ -1264,7 +1259,7 @@ template <typename KeyIterator, typename ValueIterator, typename Compare>
 void sort_by_key_reverse_forw(KeyIterator keys_first, KeyIterator keys_last,
                               ValueIterator values_first, Compare comp,
                               KeyIterator, KeyIterator, ValueIterator,
-                              Compare) {
+                              Compare, ::clad::restore_tracker& tracker) {
   const ::std::size_t n = ::thrust::distance(keys_first, keys_last);
   if (n > 0) {
     ::thrust::device_vector<::std::size_t> perm(n);
@@ -1277,7 +1272,7 @@ void sort_by_key_reverse_forw(KeyIterator keys_first, KeyIterator keys_last,
       }
     };
     ::thrust::sort(perm.begin(), perm.end(), index_comp_with{keys_first, comp});
-    detail::permutation_stack().push_back(::std::move(perm));
+    tracker.push_thrust_sort_by_key_perm(::std::move(perm));
   }
   ::thrust::sort_by_key(keys_first, keys_last, values_first, comp);
 }
@@ -1287,7 +1282,8 @@ template <typename KeyIterator, typename ValueIterator>
 void sort_by_key_pullback(KeyIterator keys_first, KeyIterator keys_last,
                           ValueIterator values_first, KeyIterator* d_keys_first,
                           KeyIterator* d_keys_last,
-                          ValueIterator* d_values_first) {
+                          ValueIterator* d_values_first,
+                          ::clad::restore_tracker& tracker) {
   using ValueConst = typename ::std::iterator_traits<ValueIterator>::value_type;
   using Value = ::std::remove_const_t<ValueConst>;
   using KeyConst = typename ::std::iterator_traits<KeyIterator>::value_type;
@@ -1297,10 +1293,8 @@ void sort_by_key_pullback(KeyIterator keys_first, KeyIterator keys_last,
   if (n == 0)
     return;
 
-  // Retrieve permutation mapping sorted position j -> original index i
-  auto& stack = detail::permutation_stack();
-  ::thrust::device_vector<::std::size_t> perm = ::std::move(stack.back());
-  stack.pop_back();
+  ::thrust::device_vector<::std::size_t> perm =
+      tracker.pop_thrust_sort_by_key_perm();
 
   // Build device pointers to adjoint buffers
   auto d_vals_const_ptr = ::thrust::raw_pointer_cast((*d_values_first).base());
@@ -1334,7 +1328,8 @@ template <typename KeyIterator, typename ValueIterator, typename Compare>
 void sort_by_key_pullback(KeyIterator keys_first, KeyIterator keys_last,
                           ValueIterator values_first, Compare comp,
                           KeyIterator* d_keys_first, KeyIterator* d_keys_last,
-                          ValueIterator* d_values_first, Compare* /*d_comp*/) {
+                          ValueIterator* d_values_first, Compare* /*d_comp*/,
+                          ::clad::restore_tracker& tracker) {
   using ValueConst = typename ::std::iterator_traits<ValueIterator>::value_type;
   using Value = ::std::remove_const_t<ValueConst>;
   using KeyConst = typename ::std::iterator_traits<KeyIterator>::value_type;
@@ -1344,9 +1339,8 @@ void sort_by_key_pullback(KeyIterator keys_first, KeyIterator keys_last,
   if (n == 0)
     return;
 
-  auto& stack = detail::permutation_stack();
-  ::thrust::device_vector<::std::size_t> perm = ::std::move(stack.back());
-  stack.pop_back();
+  ::thrust::device_vector<::std::size_t> perm =
+      tracker.pop_thrust_sort_by_key_perm();
 
   auto d_vals_const_ptr = ::thrust::raw_pointer_cast((*d_values_first).base());
   auto d_vals_ptr = const_cast<Value*>(d_vals_const_ptr);

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1085,10 +1085,10 @@ namespace clad {
       if (MD && MD->isInstance() && !MD->isConst())
         return true;
       // FIXME: clad::restore_tracker is not thread-safe.
-      // We shoudn't disable reverse_forw for CUDA
+      // Disable restore_tracker only for device/global entry points; __host__
+      // __device__ Thrust APIs still need a tracker on the host-side AD path.
       if (FD->hasAttr<clang::CUDAGlobalAttr>() ||
-          FD->hasAttr<clang::CUDADeviceAttr>() ||
-          FD->hasAttr<clang::CUDAHostAttr>())
+          FD->hasAttr<clang::CUDADeviceAttr>())
         return false;
       for (const ParmVarDecl* PVD : FD->parameters()) {
         // Some functions (like in Kokkos) have dummy parameters for
@@ -1380,6 +1380,12 @@ namespace clad {
           trackerTy = C.getLValueReferenceType(trackerTy);
           FnTypes.push_back(trackerTy);
         }
+      }
+
+      if (mode == DiffMode::pullback && shouldUseRestoreTracker) {
+        QualType trackerTy = GetRestoreTrackerType(S);
+        trackerTy = C.getLValueReferenceType(trackerTy);
+        FnTypes.push_back(trackerTy);
       }
 
       if (isForErrorEstimation)

--- a/lib/Differentiator/DerivedFnInfo.cpp
+++ b/lib/Differentiator/DerivedFnInfo.cpp
@@ -12,13 +12,15 @@ DerivedFnInfo::DerivedFnInfo(const DiffRequest& request,
       m_DiffVarsInfo(request.DVI),
       m_CUDAGlobalArgsIndexes(request.CUDAGlobalArgsIndexes),
       m_UsesEnzyme(request.use_enzyme),
-      m_DeclarationOnly(request.DeclarationOnly) {}
+      m_DeclarationOnly(request.DeclarationOnly),
+      m_UseRestoreTracker(request.UseRestoreTracker) {}
 
 bool DerivedFnInfo::SatisfiesRequest(const DiffRequest& request) const {
   return (request.Function == m_OriginalFn && request.Mode == m_Mode &&
           request.DVI == m_DiffVarsInfo && request.use_enzyme == m_UsesEnzyme &&
           request.DeclarationOnly == m_DeclarationOnly &&
-          request.CUDAGlobalArgsIndexes == m_CUDAGlobalArgsIndexes);
+          request.CUDAGlobalArgsIndexes == m_CUDAGlobalArgsIndexes &&
+          request.UseRestoreTracker == m_UseRestoreTracker);
 }
 
 bool DerivedFnInfo::IsValid() const { return m_OriginalFn && m_DerivedFn; }
@@ -29,6 +31,7 @@ bool DerivedFnInfo::RepresentsSameDerivative(const DerivedFnInfo& lhs,
          lhs.m_DiffVarsInfo == rhs.m_DiffVarsInfo &&
          lhs.m_UsesEnzyme == rhs.m_UsesEnzyme &&
          lhs.m_DeclarationOnly == rhs.m_DeclarationOnly &&
-         lhs.m_CUDAGlobalArgsIndexes == rhs.m_CUDAGlobalArgsIndexes;
+         lhs.m_CUDAGlobalArgsIndexes == rhs.m_CUDAGlobalArgsIndexes &&
+         lhs.m_UseRestoreTracker == rhs.m_UseRestoreTracker;
 }
 } // namespace clad

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -992,7 +992,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       diffParams.push_back(VarInfo.param);
     QualType dTy = utils::GetDerivativeType(S, R.Function, R.Mode, diffParams,
                                             /*forCustomDerv=*/true,
-                                            /*shouldUseRestoreTracker=*/false);
+                                            /*shouldUseRestoreTracker=*/R.UseRestoreTracker);
     // We disable diagnostics for methods and operators because they often have
     // ideantical names: `constructor_pullback`, `operator_star_pushforward`,
     // etc. If we turn it on, every such operator will trigger diagnostics
@@ -1324,6 +1324,8 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
         E->getDirectCallee();
     bool shouldUseRestoreTracker =
         utils::shouldUseRestoreTracker(request.Function);
+    if (request.Mode == DiffMode::pullback)
+      request.UseRestoreTracker = shouldUseRestoreTracker;
     if (!(LookupCustomDerivativeDecl(request) || nonDiff) || requestTBR) {
       clang::CFG::BuildOptions Options;
       std::unique_ptr<AnalysisDeclContext> AnalysisDC =
@@ -1394,6 +1396,9 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
         }
       }
     }
+
+    if (request.Mode == DiffMode::pullback)
+      request.UseRestoreTracker = shouldUseRestoreTracker;
 
     if (request.Mode == DiffMode::pullback) {
       DiffRequest forwPassRequest;

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1994,6 +1994,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     calleeFnForwPassReq.Mode = DiffMode::reverse_mode_forward_pass;
     calleeFnForwPassReq.BaseFunctionName =
         clad::utils::ComputeEffectiveFnName(FD);
+    calleeFnForwPassReq.UseRestoreTracker =
+        utils::shouldUseRestoreTracker(FD);
     FunctionDecl* calleeFnForwPassFD = FindDerivedFunction(calleeFnForwPassReq);
     bool elideReverseForw =
         (calleeFnForwPassFD &&
@@ -2056,6 +2058,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       pullbackRequest.EnableTBRAnalysis = m_DiffReq.EnableTBRAnalysis;
       pullbackRequest.EnableVariedAnalysis = m_DiffReq.EnableVariedAnalysis;
       pullbackRequest.EnableErrorEstimation = m_DiffReq.EnableErrorEstimation;
+      pullbackRequest.UseRestoreTracker = usingRestoreTracker;
       // Error estimation only uses forward mode derivatives if they are
       // user-prodived to handle builtin derivatives. We cannot determine which
       // mode is used unless we check both.
@@ -2085,6 +2088,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // Save current index in the current block, to potentially put some
     // statements there later.
     std::size_t insertionPoint = getCurrentBlock(direction::reverse).size();
+    clang::VarDecl* callLocalRestoreTrackerDecl = nullptr;
+    clang::Expr* callLocalRestoreTrackerExpr = nullptr;
 
     // Method operators have a base like methods do but it's included in the
     // call arguments so we have to shift the indexing of call arguments.
@@ -2223,6 +2228,20 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       }
 
       if (pullbackFD) {
+        if (pullbackFD->getNumParams() > 0 &&
+            utils::GetValueType(pullbackFD->parameters().back()->getType()) ==
+                trackerType) {
+          if (m_RestoreTracker)
+            callLocalRestoreTrackerExpr = m_RestoreTracker;
+          else if (!callLocalRestoreTrackerExpr) {
+            callLocalRestoreTrackerDecl =
+                BuildVarDecl(trackerType, "_tracker", getZeroInit(trackerType));
+            addToCurrentBlock(BuildDeclStmt(callLocalRestoreTrackerDecl));
+            callLocalRestoreTrackerExpr =
+                BuildDeclRef(callLocalRestoreTrackerDecl);
+          }
+          pullbackCallArgs.push_back(callLocalRestoreTrackerExpr);
+        }
         if (m_ExternalSource &&
             pullbackCallArgs.size() != pullbackFD->getNumParams())
           m_ExternalSource->ActBeforeDifferentiatingCallExpr(pullbackCallArgs);
@@ -2372,14 +2391,19 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           // ```
           trackerExpr = m_RestoreTracker;
         } else {
-          // Otherwise, generate the declaration
-          // ``clad::restore_tracker _tracker0 = {};``
-          VarDecl* trackerDecl =
-              BuildVarDecl(trackerType, "_tracker", getZeroInit(trackerType));
-          addToCurrentBlock(BuildDeclStmt(trackerDecl));
-          trackerExpr = BuildDeclRef(trackerDecl);
+          // Reuse tracker created for pullback (e.g. thrust::sort_by_key) or
+          // allocate a new one.
+          if (!callLocalRestoreTrackerExpr) {
+            callLocalRestoreTrackerDecl =
+                BuildVarDecl(trackerType, "_tracker", getZeroInit(trackerType));
+            addToCurrentBlock(BuildDeclStmt(callLocalRestoreTrackerDecl));
+            callLocalRestoreTrackerExpr =
+                BuildDeclRef(callLocalRestoreTrackerDecl);
+          }
+          trackerExpr = callLocalRestoreTrackerExpr;
           Expr* restoreCall = BuildCallExprToMemFn(
-              BuildDeclRef(trackerDecl), /*MemberFunctionName=*/"restore",
+              BuildDeclRef(callLocalRestoreTrackerDecl),
+              /*MemberFunctionName=*/"restore",
               /*ArgExprs=*/{}, Loc);
           it = std::begin(block) + insertionPoint;
           block.insert(it, restoreCall);

--- a/test/CUDA/ThrustSortByKey.cu
+++ b/test/CUDA/ThrustSortByKey.cu
@@ -26,12 +26,14 @@ void sort_by_key_simple(thrust::device_vector<int>& keys,
     thrust::sort_by_key(keys.begin(), keys.end(), vals.begin());
 }
 // CHECK: void sort_by_key_simple_grad(thrust::device_vector<int> &keys, thrust::device_vector<double> &vals, thrust::device_vector<int> *_d_keys, thrust::device_vector<double> *_d_vals) {
-// CHECK-NEXT: {{.*}}clad::custom_derivatives::thrust::sort_by_key_reverse_forw(std::begin(keys), std::end(keys), std::begin(vals), std::begin((*_d_keys)), std::end((*_d_keys)), std::begin((*_d_vals)));
+// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT: {{.*}}clad::custom_derivatives::thrust::sort_by_key_reverse_forw(std::begin(keys), std::end(keys), std::begin(vals), std::begin((*_d_keys)), std::end((*_d_keys)), std::begin((*_d_vals)), _tracker0);
 // CHECK-NEXT: {
+// CHECK-NEXT:     _tracker0.restore();
 // CHECK-NEXT:     {{.*}}iterator _r0 = std::begin((*_d_keys));
 // CHECK-NEXT:     {{.*}}iterator _r1 = std::end((*_d_keys));
 // CHECK-NEXT:     {{.*}}iterator _r2 = std::begin((*_d_vals));
-// CHECK-NEXT:     clad::custom_derivatives::thrust::sort_by_key_pullback(std::begin(keys), std::end(keys), std::begin(vals), &_r0, &_r1, &_r2);
+// CHECK-NEXT:     clad::custom_derivatives::thrust::sort_by_key_pullback(std::begin(keys), std::end(keys), std::begin(vals), &_r0, &_r1, &_r2, _tracker0);
 // CHECK-NEXT: }
 // CHECK-NEXT: }
 
@@ -41,13 +43,15 @@ void sort_by_key_comp(thrust::device_vector<int>& keys,
     thrust::sort_by_key(keys.begin(), keys.end(), vals.begin(), thrust::greater<int>());
 }
 // CHECK: void sort_by_key_comp_grad(thrust::device_vector<int> &keys, thrust::device_vector<double> &vals, thrust::device_vector<int> *_d_keys, thrust::device_vector<double> *_d_vals) {
-// CHECK-NEXT: {{.*}}clad::custom_derivatives::thrust::sort_by_key_reverse_forw(std::begin(keys), std::end(keys), std::begin(vals), thrust::greater<int>(), std::begin((*_d_keys)), std::end((*_d_keys)), std::begin((*_d_vals)), {});
+// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT: {{.*}}clad::custom_derivatives::thrust::sort_by_key_reverse_forw(std::begin(keys), std::end(keys), std::begin(vals), thrust::greater<int>(), std::begin((*_d_keys)), std::end((*_d_keys)), std::begin((*_d_vals)), {}, _tracker0);
 // CHECK-NEXT: {
+// CHECK-NEXT:     _tracker0.restore();
 // CHECK-NEXT:     {{.*}}iterator _r0 = std::begin((*_d_keys));
 // CHECK-NEXT:     {{.*}}iterator _r1 = std::end((*_d_keys));
 // CHECK-NEXT:     {{.*}}iterator _r2 = std::begin((*_d_vals));
 // CHECK-NEXT:     thrust::greater<int> _r3 = {};
-// CHECK-NEXT:     clad::custom_derivatives::thrust::sort_by_key_pullback(std::begin(keys), std::end(keys), std::begin(vals), thrust::greater<int>(), &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:     clad::custom_derivatives::thrust::sort_by_key_pullback(std::begin(keys), std::end(keys), std::begin(vals), thrust::greater<int>(), &_r0, &_r1, &_r2, &_r3, _tracker0);
 // CHECK-NEXT: }
 // CHECK-NEXT: }
 


### PR DESCRIPTION
## Summary
Fixes the static process-wide permutation stack used for `thrust::sort_by_key` reverse-mode AD. Permutation indices are now stored on the `clad::restore_tracker` instance (LIFO, CUDA builds) and passed through custom `*_reverse_forw` / `*_pullback` signatures.

## Changes
- `RestoreTracker.h`: CUDA-only stack + `push_thrust_sort_by_key_perm` / `pop_thrust_sort_by_key_perm` (not cleared by bitwise `restore()`).
- `ThrustDerivatives.h`: remove static stack; last parameter `clad::restore_tracker&` on sort_by_key custom derivatives.
- `GetDerivativeType`: append `restore_tracker&` for pullback when `shouldUseRestoreTracker`.
- `shouldUseRestoreTracker`: still skip CUDA global/device entry points; do **not** skip `__host__ __device__` Thrust-style decls (see FIXME in code).
- Planner: `getOverloadExpr` uses `R.UseRestoreTracker`; pullback `DiffRequest` sets `UseRestoreTracker`; `DiffRequest::operator==` and `DerivedFnInfo` track it for lookup.
- `ReverseModeVisitor`: resolve `reverse_forw` with tracker; pass same tracker into pullback when required; share one local `_tracker` per call.
- `test/CUDA/ThrustSortByKey.cu`: update FileCheck expectations.

## Testing
- Local build of `clad` (LLVM 19) succeeded.
- CUDA `ThrustSortByKey` test should run on CI / GPU environment.

## Note on #1694 reproducer
The large cladtorch example in the issue may also hit STL / `std::vector` metadata issues (see discussion and #1706). This PR targets the **Thrust sort_by_key static stack** described in the issue, not that separate failure mode.

Closes #1694