### PR TITLE
Remove the redundant SetIndependentVarCountDecl setter. NFC

### DIFF
--- a/include/clad/Differentiator/VectorForwardModeVisitor.h
+++ b/include/clad/Differentiator/VectorForwardModeVisitor.h
@@ -84,8 +84,6 @@ public:
 
   std::string GetPushForwardFunctionSuffix() override;
   DiffMode GetPushForwardMode() override;
-
-  void SetIndependentVarCountDecl(clang::VarDecl* VD);
 };
 } // end namespace clad
 

--- a/lib/Differentiator/VectorForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorForwardModeVisitor.cpp
@@ -28,10 +28,6 @@ DiffMode VectorForwardModeVisitor::GetPushForwardMode() {
   return DiffMode::vector_pushforward;
 }
 
-void VectorForwardModeVisitor::SetIndependentVarCountDecl(VarDecl* VD) {
-  m_IndVarCountDecl = VD;
-}
-
 DerivativeAndOverload VectorForwardModeVisitor::Derive() {
   const FunctionDecl* FD = m_DiffReq.Function;
   assert(m_DiffReq.Mode == DiffMode::vector_forward_mode);

--- a/lib/Differentiator/VectorPushForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorPushForwardModeVisitor.cpp
@@ -43,7 +43,7 @@ void VectorPushForwardModeVisitor::ExecuteInsidePushforwardFunctionBlock() {
   auto* totalIndVars =
       BuildVarDecl(m_Context.UnsignedLongTy, "indepVarCount", indVarCountExpr);
   addToCurrentBlock(BuildDeclStmt(totalIndVars));
-  SetIndependentVarCountDecl(totalIndVars);
+  m_IndVarCountDecl = totalIndVars;
 
   BaseForwardModeVisitor::ExecuteInsidePushforwardFunctionBlock();
 }


### PR DESCRIPTION
SetIndependentVarCountDecl existed only so VectorPushForwardModeVisitor could set the base's m_IndVarCountDecl. That member is protected, so a derived class assigns it directly; the setter is a needless indirection.

Assign m_IndVarCountDecl at the one call site and drop the setter.