### PR TITLE
[CI] Give push events a unique concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The concurrency group keys on github.event.pull_request.number, which is set only for pull_request events. On a push to master that expression is empty, so every master push collapses into one group and, with cancel-in-progress, each new push cancels the previous run mid-flight.
