### PR TITLE
Resolve getFullyQualifiedType in a statically-linked plugin host.

### DIFF
--- a/test/Gradient/ReverseCtorArgQualification.C
+++ b/test/Gradient/ReverseCtorArgQualification.C
@@ -1,0 +1,33 @@
+// RUN: %cladclang %s -I%S/../../include -oReverseCtorArgQualification.out
+// RUN: ./ReverseCtorArgQualification.out | %filecheck_exec %s
+//
+// Regression test for the plugin availability of
+// clang::TypeName::getFullyQualifiedType. It is used by
+// CladUtils::makeTypeReadable in reverse-mode call-argument handling, but within
+// clang only the Interpreter library references it. When clad is loaded as a
+// -fplugin into a clang driver built without LLVM_LINK_LLVM_DYLIB, the symbol is
+// absent from the host binary; without clad supplying it itself
+// (tools/RequiredSymbols.cpp + clangAST archive linkage) the call binds to null
+// and reverse-differentiating any function that constructs a class object
+// crashes with a jump to address 0. See issue vgvassilev/clad#XXXX.
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+struct Pair {
+  double a, b;
+  Pair(double x, double y) : a(x), b(y) {}
+};
+
+double f(double x) {
+  Pair p(x * x, x);
+  return p.a + p.b; // x^2 + x  ->  f'(x) = 2x + 1
+}
+
+int main() {
+  auto g = clad::gradient(f);
+  double dx = 0;
+  g.execute(3.0, &dx);
+  printf("dx = %.2f\n", dx); // CHECK-EXEC: dx = 7.00
+  return 0;
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -16,6 +16,14 @@ endif()
 
 set(link_libs cladDifferentiator)
 
+# Supply the symbols RequiredSymbols.cpp references, which such a host lacks.
+# Link the clangAST archive file, not the clangAST target: the target would
+# also drag in LLVMSupport and duplicate its cl::opt registrations. A dylib
+# build already has them from libclang-cpp.
+if (NOT LLVM_LINK_LLVM_DYLIB AND TARGET clangAST)
+  list(APPEND link_libs "$<TARGET_FILE:clangAST>")
+endif()
+
 if (NOT CLAD_BUILD_STATIC_ONLY)
   # Get rid of libLLVM-X.so which is appended to the list of static libraries.
   if (LLVM_LINK_LLVM_DYLIB)

--- a/tools/RequiredSymbols.cpp
+++ b/tools/RequiredSymbols.cpp
@@ -1,6 +1,27 @@
+#include "clang/AST/QualTypeNames.h"
+
+// MSVC has no equivalent spelling, and needs none: an unresolved symbol fails
+// the link there rather than binding to null.
+#if defined(__GNUC__) || defined(__clang__)
+#define CLAD_USED __attribute__((used))
+#else
+#define CLAD_USED
+#endif
+
 namespace clad {
-  namespace internal {
-    void symbol_requester() {
-    }
-  }
+namespace internal {
+// Force-reference clang symbols a statically-linked plugin host may not pull
+// in itself; tools/CMakeLists.txt links clangAST to supply them.
+CLAD_USED void* symbol_requester() {
+  static void* const kRequiredSymbols[] = {
+      // Spelled out so an upstream signature change fails the build here,
+      // instead of forcing in a symbol makeTypeReadable no longer calls.
+      reinterpret_cast<void*>(
+          static_cast<clang::QualType (*)(clang::QualType,
+                                          const clang::ASTContext&, bool)>(
+              &clang::TypeName::getFullyQualifiedType)),
+  };
+  return kRequiredSymbols[0];
 }
+} // namespace internal
+} // namespace clad


### PR DESCRIPTION
clad's reverse-mode argument handling (CladUtils::makeTypeReadable) calls clang::TypeName::getFullyQualifiedType, but within clang that symbol is referenced only by the Interpreter library. A clang driver built without LLVM_LINK_LLVM_DYLIB does not contain it, so loading clad as a -fplugin leaves the reference unresolved; under -undefined dynamic_lookup it binds to null and the first call jumps to address 0. Reverse mode over any class construction crashes as a result, which on such a host is most of the reverse-mode suite.

Force-reference the symbol from clad (RequiredSymbols.cpp) and link the clangAST archive file into the plugin when not building against the LLVM dylib. Linking the clangAST target instead would drag in LLVMSupport and duplicate its cl::opt registrations, so the archive file is used directly.

The attribute that keeps the reference alive is spelled for GNU compilers only and expands to nothing on MSVC, which has no equivalent and does not need one: Windows fails a link on an unresolved symbol rather than binding it to null.