### PR TITLE
[ci] Add LLVM 22 ASan matrix row.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
           - { name: ubu24-clang19-runtime20, os: ubuntu-24.04, compiler: clang-19, clang-runtime: '20' }
           - { name: ubu24-clang20-runtime21, os: ubuntu-24.04, compiler: clang-20, clang-runtime: '21' }
           - { name: ubu24-clang20-runtime22, os: ubuntu-24.04, compiler: clang-20, clang-runtime: '22' }
+          - { name: ubu24-clang22-runtime22-asan, os: ubuntu-24.04, compiler: clang-22, clang-runtime: '22', flavor: asan, extra_cmake_options: '-DLLVM_USE_SANITIZER=Address' }
           # --- MACOS: Last 5 Runtimes (17-21) ---
           # Using macOS ARM (standard) for all; Runtime 17 on Intel for x86 sanity
           - { name: osx-intel-runtime17, os: macos-15-intel, compiler: clang, clang-runtime: '17' }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ endif()
 enable_language(CXX)
 set(CMAKE_CXX_EXTENSIONS NO)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+# clad.so links libcladDifferentiator.a; every target must be PIC.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 include(GNUInstallDirs)
 
 # MUST be done before call to clad project
@@ -334,14 +336,20 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
     # need to use a supported by clad compiler. Note that's a huge hack and it is
     # not guaranteed to work with cmake.
     set(stored_cxx_compiler ${CMAKE_CXX_COMPILER})
+    set(stored_c_compiler ${CMAKE_C_COMPILER})
     set(stored_cxx_flags ${CMAKE_CXX_FLAGS})
     set(stored_c_flags ${CMAKE_C_FLAGS})
     # FIXME: Remove when vgvassilev/clad#1665 is resolved.
     disable_werror(CMAKE_CXX_FLAGS CMAKE_C_FLAGS)
+    # Swap both C and C++ -- clad_externalproject_add forwards both,
+    # so a CXX-only swap leaves gtest with a mixed toolchain.
     set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
