### PR TITLE
Encode reverse-mode early returns with a named lambda

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -11,6 +11,7 @@
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Stmt.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Basic/SourceLocation.h"
 
@@ -42,7 +43,11 @@ using OwnedAnalysisContexts =
     llvm::SmallVector<std::unique_ptr<clang::AnalysisDeclContext>, 4>;
 using ParamSet = std::set<const clang::ParmVarDecl*>;
 using ParamInfo = std::map<const clang::FunctionDecl*, ParamSet>;
-/// A struct containing information about request to differentiate a function.
+/// A read-only, AD-oriented view over the primal being differentiated: it
+/// wraps the primal FunctionDecl and surfaces the AD-relevant facts the
+/// FunctionDecl itself does not. Recording such facts here, rather than
+/// rediscovering them inside a visitor, keeps them available to every visitor
+/// and correct after a request is copied and re-pointed at another Function.
 struct DiffRequest {
 private:
   /// Based on To-Be-Recorded analysis performed before differentiation, tells
@@ -66,7 +71,28 @@ private:
     bool HasAnalysisRun = false;
   } m_UsefulRunInfo;
 
+  /// Cache for hasEarlyReturns(): whether the primal body has a return that is
+  /// not in tail position. A property of the Function, computed once on demand.
+  mutable struct EarlyReturnInfo {
+    bool HasEarlyReturns = false;
+    bool HasAnalysisRun = false;
+  } m_EarlyReturnInfo;
+
 public:
+  /// The primal body's tail-position return -- the one an early-return encoder
+  /// lets control fall through to, as opposed to an early return that needs a
+  /// jump/call. Null when the body does not end in a return. O(1): reads
+  /// Function's body directly, so a copied request re-pointed at a new Function
+  /// (a lambda's operator(), a pullback callee) answers for its own Function.
+  const clang::ReturnStmt* getTailReturn() const;
+
+  /// Whether the primal body has a return that is not the tail return -- one
+  /// the reverse mode must encode with the early-return lambda. A fact about
+  /// the primal, read directly off Function's body (returns inside nested
+  /// lambdas belong to their own function and are skipped). A void function
+  /// seeds no return value, so its returns skip the encoding.
+  bool hasEarlyReturns() const;
+
   /// Function to be differentiated.
   const clang::FunctionDecl* Function = nullptr;
   /// Name of the base function to be differentiated. Can be different from
@@ -243,17 +269,17 @@ public:
   bool HasTbrAnalysisRun() const { return m_TbrRunInfo.HasAnalysisRun; }
 };
 
-  using DiffInterval = std::vector<clang::SourceRange>;
+using DiffInterval = std::vector<clang::SourceRange>;
 
-  // FIXME: These are translation-unit-wide defaults taken from the compiler
-  // invocation, not the options of a request; rename to InvocationOptions.
-  struct RequestOptions {
-    /// This is a flag to indicate the default behaviour to enable/disable
-    /// TBR analysis during reverse-mode differentiation.
-    bool EnableTBRAnalysis = false;
-    bool EnableVariedAnalysis = false;
-    bool EnableUsefulAnalysis = false;
-  };
+// FIXME: These are translation-unit-wide defaults taken from the compiler
+// invocation, not the options of a request; rename to InvocationOptions.
+struct RequestOptions {
+  /// This is a flag to indicate the default behaviour to enable/disable
+  /// TBR analysis during reverse-mode differentiation.
+  bool EnableTBRAnalysis = false;
+  bool EnableVariedAnalysis = false;
+  bool EnableUsefulAnalysis = false;
+};
 
   class DiffCollector: public clang::RecursiveASTVisitor<DiffCollector> {
     /// The source interval where clad was activated.
@@ -298,6 +324,10 @@ public:
     /// or constructor initializers. If we use Visit they would be processed
     /// under the parent DiffRequest which is not in the lambda scope.
     bool TraverseLambdaExpr(clang::LambdaExpr* LE);
+    /// Plan a lazily-scheduled nested request the static TU walk never reaches
+    /// (built in DerivativeBuilder::HandleNestedDiffRequest). Currently records
+    /// its early-return flag by walking the request's own body.
+    bool PlanNestedRequest(DiffRequest& request);
     bool TraverseFunctionDeclOnce(const clang::FunctionDecl* FD) {
       llvm::SaveAndRestore<bool> Saved(m_IsTraversingTopLevelDecl, false);
       if (m_Traversed.count(FD))

--- a/include/clad/Differentiator/DiffScheduler.h
+++ b/include/clad/Differentiator/DiffScheduler.h
@@ -38,6 +38,10 @@ public:
 
   /// Static planning pass over a group of top-level declarations.
   void Plan(clang::DeclGroupRef DGR) { m_Collector.Walk(DGR); }
+
+  /// Plan a single lazily-scheduled request (a nested or higher-order
+  /// derivative) that the static walk never reached.
+  void Plan(DiffRequest& R) { m_Collector.PlanNestedRequest(R); }
 };
 
 } // namespace clad

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -29,6 +29,8 @@
 #include "clang/Sema/Sema.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h" // IWYU pragma: keep -- function_ref on LLVM<14
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
 #include <array>
