### PR TITLE
Guard lit_config.quiet for lit versions that removed it.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -246,7 +246,7 @@ def inferClang(PATH):
 config.clang = inferClang(config.environment['PATH']).replace('\\', '/')
 config.cladlib = inferCladLib(config.environment['PATH']).replace('\\', '/')
 
-if not lit_config.quiet:
+if not getattr(lit_config, 'quiet', False):
     lit_config.note('using clang: %r' % config.clang)
     lit_config.note('using auto diff lib: %r' % config.cladlib)
 


### PR DESCRIPTION
test/lit.cfg reads lit_config.quiet directly, but upstream lit has dropped that attribute from LitConfig: --quiet survives only as a command line flag gating the result summary, and LitConfig.note() is now unconditional. Where the attribute is gone, parsing the config raises AttributeError, so the suite fails to load and no test is discovered at all.

CI does not hit this yet, because it drives the suite with the lit package from PyPI -- currently 18.1.8, which still has the attribute -- and that version is independent of the clang-runtime a given row builds against. It does bite when running the suite with the in-tree llvm-lit of a recent LLVM, and it will bite CI once "pip install lit" resolves to a version that dropped it. Read the flag defensively so it works either way.