### PR TITLE
Fix TBRAnalyzer visiting the true branch twice in TraverseConditionalOperator 

### DIFF
--- a/lib/Differentiator/TBRAnalyzer.cpp
+++ b/lib/Differentiator/TBRAnalyzer.cpp
@@ -247,7 +247,7 @@ bool TBRAnalyzer::TraverseConditionalOperator(clang::ConditionalOperator* CO) {
 
   auto thenBranch = std::move(m_BlockData[m_CurBlockID]);
   m_BlockData[m_CurBlockID] = std::move(elseBranch);
-  TraverseStmt(CO->getTrueExpr());
+  TraverseStmt(CO->getFalseExpr());
 
   merge(m_BlockData[m_CurBlockID].get(), thenBranch.get());
   return false;

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -416,26 +416,30 @@ double f12(double x, double y) {
 
 //CHECK:   void f12_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:       double _t0;
+//CHECK-NEXT:       double _t1;
 //CHECK-NEXT:       double _d_t = 0.;
 //CHECK-NEXT:       double t;
 //CHECK-NEXT:       bool _cond0 = x > y;
 //CHECK-NEXT:       if (_cond0)
 //CHECK-NEXT:           _t0 = t;
-//CHECK-NEXT:       double *_t1 = &(_cond0 ? (t = x) : (t = y));
-//CHECK-NEXT:       double _t2 = *_t1;
-//CHECK-NEXT:       *_t1 *= y;
+//CHECK-NEXT:       else
+//CHECK-NEXT:           _t1 = t;
+//CHECK-NEXT:       double *_t2 = &(_cond0 ? (t = x) : (t = y));
+//CHECK-NEXT:       double _t3 = *_t2;
+//CHECK-NEXT:       *_t2 *= y;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_t1 = _t2;
+//CHECK-NEXT:           *_t2 = _t3;
 //CHECK-NEXT:           double _r_d0 = (_cond0 ? _d_t : _d_t);
 //CHECK-NEXT:           (_cond0 ? _d_t : _d_t) = 0.;
 //CHECK-NEXT:           (_cond0 ? _d_t : _d_t) += _r_d0 * y;
-//CHECK-NEXT:           *_d_y += *_t1 * _r_d0;
+//CHECK-NEXT:           *_d_y += *_t2 * _r_d0;
 //CHECK-NEXT:           if (_cond0) {
 //CHECK-NEXT:               t = _t0;
 //CHECK-NEXT:               *_d_x += _d_t;
 //CHECK-NEXT:               _d_t = 0.;
 //CHECK-NEXT:           } else {
+//CHECK-NEXT:               t = _t1;
 //CHECK-NEXT:               *_d_y += _d_t;
 //CHECK-NEXT:               _d_t = 0.;
 //CHECK-NEXT:           }

--- a/test/Gradient/TBRTernary.C
+++ b/test/Gradient/TBRTernary.C
@@ -1,0 +1,28 @@
+// RUN: %cladclang %s -I%S/../../include -oReverseMode.out 2>&1 | %filecheck %s
+// RUN: ./ReverseMode.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include <iostream>
+
+double f(bool cond, double a, double b) {
+    double x = cond ? (a * a) : (b * b);
+    a = 0;
+    b = 0;
+    return x;
+}
+
+int main() {
+    auto df = clad::gradient(f, "a,b");
+    double da = 0.0, db = 0.0;
+    
+    df.execute(false, 2.0, 3.0, &da, &db);
+    std::cout << "da: " << da << ", db: " << db << std::endl;
+    // CHECK-EXEC: da: 0, db: 6
+    
+    da = 0.0; db = 0.0;
+    df.execute(true, 2.0, 3.0, &da, &db);
+    std::cout << "da: " << da << ", db: " << db << std::endl;
+    // CHECK-EXEC: da: 4, db: 0
+    
+    return 0;
+}


### PR DESCRIPTION
This PR fixes a silent bug in `TBRAnalyzer::TraverseConditionalOperator`. The analyzer was visiting `getTrueExpr()` twice and completely ignoring the false branch.

Because TBR is default-on for reverse mode, a variable that only appeared in a ternary's false branch and got overwritten later, was never recorded to the tape. The backward pass would read the corrupted value and silently display an incorrect derivative. You can see the intended logic by comparing it to `VariedAnalyzer`, which correctly visits the condition, the true branch, and the false branch.

This fix corrects the second traversal to `getFalseExpr()`, matching the correct behavior already seen in `VariedAnalyzer::TraverseConditionalOperator`.

• Added a regression test that checks gradients against both the true and false conditions. I verified on a clean build that this test correctly catches the broken 0 derivative before the fix and outputs the expected 6 afterward.
• Updated a few CHECK-NEXT lines in `test/Gradient/Assignments.C` that were failing after this fix because they were  relying on the broken false-branch tape omissions.