### PR TITLE
Constrain clad::zero_init to types it can zero safely.

### DIFF
--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -238,34 +238,36 @@ CUDA_HOST_DEVICE auto back(TapeType& of) -> decltype(of.back()) {
   template <class T,
             typename std::enable_if<!is_range<T>::value, int>::type = 0>
   CUDA_HOST_DEVICE void zero_impl(volatile T& t) {
-#if defined(__CUDACC__)
-    static_assert(std::is_trivially_destructible<T>::value,
-                  "Clad device fallback zero_init requires trivially "
-                  "destructible types.");
-#endif
-    // Fill an array with zeros.
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-    unsigned char tmp[sizeof(T)] = {};
+    // Bound once so the assertion and the guard below cannot drift apart: a
+    // type the assertion rejects must not go on to be memcpy'd anyway.
+    constexpr bool is_zeroable = std::is_trivially_destructible<T>::value;
+    static_assert(is_zeroable, "Clad device fallback zero_init requires "
+                               "trivially destructible types.");
+    if constexpr (is_zeroable) {
+      // Fill an array with zeros.
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+      unsigned char tmp[sizeof(T)] = {};
 
 #if __has_builtin(__builtin_memcpy)
-    __builtin_memcpy(const_cast<T*>(&t), tmp, sizeof(T));
+      __builtin_memcpy(const_cast<T*>(&t), tmp, sizeof(T));
 #elif defined(__CUDACC__)
-    // Fallback for the devices that don't have __builtin_memcpy.
-    // Transfers the zero with a loop. Unlike memcpyt, this does not create the
-    // object in the destination region of storage and language semantics can't
-    // be fully preserved
-    volatile unsigned char* byte_ptr =
-        reinterpret_cast<volatile unsigned char*>(const_cast<T*>(&t));
-    for (std::size_t i = 0; i < sizeof(T); ++i)
-      byte_ptr[i] = 0;
+      // Fallback for the devices that don't have __builtin_memcpy.
+      // Transfers the zero with a loop. Unlike memcpyt, this does not create
+      // the object in the destination region of storage and language semantics
+      // can't be fully preserved
+      volatile unsigned char* byte_ptr =
+          reinterpret_cast<volatile unsigned char*>(const_cast<T*>(&t));
+      for (std::size_t i = 0; i < sizeof(T); ++i)
+        byte_ptr[i] = 0;
 #else
-    // Transfer the zeros with the magic function memcpy which can implicitly
-    // create objects in the destination region of storage immediately prior to
-    // copying the sequence of characters to the destination [27.5.1(3)].
-    // (C++ has deprecated the volatile qualifiers. However, we drop them here
-    // to make sure things still work with codebases which still have them)
-    std::memcpy(const_cast<T*>(&t), tmp, sizeof(T));
+      // Transfer the zeros with the magic function memcpy which can implicitly
+      // create objects in the destination region of storage immediately prior
+      // to copying the sequence of characters to the destination [27.5.1(3)].
+      // (C++ has deprecated the volatile qualifiers. However, we drop them here
+      // to make sure things still work with codebases which still have them)
+      std::memcpy(const_cast<T*>(&t), tmp, sizeof(T));
 #endif
+    }
   }
 
   template <class T, typename std::enable_if<is_range<T>::value, int>::type = 0>

--- a/test/Misc/ZeroInitViability.cpp
+++ b/test/Misc/ZeroInitViability.cpp
@@ -1,0 +1,67 @@
+// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify
+//
+// Nothing is ignored: every diagnostic is spelled out below. In particular a
+// -Wnontrivial-* warning must not appear, as it would mean the rejected type
+// still reaches the memcpy, which is the thing being prevented.
+
+// clad::zero_init's fallback zeroes an object with a byte-wise memcpy, which is
+// not well-defined for every type. Its guard used to be compiled only into CUDA
+// translation units, so a direct clad::zero_init call in an ordinary host build
+// went unchecked. Check that a host build is guarded too.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <vector>
+
+struct TrivialPod {
+  double a, b;
+};
+
+struct WithCtorTrivialCopy { // a user ctor does not stop trivial copyability
+  double a, b;
+  WithCtorTrivialCopy(double x, double y) : a(x), b(y) {}
+};
+
+struct Owning { // owns a heap handle: memcpy-zeroing it would corrupt it
+  double* p;
+  Owning() : p(new double(0)) {}
+  Owning(const Owning& o) : p(new double(*o.p)) {}
+  ~Owning() { delete p; }
+};
+
+struct HasOverload {
+  double* p;
+};
+namespace clad {
+inline void zero_init(HasOverload& h) { *h.p = 0; }
+} // namespace clad
+
+void accepted() {
+  double d = 1;
+  clad::zero_init(d);
+
+  TrivialPod p{1, 2};
+  clad::zero_init(p);
+
+  WithCtorTrivialCopy w(1, 2);
+  clad::zero_init(w);
+
+  std::vector<double> v(3);
+  clad::zero_init(v);
+
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+  double arr[2]{}; // a C array is iterable, and is what clad zeroes in a loop
+  clad::zero_init(arr);
+
+  HasOverload h{&d}; // an overload still wins over the fallback
+  clad::zero_init(h);
+}
+
+void rejected() {
+  Owning o;
+  // expected-error@clad/Differentiator/Differentiator.h:* {{Clad device fallback zero_init requires trivially destructible types}}
+  // expected-note@clad/Differentiator/Differentiator.h:* {{in instantiation of function template specialization 'clad::zero_impl<Owning, 0>' requested here}}
+  clad::zero_init(o); // expected-note {{in instantiation of function template specialization 'clad::zero_init<Owning>' requested here}}
+}
+
+int main() { return 0; }


### PR DESCRIPTION
clad zeroes a reverse-mode adjoint with clad::zero_init, whose generic fallback fills the object byte-wise. That is well-defined only for trivially-copyable types [basic.types.general]; for a resource-owning type such as a Kokkos::View it would memcpy over the handle and corrupt it. The fallback was unconstrained, so such a type matched silently: only a CUDA-only static_assert guarded it, and host builds had nothing.

Constrain the generic clad::zero_init to iterable or trivially-copyable types, so a type it cannot zero no longer matches and the unmet requirement is reported instead of the object being corrupted. Such a type must supply its own clad::zero_init overload, as the STL, Thrust and cladtorch builtins do. Drop the CUDA static_assert: it required trivial destructibility, which trivial copyability now implies, on host as well as device.