### PR TITLE
Replace static LookupResult caches with per-instance members in VisitorBase

### DIFF
--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -21,6 +21,7 @@
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Sema/DeclSpec.h"
+#include "clang/Sema/Lookup.h"
 #include "clang/Sema/Ownership.h"
 #include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/Sema.h"
@@ -152,6 +153,7 @@ namespace clad {
     // expression to be of object type in the reverse mode as well.
     clang::Expr* m_ThisExprDerivative = nullptr;
 
+  private:
     /// Per-instance cache for tape lookup results. These are tied to the
     /// current Sema/ASTContext and must not be shared across translation units.
     clad_compat::llvm_Optional<clang::LookupResult> m_TapePushLookup;
@@ -159,6 +161,7 @@ namespace clad {
     clad_compat::llvm_Optional<clang::LookupResult> m_TapeBackLookup;
     clad_compat::llvm_Optional<clang::LookupResult> m_TapeZeroInitLookup;
 
+  protected:
     /// The currently visited statement. Useful for crash pretty-printing.
     const clang::Stmt* m_CurVisitedStmt = nullptr;
 

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -34,6 +34,7 @@
 #include <cstddef>
 #include <stack>
 #include <unordered_map>
+#include <vector>
 
 namespace clang {
 class NestedNameSpecifier;
@@ -150,6 +151,13 @@ namespace clad {
     // FIXME: Fix this inconsistency, by making `this` pointer derivative
     // expression to be of object type in the reverse mode as well.
     clang::Expr* m_ThisExprDerivative = nullptr;
+
+    /// Per-instance cache for tape lookup results. These are tied to the
+    /// current Sema/ASTContext and must not be shared across translation units.
+    clad_compat::llvm_Optional<clang::LookupResult> m_TapePushLookup;
+    clad_compat::llvm_Optional<clang::LookupResult> m_TapePopLookup;
+    clad_compat::llvm_Optional<clang::LookupResult> m_TapeBackLookup;
+    clad_compat::llvm_Optional<clang::LookupResult> m_TapeZeroInitLookup;
 
     /// The currently visited statement. Useful for crash pretty-printing.
     const clang::Stmt* m_CurVisitedStmt = nullptr;

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -831,7 +831,8 @@ namespace clad {
   Stmt* VisitorBase::GetCladZeroInit(llvm::MutableArrayRef<Expr*> args) {
     if (!m_TapeZeroInitLookup)
       m_TapeZeroInitLookup = LookupCladTapeMethod("zero_init");
-    LookupResult& init = clad_compat::llvm_Optional_GetValue(m_TapeZeroInitLookup);
+    LookupResult& init =
+        clad_compat::llvm_Optional_GetValue(m_TapeZeroInitLookup);
     CXXScopeSpec CSS;
     CSS.Extend(m_Context, utils::GetCladNamespace(m_Sema), noLoc, noLoc);
     auto* pushDRE =

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -517,10 +517,9 @@ namespace clad {
   }
 
   LookupResult& VisitorBase::GetCladTapePush() {
-    static clad_compat::llvm_Optional<LookupResult> Result{};
-    if (!Result)
-      Result = LookupCladTapeMethod("push");
-    return clad_compat::llvm_Optional_GetValue(Result);
+    if (!m_TapePushLookup)
+      m_TapePushLookup = LookupCladTapeMethod("push");
+    return clad_compat::llvm_Optional_GetValue(m_TapePushLookup);
   }
 
   Expr* VisitorBase::GetFunctionCall(const std::string& funcName,
@@ -562,17 +561,15 @@ namespace clad {
   }
 
   LookupResult& VisitorBase::GetCladTapePop() {
-    static clad_compat::llvm_Optional<LookupResult> Result{};
-    if (!Result)
-      Result = LookupCladTapeMethod("pop");
-    return clad_compat::llvm_Optional_GetValue(Result);
+    if (!m_TapePopLookup)
+      m_TapePopLookup = LookupCladTapeMethod("pop");
+    return clad_compat::llvm_Optional_GetValue(m_TapePopLookup);
   }
 
   LookupResult& VisitorBase::GetCladTapeBack() {
-    static clad_compat::llvm_Optional<LookupResult> Result{};
-    if (!Result)
-      Result = LookupCladTapeMethod("back");
-    return clad_compat::llvm_Optional_GetValue(Result);
+    if (!m_TapeBackLookup)
+      m_TapeBackLookup = LookupCladTapeMethod("back");
+    return clad_compat::llvm_Optional_GetValue(m_TapeBackLookup);
   }
 
   QualType VisitorBase::GetCladTapeOfType(QualType T) {
@@ -832,10 +829,9 @@ namespace clad {
   }
 
   Stmt* VisitorBase::GetCladZeroInit(llvm::MutableArrayRef<Expr*> args) {
-    static clad_compat::llvm_Optional<LookupResult> Result{};
-    if (!Result)
-      Result = LookupCladTapeMethod("zero_init");
-    LookupResult& init = clad_compat::llvm_Optional_GetValue(Result);
+    if (!m_TapeZeroInitLookup)
+      m_TapeZeroInitLookup = LookupCladTapeMethod("zero_init");
+    LookupResult& init = clad_compat::llvm_Optional_GetValue(m_TapeZeroInitLookup);
     CXXScopeSpec CSS;
     CSS.Extend(m_Context, utils::GetCladNamespace(m_Sema), noLoc, noLoc);
     auto* pushDRE =


### PR DESCRIPTION
Fixes #1837

## Problem

`GetCladTapePush()`, `GetCladTapePop()`, `GetCladTapeBack()`, and `GetCladZeroInit()` in `VisitorBase` each use a function-local `static` variable to cache their `LookupResult`. Since `LookupResult` holds pointers into the current `ASTContext`/`Sema`, these statics become dangling when multiple translation units are processed in the same process (e.g., in Cling).

## Solution

Replace all four `static llvm::Optional<LookupResult>` locals with per-instance members on `VisitorBase`:

- `m_TapePushLookup`
- `m_TapePopLookup`
- `m_TapeBackLookup`
- `m_TapeZeroInitLookup`

Each lookup is performed lazily on first use and dies with the visitor instance, so there is no cross-TU contamination.

## Files changed

- `include/clad/Differentiator/VisitorBase.h` -- add four `llvm_Optional<LookupResult>` members, add `#include <vector>`
- `lib/Differentiator/VisitorBase.cpp` -- replace `static` caches with member access in all four functions

## Testing

This is an internal refactor that preserves external behavior. The stale-pointer bug requires a multi-TU interactive session (Cling) to reproduce, which is not covered by the existing test suite.
