### PR TITLE
Add SmallPTDiff demo

### DIFF
--- a/demos/ComputerGraphics/smallpt/SmallPTDiff.cpp
+++ b/demos/ComputerGraphics/smallpt/SmallPTDiff.cpp
@@ -1,0 +1,71 @@
+// Differentiable SmallPT path tracer (full radiance kernel via clad).
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include "SmallPTDiffRadiance.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+using Refl_t = ::Refl_t;
+
+inline double clamp(double x) { return x < 0 ? 0 : x > 1 ? 1 : x; }
+
+inline int toInt(double x) { return int(pow(clamp(x), 1 / 2.2) * 255 + .5); }
+
+inline Vec radiance(const Ray& r, int depth, unsigned short* Xi) {
+  return diff_radiance(r, depth, Xi);
+}
+
+int main(int argc, char* argv[]) {
+  int w = 512, h = 384, samps = argc >= 2 ? atoi(argv[1]) / 4 : 1;
+
+  int fr = 0;
+  Ray cam(Vec(50, 52, 295.6 - fr * 10), Vec(0, -0.042612, -1).norm());
+  Vec cx = Vec(w * .5135 / h);
+  Vec cy = (cx % cam.d).norm() * .5135;
+  Vec r;
+  Vec* frame = new Vec[w * h];
+
+#pragma omp parallel for schedule(dynamic, 1) private(r)
+  for (unsigned short y = 0; y < h; y++) {
+    for (unsigned short x = 0, Xi[3] = {0, 0, (unsigned short)(y * y * y)};
+         x < w; x++) {
+      for (int sy = 0, i = (h - y - 1) * w + x; sy < 2; sy++) {
+        for (int sx = 0; sx < 2; sx++, r = Vec()) {
+          for (int s = 0; s < samps; s++) {
+            double r1 = 2 * erand48(Xi);
+            double dx = r1 < 1 ? sqrt(r1) - 1 : 1 - sqrt(2 - r1);
+            double r2 = 2 * erand48(Xi);
+            double dy = r2 < 1 ? sqrt(r2) - 1 : 1 - sqrt(2 - r2);
+            Vec d = cx * (((sx + .5 + dx) / 2 + x) / w - .5) +
+                    cy * (((sy + .5 + dy) / 2 + y) / h - .5) + cam.d;
+            Vec d_norm = d.norm();
+            Vec origin = cam.o + d_norm * 140;
+            r = r + radiance(Ray(origin, d_norm), 0, Xi) * (1. / samps);
+          }
+          Vec clamped = Vec(clamp(r.x), clamp(r.y), clamp(r.z));
+          Vec scaled = clamped * .25;
+          frame[i] = frame[i] + scaled;
+        }
+      }
+    }
+  }
+
+  char filename[100];
+  snprintf(filename, 100, "image-%d.ppm", fr);
+  fprintf(stderr, "\rSave %s\n", filename);
+  FILE* f = fopen(filename, "wb");
+  fprintf(f, "P6\n%d %d\n%d\n", w, h, 255);
+  for (int i = 0; i < w * h; i++)
+    fprintf(f, "%c%c%c", toInt(frame[i].x), toInt(frame[i].y),
+            toInt(frame[i].z));
+  fclose(f);
+  delete[] frame;
+  return 0;
+}

--- a/demos/ComputerGraphics/smallpt/SmallPTDiff.cpp
+++ b/demos/ComputerGraphics/smallpt/SmallPTDiff.cpp
@@ -1,71 +1,194 @@
-// Differentiable SmallPT path tracer (full radiance kernel via clad).
+// Inverse-rendering demo: recover light emission scale via clad + Adam.
+//
+// To compile the demo please type:
+// path/to/clang++ -O0 -Xclang -add-plugin -Xclang clad -Xclang -load -Xclang
+// path/to/clad.so -I../../include -I. -std=c++17 SmallPTDiff.cpp -o SmallPTDiff
+//
+// To run the demo please type:
+// ./SmallPTDiff
 
 #include "clad/Differentiator/Differentiator.h"
 
