### PR TITLE
Fix clang::Scope leak in forward-mode range-for differentiation.

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -654,6 +654,7 @@ BaseForwardModeVisitor::VisitCXXForRangeStmt(const CXXForRangeStmt* FRS) {
   Stmt* forStmtDiff = new (m_Context)
       ForStmt(m_Context, nullptr, cond, /*condVar=*/nullptr, Inc, bodyResult,
               FRS->getForLoc(), FRS->getBeginLoc(), FRS->getEndLoc());
+  endScope();
   return StmtDiff(forStmtDiff);
 }
 


### PR DESCRIPTION
BaseForwardModeVisitor::VisitCXXForRangeStmt opens a scope with beginScope for the synthesized __range/__begin/__end declarations but returns the rewritten ForStmt without ever closing it. Every differentiated range-based for leaked that scope, and the unbalanced scope stack also stranded the function prototype/body scopes opened in Derive() (LeakSanitizer; e.g. FirstDerivative/Loops.C). Every other forward-mode statement handler already balances its scopes.

Pop the scope before returning.