### PR TITLE
Add AD for std::ref, std::cref, and reference_wrapper.

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -491,6 +491,12 @@ namespace clad {
     /// Returns true if T allows to edit any memory.
     bool isMemoryType(clang::QualType T);
 
+    /// \returns true if differentiating a call to \p FDecl needs a
+    /// `reverse_forw`. `isMemoryType` on the return type, plus
+    /// std::reference_wrapper's accessors, whose const reference cannot carry
+    /// the referent's adjoint.
+    bool needsReverseForw(const clang::FunctionDecl* FDecl);
+
     bool hasMemoryTypeParams(const clang::FunctionDecl* FD);
 
     bool shouldUseRestoreTracker(const clang::FunctionDecl* FD);

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -817,9 +817,47 @@ template <typename T>
 clad::ValueAndAdjoint<T&, T&> conversion_operator_reverse_forw(
     clad::Tag<T&>, const ::std::reference_wrapper<T>* x,
     const ::std::reference_wrapper<T>* dx) elidable_reverse_forw;
+
+template <class T>
+inline clad::ValueAndPushforward<const T&, const T&>
+get_pushforward(const ::std::reference_wrapper<const T>* w,
+                const ::std::reference_wrapper<const T>* d_w) noexcept {
+  return {w->get(), d_w->get()};
+}
+
+template <class T>
+inline clad::ValueAndPushforward<T&, T&>
+get_pushforward(const ::std::reference_wrapper<T>* w,
+                const ::std::reference_wrapper<T>* d_w) noexcept {
+  return {w->get(), d_w->get()};
+}
+
+template <class T>
+inline clad::ValueAndPushforward<T&, T&>
+operator_T_amp_pushforward(const ::std::reference_wrapper<T>* w,
+                           const ::std::reference_wrapper<T>* d_w) noexcept {
+  return {w->get(), d_w->get()};
+}
+
 } // namespace class_functions
 
 namespace std {
+
+// std::ref and std::cref
+
+template <class T>
+inline clad::ValueAndPushforward<::std::reference_wrapper<T>,
+                                 ::std::reference_wrapper<T>>
+ref_pushforward(T& t, T& d_t) noexcept {
+  return {::std::ref(t), ::std::ref(d_t)};
+}
+
+template <class T>
+inline clad::ValueAndPushforward<::std::reference_wrapper<const T>,
+                                 ::std::reference_wrapper<const T>>
+cref_pushforward(const T& t, const T& d_t) noexcept {
+  return {::std::cref(t), ::std::cref(d_t)};
+}
 
 // tie and maketuple forward mode
 

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -870,9 +870,47 @@ template <typename T>
 clad::ValueAndAdjoint<T&, T&> conversion_operator_reverse_forw(
     clad::Tag<T&>, const ::std::reference_wrapper<T>* x,
     const ::std::reference_wrapper<T>* dx) elidable_reverse_forw;
+
+template <class T>
+inline clad::ValueAndPushforward<const T&, const T&>
+get_pushforward(const ::std::reference_wrapper<const T>* w,
+                const ::std::reference_wrapper<const T>* d_w) noexcept {
+  return {w->get(), d_w->get()};
+}
+
+template <class T>
+inline clad::ValueAndPushforward<T&, T&>
+get_pushforward(const ::std::reference_wrapper<T>* w,
+                const ::std::reference_wrapper<T>* d_w) noexcept {
+  return {w->get(), d_w->get()};
+}
+
+template <class T>
+inline clad::ValueAndPushforward<T&, T&>
+operator_T_amp_pushforward(const ::std::reference_wrapper<T>* w,
+                           const ::std::reference_wrapper<T>* d_w) noexcept {
+  return {w->get(), d_w->get()};
+}
+
 } // namespace class_functions
 
 namespace std {
+
+// std::ref and std::cref
+
+template <class T>
+inline clad::ValueAndPushforward<::std::reference_wrapper<T>,
+                                 ::std::reference_wrapper<T>>
+ref_pushforward(T& t, T& d_t) noexcept {
+  return {::std::ref(t), ::std::ref(d_t)};
+}
+
+template <class T>
+inline clad::ValueAndPushforward<::std::reference_wrapper<const T>,
+                                 ::std::reference_wrapper<const T>>
+cref_pushforward(const T& t, const T& d_t) noexcept {
+  return {::std::cref(t), ::std::cref(d_t)};
+}
 
 // tie and maketuple forward mode
 

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -859,38 +859,71 @@ void lock_pullback(const ::std::weak_ptr<T>* p, ::std::shared_ptr<T> dthis,
 template <typename T, typename U>
 clad::ValueAndAdjoint<::std::reference_wrapper<T>, ::std::reference_wrapper<T>>
 constructor_reverse_forw(
-    clad::ConstructorReverseForwTag<::std::reference_wrapper<T>>, U&& p,
-    U&& d_p) elidable_reverse_forw;
+    clad::ConstructorReverseForwTag<::std::reference_wrapper<T>>, U&& arg,
+    U&& d_arg) elidable_reverse_forw;
 
 template <typename T, typename U>
-void constructor_pullback(U& /*p*/, ::std::reference_wrapper<T>* /*dthis*/,
-                          U* /*d_p*/);
+void constructor_pullback(U& /*arg*/, ::std::reference_wrapper<T>* /*dthis*/,
+                          U* /*d_arg*/);
 
 template <typename T>
 clad::ValueAndAdjoint<T&, T&> conversion_operator_reverse_forw(
-    clad::Tag<T&>, const ::std::reference_wrapper<T>* x,
-    const ::std::reference_wrapper<T>* dx) elidable_reverse_forw;
+    const ::std::reference_wrapper<T>* ref, clad::Tag<T&> /*tag*/,
+    const ::std::reference_wrapper<T>* d_ref) elidable_reverse_forw;
+
+// Not elidable: replaying the conversion on the adjoint gives const T&, which
+// cannot be written.
+template <typename T>
+inline clad::ValueAndAdjoint<const T&, T&> conversion_operator_reverse_forw(
+    const ::std::reference_wrapper<const T>* ref, clad::Tag<const T&> /*tag*/,
+    const ::std::reference_wrapper<const T>* d_ref) noexcept {
+  return {ref->get(), const_cast<T&>(d_ref->get())};
+}
+
+// Avoid autodiff of libc++ `return *__f_` (const T*).
+template <typename T>
+inline void conversion_operator_pullback(
+    const ::std::reference_wrapper<const T>* /*ref*/, T /*d_y*/,
+    ::std::reference_wrapper<const T>* /*d_ref*/) noexcept {}
 
 template <class T>
 inline clad::ValueAndPushforward<const T&, const T&>