-#include "SmallPTDiffRadiance.h"
+#include "SmallPTDiffObjectives.h"
 
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
+namespace {
 
-using Refl_t = ::Refl_t;
+constexpr int kImgW = 512;
+constexpr int kImgH = 384;
+constexpr int kPatchW = 16;
+constexpr int kPatchH = 16;
+constexpr int kSamps = 1;
+constexpr int kMaxSteps = 40;
+constexpr int kVizW = 64;
+constexpr int kVizH = 48;
 
-inline double clamp(double x) { return x < 0 ? 0 : x > 1 ? 1 : x; }
-
-inline int toInt(double x) { return int(pow(clamp(x), 1 / 2.2) * 255 + .5); }
-
-inline Vec radiance(const Ray& r, int depth, unsigned short* Xi) {
-  return diff_radiance(r, depth, Xi);
+inline double clamp01(double x) {
+  if (x < 0)
+    return 0;
+  if (x > 1)
+    return 1;
+  return x;
 }
 
-int main(int argc, char* argv[]) {
-  int w = 512, h = 384, samps = argc >= 2 ? atoi(argv[1]) / 4 : 1;
+inline int toInt(double x) {
+  return int(std::pow(clamp01(x), 1.0 / 2.2) * 255 + 0.5);
+}
 
-  int fr = 0;
-  Ray cam(Vec(50, 52, 295.6 - fr * 10), Vec(0, -0.042612, -1).norm());
-  Vec cx = Vec(w * .5135 / h);
-  Vec cy = (cx % cam.d).norm() * .5135;
-  Vec r;
-  Vec* frame = new Vec[w * h];
+void save_gray_ppm(const std::string& path, int w, int h,
+                   const std::vector<double>& img) {
+  std::ofstream ofs(path, std::ios::binary);
+  if (!ofs)
+    return;
+  ofs << "P6\n" << w << " " << h << "\n255\n";
+  for (double val : img) {
+    unsigned char c = static_cast<unsigned char>(toInt(val));
+    ofs.put(static_cast<char>(c));
+    ofs.put(static_cast<char>(c));
+    ofs.put(static_cast<char>(c));
+  }
+}
 
-#pragma omp parallel for schedule(dynamic, 1) private(r)
-  for (unsigned short y = 0; y < h; y++) {
-    for (unsigned short x = 0, Xi[3] = {0, 0, (unsigned short)(y * y * y)};
-         x < w; x++) {
-      for (int sy = 0, i = (h - y - 1) * w + x; sy < 2; sy++) {
-        for (int sx = 0; sx < 2; sx++, r = Vec()) {
-          for (int s = 0; s < samps; s++) {
-            double r1 = 2 * erand48(Xi);
-            double dx = r1 < 1 ? sqrt(r1) - 1 : 1 - sqrt(2 - r1);
-            double r2 = 2 * erand48(Xi);
-            double dy = r2 < 1 ? sqrt(r2) - 1 : 1 - sqrt(2 - r2);
-            Vec d = cx * (((sx + .5 + dx) / 2 + x) / w - .5) +
-                    cy * (((sy + .5 + dy) / 2 + y) / h - .5) + cam.d;
-            Vec d_norm = d.norm();
-            Vec origin = cam.o + d_norm * 140;
-            r = r + radiance(Ray(origin, d_norm), 0, Xi) * (1. / samps);
-          }
-          Vec clamped = Vec(clamp(r.x), clamp(r.y), clamp(r.z));
-          Vec scaled = clamped * .25;
-          frame[i] = frame[i] + scaled;
-        }
-      }
+void render_patch(double light_e, int x0, int y0, int pw, int ph, int samps,
+                  std::vector<double>& out) {
+  out.resize(static_cast<size_t>(pw * ph));
+  for (int py = 0; py < ph; ++py) {
+    for (int px = 0; px < pw; ++px) {
+      out[static_cast<size_t>(py * pw + px)] =
+          diff_objective_pixel_aa_samps_light_e(x0 + px, y0 + py, light_e,
+                                                samps);
     }
   }
+}
 
-  char filename[100];
-  snprintf(filename, 100, "image-%d.ppm", fr);
-  fprintf(stderr, "\rSave %s\n", filename);
-  FILE* f = fopen(filename, "wb");
-  fprintf(f, "P6\n%d %d\n%d\n", w, h, 255);
-  for (int i = 0; i < w * h; i++)
-    fprintf(f, "%c%c%c", toInt(frame[i].x), toInt(frame[i].y),
-            toInt(frame[i].z));
-  fclose(f);
-  delete[] frame;
-  return 0;
+void render_downsampled(double light_e, int viz_w, int viz_h, int samps,
+                        std::vector<double>& out) {
+  out.resize(static_cast<size_t>(viz_w * viz_h));
+  for (int vy = 0; vy < viz_h; ++vy) {
+    int py = vy * kImgH / viz_h;
+    for (int vx = 0; vx < viz_w; ++vx) {
+      int px = vx * kImgW / viz_w;
+      out[static_cast<size_t>(vy * viz_w + vx)] =
+          diff_objective_pixel_aa_samps_light_e(px, py, light_e, samps);
+    }
+  }
+}
+
+double patch_mse(double light_e, int x0, int y0, int pw, int ph, int samps,
+                 const std::vector<double>& target) {
+  double loss = 0;
+  for (int py = 0; py < ph; ++py) {
+    for (int px = 0; px < pw; ++px) {
+      double tv = target[static_cast<size_t>(py * pw + px)];
+      loss += diff_pixel_loss_light_e(light_e, x0 + px, y0 + py, samps, tv);
+    }
+  }
+  return loss / (pw * ph);
+}
+
+} // namespace
+
+int main() {
+  const int x0 = 248;
+  const int y0 = 316;
+  const double gt_light_e = kDefaultLightE;
+  double light_e = 0.35;
+  const std::string outdir = "visualizations/light_e";
+
+  std::filesystem::create_directories(outdir);
+
+  std::vector<double> target;
+  render_patch(gt_light_e, x0, y0, kPatchW, kPatchH, kSamps, target);
+  save_gray_ppm(outdir + "/target_patch.ppm", kPatchW, kPatchH, target);
+
+  std::vector<double> start_patch;
+  render_patch(light_e, x0, y0, kPatchW, kPatchH, kSamps, start_patch);
+  save_gray_ppm(outdir + "/start_patch.ppm", kPatchW, kPatchH, start_patch);
+
+  std::vector<double> viz;
+  render_downsampled(gt_light_e, kVizW, kVizH, kSamps, viz);
+  save_gray_ppm(outdir + "/target.ppm", kVizW, kVizH, viz);
+  render_downsampled(light_e, kVizW, kVizH, kSamps, viz);
+  save_gray_ppm(outdir + "/start.ppm", kVizW, kVizH, viz);
+
+  std::cout << "Target light_e=" << std::fixed << std::setprecision(4)
+            << gt_light_e << '\n';
+  std::cout << "Start  light_e=" << light_e << '\n';
+
+  std::ofstream csv(outdir + "/trajectory.csv");
+  csv << "step,light_e,loss,err\n";
+
+  auto grad = clad::gradient(diff_pixel_loss_light_e, "light_e");
+
+  double lr = 0.08;
+  double m = 0.0;
+  double v = 0.0;
+  const double beta1 = 0.9;
+  const double beta2 = 0.999;
+  const double eps = 1e-8;
+
+  const double loss0 =
+      patch_mse(light_e, x0, y0, kPatchW, kPatchH, kSamps, target);
+  double loss = loss0;
+
+  for (int step = 1; step <= kMaxSteps; ++step) {
+    double g = 0.0;
+    loss = 0.0;
+    for (int py = 0; py < kPatchH; ++py) {
+      for (int px = 0; px < kPatchW; ++px) {
+        double tv = target[static_cast<size_t>(py * kPatchW + px)];
+        double dg = 0.0;
+        grad.execute(light_e, x0 + px, y0 + py, kSamps, tv, &dg);
+        g += dg;
+        loss +=
+            diff_pixel_loss_light_e(light_e, x0 + px, y0 + py, kSamps, tv);
+      }
+    }
+    g /= (kPatchW * kPatchH);
+    loss /= (kPatchW * kPatchH);
+
+    m = beta1 * m + (1 - beta1) * g;
+    v = beta2 * v + (1 - beta2) * g * g;
+    double m_hat = m / (1 - std::pow(beta1, step));
+    double v_hat = v / (1 - std::pow(beta2, step));
+    light_e -= lr * m_hat / (std::sqrt(v_hat) + eps);
+    if (light_e < 0.0)
+      light_e = 0.0;
+    lr *= 0.995;
+
+    double err = std::fabs(light_e - gt_light_e);
+    csv << step << "," << light_e << "," << loss << "," << err << "\n";
+
+    if (step % 5 == 0 || err < 0.05) {
+      std::cout << "Step " << std::setw(3) << step << ": loss=" << std::fixed
+                << std::setprecision(6) << loss << " light_e="
+                << std::setprecision(4) << light_e << " err=" << err << '\n';
+    }
+
+    if (err < 0.05)
+      break;
+  }
+
+  render_patch(light_e, x0, y0, kPatchW, kPatchH, kSamps, start_patch);
+  save_gray_ppm(outdir + "/final_patch.ppm", kPatchW, kPatchH, start_patch);
+  render_downsampled(light_e, kVizW, kVizH, kSamps, viz);
+  save_gray_ppm(outdir + "/final.ppm", kVizW, kVizH, viz);
+
+  const double err = std::fabs(light_e - gt_light_e);
+  std::cout << "Final light_e=" << std::setprecision(4) << light_e
+            << " err=" << err << " loss0=" << std::setprecision(6) << loss0
+            << " loss=" << loss << '\n';
+
+  const bool ok = err < 0.15 && loss < loss0;
+  std::cout << "SMALLPT_DIFF_INVERSE_PASS=" << (ok ? 1 : 0) << '\n';
+  return ok ? 0 : 1;
 }

--- a/demos/ComputerGraphics/smallpt/SmallPTDiffCommon.h
+++ b/demos/ComputerGraphics/smallpt/SmallPTDiffCommon.h
@@ -1,0 +1,189 @@
+#ifndef SMALLPT_DIFF_COMMON_H
+#define SMALLPT_DIFF_COMMON_H
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cmath>
+#include <cstdlib>
+
+#define non_differentiable __attribute__((annotate("non_differentiable")))
+
+struct Vec {
+  double x, y, z;
+  Vec(double x_ = 0, double y_ = 0, double z_ = 0) : x(x_), y(y_), z(z_) {}
+  Vec operator+(const Vec& b) const { return Vec(x + b.x, y + b.y, z + b.z); }
+  Vec operator-(const Vec& b) const { return Vec(x - b.x, y - b.y, z - b.z); }
+  Vec operator*(double b) const { return Vec(x * b, y * b, z * b); }
+  double operator*(const Vec& b) const { return x * b.x + y * b.y + z * b.z; }
+  Vec operator%(const Vec& b) const {
+    return Vec(y * b.z - z * b.y, z * b.x - x * b.z, x * b.y - y * b.x);
+  }
+  Vec mult(const Vec& b) const { return Vec(x * b.x, y * b.y, z * b.z); }
+  Vec norm() const;
+};
+
+namespace clad {
+namespace custom_derivatives {
+namespace class_functions {
+inline void operator_plus_pullback(const Vec* a, const Vec& b, Vec d_out,
+                                   Vec* d_a, Vec* d_b) {
+  d_a->x += d_out.x;
+  d_a->y += d_out.y;
+  d_a->z += d_out.z;
+  d_b->x += d_out.x;
+  d_b->y += d_out.y;
+  d_b->z += d_out.z;
+}
+inline void operator_minus_pullback(const Vec* a, const Vec& b, Vec d_out,
+                                    Vec* d_a, Vec* d_b) {
+  d_a->x += d_out.x;
+  d_a->y += d_out.y;
+  d_a->z += d_out.z;
+  d_b->x -= d_out.x;
+  d_b->y -= d_out.y;
+  d_b->z -= d_out.z;
+}
+inline void operator_star_pullback(const Vec* a, double b, Vec d_out, Vec* d_a,
+                                   double* d_b) {
+  d_a->x += d_out.x * b;
+  d_a->y += d_out.y * b;
+  d_a->z += d_out.z * b;
+  *d_b += a->x * d_out.x + a->y * d_out.y + a->z * d_out.z;
+}
+inline void operator_star_pullback(const Vec* a, const Vec& b, double d_out,
+                                   Vec* d_a, Vec* d_b) {
+  d_a->x += d_out * b.x;
+  d_a->y += d_out * b.y;
+  d_a->z += d_out * b.z;
+  d_b->x += d_out * a->x;
+  d_b->y += d_out * a->y;
+  d_b->z += d_out * a->z;
+}
+inline void operator_percent_pullback(const Vec* a, const Vec& b, Vec d_out,
+                                      Vec* d_a, Vec* d_b) {
+  d_a->x += d_out.y * b.z - d_out.z * b.y;
+  d_a->y += d_out.x * b.z - d_out.z * b.x;
+  d_a->z += d_out.y * b.x - d_out.x * b.y;
+  d_b->x += d_out.y * a->z - d_out.z * a->y;
+  d_b->y += d_out.z * a->x - d_out.x * a->z;
+  d_b->z += d_out.x * a->y - d_out.y * a->x;
+}
+inline void mult_pullback(const Vec* a, const Vec& b, Vec d_out, Vec* d_a,
+                          Vec* d_b) {
+  d_a->x += d_out.x * b.x;
+  d_a->y += d_out.y * b.y;
+  d_a->z += d_out.z * b.z;
+  d_b->x += d_out.x * a->x;
+  d_b->y += d_out.y * a->y;
+  d_b->z += d_out.z * a->z;
+}
+} // namespace class_functions
+} // namespace custom_derivatives
+} // namespace clad
+
+non_differentiable inline double sample_erand48(unsigned short* Xi) {
+  return erand48(Xi);
+}
+
+namespace clad {
+namespace custom_derivatives {
+inline void sample_erand48_pullback(unsigned short* /*Xi*/, double /*d_out*/,
+                                    unsigned short* /*d_Xi*/) {}
+} // namespace custom_derivatives
+} // namespace clad
+
+struct Ray {
+  Vec o, d;
+  Ray() : o(), d() {}
+  Ray(Vec o_, Vec d_) : o(o_), d(d_) {}
+};
+
+enum Refl_t { DIFF, SPEC, REFR };
+
+static constexpr double kInf = 1e6;
+static constexpr double kEps = 1e-6;
+static constexpr double kPi = 3.14159265358979323846;
+
+static inline Vec normalize_vec(const Vec& v) {
+  double inv = 1.0 / sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+  return v * inv;
+}
+
+inline Vec Vec::norm() const { return normalize_vec(*this); }
+
+static inline double vec_avg(const Vec& v) { return (v.x + v.y + v.z) / 3.0; }
+
+struct DiffSphere {
+  double rad;
+  Vec pos, emission, color;
+  Refl_t refl;
+};
+
+static constexpr int kNumSpheres = 9;
+static constexpr int kLightSphereId = 8;
+static constexpr int kMirrorSphereId = 6;
+static constexpr double kDefaultLightY = 681.6 - .27;
+static constexpr double kDefaultMirrorX = 27.0;
+// Floor patch where mirror-reflected path-traced radiance is non-zero at
+// defaults.
+static constexpr int kMirrorRadiancePatchX0 = 200;
+static constexpr int kMirrorRadiancePatchY0 = 320;
+static constexpr int kMirrorRadiancePatchW = 4;
+static constexpr int kMirrorRadiancePatchH = 4;
+static constexpr double kDefaultCamDirX = 0.0;
+static constexpr double kDefaultCamDirY = -0.042612;
+static constexpr double kDefaultCamDirZ = -1.0;
+static const DiffSphere kDiffScene[kNumSpheres] = {
+    {1e5, Vec(1e5 + 1, 40.8, 81.6), Vec(), Vec(.75, .25, .25), DIFF},
+    {1e5, Vec(-1e5 + 99, 40.8, 81.6), Vec(), Vec(.25, .25, .75), DIFF},
+    {1e5, Vec(50, 40.8, 1e5), Vec(), Vec(.75, .75, .75), DIFF},
+    {1e5, Vec(50, 40.8, -1e5 + 170), Vec(), Vec(), DIFF},
+    {1e5, Vec(50, 1e5, 81.6), Vec(), Vec(.75, .75, .75), DIFF},
+    {1e5, Vec(50, -1e5 + 81.6, 81.6), Vec(), Vec(.75, .75, .75), DIFF},
+    {16.5, Vec(27, 16.5, 47), Vec(), Vec(.999, .999, .999), SPEC},
+    {16.5, Vec(73, 16.5, 78), Vec(), Vec(.999, .999, .999), REFR},
+    {600, Vec(50, 681.6 - .27, 81.6), Vec(12, 12, 12), Vec(), DIFF}};
+
+static inline double diff_sphere_intersect(double srad, double spx, double spy,
+                                           double spz, double rox, double roy,
+                                           double roz, double rdx, double rdy,
+                                           double rdz) {
+  double opx = spx - rox, opy = spy - roy, opz = spz - roz;
+  double b = opx * rdx + opy * rdy + opz * rdz;
+  double det = b * b - (opx * opx + opy * opy + opz * opz) + srad * srad;
+  if (det < 0)
+    return 0;
+  det = sqrt(det);
+  double t1 = b - det, t2 = b + det;
+  if (t1 > kEps)
+    return t1;
+  if (t2 > kEps)
+    return t2;
+  return 0;
+}
+
+static inline bool diff_intersect(double rox, double roy, double roz,
+                                  double rdx, double rdy, double rdz, double& t,
+                                  int& id, double light_y = kDefaultLightY,
+                                  double mirror_x = kDefaultMirrorX) {
+  t = kInf;
+  id = 0;
+  for (int i = kNumSpheres; i--;) {
+    double spx = kDiffScene[i].pos.x;
+    if (i == kMirrorSphereId)
+      spx = mirror_x;
+    double spy = kDiffScene[i].pos.y;
+    if (i == kLightSphereId)
+      spy = light_y;
+    double d =
+        diff_sphere_intersect(kDiffScene[i].rad, spx, spy, kDiffScene[i].pos.z,
+                              rox, roy, roz, rdx, rdy, rdz);
+    if (d > 0 && d < t) {
+      t = d;
+      id = i;
+    }
+  }
+  return t < kInf;
+}
+
+#endif // SMALLPT_DIFF_COMMON_H

--- a/demos/ComputerGraphics/smallpt/SmallPTDiffCommon.h
+++ b/demos/ComputerGraphics/smallpt/SmallPTDiffCommon.h
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <cstdlib>
+#include <stdlib.h>
 
 #define non_differentiable __attribute__((annotate("non_differentiable")))
 
@@ -124,12 +125,15 @@ static constexpr int kLightSphereId = 8;
 static constexpr int kMirrorSphereId = 6;
 static constexpr double kDefaultLightY = 681.6 - .27;
 static constexpr double kDefaultMirrorX = 27.0;
-// Floor patch where mirror-reflected path-traced radiance is non-zero at
-// defaults.
+static constexpr double kDefaultLightE = 1.0;
 static constexpr int kMirrorRadiancePatchX0 = 200;
 static constexpr int kMirrorRadiancePatchY0 = 320;
 static constexpr int kMirrorRadiancePatchW = 4;
 static constexpr int kMirrorRadiancePatchH = 4;
+static constexpr int kLightEmitPatchX0 = 254;
+static constexpr int kLightEmitPatchY0 = 320;
+static constexpr int kLightEmitPatchW = 4;
+static constexpr int kLightEmitPatchH = 4;
 static constexpr double kDefaultCamDirX = 0.0;
 static constexpr double kDefaultCamDirY = -0.042612;
 static constexpr double kDefaultCamDirZ = -1.0;

--- a/demos/ComputerGraphics/smallpt/SmallPTDiffObjectives.h
+++ b/demos/ComputerGraphics/smallpt/SmallPTDiffObjectives.h
@@ -1,0 +1,113 @@
+#ifndef SMALLPT_DIFF_OBJECTIVES_H
+#define SMALLPT_DIFF_OBJECTIVES_H
+
+#include "SmallPTDiffRadiance.h"
+
+inline double diff_subpixel_jitter(double r) {
+  if (r < 1)
+    return sqrt(r) - 1;
+  return 1 - sqrt(2 - r);
+}
+
+inline double diff_objective_pixel(int pixel_x, int pixel_y, int samps,
+                                   double cam_x, double cam_y, double cam_z,
+                                   double light_y, double mirror_x) {
+  const int w = 512;
+  const int h = 384;
+
+  unsigned short Xi[3] = {0, 0, (unsigned short)(pixel_y * pixel_y * pixel_y)};
+
+  Vec cam_dir_raw(kDefaultCamDirX, kDefaultCamDirY, kDefaultCamDirZ);
+  Vec cam_dir = normalize_vec(cam_dir_raw);
+  Vec cxv(w * .5135 / h);
+  Vec cx_cross = cxv % cam_dir;
+  Vec cyv = normalize_vec(cx_cross);
+  Vec cy_scaled = cyv * .5135;
+  Vec cam_pos(cam_x, cam_y, cam_z);
+
+  double inv_samps = 1.0 / samps;
+  double sum = 0;
+  for (int sy = 0; sy < 2; ++sy) {
+    for (int sx = 0; sx < 2; ++sx) {
+      double subpix_sum = 0;
+      for (int s = 0; s < samps; ++s) {
+        double r1 = 2 * sample_erand48(Xi);
+        double jitter_x = diff_subpixel_jitter(r1);
+        double r2 = 2 * sample_erand48(Xi);
+        double jitter_y = diff_subpixel_jitter(r2);
+
+        double u = ((sx + .5 + jitter_x) / 2 + pixel_x) / (double)w - .5;
+        double v = ((sy + .5 + jitter_y) / 2 + pixel_y) / (double)h - .5;
+        Vec cx_term = cxv * u;
+        Vec cy_term = cy_scaled * v;
+        Vec sum_xy = cx_term + cy_term;
+        Vec d_unnorm = sum_xy + cam_dir;
+        Vec d = normalize_vec(d_unnorm);
+        Vec offset = d * 140;
+        Vec origin = cam_pos + offset;
+        Ray ray(origin, d);
+        Vec L = diff_radiance(ray, 0, Xi, light_y, mirror_x);
+        double sample_avg = vec_avg(L);
+        subpix_sum = subpix_sum + sample_avg * inv_samps;
+      }
+      sum = sum + subpix_sum;
+    }
+  }
+  return sum * 0.25;
+}
+
+inline double diff_objective_demo_aa(double cam_x, double cam_y, double cam_z) {
+  return diff_objective_pixel(256, 192, 1, cam_x, cam_y, cam_z, kDefaultLightY,
+                              kDefaultMirrorX);
+}
+
+inline double diff_objective_pixel_aa_samps(int pixel_x, int pixel_y,
+                                            double cam_x, double cam_y,
+                                            double cam_z, int samps) {
+  return diff_objective_pixel(pixel_x, pixel_y, samps, cam_x, cam_y, cam_z,
+                              kDefaultLightY, kDefaultMirrorX);
+}
+
+inline double diff_objective_patch_mean(double cam_x, double cam_y,
+                                        double cam_z, int x0, int y0,
+                                        int patch_w, int patch_h, int samps) {
+  double sum = 0;
+  int count = patch_w * patch_h;
+  for (int py = y0; py < y0 + patch_h; ++py) {
+    for (int px = x0; px < x0 + patch_w; ++px) {
+      double pix =
+          diff_objective_pixel_aa_samps(px, py, cam_x, cam_y, cam_z, samps);
+      sum = sum + pix;
+    }
+  }
+  return sum / count;
+}
+
+inline double diff_objective_light_y(double light_y) {
+  return diff_objective_pixel(256, 192, 1, 50.0, 52.0, 295.6, light_y,
+                              kDefaultMirrorX);
+}
+
+inline double diff_objective_pixel_aa_samps_mirror_x(int pixel_x, int pixel_y,
+                                                     double mirror_x,
+                                                     int samps) {
+  return diff_objective_pixel(pixel_x, pixel_y, samps, 50.0, 52.0, 295.6,
+                              kDefaultLightY, mirror_x);
+}
+
+inline double diff_objective_patch_mirror_x(double mirror_x, int x0, int y0,
+                                            int patch_w, int patch_h,
+                                            int samps) {
+  double sum = 0;
+  int count = patch_w * patch_h;
+  for (int py = y0; py < y0 + patch_h; ++py) {
+    for (int px = x0; px < x0 + patch_w; ++px) {
+      double pix =
+          diff_objective_pixel_aa_samps_mirror_x(px, py, mirror_x, samps);
+      sum = sum + pix;
+    }
+  }
+  return sum / count;
+}
+
+#endif // SMALLPT_DIFF_OBJECTIVES_H

--- a/demos/ComputerGraphics/smallpt/SmallPTDiffObjectives.h
+++ b/demos/ComputerGraphics/smallpt/SmallPTDiffObjectives.h
@@ -11,7 +11,8 @@ inline double diff_subpixel_jitter(double r) {
 
 inline double diff_objective_pixel(int pixel_x, int pixel_y, int samps,
                                    double cam_x, double cam_y, double cam_z,
-                                   double light_y, double mirror_x) {
+                                   double light_y, double mirror_x,
+                                   double light_e = kDefaultLightE) {
   const int w = 512;
   const int h = 384;
 
@@ -46,7 +47,7 @@ inline double diff_objective_pixel(int pixel_x, int pixel_y, int samps,
         Vec offset = d * 140;
         Vec origin = cam_pos + offset;
         Ray ray(origin, d);
-        Vec L = diff_radiance(ray, 0, Xi, light_y, mirror_x);
+        Vec L = diff_radiance(ray, 0, Xi, light_y, mirror_x, light_e);
         double sample_avg = vec_avg(L);
         subpix_sum = subpix_sum + sample_avg * inv_samps;
       }
@@ -58,14 +59,14 @@ inline double diff_objective_pixel(int pixel_x, int pixel_y, int samps,
 
 inline double diff_objective_demo_aa(double cam_x, double cam_y, double cam_z) {
   return diff_objective_pixel(256, 192, 1, cam_x, cam_y, cam_z, kDefaultLightY,
-                              kDefaultMirrorX);
+                              kDefaultMirrorX, kDefaultLightE);
 }
 
 inline double diff_objective_pixel_aa_samps(int pixel_x, int pixel_y,
                                             double cam_x, double cam_y,
                                             double cam_z, int samps) {
   return diff_objective_pixel(pixel_x, pixel_y, samps, cam_x, cam_y, cam_z,
-                              kDefaultLightY, kDefaultMirrorX);
+                              kDefaultLightY, kDefaultMirrorX, kDefaultLightE);
 }
 
 inline double diff_objective_patch_mean(double cam_x, double cam_y,
@@ -85,14 +86,70 @@ inline double diff_objective_patch_mean(double cam_x, double cam_y,
 
 inline double diff_objective_light_y(double light_y) {
   return diff_objective_pixel(256, 192, 1, 50.0, 52.0, 295.6, light_y,
-                              kDefaultMirrorX);
+                              kDefaultMirrorX, kDefaultLightE);
+}
+
+inline double diff_objective_pixel_aa_samps_light_y(int pixel_x, int pixel_y,
+                                                    double light_y, int samps) {
+  return diff_objective_pixel(pixel_x, pixel_y, samps, 50.0, 52.0, 295.6,
+                              light_y, kDefaultMirrorX, kDefaultLightE);
+}
+
+inline double diff_objective_patch_light_y(double light_y, int x0, int y0,
+                                           int patch_w, int patch_h,
+                                           int samps) {
+  double sum = 0;
+  int count = patch_w * patch_h;
+  for (int py = y0; py < y0 + patch_h; ++py) {
+    for (int px = x0; px < x0 + patch_w; ++px) {
+      double pix =
+          diff_objective_pixel_aa_samps_light_y(px, py, light_y, samps);
+      sum = sum + pix;
+    }
+  }
+  return sum / count;
+}
+
+inline double diff_objective_pixel_aa_samps_light_e(int pixel_x, int pixel_y,
+                                                    double light_e, int samps) {
+  return diff_objective_pixel(pixel_x, pixel_y, samps, 50.0, 52.0, 295.6,
+                              kDefaultLightY, kDefaultMirrorX, light_e);
+}
+
+inline double diff_objective_patch_light_e(double light_e, int x0, int y0,
+                                           int patch_w, int patch_h,
+                                           int samps) {
+  double sum = 0;
+  int count = patch_w * patch_h;
+  for (int py = y0; py < y0 + patch_h; ++py) {
+    for (int px = x0; px < x0 + patch_w; ++px) {
+      double pix =
+          diff_objective_pixel_aa_samps_light_e(px, py, light_e, samps);
+      sum = sum + pix;
+    }
+  }
+  return sum / count;
+}
+
+inline double diff_pixel_loss_light_e(double light_e, int pixel_x, int pixel_y,
+                                      int samps, double target) {
+  double rendered =
+      diff_objective_pixel_aa_samps_light_e(pixel_x, pixel_y, light_e, samps);
+  double diff = rendered - target;
+  return diff * diff;
+}
+
+inline double diff_objective_light_e(double light_e) {
+  return diff_objective_pixel(kLightEmitPatchX0, kLightEmitPatchY0, 1, 50.0,
+                              52.0, 295.6, kDefaultLightY, kDefaultMirrorX,
+                              light_e);
 }
 
 inline double diff_objective_pixel_aa_samps_mirror_x(int pixel_x, int pixel_y,
                                                      double mirror_x,
                                                      int samps) {
   return diff_objective_pixel(pixel_x, pixel_y, samps, 50.0, 52.0, 295.6,
-                              kDefaultLightY, mirror_x);
+                              kDefaultLightY, mirror_x, kDefaultLightE);
 }
 
 inline double diff_objective_patch_mirror_x(double mirror_x, int x0, int y0,

--- a/demos/ComputerGraphics/smallpt/SmallPTDiffRadiance.h
+++ b/demos/ComputerGraphics/smallpt/SmallPTDiffRadiance.h
@@ -1,0 +1,134 @@
+#ifndef SMALLPT_DIFF_RADIANCE_H
+#define SMALLPT_DIFF_RADIANCE_H
+
+#include "SmallPTDiffCommon.h"
+
+// smallpt-style path tracer. light_y and mirror_x move the emissive and mirror
+// spheres; omit them (defaults) to use the fixed scene in kDiffScene.
+inline Vec diff_radiance(Ray r, int depth, unsigned short Xi[3],
+                         double light_y = kDefaultLightY,
+                         double mirror_x = kDefaultMirrorX) {
+  Vec cl(0, 0, 0); // accumulated radiance
+  Vec cf(1, 1, 1); // path throughput
+
+  for (;;) {
+    double t = 0;
+    int id = 0;
+    if (!diff_intersect(r.o.x, r.o.y, r.o.z, r.d.x, r.d.y, r.d.z, t, id,
+                        light_y, mirror_x))
+      return cl; // miss
+
+    const DiffSphere& obj = kDiffScene[id];
+    Vec x = r.o + r.d * t;
+
+    // Outward-facing normal (use parametric center for light / mirror spheres).
+    double center_x = obj.pos.x;
+    if (id == kMirrorSphereId)
+      center_x = mirror_x;
+    double center_y = obj.pos.y;
+    if (id == kLightSphereId)
+      center_y = light_y;
+    double norm_dx = x.x - center_x;
+    double norm_dy = x.y - center_y;
+    double norm_dz = x.z - obj.pos.z;
+    Vec hit_dx(norm_dx, norm_dy, norm_dz);
+    Vec n = normalize_vec(hit_dx);
+    Vec nl = n;
+    if (n * r.d >= 0) {
+      Vec neg_n = n * -1.0;
+      nl = neg_n;
+    }
+
+    Vec f = obj.color;
+    double p = f.x; // max reflectance, used for Russian roulette
+    if (f.y > p)
+      p = f.y;
+    if (f.z > p)
+      p = f.z;
+
+    Vec emission_term = cf.mult(obj.emission);
+    cl = cl + emission_term;
+
+    depth = depth + 1;
+    if (depth > 5 || !p) {
+      // Russian roulette: survive with prob p, else terminate path.
+      if (sample_erand48(Xi) < p) {
+        Vec scaled_f = f * (1.0 / p);
+        f = scaled_f;
+      } else {
+        return cl;
+      }
+    }
+
+    cf = cf.mult(f);
+
+    if (obj.refl == DIFF) {
+      // Cosine-weighted hemisphere sample.
+      double r1 = 2 * kPi * sample_erand48(Xi);
+      double r2 = sample_erand48(Xi);
+      double r2s = sqrt(r2);
+      Vec w = nl;
+      Vec basis(0, 1, 0);
+      if (fabs(w.x) > .1)
+        basis = Vec(1, 0, 0);
+      Vec u = normalize_vec(basis % w);
+      Vec v = w % u;
+      Vec u_cos = u * cos(r1);
+      Vec u_term = u_cos * r2s;
+      Vec v_sin = v * sin(r1);
+      Vec v_term = v_sin * r2s;
+      Vec uv_sum = u_term + v_term;
+      Vec w_sqrt = w * sqrt(1 - r2);
+      Vec bounce_dir = normalize_vec(uv_sum + w_sqrt);
+      r = Ray(x, bounce_dir);
+      continue;
+    }
+
+    if (obj.refl == SPEC) {
+      r = Ray(x, r.d - n * (2.0 * (n * r.d)));
+      continue;
+    }
+
+    // REFR: reflect or refract via Fresnel (Schlick).
+    double ndotr = n * r.d;
+    Vec reflect_term = n * (2.0 * ndotr);
+    Vec spec_dir = r.d - reflect_term;
+    Ray reflRay(x, spec_dir);
+
+    bool into = n * nl > 0;
+    double nc = 1.0, nt = 1.5;
+    double nnt = into ? nc / nt : nt / nc;
+    double ddn = r.d * nl;
+    double cos2t = 1 - nnt * nnt * (1 - ddn * ddn);
+
+    if (cos2t < 0) {
+      r = reflRay; // total internal reflection
+      continue;
+    }
+
+    double scale = (into ? 1.0 : -1.0) * (ddn * nnt + sqrt(cos2t));
+    Vec nnt_vec = r.d * nnt;
+    Vec ddn_vec = n * scale;
+    Vec tdir_unnorm = nnt_vec - ddn_vec;
+    Vec tdir = normalize_vec(tdir_unnorm);
+
+    double a = nt - nc, b = nt + nc;
+    double R0 = a * a / (b * b);
+    double c = 1 - (into ? -ddn : tdir * n);
+    double Re = R0 + (1 - R0) * c * c * c * c * c;
+    double Tr = 1 - Re;
+    double P = .25 + .5 * Re;
+    double RP = Re / P;
+    double TP = Tr / (1 - P);
+
+    if (sample_erand48(Xi) < P) {
+      cf = cf * RP;
+      r = reflRay;
+    } else {
+      cf = cf * TP;
+      r = Ray(x, tdir);
+    }
+  }
+}
+
+#endif // SMALLPT_DIFF_RADIANCE_H

--- a/demos/ComputerGraphics/smallpt/SmallPTDiffRadiance.h
+++ b/demos/ComputerGraphics/smallpt/SmallPTDiffRadiance.h
@@ -3,11 +3,10 @@
 
 #include "SmallPTDiffCommon.h"
 
-// smallpt-style path tracer. light_y and mirror_x move the emissive and mirror
-// spheres; omit them (defaults) to use the fixed scene in kDiffScene.
 inline Vec diff_radiance(Ray r, int depth, unsigned short Xi[3],
                          double light_y = kDefaultLightY,
-                         double mirror_x = kDefaultMirrorX) {
+                         double mirror_x = kDefaultMirrorX,
+                         double light_e = kDefaultLightE) {
   Vec cl(0, 0, 0); // accumulated radiance
   Vec cf(1, 1, 1); // path throughput
 
@@ -46,7 +45,10 @@ inline Vec diff_radiance(Ray r, int depth, unsigned short Xi[3],
     if (f.z > p)
       p = f.z;
 
-    Vec emission_term = cf.mult(obj.emission);
+    Vec emission = obj.emission;
+    if (id == kLightSphereId)
+      emission = emission * light_e;
+    Vec emission_term = cf.mult(emission);
     cl = cl + emission_term;
 
     depth = depth + 1;

--- a/demos/ComputerGraphics/smallpt/SmallPTDiffValidate.h
+++ b/demos/ComputerGraphics/smallpt/SmallPTDiffValidate.h
@@ -1,0 +1,150 @@
+// Shared AD validation helpers for SmallPT differentiable builds.
+#ifndef SMALLPT_DIFF_VALIDATE_H
+#define SMALLPT_DIFF_VALIDATE_H
+
+#include "SmallPTDiffObjectives.h"
+
+#include <cmath>
+#include <cstdio>
+
+static constexpr int kSmallPTWidth = 512;
+static constexpr int kSmallPTHeight = 384;
+
+static inline bool smallpt_essentially_equal(double a, double b,
+                                             double rel = 5e-2) {
+  if (std::fabs(a) < 1e-12 && std::fabs(b) < 1e-12)
+    return true;
+  return std::fabs(a - b) <= rel * std::fmax(std::fabs(a), std::fabs(b));
+}
+
+static inline double smallpt_central_fd3(double (*f)(double, double, double),
+                                         double x, double y, double z, int dim,
+                                         double h = 1e-4) {
+  double args[3] = {x, y, z};
+  args[dim] += h;
+  double fp = f(args[0], args[1], args[2]);
+  args[dim] -= 2 * h;
+  double fm = f(args[0], args[1], args[2]);
+  return (fp - fm) / (2 * h);
+}
+
+using smallpt_patch_fd_fn = double (*)(double, double, double, int, int, int,
+                                       int, int);
+
+static inline double smallpt_central_fd_patch(smallpt_patch_fd_fn f, double x,
+                                              double y, double z, int x0,
+                                              int y0, int pw, int ph, int samps,
+                                              int dim, double h = 1e-4) {
+  double args[3] = {x, y, z};
+  args[dim] += h;
+  double fp = f(args[0], args[1], args[2], x0, y0, pw, ph, samps);
+  args[dim] -= 2 * h;
+  double fm = f(args[0], args[1], args[2], x0, y0, pw, ph, samps);
+  return (fp - fm) / (2 * h);
+}
+
+static inline int smallpt_run_camera_grad_check() {
+  double cam_x = 50.0, cam_y = 52.0, cam_z = 295.6;
+  double g_x = 0, g_y = 0, g_z = 0;
+
+  auto grad = clad::gradient(diff_objective_demo_aa, "cam_x,cam_y,cam_z");
+  grad.execute(cam_x, cam_y, cam_z, &g_x, &g_y, &g_z);
+
+  bool pass = smallpt_essentially_equal(
+      g_x, smallpt_central_fd3(diff_objective_demo_aa, cam_x, cam_y, cam_z, 0));
+  pass &= smallpt_essentially_equal(
+      g_y, smallpt_central_fd3(diff_objective_demo_aa, cam_x, cam_y, cam_z, 1));
+  pass &= smallpt_essentially_equal(
+      g_z, smallpt_central_fd3(diff_objective_demo_aa, cam_x, cam_y, cam_z, 2));
+
+  printf("SMALLPT_GRAD_FD_PASS=%d\n", pass ? 1 : 0);
+  return pass ? 0 : 1;
+}
+
+static inline int smallpt_run_patch_grad_check(int patch_w, int patch_h,
+                                               int samps) {
+  double cam_x = 50.0, cam_y = 52.0, cam_z = 295.6;
+  int x0 = kSmallPTWidth / 2 - patch_w / 2;
+  int y0 = kSmallPTHeight / 2 - patch_h / 2;
+  double g_x = 0, g_y = 0, g_z = 0;
+
+  auto grad = clad::gradient(diff_objective_patch_mean, "cam_x,cam_y,cam_z");
+  grad.execute(cam_x, cam_y, cam_z, x0, y0, patch_w, patch_h, samps, &g_x, &g_y,
+               &g_z);
+
+  bool pass = smallpt_essentially_equal(
+      g_x, smallpt_central_fd_patch(diff_objective_patch_mean, cam_x, cam_y,
+                                    cam_z, x0, y0, patch_w, patch_h, samps, 0));
+  pass &= smallpt_essentially_equal(
+      g_y, smallpt_central_fd_patch(diff_objective_patch_mean, cam_x, cam_y,
+                                    cam_z, x0, y0, patch_w, patch_h, samps, 1));
+  pass &= smallpt_essentially_equal(
+      g_z, smallpt_central_fd_patch(diff_objective_patch_mean, cam_x, cam_y,
+                                    cam_z, x0, y0, patch_w, patch_h, samps, 2));
+
+  printf("SMALLPT_PATCH_GRAD_FD_PASS=%d\n", pass ? 1 : 0);
+  return pass ? 0 : 1;
+}
+
+static inline double smallpt_central_fd1(double (*f)(double), double x,
+                                         double h = 1e-4) {
+  double fp = f(x + h);
+  double fm = f(x - h);
+  return (fp - fm) / (2 * h);
+}
+
+static inline int smallpt_run_light_y_grad_check() {
+  double light_y = kDefaultLightY;
+  double g_y = 0;
+
+  auto grad = clad::gradient(diff_objective_light_y, "light_y");
+  grad.execute(light_y, &g_y);
+
+  bool pass = smallpt_essentially_equal(
+      g_y, smallpt_central_fd1(diff_objective_light_y, light_y));
+
+  printf("SMALLPT_LIGHT_Y_GRAD_FD_PASS=%d\n", pass ? 1 : 0);
+  return pass ? 0 : 1;
+}
+
+using smallpt_mirror_patch_fd_fn = double (*)(double, int, int, int, int, int);
+
+static inline double
+smallpt_central_fd_mirror_patch(smallpt_mirror_patch_fd_fn f, double mirror_x,
+                                int x0, int y0, int patch_w, int patch_h,
+                                int samps, double h = 1e-4) {
+  double fp = f(mirror_x + h, x0, y0, patch_w, patch_h, samps);
+  double fm = f(mirror_x - h, x0, y0, patch_w, patch_h, samps);
+  return (fp - fm) / (2 * h);
+}
+
+static inline int smallpt_run_mirror_patch_grad_check() {
+  double mirror_x = kDefaultMirrorX;
+  int x0 = kMirrorRadiancePatchX0;
+  int y0 = kMirrorRadiancePatchY0;
+  int patch_w = kMirrorRadiancePatchW;
+  int patch_h = kMirrorRadiancePatchH;
+  int samps = 1;
+
+  double radiance =
+      diff_objective_patch_mirror_x(mirror_x, x0, y0, patch_w, patch_h, samps);
+  if (radiance < 0.01) {
+    printf("PATCH_MIRROR_RADIANCE_FAIL=1\n");
+    return 1;
+  }
+  printf("PATCH_MIRROR_RADIANCE=%g\n", radiance);
+
+  double g_x = 0;
+  auto grad = clad::gradient(diff_objective_patch_mirror_x, "mirror_x");
+  grad.execute(mirror_x, x0, y0, patch_w, patch_h, samps, &g_x);
+
+  bool pass = smallpt_essentially_equal(
+      g_x,
+      smallpt_central_fd_mirror_patch(diff_objective_patch_mirror_x, mirror_x,
+                                      x0, y0, patch_w, patch_h, samps));
+
+  printf("SMALLPT_MIRROR_PATCH_GRAD_FD_PASS=%d\n", pass ? 1 : 0);
+  return pass ? 0 : 1;
+}
+
+#endif // SMALLPT_DIFF_VALIDATE_H

--- a/demos/ComputerGraphics/smallpt/SmallPTDiffValidate.h
+++ b/demos/ComputerGraphics/smallpt/SmallPTDiffValidate.h
@@ -1,4 +1,3 @@
-// Shared AD validation helpers for SmallPT differentiable builds.
 #ifndef SMALLPT_DIFF_VALIDATE_H
 #define SMALLPT_DIFF_VALIDATE_H
 
@@ -144,6 +143,89 @@ static inline int smallpt_run_mirror_patch_grad_check() {
                                       x0, y0, patch_w, patch_h, samps));
 
   printf("SMALLPT_MIRROR_PATCH_GRAD_FD_PASS=%d\n", pass ? 1 : 0);
+  return pass ? 0 : 1;
+}
+
+static inline int smallpt_run_light_e_grad_check() {
+  double light_e = kDefaultLightE;
+  double g_e = 0;
+
+  auto grad = clad::gradient(diff_objective_light_e, "light_e");
+  grad.execute(light_e, &g_e);
+
+  bool pass = smallpt_essentially_equal(
+      g_e, smallpt_central_fd1(diff_objective_light_e, light_e));
+  pass &= std::fabs(g_e) > 1e-6;
+
+  printf("SMALLPT_LIGHT_E_GRAD_FD_PASS=%d\n", pass ? 1 : 0);
+  return pass ? 0 : 1;
+}
+
+static inline int smallpt_run_light_e_gd_smoke() {
+  constexpr int patch_w = kLightEmitPatchW;
+  constexpr int patch_h = kLightEmitPatchH;
+  constexpr int samps = 1;
+  constexpr int steps = 10;
+  const int x0 = kLightEmitPatchX0;
+  const int y0 = kLightEmitPatchY0;
+  const double gt = kDefaultLightE;
+  double light_e = 0.4;
+
+  double targets[patch_w * patch_h];
+  for (int py = 0; py < patch_h; ++py) {
+    for (int px = 0; px < patch_w; ++px) {
+      targets[py * patch_w + px] =
+          diff_objective_pixel_aa_samps_light_e(x0 + px, y0 + py, gt, samps);
+    }
+  }
+
+  auto patch_loss = [&](double le) {
+    double loss = 0;
+    for (int py = 0; py < patch_h; ++py) {
+      for (int px = 0; px < patch_w; ++px) {
+        loss += diff_pixel_loss_light_e(le, x0 + px, y0 + py, samps,
+                                        targets[py * patch_w + px]);
+      }
+    }
+    return loss / (patch_w * patch_h);
+  };
+
+  const double loss0 = patch_loss(light_e);
+  const double err0 = std::fabs(light_e - gt);
+
+  auto grad = clad::gradient(diff_pixel_loss_light_e, "light_e");
+  double lr = 0.05;
+  double m = 0.0;
+  double v = 0.0;
+  const double beta1 = 0.9;
+  const double beta2 = 0.999;
+  const double eps = 1e-8;
+
+  for (int step = 1; step <= steps; ++step) {
+    double g = 0.0;
+    for (int py = 0; py < patch_h; ++py) {
+      for (int px = 0; px < patch_w; ++px) {
+        double dg = 0.0;
+        grad.execute(light_e, x0 + px, y0 + py, samps,
+                     targets[py * patch_w + px], &dg);
+        g += dg;
+      }
+    }
+    g /= (patch_w * patch_h);
+    m = beta1 * m + (1 - beta1) * g;
+    v = beta2 * v + (1 - beta2) * g * g;
+    double m_hat = m / (1 - std::pow(beta1, step));
+    double v_hat = v / (1 - std::pow(beta2, step));
+    light_e -= lr * m_hat / (std::sqrt(v_hat) + eps);
+    if (light_e < 0.0)
+      light_e = 0.0;
+    lr *= 0.995;
+  }
+
+  const double loss = patch_loss(light_e);
+  const double err = std::fabs(light_e - gt);
+  bool pass = loss < loss0 && err < err0;
+  printf("SMALLPT_LIGHT_E_GD_SMOKE_PASS=%d\n", pass ? 1 : 0);
   return pass ? 0 : 1;
 }
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2016,6 +2016,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             (utils::GetValueType(lastParamType) == trackerType);
       }
     }
+    if (isInsideLoop && usingRestoreTracker && !m_RestoreTracker) {
+      calleeFnForwPassFD = nullptr;
+      usingRestoreTracker = false;
+    }
 
     // FIXME: consider moving non-diff analysis to DiffPlanner.
     bool nonDiff = clad::utils::hasNonDifferentiableAttribute(CE);

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -174,14 +174,22 @@ DEFINE_CREATE_EXPR(CXXConstCastExpr,
                     Clone(Node->getSubExpr()), Node->getTypeInfoAsWritten(),
                     Node->getOperatorLoc(), Node->getRParenLoc(),
                     Node->getAngleBrackets()))
-DEFINE_CREATE_EXPR(
-    CXXConstructExpr,
-    (Ctx, CloneType(Node->getType()), Node->getLocation(),
-     Node->getConstructor(), Node->isElidable(),
-     clad_compat::makeArrayRef(Node->getArgs(), Node->getNumArgs()),
-     Node->hadMultipleCandidates(), Node->isListInitialization(),
-     Node->isStdInitListInitialization(), Node->requiresZeroInitialization(),
-     Node->getConstructionKind(), Node->getParenOrBraceRange()))
+Stmt* StmtClone::VisitCXXConstructExpr(CXXConstructExpr* Node) {
+  llvm::SmallVector<Expr*, 4> clonedArgs;
+  clonedArgs.reserve(Node->getNumArgs());
+  for (unsigned i = 0, e = Node->getNumArgs(); i < e; ++i)
+    clonedArgs.push_back(Clone(Node->getArg(i)));
+
+  CXXConstructExpr* result = CXXConstructExpr::Create(
+      Ctx, CloneType(Node->getType()), Node->getLocation(),
+      Node->getConstructor(), Node->isElidable(),
+      clad_compat::makeArrayRef(clonedArgs.data(), clonedArgs.size()),
+      Node->hadMultipleCandidates(), Node->isListInitialization(),
+      Node->isStdInitListInitialization(), Node->requiresZeroInitialization(),
+      Node->getConstructionKind(), Node->getParenOrBraceRange());
+  clad_compat::ExprSetDeps(result, Node);
+  return result;
+}
 DEFINE_CREATE_EXPR(CXXFunctionalCastExpr,
                    (Ctx, CloneType(Node->getType()), Node->getValueKind(),
                     Node->getTypeInfoAsWritten(), Node->getCastKind(),
@@ -194,14 +202,22 @@ DEFINE_CREATE_EXPR(ConstantExpr, (Ctx, Clone(Node->getSubExpr()),
                                   Node->getResultStorageKind(),
                                   Node->isImmediateInvocation()))
 
-DEFINE_CLONE_EXPR_CO(
-    CXXTemporaryObjectExpr,
-    (Ctx, Node->getConstructor(), CloneType(Node->getType()),
-     Node->getTypeSourceInfo(),
-     clad_compat::makeArrayRef(Node->getArgs(), Node->getNumArgs()),
-     Node->getSourceRange(), Node->hadMultipleCandidates(),
-     Node->isListInitialization(), Node->isStdInitListInitialization(),
-     Node->requiresZeroInitialization()))
+Stmt* StmtClone::VisitCXXTemporaryObjectExpr(CXXTemporaryObjectExpr* Node) {
+  llvm::SmallVector<Expr*, 4> clonedArgs;
+  clonedArgs.reserve(Node->getNumArgs());
+  for (unsigned i = 0, e = Node->getNumArgs(); i < e; ++i)
+    clonedArgs.push_back(Clone(Node->getArg(i)));
+
+  CXXTemporaryObjectExpr* result = CXXTemporaryObjectExpr::Create(
+      Ctx, Node->getConstructor(), CloneType(Node->getType()),
+      Node->getTypeSourceInfo(),
+      clad_compat::makeArrayRef(clonedArgs.data(), clonedArgs.size()),
+      Node->getSourceRange(), Node->hadMultipleCandidates(),
+      Node->isListInitialization(), Node->isStdInitListInitialization(),
+      Node->requiresZeroInitialization());
+  clad_compat::ExprSetDeps(result, Node);
+  return result;
+}
 
 DEFINE_CLONE_EXPR(MaterializeTemporaryExpr,
                   (CloneType(Node->getType()),

--- a/test/Gradient/ReverseModeLoopPullbackRepro.C
+++ b/test/Gradient/ReverseModeLoopPullbackRepro.C
@@ -1,0 +1,104 @@
+// RUN: %cladclang %s -I%S/../../include -oReverseModeLoopPullbackRepro.out 2>&1
+// RUN: ./ReverseModeLoopPullbackRepro.out
+// XFAIL: valgrind
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cmath>
+
+struct Vec {
+  double x, y, z;
+  Vec(double x_ = 0, double y_ = 0, double z_ = 0) : x(x_), y(y_), z(z_) {}
+  Vec operator+(const Vec& b) const {
+    return Vec(x + b.x, y + b.y, z + b.z);
+  }
+  Vec operator*(double b) const { return Vec(x * b, y * b, z * b); }
+  double operator*(const Vec& b) const {
+    return x * b.x + y * b.y + z * b.z;
+  }
+  Vec mult(const Vec& b) const {
+    return Vec(x * b.x, y * b.y, z * b.z);
+  }
+};
+
+namespace clad {
+namespace custom_derivatives {
+namespace class_functions {
+inline void operator_plus_pullback(const Vec* a, const Vec& b, Vec d_out,
+                                    Vec* d_a, Vec* d_b) {
+  d_a->x += d_out.x;
+  d_a->y += d_out.y;
+  d_a->z += d_out.z;
+  d_b->x += d_out.x;
+  d_b->y += d_out.y;
+  d_b->z += d_out.z;
+}
+inline void operator_star_pullback(const Vec* a, double b, Vec d_out,
+                                   Vec* d_a, double* d_b) {
+  d_a->x += d_out.x * b;
+  d_a->y += d_out.y * b;
+  d_a->z += d_out.z * b;
+  *d_b += a->x * d_out.x + a->y * d_out.y + a->z * d_out.z;
+}
+inline void operator_star_pullback(const Vec* a, const Vec& b, double d_out,
+                                   Vec* d_a, Vec* d_b) {
+  d_a->x += d_out * b.x;
+  d_a->y += d_out * b.y;
+  d_a->z += d_out * b.z;
+  d_b->x += d_out * a->x;
+  d_b->y += d_out * a->y;
+  d_b->z += d_out * a->z;
+}
+inline void mult_pullback(const Vec* a, const Vec& b, Vec d_out, Vec* d_a,
+                          Vec* d_b) {
+  d_a->x += d_out.x * b.x;
+  d_a->y += d_out.y * b.y;
+  d_a->z += d_out.z * b.z;
+  d_b->x += d_out.x * a->x;
+  d_b->y += d_out.y * a->y;
+  d_b->z += d_out.z * a->z;
+}
+} // namespace class_functions
+} // namespace custom_derivatives
+} // namespace clad
+
+static inline Vec normalize_vec(const Vec& v) {
+  double inv = 1.0 / sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+  return v * inv;
+}
+
+double loop_vec_radiance(double cx, double cy, double cz) {
+  Vec cl(0, 0, 0);
+  Vec cf(1, 1, 1);
+  Vec origin(cx, cy, cz);
+  Vec dir(0, -1, 0);
+  int depth = 0;
+  for (;;) {
+    if (depth > 2)
+      return cl.x + cl.y + cl.z;
+    Vec hit = origin + dir * 1.0;
+    Vec n = normalize_vec(hit);
+    Vec nl = n;
+    if (n * dir >= 0)
+      nl = n * -1.0;
+    Vec f(0.5, 0.5, 0.5);
+    cl = cl + cf.mult(Vec(0.1, 0.1, 0.1));
+    depth = depth + 1;
+    cf = cf.mult(f);
+    Vec basis(0, 1, 0);
+    if (fabs(nl.x) > .1)
+      basis = Vec(1, 0, 0);
+    Vec u = normalize_vec(Vec(basis.y * nl.z - basis.z * nl.y,
+                              basis.z * nl.x - basis.x * nl.z,
+                              basis.x * nl.y - basis.y * nl.x));
+    origin = hit;
+    dir = normalize_vec(u + nl);
+  }
+}
+
+int main() {
+  auto grad = clad::gradient(loop_vec_radiance, "cx");
+  double gcx = 0.;
+  grad.execute(1.0, 2.0, 3.0, &gcx);
+  return 0;
+}

--- a/test/Gradient/SmallPTDiff.C
+++ b/test/Gradient/SmallPTDiff.C
@@ -1,0 +1,24 @@
+// RUN: %cladclang %s -I%S/../../include -I%S/../../demos/ComputerGraphics/smallpt -oSmallPTDiff.out 2>&1 | %filecheck %s
+// RUN: ./SmallPTDiff.out | %filecheck_exec %s
+// FD check is not reliable on 32-bit x86.
+// UNSUPPORTED: target={{i586.*}}
+
+#include "SmallPTDiffValidate.h"
+
+int main() {
+  int fail = 0;
+  fail |= smallpt_run_camera_grad_check();
+  fail |= smallpt_run_patch_grad_check(2, 2, 1);
+  fail |= smallpt_run_light_y_grad_check();
+  fail |= smallpt_run_mirror_patch_grad_check();
+  printf("SMALLPT_DIFF_PASS=%d\n", fail ? 0 : 1);
+  return fail;
+}
+
+// CHECK-EXEC: SMALLPT_GRAD_FD_PASS=1
+// CHECK-EXEC: SMALLPT_PATCH_GRAD_FD_PASS=1
+// CHECK-EXEC: SMALLPT_LIGHT_Y_GRAD_FD_PASS=1
+// CHECK-EXEC: PATCH_MIRROR_RADIANCE=
+// CHECK-EXEC-NOT: PATCH_MIRROR_RADIANCE_FAIL=1
+// CHECK-EXEC: SMALLPT_MIRROR_PATCH_GRAD_FD_PASS=1
+// CHECK-EXEC: SMALLPT_DIFF_PASS=1

--- a/test/Gradient/SmallPTDiff.C
+++ b/test/Gradient/SmallPTDiff.C
@@ -1,5 +1,6 @@
-// RUN: %cladclang %s -I%S/../../include -I%S/../../demos/ComputerGraphics/smallpt -oSmallPTDiff.out 2>&1 | %filecheck %s
+// RUN: %cladclang %s -I%S/../../include -I%S/../../demos/ComputerGraphics/smallpt -oSmallPTDiff.out
 // RUN: ./SmallPTDiff.out | %filecheck_exec %s
+// XFAIL: valgrind
 // FD check is not reliable on 32-bit x86.
 // UNSUPPORTED: target={{i586.*}}
 
@@ -11,6 +12,8 @@ int main() {
   fail |= smallpt_run_patch_grad_check(2, 2, 1);
   fail |= smallpt_run_light_y_grad_check();
   fail |= smallpt_run_mirror_patch_grad_check();
+  fail |= smallpt_run_light_e_grad_check();
+  fail |= smallpt_run_light_e_gd_smoke();
   printf("SMALLPT_DIFF_PASS=%d\n", fail ? 0 : 1);
   return fail;
 }
@@ -21,4 +24,6 @@ int main() {
 // CHECK-EXEC: PATCH_MIRROR_RADIANCE=
 // CHECK-EXEC-NOT: PATCH_MIRROR_RADIANCE_FAIL=1
 // CHECK-EXEC: SMALLPT_MIRROR_PATCH_GRAD_FD_PASS=1
+// CHECK-EXEC: SMALLPT_LIGHT_E_GRAD_FD_PASS=1
+// CHECK-EXEC: SMALLPT_LIGHT_E_GD_SMOKE_PASS=1
 // CHECK-EXEC: SMALLPT_DIFF_PASS=1

--- a/test/Gradient/StmtCloneConstructRepro.C
+++ b/test/Gradient/StmtCloneConstructRepro.C
@@ -1,0 +1,46 @@
+// RUN: %cladclang %s -I%S/../../include -oStmtCloneConstructRepro.out 2>&1
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cmath>
+
+struct Vec {
+  double x, y, z;
+  Vec(double x_ = 0, double y_ = 0, double z_ = 0) : x(x_), y(y_), z(z_) {}
+  Vec operator*(double b) const { return Vec(x * b, y * b, z * b); }
+};
+
+namespace clad {
+namespace custom_derivatives {
+namespace class_functions {
+inline void operator_star_pullback(const Vec* a, double b, Vec d_out,
+                                   Vec* d_a, double* d_b) {
+  d_a->x += d_out.x * b;
+  d_a->y += d_out.y * b;
+  d_a->z += d_out.z * b;
+  *d_b += a->x * d_out.x + a->y * d_out.y + a->z * d_out.z;
+}
+} // namespace class_functions
+} // namespace custom_derivatives
+} // namespace clad
+
+static inline Vec normalize_vec(const Vec& v) {
+  double inv = 1.0 / sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+  return v * inv;
+}
+
+// CXXTemporaryObjectExpr with expression arguments; crashes without StmtClone deep clone.
+double inline_vec_normal(double cx, double cy, double cz) {
+  Vec hit(cx, cy, cz);
+  Vec origin(0, 0, 0);
+  Vec n = normalize_vec(
+      Vec(hit.x - origin.x, hit.y - origin.y, hit.z - origin.z));
+  return n.x + n.y + n.z;
+}
+
+int main() {
+  auto grad = clad::gradient(inline_vec_normal, "cx");
+  double gcx = 0.;
+  grad.execute(1.0, 2.0, 3.0, &gcx);
+  return 0;
+}

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -6,6 +6,11 @@
 // RUN: %cladclang %S/../../demos/ComputerGraphics/smallpt/SmallPT.cpp -I%S/../../include 2>&1
 
 //-----------------------------------------------------------------------------/
+// Demo: SmallPT differentiable path tracer
+//-----------------------------------------------------------------------------/
+// RUN: %cladclang %S/../../demos/ComputerGraphics/smallpt/SmallPTDiff.cpp -I%S/../../include -I%S/../../demos/ComputerGraphics/smallpt 2>&1
+
+//-----------------------------------------------------------------------------/
 //  Demo: Gradient.cpp
 //-----------------------------------------------------------------------------/
 


### PR DESCRIPTION
Added a SmallPTDiff demo with full path-tracing radiance through clad, plus a test validating AD vs FD (camera, patch, light, mirror). Original SmallPT.cpp is unchanged.