### PR TITLE
Fix min/max pushforwards in Hessian generation

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -1012,27 +1012,27 @@ CUDA_HOST_DEVICE void pow_pullback(T1 x, T2 exponent, T3 d_y, T1* d_x,
 }
 
 template <typename T, class Compare>
-CUDA_HOST_DEVICE ValueAndPushforward<const T&, const T&>
+CUDA_HOST_DEVICE ValueAndPushforward<T, T>
 min_pushforward(const T& a, const T& b, Compare comp, const T& d_a,
                 const T& d_b, Compare /*dcomp*/) {
   return {::std::min(a, b, comp), comp(a, b) ? d_a : d_b};
 }
 
 template <typename T>
-CUDA_HOST_DEVICE ValueAndPushforward<const T&, const T&>
+CUDA_HOST_DEVICE ValueAndPushforward<T, T>
 min_pushforward(const T& a, const T& b, const T& d_a, const T& d_b) {
   return {::std::min(a, b), a < b ? d_a : d_b};
 }
 
 template <typename T, class Compare>
-CUDA_HOST_DEVICE ValueAndPushforward<const T&, const T&>
+CUDA_HOST_DEVICE ValueAndPushforward<T, T>
 max_pushforward(const T& a, const T& b, Compare comp, const T& d_a,
                 const T& d_b, Compare /*dcomp*/) {
   return {::std::max(a, b, comp), comp(a, b) ? d_b : d_a};
 }
 
 template <typename T>
-CUDA_HOST_DEVICE ValueAndPushforward<const T&, const T&>
+CUDA_HOST_DEVICE ValueAndPushforward<T, T>
 max_pushforward(const T& a, const T& b, const T& d_a, const T& d_b) {
   return {::std::max(a, b), a < b ? d_b : d_a};
 }

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1038,6 +1038,39 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
             utils::MatchOverloadType(S, dTy, Found, FailedCandidates))
       return overload;
 
+    // Retry ValueAndPushforward<const T&, const T&> as
+    // ValueAndPushforward<T, T> after the exact match fails. This keeps
+    // reference-returning custom derivatives preferred while allowing
+    // assignable min/max results in higher-order differentiation.
+    do {
+      const auto* FPT = dTy->getAs<FunctionProtoType>();
+      if (!FPT)
+        break;
+      auto* CTSD = dyn_cast_or_null<ClassTemplateSpecializationDecl>(
+          FPT->getReturnType()->getAsCXXRecordDecl());
+      TemplateDecl* VPDecl =
+          utils::LookupTemplateDeclInCladNamespace(S, "ValueAndPushforward");
+      if (!CTSD || CTSD->getSpecializedTemplate() != VPDecl)
+        break;
+      const auto& tArgs = CTSD->getTemplateArgs();
+      QualType valueTy = tArgs[0].getAsType();
+      QualType pushforwardTy = tArgs[1].getAsType();
+      if (!valueTy->isLValueReferenceType() ||
+          !valueTy.getNonReferenceType().isConstQualified() ||
+          !C.hasSameType(valueTy, pushforwardTy))
+        break;
+      QualType relaxedTy = valueTy.getNonReferenceType().getUnqualifiedType();
+      QualType relaxedRetTy =
+          utils::InstantiateTemplate(S, VPDecl, {relaxedTy, relaxedTy});
+      QualType relaxedDTy = C.getFunctionType(
+          relaxedRetTy, FPT->getParamTypes(), FPT->getExtProtoInfo());
+      TemplateSpecCandidateSet RelaxedCandidates(R.CallContext->getBeginLoc(),
+                                                 /*ForTakingAddress=*/false);
+      if (Expr* overload =
+              utils::MatchOverloadType(S, relaxedDTy, Found, RelaxedCandidates))
+        return overload;
+    } while (false);
+
     if (!enableDiagnostics)
       return nullptr;
 

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1042,34 +1042,32 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     // ValueAndPushforward<T, T> after the exact match fails. This keeps
     // reference-returning custom derivatives preferred while allowing
     // assignable min/max results in higher-order differentiation.
