### PR TITLE
Build the reverse-mode primal DeclRef lazily via the remap map. NFC

### DIFF
--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -32,6 +32,7 @@
 #include <array>
 #include <cassert>
 #include <cstddef>
+#include <functional>
 #include <stack>
 #include <unordered_map>
 
@@ -65,6 +66,11 @@ namespace clad {
     const clang::Stmt* m_StmtDxSrc = nullptr;
     const clang::Stmt* m_RevSweepSrc = nullptr;
     utils::StmtClone* m_Cloner = nullptr;
+    // Deferred build for the forward value (data[1]): produces the node on
+    // first read, so a forward value no consumer reads constructs nothing.
+    // Only the forward slot needs it (the primal DeclRef of a reverse-mode
+    // leaf), so it is not carried for the adjoint or reverse-sweep slots.
+    std::function<clang::Stmt*()> m_StmtBuild;
 
     // Clone Src into Slot on first read; a no-op when Src is null (eager slot).
     clang::Stmt* materialize(clang::Stmt*& Slot, const clang::Stmt*& Src);
@@ -79,15 +85,20 @@ namespace clad {
       const clang::Stmt* Src;
     };
 
-    /// A constructor input for one representation: either an already-built node
-    /// (eager -- the node itself is the value) or a Lazy deferred clone. Node
-    /// and Deferred are set in the constructors rather than by default member
-    /// initializers, so In can be used as a `= {}` default argument here.
+    /// A constructor input for one representation: an already-built node (eager
+    /// -- the node itself is the value), a Lazy deferred clone, or a deferred
+    /// build (a thunk producing the node on first read, so a representation no
+    /// consumer reads constructs nothing -- unlike Lazy it clones no template).
+    /// Node and Deferred are set in the constructors rather than by default
+    /// member initializers, so In can be used as a `= {}` default argument.
     struct In {
       clang::Stmt* Node;
       Lazy Deferred;
+      std::function<clang::Stmt*()> Build;
       In(clang::Stmt* N = nullptr) : Node(N), Deferred{nullptr, nullptr} {}
       In(Lazy L) : Node(nullptr), Deferred(L) {}
+      In(std::function<clang::Stmt*()> B)
+          : Node(nullptr), Deferred{nullptr, nullptr}, Build(std::move(B)) {}
     };
 
     /// Implicit single-representation constructor. Keeps the Expr*/Stmt* ->
@@ -114,12 +125,20 @@ namespace clad {
             if (diff.Deferred.Cloner)
               return diff.Deferred.Cloner;
             return valueForRevSweep.Deferred.Cloner;
-          }()) {
+          }()),
+          m_StmtBuild(std::move(orig.Build)) {
       m_Data[1] = orig.Node;
       m_Data[0] = diff.Node;
     }
 
