### PR TITLE
Handle member access on call results in reverse mode

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3558,16 +3558,51 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   }
 
   StmtDiff ReverseModeVisitor::VisitMemberExpr(const MemberExpr* ME) {
-    auto baseDiff = Visit(ME->getBase());
+    const Expr* base = ME->getBase();
+    const Expr* unwrappedBase = base->IgnoreParenImpCasts();
+    while (true)
+      if (const auto* MTE = dyn_cast<MaterializeTemporaryExpr>(unwrappedBase))
+        unwrappedBase = MTE->getSubExpr()->IgnoreParenImpCasts();
+      else if (const auto* BTE = dyn_cast<CXXBindTemporaryExpr>(unwrappedBase))
+        unwrappedBase = BTE->getSubExpr()->IgnoreParenImpCasts();
+      else if (const auto* EWC = dyn_cast<ExprWithCleanups>(unwrappedBase))
+        unwrappedBase = EWC->getSubExpr()->IgnoreParenImpCasts();
+      else
+        break;
+
     auto* field = ME->getMemberDecl();
     assert(!isa<CXXMethodDecl>(field) &&
            "CXXMethodDecl nodes not supported yet!");
-    Expr* clonedME = baseDiff.getExpr();
     llvm::StringRef fieldName = field->getName();
-    if (baseDiff.getExpr() && !fieldName.empty())
-      clonedME = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
-                                        baseDiff.getExpr(), fieldName);
-    if (clad::utils::hasNonDifferentiableAttribute(ME)) {
+    bool nonDiffMember = clad::utils::hasNonDifferentiableAttribute(ME);
+
+    if (!nonDiffMember && dfdx() && !base->isLValue() &&
+        base->getType()->isRecordType() && isa<CallExpr>(unwrappedBase) &&
+        !fieldName.empty()) {
+      QualType dBaseTy =
+          utils::getNonConstType(CloneType(base->getType()), m_Sema);
+      VarDecl* dBaseDecl = BuildVarDecl(dBaseTy, "_r", getZeroInit(dBaseTy));
+      addToCurrentBlock(BuildDeclStmt(dBaseDecl), direction::reverse);
+      DeclRefExpr* dBaseRef = BuildDeclRef(dBaseDecl);
+      Expr* derivedME = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                               dBaseRef, fieldName);
+      if (Expr* addAssign = BuildDiffIncrement(derivedME))
+        addToCurrentBlock(addAssign, direction::reverse);
+
+      auto baseDiff = Visit(base, dBaseRef);
+      Expr* clonedME = baseDiff.getExpr();
+      if (clonedME)
+        clonedME = utils::BuildMemberExpr(m_Sema, getCurrentScope(), clonedME,
+                                          fieldName);
+      return {clonedME, derivedME};
+    }
+
+    auto baseDiff = Visit(base);
+    Expr* clonedME = baseDiff.getExpr();
+    if (clonedME && !fieldName.empty())
+      clonedME = utils::BuildMemberExpr(m_Sema, getCurrentScope(), clonedME,
+                                        fieldName);
+    if (nonDiffMember) {
       auto* zero = ConstantFolder::synthesizeLiteral(ME->getType(), m_Context,
                                                      /*val=*/0);
       return {clonedME, zero};

--- a/test/Regressions/issue-1298.cpp
+++ b/test/Regressions/issue-1298.cpp
@@ -1,0 +1,78 @@
+// RUN: %cladclang %s -I%S/../../include -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+struct A {
+  double val;
+};
+
+A objVal(double x) {
+  return {x * x};
+}
+
+double f(double x, double y) {
+  return objVal(x).val;
+}
+
+double g(double x) {
+  return 5.0 * objVal(x).val;
+}
+
+struct B {
+  double val;
+  ~B() {}
+};
+
+B makeB(double x) {
+  return {x * x};
+}
+
+double h(double x) {
+  return makeB(x).val;
+}
+
+// CHECK: void objVal_pullback(double x, A _d_y, double *_d_x)
+// CHECK: void f_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK:   A _r{{[0-9]+}} =
+// CHECK:   _r{{[0-9]+}}.val +=
+// CHECK:   objVal_pullback(x,
+// CHECK:   *_d_x +=
+// CHECK: }
+
+// CHECK: void g_grad(double x, double *_d_x) {
+// CHECK:   A _r{{[0-9]+}} =
+// CHECK:   _r{{[0-9]+}}.val +=
+// CHECK:   objVal_pullback(x,
+// CHECK:   *_d_x +=
+// CHECK: }
+
+// CHECK: void makeB_pullback(double x, B _d_y, double *_d_x)
+
+// CHECK: void h_grad(double x, double *_d_x) {
+// CHECK:   B _r{{[0-9]+}} =
+// CHECK:   _r{{[0-9]+}}.val +=
+// CHECK:   makeB_pullback(x,
+// CHECK:   *_d_x +=
+// CHECK: }
+
+int main() {
+  auto f_grad = clad::gradient(f);
+  double dx = 0, dy = 0;
+  f_grad.execute(3.0, 4.0, &dx, &dy);
+  printf("dx=%.1f dy=%.1f\n", dx, dy);
+  // CHECK-EXEC: dx=6.0 dy=0.0
+
+  auto g_grad = clad::gradient(g);
+  dx = 0;
+  g_grad.execute(3.0, &dx);
+  printf("gdx=%.1f\n", dx);
+  // CHECK-EXEC: gdx=30.0
+
+  auto h_grad = clad::gradient(h);
+  dx = 0;
+  h_grad.execute(3.0, &dx);
+  printf("hdx=%.1f\n", dx);
+  // CHECK-EXEC: hdx=6.0
+}


### PR DESCRIPTION
When a function returns a record and reverse mode differentiates a member of that result, seed the corresponding member of the record adjoint before visiting the call. This makes expressions like objVal(x).val emit the needed pullback call instead of producing an empty gradient.

Add a regression test for the reported case and for a scaled use of the same expression, so the test also checks propagation of non-unit adjoints.

Fixes: #1298