### PR TITLE
Add nullptr check in array subscripts

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -935,6 +935,19 @@ BaseForwardModeVisitor::VisitArraySubscriptExpr(const ArraySubscriptExpr* ASE) {
   //  return;
   // Create the _result[idx] expression.
   auto result_at_is = BuildArraySubscript(target, clonedIndices);
+
+  if (target->getType()->isPointerType() &&
+      target->getType()->getPointeeType().isConstQualified()) {
+
+    Expr* targetClone = Clone(target);
+    Expr* nullPtr = getZeroInit(target->getType());
+    Expr* cond = BuildOp(BO_NE, targetClone, nullPtr);
+
+    Expr* safe_result =
+        m_Sema.ActOnConditionalOp(noLoc, noLoc, cond, result_at_is, zero).get();
+    return StmtDiff(cloned, safe_result);
+  }
+
   return StmtDiff(cloned, result_at_is);
 }
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1480,8 +1480,17 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // Create the target[idx] expression.
     result = BuildArraySubscript(target, reverseIndices);
     // Create the (target += dfdx) statement.
-    if (Expr* add_assign = BuildDiffIncrement(result))
-      addToCurrentBlock(add_assign, direction::reverse);
+    if (Expr* add_assign = BuildDiffIncrement(result)) {
+      if (target->getType()->isPointerType()) {
+        Stmt* nullCheck = clad_compat::IfStmt_Create(
+            m_Context, noLoc, /*isConstexpr=*/false, /*Init=*/nullptr,
+            /*Var=*/nullptr, target, noLoc, noLoc, add_assign, noLoc,
+            /*Else=*/nullptr);
+        addToCurrentBlock(nullCheck, direction::reverse);
+      } else {
+        addToCurrentBlock(add_assign, direction::reverse);
+      }
+    }
     if (m_ExternalSource)
       m_ExternalSource->ActAfterProcessingArraySubscriptExpr(valueForRevSweep);
     return StmtDiff(cloned, result, valueForRevSweep);

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -29,7 +29,8 @@ double addArr(const double *arr, int n) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r_d0 = _d_ret;
-//CHECK-NEXT:             _d_arr[i] += _r_d0;
+//CHECK-NEXT:             if (_d_arr)
+//CHECK-NEXT:               _d_arr[i] += _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -72,14 +73,16 @@ float func(float* a, float* b) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             float _r_d1 = _d_sum;
-//CHECK-NEXT:             _d_a[i] += _r_d1;
+//CHECK-NEXT:             if (_d_a)
+//CHECK-NEXT:               _d_a[i] += _r_d1;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             a[i] = clad::pop(_t1);
 //CHECK-NEXT:             float _r_d0 = _d_a[i];
 //CHECK-NEXT:             _d_a[i] = 0.F;
 //CHECK-NEXT:             _d_a[i] += _r_d0 * b[i];
-//CHECK-NEXT:             _d_b[i] += a[i] * _r_d0;
+//CHECK-NEXT:             if (_d_b)
+//CHECK-NEXT:               _d_b[i] += a[i] * _r_d0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -115,7 +118,8 @@ float func2(float* a) {
 //CHECK-NEXT:         float _r_d0 = _d_sum;
 //CHECK-NEXT:         float _r0 = 0.F;
 //CHECK-NEXT:         _r0 += _r_d0 * helper_pushforward(a[i], 1.F).pushforward;
-//CHECK-NEXT:         _d_a[i] += _r0;
+//CHECK-NEXT:         if (_d_a)
+//CHECK-NEXT:           _d_a[i] += _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -140,9 +144,11 @@ float func3(float* a, float* b) {
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         float _r_d0 = _d_sum;
-//CHECK-NEXT:         _d_a[i] += _r_d0;
+//CHECK-NEXT:         if (_d_a)
+//CHECK-NEXT:           _d_a[i] += _r_d0;
 //CHECK-NEXT:         float _r_d1 = _d_a[i];
-//CHECK-NEXT:         _d_b[i] += _r_d1;
+//CHECK-NEXT:         if (_d_b)
+//CHECK-NEXT:           _d_b[i] += _r_d1;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -294,8 +300,10 @@ double inv_square(double *params) {
 //CHECK-NEXT:     double _t0 = (params[0] * params[0]);
 //CHECK-NEXT:     {
 //CHECK-NEXT:         double _r0 = _d_y * -(1 / (_t0 * _t0));
-//CHECK-NEXT:         _d_params[0] += _r0 * params[0];
-//CHECK-NEXT:         _d_params[0] += params[0] * _r0;
+//CHECK-NEXT:         if (_d_params)
+//CHECK-NEXT:           _d_params[0] += _r0 * params[0];
+//CHECK-NEXT:         if (_d_params)
+//CHECK-NEXT:           _d_params[0] += params[0] * _r0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -330,7 +338,8 @@ double func7(double *params) {
 //CHECK-NEXT:             inv_square_pullback(paramsPrime, _r_d0, _d_paramsPrime);
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
-//CHECK-NEXT:             _d_params[0] += _d_paramsPrime[0];
+//CHECK-NEXT:             if (_d_params)
+//CHECK-NEXT:               _d_params[0] += _d_paramsPrime[0];
 //CHECK-NEXT:             clad::zero_init(_d_paramsPrime);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
