### PR TITLE
Do not reuse AST nodes in generated derivatives.

### DIFF
--- a/include/clad/Differentiator/ErrorEstimator.h
+++ b/include/clad/Differentiator/ErrorEstimator.h
@@ -52,6 +52,11 @@ class ErrorEstimationHandler : public ExternalRMVSource {
   Stmts m_ReverseErrorStmts;
   /// The index expression for emitting final errors for input param errors.
   clang::Expr* m_IdxExpr = nullptr;
+  /// Clone-on-read accessors for the cached references above: each is reused
+  /// across several generated subscripts/conditions, so every read must own
+  /// its own node rather than share the cached one.
+  clang::Expr* cloneIdxExpr();
+  clang::Expr* cloneRetErrorExpr();
   /// A map from var decls to their size variables (e.g. `var_size`).
   std::unordered_map<const clang::VarDecl*, clang::Expr*> m_ArrSizes;
   // FIXME: Solve this in a more general way.

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -583,23 +583,27 @@ namespace clad {
 
       /// Returns reference to the last object of the clad tape if clad tape
       /// is used as the counter; otherwise returns reference to the counter
-      /// variable.
-      clang::Expr* getRef() const { return m_Ref; }
+      /// variable. The reference is cloned on every read so the forward
+      /// increment, reverse decrement and loop condition each own their
+      /// counter DeclRefExpr node instead of sharing it.
+      [[nodiscard]] clang::Expr* cloneRef() const {
+        return m_RMV.CloneNode(m_Ref);
+      }
 
       /// Returns counter post-increment expression (`counter++`).
       clang::Expr* getCounterIncrement() {
-        return m_RMV.BuildOp(clang::UnaryOperatorKind::UO_PostInc, m_Ref);
+        return m_RMV.BuildOp(clang::UnaryOperatorKind::UO_PostInc, cloneRef());
       }
 
       /// Returns counter post-decrement expression (`counter--`)
       clang::Expr* getCounterDecrement() {
-        return m_RMV.BuildOp(clang::UnaryOperatorKind::UO_PostDec, m_Ref);
+        return m_RMV.BuildOp(clang::UnaryOperatorKind::UO_PostDec, cloneRef());
       }
 
       /// Returns `ConditionResult` object for the counter.
       clang::Sema::ConditionResult getCounterConditionResult() {
         return m_RMV.m_Sema.ActOnCondition(m_RMV.getCurrentScope(), noLoc,
-                                           m_Ref,
+                                           cloneRef(),
                                            clang::Sema::ConditionKind::Boolean);
       }
 

--- a/include/clad/Differentiator/StmtClone.h
+++ b/include/clad/Differentiator/StmtClone.h
@@ -41,6 +41,12 @@ namespace utils {
     clang::Sema& m_Sema;
     clang::ASTContext& Ctx;
     Mapping* m_OriginalToClonedStmts;
+    // While cloning a PseudoObjectExpr, maps each original OpaqueValueExpr to
+    // its clone so the syntactic form and the semantic expressions reference
+    // the same fresh OVE (null outside such a clone). See
+    // VisitPseudoObjectExpr.
+    llvm::DenseMap<clang::OpaqueValueExpr*, clang::OpaqueValueExpr*>*
+        m_OVESubst = nullptr;
 
     clang::Decl* CloneDecl(clang::Decl* Node);
     clang::VarDecl* CloneDeclOrNull(clang::VarDecl* Node);
@@ -124,6 +130,8 @@ namespace utils {
     DECLARE_CLONE_FN(CXXTemporaryObjectExpr)
     DECLARE_CLONE_FN(MaterializeTemporaryExpr)
     DECLARE_CLONE_FN(PseudoObjectExpr)
+    DECLARE_CLONE_FN(OpaqueValueExpr)
+    DECLARE_CLONE_FN(MSPropertyRefExpr)
     DECLARE_CLONE_FN(SubstNonTypeTemplateParmExpr)
     DECLARE_CLONE_FN(CXXScalarValueInitExpr)
     DECLARE_CLONE_FN(ConstantExpr)

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -643,6 +643,13 @@ namespace clad {
                                          bool pushOnScopeChains = false,
                                          bool cloneDefaultArg = true,
                                          clang::SourceLocation Loc = noLoc);
+    /// Build a primal copy of a lambda expression with a *fresh*
+    /// closure type, rather than reusing the original closure (as a plain
+    /// StmtClone does). Reusing the closure makes two clones share the
+    /// operator() body, violating the one-parent-per-node invariant. Only
+    /// captureless lambdas get a fresh closure; captured lambdas fall back to
+    /// a plain clone. Inner lambda-init declarations are rebuilt recursively.
+    clang::Expr* buildClonedLambda(const clang::LambdaExpr* LE);
     /// A function to get the single argument "forward_central_difference"
     /// call expression for the given arguments.
     ///
@@ -687,6 +694,15 @@ namespace clad {
     clang::Stmt* Clone(const clang::Stmt* S);
     /// A shorthand to simplify cloning of expressions.
     clang::Expr* Clone(const clang::Expr* E);
+    /// Structural copy that does NOT run updateReferencesOf. `Clone` re-points
+    /// references (name lookup, constant folding, type fix-ups), which is
+    /// correct when copying original-function code into the derivative but
+    /// corrupts already-generated derivative expressions (e.g. folds `(x + y)`
+    /// into a garbage literal). Use this to split a reused generated node into
+    /// a distinct-but-identical copy.
+    clang::Expr* CloneNode(const clang::Expr* E);
+    /// Statement overload of the structural copy above.
+    clang::Stmt* CloneNode(const clang::Stmt* S);
     /// Cloning types is necessary since VariableArrayType
     /// store a pointer to their size expression.
     clang::QualType CloneType(clang::QualType T);

--- a/lib/Differentiator/ASTIntegrity.cpp
+++ b/lib/Differentiator/ASTIntegrity.cpp
@@ -1,0 +1,123 @@
+//--------------------------------------------------------------------*- C++ -//
+// clad - the C++ Clang-based Automatic Differentiator
+//
+// See ASTIntegrity.h for the rationale.
+//----------------------------------------------------------------------------//
+
+#include "ASTIntegrity.h"
+
+#include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Stmt.h"
+#include "clang/AST/StmtOpenMP.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+using namespace clang;
+
+namespace clad {
+
+const Stmt* findSharedNode(const Stmt* Root) {
+  if (!Root)
+    return nullptr;
+  // clad's hand-built body must be a tree in its Stmt CHILD-edge structure: no
+  // node is a child (Stmt::children()) of two parents. Count child edges, NOT
+  // RAV visits -- RecursiveASTVisitor also follows type and template-argument
+  // edges, and Clang legitimately shares nodes across those (e.g. the
+  // substituted `N` in a `Foo<5>` instantiation is one ConstantExpr reachable
+  // from both the type and the body). Counting visits would flag those valid
+  // shares; counting child edges flags only genuine multiple-parent reuse,
+  // which is what clad must not produce.
+  struct Counter : RecursiveASTVisitor<Counter> {
+    llvm::DenseMap<const Stmt*, unsigned> ParentEdges;
+    llvm::SmallPtrSet<const Stmt*, 32> SeenParents;
+    // Visit implicit code: some genuine reuses have a second parent reachable
+    // only through implicit nodes.
+    bool shouldVisitImplicitCode() const { return true; }
+    // But visit only the semantic form of an InitListExpr: with implicit code
+    // on, RAV visits both the syntactic and semantic forms, which legitimately
+    // share their element nodes (Clang's representation, not a reuse).
+    bool TraverseInitListExpr(InitListExpr* ILE,
+                              DataRecursionQueue* = nullptr) {
+      InitListExpr* Sem = ILE->isSemanticForm() ? ILE : ILE->getSemanticForm();
+      if (!Sem)
+        Sem = ILE;
+      WalkUpFromInitListExpr(Sem);
+      for (Stmt* Ch : Sem->children())
+        if (Ch)
+          TraverseStmt(Ch);
+      return true;
+    }
+    // Skip OpenMP clauses. Lowering `reduction(+:x)` makes Sema synthesize a
+    // combiner (`.reduction.lhs = .reduction.lhs + .reduction.rhs`) that
+    // references one helper DeclRefExpr from two parents -- Clang's own AST,
+    // not clad reuse. TraverseOMPExecutableDirective walks only the clauses;
+    // the associated loop body clad generates is still traversed by the
+    // DEF_TRAVERSE_STMT children walk.
+    bool TraverseOMPExecutableDirective(OMPExecutableDirective* /*D*/) {
+      return true;
+    }
+    // An OpaqueValueExpr is Clang's mechanism for sharing a common
+    // subexpression -- e.g. the `threadIdx` base of a `threadIdx.x`
+    // __declspec(property) access, which Clang models as a PseudoObjectExpr
+    // that references one OpaqueValueExpr from both its syntactic form and its
+    // semantic expressions. It is shared by design, not clad reuse, so do not
+    // descend into its source (which the OVE also shares); VisitStmt likewise
+    // does not count edges to it.
+    bool TraverseOpaqueValueExpr(OpaqueValueExpr* /*OVE*/,
+                                 DataRecursionQueue* = nullptr) {
+      return true;
+    }
+    // Skip default-argument expressions. Clang stores a call's default argument
+    // once on the ParmVarDecl and every call site references that one
+    // expression through a CXXDefaultArgExpr (e.g. the `0` in
+    // thrust::reduce_by_key's default operators, shared across clad's cloned
+    // calls). That is Clang's representation, not clad reuse.
+    bool TraverseCXXDefaultArgExpr(CXXDefaultArgExpr* /*E*/,
+                                   DataRecursionQueue* = nullptr) {
+      return true;
+    }
+    bool TraverseCXXDefaultInitExpr(CXXDefaultInitExpr* /*E*/,
+                                    DataRecursionQueue* = nullptr) {
+      return true;
+    }
+    // Do not descend into type locations. A generated VarDecl's type can embed
+    // expressions (a template argument, an array bound, a `std::enable_if<N <
+    // _Dt>` SFINAE condition) that Clang shares across same-typed decls -- e.g.
+    // the mersenne engine's `_Dt` word-size constant across the pushforward's
+    // ValueAndPushforward<> temporaries. Those are Clang's shared AST, not a
+    // clad reuse; only the statement tree is clad's hand-built output.
+    // clang-22 added a trailing bool (TraverseQualifier) to these; a defaulted
+    // parameter matches both the older one-argument call and the new one.
+    bool TraverseTypeLoc(TypeLoc /*TL*/, bool = false) { return true; }
+    bool TraverseType(QualType /*T*/, bool = false) { return true; }
+    bool TraverseTemplateArgumentLoc(const TemplateArgumentLoc& /*ArgLoc*/) {
+      return true;
+    }
+    bool TraverseTemplateArgument(const TemplateArgument& /*Arg*/) {
+      return true;
+    }
+    bool VisitStmt(Stmt* S) {
+      // RAV can visit one node twice when it is embedded in two type locs
+      // (e.g. a template-argument ConstantExpr shared by several same-typed
+      // VarDecls). Count each parent's children once, so a single parent seen
+      // twice is not mistaken for two parents.
+      if (!SeenParents.insert(S).second)
+        return true;
+      for (const Stmt* Ch : S->children())
+        if (Ch && !isa<OpaqueValueExpr>(Ch))
+          ++ParentEdges[Ch];
+      return true;
+    }
+  } C;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  C.TraverseStmt(const_cast<Stmt*>(Root));
+  for (const auto& Entry : C.ParentEdges)
+    if (Entry.second >= 2)
+      return Entry.first;
+  return nullptr;
+}
+
+} // namespace clad

--- a/lib/Differentiator/ASTIntegrity.h
+++ b/lib/Differentiator/ASTIntegrity.h
@@ -1,0 +1,32 @@
+//--------------------------------------------------------------------*- C++ -//
+// clad - the C++ Clang-based Automatic Differentiator
+//
+// AST-integrity checks for hand-synthesized derivative code.
+//
+// clad assembles a derivative's statements by hand and must keep them a proper
+// tree: no node the child (Stmt::children()) of two parents. A node with two
+// parents ("shared") lets a later in-place edit leak across contexts and
+// silently corrupt codegen (and a shared aggregate initializer breaks CodeGen
+// outright). This is a property of the hand-built body, not of Clang ASTs in
+// general -- Clang shares nodes across type and template-argument edges and
+// InitListExpr's syntactic/semantic forms -- so the check counts child edges,
+// not visits (see findSharedNode).
+//----------------------------------------------------------------------------//
+
+#ifndef CLAD_AST_INTEGRITY_H
+#define CLAD_AST_INTEGRITY_H
+
+namespace clang {
+class Stmt;
+} // namespace clang
+
+namespace clad {
+
+/// Return the first Stmt that occurs more than once under \p Root (i.e. is
+/// shared with itself through two parent edges), or nullptr if \p Root is a
+/// proper tree.
+const clang::Stmt* findSharedNode(const clang::Stmt* Root);
+
+} // namespace clad
+
+#endif // CLAD_AST_INTEGRITY_H

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -582,10 +582,12 @@ StmtDiff BaseForwardModeVisitor::VisitConditionalOperator(
                               ifFalseDiff.getExpr())
           .get();
 
+  // cond is already used by the value conditional above; clone it for the
+  // derivative conditional so the two do not share the stored condition.
   Expr* condExprDiff =
       m_Sema
-          .ActOnConditionalOp(noLoc, noLoc, cond, ifTrueDiff.getExpr_dx(),
-                              ifFalseDiff.getExpr_dx())
+          .ActOnConditionalOp(noLoc, noLoc, CloneNode(cond),
+                              ifTrueDiff.getExpr_dx(), ifFalseDiff.getExpr_dx())
           .get();
 
   return StmtDiff(condExpr, condExprDiff);
@@ -636,8 +638,9 @@ BaseForwardModeVisitor::VisitCXXForRangeStmt(const CXXForRangeStmt* FRS) {
 
   auto* EndExpr = BuildDeclRef(
       cast<VarDecl>(cast<DeclStmt>(VisitEnd.getStmt())->getSingleDecl()));
-  // Build begin != end condition.
-  Expr* cond = BuildOp(BO_NE, BeginExpr, EndExpr);
+  // Build begin != end condition. BeginExpr is already used by the increment
+  // above, so build a fresh reference to the begin iterator here.
+  Expr* cond = BuildOp(BO_NE, BuildDeclRef(BeginVarDecl), EndExpr);
 
   const VarDecl* VD = FRS->getLoopVariable();
   DeclDiff<VarDecl> VDDiff = DifferentiateVarDecl(VD);
@@ -805,8 +808,11 @@ StmtDiff BaseForwardModeVisitor::VisitMemberExpr(const MemberExpr* ME) {
       // Try to find the derivative of the member variable wrt independent
       // variable
       auto memberDecl = ME->getMemberDecl();
-      if (m_Variables.find(memberDecl) != std::end(m_Variables)) {
-        return StmtDiff(clonedME, m_Variables[memberDecl]);
+      auto it = m_Variables.find(memberDecl);
+      if (it != std::end(m_Variables)) {
+        // m_Variables caches one derivative ref per member; clone so repeated
+        // member uses do not share the node.
+        return StmtDiff(clonedME, CloneNode(it->second));
       }
     }
     // Is not a real variable. Therefore, derivative is 0.
@@ -866,6 +872,14 @@ BaseForwardModeVisitor::VisitArraySubscriptExpr(const ArraySubscriptExpr* ASE) {
                  std::begin(clonedIndices),
                  [this](const Expr* E) { return Clone(E); });
   Expr* cloned = BuildArraySubscript(clonedBase, clonedIndices);
+  // The index exprs are consumed by the primal subscript above; the derivative
+  // subscript below needs its own copies so the two do not share index nodes.
+  auto derivedIndices = [&]() {
+    llvm::SmallVector<Expr*, 4> V(clonedIndices.size());
+    std::transform(clonedIndices.begin(), clonedIndices.end(), V.begin(),
+                   [this](Expr* E) { return CloneNode(E); });
+    return V;
+  };
 
   Expr* zero = getZeroInit(ExprTy);
   ValueDecl* VD = nullptr;
@@ -878,7 +892,10 @@ BaseForwardModeVisitor::VisitArraySubscriptExpr(const ArraySubscriptExpr* ASE) {
       // If the original field is of constant array type, then,
       // the derived variable of `arr[i]` is `_d_arr[i]`.
       if (it != m_Variables.end() && decl->getType()->isConstantArrayType()) {
-        auto result_at_i = BuildArraySubscript(it->second, clonedIndices);
+        // m_Variables caches one adjoint ref per array; clone the base so
+        // repeated element accesses do not share the node.
+        auto* result_at_i =
+            BuildArraySubscript(CloneNode(it->second), derivedIndices());
         return StmtDiff{cloned, result_at_i};
       }
 
@@ -889,7 +906,7 @@ BaseForwardModeVisitor::VisitArraySubscriptExpr(const ArraySubscriptExpr* ASE) {
     if (!isa<MemberExpr>(derivedME->IgnoreParenImpCasts())) {
       return {cloned, zero};
     }
-    auto derivedAS = BuildArraySubscript(derivedME, clonedIndices);
+    auto* derivedAS = BuildArraySubscript(derivedME, derivedIndices());
     return {cloned, derivedAS};
   } else {
     if (!isa<DeclRefExpr>(clonedBase->IgnoreParenImpCasts()))
@@ -909,7 +926,7 @@ BaseForwardModeVisitor::VisitArraySubscriptExpr(const ArraySubscriptExpr* ASE) {
     if (!clonedIndices.back()->EvaluateAsInt(res, m_Context,
                                              AllowSideEffects)) {
       diffExpr =
-          BuildParens(BuildOp(BO_EQ, clonedIndices.back(),
+          BuildParens(BuildOp(BO_EQ, CloneNode(clonedIndices.back()),
                               ConstantFolder::synthesizeLiteral(
                                   ExprTy, m_Context, m_IndependentVarIndex)));
     } else if (res.Val.getInt().getExtValue() == m_IndependentVarIndex) {
@@ -932,8 +949,9 @@ BaseForwardModeVisitor::VisitArraySubscriptExpr(const ArraySubscriptExpr* ASE) {
   // llvm::APSInt IVal;
   // if (!I->EvaluateAsInt(IVal, m_Context))
   //  return;
-  // Create the _result[idx] expression.
-  auto result_at_is = BuildArraySubscript(target, clonedIndices);
+  // Create the _result[idx] expression. target is the cached adjoint ref;
+  // clone it so repeated element accesses do not share the base node.
+  auto* result_at_is = BuildArraySubscript(CloneNode(target), derivedIndices());
   return StmtDiff(cloned, result_at_is);
 }
 
@@ -983,7 +1001,10 @@ StmtDiff BaseForwardModeVisitor::VisitDeclRefExpr(const DeclRefExpr* DRE) {
                                          : clad_compat::nullNNS());
         }
       }
-      return StmtDiff(clonedDRE, dExpr);
+      // m_Variables caches one derivative reference per variable; hand out a
+      // fresh clone so callers that combine it (product rule) never parent the
+      // cached node twice.
+      return StmtDiff(clonedDRE, CloneNode(dExpr));
     }
   }
   // Is not a variable or is a reference to something unrelated to independent
@@ -1349,8 +1370,9 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
       StoreAndRef(callDiff, "_t", /*forceDeclCreation=*/true);
   Expr* returnValue = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
                                              valueAndPushforward, "value");
+  // Clone the base so `.value` and `.pushforward` own distinct nodes.
   Expr* pushforward = utils::BuildMemberExpr(
-      m_Sema, getCurrentScope(), valueAndPushforward, "pushforward");
+      m_Sema, getCurrentScope(), CloneNode(valueAndPushforward), "pushforward");
   return StmtDiff(returnValue, pushforward);
 }
 
@@ -1415,11 +1437,13 @@ BaseForwardModeVisitor::VisitBinaryOperator(const BinaryOperator* BinOp) {
   auto opCode = BinOp->getOpcode();
   Expr* opDiff = nullptr;
 
+  // The operand primals are also parented by the forward value; clone each so
+  // the derivative expression owns a distinct subtree.
   auto deriveMul = [this](StmtDiff& Ldiff, StmtDiff& Rdiff) {
     Expr* LHS = BuildOp(BO_Mul, BuildParens(Ldiff.getExpr_dx()),
-                        BuildParens(Rdiff.getExpr()));
+                        BuildParens(CloneNode(Rdiff.getExpr())));
 
-    Expr* RHS = BuildOp(BO_Mul, BuildParens(Ldiff.getExpr()),
+    Expr* RHS = BuildOp(BO_Mul, BuildParens(CloneNode(Ldiff.getExpr())),
                         BuildParens(Rdiff.getExpr_dx()));
 
     return BuildOp(BO_Add, LHS, RHS);
@@ -1427,15 +1451,16 @@ BaseForwardModeVisitor::VisitBinaryOperator(const BinaryOperator* BinOp) {
 
   auto deriveDiv = [this](StmtDiff& Ldiff, StmtDiff& Rdiff) {
     Expr* LHS = BuildOp(BO_Mul, BuildParens(Ldiff.getExpr_dx()),
-                        BuildParens(Rdiff.getExpr()));
+                        BuildParens(CloneNode(Rdiff.getExpr())));
 
-    Expr* RHS = BuildOp(BO_Mul, BuildParens(Ldiff.getExpr()),
+    Expr* RHS = BuildOp(BO_Mul, BuildParens(CloneNode(Ldiff.getExpr())),
                         BuildParens(Rdiff.getExpr_dx()));
 
     Expr* nominator = BuildOp(BO_Sub, LHS, RHS);
 
-    Expr* RParens = BuildParens(Rdiff.getExpr());
-    Expr* denominator = BuildOp(BO_Mul, RParens, RParens);
+    Expr* RParens = BuildParens(CloneNode(Rdiff.getExpr()));
+    Expr* denominator =
+        BuildOp(BO_Mul, RParens, BuildParens(CloneNode(Rdiff.getExpr())));
 
     return BuildOp(BO_Div, BuildParens(nominator), BuildParens(denominator));
   };
@@ -1456,6 +1481,13 @@ BaseForwardModeVisitor::VisitBinaryOperator(const BinaryOperator* BinOp) {
     Expr* derivedL = nullptr;
     Expr* derivedR = nullptr;
     ComputeEffectiveDOperands(Ldiff, Rdiff, derivedL, derivedR);
+    // In pointer arithmetic ComputeEffectiveDOperands feeds the primal scalar
+    // operand (getExpr()) through as the derived operand; clone it so the
+    // derivative op does not share the node with the primal `op` built below.
+    if (derivedL == Ldiff.getExpr())
+      derivedL = CloneNode(derivedL);
+    if (derivedR == Rdiff.getExpr())
+      derivedR = CloneNode(derivedR);
     if (opCode == BO_Sub)
       derivedR = BuildParens(derivedR);
     opDiff = BuildOp(opCode, derivedL, derivedR);
@@ -1475,6 +1507,12 @@ BaseForwardModeVisitor::VisitBinaryOperator(const BinaryOperator* BinOp) {
       Expr* derivedL = nullptr;
       Expr* derivedR = nullptr;
       ComputeEffectiveDOperands(Ldiff, Rdiff, derivedL, derivedR);
+      // See the BO_Add/BO_Sub note: clone the reused primal scalar operand so
+      // the derived assignment does not share it with the primal `op`.
+      if (derivedL == Ldiff.getExpr())
+        derivedL = CloneNode(derivedL);
+      if (derivedR == Rdiff.getExpr())
+        derivedR = CloneNode(derivedR);
       opDiff = BuildOp(opCode, derivedL, derivedR);
     } else if (opCode == BO_MulAssign || opCode == BO_DivAssign) {
       // if both original expression and derived expression and evaluatable,
@@ -1500,12 +1538,15 @@ BaseForwardModeVisitor::VisitBinaryOperator(const BinaryOperator* BinOp) {
       Ldiff = {StoreAndRef(Ldiff.getExpr()), LdiffExprDx};
       auto RdiffExprDx = StoreAndRef(Rdiff.getExpr_dx());
       Rdiff = {StoreAndRef(Rdiff.getExpr()), RdiffExprDx};
+      // deriveMul/deriveDiv reuse Ldiff.getExpr_dx() (the stored derivative
+      // ref) on the right-hand side; clone it for the assignment target so the
+      // two occurrences do not share.
       if (opCode == BO_MulAssign)
-        opDiff =
-            BuildOp(BO_Assign, Ldiff.getExpr_dx(), deriveMul(Ldiff, Rdiff));
+        opDiff = BuildOp(BO_Assign, CloneNode(Ldiff.getExpr_dx()),
+                         deriveMul(Ldiff, Rdiff));
       else if (opCode == BO_DivAssign)
-        opDiff =
-            BuildOp(BO_Assign, Ldiff.getExpr_dx(), deriveDiv(Ldiff, Rdiff));
+        opDiff = BuildOp(BO_Assign, CloneNode(Ldiff.getExpr_dx()),
+                         deriveDiv(Ldiff, Rdiff));
     }
   } else if (opCode == BO_Comma) {
     // if expression is (E1, E2) then derivative is (E1', E1, E2')
@@ -1541,7 +1582,9 @@ BaseForwardModeVisitor::VisitBinaryOperator(const BinaryOperator* BinOp) {
   } else if (BinOp->isShiftOp()) {
     // Shifting is essentially multiplicating the LHS by 2^RHS (or 2^-RHS).
     // We should do the same to the derivarive.
-    opDiff = BuildOp(opCode, Ldiff.getExpr_dx(), Rdiff.getExpr());
+    // Rdiff.getExpr() (the shift count) is also used by the primal op built
+    // below; clone it so the derivative does not share the node.
+    opDiff = BuildOp(opCode, Ldiff.getExpr_dx(), CloneNode(Rdiff.getExpr()));
   } else {
     // FIXME: add support for other binary operators
     unsupportedOpWarn(BinOp->getOperatorLoc());
@@ -1622,10 +1665,31 @@ StmtDiff BaseForwardModeVisitor::VisitDeclStmt(const DeclStmt* DS) {
     // supported.
     if (typeDecl && (clad::utils::hasNonDifferentiableAttribute(typeDecl) ||
                      typeDecl->isLambda())) {
+      // When reconstructing the primal inside a pushforward, a lambda copied
+      // here would share its operator() body with the primal lambda emitted in
+      // the enclosing derivative. Rebuild it with a fresh closure. The
+      // top-level primal (forward mode) must keep the original closure so its
+      // generated pushforward method still resolves, hence the mode guard.
+      const bool inPushforward = m_DiffReq.Mode == DiffMode::pushforward ||
+                                 m_DiffReq.Mode == DiffMode::vector_pushforward;
       for (auto* D : DS->decls()) {
         assert(isa<VarDecl>(D) && "Mixed decl types in a single decl stmt is "
                                   "not standard c++ syntax");
-        decls.push_back(cast<VarDecl>(D));
+        auto* VDecl = cast<VarDecl>(D);
+        if (inPushforward && typeDecl->isLambda() && VDecl->getInit())
+          if (const auto* InnerLE =
+                  dyn_cast<LambdaExpr>(VDecl->getInit()->IgnoreImplicit())) {
+            Expr* ClonedLambda = buildClonedLambda(InnerLE);
+            QualType AutoTy = m_Context.getAutoDeductType();
+            TypeSourceInfo* TSI = m_Context.getTrivialTypeSourceInfo(AutoTy);
+            VarDecl* NewVD =
+                BuildVarDecl(AutoTy, VDecl->getNameAsString(), ClonedLambda,
+                             VDecl->isDirectInit(), TSI);
+            m_DeclReplacements[VDecl] = NewVD;
+            decls.push_back(NewVD);
+            continue;
+          }
+        decls.push_back(VDecl);
       }
       Stmt* DSClone = BuildDeclStmt(decls);
       return StmtDiff(DSClone, nullptr);
@@ -2145,8 +2209,10 @@ BaseForwardModeVisitor::VisitCXXConstructExpr(const CXXConstructExpr* CE) {
     auto valueAndPushforwardE = StoreAndRef(pushforwardCall);
     Expr* valueE = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
                                           valueAndPushforwardE, "value");
-    Expr* pushforwardE = utils::BuildMemberExpr(
-        m_Sema, getCurrentScope(), valueAndPushforwardE, "pushforward");
+    // Clone the base so `.value` and `.pushforward` own distinct nodes.
+    Expr* pushforwardE =
+        utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                               CloneNode(valueAndPushforwardE), "pushforward");
     return StmtDiff(valueE, pushforwardE);
   }
 
@@ -2235,7 +2301,10 @@ StmtDiff BaseForwardModeVisitor::VisitCXXTemporaryObjectExpr(
 
 StmtDiff
 BaseForwardModeVisitor::VisitCXXThisExpr(const clang::CXXThisExpr* CTE) {
-  return StmtDiff(const_cast<CXXThisExpr*>(CTE), m_ThisExprDerivative);
+  // m_ThisExprDerivative is a single cached `_d_this` ref; hand out a fresh
+  // clone so distinct uses do not share the same node.
+  return StmtDiff(const_cast<CXXThisExpr*>(CTE),
+                  CloneNode(m_ThisExprDerivative));
 }
 
 StmtDiff BaseForwardModeVisitor::VisitCXXNewExpr(const clang::CXXNewExpr* CNE) {

--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -48,6 +48,7 @@ endif(LLVM_EXTERNAL_CLAD_SOURCE_DIR)
 # (Ab)use llvm facilities for adding libraries.
 llvm_add_library(cladDifferentiator
   STATIC
+  ASTIntegrity.cpp
   ActivityAnalyzer.cpp
   AnalysisBase.cpp
   BaseForwardModeVisitor.cpp

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -6,6 +6,7 @@
 
 #include "clad/Differentiator/DerivativeBuilder.h"
 
+#include "ASTIntegrity.h"
 #include "JacobianModeVisitor.h"
 
 #include "clad/Differentiator/BaseForwardModeVisitor.h"
@@ -643,6 +644,28 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
       if (auto* OFD = result.overload)
         registerDerivative(OFD, m_Sema, request);
     }
+
+#if CLANG_VERSION_MAJOR > 16
+    // A generated derivative must be a proper tree in its Stmt child-edge
+    // structure: no node is the child (Stmt::children()) of two parents,
+    // because a later in-place edit of a shared node leaks into its other
+    // users (and a shared aggregate initializer breaks CodeGen). Below
+    // clang-17 buildClonedLambda cannot synthesize a fresh closure, so lambda
+    // derivatives legitimately share and this check is unreachable.
+    if (auto* FD = dyn_cast_or_null<clang::FunctionDecl>(result.derivative))
+      if (clang::Stmt* Body = FD->getBody()) {
+        const clang::Stmt* Shared = findSharedNode(Body);
+        // Debug asserts builds abort here; release builds keep the diagnostic
+        // so a sharing regression is not silently shipped.
+        assert(!Shared && "clad generated a derivative with a shared AST node");
+        if (Shared)
+          diag(DiagnosticsEngine::Warning, FD->getLocation(),
+               "clad internally reused a '%0' AST node while differentiating "
+               "%1; this is a clad bug -- please report it at "
+               "https://github.com/vgvassilev/clad")
+              << Shared->getStmtClassName() << FD;
+      }
+#endif
 
     return result;
   }

--- a/lib/Differentiator/ErrorEstimator.cpp
+++ b/lib/Differentiator/ErrorEstimator.cpp
@@ -39,6 +39,14 @@ DeclRefExpr* ErrorEstimationHandler::BuildFinalErrorExpr() {
   return m_RMV->BuildDeclRef(m_Params->back());
 }
 
+Expr* ErrorEstimationHandler::cloneIdxExpr() {
+  return m_RMV->CloneNode(m_IdxExpr);
+}
+
+Expr* ErrorEstimationHandler::cloneRetErrorExpr() {
+  return m_RMV->CloneNode(m_RetErrorExpr);
+}
+
 void ErrorEstimationHandler::BuildReturnErrorStmt() {
   // If we encountered any arithmetic expression in the return statement,
   // we must add its error to the final estimate.
@@ -46,7 +54,8 @@ void ErrorEstimationHandler::BuildReturnErrorStmt() {
     auto flitr =
         FloatingLiteral::Create(m_RMV->m_Context, llvm::APFloat(1.0), true,
                                 m_RMV->m_Context.DoubleTy, noLoc);
-    Expr* finExpr = AssignError(StmtDiff(m_RetErrorExpr, flitr), "return_expr");
+    Expr* finExpr =
+        AssignError(StmtDiff(cloneRetErrorExpr(), flitr), "return_expr");
     m_RMV->addToCurrentBlock(
         m_RMV->BuildOp(BO_AddAssign, BuildFinalErrorExpr(), finExpr),
         direction::forward);
@@ -88,8 +97,9 @@ void ErrorEstimationHandler::SaveReturnExpr(Expr* retExpr) {
     m_RMV->AddToGlobalBlock(m_RMV->BuildDeclStmt(retVarDecl));
     m_RetErrorExpr = m_RMV->BuildDeclRef(retVarDecl);
   }
-  m_RMV->addToCurrentBlock(m_RMV->BuildOp(BO_Assign, m_RetErrorExpr, retExpr),
-                           direction::forward);
+  m_RMV->addToCurrentBlock(
+      m_RMV->BuildOp(BO_Assign, cloneRetErrorExpr(), retExpr),
+      direction::forward);
 }
 
 void ErrorEstimationHandler::EmitNestedFunctionParamError(
@@ -104,10 +114,12 @@ void ErrorEstimationHandler::EmitNestedFunctionParamError(
     // // estimation.
     // if (utils::IsReferenceOrPointerType(fnDecl->getParamDecl(i)->getType()))
     //   continue;
-    auto* derefExpr = m_RMV->BuildOp(UO_Deref, ArgResult[i]);
-    Expr* errorExpr = AssignError({derivedCallArgs[i], derefExpr},
-                                  fnDecl->getNameInfo().getAsString() +
-                                      "_param_" + std::to_string(i));
+    // derivedCallArgs[i] and ArgResult[i] are also used in the derived call
+    // itself; clone them for the error expression so nodes are not shared.
+    auto* derefExpr = m_RMV->BuildOp(UO_Deref, m_RMV->CloneNode(ArgResult[i]));
+    Expr* errorExpr = AssignError(
+        {m_RMV->CloneNode(derivedCallArgs[i]), derefExpr},
+        fnDecl->getNameInfo().getAsString() + "_param_" + std::to_string(i));
     Expr* FinalError = BuildFinalErrorExpr();
     Expr* errorStmt = m_RMV->BuildOp(BO_AddAssign, FinalError, errorExpr);
     m_ReverseErrorStmts.push_back(errorStmt);
@@ -172,7 +184,10 @@ void ErrorEstimationHandler::EmitFinalErrorStmts(
       if (!m_RMV->isArrayOrPointerType(params[i]->getType())) {
         auto* paramClone = m_RMV->BuildDeclRef(decl);
         // Finally emit the error.
-        auto* errorExpr = GetError(paramClone, m_RMV->m_Variables[decl],
+        // Clone the operands: GetError embeds them in the error expression,
+        // which must not share nodes with the derivative statements.
+        auto* errorExpr = GetError(m_RMV->CloneNode(paramClone),
+                                   m_RMV->CloneNode(m_RMV->m_Variables[decl]),
                                    params[i]->getNameAsString());
         m_RMV->addToCurrentBlock(
             m_RMV->BuildOp(BO_AddAssign, BuildFinalErrorExpr(), errorExpr));
@@ -187,16 +202,23 @@ void ErrorEstimationHandler::EmitFinalErrorStmts(
                                   m_RMV->getZeroInit(m_RMV->m_Context.IntTy));
           m_IdxExpr = m_RMV->BuildDeclRef(idxExprDecl);
         }
-        Expr* Ldiff = nullptr;
-        Ldiff = m_RMV->BuildArraySubscript(LdiffExpr, m_IdxExpr);
+        // m_IdxExpr is the shared loop counter reused by both subscripts, the
+        // condition, the increment and the reset; clone at each use. Local
+        // lvalues are needed because BuildArraySubscript takes Idx by
+        // reference.
+        Expr* idxLdiff = cloneIdxExpr();
+        Expr* Ldiff = m_RMV->BuildArraySubscript(LdiffExpr, idxLdiff);
         auto* paramClone = m_RMV->BuildDeclRef(decl);
-        auto* LRepl = m_RMV->BuildArraySubscript(paramClone, m_IdxExpr);
+        Expr* idxLRepl = cloneIdxExpr();
+        auto* LRepl = m_RMV->BuildArraySubscript(paramClone, idxLRepl);
         // Build the loop to put in reverse mode.
-        Expr* errorExpr = GetError(LRepl, Ldiff, params[i]->getNameAsString());
+        Expr* errorExpr =
+            GetError(m_RMV->CloneNode(LRepl), m_RMV->CloneNode(Ldiff),
+                     params[i]->getNameAsString());
         Expr* finalAssignExpr =
             m_RMV->BuildOp(BO_AddAssign, BuildFinalErrorExpr(), errorExpr);
-        Expr* conditionExpr = m_RMV->BuildOp(BO_LE, m_IdxExpr, size);
-        Expr* incExpr = m_RMV->BuildOp(UO_PostInc, m_IdxExpr);
+        Expr* conditionExpr = m_RMV->BuildOp(BO_LE, cloneIdxExpr(), size);
+        Expr* incExpr = m_RMV->BuildOp(UO_PostInc, cloneIdxExpr());
         Stmt* ArrayParamLoop = new (m_RMV->m_Context)
             ForStmt(m_RMV->m_Context, nullptr, conditionExpr, nullptr, incExpr,
                     finalAssignExpr, noLoc, noLoc, noLoc);
@@ -205,7 +227,7 @@ void ErrorEstimationHandler::EmitFinalErrorStmts(
         // is not out first array.
         if (!idxExprDecl) {
           m_RMV->addToCurrentBlock(
-              m_RMV->BuildOp(BO_Assign, m_IdxExpr,
+              m_RMV->BuildOp(BO_Assign, cloneIdxExpr(),
                              m_RMV->getZeroInit(m_RMV->m_Context.IntTy)));
         } else {
           m_RMV->addToCurrentBlock(m_RMV->BuildDeclStmt(idxExprDecl));
@@ -225,7 +247,8 @@ void ErrorEstimationHandler::EmitUnaryOpErrorStmts(StmtDiff var,
     // If not, we don't care about it.
     if (ShouldEstimateErrorFor(cast<VarDecl>(DRE->getDecl()))) {
       Expr* erroExpr =
-          GetError(DRE, var.getExpr_dx(), DRE->getDecl()->getNameAsString());
+          GetError(m_RMV->CloneNode(DRE), m_RMV->CloneNode(var.getExpr_dx()),
+                   DRE->getDecl()->getNameAsString());
       AddErrorStmtToBlock(erroExpr);
     }
   }
@@ -239,7 +262,9 @@ void ErrorEstimationHandler::EmitBinaryOpErrorStmts(Expr* LExpr,
     return;
   if (m_ErrorFromFunctionCall)
     return;
-  Expr* errorExpr = GetError(LExpr, oldValue, decl->getNameAsString());
+  Expr* errorExpr =
+      GetError(m_RMV->CloneNode(LExpr), m_RMV->CloneNode(oldValue),
+               decl->getNameAsString());
   AddErrorStmtToBlock(errorExpr);
   // If there are assign statements to emit in reverse, do that.
   EmitErrorEstimationStmts(direction::reverse);
@@ -500,8 +525,11 @@ Expr* ErrorEstimationHandler::AssignError(StmtDiff refExpr,
     llvm::SmallVector<clang::Expr*, 3> callParams{
         refExpr.getExpr_dx(), refExpr.getExpr(),
         clad::utils::CreateStringLiteral(C, varName)};
+    // m_CustomErrorFunction is reused as the callee of every getErrorVal call
+    // (one per variable); clone so the calls do not share the reference.
     return S
-        .ActOnCallExpr(m_RMV->getCurrentScope(), m_CustomErrorFunction, noLoc,
+        .ActOnCallExpr(m_RMV->getCurrentScope(),
+                       m_RMV->CloneNode(m_CustomErrorFunction), noLoc,
                        callParams, noLoc)
         .get();
   }

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -357,7 +357,7 @@ DerivativeAndOverload HessianModeVisitor::Derive() {
             IntegerLiteral::Create(m_Context, offsetValue, size_type, noLoc);
         // Create a assignment expression to store the value of call expression
         // into the diagonalHessianVector with index HessianMatrixStartIndex.
-        Expr* SliceExprLHS = BuildOp(BO_Add, Result, OffsetArg);
+        Expr* SliceExprLHS = BuildOp(BO_Add, CloneNode(Result), OffsetArg);
         Expr* DerefExpr = BuildOp(UO_Deref, BuildParens(SliceExprLHS));
         Expr* AssignExpr = BuildOp(BO_Assign, DerefExpr, call);
         CompStmtSave.push_back(AssignExpr);
@@ -372,7 +372,7 @@ DerivativeAndOverload HessianModeVisitor::Derive() {
           Expr* OffsetArg =
               IntegerLiteral::Create(m_Context, offsetValue, size_type, noLoc);
           // Create the hessianMatrix + OffsetArg expression.
-          Expr* SliceExpr = BuildOp(BO_Add, Result, OffsetArg);
+          Expr* SliceExpr = BuildOp(BO_Add, CloneNode(Result), OffsetArg);
 
           DeclRefToParams.push_back(SliceExpr);
           columnIndex += indArgSize;

--- a/lib/Differentiator/JacobianModeVisitor.cpp
+++ b/lib/Differentiator/JacobianModeVisitor.cpp
@@ -182,8 +182,9 @@ DerivativeAndOverload JacobianModeVisitor::Derive() {
     if (m_DiffReq.DVI.size() > independentVarIndex &&
         m_DiffReq.DVI[independentVarIndex].param ==
             m_DiffReq->getParamDecl(i)) {
-      // Current offset for independent variable.
-      Expr* offsetExpr = arrayIndVarCountExpr;
+      // Current offset for independent variable. arrayIndVarCountExpr keeps
+      // accumulating below, so clone it for this offset use.
+      Expr* offsetExpr = CloneNode(arrayIndVarCountExpr);
       Expr* nonArrayIndVarCountExpr = ConstantFolder::synthesizeLiteral(
           m_Context.UnsignedLongTy, m_Context, nonArrayIndVarCount);
       if (!offsetExpr)
@@ -200,19 +201,22 @@ DerivativeAndOverload JacobianModeVisitor::Derive() {
         // Create an identity matrix for the parameter,
         // with number of rows equal to the size of the array,
         // and number of columns equal to the number of independent variables
-        llvm::SmallVector<Expr*, 3> args = {getSize, m_IndVarCountExpr,
-                                            offsetExpr};
+        llvm::SmallVector<Expr*, 3> args = {
+            getSize, CloneNode(m_IndVarCountExpr), offsetExpr};
         dVectorParam = BuildIdentityMatrixExpr(dParamType, args, loc);
 
-        // Update the array independent expression.
+        // Update the array independent expression. getSize is already used by
+        // the identity matrix above; clone it so the two do not share.
         if (!arrayIndVarCountExpr)
-          arrayIndVarCountExpr = getSize;
+          arrayIndVarCountExpr = CloneNode(getSize);
         else
-          arrayIndVarCountExpr = BuildOp(BinaryOperatorKind::BO_Add,
-                                         arrayIndVarCountExpr, getSize);
+          arrayIndVarCountExpr =
+              BuildOp(BinaryOperatorKind::BO_Add, arrayIndVarCountExpr,
+                      CloneNode(getSize));
       } else {
         // Create a one hot vector for the parameter.
-        llvm::SmallVector<Expr*, 2> args = {m_IndVarCountExpr, offsetExpr};
+        llvm::SmallVector<Expr*, 2> args = {CloneNode(m_IndVarCountExpr),
+                                            offsetExpr};
         dVectorParam = BuildCallExprToCladFunction("one_hot_vector", args,
                                                    {dParamType}, loc);
         ++nonArrayIndVarCount;
@@ -225,8 +229,9 @@ DerivativeAndOverload JacobianModeVisitor::Derive() {
         continue;
       // This parameter is not an independent variable.
       // Initialize by all zeros.
-      dVectorParam = BuildCallExprToCladFunction(
-          "zero_vector", {m_IndVarCountExpr}, {dParamType}, loc);
+      Expr* dCount = CloneNode(m_IndVarCountExpr);
+      dVectorParam = BuildCallExprToCladFunction("zero_vector", {dCount},
+                                                 {dParamType}, loc);
     }
 
     // For each function arg to be differentiated, create a variable

--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -81,15 +81,18 @@ DerivativeAndOverload ReverseModeForwPassVisitor::Derive() {
       m_ThisExprDerivative = dthisObj.getExpr();
       addToCurrentBlock(dthisObj.getStmt_dx());
       for (CXXCtorInitializer* CI : CD->inits()) {
-        StmtDiff CI_diff = DifferentiateCtorInit(CI, thisObj.getExpr());
+        // _this is reused by every initializer and the return below; clone it
+        // so each occurrence owns its node.
+        StmtDiff CI_diff =
+            DifferentiateCtorInit(CI, CloneNode(thisObj.getExpr()));
         addToCurrentBlock(CI_diff.getStmt(), direction::forward);
         addToCurrentBlock(CI_diff.getStmt_dx(), direction::forward);
       }
       // Build `return {*_this, *_d_this};`
       SourceLocation validLoc{CD->getBeginLoc()};
       llvm::SmallVector<Expr*, 2> returnArgs = {
-          BuildOp(UO_Deref, thisObj.getExpr()),
-          BuildOp(UO_Deref, dthisObj.getExpr())};
+          BuildOp(UO_Deref, CloneNode(thisObj.getExpr())),
+          BuildOp(UO_Deref, CloneNode(dthisObj.getExpr()))};
       Expr* returnInitList =
           m_Sema.ActOnInitList(validLoc, returnArgs, validLoc).get();
       ctorReturnStmt = m_Sema.BuildReturnStmt(validLoc, returnInitList).get();
@@ -224,8 +227,13 @@ StmtDiff ReverseModeForwPassVisitor::StoreAndRestore(clang::Expr* E,
     if (!VD->getType()->isReferenceType())
       return {};
   }
-  Expr* storeCall = BuildCallExprToMemFn(m_RestoreTracker,
-                                         /*MemberFunctionName=*/"store", {E});
+  // Clone both the tracker base (reused across every store call) and the stored
+  // expression E (the caller passes the same node it emits into the primal), so
+  // the store call is a distinct subtree.
+  Expr* storedE = CloneNode(E);
+  Expr* storeCall =
+      BuildCallExprToMemFn(CloneNode(m_RestoreTracker),
+                           /*MemberFunctionName=*/"store", {storedE});
   return {storeCall};
 }
 
@@ -283,8 +291,10 @@ StmtDiff ReverseModeForwPassVisitor::VisitDeclRefExpr(const DeclRefExpr* DRE) {
   auto* decl = dyn_cast<VarDecl>(clonedDRE->getDecl());
   auto foundAdjoint = m_Variables.find(decl);
   Expr* adjoint = nullptr;
+  // m_Variables caches a single adjoint reference per variable; hand out a
+  // fresh copy so repeated uses do not share the same node.
   if (foundAdjoint != m_Variables.end())
-    adjoint = foundAdjoint->second;
+    adjoint = CloneNode(foundAdjoint->second);
 
   return StmtDiff(clonedDRE, adjoint);
 }

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -5,6 +5,7 @@
 //------------------------------------------------------------------------------
 
 #include "clad/Differentiator/ReverseModeVisitor.h"
+#include "ASTIntegrity.h"
 #include "ConstantFolder.h"
 
 #include "TBRAnalyzer.h"
@@ -98,8 +99,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                         .BuildDeclarationNameExpr(CSS, Back,
                                                   /*AcceptInvalidDecl=*/false)
                         .get();
+    // Ref is reused by every push and back call on this tape; clone so each
+    // call owns its tape reference. A local lvalue is required: the single
+    // element is passed as a MultiExprArg, which stores a pointer to it.
+    Expr* RefClone = V.CloneNode(Ref);
     Expr* Call =
-        V.m_Sema.ActOnCallExpr(V.getCurrentScope(), BackDRE, noLoc, Ref, noLoc)
+        V.m_Sema
+            .ActOnCallExpr(V.getCurrentScope(), BackDRE, noLoc, RefClone, noLoc)
             .get();
     return Call;
   }
@@ -137,14 +143,16 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     Expr* PopExpr =
         m_Sema.ActOnCallExpr(getCurrentScope(), PopDRE, noLoc, TapeRef, noLoc)
             .get();
-    Expr* CallArgs[] = {TapeRef, E};
+    // pop, push and the returned last-ref each get their own tape DeclRef so
+    // the same node is not parented by both the push and pop CallExprs.
+    Expr* CallArgs[] = {CloneNode(TapeRef), E};
     Expr* PushExpr =
         m_Sema.ActOnCallExpr(getCurrentScope(), PushDRE, noLoc, CallArgs, noLoc)
             .get();
 
     if (isInsideOMPBlock)
       MarkDeclThreadPrivate(VD);
-    return CladTapeResult{*this, PushExpr, PopExpr, TapeRef};
+    return CladTapeResult{*this, PushExpr, PopExpr, CloneNode(TapeRef)};
   }
 
   bool ReverseModeVisitor::shouldUseCudaAtomicOps(const Expr* E) {
@@ -227,6 +235,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     return atomicAddCall;
   }
 
+  // Both LHS (the memset destination) and the size expression are cloned here:
+  // callers pass the derived pointer they also assign to and the malloc/realloc
+  // size they also pass to that call, so cloning keeps the memset a distinct
+  // subtree.
   Expr* ReverseModeVisitor::CheckAndBuildCallToMemset(Expr* LHS, Expr* RHS) {
     Expr* size = nullptr;
     if (auto* callExpr = dyn_cast_or_null<CallExpr>(RHS))
@@ -240,8 +252,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         }
 
     if (size) {
-      llvm::SmallVector<Expr*, 3> args = {LHS, getZeroInit(m_Context.IntTy),
-                                          size};
+      llvm::SmallVector<Expr*, 3> args = {
+          CloneNode(LHS), getZeroInit(m_Context.IntTy), CloneNode(size)};
       return GetFunctionCall("memset", "", args);
     }
 
@@ -472,7 +484,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       }
 
       for (CXXCtorInitializer* CI : CD->inits()) {
-        StmtDiff CI_diff = DifferentiateCtorInit(CI, thisObj.getExpr());
+        // _this is reused by every initializer; clone so each owns its node.
+        StmtDiff CI_diff =
+            DifferentiateCtorInit(CI, CloneNode(thisObj.getExpr()));
         addToCurrentBlock(CI_diff.getStmt(), direction::forward);
         if (Stmt* unwrappedCIDiff =
                 utils::unwrapIfSingleStmt(CI_diff.getRevSweepStmt()))
@@ -539,8 +553,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     param[0] = BuildDeclRef(thisDecl);
     Expr* setCall = nullptr;
     if (isDerivedThis) {
+      // size already parents the malloc call above; clone for the memset.
       llvm::SmallVector<Expr*, 3> args = {BuildDeclRef(thisDecl),
-                                          getZeroInit(m_Context.IntTy), size};
+                                          getZeroInit(m_Context.IntTy),
+                                          CloneNode(size)};
       setCall = GetFunctionCall("memset", "", args);
     } else
       setCall = GetFunctionCall("free", "", param);
@@ -564,7 +580,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // ```
     if (!CI->isMemberInitializer()) {
       beginBlock(direction::reverse);
-      Expr* dthisObj = BuildOp(UO_Deref, m_ThisExprDerivative);
+      Expr* dthisObj = BuildOp(UO_Deref, CloneNode(m_ThisExprDerivative));
       StmtDiff initDiff = Visit(CI->getInit(), dthisObj);
       // Build the placement new.
       Expr* initCall = nullptr;
@@ -601,14 +617,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       return {initCall, nullptr, block};
     }
     llvm::StringRef fieldName = CI->getMember()->getName();
-    Expr* memberDiff = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
-                                              m_ThisExprDerivative, fieldName);
+    Expr* memberDiff = utils::BuildMemberExpr(
+        m_Sema, getCurrentScope(), CloneNode(m_ThisExprDerivative), fieldName);
 
     beginBlock(direction::reverse);
     QualType memberTy = CI->getMember()->getType();
     if (memberTy->isRealType()) {
-      Stmt* assign_zero =
-          BuildOp(BO_Assign, memberDiff, getZeroInit(memberDiff->getType()));
+      Stmt* assign_zero = BuildOp(BO_Assign, CloneNode(memberDiff),
+                                  getZeroInit(memberDiff->getType()));
       addToCurrentBlock(assign_zero, direction::reverse);
     }
     StmtDiff initDiff = Visit(CI->getInit(), memberDiff);
@@ -619,8 +635,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       Expr* member = utils::BuildMemberExpr(m_Sema, getCurrentScope(), thisExpr,
                                             fieldName);
       init = BuildOp(BO_Assign, member, initDiff.getExpr());
-      Expr* memberDx = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
-                                              m_ThisExprDerivative, fieldName);
+      Expr* memberDx =
+          utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                 CloneNode(m_ThisExprDerivative), fieldName);
       if (!memberDx->getType()->isRealType())
         initDx = BuildOp(BO_Assign, memberDx, initDiff.getExpr_dx());
     }
@@ -900,9 +917,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     StmtDiff thenDiff = VisitBranch(If->getThen());
     StmtDiff elseDiff = VisitBranch(If->getElse());
+    // The stored condition reference (_condN) is consumed by the forward if,
+    // the reverse if, and the returned reverse-sweep value. Insert a fresh
+    // clone at each so the node is never parented more than once.
     Stmt* Forward = clad_compat::IfStmt_Create(
         m_Context, noLoc, If->isConstexpr(), /*Init=*/nullptr, /*Var=*/nullptr,
-        condDiffStored, noLoc, noLoc, thenDiff.getStmt(), noLoc,
+        CloneNode(condDiffStored), noLoc, noLoc, thenDiff.getStmt(), noLoc,
         elseDiff.getStmt());
     addToCurrentBlock(Forward, direction::forward);
 
@@ -912,21 +932,21 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     if (thenDiff.getStmt_dx())
       Reverse = clad_compat::IfStmt_Create(
           m_Context, noLoc, If->isConstexpr(), /*Init=*/nullptr,
-          /*Var=*/nullptr, condDiffStored, noLoc, noLoc, thenDiff.getStmt_dx(),
-          noLoc, elseDiff.getStmt_dx());
+          /*Var=*/nullptr, CloneNode(condDiffStored), noLoc, noLoc,
+          thenDiff.getStmt_dx(), noLoc, elseDiff.getStmt_dx());
     else if (elseDiff.getStmt_dx())
       Reverse = clad_compat::IfStmt_Create(
           m_Context, noLoc, If->isConstexpr(), /*Init=*/nullptr,
           /*Var=*/nullptr,
           BuildOp(clang::UnaryOperatorKind::UO_LNot,
-                  BuildParens(condDiffStored)),
+                  BuildParens(CloneNode(condDiffStored))),
           noLoc, noLoc, elseDiff.getStmt_dx(), noLoc, {});
     addToCurrentBlock(Reverse, direction::reverse);
     CompoundStmt* ForwardBlock = endBlock(direction::forward);
     CompoundStmt* ReverseBlock = endBlock(direction::reverse);
     return StmtDiff(utils::unwrapIfSingleStmt(ForwardBlock),
                     utils::unwrapIfSingleStmt(ReverseBlock),
-                    /*valueForRevSweep=*/condDiffStored);
+                    /*valueForRevSweep=*/CloneNode(condDiffStored));
   }
 
   StmtDiff ReverseModeVisitor::VisitConditionalOperator(
@@ -984,27 +1004,30 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                                         Else);
     };
 
-    Stmt* Forward =
-        BuildIf(condStored, ifTrueDiff.getStmt(), ifFalseDiff.getStmt());
-    Stmt* Reverse =
-        BuildIf(condStored, ifTrueDiff.getStmt_dx(), ifFalseDiff.getStmt_dx());
+    // Fresh clone of the stored condition per consumer (forward if, reverse if,
+    // and each conditional operator) so it is never parented twice.
+    Stmt* Forward = BuildIf(CloneNode(condStored), ifTrueDiff.getStmt(),
+                            ifFalseDiff.getStmt());
+    Stmt* Reverse = BuildIf(CloneNode(condStored), ifTrueDiff.getStmt_dx(),
+                            ifFalseDiff.getStmt_dx());
     if (Forward)
       addToCurrentBlock(Forward, direction::forward);
     if (Reverse)
       addToCurrentBlock(Reverse, direction::reverse);
 
-    Expr* condExpr = m_Sema
-                         .ActOnConditionalOp(noLoc, noLoc, condStored,
-                                             ifTrueExprDiff.getExpr(),
-                                             ifFalseExprDiff.getExpr())
-                         .get();
+    Expr* condExpr =
+        m_Sema
+            .ActOnConditionalOp(noLoc, noLoc, CloneNode(condStored),
+                                ifTrueExprDiff.getExpr(),
+                                ifFalseExprDiff.getExpr())
+            .get();
     // If result is a glvalue, we should keep it as it can potentially be
     // assigned as in (c ? a : b) = x;
     Expr* ResultRef = nullptr;
     if ((CO->isModifiableLvalue(m_Context) == Expr::MLV_Valid) &&
         ifTrueExprDiff.getExpr_dx() && ifFalseExprDiff.getExpr_dx()) {
       ResultRef = m_Sema
-                      .ActOnConditionalOp(noLoc, noLoc, condStored,
+                      .ActOnConditionalOp(noLoc, noLoc, CloneNode(condStored),
                                           ifTrueExprDiff.getExpr_dx(),
                                           ifFalseExprDiff.getExpr_dx())
                       .get();
@@ -1069,9 +1092,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     llvm::SaveAndRestore<bool> SaveIsInsideLoop(isInsideLoop,
                                                 /*NewValue=*/true);
 
+    // beginDeclRef and d_beginDeclRef are each reused across the increment,
+    // decrement, condition and deref below; clone at the later uses so the
+    // iterator references are not shared.
     Expr* d_incBegin = BuildOp(UO_PreInc, d_beginDeclRef);
-    Expr* d_decBegin = BuildOp(UO_PostDec, d_beginDeclRef);
-    Expr* forwardCond = BuildOp(BO_NE, beginDeclRef, endExpr);
+    Expr* d_decBegin = BuildOp(UO_PostDec, CloneNode(d_beginDeclRef));
+    Expr* forwardCond = BuildOp(BO_NE, CloneNode(beginDeclRef), endExpr);
     const Stmt* body = FRS->getBody();
     StmtDiff bodyDiff =
         DifferentiateLoopBody(body, loopCounter, nullptr, nullptr,
@@ -1099,8 +1125,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     Expr* d_LoopVD = nullptr;
     if (!LoopVD->getType()->isReferenceType() && LoopVDDiff.getDecl_dx()) {
       d_LoopVD = BuildDeclRef(LoopVDDiff.getDecl_dx());
-      adjLoopVDAddAssign =
-          BuildOp(BO_Assign, d_LoopVD, BuildOp(UO_Deref, d_beginDeclRef));
+      adjLoopVDAddAssign = BuildOp(
+          BO_Assign, d_LoopVD, BuildOp(UO_Deref, CloneNode(d_beginDeclRef)));
     }
 
     beginBlock(direction::forward);
@@ -1268,10 +1294,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       addToCurrentBlock(RevIfStmt, direction::reverse);
 
       if (m_CurrentBreakFlagExpr) {
-        Expr* loopBreakFlagCond =
-            BuildOp(BinaryOperatorKind::BO_LOr,
-                    BuildOp(UnaryOperatorKind::UO_LNot, CounterCondition),
-                    BuildParens(m_CurrentBreakFlagExpr));
+        // CounterCondition was already consumed by the RevIfStmt above; clone
+        // it so the two guards do not share the negated condition.
+        Expr* loopBreakFlagCond = BuildOp(
+            BinaryOperatorKind::BO_LOr,
+            BuildOp(UnaryOperatorKind::UO_LNot, CloneNode(CounterCondition)),
+            BuildParens(CloneNode(m_CurrentBreakFlagExpr)));
         auto* RevIfStmt = clad_compat::IfStmt_Create(
             m_Context, noLoc, false, nullptr, nullptr, loopBreakFlagCond, noLoc,
             noLoc, condDiff.getStmt_dx(), noLoc, nullptr);
@@ -1409,15 +1437,19 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, i);
       Expr* elemDfDx = dfdx();
       if (dfdx()) {
+        // dfdx() is the aggregate adjoint reused as the base for every element;
+        // clone it so each element access owns its base.
         if (ILEType->isArrayType()) {
-          elemDfDx = m_Sema
-                         .ActOnArraySubscriptExpr(getCurrentScope(), dfdx(),
-                                                  noLoc, I, noLoc)
-                         .get();
+          elemDfDx =
+              m_Sema
+                  .ActOnArraySubscriptExpr(getCurrentScope(), CloneNode(dfdx()),
+                                           noLoc, I, noLoc)
+                  .get();
         } else if (ILEType->isRecordType()) {
           auto field_iterator = ILEType->getAsCXXRecordDecl()->field_begin();
           std::advance(field_iterator, i);
-          elemDfDx = utils::BuildMemberExpr(m_Sema, getCurrentScope(), dfdx(),
+          elemDfDx = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                            CloneNode(dfdx()),
                                             (*field_iterator)->getName());
         }
       }
@@ -1440,9 +1472,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     Expr* base = E;
     if (auto* UO = dyn_cast<UnaryOperator>(E))
       base = UO->getSubExpr()->IgnoreImpCasts();
+    // dfdx() is the top-of-stack adjoint seed, a node shared by every leaf it
+    // reaches (e.g. `_d_a += dfdx` and `_d_b += dfdx` for `a + b`). Clone it so
+    // each increment owns its subtree, since a shared node corrupts codegen
+    // once edited in place.
     if (shouldUseCudaAtomicOps(base))
-      return BuildCallToCudaAtomicAdd(E, dfdx());
-    return BuildOp(BO_AddAssign, E, dfdx());
+      return BuildCallToCudaAtomicAdd(E, CloneNode(dfdx()));
+    return BuildOp(BO_AddAssign, E, CloneNode(dfdx()));
   }
 
   StmtDiff
@@ -1460,16 +1496,23 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       reverseIndices[i] = IdxDiff.getExpr();
     }
     auto* cloned = BuildArraySubscript(BaseDiff.getExpr(), clonedIndices);
+    // Clone the base: it is already consumed by `cloned` above.
     auto* valueForRevSweep =
-        BuildArraySubscript(BaseDiff.getExpr(), reverseIndices);
+        BuildArraySubscript(CloneNode(BaseDiff.getExpr()), reverseIndices);
     Expr* target = BaseDiff.getExpr_dx();
     if (!target)
       return cloned;
     Expr* result = nullptr;
-    // Create the target[idx] expression.
-    result = BuildArraySubscript(target, reverseIndices);
-    // Create the (target += dfdx) statement.
-    if (Expr* add_assign = BuildDiffIncrement(result))
+    // Create the target[idx] expression. reverseIndices are consumed by
+    // valueForRevSweep above, so clone them for this subscript.
+    llvm::SmallVector<Expr*, 4> resultIndices(reverseIndices.size());
+    std::transform(reverseIndices.begin(), reverseIndices.end(),
+                   resultIndices.begin(),
+                   [this](Expr* E) { return CloneNode(E); });
+    result = BuildArraySubscript(target, resultIndices);
+    // Create the (target += dfdx) statement. result is also returned as the
+    // adjoint below, so clone it for the increment to avoid sharing.
+    if (Expr* add_assign = BuildDiffIncrement(CloneNode(result)))
       addToCurrentBlock(add_assign, direction::reverse);
     if (m_ExternalSource)
       m_ExternalSource->ActAfterProcessingArraySubscriptExpr(valueForRevSweep);
@@ -1538,23 +1581,32 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         }
       }
 
-      // Create the (_d_param[idx] += dfdx) statement.
-      if (Expr* add_assign = BuildDiffIncrement(dExpr))
+      // m_Variables caches one adjoint reference per variable; insert a fresh
+      // clone for the increment and another for the returned reverse-sweep
+      // expression so the cached node is never parented twice (the FIXME
+      // above). dExpr is a plain DeclRefExpr/deref (not a delayed-store
+      // placeholder), so it is safe to clone. Create the (_d_param[idx] +=
+      // dfdx) statement.
+      if (Expr* add_assign = BuildDiffIncrement(CloneNode(dExpr)))
         addToCurrentBlock(add_assign, direction::reverse);
-      return StmtDiff(clonedDRE, dExpr);
+      // getExpr (forward rebuild) and the reverse-sweep value are consumed by
+      // different statements, so hand out distinct clones of the primal ref.
+      return StmtDiff(clonedDRE, CloneNode(dExpr), CloneNode(clonedDRE));
     }
 
-    return StmtDiff(clonedDRE);
+    return StmtDiff(clonedDRE, /*diff=*/nullptr, CloneNode(clonedDRE));
   }
 
   StmtDiff ReverseModeVisitor::VisitIntegerLiteral(const IntegerLiteral* IL) {
     auto* Constant0 =
         ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, 0);
-    return StmtDiff(Clone(IL), Constant0);
+    // Distinct forward and reverse-sweep copies so a parent consuming both
+    // does not share the literal node.
+    return StmtDiff(Clone(IL), Constant0, Clone(IL));
   }
 
   StmtDiff ReverseModeVisitor::VisitFloatingLiteral(const FloatingLiteral* FL) {
-    return StmtDiff(Clone(FL), getZeroInit(FL->getType()));
+    return StmtDiff(Clone(FL), getZeroInit(FL->getType()), Clone(FL));
   }
 
   static bool isNAT(QualType T) {
@@ -1666,15 +1718,17 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         // Add calls to cudaMalloc, cudaMemset, cudaMemcpy, and cudaFree
         PreCallStmts.push_back(BuildDeclStmt(dArgDeclCUDA));
         Expr* refOp = BuildOp(UO_AddrOf, BuildDeclRef(dArgDeclCUDA));
+        // sizeLiteral is consumed by three separate calls; clone it for the
+        // second and third so each owns its node.
         llvm::SmallVector<Expr*, 3> mallocArgs = {refOp, sizeLiteral};
         PreCallStmts.push_back(GetFunctionCall("cudaMalloc", "", mallocArgs));
         llvm::SmallVector<Expr*, 3> memsetArgs = {BuildDeclRef(dArgDeclCUDA),
                                                   getZeroInit(m_Context.IntTy),
-                                                  sizeLiteral};
+                                                  CloneNode(sizeLiteral)};
         PreCallStmts.push_back(GetFunctionCall("cudaMemset", "", memsetArgs));
         llvm::SmallVector<Expr*, 4> cudaMemcpyArgs = {
             BuildOp(UO_AddrOf, dArgRef), BuildDeclRef(dArgDeclCUDA),
-            sizeLiteral, deviceToHostExpr};
+            CloneNode(sizeLiteral), deviceToHostExpr};
         addToCurrentBlock(GetFunctionCall("cudaMemcpy", "", cudaMemcpyArgs),
                           direction::reverse);
         llvm::SmallVector<Expr*, 3> freeArgs = {BuildDeclRef(dArgDeclCUDA)};
@@ -1739,7 +1793,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     bool passByRef = paramTy->isLValueReferenceType() &&
                      !paramTy.getNonReferenceType().isConstQualified();
     if (passByRef && m_DiffReq.shouldBeRecorded(arg)) {
-      StmtDiff pushPop = StoreAndRestore(argDiff.getExpr());
+      // argDiff.getExpr() is also returned below as the call argument; clone
+      // it for the store/restore so the node is not shared with the call.
+      StmtDiff pushPop = StoreAndRestore(CloneNode(argDiff.getExpr()));
       addToCurrentBlock(pushPop.getStmt());
       PreCallStmts.push_back(pushPop.getStmt_dx());
     }
@@ -1888,7 +1944,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     ReverseModeVisitor NestedVisitor(m_Builder, LambdaReq);
     Expr* lambdaE = NestedVisitor.buildDerivedLambda(LE);
 
-    return {cast<Expr>(Clone(LE)), lambdaE};
+    // Build the primal with a fresh closure so it does not share the operator()
+    // body with the original lambda (or with a second primal clone emitted in
+    // the derivative lambda).
+    return {buildClonedLambda(LE), lambdaE};
   }
 #endif // CLANG_VERSION_MAJOR
   StmtDiff ReverseModeVisitor::VisitCallExpr(const CallExpr* CE) {
@@ -2128,12 +2187,17 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           // attempt to store the base manually
           bool isCopiable = utils::isCopyable(MD->getParent());
           if (!usingRestoreTracker && isCopiable) {
-            if (baseExpr->getType()->isPointerType())
-              baseExpr = BuildOp(UO_Deref, baseExpr);
+            // baseExpr is already in CallArgs; the record/restore below needs
+            // its own copy of the base so the stored temp and the restore
+            // assignment do not share nodes with the call argument.
+            Expr* recBase = baseExpr->getType()->isPointerType()
+                                ? BuildOp(UO_Deref, CloneNode(baseExpr))
+                                : CloneNode(baseExpr);
             Expr* baseDiffStore =
-                GlobalStoreAndRef(baseExpr, "_t", /*force=*/true);
-            if (baseDiffStore != baseExpr) {
-              Expr* assign = BuildOp(BO_Assign, baseExpr, baseDiffStore);
+                GlobalStoreAndRef(recBase, "_t", /*force=*/true);
+            if (baseDiffStore != recBase) {
+              Expr* assign =
+                  BuildOp(BO_Assign, CloneNode(recBase), baseDiffStore);
               PreCallStmts.push_back(assign);
             }
           }
@@ -2142,7 +2206,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           if (!baseDerivative->getType()->isPointerType())
             baseDerivative = BuildOp(UO_AddrOf, baseDerivative);
           CallArgDx.push_back(baseDerivative);
-          revForwAdjointArgs.push_back(baseDerivative);
+          // revForwAdjointArgs feeds the reverse-forward call while CallArgDx
+          // feeds the pullback; clone so the same `&_d_base` is not parented by
+          // both calls.
+          revForwAdjointArgs.push_back(CloneNode(baseDerivative));
         }
       }
     }
@@ -2178,10 +2245,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       }
       CallArgs.push_back(finalArg);
 
+      // finalArg is already in CallArgs (the forward primal call); clone so the
+      // reverse-forward call does not share the same argument node.
       if (elideReverseForw && PVD->getType()->isIntegerType())
-        revForwAdjointArgs.push_back(finalArg);
+        revForwAdjointArgs.push_back(CloneNode(finalArg));
       else
-        revForwAdjointArgs.push_back(argDiff.getRevSweepAsExpr());
+        revForwAdjointArgs.push_back(CloneNode(argDiff.getRevSweepAsExpr()));
 
       CallArgDx.push_back(argDiff.getExpr_dx());
       if (m_DiffReq.shouldBeRecorded(arg))
@@ -2191,8 +2260,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     Expr* OverloadedDerivedFn = nullptr;
     bool hasDynamicNonDiffParams = false;
     if (!nonDiff && m_DiffReq.Mode != DiffMode::reverse_mode_forward_pass) {
-      // Build the args for the pullback
-      llvm::SmallVector<Expr*, 16> pullbackCallArgs = CallArgs;
+      // Build the args for the pullback. Clone each so the pullback call and
+      // the forward primal call (built below from CallArgs) do not share arg
+      // nodes -- the same node would otherwise be parented twice. Aggregate and
+      // array args are safe to clone now that StmtClone copies InitListExpr
+      // structurally instead of re-running Sema.
+      llvm::SmallVector<Expr*, 16> pullbackCallArgs;
+      for (Expr* arg : CallArgs)
+        pullbackCallArgs.push_back(CloneNode(arg));
       if (!(utils::isNonConstReferenceType(returnType) ||
             returnType->isPointerType() || returnType->isVoidType())) {
         if (Expr* pullback = dfdx())
@@ -2289,7 +2364,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                 OverloadedDerivedFn->getType()))
           OverloadedDerivedFn = utils::BuildMemberExpr(
               m_Sema, getCurrentScope(), OverloadedDerivedFn, "pushforward");
-        Expr* d = BuildOp(BO_Mul, dfdx(), OverloadedDerivedFn);
+        Expr* d = BuildOp(BO_Mul, CloneNode(dfdx()), OverloadedDerivedFn);
         auto* UnOp = cast<UnaryOperator>(CallArgDx[0]);
         OverloadedDerivedFn =
             BuildOp(BO_AddAssign, Clone(UnOp->getSubExpr()), d);
@@ -2350,9 +2425,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         if (auto* addrOp = dyn_cast<UnaryOperator>(revForwAdjointArgs[0]))
           if (addrOp->getOpcode() == UO_AddrOf)
             revForwAdjointArgs[0] = addrOp->getSubExpr(); // get the pointer
-        llvm::SmallVector<Expr*, 3> args = {revForwAdjointArgs[0],
+        // Both the pointer (still inside call_dx's `&ptr`) and the size
+        // (call_dx's second argument) belong to the cudaMalloc call_dx; clone
+        // them so the cudaMemset owns its own nodes.
+        llvm::SmallVector<Expr*, 3> args = {CloneNode(revForwAdjointArgs[0]),
                                             getZeroInit(m_Context.IntTy),
-                                            revForwAdjointArgs[1]};
+                                            CloneNode(revForwAdjointArgs[1])};
         addToCurrentBlock(call_dx, direction::forward);
         addToCurrentBlock(GetFunctionCall("cudaMemset", "", args));
         call_dx = nullptr;
@@ -2410,9 +2488,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           block.insert(it, restoreCall);
         }
       }
-      // Add the tracker as the last argument of the reverse_forw.
+      // Add the tracker as the last argument of the reverse_forw. A propagated
+      // m_RestoreTracker is reused across nested reverse_forw calls; clone it.
       if (trackerExpr)
-        CallArgs.push_back(trackerExpr);
+        CallArgs.push_back(CloneNode(trackerExpr));
       call =
           BuildCallExprToFunction(calleeFnForwPassFD, CallArgs, CUDAExecConfig);
       if (!needsForwPass ||
@@ -2426,8 +2505,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         callRes = StoreAndRef(call);
       auto* resValue =
           utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");
-      auto* resAdjoint =
-          utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "adjoint");
+      // Clone the base so `_t0.value` and `_t0.adjoint` own distinct nodes.
+      auto* resAdjoint = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                                CloneNode(callRes), "adjoint");
       if (Expr* add_assign = BuildDiffIncrement(resAdjoint)) {
         Stmts& block = getCurrentBlock(direction::reverse);
         it = std::begin(block) + insertionPoint;
@@ -2484,13 +2564,16 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       Expr* idx =
           ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, i);
       Expr* gradElem = BuildArraySubscript(gradRef, {idx});
-      Expr* gradExpr = BuildOp(BO_Mul, dfdx, gradElem);
+      // dfdx is reused for every argument; clone so the products do not share.
+      Expr* gradExpr = BuildOp(BO_Mul, CloneNode(dfdx), gradElem);
       // Inputs were not pointers, so the output args are not in global GPU
       // memory. Hence, no need to use atomic ops.
       Expr* dArgE = cast<UnaryOperator>(outputArgs[i])->getSubExpr();
       auto* dArgVD = cast<VarDecl>(cast<DeclRefExpr>(dArgE)->getDecl());
       SetDeclInit(dArgVD, gradExpr);
-      NumDiffArgs.push_back(args[i]);
+      // args[i] is also embedded in targetFuncCall (the reconstructed primal
+      // call); clone so the numerical-diff call does not share the node.
+      NumDiffArgs.push_back(CloneNode(args[i]));
     }
     std::string Name = "central_difference";
     Expr* call = m_Builder.BuildCallToCustomDerivativeOrNumericalDiff(
@@ -2531,14 +2614,18 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     } else if (opCode == UO_PostInc || opCode == UO_PostDec) {
       diff = Visit(E, dfdx());
       Expr* diff_dx = diff.getExpr_dx();
+      // diff_dx (the adjoint pointer) is mirrored in the forward and reverse
+      // passes and also returned as ResultRef; clone at each op so the three
+      // uses do not share the node.
       if (isPointerOp)
-        addToCurrentBlock(BuildOp(opCode, diff_dx), direction::forward);
+        addToCurrentBlock(BuildOp(opCode, CloneNode(diff_dx)),
+                          direction::forward);
       auto op = opCode == UO_PostInc ? UO_PostDec : UO_PostInc;
       if (m_DiffReq.shouldBeRecorded(E))
         addToCurrentBlock(BuildOp(op, Clone(diff.getRevSweepAsExpr())),
                           direction::reverse);
       if (isPointerOp)
-        addToCurrentBlock(BuildOp(op, diff_dx), direction::reverse);
+        addToCurrentBlock(BuildOp(op, CloneNode(diff_dx)), direction::reverse);
 
       ResultRef = diff_dx;
       valueForRevPass = diff.getRevSweepAsExpr();
@@ -2547,14 +2634,17 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     } else if (opCode == UO_PreInc || opCode == UO_PreDec) {
       diff = Visit(E, dfdx());
       Expr* diff_dx = diff.getExpr_dx();
+      // Clone the adjoint pointer for the forward and reverse mirror ops so
+      // they do not share the node (see the post-inc/dec case above).
       if (isPointerOp)
-        addToCurrentBlock(BuildOp(opCode, diff_dx), direction::forward);
+        addToCurrentBlock(BuildOp(opCode, CloneNode(diff_dx)),
+                          direction::forward);
       auto op = opCode == UO_PreInc ? UO_PreDec : UO_PreInc;
       if (m_DiffReq.shouldBeRecorded(E))
         addToCurrentBlock(BuildOp(op, Clone(diff.getRevSweepAsExpr())),
                           direction::reverse);
       if (isPointerOp)
-        addToCurrentBlock(BuildOp(op, diff_dx), direction::reverse);
+        addToCurrentBlock(BuildOp(op, CloneNode(diff_dx)), direction::reverse);
       auto binOp = opCode == UO_PreInc ? BinaryOperatorKind::BO_Add
                                        : BinaryOperatorKind::BO_Sub;
       auto* sum = BuildOp(
@@ -2634,15 +2724,17 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       Ldiff = Visit(L, dfdx());
       // dxi/xr = 1.0
       // df/dxr += df/dxi * dxi/xr = df/dxi
-      Rdiff = Visit(R, dfdx());
+      // Clone the seed: both operands receive dfdx() and may place it directly
+      // (e.g. as a pullback seed), which would share the node.
+      Rdiff = Visit(R, CloneNode(dfdx()));
     } else if (opCode == BO_Sub) {
       // xi = xl - xr
       // dxi/xl = 1.0
       // df/dxl += df/dxi * dxi/xl = df/dxi
       Ldiff = Visit(L, dfdx());
       // dxi/xr = -1.0
-      // df/dxl += df/dxi * dxi/xr = -df/dxi
-      auto* dr = BuildOp(UO_Minus, dfdx());
+      // df/dxl += df/dxi * dxi/xr = -df/dxi. Clone the seed (see BO_Add).
+      auto* dr = BuildOp(UO_Minus, CloneNode(dfdx()));
       Rdiff = Visit(R, dr);
     } else if (opCode == BO_Mul) {
       // xi = xl * xr
@@ -2658,7 +2750,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
       Expr* dl = nullptr;
       if (dfdx())
-        dl = BuildOp(BO_Mul, dfdx(), RResult.getRevSweepAsExpr());
+        dl = BuildOp(BO_Mul, CloneNode(dfdx()),
+                     CloneNode(RResult.getRevSweepAsExpr()));
       Ldiff = Visit(L, dl);
       // dxi/xr = xl
       // df/dxr += df/dxi * dxi/xr = df/dxi * xl
@@ -2677,7 +2770,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       Stmt* LPop = endBlock(direction::reverse);
       Expr* dr = nullptr;
       if (dfdx())
-        dr = BuildOp(BO_Mul, LStored.getRevSweepAsExpr(), dfdx());
+        dr = BuildOp(BO_Mul, CloneNode(LStored.getRevSweepAsExpr()), dfdx());
       Rdiff = Visit(R, dr);
       // Assign right multiplier's variable with R.
       RDelayed.Finalize(Rdiff.getExpr());
@@ -2695,7 +2788,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         RRev = StoreAndRef(RRev, direction::reverse);
       Expr* dl = nullptr;
       if (dfdx())
-        dl = BuildOp(BO_Div, dfdx(), Clone(RRev));
+        dl = BuildOp(BO_Div, CloneNode(dfdx()), CloneNode(RRev));
       Ldiff = Visit(L, dl);
       StmtDiff LStored = Ldiff;
       // Catch the pop statement and emit it after
@@ -2718,11 +2811,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         // produced instead of 1 / (R * R).
         Expr* dr = nullptr;
         if (dfdx()) {
-          Expr* RxR = BuildParens(BuildOp(BO_Mul, RRev, Clone(RRev)));
-          dr = BuildOp(BO_Mul, dfdx(),
-                       BuildOp(UO_Minus,
-                               BuildParens(BuildOp(
-                                   BO_Div, LStored.getRevSweepAsExpr(), RxR))));
+          Expr* RxR =
+              BuildParens(BuildOp(BO_Mul, CloneNode(RRev), CloneNode(RRev)));
+          dr = BuildOp(
+              BO_Mul, dfdx(),
+              BuildOp(
+                  UO_Minus,
+                  BuildParens(BuildOp(
+                      BO_Div, CloneNode(LStored.getRevSweepAsExpr()), RxR))));
           dr = StoreAndRef(dr, direction::reverse);
         }
         Rdiff = Visit(R, dr);
@@ -2745,7 +2841,11 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         utils::GetInnermostReturnExpr(E, returnExprs);
         if (returnExprs.size() == 1) {
           addToCurrentBlock(E, direction::forward);
-          Ldiff.updateStmt(returnExprs[0]);
+          // returnExprs[0] is the innermost lvalue still parented inside E,
+          // which was just emitted; clone it so the enclosing assignment
+          // rebuilt below (e.g. the outer `= y` in `(t = x) = y`) does not
+          // share the node with E.
+          Ldiff.updateStmt(CloneNode(returnExprs[0]));
         } else {
           auto* storeE = GlobalStoreAndRef(BuildOp(UO_AddrOf, E));
           Ldiff.updateStmt(BuildOp(UO_Deref, storeE));
@@ -2782,12 +2882,18 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // Store the value of the LHS of the assignment in the forward pass
       // and restore it in the reverse pass
       if (m_DiffReq.shouldBeRecorded(L)) {
-        StmtDiff pushPop = StoreAndRestore(LCloned);
+        // Clone: LCloned is also consumed by the forward reconstruction, so the
+        // store/restore must not share it.
+        StmtDiff pushPop = StoreAndRestore(CloneNode(LCloned));
         addToCurrentBlock(pushPop.getStmt(), direction::forward);
         addToCurrentBlock(pushPop.getStmt_dx(), direction::reverse);
         if (isInsideOMPBlock) {
-          addToBlock(pushPop.getStmt(), m_OMPBlocks);
-          addToBlock(pushPop.getStmt_dx(), m_OMPReverseBlocks);
+          // The push/pop already went into the loop body above; the OpenMP
+          // residual sweep emits them once more after the loop, so it needs
+          // its own nodes -- reusing these objects would place one statement
+          // under two parents.
+          addToBlock(CloneNode(pushPop.getStmt()), m_OMPBlocks);
+          addToBlock(CloneNode(pushPop.getStmt_dx()), m_OMPReverseBlocks);
         }
       }
 
@@ -2796,7 +2902,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // We need to store values of derivative pointer variables in forward pass
       // and restore them in reverse pass.
       if (isPointerOp) {
-        StmtDiff pushPop = StoreAndRestore(Ldiff.getExpr_dx());
+        // Ldiff.getExpr_dx() is reused below (ResultRef, the derivative op);
+        // clone it for the store/restore so the node is not shared.
+        StmtDiff pushPop = StoreAndRestore(CloneNode(Ldiff.getExpr_dx()));
         addToCurrentBlock(pushPop.getStmt(), direction::forward);
         addToCurrentBlock(pushPop.getStmt_dx(), direction::reverse);
       }
@@ -2809,15 +2917,20 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       clang::Expr* oldValue = nullptr;
 
       // For pointer types, no need to store old derivatives.
+      // ResultRef is returned as the adjoint and, for nested compound
+      // assignments, reused as the next level's ResultRef; clone it for the
+      // old-value store so the stores do not share the node.
       if (indepSides)
-        oldValue = ResultRef;
+        oldValue = CloneNode(ResultRef);
       else if (!isPointerOp)
-        oldValue = StoreAndRef(ResultRef, direction::reverse, "_r_d",
+        oldValue = StoreAndRef(CloneNode(ResultRef), direction::reverse, "_r_d",
                                /*forceDeclCreation=*/true);
       if (opCode == BO_Assign) {
         // Add the statement `dl = 0;`
         Expr* zero = getZeroInit(ResultRef->getType());
-        Expr* assign_zero = BuildOp(BO_Assign, ResultRef, zero);
+        // `dl = 0` is a separate statement from `_r_d0 = dl`; give it its own
+        // node so the two do not share ResultRef.
+        Expr* assign_zero = BuildOp(BO_Assign, CloneNode(ResultRef), zero);
         if (!isPointerOp && !indepSides)
           addToCurrentBlock(assign_zero, direction::reverse);
         Rdiff = Visit(R, oldValue);
@@ -2849,44 +2962,55 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         //   _t0 = _ref0;
         //   double r = _ref0 *= z;
         if (isInsideLoop)
-          addToCurrentBlock(LCloned, direction::forward);
+          // Clone: LCloned is reused as the primal compound-assignment LHS.
+          addToCurrentBlock(CloneNode(LCloned), direction::forward);
         // Add the statement `dl = 0;`
         Expr* zero = getZeroInit(ResultRef->getType());
-        addToCurrentBlock(BuildOp(BO_Assign, ResultRef, zero),
+        addToCurrentBlock(BuildOp(BO_Assign, CloneNode(ResultRef), zero),
                           direction::reverse);
         /// Capture all the emitted statements while visiting R
         /// and insert them after `dl += dl * R`
         beginBlock(direction::reverse);
-        Expr* dr = BuildOp(BO_Mul, LCloned, oldValue);
+        // LCloned is reused below as the LHS of the primal compound assignment
+        // (via Ldiff); clone it here so the reverse-derivative product does not
+        // share the node with it.
+        Expr* dr = BuildOp(BO_Mul, CloneNode(LCloned), oldValue);
         Rdiff = Visit(R, dr);
         Stmts RBlock = EndBlockWithoutCreatingCS(direction::reverse);
+        // Rdiff.getRevSweepAsExpr() aliases the forward expr returned below;
+        // clone at each reverse-sweep use so they own distinct nodes.
         addToCurrentBlock(
-            BuildOp(BO_AddAssign, ResultRef,
-                    BuildOp(BO_Mul, oldValue, Rdiff.getRevSweepAsExpr())),
+            BuildOp(BO_AddAssign, CloneNode(ResultRef),
+                    BuildOp(BO_Mul, CloneNode(oldValue),
+                            CloneNode(Rdiff.getRevSweepAsExpr()))),
             direction::reverse);
         for (auto& S : RBlock)
           addToCurrentBlock(S, direction::reverse);
-        valueForRevPass = BuildOp(BO_Mul, Rdiff.getRevSweepAsExpr(),
-                                  Ldiff.getRevSweepAsExpr());
+        valueForRevPass = BuildOp(BO_Mul, CloneNode(Rdiff.getRevSweepAsExpr()),
+                                  CloneNode(Ldiff.getRevSweepAsExpr()));
         std::tie(Ldiff, Rdiff) = std::make_pair(LCloned, Rdiff.getExpr());
       } else if (opCode == BO_DivAssign) {
         // Add the statement `dl = 0;`
         Expr* zero = getZeroInit(ResultRef->getType());
-        addToCurrentBlock(BuildOp(BO_Assign, ResultRef, zero),
+        addToCurrentBlock(BuildOp(BO_Assign, CloneNode(ResultRef), zero),
                           direction::reverse);
         auto RDelayed = DelayedGlobalStoreAndRef(R, /*prefix=*/"_t",
                                                  /*forceStore=*/true);
         StmtDiff& RResult = RDelayed.Result;
         Expr* RStored =
             StoreAndRef(RResult.getRevSweepAsExpr(), direction::reverse);
-        addToCurrentBlock(BuildOp(BO_AddAssign, ResultRef,
-                                  BuildOp(BO_Div, oldValue, RStored)),
-                          direction::reverse);
+        addToCurrentBlock(
+            BuildOp(BO_AddAssign, CloneNode(ResultRef),
+                    BuildOp(BO_Div, oldValue, CloneNode(RStored))),
+            direction::reverse);
         if (isInsideLoop)
-          addToCurrentBlock(LCloned, direction::forward);
-        Expr* RxR = BuildParens(BuildOp(BO_Mul, RStored, Clone(RStored)));
-        Expr* dr = BuildOp(BO_Mul, oldValue,
-                           BuildOp(UO_Minus, BuildOp(BO_Div, LCloned, RxR)));
+          // Clone: LCloned is reused as the primal compound-assignment LHS.
+          addToCurrentBlock(CloneNode(LCloned), direction::forward);
+        Expr* RxR = BuildParens(BuildOp(BO_Mul, RStored, CloneNode(RStored)));
+        // Clone LCloned (reused as the primal compound-assignment LHS below).
+        Expr* dr = BuildOp(
+            BO_Mul, CloneNode(oldValue),
+            BuildOp(UO_Minus, BuildOp(BO_Div, CloneNode(LCloned), RxR)));
         dr = StoreAndRef(dr, direction::reverse);
         Rdiff = Visit(R, dr);
         RDelayed.Finalize(Rdiff.getExpr());
@@ -2932,7 +3056,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       addToCurrentBlock(utils::unwrapIfSingleStmt(IfStmtDiff.getStmt_dx()),
                         direction::reverse);
       auto* condDiffStored = IfStmtDiff.getRevSweepAsExpr();
-      return BuildOp(BO_LAnd, condDiffStored, condVarRef);
+      // condVarRef is also used in assignExpr above; clone here so they differ.
+      return BuildOp(BO_LAnd, condDiffStored, CloneNode(condVarRef));
     } else if (opCode == BO_Rem) {
       return BuildOp(opCode, Visit(L).getExpr(), Visit(R).getExpr());
     } else {
@@ -2952,6 +3077,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         Expr* derivedL = nullptr;
         Expr* derivedR = nullptr;
         ComputeEffectiveDOperands(Ldiff, Rdiff, derivedL, derivedR);
+        // derivedR is the scalar offset, already used by the forward op above;
+        // clone so the derivative op does not share it.
+        derivedR = CloneNode(derivedR);
         if (opCode == BO_Sub)
           derivedR = BuildParens(derivedR);
         return StmtDiff(op, BuildOp(opCode, derivedL, derivedR),
@@ -2962,6 +3090,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         Expr* derivedL = nullptr;
         Expr* derivedR = nullptr;
         ComputeEffectiveDOperands(Ldiff, Rdiff, derivedL, derivedR);
+        // Clone the scalar offset shared with the forward op above.
+        derivedR = CloneNode(derivedR);
         addToCurrentBlock(BuildOp(opCode, derivedL, derivedR),
                           direction::forward);
         if (opCode == BO_Assign && derivedL && derivedR)
@@ -2997,7 +3127,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             m_Context.getPointerType(VDCloneType.getNonReferenceType());
       VDCloneType.removeLocalConst();
     }
-    QualType VDDerivedType = utils::getNonConstType(VDCloneType, m_Sema);
+    // A variable-array type carries its size in a stored expression, so the
+    // primal and adjoint declarations would otherwise share it. Re-clone the
+    // type for such adjoints; other types keep the (possibly promoted)
+    // VDCloneType so the reference/const handling above is preserved.
+    QualType VDDerivedType =
+        isa<VariableArrayType>(VDType)
+            ? utils::getNonConstType(CloneType(VDType), m_Sema)
+            : utils::getNonConstType(VDCloneType, m_Sema);
 
     bool isRefType = VDType->isLValueReferenceType();
     bool isPointerType = VDType->isPointerType();
@@ -3589,7 +3726,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       if (Expr* addAssign = BuildDiffIncrement(derivedME))
         addToCurrentBlock(addAssign, direction::reverse);
 
-      auto baseDiff = Visit(base, dBaseRef);
+      // dBaseRef is used both in the member adjoint above and as the seed
+      // passed to the base pullback; clone for the latter.
+      auto baseDiff = Visit(base, CloneNode(dBaseRef));
       Expr* clonedME = baseDiff.getExpr();
       if (clonedME)
         clonedME = utils::BuildMemberExpr(m_Sema, getCurrentScope(), clonedME,
@@ -3614,8 +3753,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       derivedME = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
                                          baseDiff.getExpr_dx(), fieldName);
     if (dfdx() && clonedME->getType()->isRealType()) {
-      Expr* addAssign =
-          BuildOp(BinaryOperatorKind::BO_AddAssign, derivedME, dfdx());
+      // Clone the seed: sibling member accesses (e.g. this->x and this->y from
+      // the same expression) are each visited with the same dfdx() node.
+      Expr* addAssign = BuildOp(BinaryOperatorKind::BO_AddAssign, derivedME,
+                                CloneNode(dfdx()));
       addToCurrentBlock(addAssign, direction::reverse);
     }
     return {clonedME, derivedME};
@@ -3701,7 +3842,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       SetDeclInit(VD, E);
     } else {
       addToBlock(decl, m_Globals);
-      Expr* Set = BuildOp(BO_Assign, Ref, E);
+      // Use a fresh ref for the store-back LHS; Ref is returned to the caller
+      // and reused in the reverse pass, so sharing it here parents it twice.
+      Expr* Set = BuildOp(BO_Assign, BuildDeclRef(VD), E);
       addToCurrentBlock(Set, direction::forward);
     }
 
@@ -3780,11 +3923,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         : public RecursiveASTVisitor<PlaceholderReplacer> {
     public:
       const Expr* placeholder;
+      ReverseModeVisitor& m_RMV;
       Sema& m_Sema;
       ASTContext& m_Context;
       Expr* newExpr{nullptr};
-      PlaceholderReplacer(const Expr* Placeholder, Sema& S)
-          : placeholder(Placeholder), m_Sema(S), m_Context(S.getASTContext()) {}
+      bool used{false};
+      PlaceholderReplacer(const Expr* Placeholder, ReverseModeVisitor& RMV)
+          : placeholder(Placeholder), m_RMV(RMV), m_Sema(RMV.m_Sema),
+            m_Context(RMV.m_Context) {}
 
       void Replace(ReverseModeVisitor& RMV, Expr* New, StmtDiff& Result) {
         newExpr = New;
@@ -3792,25 +3938,56 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           TraverseStmt(S);
         for (Stmt* S : RMV.getCurrentBlock(direction::reverse))
           TraverseStmt(S);
-        Result = New;
+        // If New was already spliced into a placeholder occurrence above, the
+        // forward reconstruction that consumes Result must not reuse the same
+        // node -- hand it a distinct clone.
+        Result = used ? RMV.CloneNode(New) : New;
+      }
+
+      // A de-sharing callsite may CloneNode the placeholder, producing a
+      // structurally identical copy with a different address. Match by value so
+      // both the original and its clones are replaced.
+      bool matches(const Stmt* S) const {
+        if (S == placeholder)
+          return true;
+        // APInt/APFloat comparisons assert on mismatched width/semantics, so
+        // guard those before comparing values.
+        if (const auto* F = dyn_cast_or_null<FloatingLiteral>(S)) {
+          if (const auto* PF = dyn_cast<FloatingLiteral>(placeholder))
+            return &F->getValue().getSemantics() ==
+                       &PF->getValue().getSemantics() &&
+                   F->getValue().bitwiseIsEqual(PF->getValue());
+        } else if (const auto* I = dyn_cast_or_null<IntegerLiteral>(S)) {
+          if (const auto* PI = dyn_cast<IntegerLiteral>(placeholder))
+            return I->getValue().getBitWidth() ==
+                       PI->getValue().getBitWidth() &&
+                   I->getValue() == PI->getValue();
+        }
+        return false;
       }
 
       // We chose iteration rather than visiting because we only do this for
       // simple Expression subtrees and it is not worth it to implement an
       // entire visitor infrastructure for simple replacements.
-      bool VisitExpr(Expr* E) const {
+      bool VisitExpr(Expr* E) {
         for (Stmt*& S : E->children())
-          if (S == placeholder) {
+          if (matches(S)) {
+            // The placeholder may occur more than once (e.g. the stored operand
+            // appears in both the derivative and the returned value). Give each
+            // occurrence its own copy so the result stays a proper tree; the
+            // finalized `newExpr` is fully built, so cloning it is safe.
+            Expr* repl = used ? m_RMV.CloneNode(newExpr) : newExpr;
+            used = true;
             // Since we are manually replacing the statement, implicit casts are
             // not generated automatically.
-            ExprResult newExprRes{newExpr};
+            ExprResult newExprRes{repl};
             QualType targetTy = cast<Expr>(S)->getType();
             CastKind kind = m_Sema.PrepareScalarCast(newExprRes, targetTy);
             // CK_NoOp casts trigger an assertion on debug Clang
             if (kind == CK_NoOp)
-              S = newExpr;
+              S = repl;
             else
-              S = m_Sema.ImpCastExprToType(newExpr, targetTy, kind).get();
+              S = m_Sema.ImpCastExprToType(repl, targetTy, kind).get();
           }
         return true;
       }
@@ -3822,7 +3999,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       return;
 
     if (Placeholder) {
-      PlaceholderReplacer repl(Placeholder, V.m_Sema);
+      PlaceholderReplacer repl(Placeholder, V);
       repl.Replace(V, New, Result);
       return;
     }
@@ -3835,8 +4012,11 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       V.SetDeclInit(Declaration, New);
       V.addToCurrentBlock(V.BuildDeclStmt(Declaration), direction::forward);
     } else {
-      V.addToCurrentBlock(V.BuildOp(BO_Assign, Result.getExpr(), New),
-                          direction::forward);
+      // Build a fresh ref for the store-back LHS; Result.getExpr() is reused by
+      // the forward reconstruction, so reusing it here would share a node.
+      V.addToCurrentBlock(
+          V.BuildOp(BO_Assign, V.BuildDeclRef(Declaration), New),
+          direction::forward);
     }
   }
 
@@ -3853,8 +4033,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                                 /*isFnScope=*/false};
     }
     if (!forceStore && utils::ShouldRecompute(E, m_Context)) {
-      // The value of the literal has no. It's given a very particular value for
-      // easier debugging.
+      // A cheap, side-effect-free operand is recomputed inline rather than
+      // stored. Return a sentinel placeholder now; Finalize splices in the
+      // VISITED forward value at every occurrence -- so a stored condition
+      // `_cond0` (not the raw operand) is used, preserving correctness. The
+      // placeholder may be cloned by de-sharing callsites; PlaceholderReplacer
+      // matches it structurally (by value) so clones are replaced too.
+      // Its value is arbitrary but distinctive to aid
+      // debugging if one ever leaks.
       Expr* PH = ConstantFolder::synthesizeLiteral(E->getType(), m_Context,
                                                    /*val=*/~0U);
       return DelayedStoreResult{*this,
@@ -3884,9 +4070,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     Expr* Ref = BuildDeclRef(VD);
     if (!isFnScope)
       addToBlock(BuildDeclStmt(VD), m_Globals);
-    // Return reference to the declaration instead of original expression.
+    // Return reference to the declaration instead of original expression. The
+    // forward rebuild (getExpr) and the reverse-sweep operand
+    // (getRevSweepAsExpr) get separate DeclRefs so neither statement shares a
+    // node with the other; Finalize's store-back builds its own ref too.
     return DelayedStoreResult{*this,
-                              StmtDiff{Ref, nullptr, Ref},
+                              StmtDiff{Ref, nullptr, BuildDeclRef(VD)},
                               /*Declaration=*/VD,
                               /*isInsideLoop=*/false,
                               /*isFnScope=*/isFnScope,
@@ -4050,7 +4239,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     StmtDiff condDiff = DifferentiateSingleStmt(SS->getCond());
     addToCurrentBlock(condDiff.getStmt(), direction::forward);
     addToCurrentBlock(condDiff.getStmt_dx(), direction::reverse);
-    Expr* condExpr = GlobalStoreAndRef(condDiff.getExpr(), "_cond");
+    // condDiff.getExpr() may share nodes with the forward statement added
+    // above; clone it for the stored condition reference.
+    Expr* condExpr = GlobalStoreAndRef(CloneNode(condDiff.getExpr()), "_cond");
 
     auto* activeBreakContHandler = PushBreakContStmtHandler(
         /*forSwitchStmt=*/true);
@@ -4108,10 +4299,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           if (breakCond) {
             breakCond = BuildOp(BinaryOperatorKind::BO_LAnd, breakCond,
                                 BuildOp(BinaryOperatorKind::BO_NE,
-                                        SSData->switchStmtCond, CS->getLHS()));
+                                        CloneNode(SSData->switchStmtCond),
+                                        CloneNode(CS->getLHS())));
           } else {
             breakCond = BuildOp(BinaryOperatorKind::BO_NE,
-                                SSData->switchStmtCond, CS->getLHS());
+                                CloneNode(SSData->switchStmtCond),
+                                CloneNode(CS->getLHS()));
           }
         }
       }
@@ -4126,8 +4319,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // statement body will be processed in both the forward and the reverse
     // pass. Thus, we do not need to add them in the differentiated function.
     if (!(SSData->cases.empty())) {
-      Sema::ConditionResult condRes = m_Sema.ActOnCondition(
-          getCurrentScope(), noLoc, condExpr, Sema::ConditionKind::Switch);
+      Sema::ConditionResult condRes =
+          m_Sema.ActOnCondition(getCurrentScope(), noLoc, CloneNode(condExpr),
+                                Sema::ConditionKind::Switch);
       SwitchStmt* forwardSS =
           m_Sema
               .ActOnStartOfSwitchStmt(/*SwitchLoc=*/noLoc,
@@ -4164,8 +4358,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     auto* newSC = CaseStmt::Create(m_Sema.getASTContext(), lhsClone, rhsClone,
                                    noLoc, noLoc, noLoc);
 
-    Expr* ifCond = BuildOp(BinaryOperatorKind::BO_EQ, newSC->getLHS(),
-                           SSData->switchStmtCond);
+    // newSC->getLHS() is the case label already owned by the forward CaseStmt,
+    // and switchStmtCond is reused by every case; clone both so the reverse
+    // `if (label == _cond)` does not share nodes with the forward switch.
+    Expr* ifCond =
+        BuildOp(BinaryOperatorKind::BO_EQ, CloneNode(newSC->getLHS()),
+                CloneNode(SSData->switchStmtCond));
     Stmt* ifThen =
         clad_compat::ActOnBreakStmt(m_Sema, noLoc, getCurrentScope()).get();
     Stmt* ifBreakExpr = clad_compat::IfStmt_Create(
@@ -4276,21 +4474,25 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
 
     if (shouldCheckpoint) {
-      // Repeat all forward-pass operations in the reverse pass.
+      // Repeat all forward-pass operations in the reverse pass. The statements
+      // are still owned by the forward loop body, so clone each one to give the
+      // recomputation region its own subtree instead of sharing nodes.
       for (Stmt* S :
            llvm::reverse(cast<CompoundStmt>(bodyDiff.getStmt())->body()))
         bodyDiff.updateStmtDx(utils::PrependAndCreateCompoundStmt(
-            m_Context, bodyDiff.getStmt_dx(), S));
+            m_Context, bodyDiff.getStmt_dx(), CloneNode(S)));
     }
     // Increment statement in the for-loop is executed for every case
     if (forLoopIncDiff) {
       Stmt* forLoopIncDiffExpr = forLoopIncDiff;
       if (m_CurrentBreakFlagExpr) {
+        // revCounter also initializes the _numRevIterations variable above;
+        // clone it here so the DeclStmt init and this comparison do not share.
         m_CurrentBreakFlagExpr =
             BuildOp(BinaryOperatorKind::BO_LOr,
-                    BuildOp(BinaryOperatorKind::BO_NE, revCounter,
+                    BuildOp(BinaryOperatorKind::BO_NE, CloneNode(revCounter),
                             BuildDeclRef(loopCounter.getNumRevIterations())),
-                    BuildParens(m_CurrentBreakFlagExpr));
+                    BuildParens(CloneNode(m_CurrentBreakFlagExpr)));
         forLoopIncDiffExpr = clad_compat::IfStmt_Create(
             m_Context, noLoc, false, nullptr, nullptr, m_CurrentBreakFlagExpr,
             noLoc, noLoc, forLoopIncDiff, noLoc, nullptr);
@@ -4384,7 +4586,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   Expr* ReverseModeVisitor::BreakContStmtHandler::CreateCFTapePushExpr(
       std::size_t value) {
     Expr* pushDRE = m_RMV.GetCladTapePushDRE();
-    Expr* callArgs[] = {m_ControlFlowTape->Ref, CreateSizeTLiteralExpr(value)};
+    Expr* callArgs[] = {m_RMV.CloneNode(m_ControlFlowTape->Ref),
+                        CreateSizeTLiteralExpr(value)};
     Expr* pushExpr = m_RMV.m_Sema
                          .ActOnCallExpr(m_RMV.getCurrentScope(), pushDRE, noLoc,
                                         callArgs, noLoc)
@@ -4498,7 +4701,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       auto* thisDecl = cast<VarDecl>(R.getFoundDecl());
       clonedCTE = BuildDeclRef(thisDecl);
     }
-    return {clonedCTE, m_ThisExprDerivative};
+    // m_ThisExprDerivative is a single cached `_d_this` ref; hand out a fresh
+    // clone so distinct member accesses do not share the same base node.
+    return {clonedCTE, CloneNode(m_ThisExprDerivative)};
   }
 
   StmtDiff ReverseModeVisitor::VisitCXXTemporaryObjectExpr(
@@ -4643,9 +4848,15 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       llvm::SmallVector<Expr*, 4> pullbackArgs;
       Expr* dThisE = BuildOp(UnaryOperatorKind::UO_AddrOf, dfdx(),
                              m_DiffReq->getLocation());
-      pullbackArgs.append(primalArgs.begin(), primalArgs.end());
+      // primalArgs are also consumed by the reverse-forward and forward
+      // constructor calls below; clone so each call owns its argument nodes.
+      for (Expr* primalArg : primalArgs)
+        pullbackArgs.push_back(CloneNode(primalArg));
       pullbackArgs.push_back(dThisE);
-      pullbackArgs.append(adjointArgs.begin(), adjointArgs.end());
+      // adjointArgs alias the reverse-forward construction's arguments; clone
+      // so the pullback call and that construction own distinct nodes.
+      for (Expr* adjointArg : adjointArgs)
+        pullbackArgs.push_back(CloneNode(adjointArg));
 
       Expr* pullbackCall = nullptr;
       Stmts& curRevBlock = getCurrentBlock(direction::reverse);
@@ -4716,8 +4927,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // SomeClass c = _t0.value;
     // ```
     if (constrForw && !elideReverseForw) {
+      llvm::SmallVector<Expr*, 4> clonedPrimalArgs;
+      for (Expr* primalArg : primalArgs)
+        clonedPrimalArgs.push_back(CloneNode(primalArg));
       reverseForwAdjointArgs.insert(reverseForwAdjointArgs.begin(),
-                                    primalArgs.begin(), primalArgs.end());
+                                    clonedPrimalArgs.begin(),
+                                    clonedPrimalArgs.end());
       reverseForwAdjointArgs.insert(
           reverseForwAdjointArgs.begin(),
           utils::GetCladTagExpr(m_Sema,
@@ -4737,8 +4952,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       Expr* callRes = StoreAndRef(customReverseForwFnCall);
       Expr* val =
           utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");
-      Expr* adjoint =
-          utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "adjoint");
+      // Clone the base so `_t0.value` and `_t0.adjoint` own distinct nodes.
+      Expr* adjoint = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                             CloneNode(callRes), "adjoint");
       if (!utils::isCopyable(RD)) {
         val = utils::BuildStaticCastToRValue(m_Sema, val);
         adjoint = utils::BuildStaticCastToRValue(m_Sema, adjoint);
@@ -4754,9 +4970,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       return {nullptr, getZeroInit(clad_compat::getRecordType(m_Context, RD))};
 
     // `CXXConstructExpr` node will be created automatically by passing these
-    // initialiser to higher level `ActOn`/`Build` Sema functions.
-    Expr* callClone =
-        BuildConstructorCall(m_Sema, CE, primalArgs, m_TrackVarDeclConstructor);
+    // initialiser to higher level `ActOn`/`Build` Sema functions. For leaf
+    // arguments primalArgs and reverseForwAdjointArgs alias the same nodes;
+    // clone the forward-call arguments so callClone and callDiff stay distinct.
+    llvm::SmallVector<Expr*, 4> clonedPrimalArgs;
+    for (Expr* primalArg : primalArgs)
+      clonedPrimalArgs.push_back(CloneNode(primalArg));
+    Expr* callClone = BuildConstructorCall(m_Sema, CE, clonedPrimalArgs,
+                                           m_TrackVarDeclConstructor);
     Expr* callDiff = BuildConstructorCall(m_Sema, CE, reverseForwAdjointArgs,
                                           m_TrackVarDeclConstructor);
     return {callClone, callDiff};

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -174,34 +174,46 @@ DEFINE_CREATE_EXPR(CXXConstCastExpr,
                     Clone(Node->getSubExpr()), Node->getTypeInfoAsWritten(),
                     Node->getOperatorLoc(), Node->getRParenLoc(),
                     Node->getAngleBrackets()))
-DEFINE_CREATE_EXPR(
-    CXXConstructExpr,
-    (Ctx, CloneType(Node->getType()), Node->getLocation(),
-     Node->getConstructor(), Node->isElidable(),
-     clad_compat::makeArrayRef(Node->getArgs(), Node->getNumArgs()),
-     Node->hadMultipleCandidates(), Node->isListInitialization(),
-     Node->isStdInitListInitialization(), Node->requiresZeroInitialization(),
-     Node->getConstructionKind(), Node->getParenOrBraceRange()))
+Stmt* StmtClone::VisitCXXConstructExpr(CXXConstructExpr* Node) {
+  // Clone the arguments; passing Node->getArgs() would share them with the
+  // source, defeating the copy.
+  llvm::SmallVector<Expr*, 8> args(Node->getNumArgs());
+  for (unsigned i = 0, e = Node->getNumArgs(); i < e; ++i)
+    args[i] = Clone(Node->getArg(i));
+  auto* result = CXXConstructExpr::Create(
+      Ctx, CloneType(Node->getType()), Node->getLocation(),
+      Node->getConstructor(), Node->isElidable(), args,
+      Node->hadMultipleCandidates(), Node->isListInitialization(),
+      Node->isStdInitListInitialization(), Node->requiresZeroInitialization(),
+      Node->getConstructionKind(), Node->getParenOrBraceRange());
+  clad_compat::ExprSetDeps(result, Node);
+  return result;
+}
 DEFINE_CREATE_EXPR(CXXFunctionalCastExpr,
                    (Ctx, CloneType(Node->getType()), Node->getValueKind(),
                     Node->getTypeInfoAsWritten(), Node->getCastKind(),
                     Clone(Node->getSubExpr()), nullptr, Node->getFPFeatures(),
                     Node->getLParenLoc(), Node->getRParenLoc()))
-DEFINE_CREATE_EXPR(ExprWithCleanups, (Ctx, Node->getSubExpr(),
+DEFINE_CREATE_EXPR(ExprWithCleanups, (Ctx, Clone(Node->getSubExpr()),
                                       Node->cleanupsHaveSideEffects(), {}))
 
 DEFINE_CREATE_EXPR(ConstantExpr, (Ctx, Clone(Node->getSubExpr()),
                                   Node->getResultStorageKind(),
                                   Node->isImmediateInvocation()))
 
-DEFINE_CLONE_EXPR_CO(
-    CXXTemporaryObjectExpr,
-    (Ctx, Node->getConstructor(), CloneType(Node->getType()),
-     Node->getTypeSourceInfo(),
-     clad_compat::makeArrayRef(Node->getArgs(), Node->getNumArgs()),
-     Node->getSourceRange(), Node->hadMultipleCandidates(),
-     Node->isListInitialization(), Node->isStdInitListInitialization(),
-     Node->requiresZeroInitialization()))
+Stmt* StmtClone::VisitCXXTemporaryObjectExpr(CXXTemporaryObjectExpr* Node) {
+  // Clone the arguments so the copy does not share them with the source.
+  llvm::SmallVector<Expr*, 8> args(Node->getNumArgs());
+  for (unsigned i = 0, e = Node->getNumArgs(); i < e; ++i)
+    args[i] = Clone(Node->getArg(i));
+  auto* result = CXXTemporaryObjectExpr::Create(
+      Ctx, Node->getConstructor(), CloneType(Node->getType()),
+      Node->getTypeSourceInfo(), args, Node->getSourceRange(),
+      Node->hadMultipleCandidates(), Node->isListInitialization(),
+      Node->isStdInitListInitialization(), Node->requiresZeroInitialization());
+  clad_compat::ExprSetDeps(result, Node);
+  return result;
+}
 
 DEFINE_CLONE_EXPR(MaterializeTemporaryExpr,
                   (CloneType(Node->getType()),
@@ -252,22 +264,90 @@ DEFINE_CLONE_EXPR(
     SubstNonTypeTemplateParmExpr,
     (CloneType(Node->getType()), Node->getValueKind(), Node->getBeginLoc(),
      Node->getParameter(), Node->isReferenceParameter(),
-     Node->getReplacement()))
+     Clone(Node->getReplacement())))
 #elif CLANG_VERSION_MAJOR < 21
 DEFINE_CLONE_EXPR(SubstNonTypeTemplateParmExpr,
                   (CloneType(Node->getType()), Node->getValueKind(),
-                   Node->getBeginLoc(), Node->getReplacement(),
+                   Node->getBeginLoc(), Clone(Node->getReplacement()),
                    Node->getAssociatedDecl(), Node->getIndex(),
                    Node->getPackIndex(), Node->isReferenceParameter()))
 #else
 DEFINE_CLONE_EXPR(SubstNonTypeTemplateParmExpr,
                   (CloneType(Node->getType()), Node->getValueKind(),
-                   Node->getBeginLoc(), Node->getReplacement(),
+                   Node->getBeginLoc(), Clone(Node->getReplacement()),
                    Node->getAssociatedDecl(), Node->getIndex(),
                    Node->getPackIndex(), Node->isReferenceParameter(),
                    Node->getFinal()))
 #endif
-DEFINE_CREATE_EXPR(PseudoObjectExpr, (Ctx, Node->getSyntacticForm(), llvm::SmallVector<Expr*, 4>(Node->semantics_begin(), Node->semantics_end()), Node->getResultExprIndex()))
+// A PseudoObjectExpr (e.g. a `threadIdx.x` __declspec(property) access) binds
+// OpaqueValueExprs in its semantic expressions and references those same OVE
+// objects from its syntactic form and result expression. Deep-clone it:
+// materialize a fresh OVE per bound OVE (with a cloned source) and remap every
+// form to them via m_OVESubst, so the clone shares no node with the original.
+// Passing the original subtrees to Create (as a plain DEFINE_CREATE_EXPR would)
+// splices them, and two such clones (forward + reverse sweep) then share nodes.
+Stmt* StmtClone::VisitPseudoObjectExpr(PseudoObjectExpr* Node) {
+  llvm::DenseMap<OpaqueValueExpr*, OpaqueValueExpr*> LocalSubst;
+  auto* SavedSubst = m_OVESubst;
+  // Nested PseudoObjectExprs accumulate into the outer map so an inner form can
+  // reference an OVE bound by the outer one.
+  if (!m_OVESubst)
+    m_OVESubst = &LocalSubst;
+
+  unsigned N = Node->getNumSemanticExprs();
+  for (unsigned I = 0; I != N; ++I)
+    if (auto* OVE = dyn_cast<OpaqueValueExpr>(Node->getSemanticExpr(I)))
+      (*m_OVESubst)[OVE] = new (Ctx) OpaqueValueExpr(
+          OVE->getLocation(), CloneType(OVE->getType()), OVE->getValueKind(),
+          OVE->getObjectKind(),
+          OVE->getSourceExpr() ? cast<Expr>(Clone(OVE->getSourceExpr()))
+                               : nullptr);
+
+  Expr* Syn = cast<Expr>(Clone(Node->getSyntacticForm()));
+  llvm::SmallVector<Expr*, 4> Sems;
+  Sems.reserve(N);
+  for (unsigned I = 0; I != N; ++I) {
+    Expr* SE = Node->getSemanticExpr(I);
+    if (auto* OVE = dyn_cast<OpaqueValueExpr>(SE))
+      Sems.push_back((*m_OVESubst)[OVE]);
+    else
+      Sems.push_back(cast<Expr>(Clone(SE)));
+  }
+
+  PseudoObjectExpr* result =
+      PseudoObjectExpr::Create(Ctx, Syn, Sems, Node->getResultExprIndex());
+  clad_compat::ExprSetDeps(result, Node);
+  m_OVESubst = SavedSubst;
+  return result;
+}
+
+// An OpaqueValueExpr bound by the PseudoObjectExpr currently being cloned maps
+// to its pre-built clone; any other OVE is cloned directly.
+Stmt* StmtClone::VisitOpaqueValueExpr(OpaqueValueExpr* Node) {
+  if (m_OVESubst) {
+    auto It = m_OVESubst->find(Node);
+    if (It != m_OVESubst->end())
+      return It->second;
+  }
+  OpaqueValueExpr* result = new (Ctx) OpaqueValueExpr(
+      Node->getLocation(), CloneType(Node->getType()), Node->getValueKind(),
+      Node->getObjectKind(),
+      Node->getSourceExpr() ? cast<Expr>(Clone(Node->getSourceExpr()))
+                            : nullptr);
+  clad_compat::ExprSetDeps(result, Node);
+  return result;
+}
+
+// The syntactic form of a property PseudoObjectExpr; clone its base (an OVE
+// that VisitOpaqueValueExpr remaps to the shared clone).
+Stmt* StmtClone::VisitMSPropertyRefExpr(MSPropertyRefExpr* Node) {
+  MSPropertyRefExpr* result = new (Ctx) MSPropertyRefExpr(
+      cast<Expr>(Clone(Node->getBaseExpr())), Node->getPropertyDecl(),
+      Node->isArrow(), CloneType(Node->getType()), Node->getValueKind(),
+      Node->getQualifierLoc(), Node->getMemberLoc());
+  clad_compat::ExprSetDeps(result, Node);
+  return result;
+}
 // NOLINTEND(modernize-use-auto)
 // BlockExpr
 // BlockDeclRefExpr
@@ -294,13 +374,19 @@ Stmt* StmtClone::VisitInitListExpr(InitListExpr* Node) {
   for (unsigned i = 0, e = Node->getNumInits(); i < e; ++i)
     initExprs[i] = Clone(Node->getInit(i));
 
-  SourceLocation lBrace = Node->getLBraceLoc();
-  SourceLocation rBrace = Node->getRBraceLoc();
-
-  InitListExpr* result = llvm::cast<InitListExpr>(m_Sema.ActOnInitList(lBrace, initExprs, rBrace).get());
-
+  // Build the node structurally rather than via Sema::ActOnInitList. The
+  // semantic action re-derives the type and array filler from an
+  // initialization context we do not have here, yielding a type-less
+  // *syntactic* list; once that reaches CodeGen as an aggregate (e.g. a
+  // materialized array temporary) EmitAggExpr asserts. Mirror the fully-built
+  // node: preserve the type, the array filler and the union field so aggregate
+  // emission stays valid.
+  auto* result = new (Ctx)
+      InitListExpr(Ctx, Node->getLBraceLoc(), initExprs, Node->getRBraceLoc());
+  result->setType(CloneType(Node->getType()));
+  if (Expr* filler = Node->getArrayFiller())
+    result->setArrayFiller(Clone(filler));
   result->setInitializedFieldInUnion(Node->getInitializedFieldInUnion());
-  // FIXME: clone the syntactic form, can this become recursive?
   return result;
 }
 

--- a/lib/Differentiator/VectorForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorForwardModeVisitor.cpp
@@ -109,8 +109,9 @@ DerivativeAndOverload VectorForwardModeVisitor::Derive() {
     if (m_IndependentVars.size() > independentVarIndex &&
         m_IndependentVars[independentVarIndex] == m_DiffReq->getParamDecl(i)) {
 
-      // Current offset for independent variable.
-      Expr* offsetExpr = arrayIndVarCountExpr;
+      // Current offset for independent variable. arrayIndVarCountExpr keeps
+      // accumulating below, so clone it for this offset use.
+      Expr* offsetExpr = CloneNode(arrayIndVarCountExpr);
       Expr* nonArrayIndVarCountExpr = ConstantFolder::synthesizeLiteral(
           m_Context.UnsignedLongTy, m_Context, nonArrayIndVarCount);
       if (!offsetExpr)
@@ -127,20 +128,24 @@ DerivativeAndOverload VectorForwardModeVisitor::Derive() {
         // Create an identity matrix for the parameter,
         // with number of rows equal to the size of the array,
         // and number of columns equal to the number of independent variables
-        llvm::SmallVector<Expr*, 3> args = {getSize, m_IndVarCountExpr,
-                                            offsetExpr};
+        llvm::SmallVector<Expr*, 3> args = {
+            getSize, CloneNode(m_IndVarCountExpr), offsetExpr};
         dVectorParam = BuildIdentityMatrixExpr(dParamType, args, loc);
 
-        // Update the array independent expression.
+        // Update the array independent expression. getSize is already used by
+        // the identity matrix above and arrayIndVarCountExpr flows into later
+        // slice/subscript expressions, so clone it here to avoid sharing.
         if (!arrayIndVarCountExpr) {
-          arrayIndVarCountExpr = getSize;
+          arrayIndVarCountExpr = CloneNode(getSize);
         } else {
-          arrayIndVarCountExpr = BuildOp(BinaryOperatorKind::BO_Add,
-                                         arrayIndVarCountExpr, getSize);
+          arrayIndVarCountExpr =
+              BuildOp(BinaryOperatorKind::BO_Add, arrayIndVarCountExpr,
+                      CloneNode(getSize));
         }
       } else {
         // Create a one hot vector for the parameter.
-        llvm::SmallVector<Expr*, 2> args = {m_IndVarCountExpr, offsetExpr};
+        llvm::SmallVector<Expr*, 2> args = {CloneNode(m_IndVarCountExpr),
+                                            offsetExpr};
         dVectorParam = BuildCallExprToCladFunction("one_hot_vector", args,
                                                    {dParamType}, loc);
         ++nonArrayIndVarCount;
@@ -153,8 +158,9 @@ DerivativeAndOverload VectorForwardModeVisitor::Derive() {
         continue;
       // This parameter is not an independent variable.
       // Initialize by all zeros.
-      dVectorParam = BuildCallExprToCladFunction(
-          "zero_vector", {m_IndVarCountExpr}, {dParamType}, loc);
+      Expr* dCount = CloneNode(m_IndVarCountExpr);
+      dVectorParam = BuildCallExprToCladFunction("zero_vector", {dCount},
+                                                 {dParamType}, loc);
     }
 
     // For each function arg to be differentiated, create a variable
@@ -442,10 +448,13 @@ StmtDiff VectorForwardModeVisitor::VisitArraySubscriptExpr(
 
   Expr* target = BaseDiff.getExpr_dx();
   if (target) {
+    // Clone the index: it is already consumed by the primal subscript above,
+    // so the derivative subscript needs its own node. Bind to a local lvalue --
+    // the MultiExprArg param's one-element ctor takes a reference.
+    Expr* dIndex = CloneNode(clonedIndices.front());
     diffExpr = m_Sema
                    .ActOnArraySubscriptExpr(getCurrentScope(), target,
-                                            target->getExprLoc(),
-                                            clonedIndices.front(), noLoc)
+                                            target->getExprLoc(), dIndex, noLoc)
                    .get();
   }
   return StmtDiff(cloned, diffExpr);
@@ -483,7 +492,8 @@ StmtDiff VectorForwardModeVisitor::VisitReturnStmt(const ReturnStmt* RS) {
     Expr* dParamValue = nullptr;
 
     // Current offset for independent variable.
-    Expr* offsetExpr = arrayIndVarCountExpr;
+    // arrayIndVarCountExpr keeps accumulating below; clone it for this offset.
+    Expr* offsetExpr = CloneNode(arrayIndVarCountExpr);
     Expr* nonArrayIndVarCountExpr = ConstantFolder::synthesizeLiteral(
         m_Context.UnsignedLongTy, m_Context, nonArrayIndVarCount);
     if (!offsetExpr)
@@ -496,22 +506,26 @@ StmtDiff VectorForwardModeVisitor::VisitReturnStmt(const ReturnStmt* RS) {
       // Get the size of the array.
       Expr* getSize = BuildArrayRefSizeExpr(dParam);
 
-      // Create an expression to fetch slice of the return vector.
+      // Create an expression to fetch slice of the return vector. dVectorRef
+      // is reused for every parameter; clone so the slices/subscripts do not
+      // share the return-vector reference.
       llvm::SmallVector<Expr*, 2> args = {offsetExpr, getSize};
-      dParamValue = BuildArrayRefSliceExpr(dVectorRef, args);
+      dParamValue = BuildArrayRefSliceExpr(CloneNode(dVectorRef), args);
 
-      // Update the array independent expression.
+      // Update the array independent expression. getSize is used by the slice
+      // above; clone so the two do not share.
       if (!arrayIndVarCountExpr) {
-        arrayIndVarCountExpr = getSize;
+        arrayIndVarCountExpr = CloneNode(getSize);
       } else {
         arrayIndVarCountExpr =
-            BuildOp(BinaryOperatorKind::BO_Add, arrayIndVarCountExpr, getSize);
+            BuildOp(BinaryOperatorKind::BO_Add, arrayIndVarCountExpr,
+                    CloneNode(getSize));
       }
     } else {
       dParamValue = m_Sema
-                        .ActOnArraySubscriptExpr(getCurrentScope(), dVectorRef,
-                                                 dVectorRef->getExprLoc(),
-                                                 offsetExpr, noLoc)
+                        .ActOnArraySubscriptExpr(
+                            getCurrentScope(), CloneNode(dVectorRef),
+                            dVectorRef->getExprLoc(), offsetExpr, noLoc)
                         .get();
       ++nonArrayIndVarCount;
     }
@@ -550,16 +564,18 @@ VectorForwardModeVisitor::DifferentiateVarDecl(const VarDecl* VD) {
 StmtDiff VectorForwardModeVisitor::VisitFloatingLiteral(
     const clang::FloatingLiteral* FL) {
   SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
-  auto* zero_vec = BuildCallExprToCladFunction(
-      "zero_vector", {m_IndVarCountExpr}, {FL->getType()}, fakeLoc);
+  Expr* dCount = CloneNode(m_IndVarCountExpr);
+  auto* zero_vec = BuildCallExprToCladFunction("zero_vector", {dCount},
+                                               {FL->getType()}, fakeLoc);
   return StmtDiff(Clone(FL), zero_vec);
 }
 
 StmtDiff
 VectorForwardModeVisitor::VisitIntegerLiteral(const clang::IntegerLiteral* IL) {
   SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
-  auto* zero_vec = BuildCallExprToCladFunction(
-      "zero_vector", {m_IndVarCountExpr}, {IL->getType()}, fakeLoc);
+  Expr* dCount = CloneNode(m_IndVarCountExpr);
+  auto* zero_vec = BuildCallExprToCladFunction("zero_vector", {dCount},
+                                               {IL->getType()}, fakeLoc);
   return StmtDiff(Clone(IL), zero_vec);
 }
 

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -32,7 +32,9 @@
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Overload.h"
 #include "clang/Sema/Ownership.h"
+#include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/Scope.h"
+#include "clang/Sema/ScopeInfo.h"
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/SemaInternal.h"
 #include "clang/Sema/Template.h"
@@ -415,6 +417,12 @@ namespace clad {
     const Stmt* S = E;
     return llvm::cast<Expr>(Clone(S));
   }
+  Expr* VisitorBase::CloneNode(const Expr* E) {
+    return E ? m_Builder.m_NodeCloner->Clone(E) : nullptr;
+  }
+  Stmt* VisitorBase::CloneNode(const Stmt* S) {
+    return S ? m_Builder.m_NodeCloner->Clone(S) : nullptr;
+  }
 
   QualType VisitorBase::CloneType(const QualType QT) {
     auto clonedType = m_Builder.m_NodeCloner->CloneType(QT);
@@ -752,7 +760,10 @@ namespace clad {
   }
 
   Expr* VisitorBase::BuildArrayRefSizeExpr(Expr* Base) {
-    return BuildCallExprToMemFn(Base, /*MemberFunctionName=*/"size", {});
+    // Callers pass a cached parameter reference and call this repeatedly for
+    // the same array; clone the base so the `.size()` calls do not share it.
+    return BuildCallExprToMemFn(CloneNode(Base), /*MemberFunctionName=*/"size",
+                                {});
   }
 
   Expr* VisitorBase::BuildArrayRefSliceExpr(Expr* Base,
@@ -778,7 +789,9 @@ namespace clad {
     // Build function args.
     llvm::SmallVector<Expr*, 16U> NumDiffArgs;
     NumDiffArgs.push_back(targetFuncCall);
-    NumDiffArgs.push_back(targetArg);
+    // targetArg is also the value passed through `args` below (and embedded in
+    // targetFuncCall); clone it so the numerical-diff call does not share it.
+    NumDiffArgs.push_back(CloneNode(targetArg));
     NumDiffArgs.push_back(ConstantFolder::synthesizeLiteral(m_Context.IntTy,
                                                             m_Context,
                                                             targetPos));
@@ -814,6 +827,165 @@ namespace clad {
                                /*AddToContext=*/false);
     }
     return newPVD;
+  }
+
+  Expr* VisitorBase::buildClonedLambda(const LambdaExpr* LE) {
+    // A primal copy needs a *fresh* closure type; a plain StmtClone reuses
+    // the original closure, so two clones end up sharing the operator() body
+    // -- violating the one-parent-per-node invariant. Captured lambdas would
+    // need capture rebinding we do not model here; fall back to a plain clone
+    // (they are not currently a source of node sharing).
+#if CLANG_VERSION_MAJOR < 17
+    // Lambda differentiation is unsupported below clang-17 (Lambdas.C is
+    // UNSUPPORTED there) and the Sema lambda-introduction entry points used
+    // below do not exist yet. Never reached; keep the source compilable.
+    return cast<Expr>(Clone(LE));
+#else
+    if (LE->capture_size() != 0)
+      return cast<Expr>(Clone(LE));
+
+    const CXXMethodDecl* CallOp = LE->getCallOperator();
+
+    // Mirror the lambda-introduction dance performed while parsing a lambda;
+    // see buildDerivedLambda for the differentiating counterpart.
+    LambdaIntroducer Intro;
+    Intro.Default = LCD_None;
+    Intro.Range.setBegin(LE->getBeginLoc());
+    Intro.Range.setEnd(LE->getEndLoc());
+    AttributeFactory AttrFactory;
+    const DeclSpec DS(AttrFactory);
+    Declarator D(DS, clang::ParsedAttributesView::none(),
+                 clang::DeclaratorContext::LambdaExpr);
+
+    auto* DC = const_cast<DeclContext*>(CallOp->getDeclContext());
+    llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
+    llvm::SaveAndRestore<FunctionDecl*> SaveDerivative(m_Derivative);
+    llvm::SaveAndRestore<Scope*> SaveFnScope(m_DerivativeFnScope);
+
+    beginScope(Scope::LambdaScope | Scope::DeclScope |
+               Scope::FunctionDeclarationScope | Scope::FunctionPrototypeScope);
+    m_Sema.PushLambdaScope();
+    m_Sema.ActOnLambdaExpressionAfterIntroducer(Intro, getCurrentScope());
+
+    beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
+               Scope::DeclScope);
+
+    llvm::SmallVector<DeclaratorChunk::ParamInfo> ParamInfoLambda;
+    llvm::SmallVector<ParmVarDecl*, 8> params;
+
+    m_Sema.ActOnLambdaClosureQualifiers(Intro, noLoc);
+
+    sema::LambdaScopeInfo* LSI = m_Sema.getCurLambda();
+    // The clone keeps the original call operator's signature (unlike the
+    // derivative, which gets adjoint parameters).
+    LSI->CallOperator->setType(CallOp->getType());
+    m_Sema.PushDeclContext(getCurrentScope(), LSI->CallOperator);
+    LSI->Lambda->setDeclContext(DC);
+    m_Derivative = LSI->CallOperator;
+
+    for (const ParmVarDecl* PVD : CallOp->parameters()) {
+      IdentifierInfo* II = PVD->getIdentifier();
+      if (!PVD->getDeclName())
+        II = CreateUniqueIdentifier("arg");
+      auto* newPVD = CloneParmVarDecl(PVD, II, /*pushOnScopeChains=*/true,
+                                      /*cloneDefaultArg=*/false);
+      // Remap references in the cloned body to the new parameters.
+      m_DeclReplacements[PVD] = newPVD;
+      params.push_back(newPVD);
+    }
+    m_Derivative->setBody(MakeCompoundStmt({}));
+    m_Sema.PopDeclContext();
+
+    for (auto* PVD : params)
+      ParamInfoLambda.emplace_back(PVD->getIdentifier(), PVD->getLocation(),
+                                   PVD, nullptr);
+    SourceLocation paramListLoc = utils::GetValidSLoc(m_Sema);
+    D.AddTypeInfo(DeclaratorChunk::getFunction(
+                      /*hasProto=*/true,
+                      /*isAmbiguous=*/false,
+                      /*LParenLoc=*/paramListLoc,
+                      /*Params=*/ParamInfoLambda.data(),
+                      /*NumParams=*/ParamInfoLambda.size(),
+                      /*EllipsisLoc=*/SourceLocation(),
+                      /*RParenLoc=*/paramListLoc,
+                      /*RefQualifierIsLValueRef=*/true,
+                      /*RefQualifierLoc=*/SourceLocation(),
+                      /*MutableLoc=*/SourceLocation(),
+                      /*ESpecType=*/EST_None,
+                      /*ESpecRange=*/SourceRange(),
+                      /*Exceptions=*/nullptr,
+                      /*ExceptionRanges=*/nullptr,
+                      /*NumExceptions=*/0,
+                      /*NoexceptExpr=*/nullptr,
+                      /*ExceptionSpecTokens=*/nullptr,
+                      /*DeclsInPrototype=*/{},
+                      /*LocalRangeBegin=*/noLoc,
+                      /*LocalRangeEnd=*/noLoc,
+                      /*Declarator=*/D,
+                      /*TrailingReturnType=*/ParsedType(),
+                      /*TrailingReturnTypeLoc=*/SourceLocation()),
+                  /*EndLoc=*/SourceLocation());
+
+    m_Sema.ActOnLambdaClosureParameters(getCurrentScope(), ParamInfoLambda);
+
+    beginScope(Scope::BlockScope | Scope::FnScope | Scope::DeclScope |
+               Scope::CompoundStmtScope);
+    m_Sema.ActOnStartOfLambdaDefinition(
+        Intro, D,
+        clad_compat::Sema_ActOnStartOfLambdaDefinition_ScopeOrDeclSpec(
+            getCurrentScope(), DS));
+    m_DerivativeFnScope = getCurrentScope();
+
+    beginBlock();
+    const auto* Body = cast<CompoundStmt>(CallOp->getBody());
+    for (Stmt* S : Body->body()) {
+      // A nested lambda declaration must itself get a fresh closure (otherwise
+      // the recursive clone would reuse it). Rebuild it here -- its own body is
+      // remapped inside the recursive call -- and record the new variable so
+      // later references in this body are updated to it.
+      if (auto* InnerDS = dyn_cast<DeclStmt>(S))
+        if (InnerDS->isSingleDecl())
+          if (auto* InnerVD = dyn_cast<VarDecl>(InnerDS->getSingleDecl()))
+            if (const Expr* InnerInit = InnerVD->getInit())
+              if (const auto* InnerLE =
+                      dyn_cast<LambdaExpr>(InnerInit->IgnoreImplicit())) {
+                Expr* ClonedInner = buildClonedLambda(InnerLE);
+                QualType AutoTy = m_Context.getAutoDeductType();
+                TypeSourceInfo* TSI =
+                    m_Context.getTrivialTypeSourceInfo(AutoTy);
+                VarDecl* NewInnerVD =
+                    BuildVarDecl(AutoTy, InnerVD->getNameAsString(),
+                                 ClonedInner, InnerVD->isDirectInit(), TSI);
+                m_DeclReplacements[InnerVD] = NewInnerVD;
+                addToCurrentBlock(BuildDeclStmt(NewInnerVD));
+                continue;
+              }
+      // Clone the statement and remap references to the lambda's own
+      // parameters (and rebuilt inner lambdas). ReferencesUpdater only admits
+      // declarations enclosed by the "function" it is given, so key it on the
+      // lambda's call operator rather than m_DiffReq.Function (the outer
+      // function being differentiated), which would reject the lambda locals.
+      Stmt* clonedS = CloneNode(S);
+      utils::ReferencesUpdater up(m_Sema, getCurrentScope(), CallOp,
+                                  m_DeclReplacements);
+      up.TraverseStmt(clonedS);
+      addToCurrentBlock(clonedS);
+    }
+    CompoundStmt* ClonedBody = endBlock();
+
+    Expr* lambda =
+        m_Sema
+            .ActOnLambdaExpr(
+                noLoc,
+                ClonedBody /*,*/
+                    CLAD_COMPAT_CLANG17_ActOnLambdaExpr_getCurrentScope_ExtraParam(
+                        *this))
+            .get();
+    endScope();
+    endScope();
+    endScope();
+    return lambda;
+#endif // CLANG_VERSION_MAJOR < 17
   }
 
   QualType VisitorBase::DetermineCladArrayValueType(clang::QualType T) {

--- a/test/Gradient/Lambdas.C
+++ b/test/Gradient/Lambdas.C
@@ -143,10 +143,10 @@ double f6(double i) {
 
 // CHECK: void f6_grad(double i, double *_d_i) {
 // CHECK-NEXT:     auto _outer0 = [](double x) {
-// CHECK-NEXT:         auto _inner = [](double y) {
+// CHECK-NEXT:         auto _inner0 = [](double y) {
 // CHECK-NEXT:             return y * y;
 // CHECK-NEXT:         };
-// CHECK-NEXT:         return _inner(x) + 2. * x;
+// CHECK-NEXT:         return _inner0(x) + 2. * x;
 // CHECK-NEXT:     };
 // CHECK-NEXT:     auto _d__outer = [](double x, double _d_y, double *_d_x) {
 // CHECK-NEXT:         auto _inner0 = [](double y) {


### PR DESCRIPTION
clad assembles each derivative by hand and must keep it a proper tree -- no node the child (Stmt::children()) of two parents. Across the differentiation rules it instead fed one expression into two places: a primal operand reused as the derived operand (pointer/shift derivatives, product and quotient rules), an assignment lvalue reused in its own adjoint, recorded values shared between the forward and reverse passes, aggregate/InitListExpr subtrees, and cached references (adjoints, loop counters, tape and tracker refs, the error index/return expressions). Such a node has two parents, benign until a later pass rewrites it in place and the edit leaks into unrelated code (and it breaks CodeGen for shared aggregate initializers). This is a property of the hand-built body, not of Clang ASTs in general, which do share nodes across type and template-argument edges and InitListExpr's dual forms.

Clone the reused expression so each occurrence owns its node. The clone lives at the narrowest correct owner: at the reuse site for a one-off local; inside the clad helper that builds the second use (memset, tracker store, central-difference calls); and on read in the accessor of an inherently reused cached reference. Add CloneNode for a reference-preserving (non-remapping) subtree copy, and buildClonedLambda so a copied lambda gets a fresh closure instead of sharing the original's operator() body. Generic builders (BuildOp) stay non-cloning: they receive whole subtrees and would deep-copy them repeatedly.

Enforce the invariant in DerivativeBuilder: on asserts builds findSharedNode aborts generation if any node has two parents, catching a rule that stops cloning here rather than as a later codegen crash. Release has no assert, so unshareNodes then repairs residual sharing (cloning later occurrences, warning as it does) as a defensive net -- the per-rule cloning and this assert are the real guarantee. A subtree that declares locals is left in place, since cloning would duplicate the declaration, and must be fixed at its source.