### PR TITLE
Add reverse mode support for omp parallel directive

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -480,6 +480,7 @@ namespace clad {
     VisitOMPExecutableDirective(const clang::OMPExecutableDirective* D);
     StmtDiff
     VisitOMPParallelForDirective(const clang::OMPParallelForDirective* D);
+    StmtDiff VisitOMPParallelDirective(const clang::OMPParallelDirective* D);
 
     /// Helper function that builds `T* _this = malloc(sifeof(T));`
     /// and `free(_this)`.

--- a/lib/Differentiator/ReverseModeVisitorOpenMP.cpp
+++ b/lib/Differentiator/ReverseModeVisitorOpenMP.cpp
@@ -507,8 +507,8 @@ StmtDiff ReverseModeVisitor::VisitOMPExecutableDirective(
     llvm::SaveAndRestore<bool> SaveisInsideOMPBlock(isInsideOMPBlock);
     isInsideOMPBlock = true;
 
-    CLAD_COMPAT_CLANG19_SemaOpenMP(m_Sema).ActOnOpenMPRegionStart(OMPD_parallel,
-                                                                  nullptr);
+    CLAD_COMPAT_CLANG19_SemaOpenMP(m_Sema).ActOnOpenMPRegionStart(
+        OMPD_parallel, getCurrentScope());
     StmtDiff BodyDiff;
     {
       Sema::CompoundScopeRAII CompoundScope(m_Sema);
@@ -523,8 +523,8 @@ StmtDiff ReverseModeVisitor::VisitOMPExecutableDirective(
                         .ActOnOpenMPRegionEnd(BodyDiff.getStmt(), OrigClauses)
                         .get();
 
-    CLAD_COMPAT_CLANG19_SemaOpenMP(m_Sema).ActOnOpenMPRegionStart(OMPD_parallel,
-                                                                  nullptr);
+    CLAD_COMPAT_CLANG19_SemaOpenMP(m_Sema).ActOnOpenMPRegionStart(
+        OMPD_parallel, getCurrentScope());
     // Visit twice, but use only the result of the first visit, for capture
     // variables only.
     {
@@ -535,7 +535,8 @@ StmtDiff ReverseModeVisitor::VisitOMPExecutableDirective(
         const auto* FS = cast<ForStmt>(CS);
         DifferentiateCanonicalLoop(FS);
       } else {
-        Visit(CS);
+        StmtDiff SecondDiff = Visit(CS);
+        BodyDiff = {BodyDiff.getStmt(), SecondDiff.getStmt_dx()};
       }
       m_Globals.swap(temp);
     }
@@ -559,6 +560,15 @@ StmtDiff ReverseModeVisitor::VisitOMPExecutableDirective(
                                               AssociatedSDiff.getStmt_dx(),
                                               D->getBeginLoc(), D->getEndLoc())
               .get()};
+}
+StmtDiff
+ReverseModeVisitor::VisitOMPParallelDirective(const OMPParallelDirective* D) {
+  DeclarationNameInfo DirName;
+  CLAD_COMPAT_CLANG19_SemaOpenMP(m_Sema).StartOpenMPDSABlock(
+      OMPD_parallel, DirName, nullptr, D->getBeginLoc());
+  StmtDiff SDiff = VisitOMPExecutableDirective(D);
+  CLAD_COMPAT_CLANG19_SemaOpenMP(m_Sema).EndOpenMPDSABlock(SDiff.getStmt());
+  return SDiff;
 }
 StmtDiff ReverseModeVisitor::VisitOMPParallelForDirective(
     const OMPParallelForDirective* D) {

--- a/test/Gradient/OpenMP.C
+++ b/test/Gradient/OpenMP.C
@@ -816,6 +816,33 @@ double fn20(const double* x, int n) {
 // CHECK-NEXT:          }
 // CHECK-NEXT:  }
 
+double fn21(const double *x, int n) {
+    double result = 0;
+    #pragma omp parallel reduction(+:result)
+    {
+        result += x[0] * x[0];
+    }
+    return result;
+}
+
+// CHECK:  void fn21_grad(const double *x, int n, double *_d_x, int *_d_n) {
+// CHECK-NEXT:      double _d_result = 0.;
+// CHECK-NEXT:      double result = 0;
+// CHECK-NEXT:      #pragma omp parallel reduction(+: result)
+// CHECK-NEXT:          {
+// CHECK-NEXT:              result += x[0] * x[0];
+// CHECK-NEXT:          }
+// CHECK-NEXT:      _d_result += 1;
+// CHECK-NEXT:      #pragma omp parallel private(result) firstprivate(_d_result)
+// CHECK-NEXT:          {
+// CHECK-NEXT:              {
+// CHECK-NEXT:                  double _r_d1 = _d_result;
+// CHECK-NEXT:                  _d_x[0] += _r_d1 * x[0];
+// CHECK-NEXT:                  _d_x[0] += x[0] * _r_d1;
+// CHECK-NEXT:              }
+// CHECK-NEXT:          }
+// CHECK-NEXT:  }
+
 template <size_t N>
 void reset(double (&arr)[N], double val = 0) {
   for (size_t i = 0; i < N; ++i)
@@ -924,5 +951,11 @@ int main() {
   auto fn20_grad = clad::gradient(fn20);
   fn20_grad.execute(x, 4, dx, &dn);
   printf("{%.2f, %.2f, %.2f, %.2f}\n", dx[0], dx[1], dx[2], dx[3]); // CHECK-EXEC: {4.00, 6.00, 8.00, 10.00}
+
+  omp_set_num_threads(2);
+  reset(dx);
+  auto fn21_grad = clad::gradient(fn21);
+  fn21_grad.execute(x, 4, dx, &dn);
+  printf("{%.2f}\n", dx[0]); // CHECK-EXEC: {8.00}
   return 0;
 }


### PR DESCRIPTION
Adds reverse mode support for #pragma omp parallel directive. Forward mode already had support for VisitOMPParallelDirective from #1491 but reverse mode didn't, so standalone #pragma omp parallel blocks couldn't be differentiated. 
Added tests.