-    clang::Stmt* getStmt() { return materialize(m_Data[1], m_StmtSrc); }
+    clang::Stmt* getStmt() {
+      // Run the deferred build once, on the first read of the forward value.
+      if (!m_Data[1] && m_StmtBuild) {
+        m_Data[1] = m_StmtBuild();
+        m_StmtBuild = nullptr;
+      }
+      return materialize(m_Data[1], m_StmtSrc);
+    }
     clang::Stmt* getStmt_dx() { return materialize(m_Data[0], m_StmtDxSrc); }
     clang::Expr* getExpr() {
       return llvm::cast_or_null<clang::Expr>(getStmt());
@@ -131,6 +150,7 @@ namespace clad {
     void updateStmt(clang::Stmt* S) {
       m_Data[1] = S;
       m_StmtSrc = nullptr;
+      m_StmtBuild = nullptr;
     }
     void updateStmtDx(clang::Stmt* S) {
       m_Data[0] = S;
@@ -781,6 +801,13 @@ namespace clad {
     /// a StmtDiff argument position.
     StmtDiff::Lazy LazyClone(const clang::Stmt* N) {
       return {m_Builder.m_NodeCloner.get(), N};
+    }
+    /// A StmtDiff forward-value input that runs \p B on first read and nothing
+    /// if the value is never read -- for a representation that is freshly
+    /// constructed (e.g. BuildDeclRef of a remapped decl) rather than cloned,
+    /// so LazyClone's template node is not orphaned.
+    StmtDiff::In LazyBuild(std::function<clang::Stmt*()> B) {
+      return StmtDiff::In(std::move(B));
     }
     /// Cloning types is necessary since VariableArrayType
     /// store a pointer to their size expression.

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1524,16 +1524,53 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   }
 
   StmtDiff ReverseModeVisitor::VisitDeclRefExpr(const DeclRefExpr* DRE) {
-    Expr* clonedDRE = Clone(DRE);
-    // Check if referenced Decl was "replaced" with another identifier inside
-    // the derivative
-    if (auto* VD = dyn_cast<VarDecl>(cast<DeclRefExpr>(clonedDRE)->getDecl())) {
+    // Resolve the remapped primal decl. Every reverse-mode param/local clone is
+    // registered in m_DeclReplacements, so for those leaves the decl is a plain
+    // map probe and the forward value can be built lazily (BuildDeclRef) -- it
+    // is constructed only if a consumer reads it, avoiding an orphaned
+    // Clone(DRE). References the map does not cover (globals, functions, decls
+    // outside the function) fall back to the eager remapping clone.
+    VarDecl* VD = nullptr;
+    StmtDiff::In primal;
+    if (auto* OrigVD = dyn_cast<VarDecl>(DRE->getDecl())) {
+      auto rit = m_DeclReplacements.find(OrigVD);
+      if (rit != m_DeclReplacements.end()) {
+        VD = rit->second;
+        // Ref-type variables that became function-global are pointers; the
+        // forward value dereferences them (their inits cannot be hoisted).
+        bool needDeref = OrigVD->getType()->isReferenceType() &&
+                         VD->getType()->isPointerType();
+        clad_compat::NestedNameSpecifierTy NNS = DRE->getQualifier();
+        SourceLocation Loc = DRE->getLocation();
+        primal = LazyBuild([this, VD, needDeref, NNS, Loc]() -> Stmt* {
+          // Construct the forward value directly (BuildDeclRef, not a
+          // clone+remap), keeping DRE's source location, which diagnostics key
+          // on. Runs only if a consumer reads the forward value.
+          auto* E = BuildDeclRef(VD, clad_compat::hasQualifier(NNS)
+                                         ? NNS
+                                         : clad_compat::nullNNS());
+          E->setLocation(Loc);
+          if (needDeref)
+            return BuildOp(UnaryOperatorKind::UO_Deref, E);
+          return static_cast<Expr*>(E);
+        });
+      }
+    }
+    Expr* clonedDRE = nullptr;
+    if (!VD) {
+      clonedDRE = Clone(DRE);
+      VD = dyn_cast<VarDecl>(cast<DeclRefExpr>(clonedDRE)->getDecl());
       // This case happens when ref-type variables have to become function
       // global. Ref-type declarations cannot be moved to the function global
       // scope because they can't be separated from their inits.
-      if (DRE->getDecl()->getType()->isReferenceType() &&
+      if (VD && DRE->getDecl()->getType()->isReferenceType() &&
           VD->getType()->isPointerType())
         clonedDRE = BuildOp(UO_Deref, clonedDRE);
+      primal = clonedDRE;
+    }
+    // Check if referenced Decl was "replaced" with another identifier inside
+    // the derivative
+    if (VD) {
       // Check DeclRefExpr is a reference to an independent variable.
       auto it = m_Variables.find(VD);
       if (it == std::end(m_Variables)) {
@@ -1549,7 +1586,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           m_Sema.LookupQualifiedName(result, DC);
           // If not found, consider non-differentiable.
           if (result.empty())
-            return StmtDiff(clonedDRE);
+            return StmtDiff(primal);
           // Found, return a reference
           Expr* foundExpr =
               m_Sema
@@ -1566,11 +1603,11 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           }
         } else
           // Is not an independent variable, ignored.
-          return StmtDiff(clonedDRE);
+          return StmtDiff(primal);
       }
 
       if (!it->second)
-        return StmtDiff(clonedDRE);
+        return StmtDiff(primal);
 
       clang::Expr* dExpr = it->second;
       if (auto* dVarDRE = dyn_cast<DeclRefExpr>(dExpr)) {
@@ -1602,10 +1639,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // those terminal leaves allocate no orphaned copy, while a consumer still
       // materializes a distinct node (no sharing). The reverse-sweep value
       // defaults to the forward node.
-      return StmtDiff(clonedDRE, LazyClone(dExpr));
+      return StmtDiff(primal, LazyClone(dExpr));
     }
 
-    return StmtDiff(clonedDRE);
+    return StmtDiff(primal);
   }
 
   StmtDiff ReverseModeVisitor::VisitIntegerLiteral(const IntegerLiteral* IL) {

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1532,7 +1532,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // outside the function) fall back to the eager remapping clone.
     VarDecl* VD = nullptr;
     StmtDiff::In primal;
-    if (auto* OrigVD = dyn_cast<VarDecl>(DRE->getDecl())) {
+    if (const auto* OrigVD = dyn_cast<VarDecl>(DRE->getDecl())) {
       auto rit = m_DeclReplacements.find(OrigVD);
       if (rit != m_DeclReplacements.end()) {
         VD = rit->second;


### PR DESCRIPTION
VisitDeclRefExpr cloned every leaf's forward value with Clone(DRE) -- a deep copy plus a scope-dependent reference remap -- even for the many leaves whose forward value no consumer reads, orphaning the clone. That made the primal DeclRef the dominant dead clone.

Now that every primal parameter and local is registered in m_DeclReplacements, resolve the remapped decl by a map probe and return the forward value through a deferred build (StmtDiff gains a build-thunk input, LazyBuild): a consumer that reads it gets a freshly constructed BuildDeclRef of the remapped decl -- cheaper than a clone and remap, and scope-independent -- while an unread leaf constructs nothing. The reference's source location is carried onto the built node so diagnostics that key on it (error estimation) are unchanged. References the map does not cover (globals, functions) keep the eager remapping clone.

On the no-STL fixture this drops dead clones from 41 to 6, all of them now non-DeclRef; the full suite is output-identical.