### PR TITLE
Fix dyn_cast assertion failures in ReverseMode AST Visitors

### DIFF
--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -300,6 +300,8 @@ ReverseModeForwPassVisitor::VisitReturnStmt(const clang::ReturnStmt* RS) {
     return m_Sema.BuildReturnStmt(validLoc, returnDiff.getExpr()).get();
   llvm::SmallVector<Expr*, 2> returnArgs = {returnDiff.getExpr(),
                                             returnDiff.getExpr_dx()};
+  if (!returnArgs[1])
+    return {nullptr, nullptr};
   Expr* returnInitList =
       m_Sema.ActOnInitList(validLoc, returnArgs, validLoc).get();
   Stmt* newRS = m_Sema.BuildReturnStmt(validLoc, returnInitList).get();

--- a/test/Regressions/issue-1855.cpp
+++ b/test/Regressions/issue-1855.cpp
@@ -1,8 +1,8 @@
-// RUN: %cladclang -fsyntax-only -std=c++17 -I%S/../../include %s
+// RUN: %cladclang -fsyntax-only -Xclang -verify -std=c++17 -I%S/../../include %s
 
 #include "clad/Differentiator/Differentiator.h"
 
-int* global_ptr;
+int* global_ptr; // expected-warning {{gradient uses a global variable}}
 
 void use(int*) {}
 
@@ -13,4 +13,31 @@ double fn(double x) {
 
 void test() {
   auto grad_fn = clad::gradient(fn);
+}
+
+typedef enum { a } b;
+typedef enum { c, d } e;
+e f;
+
+int *g() {
+  switch (f) { 
+    case c: break; 
+    case d: break; 
+  } 
+} // expected-warning {{non-void function does not return a value}}
+void h(b, e, char[], char[], int, bool, char, char *, va_list) { g(); }
+
+char i, o, j; // expected-warning 3 {{gradient uses a global variable}}
+int k; // expected-warning {{gradient uses a global variable}}
+
+void l(float) {
+  va_list arg;
+  h(a, d, &i, &o, k, 0, '\0', &j, arg); 
+}
+
+float m; // expected-warning {{gradient uses a global variable}}
+
+void n() {
+  l(m);
+  clad::gradient(n); // expected-error {{attempted to differentiate function with no parameters}}
 }


### PR DESCRIPTION
Safely fallback when trying to differentiate non void function without return value.
Added safety guards in `ReverseModeVisitor::VisitReturnStmt` and `ReverseModeForwPassVisitor::VisitReturnStmt`

Fixes #1855 