@@ -75,6 +77,10 @@ namespace clad {
     /// the reverse mode we also accumulate Stmts for the reverse pass which
     /// will be executed on return.
     std::vector<Stmts> m_Reverse;
+    /// Markers emitted at early-return sites in the forward block, patched
+    /// with `{ _rev(); return; }` at finalization, where `_rev` is the lambda
+    /// wrapping the master reverse sweep.
+    llvm::SmallPtrSet<clang::Stmt*, 4> m_EarlyReturnMarkers;
     /// Storing expressions to delete/free memory in the reverse pass.
     Stmts m_DeallocExprs;
     /// A dfdx seed: eager expression, or a deferred builder materialized on
@@ -128,6 +134,15 @@ namespace clad {
 
     // Function to Differentiate with Enzyme as Backend
     void DifferentiateWithEnzyme();
+
+    /// Walk the current forward block and replace every Stmt in
+    /// m_EarlyReturnMarkers with a fresh Stmt built by `MakeReplacement`.
+    /// Each marker gets its own node — sharing one replacement across sites
+    /// would give it multiple parents and break the single-parent AST
+    /// invariant. Called once at function-body finalization, after the
+    /// forward sweep is fully assembled and before the body is handed to Sema.
+    void
+    patchEarlyReturnMarkers(llvm::function_ref<clang::Stmt*()> MakeReplacement);
 
   public:
     using direction = rmv::direction;
@@ -327,10 +342,10 @@ namespace clad {
     /// of the stack (clad::back(S)).
     clang::Expr* GlobalStoreAndRef(clang::Expr* E, clang::QualType Type,
                                    llvm::StringRef prefix = "_t",
-                                   bool force = false);
+                                   bool force = false, bool zeroInit = false);
     clang::Expr* GlobalStoreAndRef(clang::Expr* E,
                                    llvm::StringRef prefix = "_t",
-                                   bool force = false);
+                                   bool force = false, bool zeroInit = false);
     virtual StmtDiff StoreAndRestore(clang::Expr* E,
                                      llvm::StringRef prefix = "_t",
                                      bool moveToTape = false);

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -18,6 +18,7 @@
 #include "clang/AST/StmtVisitor.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/Lambda.h"
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Sema/DeclSpec.h"
@@ -26,6 +27,7 @@
 #include "clang/Sema/Sema.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/PrettyStackTrace.h"
 
@@ -266,23 +268,56 @@ namespace clad {
     /// The currently visited statement. Useful for crash pretty-printing.
     const clang::Stmt* m_CurVisitedStmt = nullptr;
 
+    /// Resolves the captures of a lambda synthesized from a body that was
+    /// built outside the closure scope, so Sema never saw the uses. collect()
+    /// finds the body's free variables -- locals and parameters it references
+    /// but does not itself declare. resolve() re-creates those references in
+    /// the current scope, where BuildDeclRef under the `[&]` default registers
+    /// the capture and marks the reference for codegen; it must run with the
+    /// lambda scope active. contains() exposes the set for a caller that must
+    /// place the captured decls before the lambda.
+    class LambdaCaptures {
+      VisitorBase& m_V;
+      llvm::SmallPtrSet<clang::VarDecl*, 8> m_Captures;
+
+    public:
+      explicit LambdaCaptures(VisitorBase& V) : m_V(V) {}
+      void collect(llvm::ArrayRef<clang::Stmt*> Body);
+      /// A `[&]` capture binds a variable at the lambda's definition point, so
+      /// every captured decl must precede the lambda. \p Prefix and \p Suffix
+      /// are the forward block split at the lambda's insertion point; move each
+      /// captured DeclStmt from Suffix to the end of Prefix when its
+      /// initializer references only names already live there -- the function's
+      /// parameters, \p AlreadyLive (decls emitted earlier), and Prefix.
+      void orderCaptureDecls(llvm::SmallVectorImpl<clang::Stmt*>& Prefix,
+                             llvm::SmallVectorImpl<clang::Stmt*>& Suffix,
+                             llvm::ArrayRef<clang::Stmt*> AlreadyLive);
+      void resolve(llvm::ArrayRef<clang::Stmt*> Body);
+      bool contains(clang::VarDecl* VD) const { return m_Captures.count(VD); }
+    };
+
     /// Build a lambda whose body is produced by `func`. Returns the
     /// LambdaExpr without invoking it, so the caller can bind it to a VarDecl
     /// and call it from multiple sites. `func` is invoked inside the lambda's
     /// scope and block; statements are expected to be added via
     /// addToCurrentBlock from func's invocation.
+    ///
+    /// The lambda uses the `[&]` capture-default; Sema resolves captures from
+    /// the body's ODR-uses. A pre-built body whose DeclRefExprs were made
+    /// outside this scope must have those references rebuilt in scope so Sema
+    /// sees the uses (see LambdaCaptures::resolve).
     // FIXME: This will become problematic when we try to support C.
     template <typename F>
     static clang::Expr* buildLambda(VisitorBase& V, clang::Sema& S,
-                                    const clang::Expr* E, F&& func) {
+                                    const clang::Stmt* LocSrc, F&& func) {
       // FIXME: Here we use some of the things that are used from Parser, it
       // seems to be the easiest way to create lambda.
       clang::LambdaIntroducer Intro;
       Intro.Default = clang::LCD_ByRef;
       // FIXME: Using noLoc here results in assert failure. Any other valid
       // SourceLocation seems to work fine.
-      Intro.Range.setBegin(E->getBeginLoc());
-      Intro.Range.setEnd(E->getEndLoc());
+      Intro.Range.setBegin(LocSrc->getBeginLoc());
+      Intro.Range.setEnd(LocSrc->getEndLoc());
       clang::AttributeFactory AttrFactory;
       const clang::DeclSpec DS(AttrFactory);
       clang::Declarator D(
@@ -329,8 +364,8 @@ namespace clad {
     /// added by addToCurrentBlock from func invocation.
     template <typename F>
     static clang::Expr* wrapInLambda(VisitorBase& V, clang::Sema& S,
-                                     const clang::Expr* E, F&& func) {
-      clang::Expr* lambda = buildLambda(V, S, E, std::forward<F>(func));
+                                     const clang::Stmt* LocSrc, F&& func) {
+      clang::Expr* lambda = buildLambda(V, S, LocSrc, std::forward<F>(func));
       return S.ActOnCallExpr(V.getCurrentScope(), lambda, noLoc, {}, noLoc)
           .get();
     }
@@ -341,13 +376,29 @@ namespace clad {
     /// more sites via DeclRefExpr + ActOnCallExpr. Use this when the same
     /// lambda body must be invoked from multiple paths (e.g. a reverse-pass
     /// segment shared between an early-return path and the natural tail).
+    ///
+    /// The binding uses `auto` deduction so the pretty-printer renders it as
+    /// `auto X = [&] {...};` rather than the closure type's unspellable
+    /// `(lambda at ...)` form. Sema deduces the concrete closure type from
+    /// the initializer; the TypeSourceInfo retains the `auto` keyword.
+    ///
+    /// \p func emits the closure body; \p Captures then resolves that body's
+    /// references to enclosing variables (its collect() must have already run),
+    /// so callers hand over a pure body-emission callback.
     template <typename F>
-    clang::VarDecl* buildAndBindLambda(const clang::Expr* LocE,
-                                       llvm::StringRef NameHint, F&& func) {
-      clang::Expr* lambda =
-          buildLambda(*this, m_Sema, LocE, std::forward<F>(func));
+    clang::VarDecl* buildAndBindLambda(const clang::Stmt* LocSrc,
+                                       llvm::StringRef NameHint,
+                                       LambdaCaptures& Captures, F&& func) {
+      clang::Expr* lambda = buildLambda(*this, m_Sema, LocSrc, [&] {
+        std::forward<F>(func)();
+        // Resolve captures while the closure scope is active and its body is
+        // the current block.
+        Captures.resolve(getCurrentBlock());
+      });
       clang::IdentifierInfo* II = CreateUniqueIdentifier(NameHint);
-      return BuildVarDecl(lambda->getType(), II, lambda);
+      clang::QualType AutoTy = m_Context.getAutoDeductType();
+      clang::TypeSourceInfo* TSI = m_Context.getTrivialTypeSourceInfo(AutoTy);
+      return BuildVarDecl(AutoTy, II, lambda, /*DirectInit=*/false, TSI);
     }
 
     /// For a qualtype QT returns if it's type is Array or Pointer Type

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -397,9 +397,11 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
 
   clang::FunctionDecl*
   DerivativeBuilder::HandleNestedDiffRequest(DiffRequest& request) {
-    // FIXME: Find a way to do this without accessing plugin namespace functions
     bool alreadyDerived = true;
     request.UpdateDiffParamsInfo(m_Sema);
+    // Plan this lazily-scheduled request statically, so it carries the planning
+    // info (currently the early-return flag) the static TU walk never produced.
+    m_Scheduler.Plan(request);
     FunctionDecl* derivative = this->FindDerivedFunction(request);
     if (!derivative) {
       alreadyDerived = false;

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -24,6 +24,7 @@
 #include "clang/AST/ExprObjC.h"
 #include "clang/AST/OperationKinds.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Stmt.h"
 #include "clang/AST/Type.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Basic/DiagnosticSema.h"
@@ -348,6 +349,23 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     return true;
   }
 
+  bool DiffCollector::PlanNestedRequest(DiffRequest& request) {
+    // Lazily-scheduled requests (pushforward/pullback/higher-order, built in
+    // DerivativeBuilder::HandleNestedDiffRequest) never pass through the static
+    // TU walk, so their planning must be done here on demand. For now this only
+    // records the early-return flag: m_TopMostReq is left null, so
+    // VisitCallExpr and VisitDeclRefExpr bail and no sub-requests are spawned
+    // -- only VisitReturnStmt runs over this request's body.
+    // FIXME: This is where a nested request should also get its m_AnalysisDC
+    // and the analyses currently force-disabled in HandleNestedDiffRequest.
+    const FunctionDecl* Def =
+        request.Function ? request.Function->getDefinition() : nullptr;
+    if (!Def || !Def->hasBody())
+      return true;
+    llvm::SaveAndRestore<DiffRequest*> Saved(m_ParentReq, &request);
+    return TraverseStmt(Def->getBody());
+  }
+
   bool DiffCollector::isInInterval(SourceLocation Loc) const {
     const SourceManager &SM = m_Sema.getSourceManager();
     for (size_t i = 0, e = m_Interval.size(); i < e; ++i) {
@@ -362,6 +380,43 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
         return true;
     }
     return false;
+  }
+
+  const ReturnStmt* DiffRequest::getTailReturn() const {
+    const FunctionDecl* Def = Function ? Function->getDefinition() : nullptr;
+    if (!Def || !Def->hasBody())
+      return nullptr;
+    const Stmt* Body = Def->getBody();
+    // The tail return is the body's last statement, when that is a return.
+    if (const auto* CS = dyn_cast<CompoundStmt>(Body))
+      return CS->body_empty() ? nullptr
+                              : dyn_cast<ReturnStmt>(*CS->body_rbegin());
+    return dyn_cast<ReturnStmt>(Body);
+  }
+
+  bool DiffRequest::hasEarlyReturns() const {
+    if (m_EarlyReturnInfo.HasAnalysisRun)
+      return m_EarlyReturnInfo.HasEarlyReturns;
+    const FunctionDecl* Def = Function ? Function->getDefinition() : nullptr;
+    if (!Def || !Def->hasBody() || Def->getReturnType()->isVoidType())
+      return false;
+    // An early-return body has a return that is not the tail return. Returns
+    // inside a nested lambda belong to that lambda's own function, so do not
+    // descend into one.
+    struct Finder : RecursiveASTVisitor<Finder> {
+      const ReturnStmt* Tail = nullptr;
+      bool Found = false;
+      static bool TraverseLambdaExpr(LambdaExpr*) { return true; }
+      bool VisitReturnStmt(ReturnStmt* RS) {
+        if (RS != Tail)
+          Found = true;
+        return !Found; // stop at the first early return
+      }
+    } F;
+    F.Tail = getTailReturn();
+    F.TraverseStmt(Def->getBody());
+    m_EarlyReturnInfo = {F.Found, /*HasAnalysisRun=*/true};
+    return F.Found;
   }
 
   void DiffRequest::UpdateDiffParamsInfo(Sema& semaRef) {
@@ -1504,7 +1559,10 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
   }
 
   bool DiffCollector::VisitDeclRefExpr(DeclRefExpr* DRE) {
-    if (!m_ParentReq)
+    // m_TopMostReq is dereferenced below; it is null when PlanNestedRequest
+    // walks a lazy request's body just to record its early-return flag, and no
+    // global-adjoint discovery is wanted there.
+    if (!m_ParentReq || !m_TopMostReq)
       return true;
     // FIXME: Add support for globals in other modes.
     if (m_ParentReq->Mode != DiffMode::reverse &&

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -14,7 +14,6 @@
 #include "clad/Differentiator/ErrorEstimator.h"
 #include "clad/Differentiator/ExternalRMVSource.h"
 #include "clad/Differentiator/MultiplexExternalRMVSource.h"
-#include "clad/Differentiator/StmtClone.h"
 #include "clad/Differentiator/VisitorBase.h"
 
 #include "clang/AST/ASTContext.h"
@@ -28,6 +27,7 @@
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/OperationKinds.h"
+#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/Type.h"
@@ -55,6 +55,8 @@
 
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
@@ -503,18 +505,142 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // Firstly, all "global" Stmts are put into fn's body.
     for (Stmt* S : m_Globals)
       addToCurrentBlock(S, direction::forward);
-    // Forward pass.
-    if (auto* CS = dyn_cast_or_null<CompoundStmt>(Forward))
-      for (Stmt* S : CS->body())
+
+    if (!m_DiffReq.hasEarlyReturns()) {
+      // Forward pass.
+      if (auto* CS = dyn_cast_or_null<CompoundStmt>(Forward))
+        for (Stmt* S : CS->body())
+          addToCurrentBlock(S, direction::forward);
+      else
+        addToCurrentBlock(Forward, direction::forward);
+      // Reverse pass.
+      if (auto* RCS = dyn_cast_or_null<CompoundStmt>(Reverse))
+        for (Stmt* S : RCS->body())
+          addToCurrentBlock(S, direction::forward);
+      else
+        addToCurrentBlock(Reverse, direction::forward);
+    } else {
+      // Function has early returns. Wrap the master reverse in a [&] lambda
+      // and call it from each early-return path (via marker patching) plus
+      // once at the natural tail. This replaces the previous goto/label
+      // encoding which violated [stmt.dcl]/2 in the presence of locals with
+      // non-trivial initializers/destructors (vgvassilev/clad#367).
+      //
+      // Source-order matters: the lambda's [&] capture-default binds names
+      // looked up at the lambda's definition point, so every captured local
+      // must be declared before the lambda. Split the forward sweep into
+      // its leading run of DeclStmts and the rest; emit those decls, then
+      // the lambda binding, then the computation tail (which may contain
+      // markers that resolve to calls into the now-declared lambda).
+      llvm::SmallVector<Stmt*, 8> ForwardDeclPrefix;
+      llvm::SmallVector<Stmt*, 16> ForwardCompSuffix;
+      auto* FwdCS = dyn_cast_or_null<CompoundStmt>(Forward);
+      bool inDecls = true;
+      auto classify = [&](Stmt* S) {
+        if (inDecls && isa<DeclStmt>(S))
+          ForwardDeclPrefix.push_back(S);
+        else {
+          inDecls = false;
+          ForwardCompSuffix.push_back(S);
+        }
+      };
+      if (FwdCS)
+        for (Stmt* S : FwdCS->body())
+          classify(S);
+      else if (Forward)
+        classify(Forward);
+
+      // An ExternalSource (error estimation) appends an epilogue after the
+      // reverse sweep — e.g. `_final_error += ...` for each parameter and the
+      // return value. It must run on every return path, but emitting it after
+      // the lambda would make it unreachable once an early return fires (which
+      // calls the lambda and returns). Materialize it now into its own block
+      // so it can be folded into the lambda body and captured together with
+      // the reverse. ActOnEndOfDerivedFnBody is a no-op without such a source,
+      // yielding an empty block that folds to nothing.
+      CompoundStmt* Epilogue = nullptr;
+      if (m_ExternalSource) {
+        beginBlock(direction::forward);
+        m_ExternalSource->ActOnEndOfDerivedFnBody();
+        Epilogue = endBlock(direction::forward);
+      }
+
+      // The reverse sweep and the epilogue become the lambda body; collect
+      // their captures now so the hoister below can place the captured decls
+      // before the lambda.
+      llvm::SmallVector<Stmt*, 2> LambdaBody;
+      if (Reverse)
+        LambdaBody.push_back(Reverse);
+      if (Epilogue)
+        LambdaBody.push_back(Epilogue);
+      LambdaCaptures Captures(*this);
+      Captures.collect(LambdaBody);
+
+      // clad emits a zero-initialized adjoint (`double _d_b = 0.;`) lazily,
+      // next to the primal it shadows, so a captured adjoint decl can land in
+      // the computation suffix -- after the lambda. Move such decls before it.
+      Captures.orderCaptureDecls(ForwardDeclPrefix, ForwardCompSuffix,
+                                 m_Globals);
+
+      for (Stmt* S : ForwardDeclPrefix)
         addToCurrentBlock(S, direction::forward);
-    else
-      addToCurrentBlock(Forward, direction::forward);
-    // Reverse pass.
-    if (auto* RCS = dyn_cast_or_null<CompoundStmt>(Reverse))
-      for (Stmt* S : RCS->body())
+
+      // The reverse-pass lambda captures by reference, so every captured local
+      // must be declared before it. That invariant is enforced globally by
+      // findUseBeforeDecl (ASTIntegrity), which flags a lambda-body reference
+      // to a local not yet in scope at the lambda's definition point.
+
+      VarDecl* RevVD = buildAndBindLambda(
+          m_DiffReq.Function->getBody(), "_rev", Captures, [&] {
+            // Emit the master reverse into the closure. clad no longer reuses
+            // AST nodes across the forward/reverse sweeps (b75bba2c), so the
+            // reverse's nodes are closure-unique and need no clone.
+            if (auto* RCS = dyn_cast_or_null<CompoundStmt>(Reverse))
+              for (Stmt* S : RCS->body())
+                addToCurrentBlock(S, direction::forward);
+            else if (Reverse)
+              addToCurrentBlock(Reverse, direction::forward);
+
+            // Fold the ExternalSource epilogue in after the reverse sweep so it
+            // runs on every return path; emitting it after the lambda would
+            // make it unreachable once an early return fires.
+            if (Epilogue)
+              for (Stmt* S : Epilogue->body())
+                addToCurrentBlock(S, direction::forward);
+          });
+      addToCurrentBlock(BuildDeclStmt(RevVD), direction::forward);
+
+      for (Stmt* S : ForwardCompSuffix)
         addToCurrentBlock(S, direction::forward);
-    else
-      addToCurrentBlock(Reverse, direction::forward);
+
+      // Patch each marker with its own fresh `{ _rev(); return; }`. A single
+      // shared replacement would land under several parents and violate the
+      // single-parent AST invariant, so build one per marker site.
+      patchEarlyReturnMarkers([&]() -> Stmt* {
+        Expr* RevCallEarly =
+            m_Sema
+                .ActOnCallExpr(getCurrentScope(), BuildDeclRef(RevVD), noLoc,
+                               {}, noLoc)
+                .get();
+        Stmt* RetStmt = m_Sema
+                            .ActOnReturnStmt(noLoc, /*RetValExpr=*/nullptr,
+                                             getCurrentScope())
+                            .get();
+        return MakeCompoundStmt({RevCallEarly, RetStmt});
+      });
+
+      // Natural-tail path: the tail-return seed was already emitted into the
+      // forward sweep as the last statement before this point
+      // (VisitReturnStmt), so it runs only on fall-through. Follow it with the
+      // lambda call; the function's implicit fall-off-end serves as the natural
+      // return.
+      Expr* RevCallTail =
+          m_Sema
+              .ActOnCallExpr(getCurrentScope(), BuildDeclRef(RevVD), noLoc, {},
+                             noLoc)
+              .get();
+      addToCurrentBlock(RevCallTail, direction::forward);
+    }
     for (auto S = initsDiff.rbegin(), S_end = initsDiff.rend(); S != S_end; ++S)
       addToCurrentBlock(*S, direction::forward);
     // Add delete statements present in m_DeallocExprs to the current block.
@@ -525,7 +651,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       else
         addToCurrentBlock(S, direction::forward);
 
-    if (m_ExternalSource)
+    // For early-return functions the epilogue was already folded into the
+    // lambda (above) so it runs on every return path; emit it at the tail
+    // only when there is no lambda.
+    if (m_ExternalSource && !m_DiffReq.hasEarlyReturns())
       m_ExternalSource->ActOnEndOfDerivedFnBody();
   }
 
@@ -881,7 +1010,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // Condition has to be stored as a "global" variable, to take the correct
     // branch in the reverse pass.
     Expr* condDiffStored =
-        GlobalStoreAndRef(condDiff.getExpr(), m_Context.BoolTy, "_cond");
+        GlobalStoreAndRef(condDiff.getExpr(), m_Context.BoolTy, "_cond",
+                          /*force=*/false, m_DiffReq.hasEarlyReturns());
     // Convert cond to boolean condition.
     if (condDiffStored)
       condDiffStored =
@@ -960,7 +1090,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // libstdc++'s basic_string(const char*) constructor) becomes an ill-formed
     // `char* _cond = <const char*>`.
     Expr* condStored =
-        GlobalStoreAndRef(condDiff.getExpr(), m_Context.BoolTy, "_cond");
+        GlobalStoreAndRef(condDiff.getExpr(), m_Context.BoolTy, "_cond",
+                          /*force=*/false, m_DiffReq.hasEarlyReturns());
     // Convert cond to boolean condition.
     condStored = m_Sema
                      .ActOnCondition(getCurrentScope(), noLoc, condStored,
@@ -1425,33 +1556,80 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         m_ExternalSource->ActBeforeFinalizingVisitReturnStmt(ExprDiff);
     }
 
-    // If this return stmt is the last stmt in the function's body,
-    // adding goto will only introduce
-    // ```
-    // goto _label0; // the forward sweep ends
-    // _label0:  // the reverse sweep starts immediately
-    // ```
-    // Therefore, in this case, we can omit the goto.
-    const Stmt* lastFuncStmt = m_DiffReq.Function->getBody();
-    if (const auto* CS = dyn_cast<CompoundStmt>(lastFuncStmt))
-      lastFuncStmt = *CS->body_rbegin();
-    if (RS == lastFuncStmt)
+    // If this return stmt is the last stmt in the function body, the forward
+    // sweep falls through into the reverse sweep without needing any jump or
+    // call. When there are also early returns, however, the master reverse is
+    // wrapped in a [&] lambda that both the natural and early-return paths
+    // invoke; applying this tail seed inside the lambda would double-apply it
+    // on every early-return path. Emit it into the forward sweep instead -- it
+    // is the last statement visited, so it lands on the fall-through path just
+    // before the lambda's tail call (see DifferentiateWithClad).
+    if (RS == m_DiffReq.getTailReturn()) {
+      if (m_DiffReq.hasEarlyReturns()) {
+        addToCurrentBlock(Reverse, direction::forward);
+        return {nullptr, nullptr};
+      }
       return {nullptr, Reverse};
+    }
 
-    // If the original function returns at this point, some part of the reverse
-    // pass (corresponding to other branches that do not return here) must be
-    // skipped. We create a label in the reverse pass and jump to it via goto.
-    LabelDecl* LD = LabelDecl::Create(m_Context, m_Sema.CurContext, noLoc,
-                                      CreateUniqueIdentifier("_label"));
-    m_Sema.PushOnScopeChains(LD, m_DerivativeFnScope, true);
-    // Attach label to the last Stmt in the corresponding Reverse Stmt.
+    // Early return.  The previous encoding emitted a label inside the master
+    // reverse and a goto into it from the forward sweep, which violated
+    // [stmt.dcl]/2 (https://eel.is/c++draft/stmt.dcl#2) when any local with a
+    // non-trivial initializer/destructor sat between the goto and its target.
+    //
+    // Instead, emit the adjoint-seed Reverse to the current reverse block
+    // unwrapped — the cond-tape gating in the surrounding reverse loop will
+    // select this seed only on the iteration whose forward-push corresponded
+    // to this return — and emit a NullStmt marker in the forward direction.
+    // Finalization (DifferentiateWithClad) replaces every marker with
+    // `{ _rev(); return; }`, where `_rev` is a [&] lambda wrapping the master
+    // reverse (vgvassilev/clad#367).
     if (!Reverse)
       Reverse = m_Sema.ActOnNullStmt(noLoc).get();
-    Stmt* LS = m_Sema.ActOnLabelStmt(noLoc, LD, noLoc, Reverse).get();
-    addToCurrentBlock(LS, direction::reverse);
 
-    // Create goto to the label.
-    return m_Sema.ActOnGotoStmt(noLoc, noLoc, LD).get();
+    // A return inside a switch case terminates that case's fall-through group,
+    // exactly like a break. Close the group so the reverse switch enters only
+    // this case's adjoint; the entry label must precede the adjoint it guards.
+    if (!m_BreakContStmtHandlers.empty() &&
+        GetActiveBreakContStmtHandler()->m_IsInvokedBySwitchStmt)
+      addToCurrentBlock(CloseReverseSwitchCaseGroup(*GetActiveSwitchStmtInfo()),
+                        direction::reverse);
+    addToCurrentBlock(Reverse, direction::reverse);
+
+    Stmt* marker = m_Sema.ActOnNullStmt(noLoc).get();
+    m_EarlyReturnMarkers.insert(marker);
+    return marker;
+  }
+
+  void ReverseModeVisitor::patchEarlyReturnMarkers(
+      llvm::function_ref<Stmt*()> MakeReplacement) {
+    // Replace each marker with a fresh structured `{ _rev(); return; }` so the
+    // generated body is well-formed without goto. Each site gets its own node
+    // (MakeReplacement builds one per hit); sharing a single replacement across
+    // markers would give it several parents and break the single-parent AST
+    // invariant. We mutate via the child-iterator pattern used by
+    // PlaceholderReplacer; Stmt::children() returns a writable range of Stmt*&.
+    class Patcher : public RecursiveASTVisitor<Patcher> {
+    public:
+      const llvm::SmallPtrSetImpl<Stmt*>* Markers;
+      llvm::function_ref<Stmt*()> Make;
+      Patcher(const llvm::SmallPtrSetImpl<Stmt*>* M,
+              llvm::function_ref<Stmt*()> Mk)
+          : Markers(M), Make(Mk) {}
+      bool VisitStmt(Stmt* S) {
+        for (Stmt*& Child : S->children())
+          if (Child && Markers->count(Child))
+            Child = Make();
+        return true;
+      }
+    };
+    Patcher P(&m_EarlyReturnMarkers, MakeReplacement);
+    Stmts& Block = getCurrentBlock(direction::forward);
+    for (Stmt*& S : Block)
+      if (m_EarlyReturnMarkers.count(S))
+        S = MakeReplacement();
+      else
+        P.TraverseStmt(S);
   }
 
   StmtDiff ReverseModeVisitor::VisitParenExpr(const ParenExpr* PE) {
@@ -3123,7 +3301,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       valueForRevPass = Ldiff.getRevSweepAsExpr();
       ResultRef = Ldiff.getExpr();
     } else if (opCode == BO_LAnd) {
-      VarDecl* condVar = GlobalStoreImpl(m_Context.BoolTy, "_cond");
+      VarDecl* condVar = GlobalStoreImpl(m_Context.BoolTy, "_cond",
+                                         m_DiffReq.hasEarlyReturns()
+                                             ? getZeroInit(m_Context.BoolTy)
+                                             : nullptr);
       VarDecl* derivedCondVar = GlobalStoreImpl(
           m_Context.DoubleTy, "_d" + condVar->getNameAsString());
       addToBlock(BuildOp(BO_Assign, BuildDeclRef(derivedCondVar),
@@ -3911,7 +4092,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
   Expr* ReverseModeVisitor::GlobalStoreAndRef(Expr* E, QualType Type,
                                               llvm::StringRef prefix,
-                                              bool force) {
+                                              bool force, bool zeroInit) {
     assert(E && "must be provided, otherwise use DelayedGlobalStoreAndRef");
     assert(!isa<ArrayType>(Type) && "Array types cannot be stored.");
     if (!force && !UsefulToStoreGlobal(E))
@@ -3934,6 +4115,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       addToCurrentBlock(decl, direction::forward);
       SetDeclInit(VD, E);
     } else {
+      // The decl is hoisted to the top but the store below stays in the
+      // forward sweep. When the function has early returns, an exit can run
+      // the master reverse without reaching the store; a caller that reads
+      // this global there (a branch _cond flag) asks for zero-init so the
+      // unreached case reads false -- the same zero-state clad already relies
+      // on for adjoints and loop counters.
+      if (zeroInit)
+        SetDeclInit(VD, getZeroInit(Type));
       addToBlock(decl, m_Globals);
       // Use a fresh ref for the store-back LHS; Ref is returned to the caller
       // and reused in the reverse pass, so sharing it here parents it twice.
@@ -3952,13 +4141,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   }
 
   Expr* ReverseModeVisitor::GlobalStoreAndRef(Expr* E, llvm::StringRef prefix,
-                                              bool force) {
+                                              bool force, bool zeroInit) {
     assert(E && "cannot infer type");
     return GlobalStoreAndRef(
         E,
         utils::getNonConstType(clad_compat::stripPredefinedSugar(E->getType()),
                                m_Sema),
-        prefix, force);
+        prefix, force, zeroInit);
   }
 
   StmtDiff ReverseModeVisitor::StoreAndRestore(clang::Expr* E,
@@ -4334,7 +4523,9 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     addToCurrentBlock(condDiff.getStmt_dx(), direction::reverse);
     // condDiff.getExpr() may share nodes with the forward statement added
     // above; clone it for the stored condition reference.
-    Expr* condExpr = GlobalStoreAndRef(CloneNode(condDiff.getExpr()), "_cond");
+    Expr* condExpr =
+        GlobalStoreAndRef(CloneNode(condDiff.getExpr()), "_cond",
+                          /*force=*/false, m_DiffReq.hasEarlyReturns());
 
     auto* activeBreakContHandler = PushBreakContStmtHandler(
         /*forSwitchStmt=*/true);

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -23,6 +23,7 @@
 #include "clang/AST/Expr.h"
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/OperationKinds.h"
+#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/Basic/OperatorKinds.h"
@@ -40,6 +41,8 @@
 #include "clang/Sema/Template.h"
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/SaveAndRestore.h"
@@ -47,6 +50,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <numeric>
+#include <utility>
 
 #include "clad/Differentiator/Compatibility.h"
 
@@ -335,6 +339,129 @@ namespace clad {
     T = T.getNonReferenceType();
     return cast<DeclRefExpr>(clad_compat::GetResult<Expr*>(
         m_Sema.BuildDeclRefExpr(D, T, VK, D->getBeginLoc(), &CSS)));
+  }
+
+  void VisitorBase::LambdaCaptures::collect(llvm::ArrayRef<Stmt*> Body) {
+    class FreeVarCollector : public RecursiveASTVisitor<FreeVarCollector> {
+    public:
+      llvm::SmallSetVector<VarDecl*, 16> Referenced;
+      llvm::SmallPtrSet<VarDecl*, 16> Declared;
+      bool VisitDeclRefExpr(DeclRefExpr* DRE) {
+        if (auto* VD = dyn_cast<VarDecl>(DRE->getDecl()))
+          if (VD->isLocalVarDecl() || isa<ParmVarDecl>(VD))
+            Referenced.insert(VD);
+        return true;
+      }
+      bool VisitDeclStmt(DeclStmt* DS) {
+        for (Decl* D : DS->decls())
+          if (auto* VD = dyn_cast<VarDecl>(D))
+            Declared.insert(VD);
+        return true;
+      }
+    } C;
+    for (Stmt* S : Body)
+      C.TraverseStmt(S);
+    for (VarDecl* VD : C.Referenced)
+      if (!C.Declared.count(VD))
+        m_Captures.insert(VD);
+  }
+
+  void VisitorBase::LambdaCaptures::orderCaptureDecls(
+      llvm::SmallVectorImpl<Stmt*>& Prefix,
+      llvm::SmallVectorImpl<Stmt*>& Suffix, llvm::ArrayRef<Stmt*> AlreadyLive) {
+    llvm::SmallPtrSet<const VarDecl*, 16> Available;
+    auto note = [&](Stmt* S) {
+      if (auto* DS = dyn_cast_or_null<DeclStmt>(S))
+        for (Decl* D : DS->decls())
+          if (auto* VD = dyn_cast<VarDecl>(D))
+            Available.insert(VD);
+    };
+    for (const ParmVarDecl* P : m_V.m_Derivative->parameters())
+      Available.insert(P);
+    for (Stmt* S : AlreadyLive)
+      note(S);
+    for (Stmt* S : Prefix)
+      note(S);
+
+    // Moving a decl earlier preserves its value only if its initializer yields
+    // the same value there: it may reference only names already live before
+    // the lambda. This checks availability, not that those names are unmutated
+    // in between; it is sound for the decls clad moves -- zero-initialized
+    // adjoints and entry-live seeds, whose operands the forward sweep has not
+    // yet reassigned. A decl reading a value the suffix computes fails the test
+    // and stays put (findUseBeforeDecl catches a captured local left behind).
+    auto selfContained = [&](const VarDecl* VD) {
+      const Expr* Init = VD->getInit();
+      if (!Init)
+        return true;
+      bool Ok = true;
+      class RefChecker : public RecursiveASTVisitor<RefChecker> {
+      public:
+        const llvm::SmallPtrSetImpl<const VarDecl*>* Available = nullptr;
+        bool* Ok = nullptr;
+        bool VisitDeclRefExpr(DeclRefExpr* DRE) const {
+          auto* RVD = dyn_cast<VarDecl>(DRE->getDecl());
+          if (RVD && (RVD->isLocalVarDecl() || isa<ParmVarDecl>(RVD)) &&
+              !Available->count(RVD)) {
+            *Ok = false;
+            return false;
+          }
+          return true;
+        }
+      } RC;
+      RC.Available = &Available;
+      RC.Ok = &Ok;
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+      RC.TraverseStmt(const_cast<Expr*>(Init));
+      return Ok;
+    };
+
+    llvm::SmallVector<Stmt*, 16> Remaining;
+    for (Stmt* S : Suffix) {
+      auto* DS = dyn_cast<DeclStmt>(S);
+      bool Move = DS != nullptr;
+      if (DS)
+        for (Decl* D : DS->decls()) {
+          auto* VD = dyn_cast<VarDecl>(D);
+          if (!VD || !contains(VD) || !selfContained(VD)) {
+            Move = false;
+            break;
+          }
+        }
+      if (Move) {
+        Prefix.push_back(S);
+        note(S);
+      } else
+        Remaining.push_back(S);
+    }
+    Suffix = std::move(Remaining);
+  }
+
+  void VisitorBase::LambdaCaptures::resolve(llvm::ArrayRef<Stmt*> Body) {
+    class CapRefRebuilder : public RecursiveASTVisitor<CapRefRebuilder> {
+    public:
+      LambdaCaptures& Caps;
+      explicit CapRefRebuilder(LambdaCaptures& Caps) : Caps(Caps) {}
+      bool VisitStmt(Stmt* P) {
+        for (Stmt*& Child : P->children()) {
+          auto* DRE = dyn_cast_or_null<DeclRefExpr>(Child);
+          if (!DRE)
+            continue;
+          auto* VD = dyn_cast<VarDecl>(DRE->getDecl());
+          if (!VD || !Caps.contains(VD) ||
+              DRE->refersToEnclosingVariableOrCapture())
+            continue;
+          // BuildDeclRef produces a bare reference for a local (it never
+          // name-qualifies one), which is what lets Sema capture it here.
+          Child = Caps.m_V.BuildDeclRef(VD, clad_compat::nullNNS(),
+                                        DRE->getValueKind());
+        }
+        return true;
+      }
+    };
+    CapRefRebuilder CR(*this);
+    for (Stmt* S : Body)
+      CR.TraverseStmt(S);
   }
 
   Expr* VisitorBase::buildAdjoint(const AdjointInfo& A,

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -291,7 +291,15 @@ namespace clad {
     CXXScopeSpec CSS;
     SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
 
-    if (!clad_compat::hasQualifier(NNS)) {
+    // A local variable or parameter is never name-qualified: `NS::local` does
+    // not exist. Building a qualifier for one is not only meaningless printing
+    // -- when the reference crosses into a nested lambda (a capture), the bogus
+    // qualifier stops Sema from resolving it as a capture. So only qualify
+    // decls that can be qualified.
+    const bool IsLocal =
+        isa<ParmVarDecl>(D) ||
+        (isa<VarDecl>(D) && cast<VarDecl>(D)->isLocalVarDecl());
+    if (!clad_compat::hasQualifier(NNS) && !IsLocal) {
       // If no CXXScopeSpec is provided we should try to find the common path
       // between the current scope (in which presumably we will make the call)
       // and where `D` is.

--- a/test/ErrorEstimation/ConditonalStatements.C
+++ b/test/ErrorEstimation/ConditonalStatements.C
@@ -87,39 +87,43 @@ float func2(float x) {
 }
 
 //CHECK: void func2_grad(float x, float *_d_x, double &_final_error) {
-//CHECK-NEXT:     bool _cond0;
+//CHECK-NEXT:     bool _cond0 = false;
 //CHECK-NEXT:     double _ret_value0 = 0.;
 //CHECK-NEXT:     float _d_z = 0.F;
 //CHECK-NEXT:     float z = x * x;
+//CHECK-NEXT:     auto _rev0 = [&] {
+//CHECK-NEXT:         if (_cond0) {
+//CHECK-NEXT:             *_d_x += 1;
+//CHECK-NEXT:             *_d_x += 1;
+//CHECK-NEXT:         } else {
+//CHECK-NEXT:             *_d_x += 1 * x;
+//CHECK-NEXT:             *_d_x += x * 1;
+//CHECK-NEXT:         }
+//CHECK-NEXT:         {
+//CHECK-NEXT:             _final_error += std::abs(_d_z * z * {{.+}});
+//CHECK-NEXT:             *_d_x += _d_z * x;
+//CHECK-NEXT:             *_d_x += x * _d_z;
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _final_error += std::abs(*_d_x * x * {{.+}});
+//CHECK-NEXT:         _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     };
 //CHECK-NEXT:     {
 //CHECK-NEXT:     _cond0 = z > 9;
 //CHECK-NEXT:     if (_cond0) {
 //CHECK-NEXT:         _ret_value0 = x + x;
-//CHECK-NEXT:         goto _label0;
+//CHECK-NEXT:         {
+//CHECK-NEXT:             _rev0();
+//CHECK-NEXT:             return;
+//CHECK-NEXT:         }
 //CHECK-NEXT:     } else {
 //CHECK-NEXT:         _ret_value0 = x * x;
-//CHECK-NEXT:         goto _label1;
-//CHECK-NEXT:     }
-//CHECK-NEXT:     }
-//CHECK-NEXT:     if (_cond0)
-//CHECK-NEXT:       _label0:
 //CHECK-NEXT:         {
-//CHECK-NEXT:             *_d_x += 1;
-//CHECK-NEXT:             *_d_x += 1;
+//CHECK-NEXT:             _rev0();
+//CHECK-NEXT:             return;
 //CHECK-NEXT:         }
-//CHECK-NEXT:     else
-//CHECK-NEXT:       _label1:
-//CHECK-NEXT:         {
-//CHECK-NEXT:             *_d_x += 1 * x;
-//CHECK-NEXT:             *_d_x += x * 1;
-//CHECK-NEXT:         }
-//CHECK-NEXT:     {
-//CHECK-NEXT:         _final_error += std::abs(_d_z * z * {{.+}});
-//CHECK-NEXT:         *_d_x += _d_z * x;
-//CHECK-NEXT:         *_d_x += x * _d_z;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     _final_error += std::abs(*_d_x * x * {{.+}});
-//CHECK-NEXT:     _final_error += std::abs(1. * _ret_value0 * {{.+}});
+//CHECK-NEXT:     }
+//CHECK-NEXT:     _rev0();
 //CHECK-NEXT: }
 
 float func3(float x, float y) { return x > 30 ? x * y : x + y; }

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -116,27 +116,13 @@ double f5(double x, double y) {
 }
 
 //CHECK:   void f5_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       bool _cond0;
-//CHECK-NEXT:       bool _cond1;
+//CHECK-NEXT:       bool _cond0 = false;
+//CHECK-NEXT:       bool _cond1 = false;
 //CHECK-NEXT:       double _d_z = 0.;
 //CHECK-NEXT:       double z = 0.;
 //CHECK-NEXT:       double _d_t = 0.;
 //CHECK-NEXT:       double t = x * x;
-//CHECK-NEXT:       {
-//CHECK-NEXT:       _cond0 = x < 0;
-//CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:           t = -t;
-//CHECK-NEXT:           goto _label0;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       }
-//CHECK-NEXT:       {
-//CHECK-NEXT:       _cond1 = y < 0;
-//CHECK-NEXT:       if (_cond1) {
-//CHECK-NEXT:           z = t;
-//CHECK-NEXT:           t = -t;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       }
-//CHECK-NEXT:       _d_t += 1;
+//CHECK-NEXT:       auto _rev0 = [&] {
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           {
 //CHECK-NEXT:               double _r_d1 = _d_t;
@@ -146,7 +132,6 @@ double f5(double x, double y) {
 //CHECK-NEXT:           _d_t += _d_z;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:         _label0:
 //CHECK-NEXT:           _d_t += 1;
 //CHECK-NEXT:           {
 //CHECK-NEXT:               double _r_d0 = _d_t;
@@ -158,6 +143,26 @@ double f5(double x, double y) {
 //CHECK-NEXT:           *_d_x += _d_t * x;
 //CHECK-NEXT:           *_d_x += x * _d_t;
 //CHECK-NEXT:       }
+//CHECK-NEXT:       };
+//CHECK-NEXT:       {
+//CHECK-NEXT:       _cond0 = x < 0;
+//CHECK-NEXT:       if (_cond0) {
+//CHECK-NEXT:           t = -t;
+//CHECK-NEXT:           {
+//CHECK-NEXT:               _rev0();
+//CHECK-NEXT:               return;
+//CHECK-NEXT:           }
+//CHECK-NEXT:       }
+//CHECK-NEXT:       }
+//CHECK-NEXT:       {
+//CHECK-NEXT:       _cond1 = y < 0;
+//CHECK-NEXT:       if (_cond1) {
+//CHECK-NEXT:           z = t;
+//CHECK-NEXT:           t = -t;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       }
+//CHECK-NEXT:       _d_t += 1;
+//CHECK-NEXT:       _rev0();
 //CHECK-NEXT:   }
 
 // = sign(x) * sign(y) * x * x
@@ -175,27 +180,13 @@ double f6(double x, double y) {
 }
 
 //CHECK:   void f6_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       bool _cond0;
-//CHECK-NEXT:       bool _cond1;
+//CHECK-NEXT:       bool _cond0 = false;
+//CHECK-NEXT:       bool _cond1 = false;
 //CHECK-NEXT:       double _d_z = 0.;
 //CHECK-NEXT:       double z = 0.;
 //CHECK-NEXT:       double _d_t = 0.;
 //CHECK-NEXT:       double t = x * x;
-//CHECK-NEXT:       {
-//CHECK-NEXT:       _cond0 = x < 0;
-//CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:           t = -t;
-//CHECK-NEXT:           goto _label0;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       }
-//CHECK-NEXT:       {
-//CHECK-NEXT:       _cond1 = y < 0;
-//CHECK-NEXT:       if (_cond1) {
-//CHECK-NEXT:           z = t;
-//CHECK-NEXT:           t = -t;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       }
-//CHECK-NEXT:       _d_t += 1;
+//CHECK-NEXT:       auto _rev0 = [&] {
 //CHECK-NEXT:       if (_cond1) {
 //CHECK-NEXT:           {
 //CHECK-NEXT:               double _r_d1 = _d_t;
@@ -205,7 +196,6 @@ double f6(double x, double y) {
 //CHECK-NEXT:           _d_t += _d_z;
 //CHECK-NEXT:       }
 //CHECK-NEXT:       if (_cond0) {
-//CHECK-NEXT:         _label0:
 //CHECK-NEXT:           _d_t += 1;
 //CHECK-NEXT:           {
 //CHECK-NEXT:               double _r_d0 = _d_t;
@@ -217,6 +207,26 @@ double f6(double x, double y) {
 //CHECK-NEXT:           *_d_x += _d_t * x;
 //CHECK-NEXT:           *_d_x += x * _d_t;
 //CHECK-NEXT:       }
+//CHECK-NEXT:       };
+//CHECK-NEXT:       {
+//CHECK-NEXT:       _cond0 = x < 0;
+//CHECK-NEXT:       if (_cond0) {
+//CHECK-NEXT:           t = -t;
+//CHECK-NEXT:           {
+//CHECK-NEXT:               _rev0();
+//CHECK-NEXT:               return;
+//CHECK-NEXT:           }
+//CHECK-NEXT:       }
+//CHECK-NEXT:       }
+//CHECK-NEXT:       {
+//CHECK-NEXT:       _cond1 = y < 0;
+//CHECK-NEXT:       if (_cond1) {
+//CHECK-NEXT:           z = t;
+//CHECK-NEXT:           t = -t;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       }
+//CHECK-NEXT:       _d_t += 1;
+//CHECK-NEXT:       _rev0();
 //CHECK-NEXT:   }
 
 double f7(double x, double y) {

--- a/test/Gradient/EarlyReturns.C
+++ b/test/Gradient/EarlyReturns.C
@@ -1,0 +1,131 @@
+// RUN: %cladclang %s -I%S/../../include -oEarlyReturns.out 2>&1 | %filecheck %s
+// RUN: ./EarlyReturns.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oEarlyReturns.out
+// RUN: ./EarlyReturns.out | %filecheck_exec %s
+//
+// The synthesized reverse lambda makes Clang's CodeGen emit a closure
+// constructor/destructor, whose exception landing-pad path
+// (EHScopeStack::requiresLandingPad) reads an uninitialized value inside
+// libclang on some runtimes. The read is Clang-internal and does not affect
+// the generated derivative; skip the run under Valgrind like the other tests.
+// XFAIL: valgrind
+
+#include "clad/Differentiator/Differentiator.h"
+#include "../TestUtils.h"
+
+// A body whose only return is in tail position keeps the plain shape: control
+// falls through to the reverse sweep, so no lambda is materialised.
+double noEarly(double x, double y) { return x * y; }
+
+// CHECK-LABEL: void noEarly_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK-NOT: _rev
+
+// A non-tail return cannot fall through, so the reverse sweep becomes a named
+// lambda that both the early-return site and the tail return call.
+double singleEarly(double x, double y) {
+  if (x > y)
+    return x * x;
+  return x * y;
+}
+
+// CHECK-LABEL: void singleEarly_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: auto _rev0 = [&
+
+// Several early returns share one lambda; each site gets its own call
+// statement rather than reusing a single node.
+double multiEarly(double x, double y) {
+  if (x > 10)
+    return x;
+  if (y > 10)
+    return y * y;
+  return x * y;
+}
+
+// CHECK-LABEL: void multiEarly_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: auto _rev0 = [&
+
+// An early return inside a loop leaves mid-iteration: the reverse sweep runs
+// from the exit point back through the taped iterations, so the lambda must
+// bind the loop's stored state.
+double loopEarly(double x, double y) {
+  double s = 0;
+  for (int i = 0; i < 5; ++i) {
+    s += x * y;
+    if (s > 20)
+      return s;
+  }
+  return s;
+}
+
+// CHECK-LABEL: void loopEarly_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: auto _rev0 = [&
+
+// The early return fires after some primal state (a, b) is already built, so
+// the lambda captures a partially-computed forward sweep.
+double midEarly(double x, double y) {
+  double a = x * y;
+  double b = a + x;
+  if (b > 50)
+    return a * b;
+  return b * y;
+}
+
+// CHECK-LABEL: void midEarly_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: auto _rev0 = [&
+
+// A recursive callee is requested twice: once for the self-call and once for
+// the enclosing call. The two requests dedup, and the flag recording the early
+// return must survive that dedup or the pullback would lose the lambda shape.
+double recEarly(double x, double y) {
+  if (x > y)
+    return recEarly(x - 1, y);
+  return x * y;
+}
+
+// CHECK-LABEL: void recEarly_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
+// CHECK: auto _rev0 = [&
+
+double callsRec(double x, double y) { return recEarly(x, y); }
+
+int main() {
+  double dx = 0, dy = 0;
+
+  INIT_GRADIENT(noEarly);
+  TEST_GRADIENT(noEarly, /*numOfDerivativeArgs=*/2, 3, 5, &dx, &dy); // CHECK-EXEC: {5.00, 3.00}
+
+  dx = dy = 0;
+  INIT_GRADIENT(singleEarly);
+  // x > y takes the early return: d(x*x) = {2x, 0}.
+  TEST_GRADIENT(singleEarly, /*numOfDerivativeArgs=*/2, 5, 3, &dx, &dy); // CHECK-EXEC: {10.00, 0.00}
+  dx = dy = 0;
+  // x <= y falls through to the tail return: d(x*y) = {y, x}.
+  TEST_GRADIENT(singleEarly, /*numOfDerivativeArgs=*/2, 3, 5, &dx, &dy); // CHECK-EXEC: {5.00, 3.00}
+
+  dx = dy = 0;
+  INIT_GRADIENT(multiEarly);
+  TEST_GRADIENT(multiEarly, /*numOfDerivativeArgs=*/2, 20, 1, &dx, &dy); // CHECK-EXEC: {1.00, 0.00}
+  dx = dy = 0;
+  TEST_GRADIENT(multiEarly, /*numOfDerivativeArgs=*/2, 1, 20, &dx, &dy); // CHECK-EXEC: {0.00, 40.00}
+  dx = dy = 0;
+  TEST_GRADIENT(multiEarly, /*numOfDerivativeArgs=*/2, 2, 3, &dx, &dy); // CHECK-EXEC: {3.00, 2.00}
+
+  dx = dy = 0;
+  INIT_GRADIENT(loopEarly);
+  // s exceeds 20 on the 4th iteration: returns 4*x*y, so d = {4y, 4x}.
+  TEST_GRADIENT(loopEarly, /*numOfDerivativeArgs=*/2, 2, 3, &dx, &dy); // CHECK-EXEC: {12.00, 8.00}
+  dx = dy = 0;
+  // s never exceeds 20: falls through to the tail, 5*x*y, so d = {5y, 5x}.
+  TEST_GRADIENT(loopEarly, /*numOfDerivativeArgs=*/2, 1, 1, &dx, &dy); // CHECK-EXEC: {5.00, 5.00}
+
+  dx = dy = 0;
+  INIT_GRADIENT(midEarly);
+  // b > 50 takes the early return a*b = x*x*y*y + x*x*y.
+  TEST_GRADIENT(midEarly, /*numOfDerivativeArgs=*/2, 8, 7, &dx, &dy); // CHECK-EXEC: {896.00, 960.00}
+  dx = dy = 0;
+  // b <= 50 falls through to the tail b*y = x*y*y + x*y.
+  TEST_GRADIENT(midEarly, /*numOfDerivativeArgs=*/2, 6, 7, &dx, &dy); // CHECK-EXEC: {56.00, 90.00}
+
+  dx = dy = 0;
+  INIT_GRADIENT(callsRec);
+  TEST_GRADIENT(callsRec, /*numOfDerivativeArgs=*/2, 3, 1, &dx, &dy); // CHECK-EXEC: {1.00, 1.00}
+}

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -377,11 +377,23 @@ double check_and_return(double x, char c, const char* s) {
 }
 
 // CHECK: void check_and_return_pullback(double x, char c, const char *s, double _d_y, double *_d_x, char *_d_c, char *_d_s) {
-// CHECK-NEXT:    bool _cond0;
+// CHECK-NEXT:    bool _cond0 = false;
 // CHECK-NEXT:    double _d_cond0;
 // CHECK-NEXT:    _d_cond0 = 0.;
-// CHECK-NEXT:    bool _cond1;
-// CHECK-NEXT:    bool _cond2;
+// CHECK-NEXT:    bool _cond1 = false;
+// CHECK-NEXT:    bool _cond2 = false;
+// CHECK-NEXT:    auto _rev0 = [&] {
+// CHECK-NEXT:        {
+// CHECK-NEXT:            if (_cond2)
+// CHECK-NEXT:                *_d_x += _d_y;
+// CHECK-NEXT:            {
+// CHECK-NEXT:                if (_cond1) {
+// CHECK-NEXT:                    double _r_d0 = _d_cond0;
+// CHECK-NEXT:                    _d_cond0 = 0.;
+// CHECK-NEXT:                }
+// CHECK-NEXT:            }
+// CHECK-NEXT:        }
+// CHECK-NEXT:    };
 // CHECK-NEXT:    {
 // CHECK-NEXT:        {
 // CHECK-NEXT:            _cond1 = c == 'a';
@@ -389,20 +401,12 @@ double check_and_return(double x, char c, const char* s) {
 // CHECK-NEXT:                _cond0 = s[0] == 'a';
 // CHECK-NEXT:        }
 // CHECK-NEXT:        _cond2 = _cond1 && _cond0;
-// CHECK-NEXT:        if (_cond2)
-// CHECK-NEXT:            goto _label0;
-// CHECK-NEXT:    }
-// CHECK-NEXT:    {
-// CHECK-NEXT:        if (_cond2)
-// CHECK-NEXT:          _label0:
-// CHECK-NEXT:           *_d_x += _d_y;
-// CHECK-NEXT:        {
-// CHECK-NEXT:            if (_cond1) {
-// CHECK-NEXT:                double _r_d0 = _d_cond0;
-// CHECK-NEXT:                _d_cond0 = 0.;
-// CHECK-NEXT:            }
+// CHECK-NEXT:        if (_cond2) {
+// CHECK-NEXT:            _rev0();
+// CHECK-NEXT:            return;
 // CHECK-NEXT:        }
 // CHECK-NEXT:    }
+// CHECK-NEXT:    _rev0();
 // CHECK-NEXT:}
 
 double fn8(double x, double y) {
@@ -615,25 +619,28 @@ double recFun (double x, double y) {
 }
 
 //CHECK: void recFun_pullback(double x, double y, double _d_y0, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     bool _cond0;
-//CHECK-NEXT:     {
-//CHECK-NEXT:     _cond0 = x > y;
-//CHECK-NEXT:     if (_cond0)
-//CHECK-NEXT:         goto _label0;
-//CHECK-NEXT:     }
-//CHECK-NEXT:     {
-//CHECK-NEXT:         *_d_x += _d_y0 * y;
-//CHECK-NEXT:         *_d_y += x * _d_y0;
-//CHECK-NEXT:     }
-//CHECK-NEXT:     if (_cond0)
-//CHECK-NEXT:       _label0:
-//CHECK-NEXT:         {
+//CHECK-NEXT:     bool _cond0 = false;
+//CHECK-NEXT:     auto _rev0 = [&] {
+//CHECK-NEXT:         if (_cond0) {
 //CHECK-NEXT:             double _r0 = 0.;
 //CHECK-NEXT:             double _r1 = 0.;
 //CHECK-NEXT:             recFun_pullback(x - 1, y, _d_y0, &_r0, &_r1);
 //CHECK-NEXT:             *_d_x += _r0;
 //CHECK-NEXT:             *_d_y += _r1;
 //CHECK-NEXT:         }
+//CHECK-NEXT:     };
+//CHECK-NEXT:     {
+//CHECK-NEXT:     _cond0 = x > y;
+//CHECK-NEXT:     if (_cond0) {
+//CHECK-NEXT:         _rev0();
+//CHECK-NEXT:         return;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     }
+//CHECK-NEXT:     {
+//CHECK-NEXT:         *_d_x += _d_y0 * y;
+//CHECK-NEXT:         *_d_y += x * _d_y0;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     _rev0();
 //CHECK-NEXT: }
 
 double fn16(double x, double y) {

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -286,20 +286,24 @@ double f_if1(double x, double y) {
 }
 
 //CHECK:   void f_if1_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       bool _cond0;
+//CHECK-NEXT:       bool _cond0 = false;
+//CHECK-NEXT:       auto _rev0 = [&] {
+//CHECK-NEXT:           if (_cond0)
+//CHECK-NEXT:               *_d_x += 1;
+//CHECK-NEXT:           else
+//CHECK-NEXT:               *_d_y += 1;
+//CHECK-NEXT:       };
 //CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x > y;
-//CHECK-NEXT:       if (_cond0)
-//CHECK-NEXT:           goto _label0;
-//CHECK-NEXT:       else
-//CHECK-NEXT:           goto _label1;
+//CHECK-NEXT:       if (_cond0) {
+//CHECK-NEXT:           _rev0();
+//CHECK-NEXT:           return;
+//CHECK-NEXT:       } else {
+//CHECK-NEXT:           _rev0();
+//CHECK-NEXT:           return;
 //CHECK-NEXT:       }
-//CHECK-NEXT:       if (_cond0)
-//CHECK-NEXT:         _label0:
-//CHECK-NEXT:           *_d_x += 1;
-//CHECK-NEXT:       else
-//CHECK-NEXT:         _label1:
-//CHECK-NEXT:           *_d_y += 1;
+//CHECK-NEXT:       }
+//CHECK-NEXT:       _rev0();
 //CHECK-NEXT:   }
 
 void f_if1_grad(double x, double y, double *_d_x, double *_d_y);
@@ -314,29 +318,33 @@ double f_if2(double x, double y) {
 }
 
 //CHECK:   void f_if2_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       bool _cond0;
-//CHECK-NEXT:       bool _cond1;
+//CHECK-NEXT:       bool _cond0 = false;
+//CHECK-NEXT:       bool _cond1 = false;
+//CHECK-NEXT:       auto _rev0 = [&] {
+//CHECK-NEXT:           if (_cond0)
+//CHECK-NEXT:               *_d_x += 1;
+//CHECK-NEXT:           else if (_cond1)
+//CHECK-NEXT:               *_d_y += 1;
+//CHECK-NEXT:           else
+//CHECK-NEXT:               *_d_y += -1;
+//CHECK-NEXT:       };
 //CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x > y;
-//CHECK-NEXT:       if (_cond0)
-//CHECK-NEXT:           goto _label0;
-//CHECK-NEXT:       else {
+//CHECK-NEXT:       if (_cond0) {
+//CHECK-NEXT:           _rev0();
+//CHECK-NEXT:           return;
+//CHECK-NEXT:       } else {
 //CHECK-NEXT:           _cond1 = y > 0;
-//CHECK-NEXT:           if (_cond1)
-//CHECK-NEXT:               goto _label1;
-//CHECK-NEXT:           else
-//CHECK-NEXT:               goto _label2;
+//CHECK-NEXT:           if (_cond1) {
+//CHECK-NEXT:               _rev0();
+//CHECK-NEXT:               return;
+//CHECK-NEXT:           } else {
+//CHECK-NEXT:               _rev0();
+//CHECK-NEXT:               return;
+//CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       if (_cond0)
-//CHECK-NEXT:         _label0:
-//CHECK-NEXT:           *_d_x += 1;
-//CHECK-NEXT:       else if (_cond1)
-//CHECK-NEXT:         _label1:
-//CHECK-NEXT:           *_d_y += 1;
-//CHECK-NEXT:       else
-//CHECK-NEXT:         _label2:
-//CHECK-NEXT:           *_d_y += -1;
+//CHECK-NEXT:       _rev0();
 //CHECK-NEXT:   }
 
 void f_if2_grad(double x, double y, double *_d_x, double *_d_y);
@@ -538,37 +546,41 @@ double f_decls3(double x, double y) {
 
 void f_decls3_grad(double x, double y, double *_d_x, double *_d_y);
 //CHECK:   void f_decls3_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:       bool _cond0;
-//CHECK-NEXT:       bool _cond1;
+//CHECK-NEXT:       bool _cond0 = false;
+//CHECK-NEXT:       bool _cond1 = false;
 //CHECK-NEXT:       double _d_a = 0.;
 //CHECK-NEXT:       double a = 3 * x;
 //CHECK-NEXT:       double _d_c = 0.;
 //CHECK-NEXT:       double c = 333 * y;
+//CHECK-NEXT:       double _d_b = 0.;
+//CHECK-NEXT:       auto _rev0 = [&] {
+//CHECK-NEXT:           {
+//CHECK-NEXT:               _d_a += _d_b * a;
+//CHECK-NEXT:               _d_a += a * _d_b;
+//CHECK-NEXT:           }
+//CHECK-NEXT:           if (_cond0)
+//CHECK-NEXT:               _d_a += 2 * 1;
+//CHECK-NEXT:           else if (_cond1)
+//CHECK-NEXT:               _d_a += -2 * 1;
+//CHECK-NEXT:           *_d_y += 333 * _d_c;
+//CHECK-NEXT:           *_d_x += 3 * _d_a;
+//CHECK-NEXT:       };
 //CHECK-NEXT:       {
 //CHECK-NEXT:       _cond0 = x > 1;
-//CHECK-NEXT:       if (_cond0)
-//CHECK-NEXT:           goto _label0;
-//CHECK-NEXT:       else {
+//CHECK-NEXT:       if (_cond0) {
+//CHECK-NEXT:           _rev0();
+//CHECK-NEXT:           return;
+//CHECK-NEXT:       } else {
 //CHECK-NEXT:           _cond1 = x < -1;
-//CHECK-NEXT:           if (_cond1)
-//CHECK-NEXT:               goto _label1;
+//CHECK-NEXT:           if (_cond1) {
+//CHECK-NEXT:               _rev0();
+//CHECK-NEXT:               return;
+//CHECK-NEXT:           }
 //CHECK-NEXT:       }
 //CHECK-NEXT:       }
-//CHECK-NEXT:       double _d_b = 0.;
 //CHECK-NEXT:       double b = a * a;
 //CHECK-NEXT:       _d_b += 1;
-//CHECK-NEXT:       {
-//CHECK-NEXT:           _d_a += _d_b * a;
-//CHECK-NEXT:           _d_a += a * _d_b;
-//CHECK-NEXT:       }
-//CHECK-NEXT:       if (_cond0)
-//CHECK-NEXT:         _label0:
-//CHECK-NEXT:           _d_a += 2 * 1;
-//CHECK-NEXT:       else if (_cond1)
-//CHECK-NEXT:         _label1:
-//CHECK-NEXT:           _d_a += -2 * 1;
-//CHECK-NEXT:       *_d_y += 333 * _d_c;
-//CHECK-NEXT:       *_d_x += 3 * _d_a;
+//CHECK-NEXT:       _rev0();
 //CHECK-NEXT:   }
 
 double f_issue138(double x, double y) {
@@ -740,13 +752,26 @@ double fn_cond_decl(double x, double y) {
 //CHECK:        void fn_cond_decl_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:            int _d_cond = 0;
 //CHECK-NEXT:            int cond = 0;
-//CHECK-NEXT:            bool _cond0;
+//CHECK-NEXT:            bool _cond0 = false;
 //CHECK-NEXT:            int _d_flag = 0;
 //CHECK-NEXT:            int flag = 1;
+//CHECK-NEXT:            auto _rev0 = [&] {
+//CHECK-NEXT:                {
+//CHECK-NEXT:                    if (_cond0) {
+//CHECK-NEXT:                        *_d_y += 1 * y;
+//CHECK-NEXT:                        *_d_y += y * 1;
+//CHECK-NEXT:                    }
+//CHECK-NEXT:                    {
+//CHECK-NEXT:                        _d_flag += _d_cond;
+//CHECK-NEXT:                    }
+//CHECK-NEXT:                }
+//CHECK-NEXT:            };
 //CHECK-NEXT:            {
 //CHECK-NEXT:                _cond0 = cond = flag;
-//CHECK-NEXT:                if (_cond0)
-//CHECK-NEXT:                    goto _label0;
+//CHECK-NEXT:                if (_cond0) {
+//CHECK-NEXT:                    _rev0();
+//CHECK-NEXT:                    return;
+//CHECK-NEXT:                }
 //CHECK-NEXT:            }
 //CHECK-NEXT:            {
 //CHECK-NEXT:                *_d_x += 1 * x;
@@ -754,17 +779,7 @@ double fn_cond_decl(double x, double y) {
 //CHECK-NEXT:                *_d_y += 1 * y;
 //CHECK-NEXT:                *_d_y += y * 1;
 //CHECK-NEXT:            }
-//CHECK-NEXT:            {
-//CHECK-NEXT:                if (_cond0)
-//CHECK-NEXT:                  _label0:
-//CHECK-NEXT:                    {
-//CHECK-NEXT:                        *_d_y += 1 * y;
-//CHECK-NEXT:                        *_d_y += y * 1;
-//CHECK-NEXT:                    }
-//CHECK-NEXT:                {
-//CHECK-NEXT:                    _d_flag += _d_cond;
-//CHECK-NEXT:                }
-//CHECK-NEXT:            }
+//CHECK-NEXT:            _rev0();
 //CHECK-NEXT:        }
 
 double fn_cond_side_eff(double x) {
@@ -775,24 +790,29 @@ double fn_cond_side_eff(double x) {
 } // = 2x
 
 //CHECK:         void fn_cond_side_eff_grad(double x, double *_d_x) {
-//CHECK-NEXT:             bool _cond0;
+//CHECK-NEXT:             bool _cond0 = false;
+//CHECK-NEXT:             auto _rev0 = [&] {
+//CHECK-NEXT:                 {
+//CHECK-NEXT:                     if (_cond0) {
+//CHECK-NEXT:                         *_d_x += 1;
+//CHECK-NEXT:                     }
+//CHECK-NEXT:                     {
+//CHECK-NEXT:                         double _r_d0 = *_d_x;
+//CHECK-NEXT:                         *_d_x += _r_d0;
+//CHECK-NEXT:                     }
+//CHECK-NEXT:                 }
+//CHECK-NEXT:             };
 //CHECK-NEXT:             {
 //CHECK-NEXT:                 _cond0 = x += x;
 //CHECK-NEXT:                 if (_cond0) {
-//CHECK-NEXT:                     goto _label0;
+//CHECK-NEXT:                     {
+//CHECK-NEXT:                         _rev0();
+//CHECK-NEXT:                         return;
+//CHECK-NEXT:                     }
 //CHECK-NEXT:                 }
 //CHECK-NEXT:             }
 //CHECK-NEXT:             *_d_x += 1;
-//CHECK-NEXT:             {
-//CHECK-NEXT:                 if (_cond0) {
-//CHECK-NEXT:                   _label0:
-//CHECK-NEXT:                     *_d_x += 1;
-//CHECK-NEXT:                 }
-//CHECK-NEXT:                 {
-//CHECK-NEXT:                     double _r_d0 = *_d_x;
-//CHECK-NEXT:                     *_d_x += _r_d0;
-//CHECK-NEXT:                 }
-//CHECK-NEXT:             }
+//CHECK-NEXT:             _rev0();
 //CHECK-NEXT:         }
 
 double fn_cond_init(double x) {
@@ -805,23 +825,28 @@ double fn_cond_init(double x) {
 //CHECK:          void fn_cond_init_grad(double x, double *_d_x) {
 //CHECK-NEXT:              int _d_a = 0;
 //CHECK-NEXT:              int a = 0;
-//CHECK-NEXT:              bool _cond0;
+//CHECK-NEXT:              bool _cond0 = false;
+//CHECK-NEXT:              auto _rev0 = [&] {
+//CHECK-NEXT:                  if (_cond0) {
+//CHECK-NEXT:                      {
+//CHECK-NEXT:                          *_d_x += 1;
+//CHECK-NEXT:                          *_d_x += 1 * x;
+//CHECK-NEXT:                          *_d_x += x * 1;
+//CHECK-NEXT:                      }
+//CHECK-NEXT:                  }
+//CHECK-NEXT:              };
 //CHECK-NEXT:              {
 //CHECK-NEXT:                  a = 12;
 //CHECK-NEXT:                  _cond0 = a <= 0;
 //CHECK-NEXT:                  if (_cond0) {
-//CHECK-NEXT:                      goto _label0;
+//CHECK-NEXT:                      {
+//CHECK-NEXT:                          _rev0();
+//CHECK-NEXT:                          return;
+//CHECK-NEXT:                      }
 //CHECK-NEXT:                  }
 //CHECK-NEXT:              }
 //CHECK-NEXT:              *_d_x += 1;
-//CHECK-NEXT:              if (_cond0) {
-//CHECK-NEXT:                _label0:
-//CHECK-NEXT:                  {
-//CHECK-NEXT:                      *_d_x += 1;
-//CHECK-NEXT:                      *_d_x += 1 * x;
-//CHECK-NEXT:                      *_d_x += x * 1;
-//CHECK-NEXT:                  }
-//CHECK-NEXT:              }
+//CHECK-NEXT:              _rev0();
 //CHECK-NEXT:          }
 
 double fn_null_stmts(double x) {
@@ -831,13 +856,18 @@ double fn_null_stmts(double x) {
 } // = x
 
 //CHECK: void fn_null_stmts_grad(double x, double *_d_x) {
-//CHECK-NEXT:    goto _label0;
+//CHECK-NEXT:    auto _rev0 = [&] {
+//CHECK-NEXT:        ;
+//CHECK-NEXT:        ;
+//CHECK-NEXT:        *_d_x += 1;
+//CHECK-NEXT:    };
+//CHECK-NEXT:    {
+//CHECK-NEXT:        _rev0();
+//CHECK-NEXT:        return;
+//CHECK-NEXT:    }
 //CHECK-NEXT:    ;
 //CHECK-NEXT:    ;
-//CHECK-NEXT:    ;
-//CHECK-NEXT:    ;
-//CHECK-NEXT:  _label0:
-//CHECK-NEXT:    *_d_x += 1;
+//CHECK-NEXT:    _rev0();
 //CHECK-NEXT:}
 
 double fn_const_cond_op(double x) {
@@ -1070,11 +1100,20 @@ double f_ref_in_rhs(double x, double y) {
 }
 
 //CHECK: void f_ref_in_rhs_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     bool _cond0;
+//CHECK-NEXT:     bool _cond0 = false;
 //CHECK-NEXT:     double *_d_ref_x = nullptr;
 //CHECK-NEXT:     double *ref_x = {};
 //CHECK-NEXT:     double *_d_ref_y = nullptr;
 //CHECK-NEXT:     double *ref_y = {};
+//CHECK-NEXT:     auto _rev0 = [&] {
+//CHECK-NEXT:         if (_cond0) {
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 *_d_ref_y += 1 * (*ref_x + y);
+//CHECK-NEXT:                 *_d_ref_x += *ref_y * 1;
+//CHECK-NEXT:                 *_d_y += *ref_y * 1;
+//CHECK-NEXT:             }
+//CHECK-NEXT:         }
+//CHECK-NEXT:     };
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _cond0 = x != 55;
 //CHECK-NEXT:         if (_cond0) {
@@ -1082,17 +1121,13 @@ double f_ref_in_rhs(double x, double y) {
 //CHECK-NEXT:             ref_x = &x;
 //CHECK-NEXT:             _d_ref_y = _d_y;
 //CHECK-NEXT:             ref_y = &y;
-//CHECK-NEXT:             goto _label0;
+//CHECK-NEXT:             {
+//CHECK-NEXT:                 _rev0();
+//CHECK-NEXT:                 return;
+//CHECK-NEXT:             }
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     if (_cond0) {
-//CHECK-NEXT:       _label0:
-//CHECK-NEXT:         {
-//CHECK-NEXT:             *_d_ref_y += 1 * (*ref_x + y);
-//CHECK-NEXT:             *_d_ref_x += *ref_y * 1;
-//CHECK-NEXT:             *_d_y += *ref_y * 1;
-//CHECK-NEXT:         }
-//CHECK-NEXT:     }
+//CHECK-NEXT:     _rev0();
 //CHECK-NEXT: }
 
 double glob1 = 5; // expected-warning {{gradient uses a global variable 'glob1'; rerunning the gradient requires 'glob1' to be reset}}
@@ -1164,21 +1199,25 @@ double f_infinity(double x, double y) {
 }
 
 //CHECK: void f_infinity_grad(double x, double y, double *_d_x, double *_d_y) {
-//CHECK-NEXT:     bool _cond0;
+//CHECK-NEXT:     bool _cond0 = false;
 //CHECK-NEXT:     double _d_inf = 0.;
 //CHECK-NEXT:     const double inf = std::numeric_limits<double>::infinity();
+//CHECK-NEXT:     auto _rev0 = [&] {
+//CHECK-NEXT:         if (_cond0)
+//CHECK-NEXT:             *_d_y += 1;
+//CHECK-NEXT:     };
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _cond0 = x < inf;
-//CHECK-NEXT:         if (_cond0)
-//CHECK-NEXT:             goto _label0;
+//CHECK-NEXT:         if (_cond0) {
+//CHECK-NEXT:             _rev0();
+//CHECK-NEXT:             return;
+//CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_d_x += 1;
 //CHECK-NEXT:         *_d_y += 1;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     if (_cond0)
-//CHECK-NEXT:       _label0:
-//CHECK-NEXT:         *_d_y += 1;
+//CHECK-NEXT:     _rev0();
 //CHECK-NEXT: }
 
 #define TEST(F, x, y)                                                          \

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -99,32 +99,36 @@ double f3(double x) {
 // CHECK-NEXT:     double _d_t = 0.;
 // CHECK-NEXT:     double t = 1;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     auto _rev0 = [&] {
+// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (clad::back(_cond0))
+// CHECK-NEXT:                     _d_t += 1;
+// CHECK-NEXT:                 clad::pop(_cond0);
+// CHECK-NEXT:             }
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 t = clad::pop(_t1);
+// CHECK-NEXT:                 double _r_d0 = _d_t;
+// CHECK-NEXT:                 _d_t = 0.;
+// CHECK-NEXT:                 _d_t += _r_d0 * x;
+// CHECK-NEXT:                 *_d_x += t * _r_d0;
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT:     };
 // CHECK-NEXT:     for (i = 0; i < 3; i++) {
 // CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, t);
 // CHECK-NEXT:         t *= x;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::push(_cond0, i == 1);
-// CHECK-NEXT:             if (clad::back(_cond0))
-// CHECK-NEXT:                 goto _label0;
+// CHECK-NEXT:             if (clad::back(_cond0)) {
+// CHECK-NEXT:                 _rev0();
+// CHECK-NEXT:                 return;
+// CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (clad::back(_cond0))
-// CHECK-NEXT:               _label0:
-// CHECK-NEXT:                 _d_t += 1;
-// CHECK-NEXT:             clad::pop(_cond0);
-// CHECK-NEXT:         }
-// CHECK-NEXT:         {
-// CHECK-NEXT:             t = clad::pop(_t1);
-// CHECK-NEXT:             double _r_d0 = _d_t;
-// CHECK-NEXT:             _d_t = 0.;
-// CHECK-NEXT:             _d_t += _r_d0 * x;
-// CHECK-NEXT:             *_d_x += t * _r_d0;
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     _rev0();
 // CHECK-NEXT: }
 
 double f4(double x) {

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -631,13 +631,17 @@ double fn8(double x, double y) {
 // CHECK:  void fn8_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      S _d_s = {0., false};
 // CHECK-NEXT:      S s = {x, false};
-// CHECK-NEXT:      if (s.Cond(y))
-// CHECK-NEXT:          goto _label0;
+// CHECK-NEXT:      auto _rev0 = [&] {
+// CHECK-NEXT:          if (s.Cond(y))
+// CHECK-NEXT:              ;
+// CHECK-NEXT:          *_d_x += _d_s.val;
+// CHECK-NEXT:      };
+// CHECK-NEXT:      if (s.Cond(y)) {
+// CHECK-NEXT:          _rev0();
+// CHECK-NEXT:          return;
+// CHECK-NEXT:      }
 // CHECK-NEXT:      *_d_y += 1;
-// CHECK-NEXT:      if (s.Cond(y))
-// CHECK-NEXT:        _label0:
-// CHECK-NEXT:          ;
-// CHECK-NEXT:      *_d_x += _d_s.val;
+// CHECK-NEXT:      _rev0();
 // CHECK-NEXT:  }
 
 double fn9(double x, double y) {

--- a/test/Gradient/ReverseForw.C
+++ b/test/Gradient/ReverseForw.C
@@ -94,15 +94,19 @@ double* filter(double* p, State s) {
 //CHECK-NEXT: }
 
 //CHECK: void filter_pullback(double *p, State s, double *_d_p, State *_d_s) {
-//CHECK-NEXT:     bool _cond0;
+//CHECK-NEXT:     bool _cond0 = false;
+//CHECK-NEXT:     auto _rev0 = [&] {
+//CHECK-NEXT:         if (_cond0)
+//CHECK-NEXT:             ;
+//CHECK-NEXT:     };
 //CHECK-NEXT:     {
 //CHECK-NEXT:         _cond0 = s == State::should_return;
-//CHECK-NEXT:         if (_cond0)
-//CHECK-NEXT:             goto _label0;
+//CHECK-NEXT:         if (_cond0) {
+//CHECK-NEXT:             _rev0();
+//CHECK-NEXT:             return;
+//CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     if (_cond0)
-//CHECK-NEXT:       _label0:
-//CHECK-NEXT:         ;
+//CHECK-NEXT:     _rev0();
 //CHECK-NEXT: }
 
 double f2(double x) {

--- a/test/Gradient/Switch.C
+++ b/test/Gradient/Switch.C
@@ -779,59 +779,76 @@ double switchReturn(double x, double y, int k) {
 
 // CHECK: void switchReturn_grad_0_1(double x, double y, int k, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     int _d_k = 0;
-// CHECK-NEXT:     int _cond0;
+// CHECK-NEXT:     int _cond0 = 0;
+// CHECK-NEXT:     auto _rev0 = [&] {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             switch (_cond0) {
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                       default:
+// CHECK-NEXT:                         ;
+// CHECK-NEXT:                         {
+// CHECK-NEXT:                             *_d_y += 1 * y;
+// CHECK-NEXT:                             *_d_y += y * 1;
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                     if (_cond0 != 0 && _cond0 != 1)
+// CHECK-NEXT:                         break;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                       case 1:
+// CHECK-NEXT:                         ;
+// CHECK-NEXT:                         {
+// CHECK-NEXT:                             *_d_x += 1 * y;
+// CHECK-NEXT:                             *_d_y += x * 1;
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                     if (1 == _cond0)
+// CHECK-NEXT:                         break;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     {
+// CHECK-NEXT:                       case 0:
+// CHECK-NEXT:                         ;
+// CHECK-NEXT:                         {
+// CHECK-NEXT:                             *_d_x += 1 * x;
+// CHECK-NEXT:                             *_d_x += x * 1;
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                     if (0 == _cond0)
+// CHECK-NEXT:                         break;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT:     };
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _cond0 = k;
 // CHECK-NEXT:         switch (_cond0) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:               case 0:
-// CHECK-NEXT:                 goto _label0;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     _rev0();
+// CHECK-NEXT:                     return;
+// CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:               case 1:
-// CHECK-NEXT:                 goto _label1;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     _rev0();
+// CHECK-NEXT:                     return;
+// CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:             {
 // CHECK-NEXT:               default:
-// CHECK-NEXT:                 goto _label2;
+// CHECK-NEXT:                 {
+// CHECK-NEXT:                     _rev0();
+// CHECK-NEXT:                     return;
+// CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         switch (_cond0) {
-// CHECK-NEXT:           default:
-// CHECK-NEXT:           case 1:
-// CHECK-NEXT:           case 0:
-// CHECK-NEXT:             ;
-// CHECK-NEXT:             {
-// CHECK-NEXT:               _label2:
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     *_d_y += 1 * y;
-// CHECK-NEXT:                     *_d_y += y * 1;
-// CHECK-NEXT:                 }
-// CHECK-NEXT:                 if (_cond0 != 0 && _cond0 != 1)
-// CHECK-NEXT:                     break;
-// CHECK-NEXT:             }
-// CHECK-NEXT:             {
-// CHECK-NEXT:               _label1:
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     *_d_x += 1 * y;
-// CHECK-NEXT:                     *_d_y += x * 1;
-// CHECK-NEXT:                 }
-// CHECK-NEXT:                 if (1 == _cond0)
-// CHECK-NEXT:                     break;
-// CHECK-NEXT:             }
-// CHECK-NEXT:             {
-// CHECK-NEXT:               _label0:
-// CHECK-NEXT:                 {
-// CHECK-NEXT:                     *_d_x += 1 * x;
-// CHECK-NEXT:                     *_d_x += x * 1;
-// CHECK-NEXT:                 }
-// CHECK-NEXT:                 if (0 == _cond0)
-// CHECK-NEXT:                     break;
-// CHECK-NEXT:             }
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     _rev0();
 // CHECK-NEXT: }
 
 #define TEST_2(F, x, y)                                                        \

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -402,18 +402,61 @@ int main() {
 // CHECK-NEXT:}
 
 // CHECK: void pow_pushforward_pullback(float x, float exponent, float d_x, float d_exponent, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_exponent, float *_d_d_x, float *_d_d_exponent) {
-// CHECK-NEXT:     bool _cond0;
+// CHECK-NEXT:     bool _cond0 = false;
 // CHECK-NEXT:     double _d_cond0;
 // CHECK-NEXT:     _d_cond0 = 0.;
-// CHECK-NEXT:     bool _cond1;
+// CHECK-NEXT:     bool _cond1 = false;
 // CHECK-NEXT:     bool _t0;
-// CHECK-NEXT:     bool _cond2;
-// CHECK-NEXT:     bool _cond3;
+// CHECK-NEXT:     bool _cond2 = false;
+// CHECK-NEXT:     bool _cond3 = false;
 // CHECK-NEXT:     float _t2;
 // CHECK-NEXT:     float _t3;
 // CHECK-NEXT:     float _t4;
 // CHECK-NEXT:     float _d_val = 0.F;
 // CHECK-NEXT:     float val = ::std::pow(x, exponent);
+// CHECK-NEXT:     float _t1 = ::std::pow(x, exponent - 1);
+// CHECK-NEXT:     float _d_derivative = 0.F;
+// CHECK-NEXT:     float derivative = (exponent * _t1) * d_x;
+// CHECK-NEXT:     auto _rev0 = [&] {
+// CHECK-NEXT:         if (_cond3) {
+// CHECK-NEXT:             derivative = _t2;
+// CHECK-NEXT:             float _r4 = 0.F;
+// CHECK-NEXT:             float _r5 = 0.F;
+// CHECK-NEXT:             clad::custom_derivatives::std::pow_pullback(x, exponent, _d_derivative * d_exponent * _t3, &_r4, &_r5);
+// CHECK-NEXT:             *_d_x += _r4;
+// CHECK-NEXT:             *_d_exponent += _r5;
+// CHECK-NEXT:             float _r6 = 0.F;
+// CHECK-NEXT:             _r6 += _t4 * _d_derivative * d_exponent * clad::custom_derivatives::std::log_pushforward(x, 1.F).pushforward;
+// CHECK-NEXT:             *_d_x += _r6;
+// CHECK-NEXT:             *_d_d_exponent += (_t4 * _t3) * _d_derivative;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             *_d_exponent += _d_derivative * d_x * _t1;
+// CHECK-NEXT:             float _r2 = 0.F;
+// CHECK-NEXT:             float _r3 = 0.F;
+// CHECK-NEXT:             clad::custom_derivatives::std::pow_pullback(x, exponent - 1, exponent * _d_derivative * d_x, &_r2, &_r3);
+// CHECK-NEXT:             *_d_x += _r2;
+// CHECK-NEXT:             *_d_exponent += _r3;
+// CHECK-NEXT:             *_d_d_x += (exponent * _t1) * _d_derivative;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             if (_cond2)
+// CHECK-NEXT:                 _d_val += _d_y.value;
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 if (_cond1) {
+// CHECK-NEXT:                     _cond0 = _t0;
+// CHECK-NEXT:                     _d_cond0 = 0.;
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             float _r0 = 0.F;
+// CHECK-NEXT:             float _r1 = 0.F;
+// CHECK-NEXT:             clad::custom_derivatives::std::pow_pullback(x, exponent, _d_val, &_r0, &_r1);
+// CHECK-NEXT:             *_d_x += _r0;
+// CHECK-NEXT:             *_d_exponent += _r1;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     };
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _cond1 = exponent == static_cast<float>(0);
@@ -423,12 +466,11 @@ int main() {
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _cond2 = _cond1 && _cond0;
-// CHECK-NEXT:         if (_cond2)
-// CHECK-NEXT:             goto _label0;
+// CHECK-NEXT:         if (_cond2) {
+// CHECK-NEXT:             _rev0();
+// CHECK-NEXT:             return;
+// CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     float _t1 = ::std::pow(x, exponent - 1);
-// CHECK-NEXT:     float _d_derivative = 0.F;
-// CHECK-NEXT:     float derivative = (exponent * _t1) * d_x;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _cond3 = d_exponent;
 // CHECK-NEXT:         if (_cond3) {
@@ -442,44 +484,6 @@ int main() {
 // CHECK-NEXT:         _d_val += _d_y.value;
 // CHECK-NEXT:         _d_derivative += _d_y.pushforward;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     if (_cond3) {
-// CHECK-NEXT:         derivative = _t2;
-// CHECK-NEXT:         float _r4 = 0.F;
-// CHECK-NEXT:         float _r5 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(x, exponent, _d_derivative * d_exponent * _t3, &_r4, &_r5);
-// CHECK-NEXT:         *_d_x += _r4;
-// CHECK-NEXT:         *_d_exponent += _r5;
-// CHECK-NEXT:         float _r6 = 0.F;
-// CHECK-NEXT:         _r6 += _t4 * _d_derivative * d_exponent * clad::custom_derivatives::std::log_pushforward(x, 1.F).pushforward;
-// CHECK-NEXT:         *_d_x += _r6;
-// CHECK-NEXT:         *_d_d_exponent += (_t4 * _t3) * _d_derivative;
-// CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         *_d_exponent += _d_derivative * d_x * _t1;
-// CHECK-NEXT:         float _r2 = 0.F;
-// CHECK-NEXT:         float _r3 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(x, exponent - 1, exponent * _d_derivative * d_x, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r2;
-// CHECK-NEXT:         *_d_exponent += _r3;
-// CHECK-NEXT:         *_d_d_x += (exponent * _t1) * _d_derivative;
-// CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         if (_cond2)
-// CHECK-NEXT:           _label0:
-// CHECK-NEXT:             _d_val += _d_y.value;
-// CHECK-NEXT:         {
-// CHECK-NEXT:             if (_cond1) {
-// CHECK-NEXT:                 _cond0 = _t0;
-// CHECK-NEXT:                 _d_cond0 = 0.;
-// CHECK-NEXT:             }
-// CHECK-NEXT:         }
-// CHECK-NEXT:     }
-// CHECK-NEXT:     {
-// CHECK-NEXT:         float _r0 = 0.F;
-// CHECK-NEXT:         float _r1 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::pow_pullback(x, exponent, _d_val, &_r0, &_r1);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         *_d_exponent += _r1;
-// CHECK-NEXT:     }
+// CHECK-NEXT:     _rev0();
 // CHECK-NEXT: }
 }


### PR DESCRIPTION
The reverse-mode early-return encoding emitted a label inside the master reverse and a goto into it from each early-return point. That violates [stmt.dcl]/2 whenever a local with a non-trivial initializer or destructor sits between the goto and its target, which is why DifferentiateWithClad had to bypass Sema::ActOnFinishFunctionBody on the generated function.

Materialise the master reverse as a `[&]` lambda bound to an `auto` VarDecl instead, called at each early return and at the tail. The body is assembled outside the closure scope, so its references to captured variables are rebuilt in scope (rebuildLambdaCaptures) where the `[&]` default registers the capture; the reverse statements are emitted into the closure directly. An early return is a NullStmt marker in the forward block, patched with `{ _rev(); return; }` at finalization so no subtree gains a second parent.

Whether a function has a non-tail return is a fact about the primal, so DiffRequest carries it as HasEarlyReturns; the encoder reads it to pick the lambda vs plain shape up front. A branch condition read by the master reverse is zero-initialized so an early return that skips its forward store leaves it false -- the same zero-initialized additive state clad already relies on for adjoints and loop counters.

Fixes https://github.com/vgvassilev/clad/issues/367