### PR TITLE
Guard TBR analysis for untracked pointers

### DIFF
--- a/lib/Differentiator/AnalysisBase.cpp
+++ b/lib/Differentiator/AnalysisBase.cpp
@@ -169,6 +169,12 @@ bool AnalysisBase::getIDSequence(const clang::Expr* E, const VarDecl*& VD,
       QualType VDType = VD->getType();
       if (VDType->isLValueReferenceType() || VDType->isPointerType()) {
         VarData* refData = getVarDataFromDecl(VD);
+        // Globals and other untracked declarations have no VarData.
+        if (!refData) {
+          IDSequence.clear();
+          VD = nullptr;
+          return false;
+        }
         if (refData->m_Type == VarData::REF_TYPE) {
           std::set<const VarDecl*>& vars = *refData->m_Val.m_RefData;
           if (vars.size() == 1) {

--- a/test/Regressions/issue-1855.cpp
+++ b/test/Regressions/issue-1855.cpp
@@ -1,0 +1,16 @@
+// RUN: %cladclang -fsyntax-only -std=c++17 -I%S/../../include %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+int* global_ptr;
+
+void use(int*) {}
+
+double fn(double x) {
+  use(global_ptr);
+  return x * x;
+}
+
+void test() {
+  auto grad_fn = clad::gradient(fn);
+}


### PR DESCRIPTION
## Summary
- guard AnalysisBase::getIDSequence when pointer/reference analysis data is missing
- add regression for reverse-mode calls with an untracked global pointer argument

Refs #1855

## Testing
- git diff --check
- Not run: local clang/cmake are not on PATH