### PR TITLE
Skip backend pass registration when built as static library

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CLAD_PLUGIN_SRC
 
 llvm_add_library(cladPlugin STATIC ${CLAD_PLUGIN_SRC})
 
+if (CLAD_BUILD_STATIC_ONLY)
+  target_compile_definitions(cladPlugin PRIVATE CLAD_BUILD_STATIC_ONLY)
+endif()
+
 set(link_libs cladDifferentiator)
 
 if (NOT CLAD_BUILD_STATIC_ONLY)

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -143,7 +143,9 @@ void InitTimers();
         // resolved from any symbol we own. Cleaner than iterating
         // CI.getFrontendOpts().Plugins (which depends on how clang was
         // invoked) and keeps the lookup inside this DSO.
-#ifdef _WIN32
+#ifdef CLAD_BUILD_STATIC_ONLY
+        // Skip registration entirely if clad is statically linked
+#elif _WIN32
       HMODULE hm = nullptr;
       if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
                                  GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,


### PR DESCRIPTION
When clad is built with CLAD_BUILD_STATIC_ONLY=ON, only static archives are produced (libcladDifferentiator.a, libcladPlugin.a) and no clad.so

In ROOT, when using clad, dladdr is resolved to libCling.so and then registered as an LLVM pass plugin.

In LLVM20 this is ignored. In LLVM22 this errors out with:

```
  error: unable to load plugin 'libCling.so':
  'Plugin entry point not found in 'libCling.so'. Is this a legacy plugin?'
```

causing all rootcling dictionary generation steps to fail.