### PR TITLE
Add support for omp critical directive in forward and reverse mode

### DIFF
--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -131,6 +131,7 @@ public:
   StmtDiff VisitOMPParallelDirective(const clang::OMPParallelDirective* D);
   StmtDiff
   VisitOMPParallelForDirective(const clang::OMPParallelForDirective* D);
+  StmtDiff VisitOMPCriticalDirective(const clang::OMPCriticalDirective* D);
   clang::OMPClause* VisitOMPPrivateClause(const clang::OMPPrivateClause* C);
   clang::OMPClause*
   VisitOMPFirstprivateClause(const clang::OMPFirstprivateClause* C);

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -480,6 +480,7 @@ namespace clad {
     VisitOMPExecutableDirective(const clang::OMPExecutableDirective* D);
     StmtDiff
     VisitOMPParallelForDirective(const clang::OMPParallelForDirective* D);
+    StmtDiff VisitOMPCriticalDirective(const clang::OMPCriticalDirective* D);
 
     /// Helper function that builds `T* _this = malloc(sifeof(T));`
     /// and `free(_this)`.

--- a/lib/Differentiator/BaseForwardModeVisitorOpenMP.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitorOpenMP.cpp
@@ -152,4 +152,17 @@ StmtDiff BaseForwardModeVisitor::VisitOMPParallelForDirective(
   CLAD_COMPAT_CLANG19_SemaOpenMP(m_Sema).EndOpenMPDSABlock(Res.getStmt());
   return Res;
 }
+
+StmtDiff BaseForwardModeVisitor::VisitOMPCriticalDirective(
+    const OMPCriticalDirective* D) {
+  StmtDiff BodyDiff = Visit(D->getAssociatedStmt());
+  DeclarationNameInfo DirName = D->getDirectiveName();
+  OpenMPDirectiveKind CancelRegion = OMPD_unknown;
+  llvm::SmallVector<OMPClause*, 0> Clauses;
+  return CLAD_COMPAT_CLANG19_SemaOpenMP(m_Sema)
+      .ActOnOpenMPExecutableDirective(OMPD_critical, DirName, CancelRegion,
+                                      Clauses, BodyDiff.getStmt(),
+                                      D->getBeginLoc(), D->getEndLoc())
+      .get();
+}
 } // namespace clad

--- a/lib/Differentiator/ReverseModeVisitorOpenMP.cpp
+++ b/lib/Differentiator/ReverseModeVisitorOpenMP.cpp
@@ -569,4 +569,28 @@ StmtDiff ReverseModeVisitor::VisitOMPParallelForDirective(
   CLAD_COMPAT_CLANG19_SemaOpenMP(m_Sema).EndOpenMPDSABlock(SDiff.getStmt());
   return SDiff;
 }
+
+StmtDiff
+ReverseModeVisitor::VisitOMPCriticalDirective(const OMPCriticalDirective* D) {
+  StmtDiff BodyDiff = Visit(D->getAssociatedStmt());
+  DeclarationNameInfo DirName = D->getDirectiveName();
+  OpenMPDirectiveKind CancelRegion = OMPD_unknown;
+  llvm::SmallVector<OMPClause*, 0> Clauses;
+
+  Stmt* ForwardCritical =
+      CLAD_COMPAT_CLANG19_SemaOpenMP(m_Sema)
+          .ActOnOpenMPExecutableDirective(OMPD_critical, DirName, CancelRegion,
+                                          Clauses, BodyDiff.getStmt(),
+                                          D->getBeginLoc(), D->getEndLoc())
+          .get();
+
+  Stmt* ReverseCritical =
+      CLAD_COMPAT_CLANG19_SemaOpenMP(m_Sema)
+          .ActOnOpenMPExecutableDirective(OMPD_critical, DirName, CancelRegion,
+                                          Clauses, BodyDiff.getStmt_dx(),
+                                          D->getBeginLoc(), D->getEndLoc())
+          .get();
+
+  return {ForwardCritical, ReverseCritical};
+}
 } // namespace clad

