### PR TITLE
Add forward-mode std::thread differentiation: parallel derivative threads and join() handling (#1795)

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -65,8 +65,7 @@ bool IsRealNonReferenceType(QualType T) {
 // Returns true if RD is in std namespace, handles libc++ inline
 // namespaces like std::__1 correctly.
 static bool isInStdNamespace(const CXXRecordDecl* RD) {
-  for (const DeclContext* DC = RD->getDeclContext(); DC;
-       DC = DC->getParent()) {
+  for (const DeclContext* DC = RD->getDeclContext(); DC; DC = DC->getParent()) {
     if (const auto* NS = dyn_cast<NamespaceDecl>(DC))
       if (NS->isStdNamespace())
         return true;
@@ -1037,8 +1036,7 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
   if (const auto* MCE = dyn_cast<CXXMemberCallExpr>(CE)) {
     if (const auto* MD = dyn_cast<CXXMethodDecl>(FD)) {
       const CXXRecordDecl* RD = MD->getParent();
-      if (isInStdNamespace(RD) &&
-          RD->getName() == "thread" &&
+      if (isInStdNamespace(RD) && RD->getName() == "thread" &&
           FD->getName() == "join") {
 
         // Get base: t1 → {t1, _d_t1}
@@ -1059,7 +1057,7 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
       }
     }
   }
-  
+
   SourceLocation validLoc{CE->getBeginLoc()};
 
   // Calls to lambda functions are processed differently
@@ -2174,8 +2172,7 @@ BaseForwardModeVisitor::VisitCXXConstructExpr(const CXXConstructExpr* CE) {
 
   CXXConstructorDecl* CD = CE->getConstructor();
   CXXRecordDecl* RD = CD->getParent();
-  bool isStdThread = isInStdNamespace(RD) &&
-                     RD->getName() == "thread" &&
+  bool isStdThread = isInStdNamespace(RD) && RD->getName() == "thread" &&
                      CE->getNumArgs() >= 1;
 
   if (isStdThread) {
@@ -2196,7 +2193,8 @@ BaseForwardModeVisitor::VisitCXXConstructExpr(const CXXConstructExpr* CE) {
           utils::ComputeEffectiveFnName(callableFD);
       pushforwardFnRequest.VerboseDiags = false;
       pushforwardFnRequest.EnableTBRAnalysis = m_DiffReq.EnableTBRAnalysis;
-      pushforwardFnRequest.EnableVariedAnalysis = m_DiffReq.EnableVariedAnalysis;
+      pushforwardFnRequest.EnableVariedAnalysis =
+          m_DiffReq.EnableVariedAnalysis;
 
       FunctionDecl* pushforwardFD =
           m_Builder.HandleNestedDiffRequest(pushforwardFnRequest);
@@ -2205,7 +2203,8 @@ BaseForwardModeVisitor::VisitCXXConstructExpr(const CXXConstructExpr* CE) {
         // Original thread:    std::thread t1(add_square,    x, _t0.value)
         // Derivative thread:  std::thread _d_t1(add_square_pushforward,
         //                                       x, _t0.value,      ← orig args
-        //                                       _d_x, _t0.pushforward) ← deriv args
+        //                                       _d_x, _t0.pushforward) ← deriv
+        //                                       args
 
         llvm::SmallVector<Expr*, 8> derivThreadArgs;
 

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -62,6 +62,20 @@ bool IsRealNonReferenceType(QualType T) {
   return T.getNonReferenceType()->isRealType();
 }
 
+// Returns true if RD is in std namespace, handles libc++ inline
+// namespaces like std::__1 correctly.
+static bool isInStdNamespace(const CXXRecordDecl* RD) {
+  for (const DeclContext* DC = RD->getDeclContext(); DC;
+       DC = DC->getParent()) {
+    if (const auto* NS = dyn_cast<NamespaceDecl>(DC))
+      if (NS->isStdNamespace())
+        return true;
+    if (isa<TranslationUnitDecl>(DC))
+      break;
+  }
+  return false;
+}
+
 DerivativeAndOverload BaseForwardModeVisitor::Derive() {
   const FunctionDecl* FD = m_DiffReq.Function;
   assert(m_DiffReq.Mode == DiffMode::forward ||
@@ -1019,6 +1033,33 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
     return StmtDiff(Clone(CE));
   }
 
+  // When t1.join() is called, also call _d_t1.join() as the derivative
+  if (const auto* MCE = dyn_cast<CXXMemberCallExpr>(CE)) {
+    if (const auto* MD = dyn_cast<CXXMethodDecl>(FD)) {
+      const CXXRecordDecl* RD = MD->getParent();
+      if (isInStdNamespace(RD) &&
+          RD->getName() == "thread" &&
+          FD->getName() == "join") {
+
+        // Get base: t1 → {t1, _d_t1}
+        const Expr* baseExpr = MCE->getImplicitObjectArgument();
+        StmtDiff baseDiff = Visit(baseExpr);
+
+        // Build derivative: _d_t1.join()
+        Expr* derivBase = baseDiff.getExpr_dx();
+        Expr* derivJoin =
+            m_Sema
+                .ActOnCallExpr(getCurrentScope(),
+                               utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                                      derivBase, "join"),
+                               noLoc, {}, noLoc)
+                .get();
+
+        return StmtDiff(nullptr, derivJoin);
+      }
+    }
+  }
+  
   SourceLocation validLoc{CE->getBeginLoc()};
 
   // Calls to lambda functions are processed differently
@@ -2129,6 +2170,64 @@ BaseForwardModeVisitor::VisitCXXConstructExpr(const CXXConstructExpr* CE) {
     auto argDiff = Visit(arg);
     clonedArgs.push_back(argDiff.getExpr());
     derivedArgs.push_back(argDiff.getExpr_dx());
+  }
+
+  CXXConstructorDecl* CD = CE->getConstructor();
+  CXXRecordDecl* RD = CD->getParent();
+  bool isStdThread = isInStdNamespace(RD) &&
+                     RD->getName() == "thread" &&
+                     CE->getNumArgs() >= 1;
+
+  if (isStdThread) {
+    // In std::thread t1(add_square, x, ref(result))
+    // CE->getArg(0) is add_square — a DeclRefExpr pointing to FunctionDecl
+    const Expr* callableArg = CE->getArg(0)->IgnoreParenImpCasts();
+    const FunctionDecl* callableFD = nullptr;
+
+    if (const auto* DRE = dyn_cast<DeclRefExpr>(callableArg))
+      callableFD = dyn_cast<FunctionDecl>(DRE->getDecl());
+
+    if (callableFD) {
+      // This is exactly what VisitCallExpr does for regular function calls
+      DiffRequest pushforwardFnRequest;
+      pushforwardFnRequest.Function = callableFD;
+      pushforwardFnRequest.Mode = DiffMode::pushforward;
+      pushforwardFnRequest.BaseFunctionName =
+          utils::ComputeEffectiveFnName(callableFD);
+      pushforwardFnRequest.VerboseDiags = false;
+      pushforwardFnRequest.EnableTBRAnalysis = m_DiffReq.EnableTBRAnalysis;
+      pushforwardFnRequest.EnableVariedAnalysis = m_DiffReq.EnableVariedAnalysis;
+
+      FunctionDecl* pushforwardFD =
+          m_Builder.HandleNestedDiffRequest(pushforwardFnRequest);
+
+      if (pushforwardFD) {
+        // Original thread:    std::thread t1(add_square,    x, _t0.value)
+        // Derivative thread:  std::thread _d_t1(add_square_pushforward,
+        //                                       x, _t0.value,      ← orig args
+        //                                       _d_x, _t0.pushforward) ← deriv args
+
+        llvm::SmallVector<Expr*, 8> derivThreadArgs;
+
+        // First arg: the pushforward function itself
+        derivThreadArgs.push_back(BuildDeclRef(pushforwardFD));
+
+        // Original args (skip index 0 — that was the callable)
+        for (size_t i = 1; i < clonedArgs.size(); ++i)
+          derivThreadArgs.push_back(clonedArgs[i]);
+
+        // Derivative args (skip index 0 — no derivative of a function pointer)
+        for (size_t i = 1; i < derivedArgs.size(); ++i)
+          derivThreadArgs.push_back(derivedArgs[i]);
+
+        // Derivative thread args: [add_square_pushforward, x, _t0.value,
+        //                          _d_x, _t0.pushforward]
+        Expr* derivInitList =
+            m_Sema.ActOnInitList(noLoc, derivThreadArgs, noLoc).get();
+
+        return StmtDiff(nullptr, derivInitList);
+      }
+    }
   }
 
   Expr* pushforwardCall =

--- a/test/Regressions/issue-1795.cpp
+++ b/test/Regressions/issue-1795.cpp
@@ -1,0 +1,27 @@
+// RUN: %cladclang -std=c++17 -I%S/../../include %s -o %t -lpthread
+// RUN: %t | %filecheck_exec %s
+// XFAIL: valgrind
+
+#include <iostream>
+#include <thread>
+#include "clad/Differentiator/Differentiator.h"
+
+void add_square(double x, double& out) {
+    out = x * x;
+}
+
+double f(double x, double y) {
+    double rx = 0.0, ry = 0.0;
+    std::thread t1(add_square, x, std::ref(rx));
+    std::thread t2(add_square, y, std::ref(ry));
+    t1.join();
+    t2.join();
+    return rx + ry;
+}
+
+int main() {
+    auto df = clad::differentiate(f, "x");
+    std::cout << "f'(3,4) = " << df.execute(3.0, 4.0) << "\n";
+    // CHECK-EXEC: f'(3,4) = 6
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes forward-mode differentiation of `std::thread` (issue #1795).

**`VisitCXXConstructExpr`** — detects `std::thread` constructor, requests the callable's pushforward via `HandleNestedDiffRequest`, and builds a real parallel derivative thread:
```cpp
std::thread _d_t1{add_square_pushforward, x, ref(rx), _d_x, ref(_d_rx)};
```

**`VisitCallExpr`** — detects `std::thread::join()` and emits `_d_t1.join()` alongside the primal join, preventing `std::terminate()` at destruction.

Fixes #1795
```