-get_pushforward(const ::std::reference_wrapper<const T>* w,
-                const ::std::reference_wrapper<const T>* d_w) noexcept {
-  return {w->get(), d_w->get()};
+get_pushforward(const ::std::reference_wrapper<const T>* ref,
+                const ::std::reference_wrapper<const T>* d_ref) noexcept {
+  return {ref->get(), d_ref->get()};
 }
 
 template <class T>
-inline clad::ValueAndPushforward<T&, T&>
-get_pushforward(const ::std::reference_wrapper<T>* w,
-                const ::std::reference_wrapper<T>* d_w) noexcept {
-  return {w->get(), d_w->get()};
+inline clad::ValueAndAdjoint<const T&, T&>
+get_reverse_forw(const ::std::reference_wrapper<const T>* ref,
+                 const ::std::reference_wrapper<const T>* d_ref) noexcept {
+  // The adjoint is mutable storage even where the primal wrapper is const.
+  return {ref->get(), const_cast<T&>(d_ref->get())};
 }
 
 template <class T>
+inline void
+get_pullback(const ::std::reference_wrapper<const T>* /*ref*/, T /*d_y*/,
+             ::std::reference_wrapper<const T>* /*d_ref*/) noexcept {}
+
+template <class T>
 inline clad::ValueAndPushforward<T&, T&>
-operator_T_amp_pushforward(const ::std::reference_wrapper<T>* w,
-                           const ::std::reference_wrapper<T>* d_w) noexcept {
-  return {w->get(), d_w->get()};
+get_pushforward(const ::std::reference_wrapper<T>* ref,
+                const ::std::reference_wrapper<T>* d_ref) noexcept {
+  return {ref->get(), d_ref->get()};
 }
+
+template <class T>
+inline clad::ValueAndAdjoint<T&, T&>
+get_reverse_forw(const ::std::reference_wrapper<T>* ref,
+                 const ::std::reference_wrapper<T>* d_ref) noexcept {
+  return {ref->get(), d_ref->get()};
+}
+
+// T& return: no _d_y.
+template <class T>
+inline void get_pullback(const ::std::reference_wrapper<T>* /*ref*/,
+                         ::std::reference_wrapper<T>* /*d_ref*/) noexcept {}
 
 } // namespace class_functions
 
@@ -901,16 +934,40 @@ namespace std {
 template <class T>
 inline clad::ValueAndPushforward<::std::reference_wrapper<T>,
                                  ::std::reference_wrapper<T>>
-ref_pushforward(T& t, T& d_t) noexcept {
-  return {::std::ref(t), ::std::ref(d_t)};
+ref_pushforward(T& val, T& d_val) noexcept {
+  return {::std::ref(val), ::std::ref(d_val)};
 }
 
 template <class T>
 inline clad::ValueAndPushforward<::std::reference_wrapper<const T>,
                                  ::std::reference_wrapper<const T>>
-cref_pushforward(const T& t, const T& d_t) noexcept {
-  return {::std::cref(t), ::std::cref(d_t)};
+cref_pushforward(const T& val, const T& d_val) noexcept {
+  return {::std::cref(val), ::std::cref(d_val)};
 }
+
+template <class T>
+inline clad::ValueAndAdjoint<::std::reference_wrapper<T>,
+                             ::std::reference_wrapper<T>>
+ref_reverse_forw(T& val, T& d_val) noexcept {
+  return {::std::ref(val), ::std::ref(d_val)};
+}
+
+template <class T>
+inline clad::ValueAndAdjoint<::std::reference_wrapper<const T>,
+                             ::std::reference_wrapper<const T>>
+cref_reverse_forw(const T& val, const T& d_val) noexcept {
+  return {::std::cref(val), ::std::cref(d_val)};
+}
+
+// Wrappers only alias storage; adjoints accumulate through get() / conversion.
+template <class T>
+inline void ref_pullback(T& /*val*/, ::std::reference_wrapper<T> /*d_y*/,
+                         T* /*d_val*/) noexcept {}
+
+template <class T>
+inline void cref_pullback(const T& /*val*/,
+                          ::std::reference_wrapper<const T> /*d_y*/,
+                          T* /*d_val*/) noexcept {}
 
 // tie and maketuple forward mode
 

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1206,6 +1206,9 @@ namespace clad {
         return !T->getPointeeType().isConstQualified();
       if (const auto* RT = T->getAs<RecordType>()) {
         const RecordDecl* RD = RT->getDecl();
+        // Including reference_wrapper<const T>, whose field is a const T*.
+        if (RD->isInStdNamespace() && RD->getName() == "reference_wrapper")
+          return true;
         if (const auto* CRD = dyn_cast<CXXRecordDecl>(RD))
           if (!isCopyable(CRD))
             return true;
@@ -1219,6 +1222,27 @@ namespace clad {
         return false;
       }
       return false;
+    }
+
+    /// \returns true if \p FDecl is a member of std::reference_wrapper
+    /// returning a const lvalue reference, i.e. `get` and the conversion to
+    /// `const T&`.
+    static bool isConstRefReturningRefWrapperMember(const FunctionDecl* FDecl) {
+      const auto* Method = dyn_cast_or_null<CXXMethodDecl>(FDecl);
+      if (!Method)
+        return false;
+      const CXXRecordDecl* Record = Method->getParent();
+      if (!Record->isInStdNamespace() ||
+          Record->getName() != "reference_wrapper")
+        return false;
+      QualType Ty = FDecl->getReturnType().getCanonicalType();
+      return Ty->isLValueReferenceType() &&
+             Ty.getNonReferenceType().isConstQualified();
+    }
+
+    bool needsReverseForw(const FunctionDecl* FDecl) {
+      return isMemoryType(FDecl->getReturnType()) ||
+             isConstRefReturningRefWrapperMember(FDecl);
     }
 
     bool shouldUseRestoreTracker(const FunctionDecl* FD) {
@@ -1478,11 +1502,17 @@ namespace clad {
                         mode == DiffMode::pullback ||
                         mode == DiffMode::vector_forward_mode;
       if (mode == DiffMode::reverse_mode_forward_pass) {
-        if (isMemoryType(oRetTy) || isa<CXXConstructorDecl>(FD)) {
+        if (needsReverseForw(FD) || isa<CXXConstructorDecl>(FD)) {
           TemplateDecl* valAndAdjointTempDecl =
               utils::LookupTemplateDeclInCladNamespace(S, "ValueAndAdjoint");
+          // Const lvalue-reference returns: adjoint channel is non-const.
+          QualType adjointTy = oRetTy;
+          if (oRetTy->isLValueReferenceType() &&
+              oRetTy.getNonReferenceType().isConstQualified())
+            adjointTy = C.getLValueReferenceType(
+                oRetTy.getNonReferenceType().getUnqualifiedType());
           dRetTy = utils::InstantiateTemplate(S, valAndAdjointTempDecl,
-                                              {oRetTy, oRetTy});
+                                              {oRetTy, adjointTy});
         } else {
           dRetTy = oRetTy;
         }
@@ -1555,17 +1585,19 @@ namespace clad {
           FnTypes.push_back(utils::GetParameterDerivativeType(S, mode, PVDTy));
       }
 
+      // Type tag before the object prepended below; a constructor has none.
+      if (mode == DiffMode::reverse_mode_forward_pass &&
+          (isa<CXXConversionDecl>(FD) || isa<CXXConstructorDecl>(FD))) {
+        QualType typeTag = utils::GetCladTagOfType(S, oRetTy);
+        FnTypes.insert(FnTypes.begin(), typeTag);
+      }
+
       if (forCustomDerv && !thisTy.isNull()) {
         FnTypes.insert(FnTypes.begin(), thisTy);
         EPI.TypeQuals.removeConst();
       }
 
       if (mode == DiffMode::reverse_mode_forward_pass) {
-        if (isa<CXXConversionDecl>(FD) || isa<CXXConstructorDecl>(FD)) {
-          QualType typeTag = utils::GetCladTagOfType(S, oRetTy);
-          FnTypes.insert(FnTypes.begin(), typeTag);
-        }
-
         if (shouldUseRestoreTracker) {
           QualType trackerTy = GetRestoreTrackerType(S);
           trackerTy = C.getLValueReferenceType(trackerTy);

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1957,12 +1957,11 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       // TBR can prove that no state needs restoring, so refresh this before
       // scheduling the request.
       forwPassRequest.UseRestoreTracker = shouldUseRestoreTracker;
-      QualType returnType = request->getReturnType();
       bool hasCustomReverseForw = LookupCustomDerivativeDecl(forwPassRequest);
 
       if (hasCustomReverseForw ||
-          (!hasCustomPullback &&
-           (utils::isMemoryType(returnType) || shouldUseRestoreTracker))) {
+          (!hasCustomPullback && (utils::needsReverseForw(request.Function) ||
+                                  shouldUseRestoreTracker))) {
         m_DiffRequestGraph.addNode(forwPassRequest, /*isSource=*/true);
       }
     }

--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -317,7 +317,7 @@ ReverseModeForwPassVisitor::VisitReturnStmt(const clang::ReturnStmt* RS) {
   if (value)
     returnDiff = Visit(value);
   SourceLocation validLoc{RS->getBeginLoc()};
-  if (!utils::isMemoryType(m_DiffReq->getReturnType()))
+  if (!utils::needsReverseForw(m_DiffReq.Function))
     return m_Sema.BuildReturnStmt(validLoc, returnDiff.getExpr()).get();
   llvm::SmallVector<Expr*, 2> returnArgs = {returnDiff.getExpr(),
                                             returnDiff.getExpr_dx()};

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2203,7 +2203,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     QualType returnType = FD->getReturnType();
     // FIXME: Decide this in the diff planner
-    bool needsForwPass = utils::isMemoryType(returnType);
+    bool needsForwPass = utils::needsReverseForw(FD);
     bool hasStoredParams = false;
     // If the function has a single arg and does not return a reference or
     // take arg by reference, we can request a derivative w.r.t. to this arg
@@ -3556,12 +3556,19 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         cast<CXXConstructExpr>(VD->getInit()->IgnoreImplicit())->getNumArgs() &&
         utils::isCopyable(VDType->getAsCXXRecordDecl());
 
+    // A record with no default constructor cannot be declared uninitialized
+    // either, so it needs the same stand-in until the real adjoint is set.
+    const auto* VDDerivedRD = VDDerivedType->getAsCXXRecordDecl();
+    bool isDefaultConstructible = !VDDerivedRD ||
+                                  !VDDerivedRD->hasDefinition() ||
+                                  VDDerivedRD->hasDefaultConstructor();
+
     // Temporarily initialize the object with `*nullptr` to avoid
     // a potential error because of non-existing default constructor.
     Expr* dummyInit = nullptr;
     // FIXME: We need to have a more general way of determining this.
     const auto* CAT = dyn_cast<ConstantArrayType>(VDDerivedType);
-    if (shouldCopyInitialize || isRefType ||
+    if (shouldCopyInitialize || isRefType || !isDefaultConstructible ||
         (CAT && CAT->getElementType()->isRecordType())) {
       QualType dummyTy = VDDerivedType;
       if (CAT)

--- a/test/ForwardMode/Concurrency.C
+++ b/test/ForwardMode/Concurrency.C
@@ -1,0 +1,73 @@
+// RUN: %cladclang %s -I%S/../../include -oConcurrency.out 2>&1 | %filecheck %s
+// RUN: ./Concurrency.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+
+#include <cstdio>
+#include <functional>
+
+// --- helpers ---
+
+double read_ref(std::reference_wrapper<double> r) { return r.get() * r.get(); }
+
+double read_cref(std::reference_wrapper<const double> r) { return r.get() * r.get(); }
+
+double read_implicit(std::reference_wrapper<double> r) {
+  double& v = r;
+  return v * v;
+}
+
+double mul_refs(std::reference_wrapper<double> a,
+                std::reference_wrapper<double> b) {
+  return a.get() * b.get();
+}
+
+// --- forward-mode functions ---
+
+double f_ref(double x) { return read_ref(std::ref(x)); }
+
+double f_cref(double x) { return read_cref(std::cref(x)); }
+
+double f_implicit(double x) { return read_implicit(std::ref(x)); }
+
+double f_twice_ref(double x) {
+  return read_ref(std::ref(x)) + read_ref(std::ref(x));
+}
+
+double f_sum_refs(double x, double y) {
+  return read_ref(std::ref(x)) + read_ref(std::ref(y));
+}
+
+double f_mul_refs(double x, double y) { return mul_refs(std::ref(x), std::ref(y)); }
+
+// CHECK: double f_ref_darg0(double x) {
+// CHECK: double f_mul_refs_darg0(double x, double y) {
+
+int main() {
+  auto d_ref = clad::differentiate(f_ref, "x");
+  printf("ref: %.4f\n", d_ref.execute(3.0)); // CHECK-EXEC: ref: 6.0000
+
+  auto d_cref = clad::differentiate(f_cref, "x");
+  printf("cref: %.4f\n", d_cref.execute(4.0)); // CHECK-EXEC: cref: 8.0000
+
+  auto d_implicit = clad::differentiate(f_implicit, "x");
+  printf("implicit: %.4f\n", d_implicit.execute(5.0)); // CHECK-EXEC: implicit: 10.0000
+
+  auto d_twice = clad::differentiate(f_twice_ref, "x");
+  printf("twice: %.4f\n", d_twice.execute(2.0)); // CHECK-EXEC: twice: 8.0000
+
+  auto d_sum_x = clad::differentiate(f_sum_refs, "x");
+  printf("sum_x: %.4f\n", d_sum_x.execute(1.0, 2.0)); // CHECK-EXEC: sum_x: 2.0000
+
+  auto d_sum_y = clad::differentiate(f_sum_refs, "y");
+  printf("sum_y: %.4f\n", d_sum_y.execute(1.0, 2.0)); // CHECK-EXEC: sum_y: 4.0000
+
+  auto d_mul_x = clad::differentiate(f_mul_refs, "x");
+  printf("mul_x: %.4f\n", d_mul_x.execute(3.0, 4.0)); // CHECK-EXEC: mul_x: 4.0000
+
+  auto d_mul_y = clad::differentiate(f_mul_refs, "y");
+  printf("mul_y: %.4f\n", d_mul_y.execute(3.0, 4.0)); // CHECK-EXEC: mul_y: 3.0000
+
+  return 0;
+}

--- a/test/ForwardMode/Concurrency.C
+++ b/test/ForwardMode/Concurrency.C
@@ -1,0 +1,77 @@
+// RUN: %cladclang %s -I%S/../../include -oConcurrency.out 2>&1 | %filecheck %s
+// RUN: ./Concurrency.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+
+#include <cstdio>
+#include <functional>
+
+// --- helpers ---
+
+double read_ref(std::reference_wrapper<double> r) { return r.get() * r.get(); }
+
+double read_cref(std::reference_wrapper<const double> r) { return r.get() * r.get(); }
+
+double read_implicit(std::reference_wrapper<double> r) {
+  double& v = r;
+  return v * v;
+}
+
+double mul_refs(std::reference_wrapper<double> a,
+                std::reference_wrapper<double> b) {
+  return a.get() * b.get();
+}
+
+// --- forward-mode functions ---
+
+double f_ref(double x) { return read_ref(std::ref(x)); }
+
+double f_cref(double x) { return read_cref(std::cref(x)); }
+
+double f_implicit(double x) { return read_implicit(std::ref(x)); }
+
+double f_twice_ref(double x) {
+  return read_ref(std::ref(x)) + read_ref(std::ref(x));
+}
+
+double f_sum_refs(double x, double y) {
+  return read_ref(std::ref(x)) + read_ref(std::ref(y));
+}
+
+double f_mul_refs(double x, double y) { return mul_refs(std::ref(x), std::ref(y)); }
+
+// CHECK: clad::custom_derivatives::class_functions::get_pushforward
+// CHECK: double f_ref_darg0(double x) {
+// CHECK-NEXT: double _d_x = 1;
+// CHECK-NEXT: {{.*}}clad::custom_derivatives::std::ref_pushforward
+// CHECK: clad::custom_derivatives::std::cref_pushforward
+// CHECK: double f_mul_refs_darg0(double x, double y) {
+
+int main() {
+  auto d_ref = clad::differentiate(f_ref, "x");
+  printf("ref: %.4f\n", d_ref.execute(3.0)); // CHECK-EXEC: ref: 6.0000
+
+  auto d_cref = clad::differentiate(f_cref, "x");
+  printf("cref: %.4f\n", d_cref.execute(4.0)); // CHECK-EXEC: cref: 8.0000
+
+  auto d_implicit = clad::differentiate(f_implicit, "x");
+  printf("implicit: %.4f\n", d_implicit.execute(5.0)); // CHECK-EXEC: implicit: 10.0000
+
+  auto d_twice = clad::differentiate(f_twice_ref, "x");
+  printf("twice: %.4f\n", d_twice.execute(2.0)); // CHECK-EXEC: twice: 8.0000
+
+  auto d_sum_x = clad::differentiate(f_sum_refs, "x");
+  printf("sum_x: %.4f\n", d_sum_x.execute(1.0, 2.0)); // CHECK-EXEC: sum_x: 2.0000
+
+  auto d_sum_y = clad::differentiate(f_sum_refs, "y");
+  printf("sum_y: %.4f\n", d_sum_y.execute(1.0, 2.0)); // CHECK-EXEC: sum_y: 4.0000
+
+  auto d_mul_x = clad::differentiate(f_mul_refs, "x");
+  printf("mul_x: %.4f\n", d_mul_x.execute(3.0, 4.0)); // CHECK-EXEC: mul_x: 4.0000
+
+  auto d_mul_y = clad::differentiate(f_mul_refs, "y");
+  printf("mul_y: %.4f\n", d_mul_y.execute(3.0, 4.0)); // CHECK-EXEC: mul_y: 3.0000
+
+  return 0;
+}

--- a/test/Gradient/Concurrency.C
+++ b/test/Gradient/Concurrency.C
@@ -1,0 +1,183 @@
+// RUN: %cladclang %s -I%S/../../include -oConcurrency.out 2>&1 | %filecheck %s
+// RUN: ./Concurrency.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+
+#include <cstdio>
+#include <functional>
+
+// --- helpers ---
+
+double read_ref(std::reference_wrapper<double> r) { return r.get() * r.get(); }
+
+double read_cref(std::reference_wrapper<const double> r) {
+  return r.get() * r.get();
+}
+
+double read_implicit(std::reference_wrapper<double> r) {
+  double& v = r;
+  return v * v;
+}
+
+double mul_refs(std::reference_wrapper<double> a,
+                std::reference_wrapper<double> b) {
+  return a.get() * b.get();
+}
+
+double read_cref_implicit(std::reference_wrapper<const double> r) {
+  const double& v = r;
+  return v * v;
+}
+
+struct Holder {
+  double a;
+};
+
+// --- reverse-mode functions ---
+
+double f_ref(double x) { return read_ref(std::ref(x)); }
+
+double f_cref(double x) { return read_cref(std::cref(x)); }
+
+double f_implicit(double x) { return read_implicit(std::ref(x)); }
+
+double f_twice_ref(double x) {
+  return read_ref(std::ref(x)) + read_ref(std::ref(x));
+}
+
+double f_sum_refs(double x, double y) {
+  return read_ref(std::ref(x)) + read_ref(std::ref(y));
+}
+
+double f_mul_refs(double x, double y) {
+  return mul_refs(std::ref(x), std::ref(y));
+}
+
+// A wrapper held in a local variable, rather than passed straight to a callee.
+double f_local_ref(double x) {
+  auto r = std::ref(x);
+  return r.get() * r.get();
+}
+
+// Constructing the wrapper directly instead of through std::ref.
+double f_direct_ctor(double x) {
+  std::reference_wrapper<double> r(x);
+  return r.get() * r.get();
+}
+
+// Writing through the wrapper, so the adjoint flows back out of it.
+double f_write_through(double x) {
+  double y = 0;
+  std::reference_wrapper<double> r(y);
+  r.get() = x * x;
+  return y;
+}
+
+// Implicit conversion out of a const wrapper.
+double f_cref_implicit(double x) { return read_cref_implicit(std::cref(x)); }
+
+// Wrapping a user-defined type rather than a scalar.
+double f_struct_ref(double x) {
+  Holder h{x};
+  std::reference_wrapper<Holder> r(h);
+  return r.get().a * r.get().a;
+}
+
+// CHECK: void read_ref_pullback
+// CHECK: get_reverse_forw
+// CHECK: void f_ref_grad(double x, double *_d_x) {
+// CHECK: clad::custom_derivatives::std::ref_reverse_forw
+
+// CHECK: void read_cref_pullback
+// CHECK: get_reverse_forw
+// CHECK: void f_cref_grad(double x, double *_d_x) {
+// CHECK: clad::custom_derivatives::std::cref_reverse_forw
+
+// CHECK: void f_implicit_grad(double x, double *_d_x) {
+// CHECK: clad::custom_derivatives::std::ref_reverse_forw
+
+// CHECK: void f_mul_refs_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: clad::custom_derivatives::std::ref_reverse_forw
+
+// The adjoint wrapper is copy-initialized from the propagator; reference_wrapper
+// has no default constructor to fall back on.
+// CHECK: void f_local_ref_grad(double x, double *_d_x) {
+// CHECK: {{(std::)?}}reference_wrapper<double> _d_r = _t1.adjoint;
+
+// CHECK: void f_direct_ctor_grad(double x, double *_d_x) {
+// CHECK: {{(std::)?}}reference_wrapper<double> _d_r(*_d_x);
+
+// CHECK: void f_write_through_grad(double x, double *_d_x) {
+// CHECK: {{(std::)?}}reference_wrapper<double> _d_r(_d_y);
+
+// A const wrapper still hands back a mutable adjoint for the referent.
+// CHECK: void read_cref_implicit_pullback
+// CHECK: clad::ValueAndAdjoint<const double &, double &> {{.*}} = {{.*}}conversion_operator_reverse_forw(&r, clad::Tag<{{(const double|type) &}}>(), _d_r);
+// CHECK: void f_cref_implicit_grad(double x, double *_d_x) {
+// CHECK: clad::custom_derivatives::std::cref_reverse_forw
+
+// CHECK: void f_struct_ref_grad(double x, double *_d_x) {
+// CHECK: {{(std::)?}}reference_wrapper<Holder> _d_r(_d_h);
+
+int main() {
+  double dx = 0;
+
+  auto g_ref = clad::gradient(f_ref);
+  g_ref.execute(3.0, &dx);
+  printf("ref: %.4f\n", dx); // CHECK-EXEC: ref: 6.0000
+
+  dx = 0;
+  auto g_cref = clad::gradient(f_cref);
+  g_cref.execute(4.0, &dx);
+  printf("cref: %.4f\n", dx); // CHECK-EXEC: cref: 8.0000
+
+  dx = 0;
+  auto g_implicit = clad::gradient(f_implicit);
+  g_implicit.execute(5.0, &dx);
+  printf("implicit: %.4f\n", dx); // CHECK-EXEC: implicit: 10.0000
+
+  dx = 0;
+  auto g_twice = clad::gradient(f_twice_ref);
+  g_twice.execute(2.0, &dx);
+  printf("twice: %.4f\n", dx); // CHECK-EXEC: twice: 8.0000
+
+  dx = 0;
+  double dy = 0;
+  auto g_sum = clad::gradient(f_sum_refs);
+  g_sum.execute(1.0, 2.0, &dx, &dy);
+  printf("sum: %.4f %.4f\n", dx, dy); // CHECK-EXEC: sum: 2.0000 4.0000
+
+  dx = 0;
+  dy = 0;
+  auto g_mul = clad::gradient(f_mul_refs);
+  g_mul.execute(3.0, 4.0, &dx, &dy);
+  printf("mul: %.4f %.4f\n", dx, dy); // CHECK-EXEC: mul: 4.0000 3.0000
+
+  dx = 0;
+  auto g_local = clad::gradient(f_local_ref);
+  g_local.execute(3.0, &dx);
+  printf("local: %.4f\n", dx); // CHECK-EXEC: local: 6.0000
+
+  dx = 0;
+  auto g_ctor = clad::gradient(f_direct_ctor);
+  g_ctor.execute(3.0, &dx);
+  printf("ctor: %.4f\n", dx); // CHECK-EXEC: ctor: 6.0000
+
+  dx = 0;
+  auto g_write = clad::gradient(f_write_through);
+  g_write.execute(3.0, &dx);
+  printf("write: %.4f\n", dx); // CHECK-EXEC: write: 6.0000
+
+  dx = 0;
+  auto g_cref_impl = clad::gradient(f_cref_implicit);
+  g_cref_impl.execute(4.0, &dx);
+  printf("cref_implicit: %.4f\n", dx); // CHECK-EXEC: cref_implicit: 8.0000
+
+  dx = 0;
+  auto g_struct = clad::gradient(f_struct_ref);
+  g_struct.execute(3.0, &dx);
+  printf("struct: %.4f\n", dx); // CHECK-EXEC: struct: 6.0000
+
+  return 0;
+}


### PR DESCRIPTION
- Added forward and reverse customs for std::ref, std::cref, and std::reference_wrapper in STLBuiltins.h
- Added forward- and reverse-mode tests in test/ForwardMode/Concurrency.C and test/Gradient/Concurrency.C
