### PR TITLE
[test] Move stl-cmath's test_func helpers into TestUtils. NFC

### DIFF
--- a/test/Analyses/DotProductIdentity.cpp
+++ b/test/Analyses/DotProductIdentity.cpp
@@ -1,0 +1,54 @@
+// RUN: %cladclang %s -I%S/../../include -oDotProductIdentity.out
+// RUN: ./DotProductIdentity.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-ua %s \
+// RUN:     -I%S/../../include -oDotProductIdentity_ua.out
+// RUN: ./DotProductIdentity_ua.out | %filecheck_exec %s
+// CHECK-EXEC-NOT: FAIL
+
+#include "clad/Differentiator/Differentiator.h"
+#include "../TestUtils.h"
+#include <cmath>
+#include <cstdio>
+
+double h3(double a, double b, double c) {
+    return a * b + std::sin(c) * a;
+}
+
+double q(const double* x, int n) {
+    double r = 0;
+    for (int i = 0; i < n; ++i) r += x[i] * x[i] * x[i];
+    return r;
+}
+
+int main() {
+    double a = 0.7, b = -1.3, c = 2.1;
+    double da = 0, db = 0, dc = 0;
+    auto g3 = clad::gradient(h3);
+    g3.execute(a, b, c, &da, &db, &dc);
+
+    double pa = clad::differentiate(h3, "a").execute(a, b, c);
+    double pb = clad::differentiate(h3, "b").execute(a, b, c);
+    double pc = clad::differentiate(h3, "c").execute(a, b, c);
+
+    double xdot[3] = {0.31, -0.52, 0.87};
+    double Xb[3]   = {da, db, dc};
+    double Yd      = xdot[0]*pa + xdot[1]*pb + xdot[2]*pc;
+    printf("%d\n", test_utils::almost_equal(test_utils::dot(xdot, Xb, 3), Yd) ? 1 : 0);
+    // CHECK-EXEC: 1
+
+    const int n = 5;
+    double x[n], dx[n], fdg[n];
+    for (int i = 0; i < n; ++i) { x[i] = 0.5 + 0.3*i; dx[i] = 0; }
+    auto gq = clad::gradient(q, "x");
+    gq.execute(x, n, dx);
+    test_utils::fd_gradient(q, x, n, fdg);
+    printf("%d\n", test_utils::max_abs_diff(dx, fdg, n) < 1e-4 ? 1 : 0);
+    // CHECK-EXEC: 1
+
+    double bad[n];
+    for (int i = 0; i < n; ++i) bad[i] = dx[i] + 1.0;
+    printf("%d\n", test_utils::max_abs_diff(bad, fdg, n) < 1e-4 ? 1 : 0);
+    // CHECK-EXEC: 0
+
+    return 0;
+}

--- a/test/Features/stl-cmath.cpp
+++ b/test/Features/stl-cmath.cpp
@@ -131,82 +131,37 @@ namespace std {
   }
 }
 #endif
-
-template <typename T>
-T get_tolerance() {
-    if constexpr (std::is_same_v<T,float>) return T(1e-3);
-    else if constexpr (std::is_same_v<T,long double>) return T(1e-10);
-    else return T(1e-6);
-}
-
-// step for numerical derivative
-template <typename T>
-T get_h() {
-    if constexpr (std::is_same_v<T,float>) return T(1e-3);
-    else if constexpr (std::is_same_v<T,long double>) return T(1e-8);
-    else return T(1e-6);
-}
-// Central finite difference approximation
-template<typename T>
-T numerical_derivative(T (*f)(T), T x) {
-    const T h = get_h<T>();
-    return (f(x + h) - f(x - h)) / (2 * h);
-}
-
-// Test function
-template<typename T>
-void test_func(const std::string &name,
-               T (*f)(T), const clad::CladFunction<T(*)(T)> &clad_fwd,
-               const decltype(clad::gradient((T (*)(T))nullptr)) &clad_rev,
-               const T (&test_points)[7] = {-2.0,-1.0,-0.5,0.0,0.5,1.0,2.0}) {
-    const T tol = get_tolerance<T>();
-    std::cerr << std::setprecision(10);
-    for (T x : test_points) {
-        T dfwd_val = clad_fwd.execute(x);
-        T drev_val = T();
-        clad_rev.execute(x, &drev_val);
-        T df_num = numerical_derivative(f, x);
-        if (dfwd_val != drev_val || std::abs(dfwd_val - df_num) > tol) {
-            std::cerr << "FAIL: " << name << " at x=" << x
-                      << ": dfwd=" << dfwd_val
-                      << ", drev=" << drev_val
-                      << ", numerical=" << df_num << "\n";
-        } else {
-            std::cout << "PASS: " << name << " at x=" << x
-                      << " dfwd=" << dfwd_val << ", drev=" << drev_val << "\n";
-        }
-    }
-}
+#include "../TestUtils.h"
 
 #define STRINGIFY2(X) #X
 #define STRINGIFY(X) STRINGIFY2(X)
