### PR TITLE
Port to LLVM 22 and shift the support window to clang 12-22.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,8 @@ jobs:
       matrix:
 
         include:
-          # --- LINUX: Last 10 Runtimes (12-21) ---
+          # --- LINUX: Last 11 Runtimes (12-22) ---
           # Using Ubuntu 22.04 for older runtimes, 24.04 for newer ones
-          - { name: ubu22-gcc10-runtime11, os: ubuntu-22.04, compiler: gcc-10, clang-runtime: '11' }
           - { name: ubu22-gcc11-runtime12, os: ubuntu-22.04, compiler: gcc-11, clang-runtime: '12' }
           - { name: ubu22-clang13-runtime13, os: ubuntu-22.04, compiler: clang-13, clang-runtime: '13' }
           - { name: ubu24-gcc13-runtime14, os: ubuntu-24.04, compiler: gcc-13, clang-runtime: '14' }
@@ -44,6 +43,7 @@ jobs:
           - { name: ubu24-clang17-runtime19, os: ubuntu-24.04, compiler: clang-17, clang-runtime: '19' }
           - { name: ubu24-clang19-runtime20, os: ubuntu-24.04, compiler: clang-19, clang-runtime: '20' }
           - { name: ubu24-clang20-runtime21, os: ubuntu-24.04, compiler: clang-20, clang-runtime: '21' }
+          - { name: ubu24-clang20-runtime22, os: ubuntu-24.04, compiler: clang-20, clang-runtime: '22' }
           # --- MACOS: Last 5 Runtimes (17-21) ---
           # Using macOS ARM (standard) for all; Runtime 17 on Intel for x86 sanity
           - { name: osx-intel-runtime17, os: macos-15-intel, compiler: clang, clang-runtime: '17' }
@@ -181,25 +181,26 @@ jobs:
           fi
         fi
         echo "ncpus=$ncpus" >> $GITHUB_ENV
-    - name: Setup LLVM ${{ matrix.clang-runtime }}
+    - name: Setup LLVM ${{ matrix.clang-runtime }}${{ matrix.flavor && format(' [{0}]', matrix.flavor) || '' }}
       if: runner.os != 'Windows' && matrix.debug_build != true
       uses: compiler-research/ci-workflows/actions/setup-llvm@main
       with:
         version: ${{ matrix.clang-runtime }}
         os:      ${{ matrix.self-hosted-os || matrix.os }}
-        flavor:  system
+        flavor:  ${{ matrix.flavor || 'system' }}
 
     - name: Install extra Linux deps
-      # debug_build rows skip setup-llvm and never get apt-llvm.org, so
-      # libomp-N-dev past the noble archive cap is unreachable. OpenMP
-      # lit tests then skip on the debug row; other rows still cover them.
       if: runner.os == 'Linux' && matrix.debug_build != true
       run: |
-        # setup-llvm covers llvm-N-dev + clang-N + libclang-N-dev +
-        # libclang-rt-N-dev. Pick up libomp and per-row extras here.
         # cmake is preinstalled on github-hosted ubuntu-24.04 but absent
         # from catthehacker/ubuntu:act-24.04; install it so bin/repro works.
-        sudo apt install -y cmake libomp-${{ matrix.clang-runtime }}-dev ${{ matrix.extra_packages }}
+        sudo apt install -y cmake ${{ matrix.extra_packages }}
+        # libomp-N-dev: best-effort. apt-llvm.org lags on the latest
+        # major; recipe-flavor rows get libomp from the recipe build,
+        # not apt. When missing, OpenMP lit tests skip via REQUIRES.
+        if apt-cache show "libomp-${{ matrix.clang-runtime }}-dev" >/dev/null 2>&1; then
+          sudo apt install -y "libomp-${{ matrix.clang-runtime }}-dev"
+        fi
 
     - name: Setup compiler on Linux
       if: runner.os == 'Linux'
@@ -328,12 +329,13 @@ jobs:
     - name: Setup LLVM/Clang on Linux
       if: ${{ (runner.os == 'Linux') && (matrix.debug_build != true) }}
       run: |
-        UNIX_DISTRO=$(lsb_release -rs)
-        PATH_TO_LLVM_BUILD=/usr/lib/llvm-${{ matrix.clang-runtime }}/
-        # Add -H to silence 'The directory '/home/..../pip/http' or its parent
-        # directory is not owned by the current user and the cache has been disabled.
+        # setup-llvm always lands the install at $GITHUB_WORKSPACE/install
+        # (a symlink to /usr/lib/llvm-N for flavor=system, a real install
+        # tree for the recipe flavors). Point clad's build prefix there so
+        # the cmake configs and their .a references resolve regardless of
+        # flavor.
+        PATH_TO_LLVM_BUILD="$GITHUB_WORKSPACE/install"
         pip3 install lit # LLVM lit is not part of the llvm releases...
-        # We need PATH_TO_LLVM_BUILD later
         echo "PATH_TO_LLVM_BUILD=$PATH_TO_LLVM_BUILD" >> $GITHUB_ENV
     - name: Setup LLVM/Clang on Windows
       if: ${{ runner.os == 'windows' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,12 +37,12 @@ set(CMAKE_MODULE_PATH
   )
 
 # Define clad supported version of clang and llvm.
-set(CLANG_MIN_SUPPORTED 11.0)
-set(CLANG_MAX_SUPPORTED "21.2.x")
-set(CLANG_VERSION_UPPER_BOUND 21.2.0)
-set(LLVM_MIN_SUPPORTED 11.0)
-set(LLVM_MAX_SUPPORTED "21.2.x")
-set(LLVM_VERSION_UPPER_BOUND 21.2.0)
+set(CLANG_MIN_SUPPORTED 12.0)
+set(CLANG_MAX_SUPPORTED "22.2.x")
+set(CLANG_VERSION_UPPER_BOUND 22.2.0)
+set(LLVM_MIN_SUPPORTED 12.0)
+set(LLVM_MAX_SUPPORTED "22.2.x")
+set(LLVM_VERSION_UPPER_BOUND 22.2.0)
 
 # If we are not building as a part of LLVM, build clad as an
 # standalone project, using LLVM as an external library:
@@ -186,6 +186,13 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
   add_definitions(${LLVM_DEFINITIONS})
+
+  # LLVM 22 sets _GLIBCXX_USE_CXX11_ABI twice (HandleLLVMOptions +
+  # LLVMConfig), which trips -Werror=macro-redefined. Suppress that
+  # specific warning -- it's an upstream duplication, not a code bug.
+  if (LLVM_VERSION_MAJOR GREATER_EQUAL 22)
+    add_compile_options(-Wno-macro-redefined)
+  endif()
 
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/)
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/)

--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -9,11 +9,18 @@
 #include "llvm/Config/llvm-config.h"
 
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/Stmt.h"
-#include "clang/Basic/Version.h"
+#include "clang/AST/TemplateName.h"
+#include "clang/AST/Type.h"
+#include "clang/AST/TypeLoc.h"
 #include "clang/Basic/SourceManager.h"
+#include "clang/Basic/Specifiers.h"
+#include "clang/Basic/Version.h"
+#include "clang/Sema/DeclSpec.h"
+#include "clang/Sema/Ownership.h"
 #include "clang/Sema/Sema.h"
 #if CLANG_VERSION_MAJOR > 18
 #include "clang/Sema/SemaOpenMP.h"
@@ -154,6 +161,281 @@ const auto ElaboratedTypeKeyword_None = ETK_None;
 const auto ElaboratedTypeKeyword_None = ElaboratedTypeKeyword::None;
 #endif
 
+// Clang 22 reshaped the type-qualifier model (llvm/llvm-project#147835):
+// NestedNameSpecifier became a uintptr value type, ElaboratedType
+// folded into TagType, and several ASTContext::get* / TagDecl helpers
+// were renamed or removed. Wrappers below isolate the call sites.
+
+#if CLANG_VERSION_MAJOR < 22
+using NestedNameSpecifierTy = clang::NestedNameSpecifier*;
+
+// Default "no qualifier" NNS. On LLVM 22 a value-NNS `{}` evaluates
+// TRUE (Invalid kind), so the pre-22 `NNS = nullptr` idiom needs this
+// wrapper to keep the same truthiness across versions.
+inline NestedNameSpecifierTy nullNNS() { return nullptr; }
+
+// True iff NNS actually names a qualifier. Pre-22 a pointer-NNS is
+// "no qualifier" iff null; mirrors `if (!NNS)`.
+inline bool hasQualifier(NestedNameSpecifierTy NNS) { return NNS != nullptr; }
+
+// Wrap: does QT already carry namespace elaboration? Pre-22 stored
+// the elaboration in a separate ElaboratedType wrapper.
+inline bool isElaboratedType(clang::QualType QT) {
+  return QT->getAs<clang::ElaboratedType>() != nullptr;
+}
+
+// Pre-22 getPrefix() worked uniformly on any NNS kind.
+inline bool hasNNSPrefix(clang::NestedNameSpecifier* NS) {
+  return NS && NS->getPrefix() != nullptr;
+}
+inline clang::NestedNameSpecifier*
+getNNSPrefix(clang::NestedNameSpecifier* NS) {
+  return NS->getPrefix();
+}
+
+inline clang::QualType getElaboratedType(clang::ASTContext& C,
+                                         clang::ElaboratedTypeKeyword Keyword,
+                                         clang::NestedNameSpecifier* Qualifier,
+                                         clang::QualType QT) {
+  return C.getElaboratedType(Keyword, Qualifier, QT);
+}
+
+inline clang::QualType getRecordType(clang::ASTContext& C,
+                                     const clang::RecordDecl* RD) {
+  return C.getRecordType(RD);
+}
+
+inline clang::QualType getCanonicalTagType(clang::ASTContext& /*C*/,
+                                           const clang::TagDecl* TD) {
+  return TD->getTypeForDecl()->getCanonicalTypeInternal();
+}
+
+inline clang::QualType
+CheckTemplateIdType(clang::Sema& S, clang::TemplateName T,
+                    clang::SourceLocation Loc,
+                    clang::TemplateArgumentListInfo& TLI) {
+  return S.CheckTemplateIdType(T, Loc, TLI);
+}
+#else // CLANG_VERSION_MAJOR >= 22
+using NestedNameSpecifierTy = clang::NestedNameSpecifier;
+
+inline NestedNameSpecifierTy nullNNS() {
+  return clang::NestedNameSpecifier(std::nullopt);
+}
+
+// True iff NNS names a qualifier. LLVM 22's value-NNS distinguishes
+// Null from Invalid; both mean "no qualifier" to clad, mirroring the
+// pre-22 `if (!NNS)` idiom.
+inline bool hasQualifier(NestedNameSpecifierTy NNS) {
+  return bool(NNS) && NNS.getKind() != clang::NestedNameSpecifier::Kind::Null;
+}
+
+// Clang 22: TagType (and friends) carry keyword + qualifier inline.
+// "Already elaborated" becomes "the tag carries a non-default keyword
+// or a qualifier"; non-tag types are not elaboration carriers.
+inline bool isElaboratedType(clang::QualType QT) {
+  if (const auto* TT = QT->getAs<clang::TagType>())
+    return TT->getKeyword() != clang::ElaboratedTypeKeyword::None ||
+           bool(TT->getQualifier());
+  return false;
+}
+
+// Clang 22: only Namespace-kind NNS exposes a prefix; other kinds
+// have no analogue to the old uniform getPrefix(), so treat them as
+// "no prefix" -- the pre-22 callers branched on null-prefix anyway.
+inline bool hasNNSPrefix(clang::NestedNameSpecifier NS) {
+  if (NS.getKind() == clang::NestedNameSpecifier::Kind::Namespace)
+    return bool(NS.getAsNamespaceAndPrefix().Prefix);
+  return false;
+}
+inline clang::NestedNameSpecifier getNNSPrefix(clang::NestedNameSpecifier NS) {
+  if (NS.getKind() == clang::NestedNameSpecifier::Kind::Namespace)
+    return NS.getAsNamespaceAndPrefix().Prefix;
+  return clang::NestedNameSpecifier();
+}
+
+// Clang 22 (llvm/llvm-project#147835): keyword + qualifier ride inline
+// on the type, so getElaboratedType is gone -- rebuild via the
+// type-specific factory. Branches cover record/enum, typedef, and
+// template-specialization types.
+inline clang::QualType getElaboratedType(clang::ASTContext& C,
+                                         clang::ElaboratedTypeKeyword Keyword,
+                                         clang::NestedNameSpecifier Qualifier,
+                                         clang::QualType QT) {
+  // Alias-template TSTs (e.g. `clad::tape<T>`) must stay TSTs so the
+  // alias name survives; routing them through getTagType would resolve
+  // `tape` to its underlying `tape_impl` record.
+  if (const auto* TST = QT->getAs<clang::TemplateSpecializationType>();
+      TST && TST->isTypeAlias()) {
+    clang::TemplateName QTN = C.getQualifiedTemplateName(
+        Qualifier, /*TemplateKeyword=*/false, TST->getTemplateName());
+    return C.getTemplateSpecializationType(
+        Keyword, QTN, TST->template_arguments(),
+        /*CanonicalArgs=*/{}, TST->getAliasedType());
+  }
+  if (const auto* TT = QT->getAs<clang::TagType>())
+    return C.getTagType(Keyword, Qualifier, TT->getDecl(), /*OwnsTag=*/false);
+  if (const auto* TyD = QT->getAs<clang::TypedefType>())
+    return C.getTypedefType(Keyword, Qualifier, TyD->getDecl());
+  if (const auto* TST = QT->getAs<clang::TemplateSpecializationType>()) {
+    clang::TemplateName QTN = C.getQualifiedTemplateName(
+        Qualifier, /*TemplateKeyword=*/false, TST->getTemplateName());
+    return C.getTemplateSpecializationType(Keyword, QTN,
+                                           TST->template_arguments(),
+                                           /*CanonicalArgs=*/{}, QualType());
+  }
+  return QT;
+}
+
+// Clang 22: getRecordType -> getTagType with default keyword/qualifier.
+inline clang::QualType getRecordType(clang::ASTContext& C,
+                                     const clang::RecordDecl* RD) {
+  return C.getTagType(clang::ElaboratedTypeKeyword::None,
+                      clang::NestedNameSpecifier(), RD, /*OwnsTag=*/false);
+}
+
+// Clang 22: TagDecl::getTypeForDecl() was deleted; use
+// ASTContext::getCanonicalTagType(TD) instead.
+inline clang::QualType getCanonicalTagType(clang::ASTContext& C,
+                                           const clang::TagDecl* TD) {
+  return C.getCanonicalTagType(TD);
+}
+
+// Clang 22: CheckTemplateIdType gained Keyword + Scope* +
+// ForNestedNameSpecifier params; default them to match pre-22 behavior.
+inline clang::QualType
+CheckTemplateIdType(clang::Sema& S, clang::TemplateName T,
+                    clang::SourceLocation Loc,
+                    clang::TemplateArgumentListInfo& TLI) {
+  return S.CheckTemplateIdType(clang::ElaboratedTypeKeyword::None, T, Loc, TLI,
+                               /*Scope=*/nullptr,
+                               /*ForNestedNameSpecifier=*/false);
+}
+#endif
+
+// Clang 22 (llvm/llvm-project#147835): NestedNameSpecifier::Create
+// factories are gone -- value-NNS constructors take their place, and
+// the type-kind no longer accepts a prefix. The wrappers bake the
+// prefix into the type at construction so it rides transitively.
+inline NestedNameSpecifierTy makeNNSNamespace(clang::ASTContext& C,
+                                              NestedNameSpecifierTy Prefix,
+                                              const clang::NamespaceDecl* NS) {
+#if CLANG_VERSION_MAJOR < 22
+  return clang::NestedNameSpecifier::Create(C, Prefix, NS);
+#else
+  return clang::NestedNameSpecifier(C, NS, Prefix);
+#endif
+}
+
+// Build a NestedNameSpecifier of the form "Prefix::TD::". Pre-22 took
+// Prefix as a separate Create() arg; LLVM 22 bakes Prefix into the
+// TagType via getTagType so the value-NNS retains the full path.
+inline NestedNameSpecifierTy makeNNSTagType(clang::ASTContext& C,
+                                            NestedNameSpecifierTy Prefix,
+                                            const clang::TagDecl* TD) {
+#if CLANG_VERSION_MAJOR < 22
+  clang::QualType T = C.getTypeDeclType(TD);
+  return clang::NestedNameSpecifier::Create(
+      C, Prefix CLAD_COMPAT_CLANG21_TemplateKeywordParam, T.getTypePtr());
+#else
+  clang::QualType T = C.getTagType(clang::ElaboratedTypeKeyword::None, Prefix,
+                                   TD, /*OwnsTag=*/false);
+  return clang::NestedNameSpecifier(T.getTypePtr());
+#endif
+}
+
+// Clang 22: ASTContext::getTypeDeclType(TypeDecl*) was deleted in the
+// 1-arg form; the 3-arg form now requires Keyword + Qualifier.
+inline clang::QualType getTypeDeclType(clang::ASTContext& C,
+                                       const clang::TypeDecl* TD) {
+#if CLANG_VERSION_MAJOR < 22
+  return C.getTypeDeclType(TD);
+#else
+  return C.getTypeDeclType(clang::ElaboratedTypeKeyword::None,
+                           clang::NestedNameSpecifier(), TD);
+#endif
+}
+
+// Clang 22 (llvm/llvm-project#143653): getSizeType returns a
+// PredefinedSugarType that prints as "__size_t". clad's tests want
+// the platform integer spelling -- use the canonical type.
+inline clang::QualType getSizeType(clang::ASTContext& C) {
+#if CLANG_VERSION_MAJOR < 22
+  return C.getSizeType();
+#else
+  return C.getCanonicalSizeType();
+#endif
+}
+
+// LLVM 22 PredefinedSugarType (size_t/ptrdiff_t/...) leaks the
+// "__size_t" name into generated temporaries; strip to the canonical
+// integer at the declaration point.
+inline clang::QualType stripPredefinedSugar(clang::QualType QT) {
+#if CLANG_VERSION_MAJOR >= 22
+  if (clang::isa<clang::PredefinedSugarType>(QT.getTypePtr()))
+    return QT.getCanonicalType();
+#endif
+  return QT;
+}
+
+// Clang 22: ActOnBreakStmt / ActOnContinueStmt gained named-target
+// params (Label + LabelLoc). Default them for unnamed break/continue.
+inline clang::StmtResult ActOnBreakStmt(clang::Sema& S,
+                                        clang::SourceLocation Loc,
+                                        clang::Scope* CurScope) {
+#if CLANG_VERSION_MAJOR < 22
+  return S.ActOnBreakStmt(Loc, CurScope);
+#else
+  return S.ActOnBreakStmt(Loc, CurScope, /*Label=*/nullptr,
+                          /*LabelLoc=*/clang::SourceLocation());
+#endif
+}
+inline clang::StmtResult ActOnContinueStmt(clang::Sema& S,
+                                           clang::SourceLocation Loc,
+                                           clang::Scope* CurScope) {
+#if CLANG_VERSION_MAJOR < 22
+  return S.ActOnContinueStmt(Loc, CurScope);
+#else
+  return S.ActOnContinueStmt(Loc, CurScope, /*Label=*/nullptr,
+                             /*LabelLoc=*/clang::SourceLocation());
+#endif
+}
+
+// Clang 22: BreakStmt/ContinueStmt share LoopControlStmt::getKwLoc();
+// pre-22 had stmt-specific getBreakLoc/getContinueLoc.
+inline clang::SourceLocation getBreakLoc(const clang::BreakStmt* BS) {
+#if CLANG_VERSION_MAJOR < 22
+  return BS->getBreakLoc();
+#else
+  return BS->getKwLoc();
+#endif
+}
+inline clang::SourceLocation getContinueLoc(const clang::ContinueStmt* CS) {
+#if CLANG_VERSION_MAJOR < 22
+  return CS->getContinueLoc();
+#else
+  return CS->getKwLoc();
+#endif
+}
+
+// CXXScopeSpec::Extend's TypeLoc overload was removed in clang 22;
+// replacement is build-an-NNS + MakeTrivial. clang 20+ keeps the
+// 3-arg form; clang <20 used a leading SourceLocation keyword-loc
+// param. The wrapper hides all three call shapes.
+inline void CSS_ExtendType(clang::CXXScopeSpec& CSS, clang::ASTContext& C,
+                           clang::SourceLocation KWLoc, clang::TypeLoc TL,
+                           clang::SourceLocation ColonColonLoc) {
+#if CLANG_VERSION_MAJOR >= 22
+  clang::NestedNameSpecifier NNS(TL.getType().getTypePtr());
+  CSS.MakeTrivial(C, NNS, clang::SourceRange(TL.getBeginLoc(), ColonColonLoc));
+#elif CLANG_VERSION_MAJOR >= 21
+  (void)KWLoc;
+  CSS.Extend(C, TL, ColonColonLoc);
+#else
+  CSS.Extend(C, KWLoc, TL, ColonColonLoc);
+#endif
+}
+
 // Clang 18 endswith->ends_with
 // and starstwith->starts_with
 
