### PR TITLE
Fix null tangents for const pointer subscripts

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -943,6 +943,21 @@ BaseForwardModeVisitor::VisitArraySubscriptExpr(const ArraySubscriptExpr* ASE) {
     return StmtDiff(cloned, zero);
   auto* result_at_is =
       BuildArraySubscript(buildAdjoint(it->second), derivedIndices());
+  // Guard nullable tangent for pointer-to-const inputs: the outer
+  // derivative represents inactive const T* parameters as nullptr, so
+  // dereferencing _d_obs[i] without a check would be invalid at runtime.
+  if (it->second.Decl->getType().getNonReferenceType()->isPointerType()) {
+    QualType origBaseTy = base->getType();
+    if (origBaseTy->isPointerType() &&
+        origBaseTy->getPointeeType().isConstQualified()) {
+      // Build: (_d_obs != nullptr ? _d_obs[idx] : 0)
+      Expr* cond = BuildOp(BO_NE, buildAdjoint(it->second),
+                           m_Sema.ActOnCXXNullPtrLiteral(noLoc).get());
+      result_at_is = BuildParens(
+          m_Sema.ActOnConditionalOp(noLoc, noLoc, cond, result_at_is, zero)
+              .get());
+    }
+  }
   return StmtDiff(cloned, result_at_is);
 }
 

--- a/test/Regressions/issue-1871.cpp
+++ b/test/Regressions/issue-1871.cpp
@@ -1,0 +1,26 @@
+// RUN: %cladclang -D_USE_MATH_DEFINES -std=c++17 -I%S/../../include %s -o %t 2>&1
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+// The inner function accesses obs[0]; its pushforward will receive
+// _d_obs as a pointer.  When the outer derivative represents the
+// inactive const-pointer tangent as nullptr, _d_obs[0] dereferences
+// nullptr without the null-tangent guard.
+double inner_func(const double* obs, double x) {
+  return obs[0] * x * x * x;
+}
+
+// The outer function forwards the inactive const double* to inner_func.
+// clad::differentiate(outer_func, "x") generates a pushforward for
+// inner_func where the tangent of obs is nullptr.
+double outer_func(const double* obs, double x) {
+  return inner_func(obs, x);
+}
+
+int main() {
+  auto df = clad::differentiate(outer_func, "x");
+  double obs[] = {1.0};
+  printf("%.2f\n", df.execute(obs, 1.0)); // CHECK-EXEC: 3.00
+}


### PR DESCRIPTION
## Summary

- guard nullable const-pointer tangent subscripts with `_d_ptr != nullptr`
- parenthesize the conditional so it composes correctly with surrounding arithmetic
- add a nested differentiation regression for inactive `const T*` tangents

Fixes: #1871

## Testing

- `Regressions/issue-1871.cpp`
- full regression suite: 18 passed, 1 CUDA unsupported
- verified neighboring `Regressions/issue-1804.cpp` higher-order generation
- changed-line `clang-format --dry-run --Werror`
- `git diff --check`

## Performance

At `-O3`, the guard is eliminated in the reproducer's outer derivative because the null tangent is known at the call site. The previous code instead invoked undefined behavior and optimized the derivative to an empty function.