### PR TITLE
Fix: For issue-1815

### DIFF
--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -152,10 +152,10 @@ namespace clad {
                                                Stmt* S) {
       llvm::SmallVector<Stmt*, 16> block;
       block.push_back(S);
-      CompoundStmt* CS = dyn_cast<CompoundStmt>(initial);
+      auto* CS = llvm::dyn_cast_or_null<CompoundStmt>(initial);
       if (CS)
         block.append(CS->body_begin(), CS->body_end());
-      else
+      else if (initial)
         block.push_back(initial);
       auto stmtsRef = clad_compat::makeArrayRef(block.begin(), block.end());
       return clad_compat::CompoundStmt_Create(C, stmtsRef /**/CLAD_COMPAT_CLANG15_CompoundStmt_Create_ExtraParam1(CS), noLoc, noLoc);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2011,9 +2011,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // We need to check if the last parameter is actually a tracker because
     // custom derivatives currently don't have it.
     if (calleeFnForwPassFD) {
-      QualType lastParamType =
-          calleeFnForwPassFD->parameters().back()->getType();
-      usingRestoreTracker = (utils::GetValueType(lastParamType) == trackerType);
+      if (!calleeFnForwPassFD->parameters().empty()) {
+        QualType lastParamType =
+            calleeFnForwPassFD->parameters().back()->getType();
+        usingRestoreTracker =
+            (utils::GetValueType(lastParamType) == trackerType);
+      }
     }
 
     // FIXME: consider moving non-diff analysis to DiffPlanner.

--- a/test/Regressions/issue-1815.cpp
+++ b/test/Regressions/issue-1815.cpp
@@ -1,0 +1,42 @@
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fdump-derived-fn -fsyntax-only -std=c++17 -I%S/../../include %s | FileCheck %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdarg>
+
+typedef enum { a } b;
+typedef enum { c, d } e;
+e f;
+
+int *g() {
+  switch (f) { 
+    case c: 
+      break; 
+  }
+  return nullptr; 
+}
+
+void h(b, e, char[], char[], int, bool, char, char *, va_list) { 
+  g(); 
+}
+
+char i, o, j;
+int k;
+
+void l(float val) {
+  va_list arg;
+  h(a, d, &i, &o, k, 0, '\0', &j, arg);
+}
+
+double n(double x) {
+  l(x);
+  return x * x; 
+}
+
+void check() {
+  auto grad_n = clad::gradient(n);
+}
+
+// CHECK: void n_grad(double x, double *_d_x)
+// CHECK: l(x);
+// CHECK: *_d_x += 1 * x;
+// CHECK: *_d_x += x * 1;


### PR DESCRIPTION
This PR closes issue #1815. Earlier when differentiating a function containing an empty switch case null_ptr is passed to llvm::dyn_cast<CompoundStmt>, triggering the assertion failure. Fix include to safely handle empty statements. One more bug was that when the user tries to differentiate function with no parameters which leads to segmentation fault. Fix for that includes early return.