### PR TITLE
Adds missing reverse mode pullback for the vector 

### DIFF
--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -687,7 +687,21 @@ void constructor_pullback(const ::std::array<T, N>& arr,
   for (size_t i = 0; i < N; ++i)
     (*d_arr)[i] += (*d_this)[i];
 }
+template <typename T>
+void constructor_pullback(typename ::std::vector<T>::size_type count,
+                          ::std::vector<T>* d_this,
+                          typename ::std::vector<T>::size_type* d_count) {
+  d_this->clear();
+}
 
+template <typename T>
+void constructor_pullback(
+    typename ::std::vector<T>::size_type count,
+    const typename ::std::vector<T>::allocator_type& alloc,
+    ::std::vector<T>* d_this, typename ::std::vector<T>::size_type* d_count,
+    typename ::std::vector<T>::allocator_type* d_alloc) {
+  d_this->clear();
+}
 // tuple forward mode
 
 template <typename... Args1, typename... Args2>

--- a/test/Features/VectorPullback.cpp
+++ b/test/Features/VectorPullback.cpp
@@ -1,0 +1,37 @@
+// RUN: %cladclang -std=c++17 -O0 -I%S/../../include/ %s -o %t
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+#include <vector>
+#include <memory>
+#include <iostream>
+
+double f(double x) {
+    std::vector<double> v(5); 
+    return x * x; 
+}
+
+double f1(double x) {
+    std::allocator<double> alloc;
+    std::vector<double> v(5, alloc);
+    return x * x * x;
+}
+
+int main() {
+
+    auto df = clad::gradient(f);
+    auto df1 = clad::gradient(f1);
+
+    double dx1 = 0.0;
+    df.execute(3.0, &dx1); 
+    std::cout << "Diff result: " << dx1 << "\n";
+    //CHECK-EXEC: Diff result: 6
+    
+    double dx2 = 0.0;
+    df1.execute(2.0, &dx2); 
+    std::cout << "Diff result: " << dx2 << "\n";
+    //CHECK-EXEC: Diff result: 12
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds the missing reverse-mode pullback for basic std::vector initialization.
**Example:**
```cpp
std::vector<int> vec(size);
std::vector<int> vec1(size,allocated);
```