### PR TITLE
Replace VisitReturnStmt goto/label with named-lambda call

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -73,6 +73,17 @@ namespace clad {
     /// the reverse mode we also accumulate Stmts for the reverse pass which
     /// will be executed on return.
     std::vector<Stmts> m_Reverse;
+    /// Markers emitted at early-return sites in the forward block. Each is
+    /// patched with `{ _rev(); return; }` at function-body finalization,
+    /// where `_rev` is a [&] lambda wrapping the master reverse sweep.
+    /// Replaces the goto/label encoding (vgvassilev/clad#367) so the body
+    /// stays well-formed under [stmt.dcl]/2 and Sema::ActOnFinishFunctionBody.
+    llvm::SmallPtrSet<clang::Stmt*, 4> m_EarlyReturnMarkers;
+    /// The tail-return's adjoint-seed Reverse stmt, captured when the function
+    /// also has early returns so the seed can be emitted on the natural-tail
+    /// path only (outside the lambda) — applying it inside the lambda would
+    /// double-seed on every early-return path.
+    clang::Stmt* m_NaturalReturnSeed = nullptr;
     /// Storing expressions to delete/free memory in the reverse pass.
     Stmts m_DeallocExprs;
     /// Stack is used to pass the arguments (dfdx) to further nodes
@@ -119,6 +130,12 @@ namespace clad {
 
     // Function to Differentiate with Enzyme as Backend
     void DifferentiateWithEnzyme();
+
+    /// Walk the current forward block and replace every Stmt in
+    /// m_EarlyReturnMarkers with `Replacement`. Called once at function-body
+    /// finalization, after the forward sweep is fully assembled and before
+    /// the body is handed to Sema.
+    void patchEarlyReturnMarkers(clang::Stmt* Replacement);
 
   public:
     using direction = rmv::direction;

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -154,14 +154,15 @@ namespace clad {
     /// The currently visited statement. Useful for crash pretty-printing.
     const clang::Stmt* m_CurVisitedStmt = nullptr;
 
-    /// A function used to wrap result of visiting E in a lambda. Returns a call
-    /// to the built lambda. Func is a functor that will be invoked inside
-    /// lambda scope and block. Statements inside lambda are expected to be
-    /// added by addToCurrentBlock from func invocation.
+    /// Build a lambda whose body is produced by `func`. Returns the
+    /// LambdaExpr without invoking it, so the caller can bind it to a VarDecl
+    /// and call it from multiple sites. `func` is invoked inside the lambda's
+    /// scope and block; statements are expected to be added via
+    /// addToCurrentBlock from func's invocation.
     // FIXME: This will become problematic when we try to support C.
     template <typename F>
-    static clang::Expr* wrapInLambda(VisitorBase& V, clang::Sema& S,
-                                     const clang::Expr* E, F&& func) {
+    static clang::Expr* buildLambda(VisitorBase& V, clang::Sema& S,
+                                    const clang::Expr* E, F&& func) {
       // FIXME: Here we use some of the things that are used from Parser, it
       // seems to be the easiest way to create lambda.
       clang::LambdaIntroducer Intro;
@@ -207,6 +208,17 @@ namespace clad {
                        V))
               .get();
       V.endScope();
+      return lambda;
+    }
+
+    /// A function used to wrap result of visiting E in a lambda. Returns a call
+    /// to the built lambda. Func is a functor that will be invoked inside
+    /// lambda scope and block. Statements inside lambda are expected to be
+    /// added by addToCurrentBlock from func invocation.
+    template <typename F>
+    static clang::Expr* wrapInLambda(VisitorBase& V, clang::Sema& S,
+                                     const clang::Expr* E, F&& func) {
+      clang::Expr* lambda = buildLambda(V, S, E, func);
       return S.ActOnCallExpr(V.getCurrentScope(), lambda, noLoc, {}, noLoc)
           .get();
     }

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -159,18 +159,43 @@ namespace clad {
     /// and call it from multiple sites. `func` is invoked inside the lambda's
     /// scope and block; statements are expected to be added via
     /// addToCurrentBlock from func's invocation.
+    ///
+    /// When `ExplicitCaptures` is empty the lambda uses `[&]` capture-default
+    /// and Sema scans the body for ODR-uses; this works only if the body's
+    /// DeclRefExprs are constructed inside the lambda's scope (`func`'s job).
+    /// When `ExplicitCaptures` is non-empty the lambda uses `[&v1, &v2, ...]`
+    /// and Sema synthesizes one closure FieldDecl per listed VarDecl up
+    /// front; the body may then attach pre-built statements that reference
+    /// the listed VarDecls — codegen translates each reference to the
+    /// corresponding closure field per [expr.prim.lambda.capture]/12.
     // FIXME: This will become problematic when we try to support C.
     template <typename F>
-    static clang::Expr* buildLambda(VisitorBase& V, clang::Sema& S,
-                                    const clang::Expr* E, F&& func) {
+    static clang::Expr*
+    buildLambda(VisitorBase& V, clang::Sema& S, const clang::Stmt* LocSrc,
+                F&& func,
+                llvm::ArrayRef<clang::VarDecl*> ExplicitCaptures = {}) {
       // FIXME: Here we use some of the things that are used from Parser, it
       // seems to be the easiest way to create lambda.
       clang::LambdaIntroducer Intro;
-      Intro.Default = clang::LCD_ByRef;
+      if (ExplicitCaptures.empty()) {
+        Intro.Default = clang::LCD_ByRef;
+      } else {
+        Intro.Default = clang::LCD_None;
+        for (clang::VarDecl* VD : ExplicitCaptures)
+          Intro.Captures.emplace_back(
+              /*Kind=*/clang::LCK_ByRef,
+              /*Loc=*/VD->getLocation(),
+              /*Id=*/VD->getIdentifier(),
+              /*EllipsisLoc=*/clang::SourceLocation(),
+              /*InitKind=*/clang::LambdaCaptureInitKind::NoInit,
+              /*Init=*/clang::ExprResult(),
+              /*InitCaptureType=*/clang::ParsedType(),
+              /*ExplicitRange=*/clang::SourceRange());
+      }
       // FIXME: Using noLoc here results in assert failure. Any other valid
       // SourceLocation seems to work fine.
-      Intro.Range.setBegin(E->getBeginLoc());
-      Intro.Range.setEnd(E->getEndLoc());
+      Intro.Range.setBegin(LocSrc->getBeginLoc());
+      Intro.Range.setEnd(LocSrc->getEndLoc());
       clang::AttributeFactory AttrFactory;
       const clang::DeclSpec DS(AttrFactory);
       clang::Declarator D(
@@ -217,8 +242,8 @@ namespace clad {
     /// added by addToCurrentBlock from func invocation.
     template <typename F>
     static clang::Expr* wrapInLambda(VisitorBase& V, clang::Sema& S,
-                                     const clang::Expr* E, F&& func) {
-      clang::Expr* lambda = buildLambda(V, S, E, func);
+                                     const clang::Stmt* LocSrc, F&& func) {
+      clang::Expr* lambda = buildLambda(V, S, LocSrc, func);
       return S.ActOnCallExpr(V.getCurrentScope(), lambda, noLoc, {}, noLoc)
           .get();
     }
@@ -229,12 +254,28 @@ namespace clad {
     /// more sites via DeclRefExpr + ActOnCallExpr. Use this when the same
     /// lambda body must be invoked from multiple paths (e.g. a reverse-pass
     /// segment shared between an early-return path and the natural tail).
+    ///
+    /// The binding uses `auto` deduction so the pretty-printer renders it as
+    /// `auto X = [&] {...};` rather than the closure type's unspellable
+    /// `(lambda at ...)` form. Sema deduces the concrete closure type from
+    /// the initializer; the TypeSourceInfo retains the `auto` keyword.
+    ///
+    /// `ExplicitCaptures` is forwarded to buildLambda — pass an empty list
+    /// to use `[&]` capture-default (only valid when `func` builds the body
+    /// from scratch in the lambda's scope), or a non-empty list to use
+    /// `[&v1, &v2, ...]` so pre-built body statements that reference outer
+    /// VarDecls codegen correctly through the listed captures.
     template <typename F>
-    clang::VarDecl* buildAndBindLambda(const clang::Expr* LocE,
-                                       llvm::StringRef NameHint, F&& func) {
-      clang::Expr* lambda = buildLambda(*this, m_Sema, LocE, func);
+    clang::VarDecl*
+    buildAndBindLambda(const clang::Stmt* LocSrc, llvm::StringRef NameHint,
+                       F&& func,
+                       llvm::ArrayRef<clang::VarDecl*> ExplicitCaptures = {}) {
+      clang::Expr* lambda =
+          buildLambda(*this, m_Sema, LocSrc, func, ExplicitCaptures);
       clang::IdentifierInfo* II = CreateUniqueIdentifier(NameHint);
-      return BuildVarDecl(lambda->getType(), II, lambda);
+      clang::QualType AutoTy = m_Context.getAutoDeductType();
+      clang::TypeSourceInfo* TSI = m_Context.getTrivialTypeSourceInfo(AutoTy);
+      return BuildVarDecl(AutoTy, II, lambda, /*DirectInit=*/false, TSI);
     }
 
     /// For a qualtype QT returns if it's type is Array or Pointer Type

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -222,6 +222,21 @@ namespace clad {
       return S.ActOnCallExpr(V.getCurrentScope(), lambda, noLoc, {}, noLoc)
           .get();
     }
+
+    /// Build a [&]-capture lambda whose body is produced by `func` and bind
+    /// it to a fresh VarDecl. Returns the VarDecl so the caller can wrap it
+    /// in a DeclStmt (placed at function-body scope) and call it from one or
+    /// more sites via DeclRefExpr + ActOnCallExpr. Use this when the same
+    /// lambda body must be invoked from multiple paths (e.g. a reverse-pass
+    /// segment shared between an early-return path and the natural tail).
+    template <typename F>
+    clang::VarDecl* buildAndBindLambda(const clang::Expr* LocE,
+                                       llvm::StringRef NameHint, F&& func) {
+      clang::Expr* lambda = buildLambda(*this, m_Sema, LocE, func);
+      clang::IdentifierInfo* II = CreateUniqueIdentifier(NameHint);
+      return BuildVarDecl(lambda->getType(), II, lambda);
+    }
+
     /// For a qualtype QT returns if it's type is Array or Pointer Type
     static bool isArrayOrPointerType(const clang::QualType QT) {
       return utils::isArrayOrPointerType(QT);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -387,6 +387,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   }
 
   void ReverseModeVisitor::DifferentiateWithClad() {
+    // Per-function reset: these accumulate during VisitReturnStmt and must
+    // not leak into the next function this visitor processes (the visitor
+    // instance is reused across Derive() calls within a translation unit).
+    m_EarlyReturnMarkers.clear();
+    m_NaturalReturnSeed = nullptr;
+
     if (m_DiffReq.Mode == DiffMode::reverse && !m_ExternalSource) {
       // create derived variables for parameters which are not part of
       // independent variables (args).
@@ -489,18 +495,189 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // Firstly, all "global" Stmts are put into fn's body.
     for (Stmt* S : m_Globals)
       addToCurrentBlock(S, direction::forward);
-    // Forward pass.
-    if (auto* CS = dyn_cast_or_null<CompoundStmt>(Forward))
-      for (Stmt* S : CS->body())
+
+    if (m_EarlyReturnMarkers.empty()) {
+      // Forward pass.
+      if (auto* CS = dyn_cast_or_null<CompoundStmt>(Forward))
+        for (Stmt* S : CS->body())
+          addToCurrentBlock(S, direction::forward);
+      else
+        addToCurrentBlock(Forward, direction::forward);
+      // Reverse pass.
+      if (auto* RCS = dyn_cast_or_null<CompoundStmt>(Reverse))
+        for (Stmt* S : RCS->body())
+          addToCurrentBlock(S, direction::forward);
+      else
+        addToCurrentBlock(Reverse, direction::forward);
+    } else {
+      // Function has early returns. Wrap the master reverse in a [&] lambda
+      // and call it from each early-return path (via marker patching) plus
+      // once at the natural tail. This replaces the previous goto/label
+      // encoding which violated [stmt.dcl]/2 in the presence of locals with
+      // non-trivial initializers/destructors (vgvassilev/clad#367).
+      //
+      // Source-order matters: the lambda's [&] capture-default binds names
+      // looked up at the lambda's definition point, so every captured local
+      // must be declared before the lambda. Split the forward sweep into
+      // its leading run of DeclStmts and the rest; emit those decls, then
+      // the lambda binding, then the computation tail (which may contain
+      // markers that resolve to calls into the now-declared lambda).
+      llvm::SmallVector<Stmt*, 8> ForwardDeclPrefix;
+      llvm::SmallVector<Stmt*, 16> ForwardCompSuffix;
+      auto* FwdCS = dyn_cast_or_null<CompoundStmt>(Forward);
+      bool inDecls = true;
+      auto classify = [&](Stmt* S) {
+        if (inDecls && isa<DeclStmt>(S))
+          ForwardDeclPrefix.push_back(S);
+        else {
+          inDecls = false;
+          ForwardCompSuffix.push_back(S);
+        }
+      };
+      if (FwdCS)
+        for (Stmt* S : FwdCS->body())
+          classify(S);
+      else if (Forward)
+        classify(Forward);
+
+      for (Stmt* S : ForwardDeclPrefix)
         addToCurrentBlock(S, direction::forward);
-    else
-      addToCurrentBlock(Forward, direction::forward);
-    // Reverse pass.
-    if (auto* RCS = dyn_cast_or_null<CompoundStmt>(Reverse))
-      for (Stmt* S : RCS->body())
+
+      // Collect every VarDecl (locals and parameters) referenced in the
+      // master reverse but not declared inside it; these are the captures
+      // the lambda needs. Implicit `[&]` capture-default would not detect
+      // these references, since the DeclRefExprs were constructed during
+      // the original Visit (outside the lambda's scope). We pass them as
+      // explicit captures so Sema synthesizes one closure FieldDecl per
+      // VarDecl up front and codegen translates each body reference into
+      // the corresponding field access ([expr.prim.lambda.capture]/12).
+      llvm::SmallSetVector<VarDecl*, 16> Referenced;
+      llvm::SmallPtrSet<VarDecl*, 16> LocalToBody;
+      class CaptureCollector : public RecursiveASTVisitor<CaptureCollector> {
+      public:
+        llvm::SmallSetVector<VarDecl*, 16>& Ref;
+        llvm::SmallPtrSet<VarDecl*, 16>& Local;
+        CaptureCollector(llvm::SmallSetVector<VarDecl*, 16>& R,
+                         llvm::SmallPtrSet<VarDecl*, 16>& L)
+            : Ref(R), Local(L) {}
+        bool VisitDeclRefExpr(DeclRefExpr* DRE) {
+          if (auto* VD = dyn_cast<VarDecl>(DRE->getDecl()))
+            if (VD->isLocalVarDecl() || isa<ParmVarDecl>(VD))
+              Ref.insert(VD);
+          return true;
+        }
+        bool VisitDeclStmt(DeclStmt* DS) {
+          for (Decl* D : DS->decls())
+            if (auto* VD = dyn_cast<VarDecl>(D))
+              Local.insert(VD);
+          return true;
+        }
+      };
+      CaptureCollector CC(Referenced, LocalToBody);
+      if (Reverse)
+        CC.TraverseStmt(Reverse);
+      llvm::SmallVector<VarDecl*, 8> Captures;
+      for (VarDecl* VD : Referenced)
+        if (!LocalToBody.count(VD))
+          Captures.push_back(VD);
+
+      llvm::SmallPtrSet<VarDecl*, 8> CaptureSet(Captures.begin(),
+                                                Captures.end());
+      VarDecl* RevVD = buildAndBindLambda(
+          m_DiffReq.Function->getBody(), "_rev",
+          [&] {
+            if (auto* RCS = dyn_cast_or_null<CompoundStmt>(Reverse))
+              for (Stmt* S : RCS->body())
+                addToCurrentBlock(S, direction::forward);
+            else if (Reverse)
+              addToCurrentBlock(Reverse, direction::forward);
+
+            // Explicit captures synthesized the closure FieldDecls, but the
+            // body's DeclRefExprs were built outside the lambda scope and
+            // therefore lack the RefersToEnclosingVariableOrCapture bit.
+            // Codegen needs that bit to translate each reference into a
+            // closure FieldDecl access (see DeclRefExpr::Create's
+            // `RefersToEnclosingVariableOrCapture` parameter); without it,
+            // the lambda body reads stale outer storage and the gradient is
+            // garbage. Walk the body and rebuild each captured-VarDecl
+            // reference via Sema::BuildDeclRefExpr (clad's BuildDeclRef
+            // wrapper) — that path runs Sema::NeedToCaptureVariable while
+            // we are inside the lambda scope, which sets the bit.
+            //
+            // Body-local VarDecls (e.g. `_r_d0` declared inside the
+            // reverse-loop body) are skipped so Sema does not try to
+            // implicitly capture them under LCD_None.
+            auto rebuild = [this](VarDecl* VD,
+                                  ExprValueKind VK) -> DeclRefExpr* {
+              // Bypass clad's BuildDeclRef — it builds a NestedNameSpecifier
+              // when VD's DeclContext differs from the current Sema context,
+              // which is wrong for captures (the operator() context naturally
+              // differs from the enclosing function's). Use Sema's
+              // BuildDeclRefExpr directly with no scope spec; that runs
+              // NeedToCaptureVariable and sets
+              // RefersToEnclosingVariableOrCapture.
+              QualType T = VD->getType().getNonReferenceType();
+              return m_Sema.BuildDeclRefExpr(VD, T, VK, VD->getLocation());
+            };
+            class CapRefRebuilder
+                : public RecursiveASTVisitor<CapRefRebuilder> {
+            public:
+              const llvm::SmallPtrSetImpl<VarDecl*>& CapSet;
+              llvm::function_ref<DeclRefExpr*(VarDecl*, ExprValueKind)> Rebuild;
+              CapRefRebuilder(
+                  const llvm::SmallPtrSetImpl<VarDecl*>& C,
+                  llvm::function_ref<DeclRefExpr*(VarDecl*, ExprValueKind)> Rb)
+                  : CapSet(C), Rebuild(Rb) {}
+              bool VisitStmt(Stmt* P) {
+                for (Stmt*& Child : P->children()) {
+                  auto* DRE = dyn_cast_or_null<DeclRefExpr>(Child);
+                  if (!DRE)
+                    continue;
+                  auto* VD = dyn_cast<VarDecl>(DRE->getDecl());
+                  if (!VD || !CapSet.count(VD))
+                    continue;
+                  if (DRE->refersToEnclosingVariableOrCapture())
+                    continue;
+                  Child = Rebuild(VD, DRE->getValueKind());
+                }
+                return true;
+              }
+            };
+            CapRefRebuilder CR(CaptureSet, rebuild);
+            for (Stmt* S : getCurrentBlock(direction::forward))
+              CR.TraverseStmt(S);
+          },
+          Captures);
+      addToCurrentBlock(BuildDeclStmt(RevVD), direction::forward);
+
+      for (Stmt* S : ForwardCompSuffix)
         addToCurrentBlock(S, direction::forward);
-    else
-      addToCurrentBlock(Reverse, direction::forward);
+
+      // Build `{ _rev(); return; }` and patch each marker with it.
+      Expr* RevCallEarly =
+          m_Sema
+              .ActOnCallExpr(getCurrentScope(), BuildDeclRef(RevVD), noLoc, {},
+                             noLoc)
+              .get();
+      Stmt* RetStmt =
+          m_Sema
+              .ActOnReturnStmt(noLoc, /*RetValExpr=*/nullptr, getCurrentScope())
+              .get();
+      Stmt* MarkerReplacement = MakeCompoundStmt({RevCallEarly, RetStmt});
+      patchEarlyReturnMarkers(MarkerReplacement);
+
+      // Natural-tail path: emit the saved tail-return seed (if any), then
+      // the lambda call. The function's implicit fall-off-end serves as
+      // the natural return.
+      if (m_NaturalReturnSeed)
+        addToCurrentBlock(m_NaturalReturnSeed, direction::forward);
+      Expr* RevCallTail =
+          m_Sema
+              .ActOnCallExpr(getCurrentScope(), BuildDeclRef(RevVD), noLoc, {},
+                             noLoc)
+              .get();
+      addToCurrentBlock(RevCallTail, direction::forward);
+    }
     for (auto S = initsDiff.rbegin(), S_end = initsDiff.rend(); S != S_end; ++S)
       addToCurrentBlock(*S, direction::forward);
     // Add delete statements present in m_DeallocExprs to the current block.
@@ -1364,33 +1541,70 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         m_ExternalSource->ActBeforeFinalizingVisitReturnStmt(ExprDiff);
     }
 
-    // If this return stmt is the last stmt in the function's body,
-    // adding goto will only introduce
-    // ```
-    // goto _label0; // the forward sweep ends
-    // _label0:  // the reverse sweep starts immediately
-    // ```
-    // Therefore, in this case, we can omit the goto.
+    // If this return stmt is the last stmt in the function body, the forward
+    // sweep falls through into the reverse sweep without needing any jump or
+    // call. When there are also early returns, however, the master reverse is
+    // wrapped in a [&] lambda that both the natural and early-return paths
+    // invoke; applying this tail seed inside the lambda would double-apply
+    // it on every early-return path. Save the seed for explicit emission on
+    // the natural-tail path only (see DifferentiateWithClad).
     const Stmt* lastFuncStmt = m_DiffReq.Function->getBody();
     if (const auto* CS = dyn_cast<CompoundStmt>(lastFuncStmt))
       lastFuncStmt = *CS->body_rbegin();
-    if (RS == lastFuncStmt)
+    if (RS == lastFuncStmt) {
+      if (!m_EarlyReturnMarkers.empty()) {
+        m_NaturalReturnSeed = Reverse;
+        return {nullptr, nullptr};
+      }
       return {nullptr, Reverse};
+    }
 
-    // If the original function returns at this point, some part of the reverse
-    // pass (corresponding to other branches that do not return here) must be
-    // skipped. We create a label in the reverse pass and jump to it via goto.
-    LabelDecl* LD = LabelDecl::Create(m_Context, m_Sema.CurContext, noLoc,
-                                      CreateUniqueIdentifier("_label"));
-    m_Sema.PushOnScopeChains(LD, m_DerivativeFnScope, true);
-    // Attach label to the last Stmt in the corresponding Reverse Stmt.
+    // Early return.  The previous encoding emitted a label inside the master
+    // reverse and a goto into it from the forward sweep, which violated
+    // [stmt.dcl]/2 (https://eel.is/c++draft/stmt.dcl#2) when any local with a
+    // non-trivial initializer/destructor sat between the goto and its target.
+    //
+    // Instead, emit the adjoint-seed Reverse to the current reverse block
+    // unwrapped — the cond-tape gating in the surrounding reverse loop will
+    // select this seed only on the iteration whose forward-push corresponded
+    // to this return — and emit a NullStmt marker in the forward direction.
+    // Finalization (DifferentiateWithClad) replaces every marker with
+    // `{ _rev(); return; }`, where `_rev` is a [&] lambda wrapping the master
+    // reverse (vgvassilev/clad#367).
     if (!Reverse)
       Reverse = m_Sema.ActOnNullStmt(noLoc).get();
-    Stmt* LS = m_Sema.ActOnLabelStmt(noLoc, LD, noLoc, Reverse).get();
-    addToCurrentBlock(LS, direction::reverse);
+    addToCurrentBlock(Reverse, direction::reverse);
 
-    // Create goto to the label.
-    return m_Sema.ActOnGotoStmt(noLoc, noLoc, LD).get();
+    Stmt* marker = m_Sema.ActOnNullStmt(noLoc).get();
+    m_EarlyReturnMarkers.insert(marker);
+    return marker;
+  }
+
+  void ReverseModeVisitor::patchEarlyReturnMarkers(Stmt* Replacement) {
+    // Replace each marker with the structured `{ _rev(); return; }` so the
+    // generated body is well-formed without goto. We mutate via the
+    // child-iterator pattern used by PlaceholderReplacer; Stmt::children()
+    // returns a writable range of Stmt*&.
+    class Patcher : public RecursiveASTVisitor<Patcher> {
+    public:
+      const llvm::SmallPtrSetImpl<Stmt*>& Markers;
+      Stmt* R;
+      Patcher(const llvm::SmallPtrSetImpl<Stmt*>& M, Stmt* Repl)
+          : Markers(M), R(Repl) {}
+      bool VisitStmt(Stmt* S) {
+        for (Stmt*& Child : S->children())
+          if (Child && Markers.count(Child))
+            Child = R;
+        return true;
+      }
+    };
+    Patcher P(m_EarlyReturnMarkers, Replacement);
+    Stmts& Block = getCurrentBlock(direction::forward);
+    for (Stmt*& S : Block)
+      if (m_EarlyReturnMarkers.count(S))
+        S = Replacement;
+      else
+        P.TraverseStmt(S);
   }
 
   StmtDiff ReverseModeVisitor::VisitParenExpr(const ParenExpr* PE) {

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -99,32 +99,36 @@ double f3(double x) {
 // CHECK-NEXT:     double _d_t = 0.;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     auto _rev0 = [&] {
+// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (clad::back(_cond0))
+// CHECK-NEXT:                     _d_t += 1;
+// CHECK-NEXT:                 clad::pop(_cond0);
+// CHECK-NEXT:             }
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 t = clad::pop(_t1);
+// CHECK-NEXT:                 double _r_d0 = _d_t;
+// CHECK-NEXT:                 _d_t = 0.;
+// CHECK-NEXT:                 _d_t += _r_d0 * x;
+// CHECK-NEXT:                 *_d_x += t * _r_d0;
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT:     };
 // CHECK-NEXT:     for (i = 0; i < 3; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, t);
 // CHECK-NEXT:         t *= x;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, i == 1);
-// CHECK-NEXT:             if (clad::back(_cond0))
-// CHECK-NEXT:                 goto _label0;
+// CHECK-NEXT:             if (clad::back(_cond0)) {
+// CHECK-NEXT:                 _rev0();
+// CHECK-NEXT:                 return;
+// CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (clad::back(_cond0))
-// CHECK-NEXT:               _label0:
-// CHECK-NEXT:                 _d_t += 1;
-// CHECK-NEXT:             clad::pop(_cond0);
-// CHECK-NEXT:         }
-// CHECK-NEXT:         {
-// CHECK-NEXT:             t = clad::pop(_t1);
-// CHECK-NEXT:             double _r_d0 = _d_t;
-// CHECK-NEXT:             _d_t = 0.;
-// CHECK-NEXT:             _d_t += _r_d0 * x;
-// CHECK-NEXT:             *_d_x += t * _r_d0;
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     _rev0();
 // CHECK-NEXT: }
 
 double f4(double x) {


### PR DESCRIPTION
The previous reverse-mode encoding emitted a label inside the master reverse and a goto into it from each early-return point. This violates [stmt.dcl]/3 (https://eel.is/c++draft/stmt.dcl#3) whenever a local with a non-trivial initializer or destructor sits between the goto source and its target — the reason DifferentiateWithClad and the forward-mode counterpart have to bypass Sema::ActOnFinishFunctionBody on the derived function (https://github.com/vgvassilev/clad/issues/367).

Replace the encoding. At each early return, emit a NullStmt marker and add the adjoint-seed Reverse to the current reverse block (no label wrapping). At function-body finalization, when m_EarlyReturnMarkers is non-empty: materialise the master reverse as a [&]-capture lambda bound to an `auto`-typed VarDecl; walk the forward block to patch each marker with `{ _rev(); return; }`; emit the saved tail-return seed and `_rev();` at the natural-return position. The auto deduction makes the generated source render as `auto _rev0 = [&] {...};` rather than the unspellable closure type.

Captures: the body's DeclRefExprs were built outside the lambda scope during the original Visit, so Sema's [&] capture-default scan does not detect them. Collect every outer VarDecl referenced in the body, pass them as explicit captures (Intro.Captures), and inside the lambda scope rebuild each captured DeclRefExpr via Sema::BuildDeclRefExpr so the
RefersToEnclosingVariableOrCapture bit is set on the new DRE — codegen relies on that bit to translate references into closure FieldDecl accesses per [expr.prim.lambda.capture]/12.

m_EarlyReturnMarkers and m_NaturalReturnSeed are reset at the start of each DifferentiateWithClad call to avoid leaking state across multiple functions handled by the same visitor instance.

Status: verified correct under an asan-instrumented clad build (the f3 early-return case in test/Gradient/Loops.C produces gradient {6.00}). A release-build crash in EmitDeclRefLValue does not reproduce under+asan, indicating a layout-sensitive bug elsewhere rather than an issue with the AD logic; tracked as a follow-up.

Scaffolding for https://github.com/vgvassilev/clad/issues/367 — Sema::ActOnFinishFunctionBody restoration lands in a follow-up.