### PR TITLE
Fix clang::Scope leak in reverse-mode switch differentiation.

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4155,6 +4155,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     PopBreakContStmtHandler();
     PopSwitchStmtInfo();
+    // Pop the two scopes opened above (init/condition and body); leaving them
+    // open leaks the clang::Scope objects and strands Derive()'s scopes too.
+    endScope();
+    endScope();
     return {endBlock(direction::forward), endBlock(direction::reverse)};
   }
 


### PR DESCRIPTION
ReverseModeVisitor::VisitSwitchStmt opens two clang::Scope objects via beginScope -- one for the switch init/condition, one for the body -- but returns having closed only the forward/reverse blocks. Every differentiated switch leaked both scopes, and the unbalanced scope stack also made Derive()'s endScope() delete the stranded switch scopes instead of the function prototype/body scopes, leaking those too. LeakSanitizer flags it on any gradient of a function with a switch (Gradient/Switch.C, Gradient/SwitchInit.C).

Pop both scopes before returning, matching the forward-mode VisitSwitchStmt that already balances them.