### PR TITLE
Fix nullptr dereference introduced by #1819

### DIFF
--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -182,14 +182,16 @@ void InitTimers();
       auto& MultiplexC = cast<MultiplexConsumer>(m_CI.getASTConsumer());
       auto& RobbedCs = ACCESS(MultiplexC, Consumers);
       assert(RobbedCs.back().get() == this && "Clad is not the last consumer");
+
+      std::vector<std::unique_ptr<ASTConsumer>> StolenConsumers;
       const auto& Macros = m_CI.getPreprocessorOpts().Macros;
       const bool IsCling = llvm::any_of(
           Macros, [](const auto& Macro) { return Macro.first == "__CLING__"; });
       if (IsCling && m_CI.getPreprocessor().isIncrementalProcessingEnabled()) {
         std::swap(RobbedCs.front(), RobbedCs.back());
+        m_Multiplexer.reset(new MultiplexConsumer(std::move(StolenConsumers)));
         return;
       }
-      std::vector<std::unique_ptr<ASTConsumer>> StolenConsumers;
 
       // The range-based for loop in MultiplexConsumer::Initialize has
       // dispatched this call. Generally, it is unsafe to delete elements while

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -189,7 +189,7 @@ void InitTimers();
           Macros, [](const auto& Macro) { return Macro.first == "__CLING__"; });
       if (IsCling && m_CI.getPreprocessor().isIncrementalProcessingEnabled()) {
         std::swap(RobbedCs.front(), RobbedCs.back());
-        m_Multiplexer.reset(new MultiplexConsumer(std::move(StolenConsumers)));
+        m_Multiplexer = std::make_unique<MultiplexConsumer>(std::move(StolenConsumers));
         return;
       }
 

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -183,7 +183,6 @@ void InitTimers();
       auto& RobbedCs = ACCESS(MultiplexC, Consumers);
       assert(RobbedCs.back().get() == this && "Clad is not the last consumer");
 
-      std::vector<std::unique_ptr<ASTConsumer>> StolenConsumers;
       const auto& Macros = m_CI.getPreprocessorOpts().Macros;
       const bool IsCling = llvm::any_of(
           Macros, [](const auto& Macro) { return Macro.first == "__CLING__"; });
@@ -191,6 +190,7 @@ void InitTimers();
         std::swap(RobbedCs.front(), RobbedCs.back());
         return;
       }
+      std::vector<std::unique_ptr<ASTConsumer>> StolenConsumers;
 
       // The range-based for loop in MultiplexConsumer::Initialize has
       // dispatched this call. Generally, it is unsafe to delete elements while

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -189,7 +189,6 @@ void InitTimers();
           Macros, [](const auto& Macro) { return Macro.first == "__CLING__"; });
       if (IsCling && m_CI.getPreprocessor().isIncrementalProcessingEnabled()) {
         std::swap(RobbedCs.front(), RobbedCs.back());
-        m_Multiplexer = std::make_unique<MultiplexConsumer>(std::move(StolenConsumers));
         return;
       }
 
@@ -479,6 +478,8 @@ void InitTimers();
     }
 
     void CladPlugin::SendToMultiplexer() {
+      if (!m_Multiplexer)
+        return;
       for (unsigned i = m_MultiplexerProcessedDelayedCallsIdx;
            i < m_DelayedCalls.size(); ++i) {
         auto DelayedCall = m_DelayedCalls[i];
@@ -655,7 +656,8 @@ void InitTimers();
         FinalizeTranslationUnit();
         SendToMultiplexer();
       }
-      m_Multiplexer->HandleTranslationUnit(C);
+      if (m_Multiplexer)
+        m_Multiplexer->HandleTranslationUnit(C);
     }
 
     void CladPlugin::PrintStats() {
@@ -714,7 +716,8 @@ void InitTimers();
         llvm::errs() << "\n";
       }
 
-      m_Multiplexer->PrintStats();
+      if (m_Multiplexer)
+        m_Multiplexer->PrintStats();
     }
 
   } // end namespace plugin

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -243,7 +243,8 @@ struct DifferentiationOptions {
     void ForgetSema() override {
       // ForgetSema is called in the destructor of Sema which is much later
       // than where we can process anything. We can't delay this call.
-      m_Multiplexer->ForgetSema();
+      if(m_Multiplexer)
+        m_Multiplexer->ForgetSema();
     }
 
     // FIXME: We should hide ProcessDiffRequest when we implement proper

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -243,7 +243,7 @@ struct DifferentiationOptions {
     void ForgetSema() override {
       // ForgetSema is called in the destructor of Sema which is much later
       // than where we can process anything. We can't delay this call.
-      if(m_Multiplexer)
+      if (m_Multiplexer)
         m_Multiplexer->ForgetSema();
     }
 

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -229,7 +229,7 @@ struct DifferentiationOptions {
     void PrintStats() override;
 
     bool shouldSkipFunctionBody(clang::Decl* D) override {
-      return m_Multiplexer->shouldSkipFunctionBody(D);
+      return m_Multiplexer ? m_Multiplexer->shouldSkipFunctionBody(D) : true;
     }
 
     // SemaConsumer


### PR DESCRIPTION
In #1819, we prevented Clad’s consumer from replacing (stealing) the existing consumer when running under Cling’s incremental compilation. In that configuration, `m_Multiplexer` was left as nullptr.

Normally this is not an issue because Cling’s incremental compilation path does not invoke HandleTranslationUnit(). However, other code path also creates other CompilerInstances using the same invocation options. For example:
```cpp
GenerateModuleFromModuleMapAction Action;
Instance.ExecuteAction(Action);
```
This path eventually calls HandleTranslationUnit(), where Clad (and a few other places) dereferences `m_Multiplexer` without checking whether it is nullptr, resulting in a segmentation fault.

This PR fixes the issue by adding check around `m_Multiplexer` usage.