### PR TITLE
Support single statement loop body in omp reverse mode

### DIFF
--- a/lib/Differentiator/ReverseModeVisitorOpenMP.cpp
+++ b/lib/Differentiator/ReverseModeVisitorOpenMP.cpp
@@ -225,8 +225,22 @@ StmtDiff ReverseModeVisitor::DifferentiateCanonicalLoop(const ForStmt* S) {
   // are replaced with the new forward loop variable
   m_DeclReplacements[LoopVarDecl] = FwdLoopVar;
 
-  // Differentiate the loop body for forward sweep
-  StmtDiff BodyDiff = Visit(Body);
+  // Differentiate the loop body for forward sweep.
+  StmtDiff BodyDiff;
+  if (isa<CompoundStmt>(Body)) {
+    BodyDiff = Visit(Body);
+  } else {
+    beginScope(Scope::DeclScope);
+    beginBlock(direction::forward);
+    beginBlock(direction::reverse);
+    StmtDiff SDiff = DifferentiateSingleStmt(Body);
+    addToCurrentBlock(SDiff.getStmt(), direction::forward);
+    addToCurrentBlock(SDiff.getStmt_dx(), direction::reverse);
+    Stmt* Forward = endBlock(direction::forward);
+    Stmt* Reverse = endBlock(direction::reverse);
+    endScope();
+    BodyDiff = {Forward, Reverse};
+  }
 
   // Clear the replacement after Visit
   m_DeclReplacements.erase(LoopVarDecl);

--- a/test/Gradient/OpenMP.C
+++ b/test/Gradient/OpenMP.C
@@ -908,6 +908,42 @@ double fn22(const double *x, int n) {
 // CHECK-NEXT:          }
 // CHECK-NEXT:  }
 
+double fn23(const double *x, int n) {
+  double total = 0.0;
+  #pragma omp parallel for reduction(+:total)
+  for (int i = 0; i < n; i++)
+    total += x[i] * x[i];
+  return total;
+}
+
+// CHECK: void fn23_grad(const double *x, int n, double *_d_x, int *_d_n) {
+// CHECK-NEXT:     double _d_total = 0.;
+// CHECK-NEXT:     double total = 0.;
+// CHECK-NEXT:     #pragma omp parallel reduction(+: total)
+// CHECK-NEXT:         {
+// CHECK-NEXT:             int _t_chunklo0 = 0;
+// CHECK-NEXT:             int _t_chunkhi0 = 0;
+// CHECK-NEXT:             clad::GetStaticSchedule(0, n - 1, 1, &_t_chunklo0, &_t_chunkhi0);
+// CHECK-NEXT:             for (int i = _t_chunklo0; i <= _t_chunkhi0; i += 1) {
+// CHECK-NEXT:                 total += x[i] * x[i];
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT:     _d_total += 1;
+// CHECK-NEXT:     #pragma omp parallel private(total) firstprivate(_d_total)
+// CHECK-NEXT:         {
+// CHECK-NEXT:             int _t_chunklo1 = 0;
+// CHECK-NEXT:             int _t_chunkhi1 = 0;
+// CHECK-NEXT:             clad::GetStaticSchedule(0, n - 1, 1, &_t_chunklo1, &_t_chunkhi1);
+// CHECK-NEXT:             for (int i = _t_chunkhi1; i >= _t_chunklo1; i -= 1) {
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     double _r_d0 = _d_total;
+// CHECK-NEXT:                     _d_x[i] += _r_d0 * x[i];
+// CHECK-NEXT:                     _d_x[i] += x[i] * _r_d0;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT: }
+
 template <size_t N>
 void reset(double (&arr)[N], double val = 0) {
   for (size_t i = 0; i < N; ++i)
@@ -1026,5 +1062,10 @@ int main() {
   auto fn22_grad = clad::gradient(fn22);
   fn22_grad.execute(x, 4, dx, &dn);
   printf("{%.2f, %.2f, %.2f, %.2f}\n", dx[0], dx[1], dx[2], dx[3]); // CHECK-EXEC: {12.00, 8.00, 0.00, 0.00}
+
+  reset(dx);
+  auto fn23_grad = clad::gradient(fn23);
+  fn23_grad.execute(x, 4, dx, &dn);
+  printf("{%.2f, %.2f, %.2f, %.2f}\n", dx[0], dx[1], dx[2], dx[3]); // CHECK-EXEC: {4.00, 6.00, 8.00, 10.00}
   return 0;
 }


### PR DESCRIPTION
`DifferentiateCanonicalLoop` currently assumes that an `omp parallel for` body is always a compoundStmt. When the body is a single statement the `Visit(Body)` added the reverse statements outside the omp region. 
This PR differentiates single statement bodies inside it's own blocks. Single statement loops can now be properly differentiated:
``` cpp
double f(const double* x, int n) {
  double total = 0.0;
  #pragma omp parallel for reduction(+ : total)
  for (int i = 0; i < n; i++)
    total += x[i] * x[i];   
  return total;
}
```