-#define CHECK_F(X) test_func<float>(STRINGIFY(X), \
+#define CHECK_F(X) test_utils::test_func<float>(STRINGIFY(X), \
                            X, clad::differentiate(X), \
                            clad::gradient(X));
-#define CHECK_D(X) test_func<double>(STRINGIFY(X), \
+#define CHECK_D(X) test_utils::test_func<double>(STRINGIFY(X), \
                            X, clad::differentiate(X), \
                            clad::gradient(X));
-#define CHECK_LD(X) test_func<long double>(STRINGIFY(X), \
+#define CHECK_LD(X) test_utils::test_func<long double>(STRINGIFY(X), \
                            X, clad::differentiate(X), \
                            clad::gradient(X));
 #define CHECK_RANGE_F(X, ...)                           \
   {                                                     \
     float arr[] = __VA_ARGS__;                          \
-    test_func<float>(STRINGIFY(X),                      \
+    test_utils::test_func<float>(STRINGIFY(X),                      \
                      X, clad::differentiate(X),         \
                      clad::gradient(X), arr);           \
   }
 #define CHECK_RANGE_D(X, ...)                           \
   {                                                     \
     double arr[] = __VA_ARGS__;                         \
-    test_func<double>(STRINGIFY(X),                     \
+    test_utils::test_func<double>(STRINGIFY(X),                     \
                       X, clad::differentiate(X),        \
                       clad::gradient(X), arr);          \
   }
 #define CHECK_RANGE_LD(X, ...)                          \
   {                                                     \
     long double arr[] = __VA_ARGS__;                    \
-    test_func<long double>(STRINGIFY(X),                \
+    test_utils::test_func<long double>(STRINGIFY(X),                \
                            X, clad::differentiate(X),   \
                            clad::gradient(X), arr);     \
   }

--- a/test/TestUtils.h
+++ b/test/TestUtils.h
@@ -4,6 +4,11 @@
 
 #include <cstdio>
 #include <type_traits>
+#include <cmath>
+#include <cassert>
+#include <iostream>
+#include <iomanip>
+#include <string>
 
 namespace test_utils {
 
@@ -208,6 +213,96 @@ void EssentiallyEqualArrays(A* a, B* b, unsigned size) {
   }
 }
 
+template <typename T>
+T get_tolerance() {
+    if (std::is_same<T,float>::value) return T(1e-3);
+    else if (std::is_same<T,long double>::value) return T(1e-10);
+    else return T(1e-6);
+}
+
+// step for numerical derivative
+template <typename T>
+T get_h() {
+    if (std::is_same<T,float>::value) return T(1e-3);
+    else if (std::is_same<T,long double>::value) return T(1e-8);
+    else return T(1e-6);
+}
+
+// Central finite difference approximation
+template<typename T>
+T numerical_derivative(T (*f)(T), T x) {
+    const T h = get_h<T>();
+    return (f(x + h) - f(x - h)) / (2 * h);
+}
+
+// 1D Test function for comparing Forward vs Reverse vs Numerical
+template<typename T>
+void test_func(const std::string &name,
+               T (*f)(T), const clad::CladFunction<T(*)(T)> &clad_fwd,
+               const decltype(clad::gradient((T (*)(T))nullptr)) &clad_rev,
+               const T (&test_points)[7] = {-2.0,-1.0,-0.5,0.0,0.5,1.0,2.0}) {
+    const T tol = get_tolerance<T>();
+    std::cerr << std::setprecision(10);
+    for (T x : test_points) {
+        T dfwd_val = clad_fwd.execute(x);
+        T drev_val = T();
+        clad_rev.execute(x, &drev_val);
+        T df_num = numerical_derivative(f, x);
+        if (dfwd_val != drev_val || std::abs(dfwd_val - df_num) > tol) {
+            std::cerr << "FAIL: " << name << " at x=" << x
+                      << ": dfwd=" << dfwd_val
+                      << ", drev=" << drev_val
+                      << ", numerical=" << df_num << "\n";
+        } else {
+            std::cout << "PASS: " << name << " at x=" << x
+                      << " dfwd=" << dfwd_val << ", drev=" << drev_val << "\n";
+        }
+    }
+}
+
+inline double seed_component(unsigned i) {
+    unsigned s = (i * 2654435761u) ^ 0x9e3779b9u;
+    s = s * 1103515245u + 12345u;
+    return ((s >> 8) & 0xffff) / 32767.5 - 1.0;
+}
+
+inline double dot(const double* a, const double* b, int n) {
+    double r = 0;
+    for (int i = 0; i < n; ++i) r += a[i] * b[i];
+    return r;
+}
+
+inline double max_abs_diff(const double* a, const double* b, int n) {
+    double m = 0;
+    for (int i = 0; i < n; ++i) {
+        double d = std::fabs(a[i] - b[i]);
+        if (d > m) m = d;
+    }
+    return m;
+}
+
+inline bool almost_equal(double a, double b,
+                         double rel = 1e-6, double abs_tol = 1e-9) {
+    double diff = std::fabs(a - b);
+    if (diff <= abs_tol) return true;
+    double scale = std::fabs(a) > std::fabs(b) ? std::fabs(a) : std::fabs(b);
+    return diff <= rel * scale;
+}
+
+template<class F>
+void fd_gradient(F f, const double* x, int n, double* g, double h = 1e-6) {
+    double* xp = new double[n];
+    for (int i = 0; i < n; ++i) xp[i] = x[i];
+    for (int i = 0; i < n; ++i) {
+        double xi = xp[i];
+        xp[i] = xi + h; double fp = f(xp, n);
+        xp[i] = xi - h; double fm = f(xp, n);
+        xp[i] = xi;
+        g[i] = (fp - fm) / (2 * h);
+    }
+    delete[] xp;
+}
+
 #define INIT_GRADIENT_ALL(fn) auto fn##_grad = clad::gradient(fn);
 
 #define INIT_JACOBIAN_ALL(fn) auto fn##_jac = clad::jacobian(fn);
@@ -262,4 +357,4 @@ void EssentiallyEqualArrays(A* a, B* b, unsigned size) {
   test_utils::run_error_estimation<PrecissionType>(fn##_err, __VA_ARGS__);
 
 #endif
-}
+} // namespace test_utils

--- a/test/TestUtils.h
+++ b/test/TestUtils.h
@@ -1,9 +1,15 @@
 #ifndef TEST_TEST_UTILS_H
 #define TEST_TEST_UTILS_H
 #include "clad/Differentiator/ArrayRef.h"
+#include "clad/Differentiator/Differentiator.h"
 
 #include <cstdio>
 #include <type_traits>
+#include <cmath>
+#include <cassert>
+#include <iostream>
+#include <iomanip>
+#include <string>
 
 namespace test_utils {
 
@@ -208,6 +214,54 @@ void EssentiallyEqualArrays(A* a, B* b, unsigned size) {
   }
 }
 
+template <typename T>
+T get_tolerance() {
+    if (std::is_same<T,float>::value) return T(1e-3);
+    else if (std::is_same<T,long double>::value) return T(1e-10);
+    else return T(1e-6);
+}
+
+// step for numerical derivative
+template <typename T>
+T get_h() {
+    if (std::is_same<T,float>::value) return T(1e-3);
+    else if (std::is_same<T,long double>::value) return T(1e-8);
+    else return T(1e-6);
+}
+
+// Central finite difference approximation
+template<typename T>
+T numerical_derivative(T (*f)(T), T x) {
+    const T h = get_h<T>();
+    return (f(x + h) - f(x - h)) / (2 * h);
+}
+
+// 1D Test function for comparing Forward vs Reverse vs Numerical
+template<typename T>
+void test_func(const std::string &name,
+               T (*f)(T), const clad::CladFunction<T(*)(T)> &clad_fwd,
+               const decltype(clad::gradient((T (*)(T))nullptr)) &clad_rev,
+               const T (&test_points)[7] = {-2.0,-1.0,-0.5,0.0,0.5,1.0,2.0}) {
+    const T tol = get_tolerance<T>();
+    std::cerr << std::setprecision(10);
+    for (T x : test_points) {
+        T dfwd_val = clad_fwd.execute(x);
+        T drev_val = T();
+        clad_rev.execute(x, &drev_val);
+        T df_num = numerical_derivative(f, x);
+        if (dfwd_val != drev_val || std::abs(dfwd_val - df_num) > tol) {
+            std::cerr << "FAIL: " << name << " at x=" << x
+                      << ": dfwd=" << dfwd_val
+                      << ", drev=" << drev_val
+                      << ", numerical=" << df_num << "\n";
+        } else {
+            std::cout << "PASS: " << name << " at x=" << x
+                      << " dfwd=" << dfwd_val << ", drev=" << drev_val << "\n";
+        }
+    }
+}
+
+
 #define INIT_GRADIENT_ALL(fn) auto fn##_grad = clad::gradient(fn);
 
 #define INIT_JACOBIAN_ALL(fn) auto fn##_jac = clad::jacobian(fn);
@@ -262,4 +316,4 @@ void EssentiallyEqualArrays(A* a, B* b, unsigned size) {
   test_utils::run_error_estimation<PrecissionType>(fn##_err, __VA_ARGS__);
 
 #endif
-}
+} // namespace test_utils


### PR DESCRIPTION
- Moved 1D helpers from stl-cmath.cpp to shared TestUtils.h to kill duplication.
- Added multi-var central-FD helpers like fd_gradient and dot for independent checking.
- Added DotProductIdentity.cpp harness to test forward vs reverse vs FD agreementon multi-variable targets under both default and -enable-ua paths. 
- This establishesa baseline gradient testing harness to catch regressions in upcoming activity-analysis PRs.