### PR TITLE
Do not dereference a null callee in TBR analysis.

### DIFF
--- a/lib/Differentiator/TBRAnalyzer.cpp
+++ b/lib/Differentiator/TBRAnalyzer.cpp
@@ -408,6 +408,16 @@ bool TBRAnalyzer::TraverseCallExpr(clang::CallExpr* CE) {
   // variables passed by value/reference are used/used and changed. Analysis
   // could proceed to the function to analyse data flow inside it.
   FunctionDecl* FD = CE->getDirectCallee();
+  // An indirect call (e.g. through a function pointer, as reached inside
+  // Kokkos's mdspan View) has no direct callee, so the parameter walk below
+  // would dereference a null FD. Conservatively mark every argument used.
+  if (!FD) {
+    setMode(Mode::kMarkingMode | Mode::kNonLinearMode);
+    for (clang::Expr* arg : CE->arguments())
+      TraverseStmt(arg);
+    resetMode();
+    return false;
+  }
   // Use information about parameters assuming the analysis was performed.
   bool shouldAnalyzeParams = m_ModifiedParams && (m_ModifiedParams->find(FD) !=
                                                   m_ModifiedParams->end());


### PR DESCRIPTION
TBRAnalyzer::TraverseCallExpr read CE->getDirectCallee()->getNumParams() unconditionally. An indirect call -- through a function pointer, or an operator call whose operator has no resolvable FunctionDecl, as arises inside Kokkos's mdspan-based View -- has no direct callee, so this reads a null pointer. Guard the null case by conservatively marking every argument as used and stopping.

No minimal standalone test accompanies this: the indirect calls clad can otherwise differentiate (function and member-function pointers) are unsupported and crash elsewhere, so a null direct callee only arises through custom-derivative machinery such as the mdspan View. The path is exercised by unittests/Kokkos/ViewAccess.