-    do {
-      const auto* FPT = dTy->getAs<FunctionProtoType>();
-      if (!FPT)
-        break;
+    if (const auto* FPT = dTy->getAs<FunctionProtoType>()) {
       auto* CTSD = dyn_cast_or_null<ClassTemplateSpecializationDecl>(
           FPT->getReturnType()->getAsCXXRecordDecl());
       TemplateDecl* VPDecl =
           utils::LookupTemplateDeclInCladNamespace(S, "ValueAndPushforward");
-      if (!CTSD || CTSD->getSpecializedTemplate() != VPDecl)
-        break;
-      const auto& tArgs = CTSD->getTemplateArgs();
-      QualType valueTy = tArgs[0].getAsType();
-      QualType pushforwardTy = tArgs[1].getAsType();
-      if (!valueTy->isLValueReferenceType() ||
-          !valueTy.getNonReferenceType().isConstQualified() ||
-          !C.hasSameType(valueTy, pushforwardTy))
-        break;
-      QualType relaxedTy = valueTy.getNonReferenceType().getUnqualifiedType();
-      QualType relaxedRetTy =
-          utils::InstantiateTemplate(S, VPDecl, {relaxedTy, relaxedTy});
-      QualType relaxedDTy = C.getFunctionType(
-          relaxedRetTy, FPT->getParamTypes(), FPT->getExtProtoInfo());
-      TemplateSpecCandidateSet RelaxedCandidates(R.CallContext->getBeginLoc(),
-                                                 /*ForTakingAddress=*/false);
-      if (Expr* overload =
-              utils::MatchOverloadType(S, relaxedDTy, Found, RelaxedCandidates))
-        return overload;
-    } while (false);
+      if (CTSD && CTSD->getSpecializedTemplate() == VPDecl) {
+        const auto& tArgs = CTSD->getTemplateArgs();
+        QualType valueTy = tArgs[0].getAsType();
+        QualType pushforwardTy = tArgs[1].getAsType();
+        if (valueTy->isLValueReferenceType() &&
+            valueTy.getNonReferenceType().isConstQualified() &&
+            C.hasSameType(valueTy, pushforwardTy)) {
+          QualType relaxedTy =
+              valueTy.getNonReferenceType().getUnqualifiedType();
+          QualType relaxedRetTy =
+              utils::InstantiateTemplate(S, VPDecl, {relaxedTy, relaxedTy});
+          QualType relaxedDTy = C.getFunctionType(
+              relaxedRetTy, FPT->getParamTypes(), FPT->getExtProtoInfo());
+          TemplateSpecCandidateSet RelaxedCandidates(
+              R.CallContext->getBeginLoc(), /*ForTakingAddress=*/false);
+          if (Expr* overload = utils::MatchOverloadType(S, relaxedDTy, Found,
+                                                        RelaxedCandidates))
+            return overload;
+        }
+      }
+    }
 
     if (!enableDiagnostics)
       return nullptr;

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -531,7 +531,7 @@ double f_custom_max(double x, double y) { return std::max(x, y, std::greater<dou
 // CHECK:  double f_custom_max_darg0(double x, double y) {
 // CHECK-NEXT:      double _d_x = 1;
 // CHECK-NEXT:      double _d_y = 0;
-// CHECK-NEXT:      ValueAndPushforward<const double &, const double &> _t0 = clad::custom_derivatives::std::max_pushforward(x, y, std::greater<double>(), _d_x, _d_y, std::greater<double>());
+// CHECK-NEXT:      ValueAndPushforward<double, double> _t0 = clad::custom_derivatives::std::max_pushforward(x, y, std::greater<double>(), _d_x, _d_y, std::greater<double>());
 // CHECK-NEXT:      return _t0.pushforward;
 // CHECK-NEXT:  }
 
@@ -539,7 +539,7 @@ double f_custom_min(double x, double y) { return std::min(x, y, std::greater<dou
 // CHECK:  double f_custom_min_darg0(double x, double y) {
 // CHECK-NEXT:      double _d_x = 1;
 // CHECK-NEXT:      double _d_y = 0;
-// CHECK-NEXT:      ValueAndPushforward<const double &, const double &> _t0 = clad::custom_derivatives::std::min_pushforward(x, y, std::greater<double>(), _d_x, _d_y, std::greater<double>());
+// CHECK-NEXT:      ValueAndPushforward<double, double> _t0 = clad::custom_derivatives::std::min_pushforward(x, y, std::greater<double>(), _d_x, _d_y, std::greater<double>());
 // CHECK-NEXT:      return _t0.pushforward;
 // CHECK-NEXT:  }
 

--- a/test/Regressions/issue-1872.cpp
+++ b/test/Regressions/issue-1872.cpp
@@ -1,0 +1,37 @@
+// RUN: %cladclang -D_USE_MATH_DEFINES -std=c++17 -I%S/../../include %s -o %t 2>&1
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include <algorithm>
+#include <cstdio>
+
+double use_max(double x) { return std::max(0.5, x * x); }
+double use_min(double x) { return std::min(0.5, x * x); }
+double use_max_cmp(double x) {
+  return std::max(0.5, x * x, std::less<double>{});
+}
+double use_min_cmp(double x) {
+  return std::min(0.5, x * x, std::less<double>{});
+}
+
+int main() {
+  double result = 0;
+  auto h_max = clad::hessian(use_max, "x");
+  h_max.execute(1.0, &result);
+  printf("%.2f\n", result); // CHECK-EXEC: 2.00
+
+  result = 0;
+  auto h_min = clad::hessian(use_min, "x");
+  h_min.execute(0.25, &result);
+  printf("%.2f\n", result); // CHECK-EXEC: 2.00
+
+  result = 0;
+  auto h_max_cmp = clad::hessian(use_max_cmp, "x");
+  h_max_cmp.execute(1.0, &result);
+  printf("%.2f\n", result); // CHECK-EXEC: 2.00
+
+  result = 0;
+  auto h_min_cmp = clad::hessian(use_min_cmp, "x");
+  h_min_cmp.execute(0.25, &result);
+  printf("%.2f\n", result); // CHECK-EXEC: 2.00
+}


### PR DESCRIPTION
## Summary

- return `std::min` and `std::max` pushforward results by value
- preserve exact custom-derivative matches first, then retry only eligible `ValueAndPushforward<const T&, const T&>` returns with value types
- cover two-argument and explicit-comparator min/max Hessians

Fixes: #1872

## Testing

- `Regressions/issue-1872.cpp`
- `FirstDerivative/BuiltinDerivatives.C`
- `ForwardMode/STLCustomDerivatives.C` confirms reference-returning derivatives retain exact matching
- full regression suite: 18 passed, 1 CUDA unsupported
- changed-line `clang-format --dry-run --Werror`
- `git diff --check`

## Performance

Exact-HEAD versus patched, 11 alternating Release compile runs after warm-up:

- `STLCustomDerivatives.C`: 1343.6 ms -> 1390.1 ms (+3.46%, overlapping ranges)
- `BuiltinDerivatives.C`: 1307.6 ms -> 1271.4 ms (-2.77%)

At `-O3`, all four Hessian paths inline without `ValueAndPushforward` call or object overhead.