### PR TITLE
Store a conditional operator's condition as bool.

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -954,8 +954,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     beginBlock(direction::reverse);
     addToCurrentBlock(condDiff.getStmt_dx(), direction::reverse);
     // Condition has to be stored as a "global" variable, to take the correct
-    // branch in the reverse pass.
-    Expr* condStored = GlobalStoreAndRef(condDiff.getExpr(), "_cond");
+    // branch in the reverse pass. Store it as bool -- a conditional operator's
+    // condition is contextually converted to bool ([expr.cond]/1); storing the
+    // raw operand would drop qualifiers, e.g. a `const char*` condition (as in
+    // libstdc++'s basic_string(const char*) constructor) becomes an ill-formed
+    // `char* _cond = <const char*>`.
+    Expr* condStored =
+        GlobalStoreAndRef(condDiff.getExpr(), m_Context.BoolTy, "_cond");
     // Convert cond to boolean condition.
     condStored = m_Sema
                      .ActOnCondition(getCurrentScope(), noLoc, condStored,

--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -187,7 +187,7 @@ double f5(double x){
   return g;
 }
 // CHECK: void f5_grad(double x, double *_d_x) {
-// CHECK-NEXT:     double _cond0 = x;
+// CHECK-NEXT:     bool _cond0 = x;
 // CHECK-NEXT:     double _d_g = 0.;
 // CHECK-NEXT:     double g = _cond0 ? 1 : 2;
 // CHECK-NEXT:     _d_g += 1;

--- a/test/Gradient/ConditionalOperatorCondition.C
+++ b/test/Gradient/ConditionalOperatorCondition.C
@@ -1,0 +1,20 @@
+// RUN: %cladclang %s -I%S/../../include -oConditionalOperatorCondition.out 2>&1 | %filecheck %s
+// RUN: ./ConditionalOperatorCondition.out | %filecheck_exec %s
+//
+// A conditional operator's condition is a boolean context, so clad must store
+// it as bool. Storing the raw operand dropped qualifiers: a `const char*`
+// condition became an ill-formed `char* _cond = <const char*>` -- exactly what
+// libstdc++'s basic_string(const char*) constructor triggers under gcc-11.
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+double f(double x, const char *s) { return s ? x * x : x; }
+
+// CHECK: bool _cond0 = s;
+
+int main() {
+  auto g = clad::gradient(f, "x");
+  double dx = 0;
+  g.execute(3.0, "x", &dx);
+  printf("%.2f\n", dx); // CHECK-EXEC: 6.00
+}


### PR DESCRIPTION
VisitConditionalOperator stored the ternary condition via GlobalStoreAndRef without a type, so the stored variable took the operand's own (possibly qualified) type rather than bool. For a const-qualified operand -- a const char*, as in libstdc++'s basic_string(const char*) constructor under gcc-11 -- that produced an ill-formed `char* _cond = <const char*>`, dropping const.

Store it as bool, matching VisitIfStmt: a conditional operator's first operand is contextually converted to bool ([expr.cond]/1), so the branches never observe the operand's value.