### PR TITLE
Add reverse-mode support for CUDA shared memory attributes

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivativesCUDA.cuh
+++ b/include/clad/Differentiator/BuiltinDerivativesCUDA.cuh
@@ -2,6 +2,11 @@
 
 namespace clad {
 
+__device__ inline unsigned int get_dynamic_smem_size() {
+  unsigned int smem_size;
+  asm volatile("mov.u32 %0, %%dynamic_smem_size;" : "=r"(smem_size));
+  return smem_size;
+}
 namespace custom_derivatives {
 
 __device__ inline void __expf_pullback(float a, float d_y, float* d_a) {

--- a/include/clad/Differentiator/BuiltinDerivativesCUDA.cuh
+++ b/include/clad/Differentiator/BuiltinDerivativesCUDA.cuh
@@ -5,6 +5,17 @@
 
 namespace clad {
 
+__device__ inline unsigned int get_dynamic_smem_size() {
+  unsigned int smem_size;
+  asm volatile("mov.u32 %0, %%dynamic_smem_size;" : "=r"(smem_size));
+  return smem_size;
+}
+
+template <typename T> __device__ inline void clear_dynamic_smem(T* ptr) {
+  unsigned int num_elements = (get_dynamic_smem_size() / 2) / sizeof(T);
+  for (unsigned int i = threadIdx.x; i < num_elements; i += blockDim.x)
+    ptr[i] = 0;
+}
 namespace custom_derivatives {
 
 __device__ inline void __expf_pullback(float a, float d_y, float* d_a) {

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -802,6 +802,10 @@ namespace clad {
 
     /// A flag indicating if the Stmt is contained in a checkpointed loop.
     bool m_IsInsideCheckpointedLoop = false;
+    void HandleCUDASharedMemoryDecl(
+        const clang::VarDecl* VD, clang::VarDecl* VDForward,
+        clang::VarDecl* VDDerived,
+        llvm::SmallVectorImpl<clang::Stmt*>& memsetCalls);
   };
 } // end namespace clad
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -918,6 +918,10 @@ namespace clad {
 
     /// A flag indicating if the Stmt is contained in a checkpointed loop.
     bool m_IsInsideCheckpointedLoop = false;
+    void HandleCUDASharedMemoryDecl(
+        const clang::VarDecl* VD, clang::VarDecl* VDForward,
+        clang::VarDecl* VDDerived,
+        llvm::SmallVectorImpl<clang::Stmt*>& memsetCalls);
   };
 } // end namespace clad
 

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -378,7 +378,8 @@ namespace clad {
                                        clang::Expr* Init = nullptr,
                                        bool DirectInit = false,
                                        clang::TypeSourceInfo* TSI = nullptr,
-                                       clang::StorageClass SC = clang::SC_None);
+                                       clang::StorageClass SC = clang::SC_None,
+                                       const clang::VarDecl* OrigVD = nullptr);
     /// Creates a namespace declaration and enters its context. All subsequent
     /// Stmts are built inside that namespace, until
     /// m_Sema.PopDeclContextIsUsed.

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -651,7 +651,8 @@ namespace clad {
                                        clang::Expr* Init = nullptr,
                                        bool DirectInit = false,
                                        clang::TypeSourceInfo* TSI = nullptr,
-                                       clang::StorageClass SC = clang::SC_None);
+                                       clang::StorageClass SC = clang::SC_None,
+                                       const clang::VarDecl* OrigVD = nullptr);
     /// Creates a namespace declaration and enters its context. All subsequent
     /// Stmts are built inside that namespace, until
     /// m_Sema.PopDeclContextIsUsed.

--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -65,6 +65,7 @@ llvm_add_library(cladDifferentiator
   PushForwardModeVisitor.cpp
   ReverseModeForwPassVisitor.cpp
   ReverseModeVisitor.cpp
+  ReverseModeVisitorCUDA.cpp
   ReverseModeVisitorOpenMP.cpp
   TBRAnalyzer.cpp
   Timers.cpp

--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -60,6 +60,7 @@ llvm_add_library(cladDifferentiator
   PushForwardModeVisitor.cpp
   ReverseModeForwPassVisitor.cpp
   ReverseModeVisitor.cpp
+  ReverseModeVisitorCUDA.cpp
   ReverseModeVisitorEnzyme.cpp
   ReverseModeVisitorOpenMP.cpp
   TBRAnalyzer.cpp

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -151,6 +151,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     if (!m_Context.getLangOpts().CUDA)
       return false;
     if (const auto* DRE = dyn_cast<DeclRefExpr>(E)) {
+      if (const auto* VD = dyn_cast<VarDecl>(DRE->getDecl())) {
+        if (VD->hasAttr<clang::CUDASharedAttr>())
+          return true;
+      }
       if (const auto* PVD = dyn_cast<ParmVarDecl>(DRE->getDecl())) {
         if (m_DiffReq->hasAttr<clang::CUDAGlobalAttr>())
           // Check whether this param is in the global memory of the GPU
@@ -168,6 +172,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     } else if (const auto* ASE = dyn_cast<ArraySubscriptExpr>(E)) {
       const auto* base =
           dyn_cast<DeclRefExpr>(ASE->getBase()->IgnoreImpCasts());
+      if (const auto* VD = dyn_cast<VarDecl>(base->getDecl())) {
+        if (VD->hasAttr<clang::CUDASharedAttr>()) {
+          const auto* idx = ASE->getIdx();
+          return !clad::utils::isInjective(idx, m_DiffReq.m_AnalysisDC);
+        }
+      }
       if (const auto* PVD = dyn_cast<ParmVarDecl>(base->getDecl())) {
         const auto* idx = ASE->getIdx();
         if (m_DiffReq->hasAttr<clang::CUDAGlobalAttr>())
@@ -314,8 +324,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     DeclarationNameInfo DNI = utils::BuildDeclarationNameInfo(m_Sema, name);
     DeclWithContext result = m_Builder.cloneFunction(m_DiffReq.Function, *this,
                                                      DC, loc, DNI, dFnType);
+
     m_Derivative = result.first;
 
+    if (m_DiffReq.Function->hasAttr<clang::CUDAGlobalAttr>()) {
+      auto* GlobalAtt = clang::CUDAGlobalAttr::CreateImplicit(m_Context);
+      GlobalAtt->setImplicit(false);
+      m_Derivative->addAttr(GlobalAtt);
+    }
     // Function declaration scope
     beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
                Scope::DeclScope);
@@ -1958,6 +1974,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // simplest way to support begin/end functions of the former and not deal
     // with the type mismatch.
     std::string FDName = FD->getNameAsString();
+    if (FDName == "__syncthreads") {
+      addToCurrentBlock(Clone(CE), direction::reverse);
+      return StmtDiff(Clone(CE), nullptr);
+    }
     if (FDName == "begin" || FDName == "end") {
       const Expr* arg = nullptr;
       if (const auto* MCE = dyn_cast<CXXMemberCallExpr>(CE))
@@ -3052,9 +3072,20 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         dummyInit = m_Sema.ActOnInitList(noLoc, args, noLoc).get();
       }
     }
+    bool isDynamicSharedMem =
+        VD->hasAttr<CUDASharedAttr>() && VD->getType()->isIncompleteArrayType();
+
+    if (isDynamicSharedMem) {
+      QualType ElemTy = cast<IncompleteArrayType>(VD->getType().getTypePtr())
+                            ->getElementType();
+      VDDerivedType = m_Context.getPointerType(ElemTy);
+      dummyInit = nullptr; // Now perfectly in scope!
+    }
 
     StorageClass SC = isInsideOMPBlock ? SC_Static : SC_None;
 
+    if (VD->getStorageClass() == clang::SC_Extern)
+      SC = clang::SC_Extern;
     // Build the adjoint VarDecl
     VarDecl* VDDerived = nullptr;
     if (m_DiffReq.shouldHaveAdjoint(VD) &&
@@ -3062,8 +3093,20 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       if (!isLambdaDS) {
         llvm::StringRef Name = VD->getName();
         std::string CleanName = Name.ltrim('_').str();
-        VDDerived = BuildGlobalVarDecl(VDDerivedType, "_d_" + CleanName,
-                                       dummyInit, false, nullptr, SC);
+        if (isDynamicSharedMem) {
+          QualType ElemTy =
+              cast<IncompleteArrayType>(VD->getType().getTypePtr())
+                  ->getElementType();
+          QualType PointerTy = m_Context.getPointerType(ElemTy);
+          VDDerived = BuildGlobalVarDecl(PointerTy, "_d_" + CleanName,
+                                         /* dummyInit = */ nullptr, false,
+                                         nullptr, SC_None);
+        } else {
+          VDDerived = BuildGlobalVarDecl(VDDerivedType, "_d_" + CleanName,
+                                         dummyInit, false, nullptr, SC);
+        }
+        if (!isDynamicSharedMem && VD->hasAttr<clang::CUDASharedAttr>())
+          VDDerived->setInit(nullptr);
       }
     }
 
@@ -3160,18 +3203,52 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                                  initDiff.getExpr(), VD->isDirectInit(),
                                  VDCloneTSI, SC);
 
+    if (isDynamicSharedMem && VDDerived) {
+
+      llvm::SmallVector<Expr*, 0> args;
+      Expr* sizeCall = GetFunctionCall("get_dynamic_smem_size", "clad", args);
+
+      Expr* two = ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context,
+                                                    /*val=*/2);
+      Expr* halfSize = BuildOp(BO_Div, sizeCall, two);
+
+      Expr* primalRef = BuildDeclRef(VDClone);
+      QualType charPtrTy = m_Context.getPointerType(m_Context.CharTy);
+      Expr* castPrimal =
+          m_Sema
+              .BuildCStyleCastExpr(
+                  noLoc, m_Context.getTrivialTypeSourceInfo(charPtrTy), noLoc,
+                  primalRef)
+              .get();
+
+      Expr* byteOffsetPtr = BuildOp(BO_Add, castPrimal, halfSize);
+      Expr* parenOffsetPtr = BuildParens(byteOffsetPtr);
+      Expr* finalInit =
+          m_Sema
+              .BuildCStyleCastExpr(
+                  noLoc, m_Context.getTrivialTypeSourceInfo(VDDerivedType),
+                  noLoc, parenOffsetPtr)
+              .get();
+
+      initDiff.updateStmtDx(finalInit);
+    }
+
     // The choice of isDirectInit is mostly stylistic.
     bool isRealConstArray = false;
     if (const auto* arrType = dyn_cast<ConstantArrayType>(VDType))
       isRealConstArray = arrType->getElementType()->isRealType();
     bool isDirectInit = VD->isDirectInit() && (!RD || isNonAggrClass);
-    if (VDDerivedType->isBuiltinType() || !VD->getInit() || isRealConstArray) {
+    if (!isDynamicSharedMem && (VDDerivedType->isBuiltinType() ||
+                                !VD->getInit() || isRealConstArray)) {
       initDiff.updateStmtDx(getZeroInit(VDType));
       isDirectInit = false;
     } else if (Expr* size = getStdInitListSizeExpr(VD->getInit())) {
       initDiff.updateStmtDx(Clone(size));
       isConstructInit = true;
     }
+
+    if (!isDynamicSharedMem && VD->hasAttr<clang::CUDASharedAttr>())
+      initDiff.updateStmtDx(nullptr);
 
     // Update the initializer
     if (VDDerived)
@@ -3337,10 +3414,17 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           else {
             VarDecl* VDDerived = VDDiff.getDecl_dx();
             declsDiff.push_back(VDDerived);
-            if (Stmt* memsetCall = CheckAndBuildCallToMemset(
-                    BuildDeclRef(VDDerived),
-                    VDDerived->getInit()->IgnoreCasts()))
-              memsetCalls.push_back(memsetCall);
+            if (VDDerived->getInit() &&
+                !(VD->hasAttr<clang::CUDASharedAttr>() &&
+                  VD->getType()->isIncompleteArrayType())) {
+              if (Stmt* memsetCall = CheckAndBuildCallToMemset(
+                      BuildDeclRef(VDDerived),
+                      VDDerived->getInit()->IgnoreCasts()))
+                memsetCalls.push_back(memsetCall);
+            } else if (VD->hasAttr<clang::CUDASharedAttr>()) {
+              auto* VDForward = cast<clang::VarDecl>(decls.back());
+              HandleCUDASharedMemoryDecl(VD, VDForward, VDDerived, memsetCalls);
+            }
           }
         }
       } else if (auto* SAD = dyn_cast<StaticAssertDecl>(D)) {

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -155,6 +155,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     if (!m_Context.getLangOpts().CUDA)
       return false;
     if (const auto* DRE = dyn_cast<DeclRefExpr>(E)) {
+      if (const auto* VD = dyn_cast<VarDecl>(DRE->getDecl())) {
+        if (VD->hasAttr<clang::CUDASharedAttr>())
+          return true;
+      }
       if (const auto* PVD = dyn_cast<ParmVarDecl>(DRE->getDecl())) {
         if (m_DiffReq->hasAttr<clang::CUDAGlobalAttr>())
           // Check whether this param is in the global memory of the GPU
@@ -172,6 +176,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     } else if (const auto* ASE = dyn_cast<ArraySubscriptExpr>(E)) {
       const auto* base =
           dyn_cast<DeclRefExpr>(ASE->getBase()->IgnoreImpCasts());
+      if (const auto* VD = dyn_cast<VarDecl>(base->getDecl())) {
+        if (VD->hasAttr<clang::CUDASharedAttr>()) {
+          const auto* idx = ASE->getIdx();
+          return !clad::utils::isInjective(idx, m_DiffReq.m_AnalysisDC);
+        }
+      }
       if (const auto* PVD = dyn_cast<ParmVarDecl>(base->getDecl())) {
         const auto* idx = ASE->getIdx();
         if (m_DiffReq->hasAttr<clang::CUDAGlobalAttr>())
@@ -324,6 +334,11 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                                                     DC, loc, DNI, dFnType);
     m_Derivative = result.fd;
 
+    if (m_DiffReq.Function->hasAttr<clang::CUDAGlobalAttr>()) {
+      auto* GlobalAtt = clang::CUDAGlobalAttr::CreateImplicit(m_Context);
+      GlobalAtt->setImplicit(false);
+      m_Derivative->addAttr(GlobalAtt);
+    }
     // Function declaration scope
     beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
                Scope::DeclScope);
@@ -2053,6 +2068,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // simplest way to support begin/end functions of the former and not deal
     // with the type mismatch.
     std::string FDName = FD->getNameAsString();
+    if (FDName == "__syncthreads") {
+      addToCurrentBlock(Clone(CE), direction::reverse);
+      return StmtDiff(Clone(CE), nullptr);
+    }
     if (FDName == "begin" || FDName == "end") {
       const Expr* arg = nullptr;
       if (const auto* MCE = dyn_cast<CXXMemberCallExpr>(CE))
@@ -3560,9 +3579,19 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         dummyInit = BuildInitList(args);
       }
     }
+    bool isDynamicSharedMem =
+        VD->hasAttr<CUDASharedAttr>() && VD->getType()->isIncompleteArrayType();
+
+    if (isDynamicSharedMem) {
+      QualType ElemTy = cast<IncompleteArrayType>(VD->getType().getTypePtr())
+                            ->getElementType();
+      VDDerivedType = m_Context.getPointerType(ElemTy);
+      dummyInit = nullptr; // Now perfectly in scope!
+    }
 
     StorageClass SC = isInsideOMPBlock ? SC_Static : SC_None;
-
+    if (VD->getStorageClass() == clang::SC_Extern)
+      SC = clang::SC_Extern;
     // Build the adjoint VarDecl
     VarDecl* VDDerived = nullptr;
     if (m_DiffReq.shouldHaveAdjoint(VD) &&
@@ -3570,8 +3599,20 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       if (!isLambdaDS) {
         llvm::StringRef Name = VD->getName();
         std::string CleanName = Name.ltrim('_').str();
-        VDDerived = BuildGlobalVarDecl(VDDerivedType, "_d_" + CleanName,
-                                       dummyInit, false, nullptr, SC);
+        if (isDynamicSharedMem) {
+          QualType ElemTy =
+              cast<IncompleteArrayType>(VD->getType().getTypePtr())
+                  ->getElementType();
+          QualType PointerTy = m_Context.getPointerType(ElemTy);
+          VDDerived = BuildGlobalVarDecl(PointerTy, "_d_" + CleanName,
+                                         /* dummyInit = */ nullptr, false,
+                                         nullptr, SC_None);
+        } else {
+          VDDerived = BuildGlobalVarDecl(VDDerivedType, "_d_" + CleanName,
+                                         dummyInit, false, nullptr, SC);
+        }
+        if (!isDynamicSharedMem && VD->hasAttr<clang::CUDASharedAttr>())
+          VDDerived->setInit(nullptr);
       }
     }
 
@@ -3674,13 +3715,47 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     VDClone = BuildGlobalVarDecl(VDCloneType, VD->getNameAsString(),
                                  initDiff.getExpr(), VD->isDirectInit(),
                                  VDCloneTSI, SC);
+    if (isDynamicSharedMem && VDDerived) {
+
+      llvm::SmallVector<Expr*, 0> args;
+      Expr* sizeCall = GetFunctionCall("get_dynamic_smem_size", "clad", args);
+
+      // For dynamic shared memory (extern __shared__ T arr[]), the size is not
+      // known at compile time. The caller must allocate 2x the normal shared
+      // memory size during the kernel launch. The lower half of this memory
+      // is used by the primal array, and the upper half is used by the adjoint.
+      Expr* two = ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context,
+                                                    /*val=*/2);
+      Expr* halfSize = BuildOp(BO_Div, sizeCall, two);
+
+      Expr* primalRef = BuildDeclRef(VDClone);
+      QualType charPtrTy = m_Context.getPointerType(m_Context.CharTy);
+      Expr* castPrimal =
+          m_Sema
+              .BuildCStyleCastExpr(
+                  noLoc, m_Context.getTrivialTypeSourceInfo(charPtrTy), noLoc,
+                  primalRef)
+              .get();
+
+      Expr* byteOffsetPtr = BuildOp(BO_Add, castPrimal, halfSize);
+      Expr* parenOffsetPtr = BuildParens(byteOffsetPtr);
+      Expr* finalInit =
+          m_Sema
+              .BuildCStyleCastExpr(
+                  noLoc, m_Context.getTrivialTypeSourceInfo(VDDerivedType),
+                  noLoc, parenOffsetPtr)
+              .get();
+
+      initDiff.updateStmtDx(finalInit);
+    }
 
     // The choice of isDirectInit is mostly stylistic.
     bool isRealConstArray = false;
     if (const auto* arrType = dyn_cast<ConstantArrayType>(VDType))
       isRealConstArray = arrType->getElementType()->isRealType();
     bool isDirectInit = VD->isDirectInit() && (!RD || isNonAggrClass);
-    if (VDDerivedType->isBuiltinType() || !VD->getInit() || isRealConstArray) {
+    if (!isDynamicSharedMem && (VDDerivedType->isBuiltinType() ||
+                                !VD->getInit() || isRealConstArray)) {
       initDiff.updateStmtDx(getZeroInit(VDType));
       isDirectInit = false;
     } else if (Expr* size = getStdInitListSizeExpr(VD->getInit())) {
@@ -3688,6 +3763,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       isConstructInit = true;
     }
 
+    if (!isDynamicSharedMem && VD->hasAttr<clang::CUDASharedAttr>())
+      initDiff.updateStmtDx(nullptr);
     // Update the initializer
     if (VDDerived)
       SetDeclInit(VDDerived, initDiff.getExpr_dx(), isDirectInit);
@@ -3813,21 +3890,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
         VDDiff = DifferentiateVarDecl(VD);
 
-        // Here, we move the declaration to the function global scope.
-        // Initialization is replaced with an assignment operation at the same
-        // place as the original declaration. This procedure is done to make the
-        // declaration visible in the reverse sweep. The variable is stored
-        // before the assignment in case its value is overwritten in a loop.
-        // e.g.
-        // while (cond) {
-        //   double x = k * n;
-        // ...
-        // ->
-        // double x;
-        // clad::tape<double> _t0 = {};
-        // while (cond) {
-        //   clad::push(_t0, x), x = k * n;
-        // ...
         if (promoteToFnScope) {
           auto* decl = VDDiff.getDecl();
           if (VD->getInit()) {
@@ -3854,9 +3916,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
               }
             }
             inits.push_back(assignment);
-            // Same care as for the adjoint in DifferentiateVarDecl: the
-            // reverse sweep reads this clone (a promoted reference is spelled
-            // as a pointer too) on a path taken before the assignment above.
             Expr* placeholder =
                 BuildDereferenceablePlaceholder(decl->getType(), m_Globals);
             SetDeclInit(decl,
@@ -3873,15 +3932,20 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           else {
             VarDecl* VDDerived = VDDiff.getDecl_dx();
             declsDiff.push_back(VDDerived);
-            if (Stmt* memsetCall = CheckAndBuildCallToMemset(
-                    BuildDeclRef(VDDerived),
-                    VDDerived->getInit()->IgnoreCasts()))
-              memsetCalls.push_back(memsetCall);
+            if (VDDerived->getInit() &&
+                !(VD->hasAttr<clang::CUDASharedAttr>() &&
+                  VD->getType()->isIncompleteArrayType())) {
+              if (Stmt* memsetCall = CheckAndBuildCallToMemset(
+                      BuildDeclRef(VDDerived),
+                      VDDerived->getInit()->IgnoreCasts()))
+                memsetCalls.push_back(memsetCall);
+            } else if (VD->hasAttr<clang::CUDASharedAttr>()) {
+              auto* VDForward = cast<clang::VarDecl>(decls.back());
+              HandleCUDASharedMemoryDecl(VD, VDForward, VDDerived, memsetCalls);
+            }
             // Track this pointer's allocation size in bytes so an in-place
-            // realloc of it can be undone in the reverse sweep. The shadow is
-            // recorded on the pointer's adjoint entry, keyed like every other
-            // m_Variables record by the primal clone.
-            if (m_DiffReq.isInPlaceReallocated(VD))
+            // realloc of it can be undone in the reverse sweep.
+            if (m_DiffReq.isInPlaceReallocated(VD)) {
               if (Expr* bytes = buildAllocByteSize(VDDerived->getInit())) {
                 VarDecl* sizeVar = BuildVarDecl(
                     m_Context.getSizeType(),
@@ -3889,6 +3953,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                 memsetCalls.push_back(BuildDeclStmt(sizeVar));
                 m_Variables[VDDiff.getDecl()].AllocSize = sizeVar;
               }
+            }
           }
         }
       } else if (auto* SAD = dyn_cast<StaticAssertDecl>(D)) {
@@ -3905,18 +3970,29 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     Stmt* DSClone = nullptr;
     if (!decls.empty())
       DSClone = BuildDeclStmt(decls);
+
+    // For dynamic CUDA shared memory, the adjoint pointer's initialization
+    // relies on the primal array's address (e.g., `_d_sharedMem = sharedMem +
+    // offset`). Therefore, the primal variable must be emitted into the AST
+    // before the adjoint. Reordering them here prevents a
+    // use-before-declaration violation in the ASTIntegrity pass.
+    bool hasCUDAShared = false;
+    for (Decl* decl : decls)
+      if (decl->hasAttr<clang::CUDASharedAttr>())
+        hasCUDAShared = true;
+    if (hasCUDAShared && DSClone && !declsDiff.empty()) {
+      addToCurrentBlock(DSClone, direction::forward);
+      DSClone = nullptr;
+    }
+
     if (!declsDiff.empty()) {
       Stmt* DSDiff = BuildDeclStmt(declsDiff);
       Stmts& block =
           promoteToFnScope ? m_Globals : getCurrentBlock(direction::forward);
       addToBlock(DSDiff, block);
-      if (isInsideOMPBlock) {
-        for (auto* declDiff : declsDiff) {
-          // If we are inside an OpenMP parallel region, mark the decl as
-          // threadprivate
+      if (isInsideOMPBlock)
+        for (auto* declDiff : declsDiff)
           MarkDeclThreadPrivate(cast<VarDecl>(declDiff));
-        }
-      }
       for (Stmt* memset : memsetCalls)
         addToBlock(memset, block);
     }
@@ -3924,23 +4000,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // This part in necessary to replace local variables inside loops
     // with function globals and replace initializations with assignments.
     if (promoteToFnScope) {
-      // FIXME: We only need to produce separate decl stmts
-      // because arrays promoted to the function scope are
-      // turned into clad::array. This is done because of
-      // mixed declarations.
-      // e.g.
-      // double a, b[5];
-      // ->
-      // double a, b(5UL);
-      // when it should be
-      // double a;
-      // clad::array<double> b(5UL);
-      // If we remove the need for clad::array here,
-      // just add DSClone to the block.
       for (Decl* decl : decls) {
         addToBlock(BuildDeclStmt(decl), m_Globals);
-        // If we are inside an OpenMP parallel region, mark the decl as
-        // threadprivate
         if (isInsideOMPBlock)
           MarkDeclThreadPrivate(cast<VarDecl>(decl));
       }
@@ -3967,21 +4028,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             SetDeclInit(vDecl, getZeroInit(vDecl->getType()),
                         /*DirectInit=*/true);
           }
-          // if (const auto* CE =
-          //         dyn_cast<CXXConstructExpr>(init->IgnoreImplicit())) {
-          //   copyInit = CE && CE->getNumArgs() == 0;
-          //   if (!copyInit && CE) {
-          //     if (const auto* DRE =
-          //             dyn_cast<DeclRefExpr>(CE->getArg(0)->IgnoreImplicit()))
-          //             {
-          //       llvm::StringRef OrigName =
-          //           cast<VarDecl>(DRE->getDecl())->getName();
-          //       std::string CleanName = "_d_" + OrigName.ltrim('_').str();
-          //       if (cast<VarDecl>(decl)->getNameAsString() == CleanName)
-          //         copyInit = true;
-          //     }
-          //   }
-          // }
         }
         if (const auto* VAT =
                 dyn_cast<VariableArrayType>(cast<VarDecl>(decl)->getType())) {

--- a/lib/Differentiator/ReverseModeVisitorCUDA.cpp
+++ b/lib/Differentiator/ReverseModeVisitorCUDA.cpp
@@ -1,0 +1,46 @@
+#include "ConstantFolder.h"
+#include "clad/Differentiator/ReverseModeVisitor.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/Decl.h"
+
+using namespace clang;
+
+namespace clad {
+
+static void CloneCUDASharedAttr(const clang::VarDecl* OriginalVD,
+                                clang::VarDecl* VDClone) {
+  if (const auto* attr = OriginalVD->getAttr<clang::CUDASharedAttr>())
+    VDClone->addAttr(attr->clone(OriginalVD->getASTContext()));
+}
+
+void ReverseModeVisitor::HandleCUDASharedMemoryDecl(
+    const clang::VarDecl* VD, clang::VarDecl* VDForward,
+    clang::VarDecl* VDDerived,
+    llvm::SmallVectorImpl<clang::Stmt*>& memsetCalls) {
+
+  bool isDynamicSharedMem = VD->getType()->isIncompleteArrayType();
+
+  if (!isDynamicSharedMem) {
+    CloneCUDASharedAttr(VD, VDDerived);
+    VDDerived->setStorageClass(clang::SC_Static);
+
+    CloneCUDASharedAttr(VD, VDForward);
+    VDForward->setStorageClass(clang::SC_Static);
+
+    llvm::SmallVector<Expr*, 1> args = {BuildDeclRef(VDDerived)};
+    Stmt* initCall = GetCladZeroInit(args);
+    if (initCall)
+      memsetCalls.push_back(initCall);
+  } else {
+    CloneCUDASharedAttr(VD, VDForward);
+    Expr* derivedRef = BuildDeclRef(VDDerived);
+    Expr* zeroIdx =
+        ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, 0);
+    Expr* arraySub = BuildArraySubscript(derivedRef, {zeroIdx});
+    QualType elemType = VDDerived->getType()->getPointeeType();
+    Expr* assignZero = BuildOp(BO_Assign, arraySub, getZeroInit(elemType));
+    memsetCalls.push_back(assignZero);
+  }
+}
+} // namespace clad

--- a/lib/Differentiator/ReverseModeVisitorCUDA.cpp
+++ b/lib/Differentiator/ReverseModeVisitorCUDA.cpp
@@ -1,0 +1,51 @@
+#include "ConstantFolder.h"
+#include "clad/Differentiator/ReverseModeVisitor.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/Decl.h"
+
+using namespace clang;
+
+namespace clad {
+
+static void CloneCUDASharedAttr(const clang::VarDecl* OriginalVD,
+                                clang::VarDecl* VDClone) {
+  if (const auto* attr = OriginalVD->getAttr<clang::CUDASharedAttr>())
+    VDClone->addAttr(attr->clone(OriginalVD->getASTContext()));
+}
+
+void ReverseModeVisitor::HandleCUDASharedMemoryDecl(
+    const clang::VarDecl* VD, clang::VarDecl* VDForward,
+    clang::VarDecl* VDDerived,
+    llvm::SmallVectorImpl<clang::Stmt*>& memsetCalls) {
+
+  bool isDynamicSharedMem = VD->getType()->isIncompleteArrayType();
+
+  if (!isDynamicSharedMem) {
+    CloneCUDASharedAttr(VD, VDDerived);
+    VDDerived->setStorageClass(clang::SC_Static);
+
+    CloneCUDASharedAttr(VD, VDForward);
+    VDForward->setStorageClass(clang::SC_Static);
+
+    llvm::SmallVector<Expr*, 1> args = {BuildDeclRef(VDDerived)};
+    Stmt* initCall = GetCladZeroInit(args);
+    if (initCall)
+      memsetCalls.push_back(initCall);
+  } else {
+    CloneCUDASharedAttr(VD, VDForward);
+    Expr* derivedRef = BuildDeclRef(VDDerived);
+    llvm::SmallVector<Expr*, 1> args = {derivedRef};
+    Stmt* clearCall = GetFunctionCall("clear_dynamic_smem", "clad", args);
+    memsetCalls.push_back(clearCall);
+  }
+
+  // A barrier is strictly required here to prevent race conditions.
+  // Since zero-initialization is performed by threads in the block, we must
+  // ensure all threads finish zeroing the shared memory before any thread
+  // proceeds to the reverse sweep and starts accumulating into it.
+  llvm::SmallVector<Expr*, 0> syncArgs;
+  Stmt* syncCall = GetFunctionCall("__syncthreads", "", syncArgs);
+  memsetCalls.push_back(syncCall);
+}
+} // namespace clad

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -180,9 +180,15 @@ namespace clad {
   VarDecl* VisitorBase::BuildGlobalVarDecl(QualType Type,
                                            llvm::StringRef prefix, Expr* Init,
                                            bool DirectInit, TypeSourceInfo* TSI,
-                                           StorageClass SC) {
-    return BuildVarDecl(Type, CreateUniqueIdentifier(prefix),
-                        m_DerivativeFnScope, Init, DirectInit, TSI, SC);
+                                           StorageClass SC,
+                                           const VarDecl* OrigVD) {
+    VarDecl* VD = BuildVarDecl(Type, CreateUniqueIdentifier(prefix),
+                               m_DerivativeFnScope, Init, DirectInit, TSI, SC);
+    if (OrigVD) {
+      if (const auto* attr = OrigVD->getAttr<clang::CUDASharedAttr>())
+        VD->addAttr(attr->clone(OrigVD->getASTContext()));
+    }
+    return VD;
   }
 
   NamespaceDecl* VisitorBase::BuildNamespaceDecl(IdentifierInfo* II,
@@ -1086,4 +1092,4 @@ namespace clad {
     }
   }
 
-} // end namespace clad
+  } // end namespace clad

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -192,9 +192,15 @@ namespace clad {
   VarDecl* VisitorBase::BuildGlobalVarDecl(QualType Type,
                                            llvm::StringRef prefix, Expr* Init,
                                            bool DirectInit, TypeSourceInfo* TSI,
-                                           StorageClass SC) {
-    return BuildVarDecl(Type, CreateUniqueIdentifier(prefix),
-                        m_DerivativeFnScope, Init, DirectInit, TSI, SC);
+                                           StorageClass SC,
+                                           const VarDecl* OrigVD) {
+    VarDecl* VD = BuildVarDecl(Type, CreateUniqueIdentifier(prefix),
+                               m_DerivativeFnScope, Init, DirectInit, TSI, SC);
+    if (OrigVD) {
+      if (const auto* attr = OrigVD->getAttr<clang::CUDASharedAttr>())
+        VD->addAttr(attr->clone(OrigVD->getASTContext()));
+    }
+    return VD;
   }
 
   NamespaceDecl* VisitorBase::BuildNamespaceDecl(IdentifierInfo* II,
@@ -1727,4 +1733,4 @@ namespace clad {
     }
   }
 
-} // end namespace clad
+  } // end namespace clad

--- a/test/CUDA/SharedMem.cu
+++ b/test/CUDA/SharedMem.cu
@@ -1,0 +1,157 @@
+// RUN: %cladclang_cuda -I%S/../../include --cuda-path=%cudapath \
+// RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oReverseModeSharedMem.out \
+// RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
+//
+// RUN: %cudarun ./ReverseModeSharedMem.out | %filecheck_exec %s
+//
+// REQUIRES: cuda-runtime
+//
+// expected-no-diagnostics
+
+#include <iostream>
+#include "clad/Differentiator/Differentiator.h"
+#include <cuda.h>
+
+__global__ void func(int* vec_d, int val) {
+    __shared__ int sharedMem[1];
+    sharedMem[0] = val * 3;
+    __syncthreads();
+    vec_d[0] = sharedMem[0] * 5 + vec_d[0];
+}
+
+// CHECK: void func_grad(int *vec_d, int val, int *_d_vec_d, int *_d_val) {
+// CHECK-NEXT:     static int _d_sharedMem[1] __attribute__((shared));
+// CHECK-NEXT:     clad::zero_init(_d_sharedMem);
+// CHECK-NEXT:     static int sharedMem[1] __attribute__((shared));
+// CHECK-NEXT:     sharedMem[0] = val * 3;
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     vec_d[0] = sharedMem[0] * 5 + vec_d[0];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r_d1 = _d_vec_d[0];
+// CHECK-NEXT:         _d_vec_d[0] = 0;
+// CHECK-NEXT:         atomicAdd(&_d_sharedMem[0], _r_d1 * 5);
+// CHECK-NEXT:         atomicAdd(&_d_vec_d[0], _r_d1);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r_d0 = _d_sharedMem[0];
+// CHECK-NEXT:         _d_sharedMem[0] = 0;
+// CHECK-NEXT:         atomicAdd(_d_val, _r_d0 * 3);
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+__global__ void func1(int* vec1_d, int val1) {
+    extern __shared__ int sharedMem1[];
+    sharedMem1[0] = val1 * 3;
+    __syncthreads();
+    vec1_d[0] = sharedMem1[0] * 5 + vec1_d[0];
+}
+
+// CHECK: void func1_grad(int *vec1_d, int val1, int *_d_vec1_d, int *_d_val1) {
+// CHECK-NEXT:     int *_d_sharedMem1 = (int *)((char *)sharedMem1 + clad::get_dynamic_smem_size() / 2);
+// CHECK-NEXT:     _d_sharedMem1[0] = 0;
+// CHECK-NEXT:     extern int sharedMem1[] __attribute__((shared));
+// CHECK-NEXT:     sharedMem1[0] = val1 * 3;
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     vec1_d[0] = sharedMem1[0] * 5 + vec1_d[0];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r_d1 = _d_vec1_d[0];
+// CHECK-NEXT:         _d_vec1_d[0] = 0;
+// CHECK-NEXT:         _d_sharedMem1[0] += _r_d1 * 5;
+// CHECK-NEXT:         atomicAdd(&_d_vec1_d[0], _r_d1);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r_d0 = _d_sharedMem1[0];
+// CHECK-NEXT:         _d_sharedMem1[0] = 0;
+// CHECK-NEXT:         atomicAdd(_d_val1, _r_d0 * 3);
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+__global__ void scalar_func(int* vec2_d, int val2) {
+    __shared__ int x;
+    x = val2 * 3;
+    __syncthreads();
+    vec2_d[0] = x * 5;
+}
+
+// CHECK: void scalar_func_grad(int *vec2_d, int val2, int *_d_vec2_d, int *_d_val2) {
+// CHECK-NEXT:     static int _d_x __attribute__((shared));
+// CHECK-NEXT:     clad::zero_init(_d_x);
+// CHECK-NEXT:     static int x __attribute__((shared));
+// CHECK-NEXT:     x = val2 * 3;
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     vec2_d[0] = x * 5;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r_d0 = _d_vec2_d[0];
+// CHECK-NEXT:         _d_vec2_d[0] = 0;
+// CHECK-NEXT:         atomicAdd(&_d_x, _r_d0 * 5);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     {
+// CHECK-NEXT:         atomicAdd(_d_val2, _d_x * 3);
+// CHECK-NEXT:         _d_x = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+int main() {
+
+    int *d_vec, *d_vec_adj, *d_val_adj;
+    cudaMalloc(&d_vec, sizeof(int));
+    cudaMalloc(&d_vec_adj, sizeof(int));
+    cudaMalloc(&d_val_adj, sizeof(int));
+
+    int seed = 1, seed1 = 0, grad, grad1;
+
+    cudaMemcpy(d_vec_adj, &seed, sizeof(int), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_val_adj, &seed1, sizeof(int), cudaMemcpyHostToDevice);
+    
+    auto dfunc = clad::gradient(func);
+    dfunc.execute_kernel(dim3(1), dim3(1), d_vec, 90, d_vec_adj, d_val_adj);
+    cudaDeviceSynchronize();
+
+    cudaMemcpy(&grad, d_val_adj, sizeof(int), cudaMemcpyDeviceToHost);
+    cudaMemcpy(&grad1, d_vec_adj, sizeof(int), cudaMemcpyDeviceToHost);
+    
+    std::cout << "Grad dvec/dval: " << grad << std::endl;
+    // CHECK-EXEC: Grad dvec/dval: 15
+    std::cout << "Grad dvec/dvec_d[0]: " << grad1 << std::endl;
+    // CHECK-EXEC-NEXT: Grad dvec/dvec_d[0]: 1
+
+    cudaMemcpy(d_vec_adj, &seed, sizeof(int), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_val_adj, &seed1, sizeof(int), cudaMemcpyHostToDevice);
+
+    auto dfunc1 = clad::gradient(func1);
+    auto* kernel_ptr = dfunc1.getFunctionPtr();
+    kernel_ptr<<<dim3(1), dim3(1), 2 * sizeof(int)>>>(d_vec, 90, d_vec_adj, d_val_adj);
+    cudaDeviceSynchronize();
+
+    cudaMemcpy(&grad, d_val_adj, sizeof(int), cudaMemcpyDeviceToHost);
+    cudaMemcpy(&grad1, d_vec_adj, sizeof(int), cudaMemcpyDeviceToHost);
+    
+    std::cout << "Grad dvec/dval: " << grad << std::endl;
+    // CHECK-EXEC-NEXT: Grad dvec/dval: 15
+    std::cout << "Grad dvec/dvec1_d[0]: " << grad1 << std::endl;
+    // CHECK-EXEC-NEXT: Grad dvec/dvec1_d[0]: 1
+
+    cudaMemcpy(d_vec_adj, &seed, sizeof(int), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_val_adj, &seed1, sizeof(int), cudaMemcpyHostToDevice);
+
+    auto d_scalar = clad::gradient(scalar_func);
+    d_scalar.execute_kernel(dim3(1), dim3(1), d_vec, 9, d_vec_adj, d_val_adj);
+    cudaDeviceSynchronize();
+
+    cudaMemcpy(&grad, d_val_adj, sizeof(int), cudaMemcpyDeviceToHost);
+    cudaMemcpy(&grad1, d_vec_adj, sizeof(int), cudaMemcpyDeviceToHost);
+    
+    std::cout << "Grad dvec/dval: " << grad << std::endl;
+    // CHECK-EXEC-NEXT: Grad dvec/dval: 15
+    std::cout << "Grad dvec/dvec2_d[0]: " << grad1 << std::endl;
+    // CHECK-EXEC-NEXT: Grad dvec/dvec2_d[0]: 0
+
+    cudaFree(d_vec);
+    cudaFree(d_vec_adj);
+    cudaFree(d_val_adj);
+
+    return 0;
+}

