### PR TITLE
Remove the unused StmtClone clone mapping. NFC

### DIFF
--- a/include/clad/Differentiator/StmtClone.h
+++ b/include/clad/Differentiator/StmtClone.h
@@ -28,19 +28,11 @@ namespace clang {
 namespace clad {
 namespace utils {
 
-  struct StmtCloneMapping;
-
   class StmtClone : public clang::StmtVisitor<StmtClone, clang::Stmt*>  {
   public:
-    // first: original stmt, second: appropriate cloned stmt
-    typedef llvm::DenseMap<const clang::Stmt*, clang::Stmt*> StmtMapping;
-    typedef llvm::DenseMap<clang::ValueDecl*, clang::ValueDecl*> DeclMapping;
-    typedef StmtCloneMapping Mapping;
-
   private:
     clang::Sema& m_Sema;
     clang::ASTContext& Ctx;
-    Mapping* m_OriginalToClonedStmts;
     // While cloning a PseudoObjectExpr, maps each original OpaqueValueExpr to
     // its clone so the syntactic form and the semantic expressions reference
     // the same fresh OVE (null outside such a clone). See
@@ -52,8 +44,8 @@ namespace utils {
     clang::VarDecl* CloneDeclOrNull(clang::VarDecl* Node);
 
   public:
-    StmtClone(clang::Sema& sema, clang::ASTContext& ctx, Mapping* originalToClonedStmts = 0)
-      : m_Sema(sema), Ctx(ctx), m_OriginalToClonedStmts(originalToClonedStmts) {}
+    StmtClone(clang::Sema& sema, clang::ASTContext& ctx)
+        : m_Sema(sema), Ctx(ctx) {}
 
     template<class StmtTy>
     StmtTy* Clone(const StmtTy* S);
@@ -141,22 +133,12 @@ namespace utils {
     clang::Stmt* VisitStmt(clang::Stmt*);
   };
 
-  // Not a StmtClone member class to make it forwardable:
-  struct StmtCloneMapping {
-    StmtClone::StmtMapping m_StmtMapping;
-    StmtClone::DeclMapping m_DeclMapping;
-  };
-
   template<class StmtTy>
   StmtTy* StmtClone::Clone(const StmtTy* S) {
     if (!S)
       return 0;
 
     clang::Stmt* clonedStmt = Visit(const_cast<StmtTy*>(S));
-
-    if (m_OriginalToClonedStmts)
-      m_OriginalToClonedStmts->m_StmtMapping[S] = clonedStmt;
-
     return static_cast<StmtTy*>(clonedStmt);
   }
 

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -614,10 +614,7 @@ Decl* StmtClone::CloneDecl(Decl* Node)  {
     if (VD->getInit())
       m_Sema.AddInitializerToDecl(cloned_Decl, Clone(VD->getInit()), VD->isDirectInit());
     cloned_Decl->setTSCSpec(VD->getTSCSpec());
-    //cloned_Decl->setDeclaredInCondition(VD->isDeclaredInCondition());
-    if (m_OriginalToClonedStmts != 0)
-      m_OriginalToClonedStmts->m_DeclMapping[VD] = cloned_Decl;
-
+    // cloned_Decl->setDeclaredInCondition(VD->isDeclaredInCondition());
     return cloned_Decl;
   }
   assert(0 && "other decl clones aren't supported");


### PR DESCRIPTION
StmtCloneMapping recorded, for each cloned Stmt and VarDecl, the original it came from. Nothing ever read either map, and no caller passed a mapping in the first place -- the sole StmtClone is constructed without one -- so m_OriginalToClonedStmts was permanently null and both writes were dead.

Drop the struct, the member, the typedefs and the two writes. Cloning that must remap references to its clones does so through m_DeclReplacements, which the callers already maintain.