### PR TITLE
[UA]Replace m_LoopMem back-edge test with a per-block worklist fixpoint.

### DIFF
--- a/lib/Differentiator/UsefulAnalyzer.cpp
+++ b/lib/Differentiator/UsefulAnalyzer.cpp
@@ -7,6 +7,7 @@ namespace clad {
 void UsefulAnalyzer::Analyze(const FunctionDecl* FD) {
   // Build the CFG (control-flow graph) of FD.
   m_BlockData.resize(m_AnalysisDC->getCFG()->size());
+  m_LoopMem.resize(m_AnalysisDC->getCFG()->size());
   // Set current block ID to the ID of entry the block.
   CFGBlock& exit = m_AnalysisDC->getCFG()->getExit();
   m_CurBlockID = exit.getBlockID();
@@ -66,11 +67,9 @@ void UsefulAnalyzer::AnalyzeCFGBlock(const CFGBlock& block) {
 
     bool shouldPushPred = true;
     if (pred->getBlockID() < block.getBlockID()) {
-      if (m_LoopMem == *m_BlockData[block.getBlockID()])
+      if (m_LoopMem[block.getBlockID()] == *m_BlockData[block.getBlockID()])
         shouldPushPred = false;
-
-      for (const VarDecl* i : *m_BlockData[block.getBlockID()])
-        m_LoopMem.insert(i);
+      m_LoopMem[block.getBlockID()] = *m_BlockData[block.getBlockID()];
     }
 
     if (shouldPushPred)

--- a/lib/Differentiator/UsefulAnalyzer.h
+++ b/lib/Differentiator/UsefulAnalyzer.h
@@ -27,8 +27,7 @@ class UsefulAnalyzer : public clang::RecursiveASTVisitor<UsefulAnalyzer> {
   static std::unique_ptr<VarsData> createNewVarsData(VarsData toAssign) {
     return std::unique_ptr<VarsData>(new VarsData(std::move(toAssign)));
   }
-  VarsData m_LoopMem;
-
+  std::vector<VarsData> m_LoopMem;
   clang::CFGBlock* getCFGBlockByID(unsigned ID);
 
   clang::AnalysisDeclContext* m_AnalysisDC;

--- a/test/Analyses/UsefulNonTermination.cpp
+++ b/test/Analyses/UsefulNonTermination.cpp
@@ -1,0 +1,47 @@
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-ua -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oUsefulNonTermination.out
+// RUN: ./UsefulNonTermination.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "../TestUtils.h"
+
+// A loop in each arm of an if/else. Under -enable-ua this hung forever because
+// UsefulAnalyzer's back-edge termination used one never-cleared, function-wide
+// m_LoopMem set that could only ever converge for a single loop.
+// CHECK: double foo_darg1(bool cond, double x, double y) {
+// CHECK-NEXT:     bool _d_cond = 0;
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     double _d_y = 0;
+// CHECK-NEXT:     double _d_r = 0;
+// CHECK-NEXT:     double r = 0;
+// CHECK-NEXT:     if (cond) {
+// CHECK-NEXT:         for (int i = 0; i < 3; i++) {
+// CHECK-NEXT:             _d_r += _d_x;
+// CHECK-NEXT:             r += x;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     } else {
+// CHECK-NEXT:         for (int i = 0; i < 3; i++) {
+// CHECK-NEXT:             _d_r += _d_y;
+// CHECK-NEXT:             r += y;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return _d_r;
+// CHECK-NEXT: }
+double foo(bool cond, double x, double y) {
+  double r = 0;
+  if (cond) {
+    for (int i = 0; i < 3; i++)
+      r += x;
+  } else {
+    for (int i = 0; i < 3; i++)
+      r += y;
+  }
+  return r;
+}
+
+int main() {
+  INIT_DIFFERENTIATE_UA(foo, "x");
+
+  TEST_DIFFERENTIATE(foo, true, 3, 5);  // CHECK-EXEC: {3.00}
+  TEST_DIFFERENTIATE(foo, false, 3, 5); // CHECK-EXEC: {0.00}
+  return 0;
+}


### PR DESCRIPTION
This PR fixes a bug in `UsefulAnalyzer` where functions containing multiple loops hang compilation indefinitely under `-enable-ua`. 
    
`m_LoopMem` was previously declared as a single state variable that was never cleared. 
This converts `m_LoopMem` from a single `VarsData` instance into a per-block `std::vector<VarsData>` state. This allows
each loop's back-edge test to independently converge on its own local fixpoint without leaking state globally across the entire function.

**TESTS:**
- Added `test/Analyses/UsefulNonTermination.cpp`: Verifies that compilation now terminates correctly and declares the correctness of the generated gradient using `CHECK-EXEC`,