### PR TITLE
Guard statement scopes with a ScopeRAII handle. NFC

### DIFF
--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -251,6 +251,25 @@ namespace clad {
     void beginScope(unsigned ScopeFlags);
     void endScope();
 
+    /// RAII guard that opens a scope on construction and closes it on
+    /// destruction, so a beginScope is always balanced by an endScope even
+    /// when a statement handler returns early. Use it for statement scopes
+    /// that nest within a single function; Derive()'s function-spanning scope
+    /// stays explicit because it is captured into m_DerivativeFnScope and
+    /// interleaves with Push/PopDeclContext.
+    class [[nodiscard]] ScopeRAII {
+      VisitorBase& m_Visitor;
+
+    public:
+      ScopeRAII(VisitorBase& Visitor, unsigned ScopeFlags)
+          : m_Visitor(Visitor) {
+        m_Visitor.beginScope(ScopeFlags);
+      }
+      ~ScopeRAII() { m_Visitor.endScope(); }
+      ScopeRAII(const ScopeRAII&) = delete;
+      ScopeRAII& operator=(const ScopeRAII&) = delete;
+    };
+
     /// A shorthand to simplify syntax for creation of new expressions.
     /// This function uses m_Sema.BuildUnOp internally to build unary
     /// operations. Typical usage of this function looks like the following:

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -466,7 +466,7 @@ StmtDiff BaseForwardModeVisitor::VisitStmt(const Stmt* S) {
 }
 
 StmtDiff BaseForwardModeVisitor::VisitCompoundStmt(const CompoundStmt* CS) {
-  beginScope(Scope::DeclScope);
+  ScopeRAII compoundScope(*this, Scope::DeclScope);
   beginBlock();
   for (Stmt* S : CS->body()) {
     StmtDiff SDiff = Visit(S);
@@ -474,7 +474,6 @@ StmtDiff BaseForwardModeVisitor::VisitCompoundStmt(const CompoundStmt* CS) {
     addToCurrentBlock(SDiff.getStmt());
   }
   CompoundStmt* Result = endBlock();
-  endScope();
   // Differentation of CompundStmt produces another CompoundStmt with both
   // original and derived statements, i.e. Stmt() is Result and Stmt_dx() is
   // null.
@@ -484,7 +483,7 @@ StmtDiff BaseForwardModeVisitor::VisitCompoundStmt(const CompoundStmt* CS) {
 StmtDiff BaseForwardModeVisitor::VisitIfStmt(const IfStmt* If) {
   // Control scope of the IfStmt. E.g., in if (double x = ...) {...}, x goes
   // to this scope.
-  beginScope(Scope::DeclScope | Scope::ControlScope);
+  ScopeRAII ifScope(*this, Scope::DeclScope | Scope::ControlScope);
   // Create a block "around" if statement, e.g:
   // {
   //   ...
@@ -532,12 +531,11 @@ StmtDiff BaseForwardModeVisitor::VisitIfStmt(const IfStmt* If) {
       return BranchDiff.getStmt();
     } else {
       beginBlock();
-      beginScope(Scope::DeclScope);
+      ScopeRAII branchScope(*this, Scope::DeclScope);
       StmtDiff BranchDiff = Visit(Branch);
       for (Stmt* S : BranchDiff.getBothStmts())
         addToCurrentBlock(S);
       CompoundStmt* Block = endBlock();
-      endScope();
       if (Block->size() == 1)
         return Block->body_front();
       else
@@ -554,7 +552,6 @@ StmtDiff BaseForwardModeVisitor::VisitIfStmt(const IfStmt* If) {
   addToCurrentBlock(ifDiff);
   CompoundStmt* Block = endBlock();
   // If IfStmt is the only statement in the block, remove the block:
-  endScope();
   // {
   //   if (...) {...}
   // }
@@ -596,8 +593,8 @@ StmtDiff BaseForwardModeVisitor::VisitConditionalOperator(
 
 StmtDiff
 BaseForwardModeVisitor::VisitCXXForRangeStmt(const CXXForRangeStmt* FRS) {
-  beginScope(Scope::DeclScope | Scope::ControlScope | Scope::BreakScope |
-             Scope::ContinueScope);
+  ScopeRAII rangeScope(*this, Scope::DeclScope | Scope::ControlScope |
+                                  Scope::BreakScope | Scope::ContinueScope);
   // Visiting for range-based ststement produces __range1, __begin1 and __end1
   // variables, so for(auto i: a){
   //      ...
@@ -656,13 +653,12 @@ BaseForwardModeVisitor::VisitCXXForRangeStmt(const CXXForRangeStmt* FRS) {
   Stmt* forStmtDiff = new (m_Context)
       ForStmt(m_Context, nullptr, cond, /*condVar=*/nullptr, Inc, bodyResult,
               FRS->getForLoc(), FRS->getBeginLoc(), FRS->getEndLoc());
-  endScope();
   return StmtDiff(forStmtDiff);
 }
 
 StmtDiff BaseForwardModeVisitor::VisitForStmt(const ForStmt* FS) {
-  beginScope(Scope::DeclScope | Scope::ControlScope | Scope::BreakScope |
-             Scope::ContinueScope);
+  ScopeRAII forScope(*this, Scope::DeclScope | Scope::ControlScope |
+                                Scope::BreakScope | Scope::ContinueScope);
   beginBlock();
   const Stmt* init = FS->getInit();
   StmtDiff initDiff = init ? Visit(init) : StmtDiff{};
@@ -760,14 +756,15 @@ StmtDiff BaseForwardModeVisitor::VisitForStmt(const ForStmt* FS) {
 
   // Build the derived for loop body.
   const Stmt* body = FS->getBody();
-  beginScope(Scope::DeclScope);
   Stmt* bodyResult = nullptr;
-  beginBlock();
-  StmtDiff bodyVisited = Visit(body);
-  for (Stmt* S : bodyVisited.getBothStmts())
-    addToCurrentBlock(S);
-  bodyResult = utils::unwrapIfSingleStmt(endBlock());
-  endScope();
+  {
+    ScopeRAII bodyScope(*this, Scope::DeclScope);
+    beginBlock();
+    StmtDiff bodyVisited = Visit(body);
+    for (Stmt* S : bodyVisited.getBothStmts())
+      addToCurrentBlock(S);
+    bodyResult = utils::unwrapIfSingleStmt(endBlock());
+  }
 
   Stmt* forStmtDiff = new (m_Context)
       ForStmt(m_Context, initDiff.getStmt(), cond, /*condVar=*/nullptr,
@@ -775,7 +772,6 @@ StmtDiff BaseForwardModeVisitor::VisitForStmt(const ForStmt* FS) {
 
   addToCurrentBlock(forStmtDiff);
   CompoundStmt* Block = endBlock();
-  endScope();
 
   StmtDiff Result =
       (Block->size() == 1) ? StmtDiff(forStmtDiff) : StmtDiff(Block);
@@ -1823,9 +1819,9 @@ StmtDiff BaseForwardModeVisitor::VisitStringLiteral(const StringLiteral* SL) {
 }
 
 StmtDiff BaseForwardModeVisitor::VisitWhileStmt(const WhileStmt* WS) {
-  // begin scope for while loop
-  beginScope(Scope::ContinueScope | Scope::BreakScope | Scope::DeclScope |
-             Scope::ControlScope);
+  // Scope for the whole while loop.
+  ScopeRAII whileScope(*this, Scope::ContinueScope | Scope::BreakScope |
+                                  Scope::DeclScope | Scope::ControlScope);
 
   const VarDecl* condVar = WS->getConditionVariable();
   VarDecl* condVarClone = nullptr;
@@ -1882,13 +1878,12 @@ StmtDiff BaseForwardModeVisitor::VisitWhileStmt(const WhileStmt* WS) {
   if (isa<CompoundStmt>(body)) {
     bodyResult = Visit(body).getStmt();
   } else {
-    beginScope(Scope::DeclScope);
+    ScopeRAII bodyScope(*this, Scope::DeclScope);
     beginBlock();
     StmtDiff Result = Visit(body);
     for (Stmt* S : Result.getBothStmts())
       addToCurrentBlock(S);
     CompoundStmt* Block = endBlock();
-    endScope();
     bodyResult = Block;
   }
 
@@ -1897,8 +1892,6 @@ StmtDiff BaseForwardModeVisitor::VisitWhileStmt(const WhileStmt* WS) {
           .ActOnWhileStmt(/*WhileLoc=*/noLoc, /*LParenLoc=*/noLoc, condRes,
                           /*RParenLoc=*/noLoc, bodyResult)
           .get();
-  // end scope for while loop
-  endScope();
   return StmtDiff(WSDiff);
 }
 
@@ -1908,8 +1901,8 @@ BaseForwardModeVisitor::VisitContinueStmt(const ContinueStmt* ContStmt) {
 }
 
 StmtDiff BaseForwardModeVisitor::VisitDoStmt(const DoStmt* DS) {
-  // begin scope for do-while statement
-  beginScope(Scope::ContinueScope | Scope::BreakScope);
+  // Scope for the whole do-while statement.
+  ScopeRAII doScope(*this, Scope::ContinueScope | Scope::BreakScope);
   Expr* clonedCond = DS->getCond() ? Clone(DS->getCond()) : nullptr;
   const Stmt* body = DS->getBody();
 
@@ -1917,13 +1910,12 @@ StmtDiff BaseForwardModeVisitor::VisitDoStmt(const DoStmt* DS) {
   if (isa<CompoundStmt>(body)) {
     bodyResult = Visit(body).getStmt();
   } else {
-    beginScope(Scope::DeclScope);
+    ScopeRAII bodyScope(*this, Scope::DeclScope);
     beginBlock();
     StmtDiff Result = Visit(body);
     for (Stmt* S : Result.getBothStmts())
       addToCurrentBlock(S);
     CompoundStmt* Block = endBlock();
-    endScope();
     bodyResult = Block;
   }
 
@@ -1933,8 +1925,6 @@ StmtDiff BaseForwardModeVisitor::VisitDoStmt(const DoStmt* DS) {
                              /*CondRParen=*/noLoc)
                 .get();
 
-  // end scope for do-while statement
-  endScope();
   return StmtDiff(S);
 }
 

--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -236,14 +236,13 @@ StmtDiff ReverseModeForwPassVisitor::ProcessSingleStmt(const clang::Stmt* S) {
 
 StmtDiff
 ReverseModeForwPassVisitor::VisitCompoundStmt(const clang::CompoundStmt* CS) {
-  beginScope(Scope::DeclScope);
+  ScopeRAII compoundScope(*this, Scope::DeclScope);
   beginBlock();
   for (Stmt* S : CS->body()) {
     StmtDiff SDiff = ProcessSingleStmt(S);
     addToCurrentBlock(SDiff.getStmt());
   }
   CompoundStmt* forward = endBlock();
-  endScope();
   return {forward};
 }
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -753,7 +753,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // and wrap the code in a for loop to compute the derivative as follows:
     // for (int i = 0; i < N; ++i)
     //   _d_arr[i] += _d_res[i];
-    beginScope(Scope::DeclScope);
+    ScopeRAII arrayInitScope(*this, Scope::DeclScope);
     VarDecl* idxDecl = BuildVarDecl(m_Context.UnsignedIntTy, "i",
                                     getZeroInit(m_Context.IntTy));
     // Push the index to the queue so that we can replace ArrayInitIndexExpr
@@ -768,7 +768,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     Stmt* loopDiff = BuildStandardForLoop(
         idxDecl, AILE->getArraySize().getZExtValue(), block);
     addToCurrentBlock(loopDiff, direction::reverse);
-    endScope();
     // We cannot clone ArrayInitLoopExpr because it's not possible to express
     // with standard c++ syntax.
     return {};
@@ -810,7 +809,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // propagate the function scope.
     if (getCurrentScope() == m_DerivativeFnScope)
       scopeFlags |= Scope::FnScope;
-    beginScope(scopeFlags);
+    ScopeRAII compoundScope(*this, scopeFlags);
     beginBlock(direction::forward);
     beginBlock(direction::reverse);
     for (Stmt* S : CS->body()) {
@@ -825,14 +824,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
     CompoundStmt* Forward = endBlock(direction::forward);
     CompoundStmt* Reverse = endBlock(direction::reverse);
-    endScope();
     return StmtDiff(Forward, Reverse);
   }
 
   StmtDiff ReverseModeVisitor::VisitIfStmt(const clang::IfStmt* If) {
     // Control scope of the IfStmt. E.g., in if (double x = ...) {...}, x goes
     // to this scope.
-    beginScope(Scope::DeclScope | Scope::ControlScope);
+    ScopeRAII ifScope(*this, Scope::DeclScope | Scope::ControlScope);
 
     // Create a block "around" if statement, e.g:
     // {
@@ -926,7 +924,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     addToCurrentBlock(Reverse, direction::reverse);
     CompoundStmt* ForwardBlock = endBlock(direction::forward);
     CompoundStmt* ReverseBlock = endBlock(direction::reverse);
-    endScope();
     return StmtDiff(utils::unwrapIfSingleStmt(ForwardBlock),
                     utils::unwrapIfSingleStmt(ReverseBlock),
                     /*valueForRevSweep=*/condDiffStored);
@@ -952,9 +949,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     auto VisitBranch = [&](const Expr* Branch,
                            Expr* dfdx) -> std::pair<StmtDiff, StmtDiff> {
-      beginScope(Scope::DeclScope);
+      ScopeRAII branchScope(*this, Scope::DeclScope);
       auto Result = DifferentiateSingleExpr(Branch, dfdx);
-      endScope();
       StmtDiff BranchDiff = Result.first;
       StmtDiff ExprDiff = Result.second;
       Stmt* Forward = utils::unwrapIfSingleStmt(BranchDiff.getStmt());
@@ -1031,8 +1027,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     beginBlock(direction::reverse);
     LoopCounter loopCounter(*this);
-    beginScope(Scope::DeclScope | Scope::ControlScope | Scope::BreakScope |
-               Scope::ContinueScope);
+    ScopeRAII rangeScope(*this, Scope::DeclScope | Scope::ControlScope |
+                                    Scope::BreakScope | Scope::ContinueScope);
 
     llvm::SaveAndRestore<Expr*> SaveCurrentBreakFlagExpr(
         m_CurrentBreakFlagExpr);
@@ -1144,7 +1140,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                 FRS->getForLoc(), FRS->getBeginLoc(), FRS->getEndLoc());
     addToCurrentBlock(Reverse, direction::reverse);
     Reverse = endBlock(direction::reverse);
-    endScope();
 
     return {utils::unwrapIfSingleStmt(Forward),
             utils::unwrapIfSingleStmt(Reverse)};
@@ -1153,8 +1148,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   StmtDiff ReverseModeVisitor::VisitForStmt(const ForStmt* FS) {
     beginBlock(direction::reverse);
     LoopCounter loopCounter(*this);
-    beginScope(Scope::DeclScope | Scope::ControlScope | Scope::BreakScope |
-               Scope::ContinueScope);
+    ScopeRAII forScope(*this, Scope::DeclScope | Scope::ControlScope |
+                                  Scope::BreakScope | Scope::ContinueScope);
     llvm::SaveAndRestore<Expr*> SaveCurrentBreakFlagExpr(
         m_CurrentBreakFlagExpr);
     m_CurrentBreakFlagExpr = nullptr;
@@ -1302,7 +1297,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     addToCurrentBlock(initResult.getStmt_dx(), direction::reverse);
     addToCurrentBlock(Reverse, direction::reverse);
     Reverse = endBlock(direction::reverse);
-    endScope();
 
     return {utils::unwrapIfSingleStmt(Forward),
             utils::unwrapIfSingleStmt(Reverse)};
@@ -3909,9 +3903,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     beginBlock(direction::reverse);
     LoopCounter loopCounter(*this);
 
-    // begin scope for while statement
-    beginScope(Scope::DeclScope | Scope::ControlScope | Scope::BreakScope |
-               Scope::ContinueScope);
+    // Scope for the whole while statement.
+    ScopeRAII whileScope(*this, Scope::DeclScope | Scope::ControlScope |
+                                    Scope::BreakScope | Scope::ContinueScope);
 
     llvm::SaveAndRestore<bool> SaveIsInsideLoop(isInsideLoop);
     isInsideLoop = true;
@@ -3968,8 +3962,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                             CounterCondition,
                             /*RParenLoc=*/noLoc, bodyDiff.getStmt_dx())
             .get();
-    // for while statement
-    endScope();
     addToCurrentBlock(reverseWS, direction::reverse);
     reverseWS = utils::unwrapIfSingleStmt(endBlock(direction::reverse));
     return {forwardWS, reverseWS};
@@ -3979,8 +3971,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     beginBlock(direction::reverse);
     LoopCounter loopCounter(*this);
 
-    // begin scope for do statement
-    beginScope(Scope::ContinueScope | Scope::BreakScope);
+    // Scope for the whole do-while statement.
+    ScopeRAII doScope(*this, Scope::ContinueScope | Scope::BreakScope);
 
     llvm::SaveAndRestore<bool> SaveIsInsideLoop(isInsideLoop);
     isInsideLoop = true;
@@ -4013,8 +4005,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                                        /*CondLParen=*/noLoc, counterCondition,
                                        /*CondRParen=*/noLoc)
                           .get();
-    // for do-while statement
-    endScope();
     addToCurrentBlock(reverseDS, direction::reverse);
     reverseDS = utils::unwrapIfSingleStmt(endBlock(direction::reverse));
     return {forwardDS, reverseDS};
@@ -4036,7 +4026,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // Scope and blocks for the compound statement that encloses the switch
     // statement in both the forward and the reverse pass. Block is required
     // for handling condition variable and switch-init statement.
-    beginScope(Scope::DeclScope);
+    ScopeRAII switchScope(*this, Scope::DeclScope);
     beginBlock(direction::forward);
     beginBlock(direction::reverse);
 
@@ -4068,7 +4058,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     SSData->switchStmtCond = condExpr;
 
     // scope for the switch statement body.
-    beginScope(Scope::DeclScope);
+    ScopeRAII switchBodyScope(*this, Scope::DeclScope);
 
     const Stmt* body = SS->getBody();
     StmtDiff bodyDiff = nullptr;
@@ -4158,10 +4148,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     PopBreakContStmtHandler();
     PopSwitchStmtInfo();
-    // Pop the two scopes opened above (init/condition and body); leaving them
-    // open leaks the clang::Scope objects and strands Derive()'s scopes too.
-    endScope();
-    endScope();
     return {endBlock(direction::forward), endBlock(direction::reverse)};
   }
 
@@ -4258,7 +4244,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         addToCurrentBlock(S);
     } else {
       // for forward-pass loop statement body
-      beginScope(Scope::DeclScope);
+      ScopeRAII bodyScope(*this, Scope::DeclScope);
       if (m_ExternalSource)
         m_ExternalSource->ActBeforeDifferentiatingSingleStmtLoopBody();
       bodyDiff = DifferentiateSingleStmt(body, /*dfdS=*/nullptr);
@@ -4266,8 +4252,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       if (m_ExternalSource)
         m_ExternalSource->ActAfterProcessingSingleStmtBodyInVisitForLoop();
 
-      // for forward-pass loop statement body
-      endScope();
       Stmt* reverseBlock = utils::unwrapIfSingleStmt(bodyDiff.getStmt_dx());
       bodyDiff.updateStmtDx(reverseBlock);
     }


### PR DESCRIPTION
clad's statement visitors open a clang::Scope with beginScope and have to close it with a matching endScope on every exit path. A forgotten endScope leaks the Scope object and strands the function-spanning scopes opened by Derive(); this already bit the forward range-for and reverse switch handlers, each since repaired by adding the missing endScope by hand.

Introduce a ScopeRAII guard that opens a scope on construction and closes it on destruction, and adopt it in the statement handlers whose scope both opens and closes within a single function body. The balance is now enforced by the type rather than by hand, so an early return can no longer strand a scope. The scopes that do not coincide with a single C++ block stay as explicit begin/endScope pairs: Derive()'s function-spanning function and body scopes, the derived-lambda construction scopes, the forward switch body scope that closes in DeriveSwitchStmtBodyHelper, and the OpenMP canonical-loop scope.