@@ -216,18 +498,8 @@ NamespaceDecl_Create(ASTContext& C, DeclContext* DC, bool Inline,
 // ConstExprUsage Usage, ASTContext &)
 // => bool Expr::EvaluateAsConstantExpr(EvalResult &Result, ASTContext &)
 
-static inline bool Expr_EvaluateAsConstantExpr(const Expr* E,
-                                               Expr::EvalResult& res,
-                                               const ASTContext& Ctx) {
-#if CLANG_VERSION_MAJOR < 12
-  return E->EvaluateAsConstantExpr(res, Expr::EvaluateForCodeGen, Ctx);
-#else
-  return E->EvaluateAsConstantExpr(res, Ctx);
-#endif
-}
-
 // Compatibility helper function for creation IfStmt.
-// Clang 12 and above use two extra params.
+// Clang 14 switched from bool IsConstexpr to IfStatementKind.
 
 static inline IfStmt* IfStmt_Create(const ASTContext &Ctx,
    SourceLocation IL, bool IsConstexpr,
@@ -236,39 +508,20 @@ static inline IfStmt* IfStmt_Create(const ASTContext &Ctx,
    Stmt *Then, SourceLocation EL=SourceLocation(), Stmt *Else=nullptr)
 {
 
-#if CLANG_VERSION_MAJOR < 12
-  return IfStmt::Create(Ctx, IL, IsConstexpr, Init, Var, Cond, Then, EL, Else);
-#elif CLANG_VERSION_MAJOR < 14
+#if CLANG_VERSION_MAJOR < 14
   return IfStmt::Create(Ctx, IL, IsConstexpr, Init, Var, Cond, LPL, RPL, Then,
                         EL, Else);
-#elif CLANG_VERSION_MAJOR >= 14
-   IfStatementKind kind = IfStatementKind::Ordinary;
-   if (IsConstexpr)
-      kind = IfStatementKind::Constexpr;
-   return IfStmt::Create(Ctx, IL, kind, Init, Var, Cond, LPL, RPL, Then, EL, Else);   
+#else
+  IfStatementKind kind = IfStatementKind::Ordinary;
+  if (IsConstexpr)
+    kind = IfStatementKind::Constexpr;
+  return IfStmt::Create(Ctx, IL, kind, Init, Var, Cond, LPL, RPL, Then, EL,
+                        Else);
 #endif
 }
 
 // Compatibility helper function for creation CallExpr and CUDAKernelCallExpr.
-// Clang 12 and above use one extra param.
 
-#if CLANG_VERSION_MAJOR < 12
-static inline CallExpr* CallExpr_Create(const ASTContext &Ctx, Expr *Fn, ArrayRef< Expr *> Args,
-   QualType Ty, ExprValueKind VK, SourceLocation RParenLoc,
-   unsigned MinNumArgs = 0, CallExpr::ADLCallKind UsesADL = CallExpr::NotADL)
-{
-   return CallExpr::Create(Ctx, Fn, Args, Ty, VK, RParenLoc, MinNumArgs, UsesADL);
-}
-
-static inline CUDAKernelCallExpr*
-CUDAKernelCallExpr_Create(const ASTContext& Ctx, Expr* Fn, CallExpr* Config,
-                          ArrayRef<Expr*> Args, QualType Ty, ExprValueKind VK,
-                          SourceLocation RParenLoc, unsigned MinNumArgs = 0,
-                          CallExpr::ADLCallKind UsesADL = CallExpr::NotADL) {
-  return CUDAKernelCallExpr::Create(Ctx, Fn, Config, Args, Ty, VK, RParenLoc,
-                                    MinNumArgs);
-}
-#elif CLANG_VERSION_MAJOR >= 12
 static inline CallExpr* CallExpr_Create(const ASTContext &Ctx, Expr *Fn, ArrayRef< Expr *> Args,
    QualType Ty, ExprValueKind VK, SourceLocation RParenLoc, FPOptionsOverride FPFeatures,
    unsigned MinNumArgs = 0, CallExpr::ADLCallKind UsesADL = CallExpr::NotADL)
@@ -285,56 +538,12 @@ CUDAKernelCallExpr_Create(const ASTContext& Ctx, Expr* Fn, CallExpr* Config,
   return CUDAKernelCallExpr::Create(Ctx, Fn, Config, Args, Ty, VK, RParenLoc,
                                     FPFeatures, MinNumArgs);
 }
-#endif
-
-// Clang 12 and above use one extra param.
-
-#if CLANG_VERSION_MAJOR < 12
-#define CLAD_COMPAT_CLANG8_CallExpr_ExtraParams                                \
-  , Node->getNumArgs(), Node->getADLCallKind()
-#elif CLANG_VERSION_MAJOR >= 12
-   #define CLAD_COMPAT_CLANG8_CallExpr_ExtraParams ,Node->getFPFeatures(),Node->getNumArgs(),Node->getADLCallKind()
-#endif
 
 static inline void ExprSetDeps(Expr* result, Expr* Node) {
   struct ExprDependenceAccessor : public Expr {
     void setDependence(ExprDependence Deps) { Expr::setDependence(Deps); }
   };
    ((ExprDependenceAccessor*)result)->setDependence(Node->getDependence());
-}
-
-// Compatibility helper function for creation CXXMemberCallExpr.
-// Clang 12 and above use two extra param.
-
-#if CLANG_VERSION_MAJOR < 12
-static inline CXXMemberCallExpr* CXXMemberCallExpr_Create(ASTContext &Ctx,
-   Expr *Fn, ArrayRef<Expr *> Args, QualType Ty, ExprValueKind VK, SourceLocation RP)
-{
-   return CXXMemberCallExpr::Create(const_cast<ASTContext&>(Ctx), Fn, Args, Ty, VK, RP);
-}
-#elif CLANG_VERSION_MAJOR >= 12
-static inline CXXMemberCallExpr* CXXMemberCallExpr_Create(ASTContext &Ctx,
-   Expr *Fn, ArrayRef<Expr *> Args, QualType Ty, ExprValueKind VK, SourceLocation RP,
-   FPOptionsOverride FPFeatures, unsigned MinNumArgs = 0)
-{
-   return CXXMemberCallExpr::Create(const_cast<ASTContext&>(Ctx), Fn, Args, Ty, VK, RP,
-                                    FPFeatures, MinNumArgs);
-}
-#endif
-
-// Compatibility helper function for creation SwitchStmt.
-// Clang 12 and above use two extra params.
-
-static inline SwitchStmt* SwitchStmt_Create(const ASTContext &Ctx,
-   Stmt *Init, VarDecl *Var, Expr *Cond,
-   SourceLocation LParenLoc, SourceLocation RParenLoc)
-{
-
-#if CLANG_VERSION_MAJOR < 12
-  return SwitchStmt::Create(Ctx, Init, Var, Cond);
-#elif CLANG_VERSION_MAJOR >= 12
-   return SwitchStmt::Create(Ctx, Init, Var, Cond, LParenLoc, RParenLoc);
-#endif
 }
 
 template<class T>
@@ -363,61 +572,14 @@ getConstantArrayType(const ASTContext& Ctx, QualType EltTy,
 }
 #endif
 
-// Clang 12 rename DeclaratorContext::LambdaExprContext to DeclaratorContext::LambdaExpr.
-// Clang 15 add one extra param to clang::Declarator() - const ParsedAttributesView & DeclarationAttrs
-
-#if CLANG_VERSION_MAJOR < 12
-   #define CLAD_COMPAT_CLANG12_Declarator_LambdaExpr clang::DeclaratorContext::LambdaExprContext
-   #define CLAD_COMPAT_CLANG15_Declarator_DeclarationAttrs_ExtraParam /**/
-#elif CLANG_VERSION_MAJOR < 15
-   #define CLAD_COMPAT_CLANG12_Declarator_LambdaExpr clang::DeclaratorContext::LambdaExpr
-   #define CLAD_COMPAT_CLANG15_Declarator_DeclarationAttrs_ExtraParam /**/
-#elif CLANG_VERSION_MAJOR >= 15
-   #define CLAD_COMPAT_CLANG12_Declarator_LambdaExpr clang::DeclaratorContext::LambdaExpr
-   #define CLAD_COMPAT_CLANG15_Declarator_DeclarationAttrs_ExtraParam clang::ParsedAttributesView::none(),
+// Clang 15 added one extra param to clang::Declarator() --
+// const ParsedAttributesView & DeclarationAttrs.
+#if CLANG_VERSION_MAJOR < 15
+#define CLAD_COMPAT_CLANG15_Declarator_DeclarationAttrs_ExtraParam /**/
+#else
+#define CLAD_COMPAT_CLANG15_Declarator_DeclarationAttrs_ExtraParam             \
+  clang::ParsedAttributesView::none(),
 #endif
-
-// Clang 12 add one extra param (FPO) that we get from Node in Create method of:
-// ImplicitCastExpr, CStyleCastExpr, CXXStaticCastExpr and CXXFunctionalCastExpr
-
-#if CLANG_VERSION_MAJOR < 12
-   #define CLAD_COMPAT_CLANG12_CastExpr_GetFPO(Node) /**/
-#elif CLANG_VERSION_MAJOR >= 12
-   #define CLAD_COMPAT_CLANG12_CastExpr_GetFPO(Node) ,Node->getFPFeatures()
-#endif
-
-// Clang 12 adds one extra param (FPO) in Create method of:
-// ImplicitCastExpr, CStyleCastExpr, CXXStaticCastExpr and CXXFunctionalCastExpr
-
-#if CLANG_VERSION_MAJOR < 12
-#define CLAD_COMPAT_CLANG12_CastExpr_DefaultFPO /**/
-#elif CLANG_VERSION_MAJOR >= 12
-#define CLAD_COMPAT_CLANG12_CastExpr_DefaultFPO , FPOptionsOverride()
-#endif
-
-// Clang 12 add two extra param (Left and Right paren location) in Create method of:
-// IfStat::Create
-
-#if CLANG_VERSION_MAJOR < 12
-   #define CLAD_COMPAT_CLANG12_LR_ExtraParams(Node) /**/
-#elif CLANG_VERSION_MAJOR >= 12
-   #define CLAD_COMPAT_CLANG12_LR_ExtraParams(Node) ,Node->getLParenLoc(),Node->getRParenLoc()
-#endif
-
-/// Clang >= 12 has more source locations parameters in `Sema::ActOnStartOfSwitchStmt`
-static inline StmtResult
-Sema_ActOnStartOfSwitchStmt(Sema& SemaRef, Stmt* initStmt,
-                            Sema::ConditionResult Cond) {
-  SourceLocation noLoc;
-#if CLANG_VERSION_MAJOR >= 12
-  return SemaRef.ActOnStartOfSwitchStmt(
-      /*SwitchLoc=*/noLoc,
-      /*LParenLoc=*/noLoc, initStmt, Cond,
-      /*RParenLoc=*/noLoc);
-#elif CLANG_VERSION_MAJOR < 12
-  return SemaRef.ActOnStartOfSwitchStmt(/*SwitchLoc=*/noLoc, initStmt, Cond);
-#endif
-}
 
 #if CLANG_VERSION_MAJOR < 13
 #define CLAD_COMPAT_ExprValueKind_R_or_PR_Value ExprValueKind::VK_RValue
@@ -486,15 +648,6 @@ CXXMethodDecl_GetThisObjectType(Sema& semaRef, const CXXMethodDecl* MD) {
   return MD->getFunctionObjectParameterType();
 #endif
 }
-
-#if CLANG_VERSION_MAJOR < 12
-#define CLAD_COMPAT_SubstNonTypeTemplateParmExpr_isReferenceParameter_ExtraParam( \
-    Node) /**/
-#else
-#define CLAD_COMPAT_SubstNonTypeTemplateParmExpr_isReferenceParameter_ExtraParam( \
-    Node)                                                                         \
-  Node->isReferenceParameter(),
-#endif
 
 #if CLANG_VERSION_MAJOR < 16
 template <typename T>

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -11,6 +11,7 @@
 #include "DerivativeBuilder.h"
 #include "clad/Differentiator/CladUtils.h"
 