--- a/test/ForwardMode/OpenMP.C
+++ b/test/ForwardMode/OpenMP.C
@@ -80,6 +80,33 @@ double accumulate_scale_parallel(double scale, int n) {
 // CHECK-NEXT:     return _d_sum;
 // CHECK-NEXT: }
 
+double accumulate_critical(const double *x, int n) {
+    double result = 0;
+    #pragma omp parallel for
+    for (int i = 0; i < n; i++) {
+        #pragma omp critical
+        {
+            result += x[0] * x[0];
+        }
+    }
+    return result;
+}
+
+// CHECK: double accumulate_critical_darg0_0(const double *x, int n) {
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     double _d_result = 0;
+// CHECK-NEXT:     double result = 0;
+// CHECK-NEXT:     #pragma omp parallel for
+// CHECK-NEXT:         for (int i = 0; i < n; i++) {
+// CHECK-NEXT:             #pragma omp critical
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     _d_result += 1. * x[0] + x[0] * 1.;
+// CHECK-NEXT:                     result += x[0] * x[0];
+// CHECK-NEXT:                 }
+// CHECK-NEXT:         }
+// CHECK-NEXT:     return _d_result;
+// CHECK-NEXT: }
+
 int main() {
   double x[5] = {1, 2, 3, 4, 5};
   int n = 5;
@@ -90,5 +117,8 @@ int main() {
 
   auto d_accum_wrt_scale = clad::differentiate(accumulate_scale_parallel, "scale");
   double d3 = d_accum_wrt_scale.execute(3.5, 8);
+
+  auto d_critical = clad::differentiate(accumulate_critical, "x[0]");
+  double d4 = d_critical.execute(x, n);
   return 0;
 }

--- a/test/Gradient/OpenMP.C
+++ b/test/Gradient/OpenMP.C
@@ -816,6 +816,98 @@ double fn20(const double* x, int n) {
 // CHECK-NEXT:          }
 // CHECK-NEXT:  }
 
+double fn21(const double *x, int n) {
+    double result = 0;
+    #pragma omp parallel for
+    for (int i = 0; i < n; i++) {
+        #pragma omp critical
+        {
+            result += x[0] * x[0];
+        }
+    }
+    return result;
+}
+
+// CHECK:  void fn21_grad(const double *x, int n, double *_d_x, int *_d_n) {
+// CHECK-NEXT:      double _d_result = 0.;
+// CHECK-NEXT:      double result = 0;
+// CHECK-NEXT:      #pragma omp parallel
+// CHECK-NEXT:          {
+// CHECK-NEXT:              int _t_chunklo0 = 0;
+// CHECK-NEXT:              int _t_chunkhi0 = 0;
+// CHECK-NEXT:              clad::GetStaticSchedule(0, n - 1, 1, &_t_chunklo0, &_t_chunkhi0);
+// CHECK-NEXT:              for (int i = _t_chunklo0; i <= _t_chunkhi0; i += 1) {
+// CHECK-NEXT:                  #pragma omp critical
+// CHECK-NEXT:                      {
+// CHECK-NEXT:                          result += x[0] * x[0];
+// CHECK-NEXT:                      }
+// CHECK-NEXT:              }
+// CHECK-NEXT:          }
+// CHECK-NEXT:      _d_result += 1;
+// CHECK-NEXT:      #pragma omp parallel
+// CHECK-NEXT:          {
+// CHECK-NEXT:              int _t_chunklo1 = 0;
+// CHECK-NEXT:              int _t_chunkhi1 = 0;
+// CHECK-NEXT:              clad::GetStaticSchedule(0, n - 1, 1, &_t_chunklo1, &_t_chunkhi1);
+// CHECK-NEXT:              for (int i = _t_chunkhi1; i >= _t_chunklo1; i -= 1) {
+// CHECK-NEXT:                  #pragma omp critical
+// CHECK-NEXT:                      {
+// CHECK-NEXT:                          {
+// CHECK-NEXT:                              double _r_d0 = _d_result;
+// CHECK-NEXT:                              _d_x[0] += _r_d0 * x[0];
+// CHECK-NEXT:                              _d_x[0] += x[0] * _r_d0;
+// CHECK-NEXT:                          }
+// CHECK-NEXT:                      }
+// CHECK-NEXT:              }
+// CHECK-NEXT:          }
+// CHECK-NEXT:  }
+
+double fn22(const double *x, int n) {
+    double result = 0;
+    #pragma omp parallel for
+    for (int i = 0; i < n; i++) {
+        #pragma omp critical
+        {
+            result += x[0] * x[1];
+        }
+    }
+    return result;
+}
+
+// CHECK:  void fn22_grad(const double *x, int n, double *_d_x, int *_d_n) {
+// CHECK-NEXT:      double _d_result = 0.;
+// CHECK-NEXT:      double result = 0;
+// CHECK-NEXT:      #pragma omp parallel
+// CHECK-NEXT:          {
+// CHECK-NEXT:              int _t_chunklo0 = 0;
+// CHECK-NEXT:              int _t_chunkhi0 = 0;
+// CHECK-NEXT:              clad::GetStaticSchedule(0, n - 1, 1, &_t_chunklo0, &_t_chunkhi0);
+// CHECK-NEXT:              for (int i = _t_chunklo0; i <= _t_chunkhi0; i += 1) {
+// CHECK-NEXT:                  #pragma omp critical
+// CHECK-NEXT:                      {
+// CHECK-NEXT:                          result += x[0] * x[1];
+// CHECK-NEXT:                      }
+// CHECK-NEXT:              }
+// CHECK-NEXT:          }
+// CHECK-NEXT:      _d_result += 1;
+// CHECK-NEXT:      #pragma omp parallel
+// CHECK-NEXT:          {
+// CHECK-NEXT:              int _t_chunklo1 = 0;
+// CHECK-NEXT:              int _t_chunkhi1 = 0;
+// CHECK-NEXT:              clad::GetStaticSchedule(0, n - 1, 1, &_t_chunklo1, &_t_chunkhi1);
+// CHECK-NEXT:              for (int i = _t_chunkhi1; i >= _t_chunklo1; i -= 1) {
+// CHECK-NEXT:                  #pragma omp critical
+// CHECK-NEXT:                      {
+// CHECK-NEXT:                          {
+// CHECK-NEXT:                              double _r_d0 = _d_result;
+// CHECK-NEXT:                              _d_x[0] += _r_d0 * x[1];
+// CHECK-NEXT:                              _d_x[1] += x[0] * _r_d0;
+// CHECK-NEXT:                          }
+// CHECK-NEXT:                      }
+// CHECK-NEXT:              }
+// CHECK-NEXT:          }
+// CHECK-NEXT:  }
+
 template <size_t N>
 void reset(double (&arr)[N], double val = 0) {
   for (size_t i = 0; i < N; ++i)
@@ -924,5 +1016,15 @@ int main() {
   auto fn20_grad = clad::gradient(fn20);
   fn20_grad.execute(x, 4, dx, &dn);
   printf("{%.2f, %.2f, %.2f, %.2f}\n", dx[0], dx[1], dx[2], dx[3]); // CHECK-EXEC: {4.00, 6.00, 8.00, 10.00}
+
+  reset(dx);
+  auto fn21_grad = clad::gradient(fn21);
+  fn21_grad.execute(x, 4, dx, &dn);
+  printf("{%.2f, %.2f, %.2f, %.2f}\n", dx[0], dx[1], dx[2], dx[3]); // CHECK-EXEC: {16.00, 0.00, 0.00, 0.00}
+
+  reset(dx);
+  auto fn22_grad = clad::gradient(fn22);
+  fn22_grad.execute(x, 4, dx, &dn);
+  printf("{%.2f, %.2f, %.2f, %.2f}\n", dx[0], dx[1], dx[2], dx[3]); // CHECK-EXEC: {12.00, 8.00, 0.00, 0.00}
   return 0;
 }


### PR DESCRIPTION
Adds forward and reverse mode support for `pragma omp critical` directive. The critical directive doesn't outline its body in a captured region (unlike parallel), so it needs its own visitors and can't go through `VisitOMPExecutableDirective`. 
This PR adds the new forward and reverse mode visitors for the critical directive. 

OpenMP programs using critical directive can now be differentiated using clad. One simple example of such a program is this:
``` cpp
#pragma omp parallel for
for (int i = 0; i < n; i++) {
    #pragma omp critical
    {
        result += x[0] * x[1];
    }
} 
```