--- a/test/CUDA/SharedMem.cu
+++ b/test/CUDA/SharedMem.cu
@@ -1,0 +1,160 @@
+// RUN: %cladclang_cuda -I%S/../../include --cuda-path=%cudapath \
+// RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oReverseModeSharedMem.out \
+// RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
+//
+// RUN: %if cuda-runtime %{ %cudarun ./ReverseModeSharedMem.out | %filecheck_exec %s %}
+//
+// REQUIRES: cuda-compile
+//
+// expected-no-diagnostics
+
+#include <iostream>
+#include "clad/Differentiator/Differentiator.h"
+#include <cuda.h>
+
+__global__ void func(int* vec_d, int val) {
+    __shared__ int sharedMem[1];
+    sharedMem[0] = val * 3;
+    __syncthreads();
+    vec_d[0] = sharedMem[0] * 5 + vec_d[0];
+}
+
+// CHECK: void func_grad(int *vec_d, int val, int *_d_vec_d, int *_d_val) {
+// CHECK-NEXT:     static int sharedMem[1] __attribute__((shared));
+// CHECK-NEXT:     static int _d_sharedMem[1] __attribute__((shared));
+// CHECK-NEXT:     clad::zero_init(_d_sharedMem);
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     sharedMem[0] = val * 3;
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     vec_d[0] = sharedMem[0] * 5 + vec_d[0];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r_d1 = _d_vec_d[0];
+// CHECK-NEXT:         _d_vec_d[0] = 0;
+// CHECK-NEXT:         atomicAdd(&_d_sharedMem[0], _r_d1 * 5);
+// CHECK-NEXT:         atomicAdd(&_d_vec_d[0], _r_d1);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r_d0 = _d_sharedMem[0];
+// CHECK-NEXT:         _d_sharedMem[0] = 0;
+// CHECK-NEXT:         atomicAdd(_d_val, _r_d0 * 3);
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+__global__ void func1(int* vec1_d, int val1) {
+    extern __shared__ int sharedMem1[];
+    sharedMem1[0] = val1 * 3;
+    __syncthreads();
+    vec1_d[0] = sharedMem1[0] * 5 + vec1_d[0];
+}
+
+// CHECK: void func1_grad(int *vec1_d, int val1, int *_d_vec1_d, int *_d_val1) {
+// CHECK-NEXT:     extern int sharedMem1[] __attribute__((shared));
+// CHECK-NEXT:     int *_d_sharedMem1 = (int *)((char *)sharedMem1 + clad::get_dynamic_smem_size() / 2);
+// CHECK-NEXT:     clad::clear_dynamic_smem(_d_sharedMem1);
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     sharedMem1[0] = val1 * 3;
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     vec1_d[0] = sharedMem1[0] * 5 + vec1_d[0];
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r_d1 = _d_vec1_d[0];
+// CHECK-NEXT:         _d_vec1_d[0] = 0;
+// CHECK-NEXT:         _d_sharedMem1[0] += _r_d1 * 5;
+// CHECK-NEXT:         atomicAdd(&_d_vec1_d[0], _r_d1);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r_d0 = _d_sharedMem1[0];
+// CHECK-NEXT:         _d_sharedMem1[0] = 0;
+// CHECK-NEXT:         atomicAdd(_d_val1, _r_d0 * 3);
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+__global__ void scalar_func(int* vec2_d, int val2) {
+    __shared__ int x;
+    x = val2 * 3;
+    __syncthreads();
+    vec2_d[0] = x * 5;
+}
+
+// CHECK: void scalar_func_grad(int *vec2_d, int val2, int *_d_vec2_d, int *_d_val2) {
+// CHECK-NEXT:     static int x __attribute__((shared));
+// CHECK-NEXT:     static int _d_x __attribute__((shared));
+// CHECK-NEXT:     clad::zero_init(_d_x);
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     x = val2 * 3;
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     vec2_d[0] = x * 5;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r_d0 = _d_vec2_d[0];
+// CHECK-NEXT:         _d_vec2_d[0] = 0;
+// CHECK-NEXT:         atomicAdd(&_d_x, _r_d0 * 5);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     __syncthreads();
+// CHECK-NEXT:     {
+// CHECK-NEXT:         atomicAdd(_d_val2, _d_x * 3);
+// CHECK-NEXT:         _d_x = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+int main() {
+
+    int *d_vec, *d_vec_adj, *d_val_adj;
+    cudaMalloc(&d_vec, sizeof(int));
+    cudaMalloc(&d_vec_adj, sizeof(int));
+    cudaMalloc(&d_val_adj, sizeof(int));
+
+    int seed = 1, seed1 = 0, grad, grad1;
+
+    cudaMemcpy(d_vec_adj, &seed, sizeof(int), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_val_adj, &seed1, sizeof(int), cudaMemcpyHostToDevice);
+    
+    auto dfunc = clad::gradient(func);
+    dfunc.execute_kernel(dim3(1), dim3(1), d_vec, 90, d_vec_adj, d_val_adj);
+    cudaDeviceSynchronize();
+
+    cudaMemcpy(&grad, d_val_adj, sizeof(int), cudaMemcpyDeviceToHost);
+    cudaMemcpy(&grad1, d_vec_adj, sizeof(int), cudaMemcpyDeviceToHost);
+    
+    std::cout << "Grad dvec/dval: " << grad << std::endl;
+    // CHECK-EXEC: Grad dvec/dval: 15
+    std::cout << "Grad dvec/dvec_d[0]: " << grad1 << std::endl;
+    // CHECK-EXEC-NEXT: Grad dvec/dvec_d[0]: 1
+
+    cudaMemcpy(d_vec_adj, &seed, sizeof(int), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_val_adj, &seed1, sizeof(int), cudaMemcpyHostToDevice);
+
+    auto dfunc1 = clad::gradient(func1);
+    auto* kernel_ptr = dfunc1.getFunctionPtr();
+    kernel_ptr<<<dim3(1), dim3(1), 2 * sizeof(int)>>>(d_vec, 90, d_vec_adj, d_val_adj);
+    cudaDeviceSynchronize();
+
+    cudaMemcpy(&grad, d_val_adj, sizeof(int), cudaMemcpyDeviceToHost);
+    cudaMemcpy(&grad1, d_vec_adj, sizeof(int), cudaMemcpyDeviceToHost);
+    
+    std::cout << "Grad dvec/dval: " << grad << std::endl;
+    // CHECK-EXEC-NEXT: Grad dvec/dval: 15
+    std::cout << "Grad dvec/dvec1_d[0]: " << grad1 << std::endl;
+    // CHECK-EXEC-NEXT: Grad dvec/dvec1_d[0]: 1
+
+    cudaMemcpy(d_vec_adj, &seed, sizeof(int), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_val_adj, &seed1, sizeof(int), cudaMemcpyHostToDevice);
+
+    auto d_scalar = clad::gradient(scalar_func);
+    d_scalar.execute_kernel(dim3(1), dim3(1), d_vec, 9, d_vec_adj, d_val_adj);
+    cudaDeviceSynchronize();
+
+    cudaMemcpy(&grad, d_val_adj, sizeof(int), cudaMemcpyDeviceToHost);
+    cudaMemcpy(&grad1, d_vec_adj, sizeof(int), cudaMemcpyDeviceToHost);
+    
+    std::cout << "Grad dvec/dval: " << grad << std::endl;
+    // CHECK-EXEC-NEXT: Grad dvec/dval: 15
+    std::cout << "Grad dvec/dvec2_d[0]: " << grad1 << std::endl;
+    // CHECK-EXEC-NEXT: Grad dvec/dvec2_d[0]: 0
+
+    cudaFree(d_vec);
+    cudaFree(d_vec_adj);
+    cudaFree(d_val_adj);
+
+    return 0;
+}


### PR DESCRIPTION
This PR enables differentiation of CUDA kernels having `__shared__` attribute. It also enable differentiation support of dynamic shared memory `extern __shared__`.  `__syncthreads` and `atomicAdd` is also enabled during the reverse sweep of the reverse mode to ensure no race condition.