### PR TITLE
Fix use-after-poison in UsefulAnalyzer's reverse CFG walk.

### DIFF
--- a/lib/Differentiator/UsefulAnalyzer.cpp
+++ b/lib/Differentiator/UsefulAnalyzer.cpp
@@ -1,5 +1,7 @@
 #include "UsefulAnalyzer.h"
 
+#include "clang/AST/Stmt.h"
+
 using namespace clang;
 
 namespace clad {
@@ -46,12 +48,11 @@ static void mergeVarsData(std::set<const clang::VarDecl*>* targetData,
 }
 
 void UsefulAnalyzer::AnalyzeCFGBlock(const CFGBlock& block) {
-  for (auto ib = block.end(); ib != block.begin() - 1; ib--) {
-    if (ib->getKind() == clang::CFGElement::Statement) {
-
-      const clang::Stmt* S = ib->castAs<clang::CFGStmt>().getStmt();
+  for (const auto* it = block.rbegin(); it != block.rend(); ++it) {
+    if (it->getKind() == clang::CFGElement::Statement) {
+      const clang::Stmt* S = it->castAs<clang::CFGStmt>().getStmt();
       // The const_cast is inevitable, since there is no
-      // ConstRecusiveASTVisitor.
+      // ConstRecursiveASTVisitor.
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
       TraverseStmt(const_cast<clang::Stmt*>(S));
     }


### PR DESCRIPTION
UsefulAnalyzer::AnalyzeCFGBlock walks a block's CFGElements in reverse, but started the iterator at block.end() and dereferenced it, using block.begin() - 1 as the loop sentinel. Both are invalid iterators: end() is one past the last element and begin() - 1 is out of bounds. Reading a CFGElement's PointerIntPair through them is undefined; under -fsanitize=address the container annotations on the element storage turn it into a use-after-poison (e.g. Analyses/UsefulForward.cpp).

Use rbegin()/rend() instead: a plain forward walk over reverse iterators visits the same elements in the same order without ever dereferencing end() or forming the out-of-bounds sentinel.