### PR TITLE
Remove non public header Kokkos_ExecPolicy

### DIFF
--- a/include/clad/Differentiator/KokkosBuiltins.h
+++ b/include/clad/Differentiator/KokkosBuiltins.h
@@ -7,7 +7,6 @@
 
 #include "clad/Differentiator/Differentiator.h"
 #include <Kokkos_Core.hpp>
-#include <Kokkos_ExecPolicy.hpp>
 #include <cstddef>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
Remove the non public header Kokkos_ExecPolicy. It was redundantly added in #1740

Fixes #1860.