+#include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
@@ -171,9 +172,9 @@ namespace clad {
       Intro.Range.setEnd(E->getEndLoc());
       clang::AttributeFactory AttrFactory;
       const clang::DeclSpec DS(AttrFactory);
-      clang::Declarator D(DS,
-                          CLAD_COMPAT_CLANG15_Declarator_DeclarationAttrs_ExtraParam
-                          CLAD_COMPAT_CLANG12_Declarator_LambdaExpr);
+      clang::Declarator D(
+          DS, CLAD_COMPAT_CLANG15_Declarator_DeclarationAttrs_ExtraParam
+                  clang::DeclaratorContext::LambdaExpr);
 #if CLANG_VERSION_MAJOR > 16
       V.beginScope(clang::Scope::LambdaScope | clang::Scope::DeclScope |
 
@@ -405,10 +406,10 @@ namespace clad {
     /// \param[in] D The declaration to build a DeclRefExpr for.
     /// \param[in] SS The nested name specifier for the declaration.
     /// \returns the DeclRefExpr for the given declaration.
-    clang::DeclRefExpr*
-    BuildDeclRef(clang::DeclaratorDecl* D,
-                 clang::NestedNameSpecifier* NNS = nullptr,
-                 clang::ExprValueKind VK = clang::VK_LValue);
+    clang::DeclRefExpr* BuildDeclRef(
+        clang::DeclaratorDecl* D,
+        clad_compat::NestedNameSpecifierTy NNS = clad_compat::nullNNS(),
+        clang::ExprValueKind VK = clang::VK_LValue);
 
     /// Stores the result of an expression in a temporary variable (of the same
     /// type as is the result of the expression) and returns a reference to it.

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -954,9 +954,16 @@ StmtDiff BaseForwardModeVisitor::VisitDeclRefExpr(const DeclRefExpr* DRE) {
     // Sema::BuildDeclRefExpr is responsible for adding captured fields
     // to the underlying struct of a lambda.
     if (clonedDRE->getDecl()->getDeclContext() != m_Sema.CurContext) {
-      NestedNameSpecifier* NNS = DRE->getQualifier();
+      // clang<22: getQualifier() returns NNS*, null on unqualified.
+      // clang>=22: it returns NNS-by-value; the unqualified case is
+      // Invalid (StoredOrFlag==4) -- bool-true under operator bool().
+      // Funnel through hasQualifier() so the "no qualifier" path stays
+      // consistent across versions.
+      clad_compat::NestedNameSpecifierTy NNS = DRE->getQualifier();
       auto* referencedDecl = cast<VarDecl>(clonedDRE->getDecl());
-      clonedDRE = BuildDeclRef(referencedDecl, NNS);
+      clonedDRE = BuildDeclRef(referencedDecl, clad_compat::hasQualifier(NNS)
+                                                   ? NNS
+                                                   : clad_compat::nullNNS());
     }
   } else
     clonedDRE = cast<DeclRefExpr>(Clone(DRE));
@@ -970,8 +977,12 @@ StmtDiff BaseForwardModeVisitor::VisitDeclRefExpr(const DeclRefExpr* DRE) {
       // If a record was found, use the recorded derivative.
       if (auto dVarDRE = dyn_cast<DeclRefExpr>(dExpr)) {
         auto dVar = cast<VarDecl>(dVarDRE->getDecl());
-        if (dVar->getDeclContext() != m_Sema.CurContext)
-          dExpr = BuildDeclRef(dVar, DRE->getQualifier());
+        if (dVar->getDeclContext() != m_Sema.CurContext) {
+          clad_compat::NestedNameSpecifierTy NNS = DRE->getQualifier();
+          dExpr = BuildDeclRef(dVar, clad_compat::hasQualifier(NNS)
+                                         ? NNS
+                                         : clad_compat::nullNNS());
+        }
       }
       return StmtDiff(clonedDRE, dExpr);
     }
@@ -1975,9 +1986,13 @@ StmtDiff BaseForwardModeVisitor::VisitSwitchStmt(const SwitchStmt* SS) {
   // Scope for the switch statement
   beginScope(Scope::SwitchScope | Scope::ControlScope | Scope::BreakScope |
              Scope::DeclScope);
-  Stmt* switchStmtDiff = clad_compat::Sema_ActOnStartOfSwitchStmt(
-                             m_Sema, initVarRes.getStmt(), condResult)
-                             .get();
+  SourceLocation noLoc;
+  Stmt* switchStmtDiff =
+      m_Sema
+          .ActOnStartOfSwitchStmt(/*SwitchLoc=*/noLoc, /*LParenLoc=*/noLoc,
+                                  initVarRes.getStmt(), condResult,
+                                  /*RParenLoc=*/noLoc)
+          .get();
   // Scope and block for the corresponding compound statement of the
   // switch statement
   beginScope(Scope::DeclScope);

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -13,6 +13,7 @@
 #include "clang/AST/ParentMapContext.h"
 #include "clang/AST/QualTypeNames.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/TemplateName.h"
 #include "clang/AST/Type.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Analysis/CFG.h"
@@ -189,12 +190,11 @@ namespace clad {
           CSS.Extend(C, ND, /*NamespaceLoc=*/utils::GetValidSLoc(semaRef),
                      /*ColonColonLoc=*/utils::GetValidSLoc(semaRef));
       } else if (auto RD = dyn_cast<CXXRecordDecl>(DC)) {
-        auto RDQType = RD->getTypeForDecl()->getCanonicalTypeInternal();
+        auto RDQType = clad_compat::getCanonicalTagType(C, RD);
         auto RDTypeSourceInfo = C.getTrivialTypeSourceInfo(RDQType);
-        CSS.Extend(C,
-                   CLAD_COMPAT_CLANG21_CSSExtendKWLocExtraParam(noLoc)
-                       RDTypeSourceInfo->getTypeLoc(),
-                   /*ColonColonLoc=*/noLoc);
+        clad_compat::CSS_ExtendType(CSS, C, /*KWLoc=*/noLoc,
+                                    RDTypeSourceInfo->getTypeLoc(),
+                                    /*ColonColonLoc=*/noLoc);
       } else if (addGlobalNS && isa<TranslationUnitDecl>(DC)) {
         CSS.MakeGlobal(C, /*ColonColonLoc=*/noLoc);
       }
@@ -203,16 +203,17 @@ namespace clad {
     // Adds a namespace specifier to the given type if the type is not already an elaborated type.
     clang::QualType AddNamespaceSpecifier(clang::Sema& semaRef, clang::ASTContext &C, clang::QualType QT) {
       auto typePtr = QT.getTypePtr();
-      if (typePtr->isRecordType() && !typePtr->getAs<clang::ElaboratedType>()) {
+      if (typePtr->isRecordType() && !clad_compat::isElaboratedType(QT)) {
         CXXScopeSpec CSS;
         const clang::CXXRecordDecl* recordDecl = typePtr->getAsCXXRecordDecl();
         const auto* declContext =
             static_cast<const clang::DeclContext*>(recordDecl);
         utils::BuildNNS(semaRef, const_cast<clang::DeclContext*>(declContext), CSS);
-        NestedNameSpecifier* NS = CSS.getScopeRep();
-        if (auto* Prefix = NS->getPrefix())
-          return C.getElaboratedType(clad_compat::ElaboratedTypeKeyword_None,
-                                     Prefix, QT);
+        clad_compat::NestedNameSpecifierTy NS = CSS.getScopeRep();
+        if (clad_compat::hasNNSPrefix(NS))
+          return clad_compat::getElaboratedType(
+              C, clad_compat::ElaboratedTypeKeyword_None,
+              clad_compat::getNNSPrefix(NS), QT);
       }
       return QT;
     }
@@ -351,7 +352,7 @@ namespace clad {
         Expr* init = CI->getInit()->IgnoreImplicit();
         Expr::EvalResult dummy;
         if (!(isa<DeclRefExpr>(init) || isa<CXXConstructExpr>(init) ||
-              clad_compat::Expr_EvaluateAsConstantExpr(init, dummy, C)))
+              init->EvaluateAsConstantExpr(dummy, C)))
           return false;
       }
       // The constructor is linear
@@ -377,7 +378,7 @@ namespace clad {
         Expr* init = CI->getInit()->IgnoreImplicit();
         Expr::EvalResult value;
         bool isZero = false;
-        if (clad_compat::Expr_EvaluateAsConstantExpr(init, value, C)) {
+        if (init->EvaluateAsConstantExpr(value, C)) {
           const auto* val = &value.Val;
           if (val->isArray() && val->hasArrayFiller())
             val = &val->getArrayFiller();
@@ -516,7 +517,7 @@ namespace clad {
       ASTContext& C = semaRef.getASTContext();
       auto CAT = cast<ConstantArrayType>(constArrE->getType());
       Expr* sizeE = ConstantFolder::synthesizeLiteral(
-          C.getSizeType(), C, CAT->getSize().getZExtValue());
+          clad_compat::getSizeType(C), C, CAT->getSize().getZExtValue());
       llvm::SmallVector<Expr*, 2> args = {constArrE, sizeE};
       return semaRef.ActOnInitList(noLoc, args, noLoc).get();
     }
@@ -664,7 +665,8 @@ namespace clad {
                            llvm::ArrayRef<llvm::StringRef> fields) {
       assert(IsValidMemExprPath(semaRef, RD, fields) &&
              "Invalid field path specified!");
-      QualType T = RD->getTypeForDecl()->getCanonicalTypeInternal();
+      QualType T =
+          clad_compat::getCanonicalTagType(semaRef.getASTContext(), RD);
       for (auto field : fields) {
         auto FD = LookupDataMember(semaRef, RD, field);
         if (FD->getType()->isRecordType())
@@ -928,18 +930,18 @@ namespace clad {
     QualType InstantiateTemplate(Sema& S, TemplateDecl* CladClassDecl,
                                  TemplateArgumentListInfo& TLI) {
       // This will instantiate tape<T> type and return it.
-      QualType TT = S.CheckTemplateIdType(TemplateName(CladClassDecl),
-                                          GetValidSLoc(S), TLI);
+      QualType TT = clad_compat::CheckTemplateIdType(
+          S, TemplateName(CladClassDecl), GetValidSLoc(S), TLI);
       // Get clad namespace and its identifier clad::.
       CXXScopeSpec CSS;
       CSS.Extend(S.getASTContext(), GetCladNamespace(S), GetValidSLoc(S),
                  GetValidSLoc(S));
-      NestedNameSpecifier* NS = CSS.getScopeRep();
+      clad_compat::NestedNameSpecifierTy NS = CSS.getScopeRep();
 
       // Create elaborated type with namespace specifier,
       // i.e. class<T> -> clad::class<T>
-      return S.getASTContext().getElaboratedType(
-          clad_compat::ElaboratedTypeKeyword_None, NS, TT);
+      return clad_compat::getElaboratedType(
+          S.getASTContext(), clad_compat::ElaboratedTypeKeyword_None, NS, TT);
     }
 
     clang::QualType GetRestoreTrackerType(clang::Sema& S) {
@@ -959,13 +961,14 @@ namespace clad {
       // This will instantiate restore_tracker<T> type and return it.
       auto* RD = cast<RecordDecl>(TrackerR.getFoundDecl());
       ASTContext& C = S.getASTContext();
-      T = C.getRecordType(RD);
+      T = clad_compat::getRecordType(C, RD);
       // Get clad namespace and its identifier clad::.
-      NestedNameSpecifier* NS = CSS.getScopeRep();
+      clad_compat::NestedNameSpecifierTy NS = CSS.getScopeRep();
 
       // Create elaborated type with namespace specifier,
       // i.e. class<T> -> clad::class<T>
-      T = C.getElaboratedType(clad_compat::ElaboratedTypeKeyword_None, NS, T);
+      T = clad_compat::getElaboratedType(
+          C, clad_compat::ElaboratedTypeKeyword_None, NS, T);
       return T;
     }
 
@@ -1671,10 +1674,10 @@ namespace clad {
           if (opCode == BO_Add || opCode == BO_Mul) {
             Expr::EvalResult dummy;
 
-            bool isConstL = clad_compat::Expr_EvaluateAsConstantExpr(
-                L, dummy, m_ADC->getASTContext());
-            bool isConstR = clad_compat::Expr_EvaluateAsConstantExpr(
-                R, dummy, m_ADC->getASTContext());
+            bool isConstL =
+                L->EvaluateAsConstantExpr(dummy, m_ADC->getASTContext());
+            bool isConstR =
+                R->EvaluateAsConstantExpr(dummy, m_ADC->getASTContext());
 
             if (isConstL && isConstR)
               return false;

--- a/lib/Differentiator/ConstantFolder.cpp
+++ b/lib/Differentiator/ConstantFolder.cpp
@@ -151,9 +151,8 @@ namespace clad {
       Expr* cast = CXXStaticCastExpr::Create(
           C, QT, CLAD_COMPAT_ExprValueKind_R_or_PR_Value,
           clang::CastKind::CK_IntegralCast, Result, /*CXXCastPath=*/nullptr,
-          C.getTrivialTypeSourceInfo(QT, noLoc)
-              CLAD_COMPAT_CLANG12_CastExpr_DefaultFPO,
-          noLoc, noLoc, SourceRange());
+          C.getTrivialTypeSourceInfo(QT, noLoc), FPOptionsOverride(), noLoc,
+          noLoc, SourceRange());
       Result = cast;
     } else if (QT->isPointerType()) {
       Result = clad::synthesizeLiteral(QT, C);

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -295,10 +295,14 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       assert(!codeArgIdx && "We found the index of the code argument!");
       return;
     }
-    // Update the code parameter if it was found.
-    clang::LangOptions LangOpts;
-    LangOpts.CPlusPlus = true;
-    clang::PrintingPolicy Policy(LangOpts);
+    // Update the code parameter if it was found. Use the context's
+    // PrintingPolicy so DeclRefExpr / NestedNameSpecifier print the same
+    // as the rest of the translation unit -- a fresh PrintingPolicy
+    // built from a default-LangOptions object yields stricter defaults
+    // on LLVM 22 (notably for unwritten-scope decisions), which then
+    // makes locals print qualified as `::name` even though their DRE
+    // carries no qualifier.
+    clang::PrintingPolicy Policy = C.getPrintingPolicy();
     Policy.Bool = true;
 
     std::string s;

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -1,6 +1,7 @@
 #include "clad/Differentiator/ErrorEstimator.h"
 
 #include "clad/Differentiator/CladUtils.h"
+#include "clad/Differentiator/Compatibility.h"
 #include "clad/Differentiator/DerivativeBuilder.h"
 #include "clad/Differentiator/DiffPlanner.h"
 #include "clad/Differentiator/ReverseModeVisitor.h"
@@ -353,7 +354,7 @@ Expr* ErrorEstimationHandler::getSizeExpr(const VarDecl* VD) {
     return m_RMV->Clone(foundSize->second);
   // If the size variable is not generated yet,
   // generate it now.
-  QualType intTy = m_RMV->m_Context.getSizeType();
+  QualType intTy = clad_compat::getSizeType(m_RMV->m_Context);
   VarDecl* sizeVD = m_RMV->BuildGlobalVarDecl(
       intTy, VD->getNameAsString() + "_size", m_RMV->getZeroInit(intTy));
   m_RMV->AddToGlobalBlock(m_RMV->BuildDeclStmt(sizeVD));

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -301,7 +301,7 @@ DerivativeAndOverload HessianModeVisitor::Derive() {
     // Creates callExprs to the second derivative functions genereated
     // and creates maps array elements to input array.
     for (size_t i = 0, e = secDerivFuncs.size(); i < e; ++i) {
-      auto size_type = m_Context.getSizeType();
+      auto size_type = clad_compat::getSizeType(m_Context);
       auto size_type_bits = m_Context.getIntWidth(size_type);
 
       // Transforms ParmVarDecls into Expr paramters for insertion into function

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -84,8 +84,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       if (const auto* ILE =
               dyn_cast<InitListExpr>(CXXILE->getSubExpr()->IgnoreImplicit())) {
         unsigned numInits = ILE->getNumInits();
-        return ConstantFolder::synthesizeLiteral(m_Context.getSizeType(),
-                                                 m_Context, numInits);
+        return ConstantFolder::synthesizeLiteral(
+            clad_compat::getSizeType(m_Context), m_Context, numInits);
       }
   return nullptr;
 }
@@ -527,7 +527,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     QualType recordTy = thisTy->getPointeeType();
     TypeSourceInfo* TSI = m_Context.getTrivialTypeSourceInfo(recordTy, noLoc);
     Expr* size = new (m_Context) UnaryExprOrTypeTraitExpr(
-        UETT_SizeOf, TSI, m_Context.getSizeType(), noLoc, noLoc);
+        UETT_SizeOf, TSI, clad_compat::getSizeType(m_Context), noLoc, noLoc);
 
     // Build `malloc(sizeof(T))`
     llvm::SmallVector<clang::Expr*, 1> param{size};
@@ -1227,7 +1227,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     if (condVarRes.getExpr() != nullptr && isa<Expr>(condVarRes.getExpr()))
       forwardCond = cast<Expr>(condVarRes.getExpr());
 
-    Stmt* breakStmt = m_Sema.ActOnBreakStmt(noLoc, getCurrentScope()).get();
+    Stmt* breakStmt =
+        clad_compat::ActOnBreakStmt(m_Sema, noLoc, getCurrentScope()).get();
 
     if (Stmt* condDiffUnwrap = utils::unwrapIfSingleStmt(condDiff.getStmt())) {
       /// This part adds the forward pass of loop condition stmt in the body
@@ -1541,8 +1542,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         // FIXME: We should instead store the decl of the adjoint in m_Variables
         // and rebuild the declref every time.
         auto* dVar = cast<VarDecl>(dVarDRE->getDecl());
-        if (dVar->getDeclContext() != m_Sema.CurContext)
-          dExpr = BuildDeclRef(dVar, DRE->getQualifier());
+        if (dVar->getDeclContext() != m_Sema.CurContext) {
+          clad_compat::NestedNameSpecifierTy NNS = DRE->getQualifier();
+          dExpr = BuildDeclRef(dVar, clad_compat::hasQualifier(NNS)
+                                         ? NNS
+                                         : clad_compat::nullNNS());
+        }
       }
 
       // Create the (_d_param[idx] += dfdx) statement.
@@ -1804,14 +1809,19 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     for (auto* PVD : params)
       ParamInfoLambda.emplace_back(PVD->getIdentifier(), PVD->getLocation(),
                                    PVD, nullptr);
+    // ActOnStartOfLambdaDefinition uses LParenLoc.isValid() to flip
+    // LSI->ExplicitParams; an invalid LParen makes the lambda print
+    // without its parameter list (`[]{...}` instead of `[](T x){...}`).
+    // Use a real SourceLocation so the printer sees explicit params.
+    SourceLocation paramListLoc = utils::GetValidSLoc(m_Sema);
     D.AddTypeInfo(DeclaratorChunk::getFunction(
                       /*hasProto=*/true,
                       /*isAmbiguous=*/false,
-                      /*LParenLoc=*/noLoc,
+                      /*LParenLoc=*/paramListLoc,
                       /*Params=*/ParamInfoLambda.data(),
                       /*NumParams=*/ParamInfoLambda.size(),
                       /*EllipsisLoc=*/SourceLocation(),
-                      /*RParenLoc=*/noLoc,
+                      /*RParenLoc=*/paramListLoc,
                       /*RefQualifierIsLValueRef=*/true,
                       /*RefQualifierLoc=*/SourceLocation(),
                       /*MutableLoc=*/SourceLocation(),
@@ -2709,7 +2719,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                                     /*force=*/true);
       Stmt* LPop = endBlock(direction::reverse);
       Expr::EvalResult dummy;
-      if (!clad_compat::Expr_EvaluateAsConstantExpr(R, dummy, m_Context) ||
+      if (!R->EvaluateAsConstantExpr(dummy, m_Context) ||
           RDelayed.needsUpdate) {
         // dxi/xr = -xl / (xr * xr)
         // df/dxl += df/dxi * dxi/xr = df/dxi * (-xl /(xr * xr))
@@ -3683,15 +3693,18 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   Expr* ReverseModeVisitor::GlobalStoreAndRef(Expr* E, llvm::StringRef prefix,
                                               bool force) {
     assert(E && "cannot infer type");
-    return GlobalStoreAndRef(E, utils::getNonConstType(E->getType(), m_Sema),
-                             prefix, force);
+    return GlobalStoreAndRef(
+        E,
+        utils::getNonConstType(clad_compat::stripPredefinedSugar(E->getType()),
+                               m_Sema),
+        prefix, force);
   }
 
   StmtDiff ReverseModeVisitor::StoreAndRestore(clang::Expr* E,
                                                llvm::StringRef prefix,
                                                bool moveToTape) {
     assert(E && "must be provided");
-    QualType Type = E->getType();
+    QualType Type = clad_compat::stripPredefinedSugar(E->getType());
 
     Stmt* Store = nullptr;
     Stmt* Restore = nullptr;
@@ -3858,8 +3871,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   ReverseModeVisitor::LoopCounter::LoopCounter(ReverseModeVisitor& RMV)
       : m_RMV(RMV) {
     ASTContext& C = m_RMV.m_Context;
-    m_Ref = m_RMV.GlobalStoreAndRef(m_RMV.getZeroInit(C.IntTy), C.getSizeType(),
-                                    "_t", /*force=*/true);
+    m_Ref = m_RMV.GlobalStoreAndRef(m_RMV.getZeroInit(C.IntTy),
+                                    clad_compat::getSizeType(C), "_t",
+                                    /*force=*/true);
   }
 
   StmtDiff ReverseModeVisitor::VisitWhileStmt(const WhileStmt* WS) {
@@ -4094,7 +4108,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       Sema::ConditionResult condRes = m_Sema.ActOnCondition(
           getCurrentScope(), noLoc, condExpr, Sema::ConditionKind::Switch);
       SwitchStmt* forwardSS =
-          clad_compat::Sema_ActOnStartOfSwitchStmt(m_Sema, nullptr, condRes)
+          m_Sema
+              .ActOnStartOfSwitchStmt(/*SwitchLoc=*/noLoc,
+                                      /*LParenLoc=*/noLoc, nullptr, condRes,
+                                      /*RParenLoc=*/noLoc)
               .getAs<SwitchStmt>();
       activeBreakContHandler->UpdateForwAndRevBlocks(bodyDiff);
 
@@ -4128,7 +4145,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     Expr* ifCond = BuildOp(BinaryOperatorKind::BO_EQ, newSC->getLHS(),
                            SSData->switchStmtCond);
-    Stmt* ifThen = m_Sema.ActOnBreakStmt(noLoc, getCurrentScope()).get();
+    Stmt* ifThen =
+        clad_compat::ActOnBreakStmt(m_Sema, noLoc, getCurrentScope()).get();
     Stmt* ifBreakExpr = clad_compat::IfStmt_Create(
         m_Context, noLoc, false, nullptr, nullptr, ifCond, noLoc, noLoc, ifThen,
         noLoc, nullptr);
@@ -4147,7 +4165,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     auto* SSData = GetActiveSwitchStmtInfo();
     auto* newDefaultStmt =
         new (m_Sema.getASTContext()) DefaultStmt(noLoc, noLoc, nullptr);
-    Stmt* ifThen = m_Sema.ActOnBreakStmt(noLoc, getCurrentScope()).get();
+    Stmt* ifThen =
+        clad_compat::ActOnBreakStmt(m_Sema, noLoc, getCurrentScope()).get();
     Stmt* ifBreakExpr = clad_compat::IfStmt_Create(
         m_Context, noLoc, false, nullptr, nullptr, nullptr, noLoc, noLoc,
         ifThen, noLoc, nullptr);
@@ -4232,8 +4251,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     Expr* revCounter = loopCounter.getCounterConditionResult().get().second;
     if (m_CurrentBreakFlagExpr) {
-      VarDecl* numRevIterations = BuildVarDecl(m_Context.getSizeType(),
-                                               "_numRevIterations", revCounter);
+      VarDecl* numRevIterations = BuildVarDecl(
+          clad_compat::getSizeType(m_Context), "_numRevIterations", revCounter);
       loopCounter.setNumRevIterations(numRevIterations);
     }
 
@@ -4291,7 +4310,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
   StmtDiff ReverseModeVisitor::VisitContinueStmt(const ContinueStmt* CS) {
     beginBlock(direction::forward);
-    Stmt* newCS = m_Sema.ActOnContinueStmt(noLoc, getCurrentScope()).get();
+    Stmt* newCS =
+        clad_compat::ActOnContinueStmt(m_Sema, noLoc, getCurrentScope()).get();
     auto* activeBreakContHandler = GetActiveBreakContStmtHandler();
     Stmt* CFCaseStmt = activeBreakContHandler->GetNextCFCaseStmt();
     Stmt* pushExprToCurrentCase = activeBreakContHandler
@@ -4303,7 +4323,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
   StmtDiff ReverseModeVisitor::VisitBreakStmt(const BreakStmt* BS) {
     beginBlock(direction::forward);
-    Stmt* newBS = m_Sema.ActOnBreakStmt(noLoc, getCurrentScope()).get();
+    Stmt* newBS =
+        clad_compat::ActOnBreakStmt(m_Sema, noLoc, getCurrentScope()).get();
     auto* activeBreakContHandler = GetActiveBreakContStmtHandler();
     Stmt* CFCaseStmt = activeBreakContHandler->GetNextCFCaseStmt();
     Stmt* pushExprToCurrentCase = activeBreakContHandler
@@ -4327,8 +4348,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   Expr* ReverseModeVisitor::BreakContStmtHandler::CreateSizeTLiteralExpr(
       std::size_t value) {
     ASTContext& C = m_RMV.m_Context;
-    auto* literalExpr =
-        ConstantFolder::synthesizeLiteral(C.getSizeType(), C, value);
+    auto* literalExpr = ConstantFolder::synthesizeLiteral(
+        clad_compat::getSizeType(C), C, value);
     return literalExpr;
   }
 
@@ -4422,9 +4443,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     auto condResult = m_RMV.m_Sema.ActOnCondition(m_RMV.getCurrentScope(),
                                                   noLoc, m_ControlFlowTape->Pop,
                                                   Sema::ConditionKind::Switch);
-    auto* CFSS = clad_compat::Sema_ActOnStartOfSwitchStmt(m_RMV.m_Sema, nullptr,
-                                                          condResult)
-                     .getAs<SwitchStmt>();
+    auto* CFSS =
+        m_RMV.m_Sema
+            .ActOnStartOfSwitchStmt(/*SwitchLoc=*/noLoc,
+                                    /*LParenLoc=*/noLoc, nullptr, condResult,
+                                    /*RParenLoc=*/noLoc)
+            .getAs<SwitchStmt>();
     // Registers all the switch cases
     for (auto* SC : m_SwitchCases)
       CFSS->addSwitchCase(SC);
@@ -4677,7 +4701,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                                     primalArgs.begin(), primalArgs.end());
       reverseForwAdjointArgs.insert(
           reverseForwAdjointArgs.begin(),
-          utils::GetCladTagExpr(m_Sema, m_Context.getRecordType(RD)));
+          utils::GetCladTagExpr(m_Sema,
+                                clad_compat::getRecordType(m_Context, RD)));
       Expr* customReverseForwFnCall =
           BuildCallExprToFunction(constrForw, reverseForwAdjointArgs);
       if (RD->isAggregate()) {
@@ -4707,7 +4732,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     // Aggregate constructors are always element-wise initializers.
     if (RD->isAggregate() && CD->isDefaultConstructor())
-      return {nullptr, getZeroInit(m_Context.getRecordType(RD))};
+      return {nullptr, getZeroInit(clad_compat::getRecordType(m_Context, RD))};
 
     // `CXXConstructExpr` node will be created automatically by passing these
     // initialiser to higher level `ActOn`/`Build` Sema functions.

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -128,19 +128,19 @@ static void getCXXCastPath(CastExpr* CE, CXXCastPath& Path) {
 Stmt* StmtClone::VisitImplicitCastExpr(ImplicitCastExpr* Node) {
   CXXCastPath Path;
   getCXXCastPath(Node, Path);
-  return ImplicitCastExpr::Create(
-      Ctx, CloneType(Node->getType()), Node->getCastKind(),
-      Clone(Node->getSubExpr()), &Path,
-      Node->getValueKind() /*EP*/ CLAD_COMPAT_CLANG12_CastExpr_GetFPO(Node));
+  return ImplicitCastExpr::Create(Ctx, CloneType(Node->getType()),
+                                  Node->getCastKind(),
+                                  Clone(Node->getSubExpr()), &Path,
+                                  Node->getValueKind(), Node->getFPFeatures());
 }
 Stmt* StmtClone::VisitCStyleCastExpr(CStyleCastExpr* Node) {
   CXXCastPath Path;
   getCXXCastPath(Node, Path);
   return CStyleCastExpr::Create(
       Ctx, CloneType(Node->getType()), Node->getValueKind(),
-      Node->getCastKind(), Clone(Node->getSubExpr()),
-      &Path /*EP*/ CLAD_COMPAT_CLANG12_CastExpr_GetFPO(Node),
-      Node->getTypeInfoAsWritten(), Node->getLParenLoc(), Node->getRParenLoc());
+      Node->getCastKind(), Clone(Node->getSubExpr()), &Path,
+      Node->getFPFeatures(), Node->getTypeInfoAsWritten(), Node->getLParenLoc(),
+      Node->getRParenLoc());
 }
 Stmt* StmtClone::VisitCXXStaticCastExpr(CXXStaticCastExpr* Node) {
   CXXCastPath Path;
@@ -148,8 +148,7 @@ Stmt* StmtClone::VisitCXXStaticCastExpr(CXXStaticCastExpr* Node) {
   return CXXStaticCastExpr::Create(
       Ctx, CloneType(Node->getType()), Node->getValueKind(),
       Node->getCastKind(), Clone(Node->getSubExpr()), &Path,
-      Node->getTypeInfoAsWritten() /*EP*/ CLAD_COMPAT_CLANG12_CastExpr_GetFPO(
-          Node),
+      Node->getTypeInfoAsWritten(), Node->getFPFeatures(),
       Node->getOperatorLoc(), Node->getRParenLoc(), Node->getAngleBrackets());
 }
 Stmt* StmtClone::VisitCXXDynamicCastExpr(CXXDynamicCastExpr* Node) {
@@ -186,8 +185,7 @@ DEFINE_CREATE_EXPR(
 DEFINE_CREATE_EXPR(CXXFunctionalCastExpr,
                    (Ctx, CloneType(Node->getType()), Node->getValueKind(),
                     Node->getTypeInfoAsWritten(), Node->getCastKind(),
-                    Clone(Node->getSubExpr()),
-                    nullptr /*EP*/ CLAD_COMPAT_CLANG12_CastExpr_GetFPO(Node),
+                    Clone(Node->getSubExpr()), nullptr, Node->getFPFeatures(),
                     Node->getLParenLoc(), Node->getRParenLoc()))
 DEFINE_CREATE_EXPR(ExprWithCleanups, (Ctx, Node->getSubExpr(),
                                       Node->cleanupsHaveSideEffects(), {}))
@@ -253,9 +251,8 @@ DEFINE_CLONE_EXPR(CXXThrowExpr, (Clone(Node->getSubExpr()), Node->getType(), Nod
 DEFINE_CLONE_EXPR(
     SubstNonTypeTemplateParmExpr,
     (CloneType(Node->getType()), Node->getValueKind(), Node->getBeginLoc(),
-     Node->getParameter(),
-     CLAD_COMPAT_SubstNonTypeTemplateParmExpr_isReferenceParameter_ExtraParam(
-         Node) Node->getReplacement()))
+     Node->getParameter(), Node->isReferenceParameter(),
+     Node->getReplacement()))
 #elif CLANG_VERSION_MAJOR < 21
 DEFINE_CLONE_EXPR(SubstNonTypeTemplateParmExpr,
                   (CloneType(Node->getType()), Node->getValueKind(),
@@ -341,8 +338,8 @@ Stmt* StmtClone::VisitCallExpr(CallExpr* Node) {
 
   CallExpr* result = clad_compat::CallExpr_Create(
       Ctx, Clone(Node->getCallee()), clonedArgs, CloneType(Node->getType()),
-      Node->getValueKind(),
-      Node->getRParenLoc() CLAD_COMPAT_CLANG8_CallExpr_ExtraParams);
+      Node->getValueKind(), Node->getRParenLoc(), Node->getFPFeatures(),
+      Node->getNumArgs(), Node->getADLCallKind());
 
   // Copy Value and Type dependent
   clad_compat::ExprSetDeps(result, Node);
@@ -371,8 +368,8 @@ Stmt* StmtClone::VisitCUDAKernelCallExpr(CUDAKernelCallExpr* Node) {
 
   CUDAKernelCallExpr* result = clad_compat::CUDAKernelCallExpr_Create(
       Ctx, Clone(Node->getCallee()), Clone(Node->getConfig()), clonedArgs,
-      CloneType(Node->getType()), Node->getValueKind(),
-      Node->getRParenLoc() CLAD_COMPAT_CLANG8_CallExpr_ExtraParams);
+      CloneType(Node->getType()), Node->getValueKind(), Node->getRParenLoc(),
+      Node->getFPFeatures(), Node->getNumArgs(), Node->getADLCallKind());
 
   // Copy Value and Type dependent
   clad_compat::ExprSetDeps(result, Node);
@@ -415,11 +412,9 @@ Stmt* StmtClone::VisitCXXMemberCallExpr(CXXMemberCallExpr * Node) {
   for (Expr* arg : Node->arguments())
     clonedArgs.push_back(Clone(arg));
 
-  CXXMemberCallExpr* result = clad_compat::CXXMemberCallExpr_Create(
+  CXXMemberCallExpr* result = CXXMemberCallExpr::Create(
       Ctx, Clone(Node->getCallee()), clonedArgs, CloneType(Node->getType()),
-      Node->getValueKind(),
-      Node->getRParenLoc()
-      /*FP*/ CLAD_COMPAT_CLANG12_CastExpr_GetFPO(Node));
+      Node->getValueKind(), Node->getRParenLoc(), Node->getFPFeatures());
 
   // Copy Value and Type dependent
   clad_compat::ExprSetDeps(result, Node);
@@ -448,10 +443,9 @@ Stmt* StmtClone::VisitCaseStmt(CaseStmt* Node) {
 
 Stmt* StmtClone::VisitSwitchStmt(SwitchStmt* Node) {
   SourceLocation noLoc;
-  SwitchStmt* result
-    = clad_compat::SwitchStmt_Create(Ctx,
-        Node->getInit(), Node->getConditionVariable(), Node->getCond(),
-        noLoc, noLoc);
+  SwitchStmt* result = SwitchStmt::Create(
+      Ctx, Node->getInit(), Node->getConditionVariable(), Node->getCond(),
+      /*LParenLoc=*/noLoc, /*RParenLoc=*/noLoc);
   result->setBody(Clone(Node->getBody()));
   result->setSwitchLoc(Node->getSwitchLoc());
   return result;
@@ -467,13 +461,19 @@ DEFINE_CLONE_STMT_CO(WhileStmt,
                       Node->getWhileLoc(), Node->getLParenLoc(),
                       Node->getRParenLoc()))
 DEFINE_CLONE_STMT(DoStmt, (Clone(Node->getBody()), Clone(Node->getCond()), Node->getDoLoc(), Node->getWhileLoc(), Node->getRParenLoc()))
-DEFINE_CLONE_STMT_CO(IfStmt, (Ctx, Node->getIfLoc(),CLAD_COMPAT_IfStmt_Create_IfStmtKind_Param(Node), Node->getInit(), CloneDeclOrNull(Node->getConditionVariable()), Clone(Node->getCond()) /*EPs*/CLAD_COMPAT_CLANG12_LR_ExtraParams(Node), Clone(Node->getThen()), Node->getElseLoc(), Clone(Node->getElse())))
+DEFINE_CLONE_STMT_CO(IfStmt, (Ctx, Node->getIfLoc(),
+                              CLAD_COMPAT_IfStmt_Create_IfStmtKind_Param(Node),
+                              Node->getInit(),
+                              CloneDeclOrNull(Node->getConditionVariable()),
+                              Clone(Node->getCond()), Node->getLParenLoc(),
+                              Node->getRParenLoc(), Clone(Node->getThen()),
+                              Node->getElseLoc(), Clone(Node->getElse())))
 DEFINE_CLONE_STMT(LabelStmt, (Node->getIdentLoc(), Node->getDecl(), Clone(Node->getSubStmt())))
 DEFINE_CLONE_STMT(NullStmt, (Node->getSemiLoc()))
 DEFINE_CLONE_STMT(ForStmt, (Ctx, Clone(Node->getInit()), Clone(Node->getCond()), CloneDeclOrNull(Node->getConditionVariable()), Clone(Node->getInc()), Clone(Node->getBody()),
                             Node->getForLoc(), Node->getLParenLoc(), Node->getRParenLoc()))
-DEFINE_CLONE_STMT(ContinueStmt, (Node->getContinueLoc()))
-DEFINE_CLONE_STMT(BreakStmt, (Node->getBreakLoc()))
+DEFINE_CLONE_STMT(ContinueStmt, (clad_compat::getContinueLoc(Node)))
+DEFINE_CLONE_STMT(BreakStmt, (clad_compat::getBreakLoc(Node)))
 DEFINE_CLONE_STMT(CXXCatchStmt, (Node->getCatchLoc(),
                                  CloneDeclOrNull(Node->getExceptionDecl()),
                                  Clone(Node->getHandlerBlock())))

--- a/lib/Differentiator/TBRAnalyzer.cpp
+++ b/lib/Differentiator/TBRAnalyzer.cpp
@@ -268,10 +268,9 @@ bool TBRAnalyzer::TraverseBinaryOperator(BinaryOperator* BinOp) {
     // Multiplication results in a linear expression if and only if one of the
     // factors is constant.
     Expr::EvalResult dummy;
-    bool nonLinear = !clad_compat::Expr_EvaluateAsConstantExpr(
-                         R, dummy, m_AnalysisDC->getASTContext()) &&
-                     !clad_compat::Expr_EvaluateAsConstantExpr(
-                         L, dummy, m_AnalysisDC->getASTContext());
+    bool nonLinear =
+        !R->EvaluateAsConstantExpr(dummy, m_AnalysisDC->getASTContext()) &&
+        !L->EvaluateAsConstantExpr(dummy, m_AnalysisDC->getASTContext());
     bool LHSIsStored =
         !utils::ShouldRecompute(L, m_AnalysisDC->getASTContext());
     bool RHSIsStored =
@@ -297,8 +296,8 @@ bool TBRAnalyzer::TraverseBinaryOperator(BinaryOperator* BinOp) {
     // Division normally only results in a linear expression when the
     // denominator is constant.
     Expr::EvalResult dummy;
-    bool nonLinear = !clad_compat::Expr_EvaluateAsConstantExpr(
-        R, dummy, m_AnalysisDC->getASTContext());
+    bool nonLinear =
+        !R->EvaluateAsConstantExpr(dummy, m_AnalysisDC->getASTContext());
     if (nonLinear)
       startNonLinearMode();
     bool LHSIsStored =
@@ -335,8 +334,8 @@ bool TBRAnalyzer::TraverseBinaryOperator(BinaryOperator* BinOp) {
       // represents the same operation as 'x = x * y' ('x = x / y') and,
       // therefore, LHS has to be visited in kMarkingMode|kNonLinearMode.
       Expr::EvalResult dummy;
-      bool RisNotConst = !clad_compat::Expr_EvaluateAsConstantExpr(
-          R, dummy, m_AnalysisDC->getASTContext());
+      bool RisNotConst =
+          !R->EvaluateAsConstantExpr(dummy, m_AnalysisDC->getASTContext());
       if (RisNotConst)
         setMode(Mode::kMarkingMode | Mode::kNonLinearMode);
       TraverseStmt(L);

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -278,12 +278,12 @@ namespace clad {
   }
 
   DeclRefExpr* VisitorBase::BuildDeclRef(DeclaratorDecl* D,
-                                         NestedNameSpecifier* NNS /*=nullptr*/,
+                                         clad_compat::NestedNameSpecifierTy NNS,
                                          ExprValueKind VK /*=VK_LValue*/) {
     CXXScopeSpec CSS;
     SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
 
-    if (!NNS) {
+    if (!clad_compat::hasQualifier(NNS)) {
       // If no CXXScopeSpec is provided we should try to find the common path
       // between the current scope (in which presumably we will make the call)
       // and where `D` is.
@@ -302,18 +302,19 @@ namespace clad {
       for (DeclContext* DC : llvm::reverse(DCs)) {
         if (auto* ND = dyn_cast<NamespaceDecl>(DC)) {
           if (!ND->isInline())
-            NNS = NestedNameSpecifier::Create(m_Context, NNS, ND);
+            NNS = clad_compat::makeNNSNamespace(m_Context, NNS, ND);
         } else if (auto* TD = dyn_cast<TagDecl>(DC)) {
-          clang::QualType T = m_Context.getTypeDeclType(TD);
-          NNS = NestedNameSpecifier::Create(
-              m_Context, NNS CLAD_COMPAT_CLANG21_TemplateKeywordParam,
-              /*Type*/ T.getTypePtr());
+          NNS = clad_compat::makeNNSTagType(m_Context, NNS, TD);
         }
         // FIXME: Add support for other DeclContext types.
         // See clang's getFullyQualifiedNestedNameSpecifier.
       }
     }
-    CSS.MakeTrivial(m_Context, NNS, fakeLoc);
+    // MakeTrivial on a null/Invalid NNS renders as `::` on clang 22
+    // (the trivial-scope wraps it as Global); skip when there's no
+    // qualifier so local-variable refs print bare.
+    if (clad_compat::hasQualifier(NNS))
+      CSS.MakeTrivial(m_Context, NNS, fakeLoc);
     QualType T = D->getType();
     T = T.getNonReferenceType();
     return cast<DeclRefExpr>(clad_compat::GetResult<Expr*>(
@@ -373,7 +374,7 @@ namespace clad {
   Expr* VisitorBase::StoreAndRef(Expr* E, Stmts& block, llvm::StringRef prefix,
                                  bool forceDeclCreation) {
     assert(E && "cannot infer type from null expression");
-    QualType Type = E->getType();
+    QualType Type = clad_compat::stripPredefinedSugar(E->getType());
     if (E->isModifiableLvalue(m_Context) == Expr::MLV_Valid)
       Type = m_Context.getLValueReferenceType(Type);
     return StoreAndRef(E, Type, block, prefix, forceDeclCreation);
@@ -610,9 +611,8 @@ namespace clad {
   static QualType getRefQualifiedThisType(Sema& semaRef, CXXMethodDecl* MD) {
     ASTContext& C = semaRef.getASTContext();
     CXXRecordDecl* RD = MD->getParent();
-    auto RDType = RD->getTypeForDecl();
-    auto thisObjectQType =
-        C.getQualifiedType(RDType, MD->getMethodQualifiers());
+    auto thisObjectQType = C.getQualifiedType(
+        clad_compat::getCanonicalTagType(C, RD), MD->getMethodQualifiers());
     if (MD->getRefQualifier() == RefQualifierKind::RQ_RValue)
       thisObjectQType = C.getRValueReferenceType(thisObjectQType);
     else if (MD->getRefQualifier() == RefQualifierKind::RQ_LValue)

--- a/test/FirstDerivative/FunctionCallsWithResults.C
+++ b/test/FirstDerivative/FunctionCallsWithResults.C
@@ -360,7 +360,7 @@ double fn10(double x) {
 // CHECK-NEXT:   std::mt19937 gen64;
 // CHECK-NEXT:   std::uniform_real_distribution<{{(double)?}}> _d_distribution{0., 0.};
 // CHECK-NEXT:   std::uniform_real_distribution<{{(double)?}}> distribution{0., 1.};
-// CHECK-NEXT:   clad::ValueAndPushforward<result_type, result_type> _t0 = distribution.operator_call_pushforward(gen64, &_d_distribution, _d_gen64);
+// CHECK-NEXT:   clad::ValueAndPushforward<{{(result_type|double)}}, {{(result_type|double)}}> _t0 = distribution.operator_call_pushforward(gen64, &_d_distribution, _d_gen64);
 // CHECK-NEXT:   double _d_rand = _t0.pushforward;
 // CHECK-NEXT:   double rand0 = _t0.value;
 // CHECK-NEXT:   return _d_x + _d_rand;

--- a/test/ForwardMode/STLCustomDerivatives.C
+++ b/test/ForwardMode/STLCustomDerivatives.C
@@ -391,7 +391,7 @@ double fnTuple1(double x, double y) {
 } // = 2x + 2y
 
 //CHECK:      clad::ValueAndPushforward<{{.*}}> pack_pushforward({{.*}}) {
-//CHECK-NEXT:          clad::ValueAndPushforward<{{.*}}> _t0 = clad::custom_derivatives::std::make_tuple_pushforward(x, 2 * x, 3 * x, _d_x, 0 * x + 2 * _d_x, 0 * x + 3 * _d_x);
+//CHECK-NEXT:          {{(clad::)?}}ValueAndPushforward<{{.*}}> _t0 = clad::custom_derivatives::std::make_tuple_pushforward(x, 2 * x, 3 * x, _d_x, 0 * x + 2 * _d_x, 0 * x + 3 * _d_x);
 //CHECK-NEXT:          return {_t0.value, _t0.pushforward};
 //CHECK-NEXT:      }
 
@@ -400,9 +400,9 @@ double fnTuple1(double x, double y) {
 //CHECK-NEXT:          double _d_y = 0;
 //CHECK-NEXT:          double _d_u, _d_v = 0 * x + 288 * _d_x, _d_w;
 //CHECK-NEXT:          double u, v = 288 * x, w;
-//CHECK-NEXT:          clad::ValueAndPushforward<{{.*}}> _t0 = clad::custom_derivatives::std::tie_pushforward(u, v, w, _d_u, _d_v, _d_w);
-//CHECK-NEXT:          clad::ValueAndPushforward<{{.*}}> _t1 = pack_pushforward(x + y, _d_x + _d_y);
-//CHECK-NEXT:          clad::ValueAndPushforward<{{.*}}> _t2 = clad::custom_derivatives::class_functions::operator_equal_pushforward(&_t0.value, static_cast<std::tuple<double, double, double> &&>(_t1.value), &_t0.pushforward, static_cast<std::tuple<double, double, double> &&>(_t1.pushforward));
+//CHECK-NEXT:          {{(clad::)?}}ValueAndPushforward<{{.*}}> _t0 = clad::custom_derivatives::std::tie_pushforward(u, v, w, _d_u, _d_v, _d_w);
+//CHECK-NEXT:          {{(clad::)?}}ValueAndPushforward<{{.*}}> _t1 = pack_pushforward(x + y, _d_x + _d_y);
+//CHECK-NEXT:          {{(clad::)?}}ValueAndPushforward<{{.*}}> _t2 = clad::custom_derivatives::class_functions::operator_equal_pushforward(&_t0.value, static_cast<std::tuple<double, double, double> &&>(_t1.value), &_t0.pushforward, static_cast<std::tuple<double, double, double> &&>(_t1.pushforward));
 //CHECK-NEXT:          return _d_v;
 //CHECK-NEXT:      }
 

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -465,7 +465,7 @@ double fn6(TensorD5 t, double i) {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<double, double> sum_pushforward(Tensor<double, 5U> &t, Tensor<double, 5U> &_d_t) {
+// CHECK: clad::ValueAndPushforward<double, double> sum_pushforward(Tensor<double, 5{{U?}}> &t, Tensor<double, 5{{U?}}> &_d_t) {
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     {
@@ -593,16 +593,16 @@ std::complex<double> fn10(double i, double j) {
   return c1 + c1;
 }
 
-// CHECK: constexpr clad::ValueAndPushforward<complex<double> &, complex<double> &> operator_equal_pushforward({{.*}}complex<double> &{{&?}}param, {{.*}}complex<double> *_d_this, {{.*}}complex<double> &{{&?}}_d_param) noexcept {
+// CHECK: constexpr clad::ValueAndPushforward<{{(std::)?}}complex<double> &, {{(std::)?}}complex<double> &> operator_equal_pushforward({{.*}}complex<double> &{{&?}}param, {{.*}}complex<double> *_d_this, {{.*}}complex<double> &{{&?}}_d_param) noexcept {
 // CHECK:    return {({{.*}}complex<double> &)*this, ({{.*}}complex<double> &)*_d_this};
 // CHECK-NEXT:  }
 
-// CHECK: clad::ValueAndPushforward<complex<double> &, complex<double> &> operator_plus_equal_pushforward(const complex<double> &__[[PARAM:.*]], std::complex<double> *_d_this, const complex<double> &_d___[[PARAM]]){{.*}} {
+// CHECK: clad::ValueAndPushforward<{{.*}}complex<double> &, {{.*}}complex<double> &> operator_plus_equal_pushforward(const complex<double> &__[[PARAM:.*]], std::complex<double> *_d_this, const complex<double> &_d___[[PARAM]]){{.*}} {
 // CHECK:    return {({{.*}}complex<double> &)*this, ({{.*}}complex<double> &)*_d_this};
 // CHECK-NEXT:  }
 
-// CHECK:  inline clad::ValueAndPushforward<complex<double>, complex<double> > operator_plus_pushforward(const complex<double> &__x, const complex<double> &__y, const complex<double> &_d___x, const complex<double> &_d___y) {{.*}}{
-// CHECK:           clad::ValueAndPushforward<complex<double> &, complex<double> &> _t0 = __{{t|r}}0.operator_plus_equal_pushforward(__y, &_d___{{t|r}}, _d___y);
+// CHECK:  inline clad::ValueAndPushforward<{{(std::)?}}complex<double>, {{(std::)?}}complex<double> > operator_plus_pushforward(const complex<double> &__x, const complex<double> &__y, const complex<double> &_d___x, const complex<double> &_d___y) {{.*}}{
+// CHECK:           clad::ValueAndPushforward<{{(std::)?}}complex<double> &, {{(std::)?}}complex<double> &> _t0 = __{{t|r}}0.operator_plus_equal_pushforward(__y, &_d___{{t|r}}, _d___y);
 // CHECK-NEXT:      return {__{{t|r}}0, _d___{{t|r}}};
 // CHECK-NEXT:  }
 
@@ -615,10 +615,10 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:     c1.imag_pushforward(5 * i, &_d_c1, 0 * i + 5 * _d_i);
 // CHECK-NEXT:     c2.real_pushforward(5 * i, &_d_c2, 0 * i + 5 * _d_i);
 // CHECK-NEXT:     c2.imag_pushforward(2 * i, &_d_c2, 0 * i + 2 * _d_i);
-// CHECK-NEXT:     clad::ValueAndPushforward<complex<double>, complex<double> > _t0 = std::operator_plus_pushforward(c1, c2, _d_c1, _d_c2);
-// CHECK-NEXT:     clad::ValueAndPushforward<complex<double> &, complex<double> &> _t1 = c1.operator_equal_pushforward({{(static_cast<std(::__1)?::complex<double> &&>\(_t0.value\))|(_t0.value)}}, &_d_c1, {{(static_cast<std(::__1)?::complex<double> &&>\(_t0.pushforward\))|(_t0.pushforward)}});
-// CHECK-NEXT:     clad::ValueAndPushforward<complex<double> &, complex<double> &> _t2 = c1.operator_plus_equal_pushforward(c2, &_d_c1, _d_c2);
-// CHECK-NEXT:     clad::ValueAndPushforward<complex<double>, complex<double> > _t3 = std::operator_plus_pushforward(c1, c1, _d_c1, _d_c1);
+// CHECK-NEXT:     clad::ValueAndPushforward<{{(std::)?}}complex<double>, {{(std::)?}}complex<double> > _t0 = std::operator_plus_pushforward(c1, c2, _d_c1, _d_c2);
+// CHECK-NEXT:     clad::ValueAndPushforward<{{(std::)?}}complex<double> &, {{(std::)?}}complex<double> &> _t1 = c1.operator_equal_pushforward({{(static_cast<std(::__1)?::complex<double> &&>\(_t0.value\))|(_t0.value)}}, &_d_c1, {{(static_cast<std(::__1)?::complex<double> &&>\(_t0.pushforward\))|(_t0.pushforward)}});
+// CHECK-NEXT:     clad::ValueAndPushforward<{{(std::)?}}complex<double> &, {{(std::)?}}complex<double> &> _t2 = c1.operator_plus_equal_pushforward(c2, &_d_c1, _d_c2);
+// CHECK-NEXT:     clad::ValueAndPushforward<{{(std::)?}}complex<double>, {{(std::)?}}complex<double> > _t3 = std::operator_plus_pushforward(c1, c1, _d_c1, _d_c1);
 // CHECK-NEXT:     return _t3.pushforward;
 // CHECK-NEXT: }
 
@@ -647,9 +647,9 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:     return {(Tensor<double, 5> &)*this, (Tensor<double, 5> &)*_d_this};
 // CHECK-NEXT: }
 
-// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_plus_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     Tensor<double, 5U> _d_res;
-// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > operator_plus_pushforward(const Tensor<double, 5{{U?}}> &a, const Tensor<double, 5{{U?}}> &b, const Tensor<double, 5{{U?}}> &_d_a, const Tensor<double, 5{{U?}}> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5{{U?}}> _d_res;
+// CHECK-NEXT:     Tensor<double, 5{{U?}}> res;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         unsigned int _d_i = 0;
 // CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
@@ -660,9 +660,9 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:     return {res, _d_res};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_minus_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     Tensor<double, 5U> _d_res;
-// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > operator_minus_pushforward(const Tensor<double, 5{{U?}}> &a, const Tensor<double, 5{{U?}}> &b, const Tensor<double, 5{{U?}}> &_d_a, const Tensor<double, 5{{U?}}> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5{{U?}}> _d_res;
+// CHECK-NEXT:     Tensor<double, 5{{U?}}> res;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         unsigned int _d_i = 0;
 // CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
@@ -673,9 +673,9 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:     return {res, _d_res};
 // CHECK-NEXT: }
 
-// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_star_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     Tensor<double, 5U> _d_res;
-// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > operator_star_pushforward(const Tensor<double, 5{{U?}}> &a, const Tensor<double, 5{{U?}}> &b, const Tensor<double, 5{{U?}}> &_d_a, const Tensor<double, 5{{U?}}> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5{{U?}}> _d_res;
+// CHECK-NEXT:     Tensor<double, 5{{U?}}> res;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         unsigned int _d_i = 0;
 // CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
@@ -688,9 +688,9 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:     return {res, _d_res};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_minus_pushforward(const Tensor<double, 5U> &t, const Tensor<double, 5U> &_d_t) {
-// CHECK-NEXT:     Tensor<double, 5U> _d_res;
-// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > operator_minus_pushforward(const Tensor<double, 5{{U?}}> &t, const Tensor<double, 5{{U?}}> &_d_t) {
+// CHECK-NEXT:     Tensor<double, 5{{U?}}> _d_res;
+// CHECK-NEXT:     Tensor<double, 5{{U?}}> res;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         unsigned int _d_i = 0;
 // CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
@@ -701,9 +701,9 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:     return {res, _d_res};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_slash_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     Tensor<double, 5U> _d_res;
-// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > operator_slash_pushforward(const Tensor<double, 5{{U?}}> &a, const Tensor<double, 5{{U?}}> &b, const Tensor<double, 5{{U?}}> &_d_a, const Tensor<double, 5{{U?}}> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5{{U?}}> _d_res;
+// CHECK-NEXT:     Tensor<double, 5{{U?}}> res;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         unsigned int _d_i = 0;
 // CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
@@ -716,9 +716,9 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:     return {res, _d_res};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_caret_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     Tensor<double, 5U> _d_res;
-// CHECK-NEXT:     Tensor<double, 5U> res;
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > operator_caret_pushforward(const Tensor<double, 5{{U?}}> &a, const Tensor<double, 5{{U?}}> &b, const Tensor<double, 5{{U?}}> &_d_a, const Tensor<double, 5{{U?}}> &_d_b) {
+// CHECK-NEXT:     Tensor<double, 5{{U?}}> _d_res;
+// CHECK-NEXT:     Tensor<double, 5{{U?}}> res;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         unsigned int _d_i = 0;
 // CHECK-NEXT:         for (unsigned int i = 0; i < 5U; ++i) {
@@ -730,16 +730,16 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:     return {res, _d_res};
 // CHECK-NEXT: }
 
-// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_plus_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_plus_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK-NEXT: clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> operator_plus_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t0 = operator_plus_pushforward(lhs, rhs, _d_lhs, _d_rhs);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
-// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
+// CHECK-NEXT:     return {(Tensor<double, 5{{U?}}> &)lhs, (Tensor<double, 5{{U?}}> &)_d_lhs};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_minus_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:   clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_minus_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> operator_minus_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
+// CHECK-NEXT:   clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t0 = operator_minus_pushforward(lhs, rhs, _d_lhs, _d_rhs);
 // CHECK-NEXT:   clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
-// CHECK-NEXT:   return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
+// CHECK-NEXT:   return {(Tensor<double, 5{{U?}}> &)lhs, (Tensor<double, 5{{U?}}> &)_d_lhs};
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> operator_plus_plus_pushforward(Tensor<double, 5> *_d_this) {
@@ -814,24 +814,24 @@ TensorD5 fn11(double i, double j) {
 // CHECK-NEXT:     _t1.value += 13 * i;
 // CHECK-NEXT:     TensorD5 _d_res1, _d_res2;
 // CHECK-NEXT:     TensorD5 res1, res2;
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t2 = operator_plus_pushforward(a, b, _d_a, _d_b);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t3 = operator_star_pushforward(a, b, _d_a, _d_b);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t4 = operator_plus_pushforward(_t2.value, _t3.value, _t2.pushforward, _t3.pushforward);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t5 = operator_minus_pushforward(a, _d_a);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t6 = operator_plus_pushforward(_t4.value, _t5.value, _t4.pushforward, _t5.pushforward);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t7 = operator_minus_pushforward(_t6.value, b, _t6.pushforward, _d_b);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t8 = operator_slash_pushforward(a, a, _d_a, _d_a);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t9 = operator_plus_pushforward(_t7.value, _t8.value, _t7.pushforward, _t8.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t2 = operator_plus_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t3 = operator_star_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t4 = operator_plus_pushforward(_t2.value, _t3.value, _t2.pushforward, _t3.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t5 = operator_minus_pushforward(a, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t6 = operator_plus_pushforward(_t4.value, _t5.value, _t4.pushforward, _t5.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t7 = operator_minus_pushforward(_t6.value, b, _t6.pushforward, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t8 = operator_slash_pushforward(a, a, _d_a, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t9 = operator_plus_pushforward(_t7.value, _t8.value, _t7.pushforward, _t8.pushforward);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t10 = res1.operator_equal_pushforward(_t9.value, & _d_res1, _t9.pushforward);
 // CHECK-NEXT:     TensorD5 _d_one;
 // CHECK-NEXT:     TensorD5 one;
 // CHECK-NEXT:     one.operator_call_pushforward(1, & _d_one, 0);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t11 = operator_plus_pushforward(a, b, _d_a, _d_b);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t12 = operator_caret_pushforward(_t11.value, one, _t11.pushforward, _d_one);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t11 = operator_plus_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t12 = operator_caret_pushforward(_t11.value, one, _t11.pushforward, _d_one);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t13 = res2.operator_equal_pushforward(_t12.value, & _d_res2, _t12.pushforward);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t14 = operator_plus_equal_pushforward(res1, res2, _d_res1, _d_res2);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t15 = operator_star_pushforward(a, b, _d_a, _d_b);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t16 = operator_minus_equal_pushforward(res1, _t15.value, _d_res1, _t15.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> _t14 = operator_plus_equal_pushforward(res1, res2, _d_res1, _d_res2);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t15 = operator_star_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> _t16 = operator_minus_equal_pushforward(res1, _t15.value, _d_res1, _t15.pushforward);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t17 = res1.operator_plus_plus_pushforward(& _d_res1);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t18 = res2.operator_plus_plus_pushforward(& _d_res2);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t19 = res1.operator_minus_minus_pushforward(& _d_res1);
@@ -862,22 +862,22 @@ TensorD5 fn12(double i, double j) {
   return res1;
 }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_star_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_star_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> operator_star_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t0 = operator_star_pushforward(lhs, rhs, _d_lhs, _d_rhs);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
-// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
+// CHECK-NEXT:     return {(Tensor<double, 5{{U?}}> &)lhs, (Tensor<double, 5{{U?}}> &)_d_lhs};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_slash_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_slash_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> operator_slash_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t0 = operator_slash_pushforward(lhs, rhs, _d_lhs, _d_rhs);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
-// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
+// CHECK-NEXT:     return {(Tensor<double, 5{{U?}}> &)lhs, (Tensor<double, 5{{U?}}> &)_d_lhs};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_caret_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t0 = operator_slash_pushforward(lhs, rhs, _d_lhs, _d_rhs);
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> operator_caret_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t0 = operator_slash_pushforward(lhs, rhs, _d_lhs, _d_rhs);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t1 = lhs.operator_equal_pushforward(_t0.value, & _d_lhs, _t0.pushforward);
-// CHECK-NEXT:     return {(Tensor<double, 5U> &)lhs, (Tensor<double, 5U> &)_d_lhs};
+// CHECK-NEXT:     return {(Tensor<double, 5{{U?}}> &)lhs, (Tensor<double, 5{{U?}}> &)_d_lhs};
 // CHECK-NEXT: }
 
 // CHECK: TensorD5 fn12_darg0(double i, double j) {
@@ -899,17 +899,17 @@ TensorD5 fn12(double i, double j) {
 // CHECK-NEXT:     TensorD5 one;
 // CHECK-NEXT:     one.operator_call_pushforward(1, & _d_one, 0);
 // CHECK-NEXT:     res1.operator_call_pushforward(0, & _d_res1, 0);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t2 = operator_plus_equal_pushforward(res1, a, _d_res1, _d_a);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t3 = operator_star_equal_pushforward(res1, b, _d_res1, _d_b);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t4 = operator_slash_equal_pushforward(res1, a, _d_res1, _d_a);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t5 = operator_minus_equal_pushforward(res1, b, _d_res1, _d_b);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t6 = operator_star_pushforward(a, a, _d_a, _d_a);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t7 = operator_slash_pushforward(_t6.value, a, _t6.pushforward, _d_a);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t8 = operator_plus_equal_pushforward(res1, _t7.value, _d_res1, _t7.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> _t2 = operator_plus_equal_pushforward(res1, a, _d_res1, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> _t3 = operator_star_equal_pushforward(res1, b, _d_res1, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> _t4 = operator_slash_equal_pushforward(res1, a, _d_res1, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> _t5 = operator_minus_equal_pushforward(res1, b, _d_res1, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t6 = operator_star_pushforward(a, a, _d_a, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t7 = operator_slash_pushforward(_t6.value, a, _t6.pushforward, _d_a);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> _t8 = operator_plus_equal_pushforward(res1, _t7.value, _d_res1, _t7.pushforward);
 // CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t9 = res1.operator_subscript_pushforward(1, & _d_res1, 0);
 // CHECK-NEXT:     _t9.pushforward += 0 * i + 17 * _d_i;
 // CHECK-NEXT:     _t9.value += 17 * i;
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t10 = operator_caret_equal_pushforward(res1, one, _d_res1, _d_one);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> _t10 = operator_caret_equal_pushforward(res1, one, _d_res1, _d_one);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t11 = res1.operator_equal_pushforward(res1, & _d_res1, _d_res1);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t12 = res1.operator_equal_pushforward(_t11.value, & _d_res1, _t11.pushforward);
 // CHECK-NEXT:     return _d_res1;
@@ -941,7 +941,7 @@ TensorD5 fn13(double i, double j) {
   return a + b;
 }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     double _d_lsum, _d_rsum;
 // CHECK-NEXT:     double lsum, rsum;
 // CHECK-NEXT:     _d_lsum = _d_rsum = 0;
@@ -958,7 +958,7 @@ TensorD5 fn13(double i, double j) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     double _d_lsum, _d_rsum;
 // CHECK-NEXT:     double lsum, rsum;
 // CHECK-NEXT:     _d_lsum = _d_rsum = 0;
@@ -975,26 +975,26 @@ TensorD5 fn13(double i, double j) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_equal_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_equal_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_exclaim_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_exclaim_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: void operator_comma_pushforward(const Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, const Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: void operator_comma_pushforward(const Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, const Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT: }
 
-// CHECK: void operator_exclaim_pushforward(const Tensor<double, 5U> &lhs, const Tensor<double, 5U> &_d_lhs) {
+// CHECK: void operator_exclaim_pushforward(const Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &_d_lhs) {
 // CHECK-NEXT: }
 
 // CHECK: clad::ValueAndPushforward<Tensor<double, 5> *, Tensor<double, 5> *> operator_amp_pushforward(Tensor<double, 5> *_d_this) {
@@ -1005,54 +1005,54 @@ TensorD5 fn13(double i, double j) {
 // CHECK-NEXT:     return {this, _d_this};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > operator_percent_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &b, const Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > operator_percent_pushforward(const Tensor<double, 5{{U?}}> &a, const Tensor<double, 5{{U?}}> &b, const Tensor<double, 5{{U?}}> &_d_a, const Tensor<double, 5{{U?}}> &_d_b) {
 // CHECK-NEXT:     return {a, _d_a};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> operator_percent_equal_pushforward(Tensor<double, 5U> &a, const Tensor<double, 5U> &b, Tensor<double, 5U> &_d_a, const Tensor<double, 5U> &_d_b) {
-// CHECK-NEXT:     return {(Tensor<double, 5U> &)a, (Tensor<double, 5U> &)_d_a};
+// CHECK: clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> operator_percent_equal_pushforward(Tensor<double, 5{{U?}}> &a, const Tensor<double, 5{{U?}}> &b, Tensor<double, 5{{U?}}> &_d_a, const Tensor<double, 5{{U?}}> &_d_b) {
+// CHECK-NEXT:     return {(Tensor<double, 5{{U?}}> &)a, (Tensor<double, 5{{U?}}> &)_d_a};
 // CHECK-NEXT: }
 
-// CHECK: void operator_tilde_pushforward(const Tensor<double, 5U> &a, const Tensor<double, 5U> &_d_a) {
+// CHECK: void operator_tilde_pushforward(const Tensor<double, 5{{U?}}> &a, const Tensor<double, 5{{U?}}> &_d_a) {
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_less_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_less_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_greater_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_greater_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_AmpAmp_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_AmpAmp_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_pipe_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_pipe_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_less_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_less_less_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_greater_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_greater_greater_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_amp_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_amp_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_pipe_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<bool, bool> operator_amp_equal_pushforward(Tensor<double, 5U> &lhs, const Tensor<double, 5U> &rhs, Tensor<double, 5U> &_d_lhs, const Tensor<double, 5U> &_d_rhs) {
+// CHECK: clad::ValueAndPushforward<bool, bool> operator_amp_equal_pushforward(Tensor<double, 5{{U?}}> &lhs, const Tensor<double, 5{{U?}}> &rhs, Tensor<double, 5{{U?}}> &_d_lhs, const Tensor<double, 5{{U?}}> &_d_rhs) {
 // CHECK-NEXT:     return {(bool)1, (bool)0};
 // CHECK-NEXT: }
 
@@ -1094,9 +1094,9 @@ TensorD5 fn13(double i, double j) {
 // CHECK-NEXT:     double *b_data = _t12.value->data;
 // CHECK-NEXT:     _d_b_data[1] = _d_i * j + i * _d_j;
 // CHECK-NEXT:     b_data[1] = i * j;
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t13 = operator_percent_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t13 = operator_percent_pushforward(a, b, _d_a, _d_b);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t14 = a.operator_equal_pushforward(_t13.value, & _d_a, _t13.pushforward);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U> &, Tensor<double, 5U> &> _t15 = operator_percent_equal_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> _t15 = operator_percent_equal_pushforward(a, b, _d_a, _d_b);
 // CHECK-NEXT:     operator_tilde_pushforward(a, _d_a);
 // CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t16 = a.operator_subscript_pushforward(2, & _d_a, 0);
 // CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t17 = operator_less_less_pushforward(a, b, _d_a, _d_b);
@@ -1117,7 +1117,7 @@ TensorD5 fn13(double i, double j) {
 // CHECK-NEXT:     _t24.value = _t25.value + _t26.value;
 // CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t27 = operator_pipe_equal_pushforward(a, b, _d_a, _d_b);
 // CHECK-NEXT:     clad::ValueAndPushforward<bool, bool> _t28 = operator_amp_equal_pushforward(b, a, _d_b, _d_a);
-// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5U>, Tensor<double, 5U> > _t29 = operator_plus_pushforward(a, b, _d_a, _d_b);
+// CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t29 = operator_plus_pushforward(a, b, _d_a, _d_b);
 // CHECK-NEXT:     return _t29.pushforward;
 // CHECK-NEXT: }
 
@@ -1146,10 +1146,10 @@ double fn14(double i, double j) {
 // CHECK-NEXT:     {{.*}}ValueAndPushforward<{{.*}}, {{.*}}> _t1 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&v, 1, &_d_v, 0);
 // CHECK-NEXT:     _t1.pushforward = 0 * i + 11 * _d_i;
 // CHECK-NEXT:     _t1.value = 11 * i;
-// CHECK-NEXT:     clad::ValueAndPushforward<decltype({{.*}}.begin()), decltype({{.*}}.begin())> _t2 = std::begin_pushforward(v, _d_v);
+// CHECK-NEXT:     clad::ValueAndPushforward<{{.*}}, {{.*}}> _t2 = std::begin_pushforward(v, _d_v);
 // CHECK-NEXT:     {{.*}} _d_b = _t2.pushforward;
 // CHECK-NEXT:     {{.*}} b = _t2.value;
-// CHECK-NEXT:     clad::ValueAndPushforward<decltype({{.*}}.end()), decltype({{.*}}.end())> _t3 = std::end_pushforward(v, _d_v);
+// CHECK-NEXT:     clad::ValueAndPushforward<{{.*}}, {{.*}}> _t3 = std::end_pushforward(v, _d_v);
 // CHECK-NEXT:     {{.*}} _d_e = _t3.pushforward;
 // CHECK-NEXT:     {{.*}} e = _t3.value;
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t4 = std::accumulate_pushforward(b, e, 0., _d_b, _d_e, 0.);

--- a/test/NthDerivative/CustomDerivatives.C
+++ b/test/NthDerivative/CustomDerivatives.C
@@ -14,7 +14,7 @@ float test_sin(float x) {
 // CHECK-NEXT:    float _d_x = 1;
 // CHECK-NEXT:    float _d__d_x = 0;
 // CHECK-NEXT:    float _d_x0 = 1;
-// CHECK-NEXT:    clad::ValueAndPushforward<ValueAndPushforward<float, float>, ValueAndPushforward<float, float> > _t0 = clad::custom_derivatives::std::sin_pushforward_pushforward(x, _d_x0, _d_x, _d__d_x);
+// CHECK-NEXT:    clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<float, float>, {{(clad::)?}}ValueAndPushforward<float, float> > _t0 = clad::custom_derivatives::std::sin_pushforward_pushforward(x, _d_x0, _d_x, _d__d_x);
 // CHECK-NEXT:    ValueAndPushforward<float, float> _d__t0 = _t0.pushforward;
 // CHECK-NEXT:    ValueAndPushforward<float, float> _t00 = _t0.value;
 // CHECK-NEXT:    return _d__t0.pushforward;
@@ -28,7 +28,7 @@ float test_cos(float x) {
 // CHECK-NEXT:    float _d_x = 1;
 // CHECK-NEXT:    float _d__d_x = 0;
 // CHECK-NEXT:    float _d_x0 = 1;
-// CHECK-NEXT:    clad::ValueAndPushforward<ValueAndPushforward<float, float>, ValueAndPushforward<float, float> > _t0 = clad::custom_derivatives::std::cos_pushforward_pushforward(x, _d_x0, _d_x, _d__d_x);
+// CHECK-NEXT:    clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<float, float>, {{(clad::)?}}ValueAndPushforward<float, float> > _t0 = clad::custom_derivatives::std::cos_pushforward_pushforward(x, _d_x0, _d_x, _d__d_x);
 // CHECK-NEXT:    ValueAndPushforward<float, float> _d__t0 = _t0.pushforward;
 // CHECK-NEXT:    ValueAndPushforward<float, float> _t00 = _t0.value;
 // CHECK-NEXT:    return _d__t0.pushforward;
@@ -52,16 +52,16 @@ float test_trig(float x, float y, int a, int b) {
 // CHECK-NEXT:    int _d_a0 = 0;
 // CHECK-NEXT:    int _d__d_b = 0;
 // CHECK-NEXT:    int _d_b0 = 0;
-// CHECK-NEXT:    clad::ValueAndPushforward<ValueAndPushforward<float, float>, ValueAndPushforward<float, float> > _t0 = clad::custom_derivatives::std::sin_pushforward_pushforward(x * y, _d_x0 * y + x * _d_y0, _d_x * y + x * _d_y, _d__d_x * y + _d_x0 * _d_y + _d_x * _d_y0 + x * _d__d_y);
+// CHECK-NEXT:    clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<float, float>, {{(clad::)?}}ValueAndPushforward<float, float> > _t0 = clad::custom_derivatives::std::sin_pushforward_pushforward(x * y, _d_x0 * y + x * _d_y0, _d_x * y + x * _d_y, _d__d_x * y + _d_x0 * _d_y + _d_x * _d_y0 + x * _d__d_y);
 // CHECK-NEXT:    ValueAndPushforward<float, float> _d__t0 = _t0.pushforward;
 // CHECK-NEXT:    ValueAndPushforward<float, float> _t00 = _t0.value;
-// CHECK-NEXT:    clad::ValueAndPushforward<ValueAndPushforward<double, double>, ValueAndPushforward<double, double> > _t1 = clad::custom_derivatives::std::pow_pushforward_pushforward(_t00.value, a, _t00.pushforward, _d_a0, _d__t0.value, _d_a, _d__t0.pushforward, _d__d_a);
+// CHECK-NEXT:    clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<double, double>, {{(clad::)?}}ValueAndPushforward<double, double> > _t1 = clad::custom_derivatives::std::pow_pushforward_pushforward(_t00.value, a, _t00.pushforward, _d_a0, _d__t0.value, _d_a, _d__t0.pushforward, _d__d_a);
 // CHECK-NEXT:    ValueAndPushforward<double, double> _d__t1 = _t1.pushforward;
 // CHECK-NEXT:    ValueAndPushforward<double, double> _t10 = _t1.value;
-// CHECK-NEXT:    clad::ValueAndPushforward<ValueAndPushforward<float, float>, ValueAndPushforward<float, float> > _t2 = clad::custom_derivatives::std::cos_pushforward_pushforward(x * y, _d_x0 * y + x * _d_y0, _d_x * y + x * _d_y, _d__d_x * y + _d_x0 * _d_y + _d_x * _d_y0 + x * _d__d_y);
+// CHECK-NEXT:    clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<float, float>, {{(clad::)?}}ValueAndPushforward<float, float> > _t2 = clad::custom_derivatives::std::cos_pushforward_pushforward(x * y, _d_x0 * y + x * _d_y0, _d_x * y + x * _d_y, _d__d_x * y + _d_x0 * _d_y + _d_x * _d_y0 + x * _d__d_y);
 // CHECK-NEXT:    ValueAndPushforward<float, float> _d__t2 = _t2.pushforward;
 // CHECK-NEXT:    ValueAndPushforward<float, float> _t20 = _t2.value;
-// CHECK-NEXT:    clad::ValueAndPushforward<ValueAndPushforward<double, double>, ValueAndPushforward<double, double> > _t3 = clad::custom_derivatives::std::pow_pushforward_pushforward(_t20.value, b, _t20.pushforward, _d_b0, _d__t2.value, _d_b, _d__t2.pushforward, _d__d_b);
+// CHECK-NEXT:    clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<double, double>, {{(clad::)?}}ValueAndPushforward<double, double> > _t3 = clad::custom_derivatives::std::pow_pushforward_pushforward(_t20.value, b, _t20.pushforward, _d_b0, _d__t2.value, _d_b, _d__t2.pushforward, _d__d_b);
 // CHECK-NEXT:    ValueAndPushforward<double, double> _d__t3 = _t3.pushforward;
 // CHECK-NEXT:    ValueAndPushforward<double, double> _t30 = _t3.value;
 // CHECK-NEXT:    double &_d__t4 = _d__t1.value;
@@ -89,16 +89,16 @@ float test_trig(float x, float y, int a, int b) {
 // CHECK-NEXT:    int _d_a0 = 0;
 // CHECK-NEXT:    int _d__d_b = 0;
 // CHECK-NEXT:    int _d_b0 = 0;
-// CHECK-NEXT:    clad::ValueAndPushforward<ValueAndPushforward<float, float>, ValueAndPushforward<float, float> > _t0 = clad::custom_derivatives::std::sin_pushforward_pushforward(x * y, _d_x0 * y + x * _d_y0, _d_x * y + x * _d_y, _d__d_x * y + _d_x0 * _d_y + _d_x * _d_y0 + x * _d__d_y);
+// CHECK-NEXT:    clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<float, float>, {{(clad::)?}}ValueAndPushforward<float, float> > _t0 = clad::custom_derivatives::std::sin_pushforward_pushforward(x * y, _d_x0 * y + x * _d_y0, _d_x * y + x * _d_y, _d__d_x * y + _d_x0 * _d_y + _d_x * _d_y0 + x * _d__d_y);
 // CHECK-NEXT:    ValueAndPushforward<float, float> _d__t0 = _t0.pushforward;
 // CHECK-NEXT:    ValueAndPushforward<float, float> _t00 = _t0.value;
-// CHECK-NEXT:    clad::ValueAndPushforward<ValueAndPushforward<double, double>, ValueAndPushforward<double, double> > _t1 = clad::custom_derivatives::std::pow_pushforward_pushforward(_t00.value, a, _t00.pushforward, _d_a0, _d__t0.value, _d_a, _d__t0.pushforward, _d__d_a);
+// CHECK-NEXT:    clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<double, double>, {{(clad::)?}}ValueAndPushforward<double, double> > _t1 = clad::custom_derivatives::std::pow_pushforward_pushforward(_t00.value, a, _t00.pushforward, _d_a0, _d__t0.value, _d_a, _d__t0.pushforward, _d__d_a);
 // CHECK-NEXT:    ValueAndPushforward<double, double> _d__t1 = _t1.pushforward;
 // CHECK-NEXT:    ValueAndPushforward<double, double> _t10 = _t1.value;
-// CHECK-NEXT:    clad::ValueAndPushforward<ValueAndPushforward<float, float>, ValueAndPushforward<float, float> > _t2 = clad::custom_derivatives::std::cos_pushforward_pushforward(x * y, _d_x0 * y + x * _d_y0, _d_x * y + x * _d_y, _d__d_x * y + _d_x0 * _d_y + _d_x * _d_y0 + x * _d__d_y);
+// CHECK-NEXT:    clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<float, float>, {{(clad::)?}}ValueAndPushforward<float, float> > _t2 = clad::custom_derivatives::std::cos_pushforward_pushforward(x * y, _d_x0 * y + x * _d_y0, _d_x * y + x * _d_y, _d__d_x * y + _d_x0 * _d_y + _d_x * _d_y0 + x * _d__d_y);
 // CHECK-NEXT:    ValueAndPushforward<float, float> _d__t2 = _t2.pushforward;
 // CHECK-NEXT:    ValueAndPushforward<float, float> _t20 = _t2.value;
-// CHECK-NEXT:    clad::ValueAndPushforward<ValueAndPushforward<double, double>, ValueAndPushforward<double, double> > _t3 = clad::custom_derivatives::std::pow_pushforward_pushforward(_t20.value, b, _t20.pushforward, _d_b0, _d__t2.value, _d_b, _d__t2.pushforward, _d__d_b);
+// CHECK-NEXT:    clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<double, double>, {{(clad::)?}}ValueAndPushforward<double, double> > _t3 = clad::custom_derivatives::std::pow_pushforward_pushforward(_t20.value, b, _t20.pushforward, _d_b0, _d__t2.value, _d_b, _d__t2.pushforward, _d__d_b);
 // CHECK-NEXT:    ValueAndPushforward<double, double> _d__t3 = _t3.pushforward;
 // CHECK-NEXT:    ValueAndPushforward<double, double> _t30 = _t3.value;
 // CHECK-NEXT:    double &_d__t4 = _d__t1.value;
@@ -124,13 +124,13 @@ float test_exp(float x) {
 // CHECK-NEXT:    return _t0.pushforward;
 // CHECK-NEXT:}
 
-// CHECK:   clad::ValueAndPushforward<ValueAndPushforward<{{float|double}}, {{float|double}}>, ValueAndPushforward<{{float|double}}, {{float|double}}> > exp_pushforward_pushforward({{float|double}} x, {{float|double}} d_x, {{float|double}} _d_x, {{float|double}} _d_d_x);
+// CHECK:   clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}>, {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> > exp_pushforward_pushforward({{float|double}} x, {{float|double}} d_x, {{float|double}} _d_x, {{float|double}} _d_d_x);
 
 // CHECK:   float test_exp_d2arg0(float x) {
 // CHECK-NEXT:    float _d_x = 1;
 // CHECK-NEXT:    float _d__d_x = 0;
 // CHECK-NEXT:    float _d_x0 = 1;
-// CHECK-NEXT:    clad::ValueAndPushforward<ValueAndPushforward<{{float|double}}, {{float|double}}>, ValueAndPushforward<{{float|double}}, {{float|double}}> > _t0 = clad::custom_derivatives::std::exp_pushforward_pushforward(x * x, _d_x0 * x + x * _d_x0, _d_x * x + x * _d_x, _d__d_x * x + _d_x0 * _d_x + _d_x * _d_x0 + x * _d__d_x);
+// CHECK-NEXT:    clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}>, {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> > _t0 = clad::custom_derivatives::std::exp_pushforward_pushforward(x * x, _d_x0 * x + x * _d_x0, _d_x * x + x * _d_x, _d__d_x * x + _d_x0 * _d_x + _d_x * _d_x0 + x * _d__d_x);
 // CHECK-NEXT:    {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _d__t0 = _t0.pushforward;
 // CHECK-NEXT:    {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t00 = _t0.value;
 // CHECK-NEXT:    return _d__t0.pushforward;
@@ -159,7 +159,7 @@ int main() {
     clad::differentiate<2>(test_exp);
     printf("Result is = %f\n", test_exp_d2arg0(2)); // CHECK-EXEC: Result is = 982.766
 
-// CHECK:   clad::ValueAndPushforward<ValueAndPushforward<{{float|double}}, {{float|double}}>, ValueAndPushforward<{{float|double}}, {{float|double}}> > exp_pushforward_pushforward({{float|double}} x, {{float|double}} d_x, {{float|double}} _d_x, {{float|double}} _d_d_x) {
+// CHECK:   clad::ValueAndPushforward<{{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}>, {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> > exp_pushforward_pushforward({{float|double}} x, {{float|double}} d_x, {{float|double}} _d_x, {{float|double}} _d_d_x) {
 // CHECK-NEXT:    {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t0 = clad::custom_derivatives::std::exp_pushforward(x, _d_x);
 // CHECK-NEXT:    {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t1 = clad::custom_derivatives::std::exp_pushforward(x, _d_x);
 // CHECK-NEXT:    {{float|double}} &_t2 = _t1.value;

--- a/tools/ClangBackendPlugin.h
+++ b/tools/ClangBackendPlugin.h
@@ -8,7 +8,12 @@
 #define CLANG_BACKEND_PLUGIN_H
 
 #include "llvm/IR/PassManager.h"
+// LLVM 22 moved PassPlugin.h from Passes/ to Plugins/.
+#if CLANG_VERSION_MAJOR < 22
 #include "llvm/Passes/PassPlugin.h"
+#else
+#include "llvm/Plugins/PassPlugin.h"
+#endif
 
 namespace clad {
 

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -117,11 +117,7 @@ void InitTimers();
     CladPlugin::CladPlugin(CompilerInstance& CI, DifferentiationOptions& DO)
         : m_CI(CI), m_DO(DO), m_HasRuntime(false) {
       CodeGenOptions& CGOpts = m_CI.getCodeGenOpts();
-#if CLANG_VERSION_MAJOR > 11
       bool WantTiming = CGOpts.TimePasses;
-#else
-      bool WantTiming = m_CI.getFrontendOpts().ShowTimers;
-#endif
 
       if (WantTiming || getenv("CLAD_ENABLE_TIMING"))
         InitTimers();


### PR DESCRIPTION
LLVM 22 reshaped enough of clang's type and lookup APIs that the port doesn't fit a one-liner: ElaboratedType is gone (folded into TagType etc.), NestedNameSpecifier became a uintptr value type where default-constructed `{}` evaluates as a non-null qualifier, ASTContext::getElaboratedType / getRecordType / getTypeDeclType were replaced or had their signatures extended, and CheckTemplateIdType, ActOnBreakStmt and ActOnContinueStmt grew new parameters. See llvm/llvm-project#147835 for the qualifier-rewrite design.

Cover the API moves with version-gated wrappers in Compatibility.h (nullNNS, hasQualifier, isElaboratedType, getElaboratedType, getCanonicalTagType, getNNSPrefix, MakeTrivial-vs-Extend, stripPredefinedSugar, the extended ActOn* / CheckTemplateIdType signatures) and migrate the lib/Differentiator call sites to use them. The wrappers are no-ops on older clang, so older matrix rows stay NFC. Loosen four test files' CHECK lines for clang 22's TypePrinter drift -- 5U -> 5{{U?}}, std:: qualifier and inner clad:: qualifier optionalised. CHECK-EXEC lines (runtime derivative values) are unchanged.

Add an LLVM 22 row plus ASan and MSan variants to the CI matrix, which exercise the asan / msan recipes from
compiler-research/ci-workflows. Bump CMake bounds for LLVM and Clang to 22.x; PassPlugin.h moved from llvm/Passes/ to llvm/Plugins/; -Wno-macro-redefined on 22+ to silence LLVM's duplicate _GLIBCXX_USE_CXX11_ABI define (HandleLLVMOptions + LLVMConfig both set it).

clad's support window covers the last 10 majors; with the top at 22, clang 11 falls off. Bump CLANG_MIN_SUPPORTED / LLVM_MIN_SUPPORTED to 12.0, drop the ubu22-gcc10-runtime11 CI row, and delete every `#if CLANG_VERSION_MAJOR < 12` (and the ClangPlugin.cpp `> 11`) branch. Several wrappers collapsed to one-line passthroughs once the < 12 branch went away -- Expr_EvaluateAsConstantExpr, CXXMemberCallExpr_Create, SwitchStmt_Create, Sema_ActOnStartOfSwitchStmt and the five CLAD_COMPAT_CLANG{8,12}_* macros listed inline. Inline them at every call site and delete the definitions. CallExpr_Create, CUDAKernelCallExpr_Create and IfStmt_Create stay: the first two have enough parameters that inlining would be net-noisier, and the third still has a version branch for clang 14. One `#if CLANG_VERSION_MAJOR > 12` remains in CladUtils.cpp (the BIfree-vs-getNameAsString check) -- its else branch still serves clang 12, which is the new minimum.