-    # Filter some unsupported flags by clang.
-    string(REPLACE "-fno-lifetime-dse" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    string(REPLACE "-Wno-class-memaccess" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    set(CMAKE_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
+    # Drop GCC-only flags now that both C and CXX route through clang.
+    foreach(_flags CMAKE_CXX_FLAGS CMAKE_C_FLAGS)
+      string(REPLACE "-fno-lifetime-dse" "" ${_flags} "${${_flags}}")
+      string(REPLACE "-Wno-class-memaccess" "" ${_flags} "${${_flags}}")
+    endforeach()
   endif()
 
   if (NOT CLAD_DISABLE_TESTS)
@@ -355,8 +363,9 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
   endif(CLAD_ENABLE_BENCHMARKS)
 
   if (stored_cxx_compiler)
-    # Restore the default compiler.
+    # Restore the default compilers.
     set(CMAKE_CXX_COMPILER ${stored_cxx_compiler})
+    set(CMAKE_C_COMPILER ${stored_c_compiler})
     set(CMAKE_CXX_FLAGS ${stored_cxx_flags})
     set(CMAKE_C_FLAGS ${stored_c_flags})
   endif()

--- a/cmake/modules/AddClad.cmake
+++ b/cmake/modules/AddClad.cmake
@@ -234,6 +234,15 @@ function(clad_externalproject_add NAME)
   remove_coverage_flags(C_FLAGS_EXT CXX_FLAGS_EXT SHARED_CREATE_CXX_FLAGS_EXT EXE_LINKER_FLAGS_EXT SHARED_LINKER_FLAGS_EXT)
   disable_werror(C_FLAGS_EXT CXX_FLAGS_EXT)
 
+
+  # Strip sanitizer flags: 3rd-party externals build with cmake
+  # defaults; the parent keeps its -fsanitize=* from LLVM_USE_SANITIZER.
+  foreach(_flags C_FLAGS_EXT CXX_FLAGS_EXT)
+    foreach(_san "-fsanitize=address" "-fsanitize=undefined" "-fsanitize=memory")
+      string(REPLACE "${_san}" "" ${_flags} "${${_flags}}")
+    endforeach()
+  endforeach()
+
   # Everything EXCEPT EXTRA_CMAKE_ARGS gets forwarded unchanged
   set(FORWARDED_ARGS ${ARG_UNPARSED_ARGUMENTS})
 

--- a/include/clad/Differentiator/Compatibility.h
+++ b/include/clad/Differentiator/Compatibility.h
@@ -251,7 +251,9 @@ inline bool hasNNSPrefix(clang::NestedNameSpecifier NS) {
 inline clang::NestedNameSpecifier getNNSPrefix(clang::NestedNameSpecifier NS) {
   if (NS.getKind() == clang::NestedNameSpecifier::Kind::Namespace)
     return NS.getAsNamespaceAndPrefix().Prefix;
-  return clang::NestedNameSpecifier();
+  // Null (std::nullopt), not the default ctor's FlagKind::Invalid, which
+  // would later UNREACHABLE in getKind() if anyone inspected it.
+  return std::nullopt;
 }
 
 // Clang 22 (llvm/llvm-project#147835): keyword + qualifier ride inline
@@ -290,8 +292,8 @@ inline clang::QualType getElaboratedType(clang::ASTContext& C,
 // Clang 22: getRecordType -> getTagType with default keyword/qualifier.
 inline clang::QualType getRecordType(clang::ASTContext& C,
                                      const clang::RecordDecl* RD) {
-  return C.getTagType(clang::ElaboratedTypeKeyword::None,
-                      clang::NestedNameSpecifier(), RD, /*OwnsTag=*/false);
+  return C.getTagType(clang::ElaboratedTypeKeyword::None, std::nullopt, RD,
+                      /*OwnsTag=*/false);
 }
 
 // Clang 22: TagDecl::getTypeForDecl() was deleted; use
@@ -351,8 +353,8 @@ inline clang::QualType getTypeDeclType(clang::ASTContext& C,
 #if CLANG_VERSION_MAJOR < 22
   return C.getTypeDeclType(TD);
 #else
-  return C.getTypeDeclType(clang::ElaboratedTypeKeyword::None,
-                           clang::NestedNameSpecifier(), TD);
+  return C.getTypeDeclType(clang::ElaboratedTypeKeyword::None, std::nullopt,
+                           TD);
 #endif
 }
 

--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -53,12 +53,36 @@ namespace clad {
 namespace clad {
 class ErrorEstimationHandler;
 
-/// A pair of FunctionDecl and potential enclosing context, e.g. a function
-/// in nested namespaces.
-// This is the type returned by cloneFunction. Using OverloadedDeclWithContext
-// instead would lead to unnecessarily returning a nullptr in the overloaded
-// FD
-using DeclWithContext = std::pair<clang::FunctionDecl*, clang::Decl*>;
+class VisitorBase;
+
+/// RAII handle for a cloned derivative function. cloneFunction opens one
+/// clang::Scope and pushes one DeclContext per enclosing namespace of the
+/// original function; ClonedFunction owns those and pops them on
+/// destruction. The contained FunctionDecl* is independently AST-owned,
+/// so callers may keep using it after the handle goes away.
+///
+/// The handle is neither copyable nor movable: cloneFunction returns it by
+/// value, but under C++17 guaranteed copy elision the prvalue constructs the
+/// caller's object directly (ClonedFunction r = cloneFunction(...)), so no
+/// move is ever performed and none needs to exist.
+class ClonedFunction {
+  VisitorBase* m_Owner = nullptr;
+  unsigned m_NamespaceCount = 0;
+
+public:
+  clang::FunctionDecl* fd = nullptr;
+
+  ClonedFunction(VisitorBase& VB, unsigned NamespaceCount,
+                 clang::FunctionDecl* FD)
+      : m_Owner(&VB), m_NamespaceCount(NamespaceCount), fd(FD) {}
+
+  ClonedFunction(const ClonedFunction&) = delete;
+  ClonedFunction& operator=(const ClonedFunction&) = delete;
+  ClonedFunction(ClonedFunction&&) = delete;
+  ClonedFunction& operator=(ClonedFunction&&) = delete;
+  ~ClonedFunction();
+};
+
 /// Stores derivative and the corresponding overload. If no overload exist
 /// then `second` data member should be `nullptr`.
 struct DerivativeAndOverload {
@@ -95,11 +119,11 @@ struct DerivativeAndOverload {
     /// A flag to keep track of whether error diagnostics are requested by user
     /// for numerical differentiation.
     bool m_PrintNumericalDiffErrorDiag = false;
-    DeclWithContext cloneFunction(const clang::FunctionDecl* FD,
-                                  clad::VisitorBase& VB, clang::DeclContext* DC,
-                                  clang::SourceLocation& noLoc,
-                                  clang::DeclarationNameInfo name,
-                                  clang::QualType functionType);
+    ClonedFunction cloneFunction(const clang::FunctionDecl* FD,
+                                 clad::VisitorBase& VB, clang::DeclContext* DC,
+                                 clang::SourceLocation& noLoc,
+                                 clang::DeclarationNameInfo name,
+                                 clang::QualType functionType);
     /// Looks for a suitable overload for a given function.
     ///
     /// \param[in] Name The identification information of the function

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -654,8 +654,16 @@ namespace clad {
     /// modes.
     clang::FunctionDecl*
     CreateDerivativeOverload(clang::FunctionDecl derivative);
-    /// Rebuild a sequence of nested namespaces ending with DC.
-    clang::NamespaceDecl* RebuildEnclosingNamespaces(clang::DeclContext* DC);
+    /// Rebuild a sequence of nested namespaces ending with DC and return
+    /// how many were opened. Each opens a Scope that the caller (via
+    /// ClonedFunction's RAII handle) must balance with the same count
+    /// passed to popEnclosingNamespaceScopes -- otherwise the Scope
+    /// objects leak when SaveAndRestore restores the outer Scope*.
+    unsigned RebuildEnclosingNamespaces(clang::DeclContext* DC);
+
+    /// Pop N namespace Scopes (and their matching DeclContext pushes).
+    /// Used only by ClonedFunction's destructor.
+    void popEnclosingNamespaceScopes(unsigned N);
     /// Clones a statement
     clang::Stmt* Clone(const clang::Stmt* S);
     /// A shorthand to simplify cloning of expressions.

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -157,9 +157,11 @@ DerivativeAndOverload BaseForwardModeVisitor::Derive() {
 
   m_Sema.CurContext = DC;
   QualType derivedFnType = GetDerivativeType();
-  DeclWithContext result =
+  // `result` owns the namespace Scopes cloneFunction opens; its
+  // destructor pops them before SaveScope restores.
+  ClonedFunction result =
       m_Builder.cloneFunction(FD, *this, DC, validLoc, name, derivedFnType);
-  FunctionDecl* derivedFD = result.first;
+  FunctionDecl* derivedFD = result.fd;
   m_Derivative = derivedFD;
 
   // Function declaration scope
@@ -232,7 +234,7 @@ DerivativeAndOverload BaseForwardModeVisitor::Derive() {
 
   endScope(); // Function decl scope
 
-  return DerivativeAndOverload{result.first,
+  return DerivativeAndOverload{result.fd,
                                /*OverloadFunctionDecl=*/nullptr};
 }
 

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -24,6 +24,7 @@
 #include "clad/Differentiator/Timers.h"
 #include "clad/Differentiator/VectorForwardModeVisitor.h"
 #include "clad/Differentiator/VectorPushForwardModeVisitor.h"
+#include "clad/Differentiator/VisitorBase.h"
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
@@ -49,7 +50,6 @@
 #include <cstddef>
 #include <memory>
 #include <string>
-#include <utility>
 
 using namespace clang;
 
@@ -113,12 +113,14 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
     return false;
   }
 
-  DeclWithContext DerivativeBuilder::cloneFunction(
+  ClonedFunction DerivativeBuilder::cloneFunction(
       const clang::FunctionDecl* FD, clad::VisitorBase& VB,
       clang::DeclContext* DC, clang::SourceLocation& noLoc,
       clang::DeclarationNameInfo name, clang::QualType functionType) {
     FunctionDecl* returnedFD = nullptr;
-    NamespaceDecl* enclosingNS = nullptr;
+    // Count of namespace Scopes RebuildEnclosingNamespaces opens for
+    // this clone -- the returned handle pops exactly that many.
+    unsigned NamespaceCount = 0;
     TypeSourceInfo* TSI = m_Context.getTrivialTypeSourceInfo(functionType);
     if (isa<CXXMethodDecl>(FD)) {
       CXXRecordDecl* CXXRD = cast<CXXRecordDecl>(DC);
@@ -136,7 +138,7 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
       returnedFD->setAccess(AS_public);
     } else {
       assert (isa<FunctionDecl>(FD) && "Unexpected!");
-      enclosingNS = VB.RebuildEnclosingNamespaces(DC);
+      NamespaceCount = VB.RebuildEnclosingNamespaces(DC);
 
       auto TrailingRequiresClause =
           CLAD_COMPAT_CLANG21_getTrailingRequiresClause(FD);
@@ -167,7 +169,14 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
       }
     }
 
-    return { returnedFD, enclosingNS };
+    return ClonedFunction{VB, NamespaceCount, returnedFD};
+  }
+
+  // The destructor is defined here so the header can hold just a forward
+  // declaration of VisitorBase.
+  ClonedFunction::~ClonedFunction() {
+    if (m_Owner)
+      m_Owner->popEnclosingNamespaceScopes(m_NamespaceCount);
   }
 
   // This method is derived from the source code of both

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -239,9 +239,11 @@ DerivativeAndOverload HessianModeVisitor::Derive() {
                                            getEnclosingNamespaceOrTUScope());
     m_Sema.CurContext = DC;
 
-    DeclWithContext result = m_Builder.cloneFunction(
+    // `result` owns the namespace Scopes cloneFunction opens; its
+    // destructor pops them before SaveScope restores.
+    ClonedFunction result = m_Builder.cloneFunction(
         m_DiffReq.Function, *this, DC, noLoc, name, hessianFunctionType);
-    FunctionDecl* hessianFD = result.first;
+    FunctionDecl* hessianFD = result.fd;
 
     beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
                Scope::DeclScope);
@@ -392,7 +394,7 @@ DerivativeAndOverload HessianModeVisitor::Derive() {
     m_Sema.PopDeclContext();
     endScope(); // Function decl scope
 
-    return DerivativeAndOverload{result.first,
+    return DerivativeAndOverload{result.fd,
                                  /*OverloadFunctionDecl=*/nullptr};
   }
 } // end namespace clad

--- a/lib/Differentiator/JacobianModeVisitor.cpp
+++ b/lib/Differentiator/JacobianModeVisitor.cpp
@@ -36,19 +36,22 @@ DerivativeAndOverload JacobianModeVisitor::Derive() {
 
   QualType vectorDiffFunctionType = GetDerivativeType();
 
+  // Save Sema state before cloneFunction mutates it.
+  llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
+  llvm::SaveAndRestore<Scope*> SaveScope(getCurrentScope());
   // Create the function declaration for the derivative.
   // FIXME: We should not use const_cast to get the decl context here.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   auto* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
   m_Sema.CurContext = DC;
-  DeclWithContext result = m_Builder.cloneFunction(
+  // `result` owns the namespace Scopes cloneFunction opens; its
+  // destructor pops them before SaveScope restores.
+  ClonedFunction result = m_Builder.cloneFunction(
       m_DiffReq.Function, *this, DC, loc, name, vectorDiffFunctionType);
-  FunctionDecl* vectorDiffFD = result.first;
+  FunctionDecl* vectorDiffFD = result.fd;
   m_Derivative = vectorDiffFD;
 
   // Function declaration scope
-  llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
-  llvm::SaveAndRestore<Scope*> SaveScope(getCurrentScope());
   beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
              Scope::DeclScope);
   m_Sema.PushFunctionScope();

--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -47,9 +47,11 @@ DerivativeAndOverload ReverseModeForwPassVisitor::Derive() {
 
   m_Sema.CurContext = DC;
   SourceLocation validLoc{m_DiffReq->getLocation()};
-  DeclWithContext fnBuildRes = m_Builder.cloneFunction(
+  // `fnBuildRes` owns the namespace Scopes cloneFunction opens; its
+  // destructor pops them before saveScope restores.
+  ClonedFunction fnBuildRes = m_Builder.cloneFunction(
       m_DiffReq.Function, *this, m_Sema.CurContext, validLoc, fnDNI, fnType);
-  m_Derivative = fnBuildRes.first;
+  m_Derivative = fnBuildRes.fd;
 
   beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
              Scope::DeclScope);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -303,9 +303,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     m_Sema.CurContext = DC;
     SourceLocation loc = m_DiffReq->getLocation();
     DeclarationNameInfo DNI = utils::BuildDeclarationNameInfo(m_Sema, name);
-    DeclWithContext result = m_Builder.cloneFunction(m_DiffReq.Function, *this,
-                                                     DC, loc, DNI, dFnType);
-    m_Derivative = result.first;
+    // `result` owns the namespace Scopes cloneFunction opens; its
+    // destructor pops them before SaveScope restores -- declaration order
+    // gives the correct LIFO unwind.
+    ClonedFunction result = m_Builder.cloneFunction(m_DiffReq.Function, *this,
+                                                    DC, loc, DNI, dFnType);
+    m_Derivative = result.fd;
 
     // Function declaration scope
     beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
@@ -378,9 +381,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
 
     if (!shouldCreateOverload)
-      return DerivativeAndOverload{result.first, /*overload=*/nullptr};
+      return DerivativeAndOverload{result.fd, /*overload=*/nullptr};
 
-    return DerivativeAndOverload{result.first, CreateDerivativeOverload()};
+    return DerivativeAndOverload{result.fd, CreateDerivativeOverload()};
   }
 
   void ReverseModeVisitor::DifferentiateWithClad() {

--- a/lib/Differentiator/VectorForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorForwardModeVisitor.cpp
@@ -46,18 +46,21 @@ DerivativeAndOverload VectorForwardModeVisitor::Derive() {
   SourceLocation loc{m_DiffReq->getLocation()};
   DeclarationNameInfo name(II, loc);
 
+  // Save Sema state before cloneFunction mutates it.
+  llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
+  llvm::SaveAndRestore<Scope*> SaveScope(getCurrentScope());
   // FIXME: We should not use const_cast to get the decl context here.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   auto* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
   m_Sema.CurContext = DC;
-  DeclWithContext result = m_Builder.cloneFunction(
+  // `result` owns the namespace Scopes cloneFunction opens; its
+  // destructor pops them before SaveScope restores.
+  ClonedFunction result = m_Builder.cloneFunction(
       m_DiffReq.Function, *this, DC, loc, name, vectorDiffFunctionType);
-  FunctionDecl* vectorDiffFD = result.first;
+  FunctionDecl* vectorDiffFD = result.fd;
   m_Derivative = vectorDiffFD;
 
   // Function declaration scope
-  llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
-  llvm::SaveAndRestore<Scope*> SaveScope(getCurrentScope());
   beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
              Scope::DeclScope);
   m_Sema.PushFunctionScope();
@@ -233,11 +236,18 @@ VectorForwardModeVisitor::CreateVectorModeOverload(FunctionDecl* derivative) {
   // FIXME: We should not use const_cast to get the decl context here.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   auto* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
+  // Called while the caller's Derive() still holds a ClonedFunction for the
+  // same namespaces; cloneFunction rebuilds them from the root, so restore
+  // CurContext/Scope here or the caller's handle pops past the TU and crashes.
+  llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
+  llvm::SaveAndRestore<Scope*> SaveScope(getCurrentScope());
   m_Sema.CurContext = DC;
-  DeclWithContext result =
+  // `result` owns its namespace Scopes; pops at end of this function,
+  // rebasing to the depth its outer caller had on entry.
+  ClonedFunction result =
       m_Builder.cloneFunction(m_DiffReq.Function, *this, DC, noLoc,
                               vectorModeNameInfo, vectorModeFuncOverloadType);
-  FunctionDecl* vectorModeOverloadFD = result.first;
+  FunctionDecl* vectorModeOverloadFD = result.fd;
 
   // Function declaration scope
   beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -40,6 +40,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/SaveAndRestore.h"
 
 #include <algorithm>
 #include <cstddef>
@@ -241,15 +242,20 @@ namespace clad {
     return NDecl;
   }
 
-  NamespaceDecl* VisitorBase::RebuildEnclosingNamespaces(DeclContext* DC) {
+  unsigned VisitorBase::RebuildEnclosingNamespaces(DeclContext* DC) {
     if (NamespaceDecl* ND = dyn_cast_or_null<NamespaceDecl>(DC)) {
-      NamespaceDecl* Head = RebuildEnclosingNamespaces(ND->getDeclContext());
-      NamespaceDecl* NewD =
-          BuildNamespaceDecl(ND->getIdentifier(), ND->isInline());
-      return Head ? Head : NewD;
-    } else {
-      m_Sema.CurContext = DC;
-      return nullptr;
+      unsigned N = RebuildEnclosingNamespaces(ND->getDeclContext());
+      BuildNamespaceDecl(ND->getIdentifier(), ND->isInline());
+      return N + 1;
+    }
+    m_Sema.CurContext = DC;
+    return 0;
+  }
+
+  void VisitorBase::popEnclosingNamespaceScopes(unsigned N) {
+    for (unsigned i = 0; i < N; ++i) {
+      m_Sema.PopDeclContext();
+      endScope();
     }
   }
 
@@ -892,11 +898,19 @@ namespace clad {
     // FIXME: We should not use const_cast to get the decl context here.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     auto* DC = const_cast<DeclContext*>(m_DiffReq->getDeclContext());
+    // Called while the caller's Derive() still holds a ClonedFunction for the
+    // same namespaces; cloneFunction rebuilds them from the root, so restore
+    // CurContext/Scope here or the caller's handle pops past the TU and
+    // crashes.
+    llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
+    llvm::SaveAndRestore<Scope*> SaveScope(getCurrentScope());
     m_Sema.CurContext = DC;
-    DeclWithContext diffOverloadFDWC =
+    // `cloned` owns its namespace Scopes; pops at end of this function,
+    // rebasing to the depth the outer Derive had on entry.
+    ClonedFunction cloned =
         m_Builder.cloneFunction(m_DiffReq.Function, *this, DC, noLoc,
                                 diffNameInfo, diffFunctionOverloadType);
-    FunctionDecl* diffOverloadFD = diffOverloadFDWC.first;
+    FunctionDecl* diffOverloadFD = cloned.fd;
 
     beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
                Scope::DeclScope);

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -21,6 +21,22 @@
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/Basic/LLVM.h" // isa, dyn_cast
 #include "clang/Basic/SourceLocation.h"
+
+#ifdef _WIN32
+// <windows.h> defines function-like min/max macros that mangle
+// std::numeric_limits<>::max() in llvm/ADT/Sequence.h (included below);
+// NOMINMAX suppresses them. WIN32_LEAN_AND_MEAN trims unrelated Win32 surface.
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
 #include "clang/Basic/Version.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
@@ -123,18 +139,26 @@ void InitTimers();
       if (WantTiming || getenv("CLAD_ENABLE_TIMING"))
         InitTimers();
 
-      FrontendOptions& Opts = CI.getFrontendOpts();
-      // Find the path to clad.
-      llvm::StringRef CladSoPath;
-      for (llvm::StringRef P : Opts.Plugins)
-        if (llvm::sys::path::stem(P).ends_with("clad")) {
-          CladSoPath = P;
-          break;
-        }
-
-      // Register clad as a backend pass.
-      if (!CladSoPath.empty())
-        CGOpts.PassPlugins.push_back(CladSoPath.str());
+        // Register clad as a backend pass via the path of clad.so itself,
+        // resolved from any symbol we own. Cleaner than iterating
+        // CI.getFrontendOpts().Plugins (which depends on how clang was
+        // invoked) and keeps the lookup inside this DSO.
+#ifdef _WIN32
+      HMODULE hm = nullptr;
+      if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                 GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                             reinterpret_cast<LPCSTR>(&InitTimers), &hm) &&
+          hm) {
+        char buf[MAX_PATH];
+        if (DWORD n = GetModuleFileNameA(hm, buf, MAX_PATH);
+            n > 0 && n < MAX_PATH)
+          CGOpts.PassPlugins.emplace_back(buf);
+      }
+#else
+      if (Dl_info info;
+          dladdr(reinterpret_cast<void*>(&InitTimers), &info) && info.dli_fname)
+        CGOpts.PassPlugins.emplace_back(info.dli_fname);
+#endif
 
       // Add define for __CLAD__, so that CladFunction::CladFunction()
       // doesn't throw an error.

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -47,27 +47,24 @@ namespace clad {
 bool checkClangVersion();
 namespace plugin {
 struct DifferentiationOptions {
-  DifferentiationOptions()
-      : DumpSourceFn(false), DumpSourceFnAST(false), DumpDerivedFn(false),
-        DumpDerivedAST(false), GenerateSourceFile(false),
-        ValidateClangVersion(true), EnableTBRAnalysis(false),
-        DisableTBRAnalysis(false), EnableVariedAnalysis(false),
-        DisableVariedAnalysis(false), EnableUsefulAnalysis(false),
-        DisableUsefulAnalysis(false), PrintNumDiffErrorInfo(false) {}
-
-  bool DumpSourceFn : 1;
-  bool DumpSourceFnAST : 1;
-  bool DumpDerivedFn : 1;
-  bool DumpDerivedAST : 1;
-  bool GenerateSourceFile : 1;
-  bool ValidateClangVersion : 1;
-  bool EnableTBRAnalysis : 1;
-  bool DisableTBRAnalysis : 1;
-  bool EnableVariedAnalysis : 1;
-  bool DisableVariedAnalysis : 1;
-  bool EnableUsefulAnalysis : 1;
-  bool DisableUsefulAnalysis : 1;
-  bool PrintNumDiffErrorInfo : 1;
+  // Plain bool, not `: 1` bit-fields: with 13 single-bit bools packed
+  // into shared bytes, the compiler emits each ctor-init-list write as
+  // a read-modify-write of the storage byte. The first RMW reads the
+  // byte while it is still uninitialised, which MSan reports as a SEGV
+  // on uninitialised memory under -fsanitize=memory.
+  bool DumpSourceFn = false;
+  bool DumpSourceFnAST = false;
+  bool DumpDerivedFn = false;
+  bool DumpDerivedAST = false;
+  bool GenerateSourceFile = false;
+  bool ValidateClangVersion = true;
+  bool EnableTBRAnalysis = false;
+  bool DisableTBRAnalysis = false;
+  bool EnableVariedAnalysis = false;
+  bool DisableVariedAnalysis = false;
+  bool EnableUsefulAnalysis = false;
+  bool DisableUsefulAnalysis = false;
+  bool PrintNumDiffErrorInfo = false;
 };
 
     class CladExternalSource : public clang::ExternalSemaSource {


### PR DESCRIPTION
Both rows consume recipe-flavor LLVM 22 builds from compiler-research/ci-workflows -- the llvm-asan and llvm-msan recipes -- and propagate the sanitizer to every clad target via LLVM_USE_SANITIZER, so the runtime clad links against matches the instrumented LLVM it was built with.

Sanitizer coverage isn't a fit for the system-flavor rows (apt-llvm.org ships a vanilla build), so this lands on top of the LLVM 22 port and only exercises the recipe-cache path.