### PR TITLE
Fix unused _d_i adjoints in hessian with -enable-va

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -113,6 +113,7 @@ struct DerivativeAndOverload {
     clang::ASTContext& m_Context;
     DerivedFnCollector& m_DFC;
     clad::DynamicGraph<DiffRequest>& m_DiffRequestGraph;
+    OwnedAnalysisContexts& m_AllAnalysisDC;
     std::unique_ptr<utils::StmtClone> m_NodeCloner;
     clang::NamespaceDecl* m_BuiltinDerivativesNSD;
     clang::NamespaceDecl* m_NumericalDiffNSD;
@@ -178,7 +179,8 @@ struct DerivativeAndOverload {
   public:
     DerivativeBuilder(clang::Sema& S, plugin::CladPlugin& P,
                       DerivedFnCollector& DFC,
-                      clad::DynamicGraph<DiffRequest>& DRG);
+                      clad::DynamicGraph<DiffRequest>& DRG,
+                      OwnedAnalysisContexts& ADC);
     ~DerivativeBuilder();
     /// Fuction to set the error diagnostic printing value for numerical
     /// differentiation.

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -25,6 +25,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <vector>
 
 namespace clang {
 class CallExpr;
@@ -243,15 +244,21 @@ public:
   bool HasTbrAnalysisRun() const { return m_TbrRunInfo.HasAnalysisRun; }
 };
 
-  using DiffInterval = std::vector<clang::SourceRange>;
+/// Builds an AnalysisDeclContext for \p request.Function, runs
+/// VariedAnalyzer against it if enabled, and stores the resulting context
+/// in \p AllAnalysisDC and on \p request.m_AnalysisDC.
+void PrepareRequestAnalysis(DiffRequest& request,
+                            OwnedAnalysisContexts& AllAnalysisDC);
 
-  struct RequestOptions {
-    /// This is a flag to indicate the default behaviour to enable/disable
-    /// TBR analysis during reverse-mode differentiation.
-    bool EnableTBRAnalysis = false;
-    bool EnableVariedAnalysis = false;
-    bool EnableUsefulAnalysis = false;
-  };
+using DiffInterval = std::vector<clang::SourceRange>;
+
+struct RequestOptions {
+  /// This is a flag to indicate the default behaviour to enable/disable
+  /// TBR analysis during reverse-mode differentiation.
+  bool EnableTBRAnalysis = false;
+  bool EnableVariedAnalysis = false;
+  bool EnableUsefulAnalysis = false;
+};
 
   class DiffCollector: public clang::RecursiveASTVisitor<DiffCollector> {
     /// The source interval where clad was activated.

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -58,9 +58,10 @@ namespace clad {
 
 DerivativeBuilder::DerivativeBuilder(clang::Sema& S, plugin::CladPlugin& P,
                                      DerivedFnCollector& DFC,
-                                     clad::DynamicGraph<DiffRequest>& G)
+                                     clad::DynamicGraph<DiffRequest>& G,
+                                     OwnedAnalysisContexts& ADC)
     : m_Sema(S), m_CladPlugin(P), m_Context(S.getASTContext()), m_DFC(DFC),
-      m_DiffRequestGraph(G),
+      m_DiffRequestGraph(G), m_AllAnalysisDC(ADC),
       m_NodeCloner(new utils::StmtClone(m_Sema, m_Context)),
       m_BuiltinDerivativesNSD(nullptr), m_NumericalDiffNSD(nullptr) {}
 
@@ -402,11 +403,17 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
     FunctionDecl* derivative = this->FindDerivedFunction(request);
     if (!derivative) {
       alreadyDerived = false;
-      // FIXME: Our analyses are closely tied to the DiffPlanner. Dynamic
-      // derivatives don't have m_AnalysisDC. We should either disable
-      // dynamic scheduling or build m_AnalysisDC here.
-      request.EnableTBRAnalysis = false;
-      request.EnableVariedAnalysis = false;
+
+      if (request.Mode == DiffMode::reverse && request.Function &&
+          request.Function->isDefined() && request.EnableVariedAnalysis) {
+        for (const auto& dParam : request.DVI)
+          if (const auto* PVD = dyn_cast<VarDecl>(dParam.param))
+            request.addVariedDecl(PVD);
+        PrepareRequestAnalysis(request, m_AllAnalysisDC);
+      } else {
+        request.EnableTBRAnalysis = false;
+        request.EnableVariedAnalysis = false;
+      }
       request.EnableUsefulAnalysis = false;
 
       {

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -26,6 +26,7 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Type.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
+#include "clang/Analysis/CFG.h"
 #include "clang/Basic/DiagnosticSema.h"
 #include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LLVM.h" // isa, dyn_cast
@@ -690,10 +691,13 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
   }
 
   bool DiffRequest::shouldHaveAdjointForw(const VarDecl* VD) const {
-    if (!EnableUsefulAnalysis)
-      return true;
-    auto found = m_UsefulRunInfo.UsefulDecls.find(VD);
-    return found != m_UsefulRunInfo.UsefulDecls.end();
+    if (EnableUsefulAnalysis) {
+      auto found = m_UsefulRunInfo.UsefulDecls.find(VD);
+      return found != m_UsefulRunInfo.UsefulDecls.end();
+    }
+    if (EnableVariedAnalysis)
+      return getVariedDecls().find(VD) != getVariedDecls().end();
+    return true;
   }
 
   bool DiffRequest::shouldHaveAdjoint(const Stmt* S) const {
@@ -1130,6 +1134,24 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     return false;
   }
 
+  void PrepareRequestAnalysis(DiffRequest& request,
+                              OwnedAnalysisContexts& AllAnalysisDC) {
+    clang::CFG::BuildOptions Options;
+    std::unique_ptr<AnalysisDeclContext> AnalysisDC =
+        std::make_unique<AnalysisDeclContext>(
+            /*AnalysisDeclContextManager=*/nullptr, request.Function, Options);
+
+    if (request.EnableVariedAnalysis && request->isDefined()) {
+      TimedAnalysisRegion R("VA " + request.BaseFunctionName);
+      VariedAnalyzer analyzer(AnalysisDC.get(), request,
+                              request.getVariedStmt());
+      analyzer.Analyze();
+    }
+
+    AllAnalysisDC.push_back(std::move(AnalysisDC));
+    request.m_AnalysisDC = AllAnalysisDC.back().get();
+  }
+
   bool DiffCollector::VisitCallExpr(CallExpr* E) {
     // Check if we should look into this.
     DiffRequest request;
@@ -1177,7 +1199,11 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
 
       request.Args = E->getArg(1);
       request.UpdateDiffParamsInfo(m_Sema);
-      if (request.Mode == DiffMode::reverse && request.EnableVariedAnalysis) {
+      if ((request.Mode == DiffMode::forward ||
+           request.Mode == DiffMode::reverse ||
+           request.Mode == DiffMode::hessian ||
+           request.Mode == DiffMode::hessian_diagonal) &&
+          request.EnableVariedAnalysis) {
         if (request.Args)
           for (const auto& dParam : request.DVI)
             request.addVariedDecl(cast<VarDecl>(dParam.param));
@@ -1372,27 +1398,13 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     bool shouldUseRestoreTracker =
         utils::shouldUseRestoreTracker(request.Function);
     if (!(LookupCustomDerivativeDecl(request) || nonDiff) || requestTBR) {
-      clang::CFG::BuildOptions Options;
-      std::unique_ptr<AnalysisDeclContext> AnalysisDC =
-          std::make_unique<AnalysisDeclContext>(
-              /*AnalysisDeclContextManager=*/nullptr, request.Function,
-              Options);
-
-      if (request.EnableVariedAnalysis && request->isDefined()) {
-        TimedAnalysisRegion R("VA " + request.BaseFunctionName);
-        VariedAnalyzer analyzer(AnalysisDC.get(), request,
-                                request.getVariedStmt());
-        analyzer.Analyze();
-      }
+      PrepareRequestAnalysis(request, m_AllAnalysisDC);
 
       if (m_TopMostReq->EnableUsefulAnalysis) {
         TimedAnalysisRegion R("UA " + request.BaseFunctionName);
-        UsefulAnalyzer analyzer(AnalysisDC.get(), request.getUsefulDecls());
+        UsefulAnalyzer analyzer(request.m_AnalysisDC, request.getUsefulDecls());
         analyzer.Analyze(request.Function);
       }
-
-      m_AllAnalysisDC.push_back(std::move(AnalysisDC));
-      request.m_AnalysisDC = m_AllAnalysisDC.back().get();
 
       //  Recurse into call graph.
       TraverseFunctionDeclOnce(request.Function);
@@ -1563,20 +1575,8 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       return true;
 
     if (!LookupCustomDerivativeDecl(request)) {
-      clang::CFG::BuildOptions Options;
-      std::unique_ptr<AnalysisDeclContext> AnalysisDC =
-          std::make_unique<AnalysisDeclContext>(
-              /*AnalysisDeclContextManager=*/nullptr, request.Function,
-              Options);
-      if (request.EnableVariedAnalysis) {
-        TimedAnalysisRegion R("VA " + request.BaseFunctionName);
-        VariedAnalyzer analyzer(AnalysisDC.get(), request,
-                                request.getVariedStmt());
-        analyzer.Analyze();
-      }
       // FIXME: Add proper support for objects in VA and UA.
-      m_AllAnalysisDC.push_back(std::move(AnalysisDC));
-      request.m_AnalysisDC = m_AllAnalysisDC.back().get();
+      PrepareRequestAnalysis(request, m_AllAnalysisDC);
 
       // Recurse into call graph.
       TraverseFunctionDeclOnce(request.Function);

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -59,6 +59,10 @@ static FunctionDecl* DeriveUsingForwardAndReverseMode(
   ReverseModeRequest.BaseFunctionName = firstDerivative->getNameAsString();
   ReverseModeRequest.m_CladLoopCheckpoints =
       IndependentArgRequest.m_CladLoopCheckpoints;
+  // Propagate EnableVariedAnalysis to the internal reverse-mode pass so
+  // HandleNestedDiffRequest can run VariedAnalyzer.
+  ReverseModeRequest.EnableVariedAnalysis =
+      IndependentArgRequest.EnableVariedAnalysis;
 
   FunctionDecl* secondDerivative =
       Builder.HandleNestedDiffRequest(ReverseModeRequest);

--- a/test/Regressions/issue-1665.cpp
+++ b/test/Regressions/issue-1665.cpp
@@ -1,0 +1,31 @@
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-va %s -I%S/../../include -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-va -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -o %t
+// RUN: %t | %filecheck_exec %s
+// XFAIL: valgrind
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+double weightedSum(const double p[], const double w[], int n) {
+  double sum = 0;
+  for (int i = 0; i < n; i++)
+    sum += p[i] * w[i];
+  return sum;
+}
+// CHECK-NOT: _d_i
+
+int main() {
+  auto hess = clad::hessian(weightedSum, "p[0:1],w[0:1]");
+  double p[2] = {1, 2};
+  double w[2] = {3, 4};
+  double result[16] = {};
+  hess.execute(p, w, 2, result);
+  for (int i = 0; i < 4; i++)
+    for (int j = 0; j < 4; j++)
+      printf("%.2f%c", result[i * 4 + j], j == 3 ? '\n' : ' ');
+  // CHECK-EXEC: 0.00 0.00 1.00 0.00
+  // CHECK-EXEC: 0.00 0.00 0.00 1.00
+  // CHECK-EXEC: 1.00 0.00 0.00 0.00
+  // CHECK-EXEC: 0.00 1.00 0.00 0.00
+}

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -349,7 +349,7 @@ void InitTimers();
       Sema& S = m_CI.getSema();
       if (!m_DerivativeBuilder)
         m_DerivativeBuilder = std::make_unique<DerivativeBuilder>(
-            S, *this, m_DFC, m_DiffRequestGraph);
+            S, *this, m_DFC, m_DiffRequestGraph, m_AllAnalysisDC);
 
       if (request.Global) {
         auto deriveResult = m_DerivativeBuilder->Derive(request);


### PR DESCRIPTION
shouldHaveAdjointForw now checks VariedDecls when EnableVariedAnalysis is true, and VariedDecls seeding covers forward, hessian, and hessian_diagonal modes. HandleNestedDiffRequest runs VariedAnalyzer for reverse-mode nested requests instead of unconditionally zeroing analysis flags.

Fixes #1665