### PR TITLE
Split DiffCollector construction from its TU walk. NFC

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -280,9 +280,13 @@ public:
     bool m_IsTraversingTopLevelDecl = true;
 
   public:
-    DiffCollector(clang::DeclGroupRef DGR, DiffInterval& Interval,
+    DiffCollector(DiffInterval& Interval,
                   clad::DynamicGraph<DiffRequest>& requestGraph, clang::Sema& S,
                   RequestOptions& opts, OwnedAnalysisContexts& AllAnalysisDC);
+    /// Run the static planning pass over a group of top-level declarations,
+    /// populating the request graph. A no-op when the clad-enabled interval is
+    /// empty.
+    void Walk(clang::DeclGroupRef DGR);
     bool VisitCallExpr(clang::CallExpr* E);
     bool VisitDeclRefExpr(clang::DeclRefExpr* DRE);
     bool VisitCXXConstructExpr(clang::CXXConstructExpr* e);

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -317,14 +317,15 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     call->setArg(*codeArgIdx, CodeArg);
   }
 
-  DiffCollector::DiffCollector(DeclGroupRef DGR, DiffInterval& Interval,
+  DiffCollector::DiffCollector(DiffInterval& Interval,
                                clad::DynamicGraph<DiffRequest>& requestGraph,
                                clang::Sema& S, RequestOptions& opts,
                                OwnedAnalysisContexts& AllAnalysisDC)
       : m_Interval(Interval), m_DiffRequestGraph(requestGraph),
-        m_AllAnalysisDC(AllAnalysisDC), m_Sema(S), m_Options(opts) {
+        m_AllAnalysisDC(AllAnalysisDC), m_Sema(S), m_Options(opts) {}
 
-    if (Interval.empty())
+  void DiffCollector::Walk(DeclGroupRef DGR) {
+    if (m_Interval.empty())
       return;
 
     assert(!m_TopMostReq && "Traversal already in flight!");

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -218,8 +218,9 @@ void InitTimers();
             continue;
           auto* FD = cast<FunctionDecl>(D);
           if (FD->isConstexpr() || !m_Multiplexer) {
-            DiffCollector collector(DGR, CladEnabledRange, m_DiffRequestGraph,
-                                    S, opts, m_AllAnalysisDC);
+            DiffCollector collector(CladEnabledRange, m_DiffRequestGraph, S,
+                                    opts, m_AllAnalysisDC);
+            collector.Walk(DGR);
             break;
           }
         }
@@ -641,9 +642,9 @@ void InitTimers();
             if (const auto* FD = dyn_cast<FunctionDecl>(D))
               if (FD->isConstexpr())
                 continue;
-            DiffCollector collector(DCI.m_DGR, CladEnabledRange,
-                                    m_DiffRequestGraph, S, opts,
-                                    m_AllAnalysisDC);
+            DiffCollector collector(CladEnabledRange, m_DiffRequestGraph, S,
+                                    opts, m_AllAnalysisDC);
+            collector.Walk(DCI.m_DGR);
             break;
           }
 


### PR DESCRIPTION
The collector's constructor doubled as the static planning pass: it traversed the DeclGroupRef and the object was then discarded, forcing a throwaway collector for every walk.

Move the traversal into a Walk() method so construction only binds the collaborators. This lets the collector become a persistent, reusable planning engine -- the basis for a DiffScheduler that owns it -- rather than a per-walk temporary.