### PR TITLE
Add buildLambda and buildAndBindLambda helpers. NFC

### DIFF
--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -36,6 +36,7 @@
 #include <functional>
 #include <stack>
 #include <unordered_map>
+#include <utility>
 
 namespace clang {
 class NestedNameSpecifier;
@@ -265,14 +266,15 @@ namespace clad {
     /// The currently visited statement. Useful for crash pretty-printing.
     const clang::Stmt* m_CurVisitedStmt = nullptr;
 
-    /// A function used to wrap result of visiting E in a lambda. Returns a call
-    /// to the built lambda. Func is a functor that will be invoked inside
-    /// lambda scope and block. Statements inside lambda are expected to be
-    /// added by addToCurrentBlock from func invocation.
+    /// Build a lambda whose body is produced by `func`. Returns the
+    /// LambdaExpr without invoking it, so the caller can bind it to a VarDecl
+    /// and call it from multiple sites. `func` is invoked inside the lambda's
+    /// scope and block; statements are expected to be added via
+    /// addToCurrentBlock from func's invocation.
     // FIXME: This will become problematic when we try to support C.
     template <typename F>
-    static clang::Expr* wrapInLambda(VisitorBase& V, clang::Sema& S,
-                                     const clang::Expr* E, F&& func) {
+    static clang::Expr* buildLambda(VisitorBase& V, clang::Sema& S,
+                                    const clang::Expr* E, F&& func) {
       // FIXME: Here we use some of the things that are used from Parser, it
       // seems to be the easiest way to create lambda.
       clang::LambdaIntroducer Intro;
@@ -308,7 +310,7 @@ namespace clad {
 #endif // CLANG_VERSION_MAJOR
 
       V.beginBlock();
-      func();
+      std::forward<F>(func)();
       clang::CompoundStmt* body = V.endBlock();
       clang::Expr* lambda =
           S.ActOnLambdaExpr(
@@ -318,9 +320,36 @@ namespace clad {
                        V))
               .get();
       V.endScope();
+      return lambda;
+    }
+
+    /// A function used to wrap result of visiting E in a lambda. Returns a call
+    /// to the built lambda. Func is a functor that will be invoked inside
+    /// lambda scope and block. Statements inside lambda are expected to be
+    /// added by addToCurrentBlock from func invocation.
+    template <typename F>
+    static clang::Expr* wrapInLambda(VisitorBase& V, clang::Sema& S,
+                                     const clang::Expr* E, F&& func) {
+      clang::Expr* lambda = buildLambda(V, S, E, std::forward<F>(func));
       return S.ActOnCallExpr(V.getCurrentScope(), lambda, noLoc, {}, noLoc)
           .get();
     }
+
+    /// Build a [&]-capture lambda whose body is produced by `func` and bind
+    /// it to a fresh VarDecl. Returns the VarDecl so the caller can wrap it
+    /// in a DeclStmt (placed at function-body scope) and call it from one or
+    /// more sites via DeclRefExpr + ActOnCallExpr. Use this when the same
+    /// lambda body must be invoked from multiple paths (e.g. a reverse-pass
+    /// segment shared between an early-return path and the natural tail).
+    template <typename F>
+    clang::VarDecl* buildAndBindLambda(const clang::Expr* LocE,
+                                       llvm::StringRef NameHint, F&& func) {
+      clang::Expr* lambda =
+          buildLambda(*this, m_Sema, LocE, std::forward<F>(func));
+      clang::IdentifierInfo* II = CreateUniqueIdentifier(NameHint);
+      return BuildVarDecl(lambda->getType(), II, lambda);
+    }
+
     /// For a qualtype QT returns if it's type is Array or Pointer Type
     static bool isArrayOrPointerType(const clang::QualType QT) {
       return utils::isArrayOrPointerType(QT);


### PR DESCRIPTION
VisitorBase::wrapInLambda built a lambda and immediately called it (IIFE-style), entangling construction and invocation so no caller could bind the lambda to a VarDecl and invoke it from multiple sites.

Split wrapInLambda into buildLambda, which performs the construction and returns the LambdaExpr, plus a thin wrapInLambda wrapper that appends ActOnCallExpr to preserve the IIFE shape; the single existing caller in BaseForwardModeVisitor is unchanged. Add buildAndBindLambda, which routes through buildLambda and binds the result to a fresh VarDecl, returning the decl so a caller can construct DeclStmt and CallExpr nodes at the sites it needs. buildAndBindLambda is templated and unused here, so it carries no instantiation cost.

Scaffolding for replacing the goto/label emission in VisitReturnStmt with a [&] lambda bound to a VarDecl and called from each return path (vgvassilev/clad#367).