### PR TITLE
[cmake] Use target-based compiler config for benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,19 +326,22 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
     add_subdirectory(unittests)
     add_subdirectory(test)
   endif()
-  function(clad_apply_test_compiler target)
+function(clad_apply_test_compiler target)
+
   target_compile_options(${target} PRIVATE
-    -Wno-class-memaccess
     -Wno-undefined-inline
-    -fno-lifetime-dse
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-class-memaccess>
+    $<$<CXX_COMPILER_ID:GNU>:-fno-lifetime-dse>
   )
 
   target_compile_options(${target} PRIVATE
-    $<$<NOT:$<CXX_COMPILER_ID:Clang>>:-fno-exceptions>
+     $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-fno-exceptions>
   )
 
   target_compile_definitions(${target} PRIVATE CLAD_TESTING=1)
-  endfunction()
+
+endfunction()
+
   # Add benchmarking infrastructure.
   if (CLAD_ENABLE_BENCHMARKS)
     add_subdirectory(benchmark)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,37 +322,28 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
     include(GoogleBenchmark)
   endif(CLAD_ENABLE_BENCHMARKS)
 
-  if (NOT CLAD_DISABLE_TESTS OR CLAD_ENABLE_BENCHMARKS)
-    # Change the default compiler to the clang which we run clad upon. Our unittests
-    # need to use a supported by clad compiler. Note that's a huge hack and it is
-    # not guaranteed to work with cmake.
-    set(stored_cxx_compiler ${CMAKE_CXX_COMPILER})
-    set(stored_cxx_flags ${CMAKE_CXX_FLAGS})
-    set(stored_c_flags ${CMAKE_C_FLAGS})
-    # FIXME: Remove when vgvassilev/clad#1665 is resolved.
-    disable_werror(CMAKE_CXX_FLAGS CMAKE_C_FLAGS)
-    set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
-    # Filter some unsupported flags by clang.
-    string(REPLACE "-fno-lifetime-dse" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    string(REPLACE "-Wno-class-memaccess" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  endif()
-
   if (NOT CLAD_DISABLE_TESTS)
     add_subdirectory(unittests)
     add_subdirectory(test)
   endif()
+  function(clad_apply_test_compiler target)
+  target_compile_options(${target} PRIVATE
+    -Wno-class-memaccess
+    -Wno-undefined-inline
+    -fno-lifetime-dse
+  )
 
+  target_compile_options(${target} PRIVATE
+    $<$<NOT:$<CXX_COMPILER_ID:Clang>>:-fno-exceptions>
+  )
+
+  target_compile_definitions(${target} PRIVATE CLAD_TESTING=1)
+  endfunction()
   # Add benchmarking infrastructure.
   if (CLAD_ENABLE_BENCHMARKS)
     add_subdirectory(benchmark)
   endif(CLAD_ENABLE_BENCHMARKS)
 
-  if (stored_cxx_compiler)
-    # Restore the default compiler.
-    set(CMAKE_CXX_COMPILER ${stored_cxx_compiler})
-    set(CMAKE_CXX_FLAGS ${stored_cxx_flags})
-    set(CMAKE_C_FLAGS ${stored_c_flags})
-  endif()
 endif()
 
 # Workaround for MSVS10 to avoid the Dialog Hell

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -2,10 +2,14 @@ set(CTEST_BUILD_NAME ${ROOT_ARCHITECTURE}-${CMAKE_BUILD_TYPE})
 enable_testing()
 
 CB_ADD_GBENCHMARK(Simple Simple.cpp)
+clad_apply_test_compiler(Simple)
 CB_ADD_GBENCHMARK(AlgorithmicComplexity AlgorithmicComplexity.cpp)
+clad_apply_test_compiler(AlgorithmicComplexity)
 CB_ADD_GBENCHMARK(ArrayExpressionTemplates ArrayExpressionTemplates.cpp)
+clad_apply_test_compiler(ArrayExpressionTemplates)
 if (CLAD_ENABLE_ENZYME_BACKEND)
   CB_ADD_GBENCHMARK(EnzymeCladComparison EnzymeCladComparison.cpp)
+  clad_apply_test_compiler(EnzymeCladComparison)
 endif(CLAD_ENABLE_ENZYME_BACKEND)
 
 include(FetchContent)
@@ -30,10 +34,15 @@ target_compile_definitions(tapenade_support PRIVATE
 )
 
 CB_ADD_GBENCHMARK(VectorModeComparison VectorModeComparison.cpp)
+clad_apply_test_compiler(VectorModeComparison)
 CB_ADD_GBENCHMARK(MemoryComplexity_tapenade MemoryComplexity.cpp)
+clad_apply_test_compiler(MemoryComplexity_tapenade)
 CB_ADD_GBENCHMARK(Multithreading Multithreading.cpp)
+clad_apply_test_compiler(Multithreading)
 CB_ADD_GBENCHMARK(Hessians Hessians.cpp)
+clad_apply_test_compiler(Hessians)
 CB_ADD_GBENCHMARK(GPT2Training GPT2Training.cpp)
+clad_apply_test_compiler(GPT2Training)
 
 if(APPLE)
   # On macOS, we want to explicitly use the high-performance Accelerate framework for BLAS.


### PR DESCRIPTION
This replaces the global compiler override used for benchmarks with a target-based approach.

- Introduces `clad_apply_test_compiler(target)`
- Applies it to all benchmark targets
- Avoids modifying global CMake state

This follows the suggestion in #1666.