### PR TITLE
Diagnose derivatives that use a variable before its declaration

### DIFF
--- a/lib/Differentiator/ASTIntegrity.cpp
+++ b/lib/Differentiator/ASTIntegrity.cpp
@@ -96,10 +96,82 @@ const ValueDecl* findOriginalRef(const Stmt* Derivative,
   return F.Stray;
 }
 
+/// Visit a block, scoping the declarations it introduces to it.
+static const ValueDecl* walkScope(const Stmt* S,
+                                  llvm::DenseSet<const VarDecl*> Declared);
+
+/// Visit \p S in order, threading \p Declared through so later siblings see
+/// what earlier ones declared. Returns the first offender, or null.
+static const ValueDecl* walkStmt(const Stmt* S,
+                                 llvm::DenseSet<const VarDecl*>& Declared) {
+  if (!S)
+    return nullptr;
+
+  if (const auto* DRE = dyn_cast<DeclRefExpr>(S)) {
+    const auto* VD = dyn_cast<VarDecl>(DRE->getDecl());
+    // Only block-scope locals can be used before their declaration. Parameters
+    // and globals are live for the whole body.
+    if (VD && VD->isLocalVarDecl() && !Declared.count(VD))
+      return VD;
+    return nullptr;
+  }
+
+  if (const auto* LE = dyn_cast<LambdaExpr>(S)) {
+    llvm::DenseSet<const VarDecl*> Inner = Declared;
+    if (const CXXMethodDecl* Call = LE->getCallOperator())
+      for (const ParmVarDecl* P : Call->parameters())
+        Inner.insert(P);
+    return walkScope(LE->getBody(), std::move(Inner));
+  }
+
+  // A block's declarations do not escape it.
+  if (isa<CompoundStmt>(S))
+    return walkScope(S, Declared);
+
+  if (const auto* DS = dyn_cast<DeclStmt>(S)) {
+    // An initializer is evaluated before its own variable is in scope.
+    for (const Decl* D : DS->decls())
+      if (const auto* VD = dyn_cast<VarDecl>(D)) {
+        if (const ValueDecl* Bad = walkStmt(VD->getInit(), Declared))
+          return Bad;
+        Declared.insert(VD);
+      }
+    return nullptr;
+  }
+
+  for (const Stmt* Child : S->children())
+    if (const ValueDecl* Bad = walkStmt(Child, Declared))
+      return Bad;
+  return nullptr;
+}
+
+static const ValueDecl* walkScope(const Stmt* S,
+                                  llvm::DenseSet<const VarDecl*> Declared) {
+  if (!S)
+    return nullptr;
+  if (!isa<CompoundStmt>(S))
+    return walkStmt(S, Declared);
+  for (const Stmt* Child : cast<CompoundStmt>(S)->body())
+    if (const ValueDecl* Bad = walkStmt(Child, Declared))
+      return Bad;
+  return nullptr;
+}
+
+const ValueDecl* findUseBeforeDecl(const Stmt* Derivative,
+                                   const FunctionDecl* Derived) {
+  llvm::DenseSet<const VarDecl*> Declared;
+  if (Derived)
+    for (const ParmVarDecl* P : Derived->parameters())
+      Declared.insert(P);
+  return walkScope(Derivative, std::move(Declared));
+}
+
 IntegrityReport verifyDerivative(const Stmt* Derivative,
-                                 const FunctionDecl* Original) {
+                                 const FunctionDecl* Original,
+                                 const FunctionDecl* Derived) {
   IntegrityReport R;
   R.SharedNode = findSharedNode(Derivative);
+  R.UseBeforeDecl = findUseBeforeDecl(Derivative, Derived);
   if (Original) {
     if (const Stmt* PrimalBody = Original->getBody())
       R.PrimalNode = findPrimalSharedNode(Derivative, PrimalBody);

--- a/lib/Differentiator/ASTIntegrity.h
+++ b/lib/Differentiator/ASTIntegrity.h
@@ -50,6 +50,16 @@ const clang::Stmt* findPrimalSharedNode(const clang::Stmt* Derivative,
 const clang::ValueDecl* findOriginalRef(const clang::Stmt* Derivative,
                                         const clang::FunctionDecl* Original);
 
+/// Return the first block-scope variable \p Derivative references before its
+/// declaration, or nullptr if every use is preceded by its decl. clad builds
+/// bodies by hand, so nothing enforces the ordering that parsing guarantees for
+/// user code. Also validates lambda bodies against what is visible at the
+/// lambda's definition point, which catches references built outside the
+/// closure's scope that never became captures. \p Derived supplies the
+/// generated function whose parameters are in scope throughout.
+const clang::ValueDecl* findUseBeforeDecl(const clang::Stmt* Derivative,
+                                          const clang::FunctionDecl* Derived);
+
 /// The structural violations a generated derivative body may exhibit, each the
 /// first offending node/decl or null. Purely a function of the AST -- the
 /// caller supplies the differentiation context (whether the derivation was
@@ -62,6 +72,8 @@ struct IntegrityReport {
   /// A reference left bound to one of the original function's own
   /// params/locals.
   const clang::ValueDecl* StrayRef = nullptr;
+  /// A variable referenced before its declaration.
+  const clang::ValueDecl* UseBeforeDecl = nullptr;
 };
 
 /// Run every structural integrity check on a generated \p Derivative body.
@@ -70,7 +82,8 @@ struct IntegrityReport {
 /// the AST; StrayRef in particular is meaningful only for a clean derivation,
 /// which the caller must establish before acting on it.
 IntegrityReport verifyDerivative(const clang::Stmt* Derivative,
-                                 const clang::FunctionDecl* Original);
+                                 const clang::FunctionDecl* Original,
+                                 const clang::FunctionDecl* Derived);
 
 } // namespace clad
 

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -666,7 +666,7 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
         // Compute cleanliness before the diagnostics below inflate the tally.
         bool CleanDerivation =
             Diags.getNumWarnings() + Diags.getNumErrors() == DiagsBefore;
-        IntegrityReport Report = verifyDerivative(Body, request.Function);
+        IntegrityReport Report = verifyDerivative(Body, request.Function, FD);
 
         // A derivative must be a proper tree in its Stmt child-edge structure:
         // no node the child of two parents, because a later in-place edit of a
@@ -701,6 +701,21 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
         // unsupported construct is cloned wholesale and knowingly keeps such
         // references in a derivative that is not used.
         if (CleanDerivation) {
+          // Nothing enforces declaration-before-use in a hand-assembled body
+          // the way parsing does for user code, so a reference can name a
+          // variable whose declaration has not been reached -- or one owned by
+          // the original function. Gated with StrayRef: an unsupported
+          // construct is diagnosed and its body is not expected to be
+          // well-formed.
+          assert(!Report.UseBeforeDecl &&
+                 "clad generated a use of a variable before its declaration");
+          if (Report.UseBeforeDecl)
+            diag(DiagnosticsEngine::Warning, FD->getLocation(),
+                 "clad referenced '%0' before its declaration while "
+                 "differentiating %1; this is a clad bug -- please report it "
+                 "at %2")
+                << Report.UseBeforeDecl << FD << getCladRepositoryURL();
+
           assert(!Report.StrayRef &&
                  "derivative references an un-remapped decl of the original");
           if (Report.StrayRef)

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1078,8 +1078,18 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     if (VisitRange.getDecl_dx())
       addToCurrentBlock(BuildDeclStmt(VisitRange.getDecl_dx()));
     addToCurrentBlock(BuildDeclStmt(VisitBegin.getDecl()));
-    if (VisitBegin.getDecl_dx())
-      addToCurrentBlock(BuildDeclStmt(VisitBegin.getDecl_dx()));
+    // The reverse sweep decrements the adjoint iterator, but its loop is a
+    // sibling of the forward one -- for a nested loop no block encloses both
+    // short of the function body. Hoist the declaration to function scope so
+    // both sweeps name the same object, and keep the initialization here,
+    // where the adjoint range it reads is in scope.
+    if (VarDecl* DBegin = VisitBegin.getDecl_dx()) {
+      Expr* Init = DBegin->getInit();
+      DBegin->setInit(nullptr);
+      addToBlock(BuildDeclStmt(DBegin), m_Globals);
+      if (Init)
+        addToCurrentBlock(BuildOp(BO_Assign, BuildDeclRef(DBegin), Init));
+    }
 
     const auto* EndDecl = cast<VarDecl>(FRS->getEndStmt()->getSingleDecl());
     QualType endType = CloneType(EndDecl->getType());
@@ -1119,13 +1129,17 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     StmtDiff storeAdjLoop;
     if (LoopVDDiff.getDecl_dx())
       storeAdjLoop = StoreAndRestore(BuildDeclRef(LoopVDDiff.getDecl_dx()));
+    // The reverse sweep restores the loop variable and its adjoint from the
+    // tape, but it does so from a sibling block of the forward loop. Declare
+    // both at function scope so the restore names the same object; each is
+    // zero-initialized, so nothing in the initializer needs the loop's scope.
     if (LoopVDDiff.getDecl_dx())
-      addToCurrentBlock(BuildDeclStmt(LoopVDDiff.getDecl_dx()));
+      addToBlock(BuildDeclStmt(LoopVDDiff.getDecl_dx()), m_Globals);
     Expr* loopInit = LoopVDDiff.getDecl()->getInit();
     SetDeclInit(LoopVDDiff.getDecl(),
                 getZeroInit(LoopVDDiff.getDecl()->getType()));
     if (LoopVDDiff.getDecl())
-      addToCurrentBlock(BuildDeclStmt(LoopVDDiff.getDecl()));
+      addToBlock(BuildDeclStmt(LoopVDDiff.getDecl()), m_Globals);
     Expr* assignLoop =
         BuildOp(BO_Assign, BuildDeclRef(LoopVDDiff.getDecl()), loopInit);
 

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -1029,6 +1029,20 @@ namespace clad {
       utils::ReferencesUpdater up(m_Sema, getCurrentScope(), CallOp,
                                   m_DeclReplacements);
       up.TraverseStmt(clonedS);
+      // Cloning a DeclStmt produces a fresh VarDecl, but StmtClone records that
+      // only in its own decl mapping. Register it here too, or a later
+      // statement's clone keeps referring to the original lambda's variable --
+      // a reference into the user's AST that outlives differentiation.
+      if (const auto* DS = dyn_cast<DeclStmt>(S))
+        if (auto* ClonedDS = dyn_cast<DeclStmt>(clonedS)) {
+          auto O = DS->decl_begin();
+          auto C = ClonedDS->decl_begin();
+          for (; O != DS->decl_end() && C != ClonedDS->decl_end(); ++O, ++C)
+            if (const auto* OVD = dyn_cast<VarDecl>(*O))
+              if (auto* CVD = dyn_cast<VarDecl>(*C))
+                if (OVD != CVD)
+                  m_DeclReplacements[OVD] = CVD;
+        }
       addToCurrentBlock(clonedS);
     }
     CompoundStmt* ClonedBody = endBlock();

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -2101,8 +2101,11 @@ double fn34(double x, double y){
 }
 
 //CHECK: void fn34_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK-NEXT:     double *_d_begin1;
 //CHECK-NEXT:     clad::tape<double *> _t1 = {};
 //CHECK-NEXT:     clad::tape<double *> _t2 = {};
+//CHECK-NEXT:     double *_d_i = nullptr;
+//CHECK-NEXT:     double *i = nullptr;
 //CHECK-NEXT:     double _d_r = 0.;
 //CHECK-NEXT:     double r = 0;
 //CHECK-NEXT:     double _d_a[3] = {0};
@@ -2111,10 +2114,8 @@ double fn34(double x, double y){
 //CHECK-NEXT:     double (&__range1)[3] = a;
 //CHECK-NEXT:     double (&_d_range1)[3] = _d_a;
 //CHECK-NEXT:     double *__begin1 = __range1;
-//CHECK-NEXT:     double *_d_begin1 = _d_range1;
+//CHECK-NEXT:     _d_begin1 = _d_range1;
 //CHECK-NEXT:     double *__end1 = __range1 + {{3|3L}};
-//CHECK-NEXT:     double *_d_i = nullptr;
-//CHECK-NEXT:     double *i = nullptr;
 //CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d_begin1) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _d_i = _d_begin1;
@@ -2124,31 +2125,31 @@ double fn34(double x, double y){
 //CHECK-NEXT:         }
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         r += *i * *i;
-//CHECK-NEXT:     }
+//CHECK-NEXT:         }
 //CHECK-NEXT:     _d_r += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
-//CHECK-NEXT:             {
+//CHECK-NEXT:         {
 //CHECK-NEXT:                 _d_begin1--;
 //CHECK-NEXT:                 i = clad::pop(_t1);
 //CHECK-NEXT:                 _d_i = clad::pop(_t2);
-//CHECK-NEXT:             }
-//CHECK-NEXT:             {
+//CHECK-NEXT:         }
+//CHECK-NEXT:         {
 //CHECK-NEXT:                 double _r_d0 = _d_r;
 //CHECK-NEXT:                 *_d_i += _r_d0 * *i;
 //CHECK-NEXT:                 *_d_i += *i * _r_d0;
-//CHECK-NEXT:             }
 //CHECK-NEXT:         }
-//CHECK-NEXT:     }
-//CHECK-NEXT:     {
+//CHECK-NEXT:         }
+//CHECK-NEXT:         }
+//CHECK-NEXT:         {
 //CHECK-NEXT:         *_d_y += _d_a[0];
 //CHECK-NEXT:         *_d_x += _d_a[1] * y;
 //CHECK-NEXT:         *_d_y += x * _d_a[1];
 //CHECK-NEXT:         *_d_x += _d_a[2] * x;
 //CHECK-NEXT:         *_d_x += x * _d_a[2];
 //CHECK-NEXT:         *_d_y += _d_a[2];
-//CHECK-NEXT:     }
-//CHECK-NEXT: }
+//CHECK-NEXT:         }
+//CHECK-NEXT:         }
 
 double fn35(double x, double y){
   double r = 0;
@@ -2166,14 +2167,20 @@ double fn35(double x, double y){
 }
 
 // CHECK: void fn35_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK-NEXT:     double *_d_begin1;
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t1 = {};
+// CHECK-NEXT:     double *_d_begin2;
 // CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 // CHECK-NEXT:     clad::tape<bool> _cond1 = {};
 // CHECK-NEXT:     clad::tape<unsigned {{int|long}}> _t2 = {};
 // CHECK-NEXT:     clad::tape<double *> _t3 = {};
 // CHECK-NEXT:     clad::tape<double *> _t4 = {};
+// CHECK-NEXT:         double *_d_j = nullptr;
+// CHECK-NEXT:         double *j = nullptr;
 // CHECK-NEXT:     clad::tape<double *> _t5 = {};
 // CHECK-NEXT:     clad::tape<double *> _t6 = {};
+// CHECK-NEXT:     double *_d_i = nullptr;
+// CHECK-NEXT:     double *i = nullptr;
 // CHECK-NEXT:     double _d_r = 0.;
 // CHECK-NEXT:     double r = 0;
 // CHECK-NEXT:     double _d_a[3] = {0};
@@ -2182,10 +2189,8 @@ double fn35(double x, double y){
 // CHECK-NEXT:     double (&__range1)[3] = a;
 // CHECK-NEXT:     double (&_d_range1)[3] = _d_a;
 // CHECK-NEXT:     double *__begin1 = __range1;
-// CHECK-NEXT:     double *_d_begin1 = _d_range1;
+// CHECK-NEXT:     _d_begin1 = _d_range1;
 // CHECK-NEXT:     double *__end1 = __range1 + {{3|3L}};
-// CHECK-NEXT:     double *_d_i = nullptr;
-// CHECK-NEXT:     double *i = nullptr;
 // CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d_begin1) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _d_i = _d_begin1;
@@ -2198,83 +2203,81 @@ double fn35(double x, double y){
 // CHECK-NEXT:         double (&__range2)[3] = a;
 // CHECK-NEXT:         double (&_d_range2)[3] = _d_a;
 // CHECK-NEXT:         double *__begin2 = __range2;
-// CHECK-NEXT:         double *_d_begin2 = _d_range2;
+// CHECK-NEXT:         _d_begin2 = _d_range2;
 // CHECK-NEXT:         double *__end2 = __range2 + {{3|3L}};
-// CHECK-NEXT:         double *_d_j = nullptr;
-// CHECK-NEXT:         double *j = nullptr;
 // CHECK-NEXT:         for (; __begin2 != __end2; ++__begin2 , ++_d_begin2) {
-// CHECK-NEXT:             {
+// CHECK-NEXT:         {
 // CHECK-NEXT:                 _d_j = _d_begin2;
 // CHECK-NEXT:                 j = __begin2;
 // CHECK-NEXT:                 clad::push(_t3, j);
 // CHECK-NEXT:                 clad::push(_t4, _d_j);
-// CHECK-NEXT:             }
+// CHECK-NEXT:         }
 // CHECK-NEXT:             clad::back(_t1)++;
-// CHECK-NEXT:             {
+// CHECK-NEXT:         {
 // CHECK-NEXT:                 clad::push(_cond0, r <= x * x);
 // CHECK-NEXT:                 if (clad::back(_cond0)) {
 // CHECK-NEXT:                     r += *i * *j;
 // CHECK-NEXT:                 } else {
 // CHECK-NEXT:                     clad::push(_cond1, r > x * x);
 // CHECK-NEXT:                     if (clad::back(_cond1)) {
-// CHECK-NEXT:                         {
+// CHECK-NEXT:         {
 // CHECK-NEXT:                             clad::push(_t2, {{1U|1UL}});
 // CHECK-NEXT:                             break;
-// CHECK-NEXT:                         }
-// CHECK-NEXT:                     }
-// CHECK-NEXT:                 }
-// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT:         }
+// CHECK-NEXT:         }
+// CHECK-NEXT:         }
 // CHECK-NEXT:             clad::push(_t2, {{2U|2UL}});
 // CHECK-NEXT:         }
-// CHECK-NEXT:     }
+// CHECK-NEXT:         }
 // CHECK-NEXT:     _d_r += 1;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         {
-// CHECK-NEXT:             {
+// CHECK-NEXT:         {
 // CHECK-NEXT:                 _d_begin1--;
 // CHECK-NEXT:                 i = clad::pop(_t5);
 // CHECK-NEXT:                 _d_i = clad::pop(_t6);
-// CHECK-NEXT:             }
-// CHECK-NEXT:             {
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
 // CHECK-NEXT:                 for (; clad::back(_t1); clad::back(_t1)--) {
-// CHECK-NEXT:                     {
-// CHECK-NEXT:                         {
+// CHECK-NEXT:         {
+// CHECK-NEXT:         {
 // CHECK-NEXT:                             _d_begin2--;
 // CHECK-NEXT:                             j = clad::pop(_t3);
 // CHECK-NEXT:                             _d_j = clad::pop(_t4);
-// CHECK-NEXT:                         }
+// CHECK-NEXT:         }
 // CHECK-NEXT:                         switch (clad::pop(_t2)) {
 // CHECK-NEXT:                           case {{2U|2UL}}:
 // CHECK-NEXT:                             ;
-// CHECK-NEXT:                             {
-// CHECK-NEXT:                                 if (clad::back(_cond0)) {
-// CHECK-NEXT:                                     {
+// CHECK-NEXT:         {
+// CHECK-NEXT:                 if (clad::back(_cond0)) {
+// CHECK-NEXT:         {
 // CHECK-NEXT:                                         double _r_d0 = _d_r;
 // CHECK-NEXT:                                         *_d_i += _r_d0 * *j;
 // CHECK-NEXT:                                         *_d_j += *i * _r_d0;
-// CHECK-NEXT:                                     }
-// CHECK-NEXT:                                 } else {
-// CHECK-NEXT:                                     if (clad::back(_cond1)) {
-// CHECK-NEXT:                                       case {{1U|1UL}}:
-// CHECK-NEXT:                                         ;
-// CHECK-NEXT:                                     }
-// CHECK-NEXT:                                     clad::pop(_cond1);
-// CHECK-NEXT:                                 }
-// CHECK-NEXT:                                 clad::pop(_cond0);
-// CHECK-NEXT:                             }
-// CHECK-NEXT:                         }
-// CHECK-NEXT:                     }
-// CHECK-NEXT:                 }
-// CHECK-NEXT:                 clad::pop(_t1);
-// CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     {
+// CHECK-NEXT:                 } else {
+// CHECK-NEXT:                     if (clad::back(_cond1)) {
+// CHECK-NEXT:                                       case {{1U|1UL}}:
+// CHECK-NEXT:                             ;
+// CHECK-NEXT:         }
+// CHECK-NEXT:                                     clad::pop(_cond1);
+// CHECK-NEXT:         }
+// CHECK-NEXT:                                 clad::pop(_cond0);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         }
+// CHECK-NEXT:         }
+// CHECK-NEXT:         }
+// CHECK-NEXT:                 clad::pop(_t1);
+// CHECK-NEXT:         }
+// CHECK-NEXT:         }
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
 // CHECK-NEXT:         *_d_x += _d_a[0];
 // CHECK-NEXT:         *_d_x += _d_a[1] * y;
 // CHECK-NEXT:         *_d_y += x * _d_a[1];
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
+// CHECK-NEXT:         }
+// CHECK-NEXT:         }
 
 double fn36(double x, double y){
   double a[] = {1, 2, 3};
@@ -2290,11 +2293,14 @@ double fn36(double x, double y){
 }
 
 //CHECK: void fn36_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK-NEXT:     double *_d_begin1;
 //CHECK-NEXT:     clad::tape<bool> _cond0 = {};
 //CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
 //CHECK-NEXT:     clad::tape<double> _t3 = {};
 //CHECK-NEXT:     clad::tape<double> _t4 = {};
+//CHECK-NEXT:     double _d_i = 0.;
+//CHECK-NEXT:     double i = 0.;
 //CHECK-NEXT:     double _d_a[3] = {0};
 //CHECK-NEXT:     double a[3] = {1, 2, 3};
 //CHECK-NEXT:     double _d_sum = 0.;
@@ -2303,10 +2309,8 @@ double fn36(double x, double y){
 //CHECK-NEXT:     double (&__range1)[3] = a;
 //CHECK-NEXT:     double (&_d_range1)[3] = _d_a;
 //CHECK-NEXT:     double *__begin1 = __range1;
-//CHECK-NEXT:     double *_d_begin1 = _d_range1;
+//CHECK-NEXT:     _d_begin1 = _d_range1;
 //CHECK-NEXT:     double *__end1 = __range1 + {{3|3L}};
-//CHECK-NEXT:     double _d_i = 0.;
-//CHECK-NEXT:     double i = 0.;
 //CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d_begin1) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _d_i = *_d_begin1;
@@ -2318,48 +2322,48 @@ double fn36(double x, double y){
 //CHECK-NEXT:         {
 //CHECK-NEXT:             clad::push(_cond0, sum > x);
 //CHECK-NEXT:             if (clad::back(_cond0)) {
-//CHECK-NEXT:                 {
+//CHECK-NEXT:         {
 //CHECK-NEXT:                     clad::push(_t1, {{1U|1UL|1ULL}});
 //CHECK-NEXT:                     continue;
-//CHECK-NEXT:                 }
+//CHECK-NEXT:         }
 //CHECK-NEXT:             } else if (1) {
 //CHECK-NEXT:                 clad::push(_t2, sin(i));
 //CHECK-NEXT:                 sum += clad::back(_t2) * x;
-//CHECK-NEXT:             }
+//CHECK-NEXT:         }
 //CHECK-NEXT:         }
 //CHECK-NEXT:         clad::push(_t1, {{2U|2UL|2ULL}});
-//CHECK-NEXT:     }
+//CHECK-NEXT:         }
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
-//CHECK-NEXT:             {
+//CHECK-NEXT:         {
 //CHECK-NEXT:                 _d_begin1--;
 //CHECK-NEXT:                 i = clad::pop(_t3);
 //CHECK-NEXT:                 _d_i = clad::pop(_t4);
-//CHECK-NEXT:             }
+//CHECK-NEXT:         }
 //CHECK-NEXT:             switch (clad::pop(_t1)) {
 //CHECK-NEXT:               case {{2U|2UL|2ULL}}:
 //CHECK-NEXT:                 ;
-//CHECK-NEXT:                 {
-//CHECK-NEXT:                     if (clad::back(_cond0)) {
+//CHECK-NEXT:         {
+//CHECK-NEXT:             if (clad::back(_cond0)) {
 //CHECK-NEXT:                       case {{1U|1UL|1ULL}}:
-//CHECK-NEXT:                         ;
-//CHECK-NEXT:                     } else if (1) {
-//CHECK-NEXT:                         {
+//CHECK-NEXT:                 ;
+//CHECK-NEXT:             } else if (1) {
+//CHECK-NEXT:         {
 //CHECK-NEXT:                             double _r0 = 0.;
 //CHECK-NEXT:                             _r0 += _d_sum * x * clad::custom_derivatives::std::sin_pushforward(i, 1.).pushforward;
 //CHECK-NEXT:                             _d_i += _r0;
 //CHECK-NEXT:                             *_d_x += clad::back(_t2) * _d_sum;
 //CHECK-NEXT:                             clad::pop(_t2);
-//CHECK-NEXT:                         }
-//CHECK-NEXT:                     }
+//CHECK-NEXT:         }
+//CHECK-NEXT:         }
 //CHECK-NEXT:                     clad::pop(_cond0);
-//CHECK-NEXT:                 }
-//CHECK-NEXT:             }
+//CHECK-NEXT:         }
+//CHECK-NEXT:         }
 //CHECK-NEXT:         }
 //CHECK-NEXT:         *_d_begin1 += _d_i;
-//CHECK-NEXT:     }
-//CHECK-NEXT: }
+//CHECK-NEXT:         }
+//CHECK-NEXT:         }
 
 double fn37(double x, double y) {
   double range[] = {x, 4., y};
@@ -2370,8 +2374,11 @@ double fn37(double x, double y) {
 }
 
 //CHECK: void fn37_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK-NEXT:     double *_d_begin1;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
+//CHECK-NEXT:     double _d_elem = 0.;
+//CHECK-NEXT:     double elem = 0.;
 //CHECK-NEXT:     double _d_range[3] = {0};
 //CHECK-NEXT:     double range[3] = {x, 4., y};
 //CHECK-NEXT:     double _d_sum = 0.;
@@ -2380,10 +2387,8 @@ double fn37(double x, double y) {
 //CHECK-NEXT:     double (&__range1)[3] = range;
 //CHECK-NEXT:     double (&_d_range1)[3] = _d_range;
 //CHECK-NEXT:     double *__begin1 = __range1;
-//CHECK-NEXT:     double *_d_begin1 = _d_range1;
+//CHECK-NEXT:     _d_begin1 = _d_range1;
 //CHECK-NEXT:     double *__end1 = __range1 + {{3|3L}};
-//CHECK-NEXT:     double _d_elem = 0.;
-//CHECK-NEXT:     double elem = 0.;
 //CHECK-NEXT:     for (; __begin1 != __end1; ++__begin1 , ++_d_begin1) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _d_elem = *_d_begin1;
@@ -2393,24 +2398,24 @@ double fn37(double x, double y) {
 //CHECK-NEXT:         }
 //CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         sum += elem;
-//CHECK-NEXT:     }
+//CHECK-NEXT:         }
 //CHECK-NEXT:     _d_sum += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         {
-//CHECK-NEXT:             {
+//CHECK-NEXT:         {
 //CHECK-NEXT:                 _d_begin1--;
 //CHECK-NEXT:                 elem = clad::pop(_t1);
 //CHECK-NEXT:                 _d_elem = clad::pop(_t2);
-//CHECK-NEXT:             }
+//CHECK-NEXT:         }
 //CHECK-NEXT:             _d_elem += _d_sum;
 //CHECK-NEXT:         }
 //CHECK-NEXT:         *_d_begin1 += _d_elem;
-//CHECK-NEXT:     }
-//CHECK-NEXT:     {
+//CHECK-NEXT:         }
+//CHECK-NEXT:         {
 //CHECK-NEXT:         *_d_x += _d_range[0];
 //CHECK-NEXT:         *_d_y += _d_range[2];
-//CHECK-NEXT:     }
-//CHECK-NEXT: }
+//CHECK-NEXT:         }
+//CHECK-NEXT:         }
 
 double fn38(double x, double y) {
   double sum = 0;
@@ -2427,8 +2432,11 @@ double fn38(double x, double y) {
 //CHECK-NEXT:     clad::array<double> _d_range = {{5U|5UL}};
 //CHECK-NEXT:     clad::array<double> range = {};
 //CHECK-NEXT:     unsigned {{int|long}} _t0;
+//CHECK-NEXT:     double *_d_begin2;
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     clad::tape<double> _t2 = {};
+//CHECK-NEXT:             double _d_elem = 0.;
+//CHECK-NEXT:             double elem = 0.;
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
 //CHECK-NEXT:     {
@@ -2439,12 +2447,10 @@ double fn38(double x, double y) {
 //CHECK-NEXT:             clad::array<double> &__range2 = range;
 //CHECK-NEXT:             clad::array<double> &_d_range2 = _d_range;
 //CHECK-NEXT:             {{const double *\*|const_iterator }}__begin2 = std::begin(__range2);
-//CHECK-NEXT:             double *_d_begin2 = std::begin(_d_range2);
+//CHECK-NEXT:             _d_begin2 = std::begin(_d_range2);
 //CHECK-NEXT:             {{const double *\*|const_iterator }}__end2 = std::end(__range2);
-//CHECK-NEXT:             double _d_elem = 0.;
-//CHECK-NEXT:             double elem = 0.;
 //CHECK-NEXT:             for (; __begin2 != __end2; ++__begin2 , ++_d_begin2) {
-//CHECK-NEXT:                 {
+//CHECK-NEXT:     {
 //CHECK-NEXT:                     _d_elem = *_d_begin2;
 //CHECK-NEXT:                     elem = *__begin2;
 //CHECK-NEXT:                     clad::push(_t1, elem);
@@ -2452,28 +2458,28 @@ double fn38(double x, double y) {
 //CHECK-NEXT:                 }
 //CHECK-NEXT:                 _t0++;
 //CHECK-NEXT:                 sum += elem;
-//CHECK-NEXT:             }
-//CHECK-NEXT:         }
-//CHECK-NEXT:     }
+//CHECK-NEXT:                 }
+//CHECK-NEXT:                 }
+//CHECK-NEXT:                 }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     if (_cond0) {
+//CHECK-NEXT:         if (_cond0) {
 //CHECK-NEXT:         for (; _t0; _t0--) {
-//CHECK-NEXT:             {
-//CHECK-NEXT:                 {
+//CHECK-NEXT:     {
+//CHECK-NEXT:     {
 //CHECK-NEXT:                     _d_begin2--;
 //CHECK-NEXT:                     elem = clad::pop(_t1);
 //CHECK-NEXT:                     _d_elem = clad::pop(_t2);
 //CHECK-NEXT:                 }
 //CHECK-NEXT:                 _d_elem += _d_sum;
-//CHECK-NEXT:             }
+//CHECK-NEXT:                 }
 //CHECK-NEXT:             *_d_begin2 += _d_elem;
-//CHECK-NEXT:         }
-//CHECK-NEXT:         {
+//CHECK-NEXT:                 }
+//CHECK-NEXT:     {
 //CHECK-NEXT:             *_d_x += _d_range[1];
 //CHECK-NEXT:             *_d_y += _d_range[3];
-//CHECK-NEXT:         }
-//CHECK-NEXT:     }
-//CHECK-NEXT: }
+//CHECK-NEXT:                 }
+//CHECK-NEXT:                 }
+//CHECK-NEXT:                 }
 
 double fn39(double x) {
   double res = 0;
@@ -2502,14 +2508,14 @@ double fn39(double x) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             i--;
 //CHECK-NEXT:             _d_i--;
-//CHECK-NEXT:         }
+//CHECK-NEXT:     }
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r_d0 = _d_res;
 //CHECK-NEXT:             *_d_x += _r_d0 * *i;
 //CHECK-NEXT:             *_d_i += x * _r_d0;
-//CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT: }
+//CHECK-NEXT:     }
+//CHECK-NEXT:     }
 
 double fn40(double u, double v) {
     double res = 11 * u;


### PR DESCRIPTION
clad assembles derivative bodies by hand, so nothing enforces that a declaration precedes its uses the way parsing does for user code, and the generated function is never handed to Sema::ActOnFinishFunctionBody, which would re-check it. Such a body can therefore name a variable that is not in scope at that point and still compile.

Add findUseBeforeDecl alongside the existing structural checks. It walks the body in execution order carrying the block-scope locals declared so far, which also validates lambda bodies against what is visible at the lambda's definition point -- notably catching references built outside a closure that never became captures, and which LambdaExpr::captures() therefore cannot report. It is gated on a clean derivation like StrayRef: an unsupported construct is diagnosed and its body is not expected to be well-formed.

The check found three violations, fixed here. Cloning a lambda body created fresh VarDecls but left later statements referring to the original lambda's variables, so register the clones for remapping. A range-for declared its adjoint iterator and loop variable inside the forward loop while the reverse sweep, a sibling block, restored them -- for a nested loop no block encloses both short of the function body, so declare them there and initialize in place.