### PR TITLE
Disable the cppcoreguidelines alias of an already-disabled check. NFC

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,6 +17,7 @@ Checks: >
   -misc-const-correctness,
   -misc-unused-parameters,
   -misc-non-private-member-variables-in-classes,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
   -misc-no-recursion,
   -misc-use-anonymous-namespace,
   -modernize-return-braced-init-list,


### PR DESCRIPTION
misc-non-private-member-variables-in-classes is disabled because the visitor classes deliberately expose protected state to their subclasses. cppcoreguidelines-non-private-member-variables-in-classes is an alias of that same check and still fires, so any new protected member reintroduces the warning the existing entry meant to silence.