@@ -342,7 +351,8 @@ double helper2(double i, double *arr, int n) {
 
 //CHECK: void helper2_pullback(double i, double *arr, int n, double _d_y, double *_d_i, double *_d_arr, int *_d_n) {
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _d_arr[0] += _d_y * i;
+//CHECK-NEXT:         if (_d_arr)
+//CHECK-NEXT:           _d_arr[0] += _d_y * i;
 //CHECK-NEXT:         *_d_i += arr[0] * _d_y;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -560,7 +570,8 @@ double func12(double x[3], double y[3]) {
 //CHECK-NEXT:       for (; _t0; _t0--) {
 //CHECK-NEXT:           --i;
 //CHECK-NEXT:           double _r_d0 = _d_prod;
-//CHECK-NEXT:           _d_x[i] += _r_d0 * y[i];
+//CHECK-NEXT:           if (_d_x)
+//CHECK-NEXT:             _d_x[i] += _r_d0 * y[i];
 //CHECK-NEXT:           _d_y[i] += x[i] * _r_d0;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
@@ -593,13 +604,17 @@ double func13(double* x, double y) {
 // CHECK-NEXT:          {
 // CHECK-NEXT:              double _r_d0 = _d_prod;
 // CHECK-NEXT:              _d_arr[0] += _r_d0 * x[0];
-// CHECK-NEXT:              _d_x[0] += arr[0] * _r_d0;
+//CHECK-NEXT:               if (_d_x)
+// CHECK-NEXT:                _d_x[0] += arr[0] * _r_d0;
 // CHECK-NEXT:              _d_arr[1] += _r_d0 * x[1];
-// CHECK-NEXT:              _d_x[1] += arr[1] * _r_d0;
+//CHECK-NEXT:               if (_d_x)
+// CHECK-NEXT:                _d_x[1] += arr[1] * _r_d0;
 // CHECK-NEXT:              _d_arr[2] += _r_d0 * x[2];
-// CHECK-NEXT:              _d_x[2] += arr[2] * _r_d0;
+//CHECK-NEXT:               if (_d_x)
+// CHECK-NEXT:                _d_x[2] += arr[2] * _r_d0;
 // CHECK-NEXT:              _d_arr[3] += _r_d0 * x[3];
-// CHECK-NEXT:              _d_x[3] += arr[3] * _r_d0;
+//CHECK-NEXT:               if (_d_x)
+// CHECK-NEXT:                _d_x[3] += arr[3] * _r_d0;
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              _d_i += _d_arr[0];

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -71,8 +71,10 @@ __device__ __host__ double gauss(const double* x, double* p, double sigma, int d
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         double _r_d0 = _d_t;
-//CHECK-NEXT:         _d_p[i] += -_r_d0 * (x[i] - p[i]);
-//CHECK-NEXT:         _d_p[i] += -(x[i] - p[i]) * _r_d0;
+//CHECK-NEXT:         if (_d_p)
+//CHECK-NEXT:           _d_p[i] += -_r_d0 * (x[i] - p[i]);
+//CHECK-NEXT:         if (_d_p)
+//CHECK-NEXT:           _d_p[i] += -(x[i] - p[i]) * _r_d0;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 

--- a/test/CUDA/GradientKernels.cu
+++ b/test/CUDA/GradientKernels.cu
@@ -44,7 +44,8 @@ __global__ void add_kernel(int *out, int *in) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         out[index0] = _t0;
 //CHECK-NEXT:         int _r_d0 = _d_out[index0];
-//CHECK-NEXT:         atomicAdd(&_d_in[index0], _r_d0);
+//CHECK-NEXT:         if (_d_in)
+//CHECK-NEXT:           atomicAdd(&_d_in[index0], _r_d0);
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -58,7 +59,8 @@ __global__ void add_kernel_2(int *out, int *in) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         out[threadIdx.x] = _t0;
 //CHECK-NEXT:         int _r_d0 = _d_out[threadIdx.x];
-//CHECK-NEXT:         atomicAdd(&_d_in[threadIdx.x], _r_d0);
+//CHECK-NEXT:         if (_d_in)
+//CHECK-NEXT:           atomicAdd(&_d_in[threadIdx.x], _r_d0);
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -75,7 +77,8 @@ __global__ void add_kernel_3(int *out, int *in) {
 //CHECK-NEXT:    {
 //CHECK-NEXT:        out[index0] = _t0;
 //CHECK-NEXT:        int _r_d0 = _d_out[index0];
-//CHECK-NEXT:        _d_in[index0] += _r_d0;
+//CHECK-NEXT:        if (_d_in)
+//CHECK-NEXT:           _d_in[index0] += _r_d0;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
@@ -132,7 +135,8 @@ __global__ void add_kernel_4(int *out, int *in, int N) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     sum = clad::pop(_t2);
 // CHECK-NEXT:                     int _r_d0 = _d_sum;
-// CHECK-NEXT:                     atomicAdd(&_d_in[i], _r_d0);
+//CHECK-NEXT:                      if (_d_in)
+// CHECK-NEXT:                        atomicAdd(&_d_in[i], _r_d0);
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _d_index += _d_i;
@@ -200,7 +204,8 @@ __global__ void add_kernel_5(int *out, int *in, int N) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     sum = clad::pop(_t2);
 // CHECK-NEXT:                     int _r_d0 = _d_sum;
-// CHECK-NEXT:                     atomicAdd(&_d_in[i], _r_d0);
+//CHECK-NEXT:                      if (_d_in)
+// CHECK-NEXT:                        atomicAdd(&_d_in[i], _r_d0);
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _d_index += _d_i;
@@ -243,13 +248,15 @@ __global__ void add_kernel_7(double *a, double *b) {
 // CHECK-NEXT:         a[2 * index0 + 1] = _t1;
 // CHECK-NEXT:         double _r_d1 = _d_a[2 * index0 + 1];
 // CHECK-NEXT:         _d_a[2 * index0 + 1] = 0.;
-// CHECK-NEXT:         atomicAdd(&_d_b[0], _r_d1);
+//CHECK-NEXT:          if (_d_b)
+// CHECK-NEXT:            atomicAdd(&_d_b[0], _r_d1);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a[2 * index0] = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_a[2 * index0];
 // CHECK-NEXT:         _d_a[2 * index0] = 0.;
-// CHECK-NEXT:         atomicAdd(&_d_b[0], _r_d0);
+//CHECK-NEXT:          if (_d_b)
+// CHECK-NEXT:            atomicAdd(&_d_b[0], _r_d0);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -325,7 +332,8 @@ __global__ void dup_kernel_with_device_call_2(double *out, const double *in, dou
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        _d_in[index0] += _d_y;
+//CHECK-NEXT:        if (_d_in)
+//CHECK-NEXT:           _d_in[index0] += _d_y;
 //CHECK-NEXT:        *_d_val += _d_y;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
@@ -360,7 +368,8 @@ __global__ void kernel_with_device_call_3(double *out, double *in, double *val) 
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        _d_in[index0] += _d_y;
+//CHECK-NEXT:        if (_d_in)
+//CHECK-NEXT:           _d_in[index0] += _d_y;
 //CHECK-NEXT:        atomicAdd(_d_val, _d_y);
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
@@ -396,7 +405,8 @@ __global__ void kernel_with_nested_device_call(double *out, double *in, double v
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        _d_in[index0] += _d_y;
+//CHECK-NEXT:        if (_d_in)
+//CHECK-NEXT:           _d_in[index0] += _d_y;
 //CHECK-NEXT:        *_d_val += _d_y;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
@@ -515,7 +525,8 @@ double fn_memory(double *out, double *in) {
 //CHECK-NEXT:        {
 //CHECK-NEXT:            res = clad::pop(_t1);
 //CHECK-NEXT:            double _r_d0 = _d_res;
-//CHECK-NEXT:            _d_out_host[i] += _r_d0;
+//CHECK-NEXT:            if (_d_out_host)
+//CHECK-NEXT:               _d_out_host[i] += _r_d0;
 //CHECK-NEXT:        }
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
@@ -590,7 +601,8 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
 // CHECK-NEXT:                 {
 // CHECK-NEXT:                     sum = clad::pop(_t2);
 // CHECK-NEXT:                     int _r_d0 = _d_sum;
-// CHECK-NEXT:                     atomicAdd(&_d_in[i], _r_d0);
+// CHECK-NEXT:                     if (_d_in)
+// CHECK-NEXT:                        atomicAdd(&_d_in[i], _r_d0);
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             _d_index += _d_i;
@@ -680,22 +692,26 @@ __global__ void indices_perm(int *out, int *in) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         out[index4] = _t3;
 // CHECK-NEXT:         int _r_d3 = _d_out[index4];
-// CHECK-NEXT:         _d_in[index4] += _r_d3;
+// CHECK-NEXT:         if (_d_in)
+// CHECK-NEXT:            _d_in[index4] += _r_d3;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         out[index3] = _t2;
 // CHECK-NEXT:         int _r_d2 = _d_out[index3];
-// CHECK-NEXT:         _d_in[index3] += _r_d2;
+// CHECK-NEXT:         if (_d_in)
+// CHECK-NEXT:            _d_in[index3] += _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         out[index2] = _t1;
 // CHECK-NEXT:         int _r_d1 = _d_out[index2];
-// CHECK-NEXT:         _d_in[index2] += _r_d1;
+// CHECK-NEXT:         if (_d_in)
+// CHECK-NEXT:            _d_in[index2] += _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         out[index1] = _t0;
 // CHECK-NEXT:         int _r_d0 = _d_out[index1];
-// CHECK-NEXT:         _d_in[index1] += _r_d0;
+// CHECK-NEXT:         if (_d_in)
+// CHECK-NEXT:            _d_in[index1] += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -730,32 +746,38 @@ __global__ void indices_lin_comb(int *out, int *in) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         out[index0] = _t6;
 // CHECK-NEXT:         int _r_d5 = _d_out[index0];
-// CHECK-NEXT:         atomicAdd(&_d_in[index0 / 2], _r_d5);
+// CHECK-NEXT:         if (_d_in)
+// CHECK-NEXT:            atomicAdd(&_d_in[index0 / 2], _r_d5);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         out[index0] = _t5;
 // CHECK-NEXT:         int _r_d4 = _d_out[index0];
-// CHECK-NEXT:         atomicAdd(&_d_in[1 + 1], _r_d4);
+// CHECK-NEXT:         if (_d_in)
+// CHECK-NEXT:            atomicAdd(&_d_in[1 + 1], _r_d4);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         out[index0] = _t3;
 // CHECK-NEXT:         int _r_d3 = _d_out[index0];
-// CHECK-NEXT:         _d_in[2 * _t4 + 1] += _r_d3;
+// CHECK-NEXT:         if (_d_in)
+// CHECK-NEXT:            _d_in[2 * _t4 + 1] += _r_d3;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         out[index0] = _t2;
 // CHECK-NEXT:         int _r_d2 = _d_out[index0];
-// CHECK-NEXT:         _d_in[threadIdx.x + blockIdx.x * blockDim.x] += _r_d2;
+// CHECK-NEXT:         if (_d_in)
+// CHECK-NEXT:            _d_in[threadIdx.x + blockIdx.x * blockDim.x] += _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         out[index0] = _t1;
 // CHECK-NEXT:         int _r_d1 = _d_out[index0];
-// CHECK-NEXT:         _d_in[1 + index0] += _r_d1;
+// CHECK-NEXT:         if (_d_in)
+// CHECK-NEXT:            _d_in[1 + index0] += _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         out[index0] = _t0;
 // CHECK-NEXT:         int _r_d0 = _d_out[index0];
-// CHECK-NEXT:         _d_in[2 * index0] += _r_d0;
+// CHECK-NEXT:         if (_d_in)
+// CHECK-NEXT:            _d_in[2 * index0] += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -782,12 +804,14 @@ __global__ void kernel_device_injective(int *a) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a[index2] = _t1;
 // CHECK-NEXT:         int _r_d1 = _d_a[index2];
-// CHECK-NEXT:         atomicAdd(&_d_a[index2], _r_d1);
+// CHECK-NEXT:         if (_d_a)
+// CHECK-NEXT:            atomicAdd(&_d_a[index2], _r_d1);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a[index1] = _t0;
 // CHECK-NEXT:         int _r_d0 = _d_a[index1];
-// CHECK-NEXT:         _d_a[index1] += _r_d0;
+// CHECK-NEXT:         if (_d_a)
+// CHECK-NEXT:            _d_a[index1] += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -832,7 +856,8 @@ __global__ void injective_reassignment(int *a) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a[1] = _t3;
 // CHECK-NEXT:         int _r_d1 = _d_a[1];
-// CHECK-NEXT:         atomicAdd(&_d_a[index1], _r_d1);
+// CHECK-NEXT:         if (_d_a)
+// CHECK-NEXT:            atomicAdd(&_d_a[index1], _r_d1);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     if (_cond0) {
 // CHECK-NEXT:         index2 = _t2;
@@ -841,7 +866,8 @@ __global__ void injective_reassignment(int *a) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         a[1] = _t1;
 // CHECK-NEXT:         int _r_d0 = _d_a[1];
-// CHECK-NEXT:         atomicAdd(&_d_a[index1], _r_d0);
+// CHECK-NEXT:         if (_d_a)
+// CHECK-NEXT:            atomicAdd(&_d_a[index1], _r_d0);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         index1 = _t0;
@@ -868,7 +894,8 @@ __global__ void injective_reassignment_loop(int *a) {
 //CHECK-NEXT:         i++;
 //CHECK-NEXT:         a[i] = clad::pop(_t1);
 //CHECK-NEXT:         int _r_d0 = _d_a[i];
-//CHECK-NEXT:         atomicAdd(&_d_a[i], _r_d0);
+// CHECK-NEXT:        if (_d_a)
+//CHECK-NEXT:           atomicAdd(&_d_a[i], _r_d0);
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -36,7 +36,8 @@ float func(float* p, int n) {
 //CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             float _r_d0 = _d_sum;
-//CHECK-NEXT:             _d_p[i] += _r_d0;
+//CHECK-NEXT:             if (_d_p)
+//CHECK-NEXT:               _d_p[i] += _r_d0;
 //CHECK-NEXT:             p_size = std::max(p_size, i);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
@@ -171,14 +172,16 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:             sum = clad::pop(_t2);
 //CHECK-NEXT:             float _r_d1 = _d_sum;
-//CHECK-NEXT:             _d_x[i] += _r_d1;
+//CHECK-NEXT:             if (_d_x)
+//CHECK-NEXT:               _d_x[i] += _r_d1;
 //CHECK-NEXT:             x_size = std::max(x_size, i);
 //CHECK-NEXT:         }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_x[i] * x[i] * {{.+}});
 //CHECK-NEXT:             x[i] = clad::pop(_t1);
 //CHECK-NEXT:             float _r_d0 = _d_x[i];
-//CHECK-NEXT:             _d_y[i] += _r_d0;
+//CHECK-NEXT:             if (_d_y)
+//CHECK-NEXT:               _d_y[i] += _r_d0;
 //CHECK-NEXT:             y_size = std::max(y_size, i);
 //CHECK-NEXT:             x_size = std::max(x_size, i);
 //CHECK-NEXT:         }
@@ -213,11 +216,14 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:     output[2] = x[0] * y[1] - y[0] * x[1];
 //CHECK-NEXT:     _ret_value0 = output[0] + output[1] + output[2];
 //CHECK-NEXT:     {
-//CHECK-NEXT:         _d_output[0] += 1;
+//CHECK-NEXT:         if (_d_output)
+//CHECK-NEXT:           _d_output[0] += 1;
 //CHECK-NEXT:         output_size = std::max(output_size, 0);
-//CHECK-NEXT:         _d_output[1] += 1;
+//CHECK-NEXT:         if (_d_output)
+//CHECK-NEXT:           _d_output[1] += 1;
 //CHECK-NEXT:         output_size = std::max(output_size, 1);
-//CHECK-NEXT:         _d_output[2] += 1;
+//CHECK-NEXT:         if (_d_output)
+//CHECK-NEXT:           _d_output[2] += 1;
 //CHECK-NEXT:         output_size = std::max(output_size, 2);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
@@ -226,14 +232,18 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         double _r_d2 = _d_output[2];
 //CHECK-NEXT:         _d_output[2] = 0.;
 //CHECK-NEXT:         y_size = std::max(y_size, 1);
-//CHECK-NEXT:         _d_x[0] += _r_d2 * y[1];
+//CHECK-NEXT:         if (_d_x)
+//CHECK-NEXT:           _d_x[0] += _r_d2 * y[1];
 //CHECK-NEXT:         x_size = std::max(x_size, 0);
-//CHECK-NEXT:         _d_y[1] += x[0] * _r_d2;
+//CHECK-NEXT:         if (_d_y)
+//CHECK-NEXT:           _d_y[1] += x[0] * _r_d2;
 //CHECK-NEXT:         y_size = std::max(y_size, 1);
 //CHECK-NEXT:         x_size = std::max(x_size, 1);
-//CHECK-NEXT:         _d_y[0] += -_r_d2 * x[1];
+//CHECK-NEXT:         if (_d_y)
+//CHECK-NEXT:           _d_y[0] += -_r_d2 * x[1];
 //CHECK-NEXT:         y_size = std::max(y_size, 0);
-//CHECK-NEXT:         _d_x[1] += y[0] * -_r_d2;
+//CHECK-NEXT:         if (_d_x)
+//CHECK-NEXT:           _d_x[1] += y[0] * -_r_d2;
 //CHECK-NEXT:         x_size = std::max(x_size, 1);
 //CHECK-NEXT:         output_size = std::max(output_size, 2);
 //CHECK-NEXT:     }
@@ -243,14 +253,18 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         double _r_d1 = _d_output[1];
 //CHECK-NEXT:         _d_output[1] = 0.;
 //CHECK-NEXT:         y_size = std::max(y_size, 0);
-//CHECK-NEXT:         _d_x[2] += _r_d1 * y[0];
+//CHECK-NEXT:         if (_d_x)
+//CHECK-NEXT:           _d_x[2] += _r_d1 * y[0];
 //CHECK-NEXT:         x_size = std::max(x_size, 2);
-//CHECK-NEXT:         _d_y[0] += x[2] * _r_d1;
+//CHECK-NEXT:         if (_d_y)
+//CHECK-NEXT:           _d_y[0] += x[2] * _r_d1;
 //CHECK-NEXT:         y_size = std::max(y_size, 0);
 //CHECK-NEXT:         y_size = std::max(y_size, 2);
-//CHECK-NEXT:         _d_x[0] += -_r_d1 * y[2];
+//CHECK-NEXT:         if (_d_x)
+//CHECK-NEXT:           _d_x[0] += -_r_d1 * y[2];
 //CHECK-NEXT:         x_size = std::max(x_size, 0);
-//CHECK-NEXT:         _d_y[2] += x[0] * -_r_d1;
+//CHECK-NEXT:         if (_d_y)
+//CHECK-NEXT:           _d_y[2] += x[0] * -_r_d1;
 //CHECK-NEXT:         y_size = std::max(y_size, 2);
 //CHECK-NEXT:         output_size = std::max(output_size, 1);
 //CHECK-NEXT:     }
@@ -260,14 +274,18 @@ double func5(double* x, double* y, double* output) {
 //CHECK-NEXT:         double _r_d0 = _d_output[0];
 //CHECK-NEXT:         _d_output[0] = 0.;
 //CHECK-NEXT:         y_size = std::max(y_size, 2);
-//CHECK-NEXT:         _d_x[1] += _r_d0 * y[2];
+//CHECK-NEXT:         if (_d_x)
+//CHECK-NEXT:           _d_x[1] += _r_d0 * y[2];
 //CHECK-NEXT:         x_size = std::max(x_size, 1);
-//CHECK-NEXT:         _d_y[2] += x[1] * _r_d0;
+//CHECK-NEXT:         if (_d_y)
+//CHECK-NEXT:           _d_y[2] += x[1] * _r_d0;
 //CHECK-NEXT:         y_size = std::max(y_size, 2);
 //CHECK-NEXT:         y_size = std::max(y_size, 1);
-//CHECK-NEXT:         _d_x[2] += -_r_d0 * y[1];
+//CHECK-NEXT:         if (_d_x)
+//CHECK-NEXT:           _d_x[2] += -_r_d0 * y[1];
 //CHECK-NEXT:         x_size = std::max(x_size, 2);
-//CHECK-NEXT:         _d_y[1] += x[2] * -_r_d0;
+//CHECK-NEXT:         if (_d_y)
+//CHECK-NEXT:           _d_y[1] += x[2] * -_r_d0;
 //CHECK-NEXT:         y_size = std::max(y_size, 1);
 //CHECK-NEXT:         output_size = std::max(output_size, 0);
 //CHECK-NEXT:     }

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -35,9 +35,11 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});
 //CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
-//CHECK-NEXT:             _d_f[i] += _r_d0;
+// CHECK-NEXT:            if (_d_f)
+// CHECK-NEXT:               _d_f[i] += _r_d0;
 //CHECK-NEXT:             f_size = std::max(f_size, i);
-//CHECK-NEXT:             _d_f[i - 1] += _r_d0;
+// CHECK-NEXT:            if (_d_f)
+//CHECK-NEXT:                _d_f[i - 1] += _r_d0;
 //CHECK-NEXT:             f_size = std::max(f_size, i - 1);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
@@ -88,9 +90,11 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:                 sum = clad::pop(_t3);
 //CHECK-NEXT:                 double _r_d0 = _d_sum;
 //CHECK-NEXT:                 b_size = std::max(b_size, j);
-//CHECK-NEXT:                 _d_a[i] += _r_d0 * b[j];
+//CHECK-NEXT:                 if (_d_a)
+//CHECK-NEXT:                   _d_a[i] += _r_d0 * b[j];
 //CHECK-NEXT:                 a_size = std::max(a_size, i);
-//CHECK-NEXT:                 _d_b[j] += a[i] * _r_d0;
+//CHECK-NEXT:                 if (_d_b)
+//CHECK-NEXT:                   _d_b[j] += a[i] * _r_d0;
 //CHECK-NEXT:                 b_size = std::max(b_size, j);
 //CHECK-NEXT:             }
 //CHECK-NEXT:             {
@@ -139,10 +143,12 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:             sum = clad::pop(_t1);
 //CHECK-NEXT:             double _r_d0 = _d_sum;
 //CHECK-NEXT:             b_size = std::max(b_size, i);
-//CHECK-NEXT:             _d_a[i] += _r_d0 / b[i];
+//CHECK-NEXT:             if (_d_a)
+//CHECK-NEXT:               _d_a[i] += _r_d0 / b[i];
 //CHECK-NEXT:             a_size = std::max(a_size, i);
 //CHECK-NEXT:             double _r0 = _r_d0 * -(a[i] / (b[i] * b[i]));
-//CHECK-NEXT:             _d_b[i] += _r0;
+//CHECK-NEXT:             if (_d_b)
+//CHECK-NEXT:               _d_b[i] += _r0;
 //CHECK-NEXT:             b_size = std::max(b_size, i);
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -499,7 +499,8 @@ double func2(S s) {
 }
 
 // CHECK:  void func2_pullback(S s, double _d_y, S *_d_s) {
-// CHECK-NEXT:      (*_d_s).a[2] += _d_y;
+// CHECK-NEXT:      if ((*_d_s).a)
+// CHECK-NEXT:        (*_d_s).a[2] += _d_y;
 // CHECK-NEXT:  }
 
 double fn9(S& s) {

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -174,12 +174,14 @@ float sum(double* arr, int n) {
 // CHECK-NEXT:     _d_res += _d_y;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d1 = _d_arr[0];
-// CHECK-NEXT:         _d_arr[0] += 10 * _r_d1;
+// CHECK-NEXT:         if (_d_arr)
+// CHECK-NEXT:            _d_arr[0] += 10 * _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         float _r_d0 = _d_res;
-// CHECK-NEXT:         _d_arr[i] += _r_d0;
+// CHECK-NEXT:         if (_d_arr)
+// CHECK-NEXT:            _d_arr[i] += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -226,7 +228,8 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d1 = _d_res;
-// CHECK-NEXT:             _d_arr[i] += _r_d1;
+// CHECK-NEXT:             if (_d_arr)
+// CHECK-NEXT:                _d_arr[i] += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             arr[i] = clad::pop(_t1);
@@ -258,8 +261,10 @@ double modify2(double* arr) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_arr[0];
 // CHECK-NEXT:         _d_arr[0] = 0.;
-// CHECK-NEXT:         _d_arr[0] += 5 * _r_d0;
-// CHECK-NEXT:         _d_arr[1] += _r_d0;
+// CHECK-NEXT:         if (_d_arr)
+// CHECK-NEXT:            _d_arr[0] += 5 * _r_d0;
+// CHECK-NEXT:         if (_d_arr)
+// CHECK-NEXT:            _d_arr[1] += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -272,7 +277,8 @@ double fn5(double* arr, int n) {
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
 // CHECK-NEXT:     double _d_temp = 0.;
 // CHECK-NEXT:     double temp = modify2_reverse_forw(arr, _d_arr, _tracker0);
-// CHECK-NEXT:     _d_arr[0] += 1;
+// CHECK-NEXT:     if (_d_arr)
+// CHECK-NEXT:        _d_arr[0] += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:       _tracker0.restore();
 // CHECK-NEXT:       modify2_pullback(arr, _d_temp, _d_arr);
@@ -527,7 +533,8 @@ double do_nothing(double* u, double* v, double* w) {
 }
 
 // CHECK: void do_nothing_pullback(double *u, double *v, double *w, double _d_y, double *_d_u, double *_d_v, double *_d_w) {
-// CHECK-NEXT:     _d_u[0] += _d_y;
+// CHECK-NEXT:     if (_d_u)
+// CHECK-NEXT:        _d_u[0] += _d_y;
 // CHECK-NEXT: }
 
 double fn12(double x, double y) {
@@ -544,8 +551,10 @@ double multiply(double* a, double* b) {
 
 // CHECK: void multiply_pullback(double *a, double *b, double _d_y, double *_d_a, double *_d_b) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_a[0] += _d_y * b[0];
-// CHECK-NEXT:         _d_b[0] += a[0] * _d_y;
+// CHECK-NEXT:         if (_d_a)
+// CHECK-NEXT:            _d_a[0] += _d_y * b[0];
+// CHECK-NEXT:         if (_d_b)
+// CHECK-NEXT:            _d_b[0] += a[0] * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -662,7 +671,8 @@ double add(double a, const double* b) {
 //CHECK: void add_pullback(double a, const double *b, double _d_y, double *_d_a, double *_d_b) {
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_a += _d_y;
-//CHECK-NEXT:         _d_b[0] += _d_y;
+// CHECK-NEXT:        if (_d_b)
+//CHECK-NEXT:           _d_b[0] += _d_y;
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -867,7 +877,8 @@ double inner_func(double *params, double const *constants) {
 // CHECK-NOT: void inner_func_pullback(double *params, const double *constants, double _d_y, double *_d_params, double *_d_constants) {
 
 // CHECK: void inner_func_pullback(double *params, const double *constants, double _d_y, double *_d_params) {
-// CHECK-NEXT:     _d_params[0] += _d_y * constants[0];
+// CHECK-NEXT:     if (_d_params)
+// CHECK-NEXT:        _d_params[0] += _d_y * constants[0];
 // CHECK-NEXT: }
 
 double fn26(double *params, double const *constants) {
@@ -1026,8 +1037,10 @@ void foo(double *x) {
 // CHECK-NEXT:         x[0] = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_x[0];
 // CHECK-NEXT:         _d_x[0] = 0.;
-// CHECK-NEXT:         _d_x[0] += _r_d0 * x[0];
-// CHECK-NEXT:         _d_x[0] += x[0] * _r_d0;
+// CHECK-NEXT:         if (_d_x)
+// CHECK-NEXT:            _d_x[0] += _r_d0 * x[0];
+// CHECK-NEXT:         if (_d_x)
+// CHECK-NEXT:            _d_x[0] += x[0] * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -1040,8 +1053,10 @@ double fn29(double *x) {
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
 // CHECK-NEXT:     foo_reverse_forw(x, _d_x, _tracker0);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_x[0] += 1 * x[1];
-// CHECK-NEXT:         _d_x[1] += x[0] * 1;
+// CHECK-NEXT:         if (_d_x)
+// CHECK-NEXT:            _d_x[0] += 1 * x[1];
+// CHECK-NEXT:         if (_d_x)
+// CHECK-NEXT:            _d_x[1] += x[0] * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _tracker0.restore();
@@ -1071,7 +1086,8 @@ inline double flexibleInterp(double const *params, const double *high) {
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         double _r_d0 = _d_total;
-// CHECK-NEXT:         _d_params[i] += _r_d0;
+// CHECK-NEXT:         if (_d_params)
+// CHECK-NEXT:            _d_params[i] += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -1154,11 +1170,14 @@ void fast_interp(double const *coefs, double const *sum_param, double const *dif
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_out[0];
 // CHECK-NEXT:         _d_x += _r_d0 * (diff[0] + x * sum0[0]);
-// CHECK-NEXT:         _d_diff[0] += x * _r_d0;
+// CHECK-NEXT:         if (_d_diff)
+// CHECK-NEXT:            _d_diff[0] += x * _r_d0;
 // CHECK-NEXT:         _d_x += x * _r_d0 * sum0[0];
-// CHECK-NEXT:         _d_sum[0] += x * x * _r_d0;
+// CHECK-NEXT:         if (_d_sum)
+// CHECK-NEXT:            _d_sum[0] += x * x * _r_d0;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_coefs[0] += _d_x;
+// CHECK-NEXT:     if (_d_coefs)
+// CHECK-NEXT:        _d_coefs[0] += _d_x;
 // CHECK-NEXT: }
 
 double fn32(double *params) {
@@ -1179,7 +1198,8 @@ double fn32(double *params) {
 // CHECK-NEXT:     fast_interp(t3, xlArr, xlArr + 1, t2);
 // CHECK-NEXT:     _d_t2[0] += 1;
 // CHECK-NEXT:     fast_interp_pullback(t3, xlArr, xlArr + 1, t2, _d_t3, _d_xlArr, _d_xlArr + 1, _d_t2);
-// CHECK-NEXT:     _d_params[0] += _d_t3[0];
+// CHECK-NEXT:     if (_d_params)
+// CHECK-NEXT:        _d_params[0] += _d_t3[0];
 // CHECK-NEXT: }
 
 double iden_func(double x) { return x; }
@@ -1212,7 +1232,8 @@ void inner_fn(double const *coefs, double *out) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         _r0 += _d_b * iden_func_pushforward(coefs[0], 1.).pushforward;
-// CHECK-NEXT:         _d_coefs[0] += _r0;
+// CHECK-NEXT:         if (_d_coefs)
+// CHECK-NEXT:            _d_coefs[0] += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -1454,8 +1475,10 @@ double fn25_defined_later(double x) {
 
 // CHECK: void weighted_sum_pullback(double *x, const double *w, double _d_y, double *_d_x) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_x[0] += w[0] * _d_y;
-// CHECK-NEXT:         _d_x[1] += w[1] * _d_y;
+// CHECK-NEXT:         if (_d_x)
+// CHECK-NEXT:            _d_x[0] += w[0] * _d_y;
+// CHECK-NEXT:         if (_d_x)
+// CHECK-NEXT:            _d_x[1] += w[1] * _d_y;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -1476,6 +1499,7 @@ double fn25_defined_later(double x) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         total = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_total;
-// CHECK-NEXT:         _d_params[i] += _r_d0;
+// CHECK-NEXT:         if (_d_params)
+// CHECK-NEXT:            _d_params[i] += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -653,12 +653,14 @@ float running_sum(float* p, int n) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         p[i] += p[i - 1];
 // CHECK-NEXT:     }
-// CHECK-NEXT:     _d_p[n - 1] += 1;
+// CHECK-NEXT:     if (_d_p)
+// CHECK-NEXT:        _d_p[n - 1] += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             float _r_d0 = _d_p[i];
-// CHECK-NEXT:             _d_p[i - 1] += _r_d0;
+// CHECK-NEXT:             if (_d_p)
+// CHECK-NEXT:                _d_p[i - 1] += _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -232,7 +232,8 @@ double f_sum(double *p, int n) {
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         double _r_d0 = _d_s;
-// CHECK-NEXT:         _d_p[i] += _r_d0;
+// CHECK-NEXT:         if (_d_p)
+// CHECK-NEXT:           _d_p[i] += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -265,7 +266,8 @@ double f_sum_squares(double *p, int n) {
 // CHECK-NEXT:         double _r_d0 = _d_s;
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         _r0 += _r_d0 * sq_pushforward(p[i], 1.).pushforward;
-// CHECK-NEXT:         _d_p[i] += _r0;
+// CHECK-NEXT:         if (_d_p)
+// CHECK-NEXT:            _d_p[i] += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -332,7 +334,8 @@ double f_log_gaus(const double* x, double* p /*means*/, double n, double sigma) 
 // CHECK-NEXT:         double _r_d0 = _d_power;
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         _r0 += _r_d0 * sq_pushforward(x[i] - p[i], 1.).pushforward;
-// CHECK-NEXT:         _d_p[i] += -_r0;
+// CHECK-NEXT:         if (_d_p)
+// CHECK-NEXT:            _d_p[i] += -_r0;
 // CHECK-NEXT:     }
 
 double f_const(const double a, const double b) {
@@ -1356,7 +1359,8 @@ double fn20(double *arr, int n) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = _d_res;
-// CHECK-NEXT:             _d_arr[i] += _r_d0;
+// CHECK-NEXT:             if (_d_arr)
+// CHECK-NEXT:                _d_arr[i] += _r_d0;
 // CHECK-NEXT:             double _r_d1 = _d_arr[i];
 // CHECK-NEXT:             _d_arr[i] = 0.;
 // CHECK-NEXT:             _d_arr[i] += _r_d1 * 5;
@@ -2686,7 +2690,8 @@ double fn43(double* x, double y) {
 //CHECK-NEXT:            _d_t4 += _r0;
 //CHECK-NEXT:        }
 //CHECK-NEXT:        {
-//CHECK-NEXT:            _d_x[i] += _d_t4;
+//CHECK-NEXT:            if (_d_x)
+//CHECK-NEXT:               _d_x[i] += _d_t4;
 //CHECK-NEXT:            _d_t4 = 0.;
 //CHECK-NEXT:            t4 = clad::pop(_t1);
 //CHECK-NEXT:        }

--- a/test/Gradient/NonDifferentiable.C
+++ b/test/Gradient/NonDifferentiable.C
@@ -268,6 +268,7 @@ int main() {
   clad::gradient(fn_non_diff_ptr_param, "input");
 
   // CHECK: void fn_non_diff_ptr_param_grad_0(float *input, const float *factors, float *buffer, float *_d_input) {
-  // CHECK-NEXT:    _d_input[0] += 1;
+  // CHECK-NEXT: if (_d_input)
+  // CHECK-NEXT:   _d_input[0] += 1;
   // CHECK-NEXT: }
 }

--- a/test/Gradient/OpenMP.C
+++ b/test/Gradient/OpenMP.C
@@ -36,7 +36,8 @@ double fn1(const double *x, int n) {
 // CHECK-NEXT:                  for (int i = _t_chunkhi1; i >= _t_chunklo1; i -= 1) {
 // CHECK-NEXT:                      {
 // CHECK-NEXT:                          double _r_d0 = _d_total;
-// CHECK-NEXT:                          _d_x[i] += _r_d0;
+// CHECK-NEXT:                          if (_d_x)
+// CHECK-NEXT:                            _d_x[i] += _r_d0;
 // CHECK-NEXT:                      }
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
@@ -80,8 +81,10 @@ void fn2(const double *x, int n, double *y) {
 // CHECK-NEXT:                      _d_t += t * _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:                  {
-// CHECK-NEXT:                      _d_x[i] += _d_t * x[i];
-// CHECK-NEXT:                      _d_x[i] += x[i] * _d_t;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _d_t * x[i];
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += x[i] * _d_t;
 // CHECK-NEXT:                      _d_t = 0.;
 // CHECK-NEXT:                      t = clad::pop(_t0);
 // CHECK-NEXT:                  }
@@ -119,7 +122,8 @@ void fn3(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i0];
 // CHECK-NEXT:                      _d_y[i0] = 0.;
-// CHECK-NEXT:                      _d_x[i0] += _r_d0 * 2.;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i0] += _r_d0 * 2.;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -152,8 +156,10 @@ void fn4(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0;
-// CHECK-NEXT:                      _d_x[i] += _r_d0;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -186,8 +192,10 @@ void fn5(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * x[i];
-// CHECK-NEXT:                      _d_x[i] += x[i] * _r_d0;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * x[i];
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += x[i] * _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -220,7 +228,8 @@ void fn6(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * 3.;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * 3.;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -253,8 +262,10 @@ void fn7(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * x[i];
-// CHECK-NEXT:                      _d_x[i] += x[i] * _r_d0;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * x[i];
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += x[i] * _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -287,7 +298,8 @@ void fn8(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -320,7 +332,8 @@ void fn9(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * 2.;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * 2.;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -353,7 +366,8 @@ void fn10(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * 4.;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * 4.;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -386,8 +400,10 @@ void fn11(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * x[i];
-// CHECK-NEXT:                      _d_x[i] += x[i] * _r_d0;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * x[i];
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += x[i] * _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -420,7 +436,8 @@ void fn12(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * 5.;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * 5.;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -453,8 +470,10 @@ void fn13(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * x[i];
-// CHECK-NEXT:                      _d_x[i] += x[i] * _r_d0;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * x[i];
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += x[i] * _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -497,8 +516,10 @@ void fn14(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_temp;
 // CHECK-NEXT:                      _d_temp = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * x[i];
-// CHECK-NEXT:                      _d_x[i] += x[i] * _r_d0;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * x[i];
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += x[i] * _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -534,7 +555,8 @@ void fn15(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * scale;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * scale;
 // CHECK-NEXT:                      _d_scale += x[i] * _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
@@ -571,8 +593,10 @@ void fn16(const double *x, int n, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * x[i];
-// CHECK-NEXT:                      _d_x[i] += x[i] * _r_d0;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * x[i];
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += x[i] * _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -626,7 +650,8 @@ void fn17(const double *x, int n, double *y) {
 // CHECK-NEXT:                      temp = clad::pop(_t0);
 // CHECK-NEXT:                      double _r_d0 = _d_temp;
 // CHECK-NEXT:                      _d_temp = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * scale;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * scale;
 // CHECK-NEXT:                      _d_scale += x[i] * _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
@@ -708,7 +733,8 @@ void fn18(const double *x, int n, double *y) {
 // CHECK-NEXT:                      _d_b = 0.;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:                  {
-// CHECK-NEXT:                      _d_x[i] += _d_a;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _d_a;
 // CHECK-NEXT:                      _d_a = 0.;
 // CHECK-NEXT:                      a = clad::pop(_t0);
 // CHECK-NEXT:                  }
@@ -743,8 +769,10 @@ void fn19(const double *x, int start, int end, double *y) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_y[i];
 // CHECK-NEXT:                      _d_y[i] = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0 * x[i];
-// CHECK-NEXT:                      _d_x[i] += x[i] * _r_d0;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0 * x[i];
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += x[i] * _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
@@ -806,7 +834,8 @@ double fn20(const double* x, int n) {
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      double _r_d0 = _d_b.v;
 // CHECK-NEXT:                      _d_b.v = 0.;
-// CHECK-NEXT:                      _d_x[i] += _r_d0;
+// CHECK-NEXT:                      if (_d_x)
+// CHECK-NEXT:                        _d_x[i] += _r_d0;
 // CHECK-NEXT:                  }
 // CHECK-NEXT:                  {
 // CHECK-NEXT:                      _d_b = clad::pop(_t0);

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -148,7 +148,8 @@ double pointerParam(const double* arr, size_t n) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = _d_sum;
-// CHECK-NEXT:             _d_arr[0] += _r_d0 * *j;
+// CHECK-NEXT:             if (_d_arr)
+// CHECK-NEXT:               _d_arr[0] += _r_d0 * *j;
 // CHECK-NEXT:             *_d_j += arr[0] * _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         j = clad::pop(_t2);
@@ -200,34 +201,43 @@ double pointerMultipleParams(const double* a, const double* b) {
 // CHECK-NEXT:     _d_sum += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d3 = _d_sum;
-// CHECK-NEXT:         _d_a[0] += _r_d3;
-// CHECK-NEXT:         _d_b[0] += _r_d3;
+// CHECK-NEXT:         if (_d_a)
+// CHECK-NEXT:            _d_a[0] += _r_d3;
+// CHECK-NEXT:         if (_d_b)
+// CHECK-NEXT:            _d_b[0] += _r_d3;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     ++_d_a;
 // CHECK-NEXT:     ++_d_b;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d2 = _d_sum;
-// CHECK-NEXT:         _d_a[0] += _r_d2;
-// CHECK-NEXT:         _d_b[0] += _r_d2;
+// CHECK-NEXT:         if (_d_a)
+// CHECK-NEXT:            _d_a[0] += _r_d2;
+// CHECK-NEXT:         if (_d_b)
+// CHECK-NEXT:            _d_b[0] += _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_a++;
 // CHECK-NEXT:     _d_b++;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d1 = _d_sum;
-// CHECK-NEXT:         _d_a[0] += _r_d1;
-// CHECK-NEXT:         _d_b[0] += _r_d1;
+// CHECK-NEXT:         if (_d_a)
+// CHECK-NEXT:            _d_a[0] += _r_d1;
+// CHECK-NEXT:         if (_d_b)
+// CHECK-NEXT:            _d_b[0] += _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_a--;
 // CHECK-NEXT:     _d_b--;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_sum;
-// CHECK-NEXT:         _d_a[0] += _r_d0;
-// CHECK-NEXT:         _d_b[0] += _r_d0;
+// CHECK-NEXT:         if (_d_a)
+// CHECK-NEXT:            _d_a[0] += _r_d0;
+// CHECK-NEXT:         if (_d_b)
+// CHECK-NEXT:            _d_b[0] += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     --_d_b;
 // CHECK-NEXT:     _d_a = _t1;
 // CHECK-NEXT:     _d_b = _t0;
-// CHECK-NEXT:     _d_b[2] += _d_sum;
+// CHECK-NEXT:     if (_d_b)
+// CHECK-NEXT:        _d_b[2] += _d_sum;
 // CHECK-NEXT: }
 
 double newAndDeletePointer(double i, double j) {
@@ -258,8 +268,10 @@ double newAndDeletePointer(double i, double j) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_p += _d_sum;
 // CHECK-NEXT:         *_d_q += _d_sum;
-// CHECK-NEXT:         _d_r[0] += _d_sum;
-// CHECK-NEXT:         _d_r[1] += _d_sum;
+// CHECK-NEXT:         if (_d_r)
+// CHECK-NEXT:            _d_r[0] += _d_sum;
+// CHECK-NEXT:         if (_d_r)
+// CHECK-NEXT:            _d_r[1] += _d_sum;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d1 = _d_r[1];
@@ -350,7 +362,8 @@ double cStyleMemoryAlloc(double x, size_t n) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         res = _t5;
 // CHECK-NEXT:         double _r_d3 = _d_res;
-// CHECK-NEXT:         _d_p[1] += _r_d3;
+// CHECK-NEXT:         if (_d_p)
+// CHECK-NEXT:            _d_p[1] += _r_d3;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         p[1] = _t4;

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -1050,7 +1050,8 @@ int main() {
 // CHECK-NEXT:         id--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             float _r_d0 = _d_out;
-// CHECK-NEXT:             _d_tensor_theory_params[0] += arr[id] * _r_d0;
+// CHECK-NEXT:             if (_d_tensor_theory_params)
+// CHECK-NEXT:                _d_tensor_theory_params[0] += arr[id] * _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -94,7 +94,8 @@ double sum(double *data) {
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         _d_data[i] += _r_d0;
+// CHECK-NEXT:         if (_d_data)
+// CHECK-NEXT:           _d_data[i] += _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -480,7 +481,8 @@ void fn13(double *x, double *y, int size)
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d2 = _d_y[p.j];
 // CHECK-NEXT:             _d_y[p.j] = 0.;
-// CHECK-NEXT:             _d_x[p.j] += 2. * _r_d2;
+// CHECK-NEXT:             if (_d_x)
+// CHECK-NEXT:                _d_x[p.j] += 2. * _r_d2;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -1085,7 +1087,8 @@ float fn29(float *input, Session const *session) {
 // CHECK-NEXT:          id0--;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              float _r_d1 = _d_out;
-// CHECK-NEXT:              _d_input[id0] += _r_d1;
+// CHECK-NEXT:              if (_d_input)
+// CHECK-NEXT:                _d_input[id0] += _r_d1;
 // CHECK-NEXT:          }
 // CHECK-NEXT:      }
 // CHECK-NEXT:      for (; _t0; _t0--) {
@@ -1093,7 +1096,8 @@ float fn29(float *input, Session const *session) {
 // CHECK-NEXT:          {
 // CHECK-NEXT:              float _r_d0 = _d_buffer[id];
 // CHECK-NEXT:              _d_buffer[id] = 0.F;
-// CHECK-NEXT:              _d_input[id] += sess.factors[id] * _r_d0;
+// CHECK-NEXT:              if (_d_input)
+// CHECK-NEXT:                _d_input[id] += sess.factors[id] * _r_d0;
 // CHECK-NEXT:          }
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }

--- a/test/Hessian/NestedArrays.C
+++ b/test/Hessian/NestedArrays.C
@@ -52,41 +52,68 @@ double f2_outer(double x) {
 // CHECK-NEXT:     double {{_t[0-9]+}} = params[0] * params[1];
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{_d_t[0-9]+}} += _d_y.value * params[2];
-// CHECK-NEXT:         _d_params0[2] += {{_t[0-9]+}} * _d_y.value;
-// CHECK-NEXT:         _d_params0[3] += _d_y.value * params[3];
-// CHECK-NEXT:         _d_params0[3] += params[3] * _d_y.value;
-// CHECK-NEXT:         _d_params0[4] += _d_y.value * params[0];
-// CHECK-NEXT:         _d_params0[0] += params[4] * _d_y.value;
-// CHECK-NEXT:         _d_d_params[0] += _d_y.pushforward * params[2] * params[1];
-// CHECK-NEXT:         _d_params0[1] += _d_params[0] * _d_y.pushforward * params[2];
-// CHECK-NEXT:         _d_params0[0] += _d_y.pushforward * params[2] * _d_params[1];
-// CHECK-NEXT:         _d_d_params[1] += params[0] * _d_y.pushforward * params[2];
-// CHECK-NEXT:         _d_params0[2] += (_d_params[0] * params[1] + params[0] * _d_params[1]) * _d_y.pushforward;
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[2] += {{_t[0-9]+}} * _d_y.value;
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[3] += _d_y.value * params[3];
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[3] += params[3] * _d_y.value;
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[4] += _d_y.value * params[0];
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[0] += params[4] * _d_y.value;
+// CHECK-NEXT:         if (_d_d_params)
+// CHECK-NEXT:             _d_d_params[0] += _d_y.pushforward * params[2] * params[1];
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[1] += _d_params[0] * _d_y.pushforward * params[2];
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[0] += _d_y.pushforward * params[2] * _d_params[1];
+// CHECK-NEXT:         if (_d_d_params)
+// CHECK-NEXT:             _d_d_params[1] += params[0] * _d_y.pushforward * params[2];
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[2] += (_d_params[0] * params[1] + params[0] * _d_params[1]) * _d_y.pushforward;
 // CHECK-NEXT:         {{_d_t[0-9]+}} += _d_y.pushforward * _d_params[2];
-// CHECK-NEXT:         _d_d_params[2] += {{_t[0-9]+}} * _d_y.pushforward;
-// CHECK-NEXT:         _d_d_params[3] += _d_y.pushforward * params[3];
-// CHECK-NEXT:         _d_params0[3] += _d_params[3] * _d_y.pushforward;
-// CHECK-NEXT:         _d_params0[3] += _d_y.pushforward * _d_params[3];
-// CHECK-NEXT:         _d_d_params[3] += params[3] * _d_y.pushforward;
-// CHECK-NEXT:         _d_d_params[4] += _d_y.pushforward * params[0];
-// CHECK-NEXT:         _d_params0[0] += _d_params[4] * _d_y.pushforward;
-// CHECK-NEXT:         _d_params0[4] += _d_y.pushforward * _d_params[0];
-// CHECK-NEXT:         _d_d_params[0] += params[4] * _d_y.pushforward;
+// CHECK-NEXT:         if (_d_d_params)
+// CHECK-NEXT:             _d_d_params[2] += {{_t[0-9]+}} * _d_y.pushforward;
+// CHECK-NEXT:         if (_d_d_params)
+// CHECK-NEXT:             _d_d_params[3] += _d_y.pushforward * params[3];
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[3] += _d_params[3] * _d_y.pushforward;
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[3] += _d_y.pushforward * _d_params[3];
+// CHECK-NEXT:         if (_d_d_params)
+// CHECK-NEXT:             _d_d_params[3] += params[3] * _d_y.pushforward;
+// CHECK-NEXT:         if (_d_d_params)
+// CHECK-NEXT:             _d_d_params[4] += _d_y.pushforward * params[0];
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[0] += _d_params[4] * _d_y.pushforward;
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[4] += _d_y.pushforward * _d_params[0];
+// CHECK-NEXT:         if (_d_d_params)
+// CHECK-NEXT:             _d_d_params[0] += params[4] * _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_params0[0] += {{_d_t[0-9]+}} * params[1];
-// CHECK-NEXT:         _d_params0[1] += params[0] * {{_d_t[0-9]+}};
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[0] += {{_d_t[0-9]+}} * params[1];
+// CHECK-NEXT:         if (_d_params0)
+// CHECK-NEXT:             _d_params0[1] += params[0] * {{_d_t[0-9]+}};
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK: void f1_inner_pushforward_pullback(double *p, double *_d_p, clad::ValueAndPushforward<double, double> _d_y, double *_d_p0, double *_d_d_p) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_p0[0] += _d_y.value * p[1];
-// CHECK-NEXT:         _d_p0[1] += p[0] * _d_y.value;
-// CHECK-NEXT:         _d_d_p[0] += _d_y.pushforward * p[1];
-// CHECK-NEXT:         _d_p0[1] += _d_p[0] * _d_y.pushforward;
-// CHECK-NEXT:         _d_p0[0] += _d_y.pushforward * _d_p[1];
-// CHECK-NEXT:         _d_d_p[1] += p[0] * _d_y.pushforward;
+// CHECK-NEXT:         if (_d_p0)
+// CHECK-NEXT:             _d_p0[0] += _d_y.value * p[1];
+// CHECK-NEXT:         if (_d_p0)
+// CHECK-NEXT:             _d_p0[1] += p[0] * _d_y.value;
+// CHECK-NEXT:         if (_d_d_p)
+// CHECK-NEXT:             _d_d_p[0] += _d_y.pushforward * p[1];
+// CHECK-NEXT:         if (_d_p0)
+// CHECK-NEXT:             _d_p0[1] += _d_p[0] * _d_y.pushforward;
+// CHECK-NEXT:         if (_d_p0)
+// CHECK-NEXT:             _d_p0[0] += _d_y.pushforward * _d_p[1];
+// CHECK-NEXT:         if (_d_d_p)
+// CHECK-NEXT:             _d_d_p[1] += p[0] * _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -96,16 +123,19 @@ double f2_outer(double x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {{_d_t[0-9]+}} += _d_y.value * x;
 // CHECK-NEXT:         *_d_x0 += {{_t[0-9]+}} * _d_y.value;
-// CHECK-NEXT:         _d_d_p[0] += _d_y.pushforward * x * x;
+// CHECK-NEXT:         if (_d_d_p)
+// CHECK-NEXT:             _d_d_p[0] += _d_y.pushforward * x * x;
 // CHECK-NEXT:         *_d_x0 += _d_p[0] * _d_y.pushforward * x;
-// CHECK-NEXT:         _d_p0[0] += _d_y.pushforward * x * _d_x;
+// CHECK-NEXT:         if (_d_p0)
+// CHECK-NEXT:             _d_p0[0] += _d_y.pushforward * x * _d_x;
 // CHECK-NEXT:         *_d_d_x += p[0] * _d_y.pushforward * x;
 // CHECK-NEXT:         *_d_x0 += (_d_p[0] * x + p[0] * _d_x) * _d_y.pushforward;
 // CHECK-NEXT:         {{_d_t[0-9]+}} += _d_y.pushforward * _d_x;
 // CHECK-NEXT:         *_d_d_x += {{_t[0-9]+}} * _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_p0[0] += {{_d_t[0-9]+}} * x;
+// CHECK-NEXT:         if (_d_p0)
+// CHECK-NEXT:             _d_p0[0] += {{_d_t[0-9]+}} * x;
 // CHECK-NEXT:         *_d_x0 += p[0] * {{_d_t[0-9]+}};
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/ROOT/Interface.C
+++ b/test/ROOT/Interface.C
@@ -22,8 +22,10 @@ void f_grad_1(const Double_t* x, Double_t* p, Double_t *_d_p);
 
 // CHECK: void f_grad_1(const Double_t *x, Double_t *p, Double_t *_d_p) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_p[0] += 1;
-// CHECK-NEXT:         _d_p[1] += x[0] * 1;
+// CHECK-NEXT:         if (_d_p)
+// CHECK-NEXT:            _d_p[0] += 1;
+// CHECK-NEXT:         if (_d_p)
+// CHECK-NEXT:            _d_p[1] += x[0] * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -40,15 +40,20 @@ Double_t TFormula_example(const Double_t* x, Double_t* p) {
 void TFormula_example_grad_1(const Double_t* x, Double_t* p, Double_t* _d_p);
 //CHECK:   void TFormula_example_grad_1(const Double_t *x, Double_t *p, Double_t *_d_p) {
 //CHECK-NEXT:       {
-//CHECK-NEXT:           _d_p[0] += x[0] * 1;
-//CHECK-NEXT:           _d_p[1] += x[0] * 1;
-//CHECK-NEXT:           _d_p[2] += x[0] * 1;
+//CHECK-NEXT:           if (_d_p)
+//CHECK-NEXT:             _d_p[0] += x[0] * 1;
+//CHECK-NEXT:           if (_d_p)
+//CHECK-NEXT:             _d_p[1] += x[0] * 1;
+//CHECK-NEXT:           if (_d_p)
+//CHECK-NEXT:             _d_p[2] += x[0] * 1;
 //CHECK-NEXT:           Double_t _r0 = 0.;
 //CHECK-NEXT:           _r0 += 1 * clad::custom_derivatives::TMath::Exp_pushforward(-p[0], 1.).pushforward;
-//CHECK-NEXT:           _d_p[0] += -_r0;
+//CHECK-NEXT:           if (_d_p)
+//CHECK-NEXT:             _d_p[0] += -_r0;
 //CHECK-NEXT:           Double_t _r1 = 0.;
 //CHECK-NEXT:           _r1 += 1 * clad::custom_derivatives::TMath::Abs_pushforward(p[1], 1.).pushforward;
-//CHECK-NEXT:           _d_p[1] += _r1;
+//CHECK-NEXT:           if (_d_p)
+//CHECK-NEXT:             _d_p[1] += _r1;
 //CHECK-NEXT:       }
 //CHECK-NEXT:   }
 

--- a/test/Regressions/issue-1804.cpp
+++ b/test/Regressions/issue-1804.cpp
@@ -1,4 +1,5 @@
-// RUN: %cladclang -c -std=c++17 -I%S/../../include %s
+// RUN: %cladclang -std=c++17 -I%S/../../include %s -o %t
+// RUN: %t | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
 
@@ -11,8 +12,18 @@ double f_outer(double *params, double const *obs) {
    return f_inner(params, obs) + params[0];
 }
 
-void check() {
-   auto hess = clad::hessian(f_outer, "params[0:2]");
-}
+int main() {
+   double params[] = {0.5, -1, 2};
+   double obs[] = {-9.9};
+   double h[9] = {};
 
-// CHECK: f_inner_pushforward_pullback(params, obs, (double[3]){1., 0., 0.}, nullptr, _d_t0, _d_params, (double[3]){0., 0., 0.}, nullptr);
+   auto hess = clad::hessian(f_outer, "params[0:2]");
+   hess.execute(params, obs, h);
+
+   printf("H_00 : %.2f\n", h[0]); // CHECK-EXEC: H_00 : 0.00
+   printf("H_11 : %.2f\n", h[4]); // CHECK-EXEC: H_11 : 0.50
+   printf("H_12 : %.2f\n", h[5]); // CHECK-EXEC: H_12 : -4.45
+   printf("H_21 : %.2f\n", h[7]); // CHECK-EXEC: H_21 : -4.45
+
+   return 0;
+}

--- a/unittests/Misc/CallDeclOnly.cpp
+++ b/unittests/Misc/CallDeclOnly.cpp
@@ -35,7 +35,8 @@ void wrapper1_grad(double *params, double *_d_params) {
         double _r3 = 1 * _grad0[3];
         _d_ix += _r1;
     }
-    _d_params[0] += _d_ix;
+    if (_d_params)
+        _d_params[0] += _d_ix;
 }
 
 )";


### PR DESCRIPTION
This PR fixes the segfault described in the follow up of #1804. The issue was that the pushforward and pullback functions were trying to read/write the adjoints for inactive parameters with nullptr values, causing the segfault.
`nullptr` checks have been added in `VisitArraySubuscriptExpr` to resolve it.
All the affected tests have been modified.

Fixes #1804 