### PR TITLE
Add torch backend

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           build_dir: build
           apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libthrust-dev,libbenchmark-dev,libomp-20-dev,libopenblas-dev
-          exclude: "test/*,unittests/*"
+          exclude: "test/*,unittests/*,benchmark/LibTorch/*,include/clad/Differentiator/TorchBuiltins.h,include/clad/Differentiator/TorchBuiltins/*"
           split_workflow: true
           config_file: .clang-tidy
           cmake_command: >

--- a/.github/workflows/libtorch.yml
+++ b/.github/workflows/libtorch.yml
@@ -1,0 +1,109 @@
+name: LibTorch
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/libtorch.yml'
+      - '.clang-tidy'
+      - '**/CMakeLists.txt'
+      - 'cmake/**'
+      - 'benchmark/LibTorch/**'
+      - 'include/clad/Differentiator/**'
+      - 'lib/Differentiator/**'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/libtorch.yml'
+      - '.clang-tidy'
+      - '**/CMakeLists.txt'
+      - 'cmake/**'
+      - 'benchmark/LibTorch/**'
+      - 'include/clad/Differentiator/**'
+      - 'lib/Differentiator/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cpu:
+    name: cpu-clang21
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      LLVM_ROOT: /usr/lib/llvm-21
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install LLVM and build dependencies
+        run: |
+          curl --fail --location --silent --show-error \
+            https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo gpg --dearmor --yes \
+              --output /usr/share/keyrings/apt.llvm.org.gpg
+          echo 'deb [signed-by=/usr/share/keyrings/apt.llvm.org.gpg] https://apt.llvm.org/noble/ llvm-toolchain-noble-21 main' \
+            | sudo tee /etc/apt/sources.list.d/llvm-21.list
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang-21 clang-tidy-21 libclang-21-dev llvm-21-dev \
+            ninja-build unzip
+
+      - name: Cache LibTorch
+        id: cache-libtorch
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/libtorch
+          key: libtorch-cpu-2.11.0
+
+      - name: Download LibTorch
+        if: steps.cache-libtorch.outputs.cache-hit != 'true'
+        run: |
+          curl --fail --location --retry 3 \
+            --output "$RUNNER_TEMP/libtorch.zip" \
+            'https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.11.0%2Bcpu.zip'
+          echo 'ee3f453f6c3e3d934339875d76a2b04d6a1731554c016fc82be1f4b8d1d4ae62  '"$RUNNER_TEMP/libtorch.zip" \
+            | sha256sum --check
+          unzip -q "$RUNNER_TEMP/libtorch.zip" -d "$RUNNER_TEMP"
+
+      - name: Configure
+        run: |
+          cmake -S . -B build/libtorch -G Ninja \
+            -DCLAD_DISABLE_TESTS=ON \
+            -DCLAD_ENABLE_BENCHMARKS=OFF \
+            -DCLAD_ENABLE_LIBTORCH_BENCHMARKS=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER="$LLVM_ROOT/bin/clang" \
+            -DCMAKE_CXX_COMPILER="$LLVM_ROOT/bin/clang++" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DClang_DIR="$LLVM_ROOT/lib/cmake/clang" \
+            -DLLVM_DIR="$LLVM_ROOT/lib/cmake/llvm" \
+            -DTorch_DIR="$RUNNER_TEMP/libtorch/share/cmake/Torch"
+
+      - name: Build
+        run: >-
+          cmake --build build/libtorch
+          --target LibTorchOpsTest LibTorchOpsBenchmark
+          --parallel 2
+
+      - name: Test
+        run: >-
+          ctest --test-dir build/libtorch
+          --output-on-failure
+          -R '^clad-LibTorchOpsTest$'
+
+      - name: Run clang-tidy
+        run: |
+          # clang-tidy interprets compiler plugins as analyzer checker plugins.
+          sed -E -i 's# -fplugin=[^ ]+# -D__CLAD__=1#g' \
+            build/libtorch/compile_commands.json
+          "$LLVM_ROOT/bin/clang-tidy" \
+            -p=build/libtorch \
+            --checks='-misc-include-cleaner' \
+            --warnings-as-errors='*' \
+            --header-filter='^.*/include/clad/Differentiator/TorchBuiltins.*' \
+            benchmark/LibTorch/TorchOpsBenchmark.cpp \
+            benchmark/LibTorch/TorchOpsTest.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,8 @@ add_definitions( -D_GNU_SOURCE
   -DCLAD_INSTDIR_INCL="${CLAD_BINARY_DIR}/include" )
 
 option(CLAD_BUILD_STATIC_ONLY "Does not build shared libraries. Useful when we have LLVM_ENABLE_PLUGINS=OFF (eg. Win or CYGWIN)" OFF)
+option(CLAD_ENABLE_LIBTORCH_BENCHMARKS
+  "Build benchmarks for the Clad-backed LibTorch integration." OFF)
 if (NOT CLAD_BUILD_STATIC_ONLY AND NOT LLVM_ENABLE_PLUGINS)
   message(FATAL_ERROR "LLVM_ENABLE_PLUGINS is set to OFF. Please build clad with -DCLAD_BUILD_STATIC_ONLY=ON.")
 endif()
@@ -327,11 +329,12 @@ endif()
 
 
 if (NOT CLAD_BUILD_STATIC_ONLY)
-  if (CLAD_ENABLE_BENCHMARKS)
+  if (CLAD_ENABLE_BENCHMARKS OR CLAD_ENABLE_LIBTORCH_BENCHMARKS)
     include(GoogleBenchmark)
-  endif(CLAD_ENABLE_BENCHMARKS)
+  endif()
 
-  if (NOT CLAD_DISABLE_TESTS OR CLAD_ENABLE_BENCHMARKS)
+  if (NOT CLAD_DISABLE_TESTS OR CLAD_ENABLE_BENCHMARKS OR
+      CLAD_ENABLE_LIBTORCH_BENCHMARKS)
     # Change the default compiler to the clang which we run clad upon. Our unittests
     # need to use a supported by clad compiler. Note that's a huge hack and it is
     # not guaranteed to work with cmake.
@@ -361,6 +364,10 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
   if (CLAD_ENABLE_BENCHMARKS)
     add_subdirectory(benchmark)
   endif(CLAD_ENABLE_BENCHMARKS)
+  if (CLAD_ENABLE_LIBTORCH_BENCHMARKS)
+    enable_testing()
+    add_subdirectory(benchmark/LibTorch)
+  endif()
 
   if (stored_cxx_compiler)
     # Restore the default compilers.

--- a/benchmark/LibTorch/CMakeLists.txt
+++ b/benchmark/LibTorch/CMakeLists.txt
@@ -1,0 +1,11 @@
+find_package(Torch REQUIRED)
+
+CB_ADD_GBENCHMARK(LibTorchOpsBenchmark TorchOpsBenchmark.cpp)
+target_link_libraries(LibTorchOpsBenchmark PRIVATE torch)
+
+ADD_CLAD_EXECUTABLE(LibTorchOpsTest TorchOpsTest.cpp)
+target_link_libraries(LibTorchOpsTest PRIVATE torch)
+add_test(NAME clad-LibTorchOpsTest COMMAND LibTorchOpsTest)
+set_tests_properties(clad-LibTorchOpsTest PROPERTIES
+  LABELS "libtorch;benchmark"
+  TIMEOUT 120)

--- a/benchmark/LibTorch/TorchOpsBenchmark.cpp
+++ b/benchmark/LibTorch/TorchOpsBenchmark.cpp
@@ -1,13 +1,198 @@
+#include "benchmark/benchmark.h"
+
 #include "clad/Differentiator/Differentiator.h"
 #include "clad/Differentiator/TorchBuiltins.h" // IWYU pragma: keep
 
-#include "benchmark/benchmark.h"
-
+#include <c10/core/CPUAllocator.h>
 #include <torch/torch.h> // IWYU pragma: keep
 
+#include <atomic>
+#include <cstddef>
 #include <cstdint>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace {
+
+// Track CPU Tensor storage during Google Benchmark's separate memory run while
+// leaving the timed run on LibTorch's direct allocator path.
+class TensorMemoryManager final : public benchmark::MemoryManager {
+  static constexpr std::uint8_t AllocatorPriority =
+      std::numeric_limits<std::uint8_t>::max();
+
+  struct AllocationContext {
+    c10::DataPtr Allocation;
+    TensorMemoryManager* Manager;
+    std::size_t Bytes;
+    std::uint64_t Epoch;
+
+    AllocationContext(c10::DataPtr allocation, TensorMemoryManager* manager,
+                      std::size_t bytes, std::uint64_t epoch)
+        : Allocation(std::move(allocation)), Manager(manager), Bytes(bytes),
+          Epoch(epoch) {}
+  };
+
+  class TrackingAllocator final : public c10::Allocator {
+    c10::Allocator* m_Underlying;
+    TensorMemoryManager& m_Manager;
+
+    static void release(void* opaque) {
+      std::unique_ptr<AllocationContext> context(
+          static_cast<AllocationContext*>(opaque));
+      context->Manager->recordDeallocation(context->Bytes, context->Epoch);
+    }
+
+  public:
+    TrackingAllocator(c10::Allocator* underlying, TensorMemoryManager& manager)
+        : m_Underlying(underlying), m_Manager(manager) {}
+
+    c10::DataPtr allocate(std::size_t bytes) override {
+      if (!m_Manager.isRecording())
+        return m_Underlying->allocate(bytes);
+
+      auto allocation = m_Underlying->allocate(bytes);
+      void* data = allocation.get();
+      const auto device = allocation.device();
+      const auto epoch = m_Manager.currentEpoch();
+      auto* context = new AllocationContext(std::move(allocation), &m_Manager,
+                                            bytes, epoch);
+      m_Manager.recordAllocation(bytes, epoch);
+      return {data, context, &release, device};
+    }
+
+    bool is_simple_data_ptr(const c10::DataPtr& data) const override {
+      return m_Underlying->is_simple_data_ptr(data);
+    }
+
+    void copy_data(void* destination, const void* source,
+                   std::size_t count) const override {
+      m_Underlying->copy_data(destination, source, count);
+    }
+  };
+
+  std::atomic<bool> m_Recording{false};
+  std::atomic<std::uint64_t> m_Epoch{0};
+  std::atomic<std::uint64_t> m_Allocations{0};
+  std::atomic<std::uint64_t> m_TotalAllocatedBytes{0};
+  std::atomic<std::uint64_t> m_LiveBytes{0};
+  std::atomic<std::uint64_t> m_PeakBytes{0};
+  c10::Allocator* m_Underlying;
+  TrackingAllocator m_Allocator;
+
+  bool isRecording() const {
+    return m_Recording.load(std::memory_order_acquire);
+  }
+
+  std::uint64_t currentEpoch() const {
+    return m_Epoch.load(std::memory_order_relaxed);
+  }
+
+  void recordAllocation(std::size_t bytes, std::uint64_t epoch) {
+    if (!isRecording() || epoch != currentEpoch())
+      return;
+
+    m_Allocations.fetch_add(1, std::memory_order_relaxed);
+    m_TotalAllocatedBytes.fetch_add(bytes, std::memory_order_relaxed);
+    const auto live =
+        m_LiveBytes.fetch_add(bytes, std::memory_order_relaxed) + bytes;
+    auto peak = m_PeakBytes.load(std::memory_order_relaxed);
+    while (live > peak && !m_PeakBytes.compare_exchange_weak(
+                              peak, live, std::memory_order_relaxed,
+                              std::memory_order_relaxed)) {
+    }
+  }
+
+  void recordDeallocation(std::size_t bytes, std::uint64_t epoch) {
+    if (!isRecording() || epoch != currentEpoch())
+      return;
+    m_LiveBytes.fetch_sub(bytes, std::memory_order_relaxed);
+  }
+
+public:
+  TensorMemoryManager()
+      : m_Underlying(c10::GetCPUAllocator()), m_Allocator(m_Underlying, *this) {
+  }
+
+  void install() { c10::SetCPUAllocator(&m_Allocator, AllocatorPriority); }
+
+  void uninstall() { c10::SetCPUAllocator(m_Underlying, AllocatorPriority); }
+
+  void Start() override {
+    m_Recording.store(false, std::memory_order_release);
+    install();
+    m_Epoch.fetch_add(1, std::memory_order_relaxed);
+    m_Allocations.store(0, std::memory_order_relaxed);
+    m_TotalAllocatedBytes.store(0, std::memory_order_relaxed);
+    m_LiveBytes.store(0, std::memory_order_relaxed);
+    m_PeakBytes.store(0, std::memory_order_relaxed);
+    m_Recording.store(true, std::memory_order_release);
+  }
+
+  void Stop(Result& result) override {
+    m_Recording.store(false, std::memory_order_release);
+    result.num_allocs = m_Allocations.load(std::memory_order_relaxed);
+    result.max_bytes_used = m_PeakBytes.load(std::memory_order_relaxed);
+    result.total_allocated_bytes =
+        m_TotalAllocatedBytes.load(std::memory_order_relaxed);
+    result.net_heap_growth = m_LiveBytes.load(std::memory_order_relaxed);
+    uninstall();
+  }
+};
+
+struct BenchmarkRegistration {
+  TensorMemoryManager MemoryManager;
+
+  BenchmarkRegistration() {
+    torch::set_num_threads(1);
+    torch::set_num_interop_threads(1);
+    benchmark::RegisterMemoryManager(&MemoryManager);
+  }
+
+  ~BenchmarkRegistration() { benchmark::RegisterMemoryManager(nullptr); }
+};
+
+static BenchmarkRegistration benchmark_registration;
+
+struct BinaryInputs {
+  torch::Tensor lhs{};
+  torch::Tensor rhs{};
+};
+
+struct ReductionInputs {
+  torch::Tensor input{};
+  torch::Tensor weights{};
+};
+
+torch::TensorOptions options(bool requires_grad) {
+  return torch::TensorOptions()
+      .dtype(torch::kFloat32)
+      .requires_grad(requires_grad);
+}
+
+BinaryInputs make_vector_inputs(std::int64_t size, bool requires_grad) {
+  return {torch::linspace(-1.0, 1.0, size, options(requires_grad)),
+          torch::linspace(0.75, -0.25, size, options(requires_grad))};
+}
+
+BinaryInputs make_broadcast_inputs(std::int64_t batch, std::int64_t channels,
+                                   std::int64_t width, bool requires_grad) {
+  auto lhs = torch::linspace(-1.0, 1.0, batch * width, options(requires_grad))
+                 .reshape({batch, 1, width});
+  auto rhs = torch::linspace(-0.75, 1.25, channels, options(requires_grad))
+                 .reshape({1, channels, 1});
+  return {::std::move(lhs), ::std::move(rhs)};
+}
+
+ReductionInputs make_reduction_inputs(std::int64_t batch, std::int64_t channels,
+                                      std::int64_t width, bool requires_grad) {
+  auto input = torch::linspace(-1.0, 1.0, batch * channels * width,
+                               options(requires_grad))
+                   .reshape({batch, channels, width});
+  auto weights = torch::linspace(0.5, 1.5, channels, options(requires_grad));
+  return {::std::move(input), ::std::move(weights)};
+}
 
 float squared_error(const torch::Tensor& prediction,
                     const torch::Tensor& target) {
@@ -16,74 +201,286 @@ float squared_error(const torch::Tensor& prediction,
   return loss.item<float>();
 }
 
-struct Inputs {
-  torch::Tensor prediction{};
-  torch::Tensor target{};
-};
-
-Inputs make_inputs(std::int64_t size, bool requires_grad) {
-  const auto options = torch::TensorOptions()
-                           .dtype(torch::kFloat32)
-                           .requires_grad(requires_grad);
-  return {torch::linspace(-1.0, 1.0, size, options),
-          torch::linspace(0.75, -0.25, size, options)};
+float broadcast_relu_loss(const torch::Tensor& lhs, const torch::Tensor& rhs) {
+  auto product = lhs * rhs;
+  auto activated = product.relu();
+  auto loss = activated.sum();
+  return loss.item<float>();
 }
 
-void set_items_processed(benchmark::State& state, std::int64_t size) {
-  state.SetItemsProcessed(state.iterations() * size);
+float sum_dims_loss(const torch::Tensor& input, const torch::Tensor& weights,
+                    at::OptionalIntArrayRef dims) {
+  auto reduced = input.sum(dims, /*keepdim=*/false);
+  auto weighted = reduced * weights;
+  auto loss = weighted.sum();
+  return loss.item<float>();
 }
 
-void BM_CladGradient(benchmark::State& state) {
+void report_work(benchmark::State& state, std::int64_t elements,
+                 std::int64_t problem_bytes) {
+  state.SetItemsProcessed(state.iterations() * elements);
+  state.SetBytesProcessed(state.iterations() * problem_bytes);
+}
+
+std::int64_t volume(const benchmark::State& state) {
+  return state.range(0) * state.range(1) * state.range(2);
+}
+
+float materialized_gradient_checksum(const torch::Tensor& first,
+                                     const torch::Tensor& second) {
+  torch::NoGradGuard guard;
+  auto first_dense = first.contiguous();
+  auto second_dense = second.contiguous();
+  return first_dense.sum().item<float>() + second_dense.sum().item<float>();
+}
+
+float materialized_gradient_checksum(const torch::Tensor& gradient) {
+  torch::NoGradGuard guard;
+  return gradient.contiguous().sum().item<float>();
+}
+
+void composite_relu_vjp(const torch::Tensor& input,
+                        const torch::Tensor& d_output, torch::Tensor* d_input) {
+  clad::torch::detail::validate_tensor(input);
+  clad::torch::detail::validate_tensor(d_output);
+  torch::NoGradGuard guard;
+  auto mask = torch::gt(input, 0).to(input.scalar_type());
+  clad::torch::detail::accumulate(d_input, torch::mul(d_output, mask));
+}
+
+void BM_ReluVJPComposite(benchmark::State& state) {
   const auto size = state.range(0);
-  const auto inputs = make_inputs(size, /*requires_grad=*/false);
-  auto prediction_gradient = torch::zeros_like(inputs.prediction);
-  auto target_gradient = torch::zeros_like(inputs.target);
+  const auto inputs = make_vector_inputs(size, /*requires_grad=*/false);
+  auto input_gradient = torch::zeros_like(inputs.lhs);
+
+  for (auto _ : state) {
+    input_gradient.zero_();
+    composite_relu_vjp(inputs.lhs, inputs.rhs, &input_gradient);
+    auto checksum = materialized_gradient_checksum(input_gradient);
+    benchmark::DoNotOptimize(checksum);
+  }
+  report_work(state, size, 3 * size * sizeof(float));
+}
+
+void BM_ReluVJPNative(benchmark::State& state) {
+  const auto size = state.range(0);
+  const auto inputs = make_vector_inputs(size, /*requires_grad=*/false);
+  auto input_gradient = torch::zeros_like(inputs.lhs);
+
+  for (auto _ : state) {
+    input_gradient.zero_();
+    clad::custom_derivatives::at::relu_pullback(inputs.lhs, inputs.rhs,
+                                                &input_gradient);
+    auto checksum = materialized_gradient_checksum(input_gradient);
+    benchmark::DoNotOptimize(checksum);
+  }
+  report_work(state, size, 3 * size * sizeof(float));
+}
+
+void BM_SquaredErrorForward(benchmark::State& state) {
+  const auto size = state.range(0);
+  const auto inputs = make_vector_inputs(size, /*requires_grad=*/false);
+  torch::NoGradGuard guard;
+
+  for (auto _ : state) {
+    auto loss = squared_error(inputs.lhs, inputs.rhs);
+    benchmark::DoNotOptimize(loss);
+  }
+  report_work(state, size, 2 * size * sizeof(float));
+}
+
+void BM_SquaredErrorClad(benchmark::State& state) {
+  const auto size = state.range(0);
+  const auto inputs = make_vector_inputs(size, /*requires_grad=*/false);
+  auto lhs_gradient = torch::zeros_like(inputs.lhs);
+  auto rhs_gradient = torch::zeros_like(inputs.rhs);
   auto gradient = clad::gradient(squared_error, "prediction, target");
 
-  for ([[maybe_unused]] auto _ : state) {
-    prediction_gradient.zero_();
-    target_gradient.zero_();
-    gradient.execute(inputs.prediction, inputs.target, &prediction_gradient,
-                     &target_gradient);
-    benchmark::DoNotOptimize(prediction_gradient.data_ptr<float>());
-    benchmark::DoNotOptimize(target_gradient.data_ptr<float>());
+  for (auto _ : state) {
+    lhs_gradient.zero_();
+    rhs_gradient.zero_();
+    gradient.execute(inputs.lhs, inputs.rhs, &lhs_gradient, &rhs_gradient);
+    auto checksum = materialized_gradient_checksum(lhs_gradient, rhs_gradient);
+    benchmark::DoNotOptimize(checksum);
   }
-  set_items_processed(state, size);
+  report_work(state, size, 2 * size * sizeof(float));
 }
 
-void BM_LibTorchAutograd(benchmark::State& state) {
+void BM_SquaredErrorAutograd(benchmark::State& state) {
   const auto size = state.range(0);
-  const auto inputs = make_inputs(size, /*requires_grad=*/true);
+  const auto inputs = make_vector_inputs(size, /*requires_grad=*/true);
 
-  for ([[maybe_unused]] auto _ : state) {
-    auto residual = inputs.prediction - inputs.target;
+  for (auto _ : state) {
+    auto residual = inputs.lhs - inputs.rhs;
     auto loss = residual.dot(residual);
-    auto gradients =
-        torch::autograd::grad({loss}, {inputs.prediction, inputs.target});
-    benchmark::DoNotOptimize(gradients[0].data_ptr<float>());
-    benchmark::DoNotOptimize(gradients[1].data_ptr<float>());
+    auto scalar_loss = loss.item<float>();
+    auto gradients = torch::autograd::grad({loss}, {inputs.lhs, inputs.rhs});
+    auto checksum = materialized_gradient_checksum(gradients[0], gradients[1]);
+    benchmark::DoNotOptimize(scalar_loss);
+    benchmark::DoNotOptimize(checksum);
   }
-  set_items_processed(state, size);
+  report_work(state, size, 2 * size * sizeof(float));
 }
 
-void configure(benchmark::internal::Benchmark* benchmark) {
+void BM_BroadcastReluForward(benchmark::State& state) {
+  const auto inputs =
+      make_broadcast_inputs(state.range(0), state.range(1), state.range(2),
+                            /*requires_grad=*/false);
+  torch::NoGradGuard guard;
+
+  for (auto _ : state) {
+    auto loss = broadcast_relu_loss(inputs.lhs, inputs.rhs);
+    benchmark::DoNotOptimize(loss);
+  }
+  const auto elements = volume(state);
+  const auto input_elements = state.range(0) * state.range(2) + state.range(1);
+  report_work(state, elements, input_elements * sizeof(float));
+}
+
+void BM_BroadcastReluClad(benchmark::State& state) {
+  const auto inputs =
+      make_broadcast_inputs(state.range(0), state.range(1), state.range(2),
+                            /*requires_grad=*/false);
+  auto lhs_gradient = torch::zeros_like(inputs.lhs);
+  auto rhs_gradient = torch::zeros_like(inputs.rhs);
+  auto gradient = clad::gradient(broadcast_relu_loss, "lhs, rhs");
+
+  for (auto _ : state) {
+    lhs_gradient.zero_();
+    rhs_gradient.zero_();
+    gradient.execute(inputs.lhs, inputs.rhs, &lhs_gradient, &rhs_gradient);
+    auto checksum = materialized_gradient_checksum(lhs_gradient, rhs_gradient);
+    benchmark::DoNotOptimize(checksum);
+  }
+  const auto elements = volume(state);
+  const auto input_elements = state.range(0) * state.range(2) + state.range(1);
+  report_work(state, elements, input_elements * sizeof(float));
+}
+
+void BM_BroadcastReluAutograd(benchmark::State& state) {
+  const auto inputs =
+      make_broadcast_inputs(state.range(0), state.range(1), state.range(2),
+                            /*requires_grad=*/true);
+
+  for (auto _ : state) {
+    auto product = inputs.lhs * inputs.rhs;
+    auto activated = product.relu();
+    auto loss = activated.sum();
+    auto scalar_loss = loss.item<float>();
+    auto gradients = torch::autograd::grad({loss}, {inputs.lhs, inputs.rhs});
+    auto checksum = materialized_gradient_checksum(gradients[0], gradients[1]);
+    benchmark::DoNotOptimize(scalar_loss);
+    benchmark::DoNotOptimize(checksum);
+  }
+  const auto elements = volume(state);
+  const auto input_elements = state.range(0) * state.range(2) + state.range(1);
+  report_work(state, elements, input_elements * sizeof(float));
+}
+
+void BM_SumDimsForward(benchmark::State& state) {
+  const auto inputs =
+      make_reduction_inputs(state.range(0), state.range(1), state.range(2),
+                            /*requires_grad=*/false);
+  const std::vector<std::int64_t> dims{0, -1};
+  torch::NoGradGuard guard;
+
+  for (auto _ : state) {
+    auto loss = sum_dims_loss(inputs.input, inputs.weights, dims);
+    benchmark::DoNotOptimize(loss);
+  }
+  const auto elements = volume(state);
+  report_work(state, elements, (elements + state.range(1)) * sizeof(float));
+}
+
+void BM_SumDimsClad(benchmark::State& state) {
+  const auto inputs =
+      make_reduction_inputs(state.range(0), state.range(1), state.range(2),
+                            /*requires_grad=*/false);
+  const std::vector<std::int64_t> dims{0, -1};
+  auto input_gradient = torch::zeros_like(inputs.input);
+  auto weights_gradient = torch::zeros_like(inputs.weights);
+  auto gradient = clad::gradient(sum_dims_loss, "input, weights");
+
+  for (auto _ : state) {
+    input_gradient.zero_();
+    weights_gradient.zero_();
+    gradient.execute(inputs.input, inputs.weights, dims, &input_gradient,
+                     &weights_gradient);
+    auto checksum =
+        materialized_gradient_checksum(input_gradient, weights_gradient);
+    benchmark::DoNotOptimize(checksum);
+  }
+  const auto elements = volume(state);
+  report_work(state, elements, (elements + state.range(1)) * sizeof(float));
+}
+
+void BM_SumDimsAutograd(benchmark::State& state) {
+  const auto inputs =
+      make_reduction_inputs(state.range(0), state.range(1), state.range(2),
+                            /*requires_grad=*/true);
+  const std::vector<std::int64_t> dims{0, -1};
+
+  for (auto _ : state) {
+    auto reduced = inputs.input.sum(dims, /*keepdim=*/false);
+    auto weighted = reduced * inputs.weights;
+    auto loss = weighted.sum();
+    auto scalar_loss = loss.item<float>();
+    auto gradients =
+        torch::autograd::grad({loss}, {inputs.input, inputs.weights});
+    auto checksum = materialized_gradient_checksum(gradients[0], gradients[1]);
+    benchmark::DoNotOptimize(scalar_loss);
+    benchmark::DoNotOptimize(checksum);
+  }
+  const auto elements = volume(state);
+  report_work(state, elements, (elements + state.range(1)) * sizeof(float));
+}
+
+void configure_vector(benchmark::internal::Benchmark* benchmark) {
   benchmark->RangeMultiplier(4)
       ->Range(256, 1 << 20)
+      ->ArgName("elements")
       ->Unit(benchmark::kMicrosecond);
 }
 
-BENCHMARK(BM_CladGradient)->Apply(configure);
-BENCHMARK(BM_LibTorchAutograd)->Apply(configure);
+void configure_3d(benchmark::internal::Benchmark* benchmark) {
+  benchmark->Args({1, 8, 32})
+      ->Args({4, 16, 64})
+      ->Args({8, 32, 128})
+      ->Args({16, 64, 256})
+      ->Args({16, 128, 512})
+      ->ArgNames({"batch", "channels", "width"})
+      ->Unit(benchmark::kMicrosecond);
+}
+
+BENCHMARK(BM_SquaredErrorForward)
+    ->Name("BM_SquaredError/Forward")
+    ->Apply(configure_vector);
+BENCHMARK(BM_SquaredErrorClad)
+    ->Name("BM_SquaredError/Clad")
+    ->Apply(configure_vector);
+BENCHMARK(BM_SquaredErrorAutograd)
+    ->Name("BM_SquaredError/Autograd")
+    ->Apply(configure_vector);
+
+BENCHMARK(BM_ReluVJPComposite)
+    ->Name("BM_ReluVJP/Composite")
+    ->Apply(configure_vector);
+BENCHMARK(BM_ReluVJPNative)->Name("BM_ReluVJP/Native")->Apply(configure_vector);
+
+BENCHMARK(BM_BroadcastReluForward)
+    ->Name("BM_BroadcastRelu/Forward")
+    ->Apply(configure_3d);
+BENCHMARK(BM_BroadcastReluClad)
+    ->Name("BM_BroadcastRelu/Clad")
+    ->Apply(configure_3d);
+BENCHMARK(BM_BroadcastReluAutograd)
+    ->Name("BM_BroadcastRelu/Autograd")
+    ->Apply(configure_3d);
+
+BENCHMARK(BM_SumDimsForward)->Name("BM_SumDims/Forward")->Apply(configure_3d);
+BENCHMARK(BM_SumDimsClad)->Name("BM_SumDims/Clad")->Apply(configure_3d);
+BENCHMARK(BM_SumDimsAutograd)->Name("BM_SumDims/Autograd")->Apply(configure_3d);
 
 } // namespace
 
-int main(int argc, char** argv) {
-  torch::set_num_threads(1);
-  torch::set_num_interop_threads(1);
-  benchmark::Initialize(&argc, argv);
-  if (benchmark::ReportUnrecognizedArguments(argc, argv))
-    return 1;
-  benchmark::RunSpecifiedBenchmarks();
-  benchmark::Shutdown();
-  return 0;
-}
+BENCHMARK_MAIN();

--- a/benchmark/LibTorch/TorchOpsBenchmark.cpp
+++ b/benchmark/LibTorch/TorchOpsBenchmark.cpp
@@ -239,8 +239,9 @@ float materialized_gradient_checksum(const torch::Tensor& gradient) {
   return gradient.contiguous().sum().item<float>();
 }
 
-void composite_relu_vjp(const torch::Tensor& input,
-                        const torch::Tensor& d_output, torch::Tensor* d_input) {
+void composite_relu_backward(const torch::Tensor& input,
+                             const torch::Tensor& d_output,
+                             torch::Tensor* d_input) {
   clad::torch::detail::validate_tensor(input);
   clad::torch::detail::validate_tensor(d_output);
   torch::NoGradGuard guard;
@@ -248,29 +249,70 @@ void composite_relu_vjp(const torch::Tensor& input,
   clad::torch::detail::accumulate(d_input, torch::mul(d_output, mask));
 }
 
-void BM_ReluVJPComposite(benchmark::State& state) {
+void BM_ReluBackwardComposite(benchmark::State& state) {
   const auto size = state.range(0);
   const auto inputs = make_vector_inputs(size, /*requires_grad=*/false);
-  auto input_gradient = torch::zeros_like(inputs.lhs);
+  torch::Tensor input_gradient;
 
   for (auto _ : state) {
-    input_gradient.zero_();
-    composite_relu_vjp(inputs.lhs, inputs.rhs, &input_gradient);
+    input_gradient = torch::Tensor();
+    composite_relu_backward(inputs.lhs, inputs.rhs, &input_gradient);
     auto checksum = materialized_gradient_checksum(input_gradient);
     benchmark::DoNotOptimize(checksum);
   }
   report_work(state, size, 3 * size * sizeof(float));
 }
 
-void BM_ReluVJPNative(benchmark::State& state) {
+void BM_ReluBackwardNative(benchmark::State& state) {
   const auto size = state.range(0);
   const auto inputs = make_vector_inputs(size, /*requires_grad=*/false);
-  auto input_gradient = torch::zeros_like(inputs.lhs);
+  torch::Tensor input_gradient;
 
   for (auto _ : state) {
-    input_gradient.zero_();
+    input_gradient = torch::Tensor();
     clad::custom_derivatives::at::relu_pullback(inputs.lhs, inputs.rhs,
                                                 &input_gradient);
+    auto checksum = materialized_gradient_checksum(input_gradient);
+    benchmark::DoNotOptimize(checksum);
+  }
+  report_work(state, size, 3 * size * sizeof(float));
+}
+
+void separate_dot_backward(const torch::Tensor& input,
+                           const torch::Tensor& d_output,
+                           torch::Tensor* d_input) {
+  clad::torch::detail::validate_dot_inputs(input, input);
+  clad::torch::detail::validate_tensor(d_output);
+  torch::NoGradGuard guard;
+  clad::torch::detail::accumulate(d_input, torch::mul(input, d_output));
+  clad::torch::detail::accumulate(d_input, torch::mul(input, d_output));
+}
+
+void BM_DotBackwardSeparate(benchmark::State& state) {
+  const auto size = state.range(0);
+  const auto inputs = make_vector_inputs(size, /*requires_grad=*/false);
+  const auto d_output = torch::scalar_tensor(1.25, options(false));
+  torch::Tensor input_gradient;
+
+  for (auto _ : state) {
+    input_gradient = torch::Tensor();
+    separate_dot_backward(inputs.lhs, d_output, &input_gradient);
+    auto checksum = materialized_gradient_checksum(input_gradient);
+    benchmark::DoNotOptimize(checksum);
+  }
+  report_work(state, size, 3 * size * sizeof(float));
+}
+
+void BM_DotBackwardCombined(benchmark::State& state) {
+  const auto size = state.range(0);
+  const auto inputs = make_vector_inputs(size, /*requires_grad=*/false);
+  const auto d_output = torch::scalar_tensor(1.25, options(false));
+  torch::Tensor input_gradient;
+
+  for (auto _ : state) {
+    input_gradient = torch::Tensor();
+    clad::custom_derivatives::at::dot_pullback(
+        inputs.lhs, inputs.lhs, d_output, &input_gradient, &input_gradient);
     auto checksum = materialized_gradient_checksum(input_gradient);
     benchmark::DoNotOptimize(checksum);
   }
@@ -292,13 +334,13 @@ void BM_SquaredErrorForward(benchmark::State& state) {
 void BM_SquaredErrorClad(benchmark::State& state) {
   const auto size = state.range(0);
   const auto inputs = make_vector_inputs(size, /*requires_grad=*/false);
-  auto lhs_gradient = torch::zeros_like(inputs.lhs);
-  auto rhs_gradient = torch::zeros_like(inputs.rhs);
+  torch::Tensor lhs_gradient;
+  torch::Tensor rhs_gradient;
   auto gradient = clad::gradient(squared_error, "prediction, target");
 
   for (auto _ : state) {
-    lhs_gradient.zero_();
-    rhs_gradient.zero_();
+    lhs_gradient = torch::Tensor();
+    rhs_gradient = torch::Tensor();
     gradient.execute(inputs.lhs, inputs.rhs, &lhs_gradient, &rhs_gradient);
     auto checksum = materialized_gradient_checksum(lhs_gradient, rhs_gradient);
     benchmark::DoNotOptimize(checksum);
@@ -341,13 +383,13 @@ void BM_BroadcastReluClad(benchmark::State& state) {
   const auto inputs =
       make_broadcast_inputs(state.range(0), state.range(1), state.range(2),
                             /*requires_grad=*/false);
-  auto lhs_gradient = torch::zeros_like(inputs.lhs);
-  auto rhs_gradient = torch::zeros_like(inputs.rhs);
+  torch::Tensor lhs_gradient;
+  torch::Tensor rhs_gradient;
   auto gradient = clad::gradient(broadcast_relu_loss, "lhs, rhs");
 
   for (auto _ : state) {
-    lhs_gradient.zero_();
-    rhs_gradient.zero_();
+    lhs_gradient = torch::Tensor();
+    rhs_gradient = torch::Tensor();
     gradient.execute(inputs.lhs, inputs.rhs, &lhs_gradient, &rhs_gradient);
     auto checksum = materialized_gradient_checksum(lhs_gradient, rhs_gradient);
     benchmark::DoNotOptimize(checksum);
@@ -397,13 +439,13 @@ void BM_SumDimsClad(benchmark::State& state) {
       make_reduction_inputs(state.range(0), state.range(1), state.range(2),
                             /*requires_grad=*/false);
   const std::vector<std::int64_t> dims{0, -1};
-  auto input_gradient = torch::zeros_like(inputs.input);
-  auto weights_gradient = torch::zeros_like(inputs.weights);
+  torch::Tensor input_gradient;
+  torch::Tensor weights_gradient;
   auto gradient = clad::gradient(sum_dims_loss, "input, weights");
 
   for (auto _ : state) {
-    input_gradient.zero_();
-    weights_gradient.zero_();
+    input_gradient = torch::Tensor();
+    weights_gradient = torch::Tensor();
     gradient.execute(inputs.input, inputs.weights, dims, &input_gradient,
                      &weights_gradient);
     auto checksum =
@@ -462,10 +504,19 @@ BENCHMARK(BM_SquaredErrorAutograd)
     ->Name("BM_SquaredError/Autograd")
     ->Apply(configure_vector);
 
-BENCHMARK(BM_ReluVJPComposite)
-    ->Name("BM_ReluVJP/Composite")
+BENCHMARK(BM_ReluBackwardComposite)
+    ->Name("BM_ReluBackward/Composite")
     ->Apply(configure_vector);
-BENCHMARK(BM_ReluVJPNative)->Name("BM_ReluVJP/Native")->Apply(configure_vector);
+BENCHMARK(BM_ReluBackwardNative)
+    ->Name("BM_ReluBackward/Native")
+    ->Apply(configure_vector);
+
+BENCHMARK(BM_DotBackwardSeparate)
+    ->Name("BM_DotBackward/Separate")
+    ->Apply(configure_vector);
+BENCHMARK(BM_DotBackwardCombined)
+    ->Name("BM_DotBackward/Combined")
+    ->Apply(configure_vector);
 
 BENCHMARK(BM_BroadcastReluForward)
     ->Name("BM_BroadcastRelu/Forward")

--- a/benchmark/LibTorch/TorchOpsBenchmark.cpp
+++ b/benchmark/LibTorch/TorchOpsBenchmark.cpp
@@ -1,0 +1,89 @@
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/TorchBuiltins.h" // IWYU pragma: keep
+
+#include "benchmark/benchmark.h"
+
+#include <torch/torch.h> // IWYU pragma: keep
+
+#include <cstdint>
+
+namespace {
+
+float squared_error(const torch::Tensor& prediction,
+                    const torch::Tensor& target) {
+  auto residual = torch::sub(prediction, target);
+  auto loss = torch::dot(residual, residual);
+  return loss.item<float>();
+}
+
+struct Inputs {
+  torch::Tensor prediction{};
+  torch::Tensor target{};
+};
+
+Inputs make_inputs(std::int64_t size, bool requires_grad) {
+  const auto options = torch::TensorOptions()
+                           .dtype(torch::kFloat32)
+                           .requires_grad(requires_grad);
+  return {torch::linspace(-1.0, 1.0, size, options),
+          torch::linspace(0.75, -0.25, size, options)};
+}
+
+void set_items_processed(benchmark::State& state, std::int64_t size) {
+  state.SetItemsProcessed(state.iterations() * size);
+}
+
+void BM_CladGradient(benchmark::State& state) {
+  const auto size = state.range(0);
+  const auto inputs = make_inputs(size, /*requires_grad=*/false);
+  auto prediction_gradient = torch::zeros_like(inputs.prediction);
+  auto target_gradient = torch::zeros_like(inputs.target);
+  auto gradient = clad::gradient(squared_error, "prediction, target");
+
+  for ([[maybe_unused]] auto _ : state) {
+    prediction_gradient.zero_();
+    target_gradient.zero_();
+    gradient.execute(inputs.prediction, inputs.target, &prediction_gradient,
+                     &target_gradient);
+    benchmark::DoNotOptimize(prediction_gradient.data_ptr<float>());
+    benchmark::DoNotOptimize(target_gradient.data_ptr<float>());
+  }
+  set_items_processed(state, size);
+}
+
+void BM_LibTorchAutograd(benchmark::State& state) {
+  const auto size = state.range(0);
+  const auto inputs = make_inputs(size, /*requires_grad=*/true);
+
+  for ([[maybe_unused]] auto _ : state) {
+    auto residual = torch::sub(inputs.prediction, inputs.target);
+    auto loss = torch::dot(residual, residual);
+    auto gradients =
+        torch::autograd::grad({loss}, {inputs.prediction, inputs.target});
+    benchmark::DoNotOptimize(gradients[0].data_ptr<float>());
+    benchmark::DoNotOptimize(gradients[1].data_ptr<float>());
+  }
+  set_items_processed(state, size);
+}
+
+void configure(benchmark::internal::Benchmark* benchmark) {
+  benchmark->RangeMultiplier(4)
+      ->Range(256, 1 << 20)
+      ->Unit(benchmark::kMicrosecond);
+}
+
+BENCHMARK(BM_CladGradient)->Apply(configure);
+BENCHMARK(BM_LibTorchAutograd)->Apply(configure);
+
+} // namespace
+
+int main(int argc, char** argv) {
+  torch::set_num_threads(1);
+  torch::set_num_interop_threads(1);
+  benchmark::Initialize(&argc, argv);
+  if (benchmark::ReportUnrecognizedArguments(argc, argv))
+    return 1;
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+  return 0;
+}

--- a/benchmark/LibTorch/TorchOpsBenchmark.cpp
+++ b/benchmark/LibTorch/TorchOpsBenchmark.cpp
@@ -1,0 +1,89 @@
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/TorchBuiltins.h" // IWYU pragma: keep
+
+#include "benchmark/benchmark.h"
+
+#include <torch/torch.h> // IWYU pragma: keep
+
+#include <cstdint>
+
+namespace {
+
+float squared_error(const torch::Tensor& prediction,
+                    const torch::Tensor& target) {
+  auto residual = prediction - target;
+  auto loss = residual.dot(residual);
+  return loss.item<float>();
+}
+
+struct Inputs {
+  torch::Tensor prediction{};
+  torch::Tensor target{};
+};
+
+Inputs make_inputs(std::int64_t size, bool requires_grad) {
+  const auto options = torch::TensorOptions()
+                           .dtype(torch::kFloat32)
+                           .requires_grad(requires_grad);
+  return {torch::linspace(-1.0, 1.0, size, options),
+          torch::linspace(0.75, -0.25, size, options)};
+}
+
+void set_items_processed(benchmark::State& state, std::int64_t size) {
+  state.SetItemsProcessed(state.iterations() * size);
+}
+
+void BM_CladGradient(benchmark::State& state) {
+  const auto size = state.range(0);
+  const auto inputs = make_inputs(size, /*requires_grad=*/false);
+  auto prediction_gradient = torch::zeros_like(inputs.prediction);
+  auto target_gradient = torch::zeros_like(inputs.target);
+  auto gradient = clad::gradient(squared_error, "prediction, target");
+
+  for ([[maybe_unused]] auto _ : state) {
+    prediction_gradient.zero_();
+    target_gradient.zero_();
+    gradient.execute(inputs.prediction, inputs.target, &prediction_gradient,
+                     &target_gradient);
+    benchmark::DoNotOptimize(prediction_gradient.data_ptr<float>());
+    benchmark::DoNotOptimize(target_gradient.data_ptr<float>());
+  }
+  set_items_processed(state, size);
+}
+
+void BM_LibTorchAutograd(benchmark::State& state) {
+  const auto size = state.range(0);
+  const auto inputs = make_inputs(size, /*requires_grad=*/true);
+
+  for ([[maybe_unused]] auto _ : state) {
+    auto residual = inputs.prediction - inputs.target;
+    auto loss = residual.dot(residual);
+    auto gradients =
+        torch::autograd::grad({loss}, {inputs.prediction, inputs.target});
+    benchmark::DoNotOptimize(gradients[0].data_ptr<float>());
+    benchmark::DoNotOptimize(gradients[1].data_ptr<float>());
+  }
+  set_items_processed(state, size);
+}
+
+void configure(benchmark::internal::Benchmark* benchmark) {
+  benchmark->RangeMultiplier(4)
+      ->Range(256, 1 << 20)
+      ->Unit(benchmark::kMicrosecond);
+}
+
+BENCHMARK(BM_CladGradient)->Apply(configure);
+BENCHMARK(BM_LibTorchAutograd)->Apply(configure);
+
+} // namespace
+
+int main(int argc, char** argv) {
+  torch::set_num_threads(1);
+  torch::set_num_interop_threads(1);
+  benchmark::Initialize(&argc, argv);
+  if (benchmark::ReportUnrecognizedArguments(argc, argv))
+    return 1;
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+  return 0;
+}

--- a/benchmark/LibTorch/TorchOpsBenchmark.cpp
+++ b/benchmark/LibTorch/TorchOpsBenchmark.cpp
@@ -11,8 +11,8 @@ namespace {
 
 float squared_error(const torch::Tensor& prediction,
                     const torch::Tensor& target) {
-  auto residual = torch::sub(prediction, target);
-  auto loss = torch::dot(residual, residual);
+  auto residual = prediction - target;
+  auto loss = residual.dot(residual);
   return loss.item<float>();
 }
 
@@ -56,8 +56,8 @@ void BM_LibTorchAutograd(benchmark::State& state) {
   const auto inputs = make_inputs(size, /*requires_grad=*/true);
 
   for ([[maybe_unused]] auto _ : state) {
-    auto residual = torch::sub(inputs.prediction, inputs.target);
-    auto loss = torch::dot(residual, residual);
+    auto residual = inputs.prediction - inputs.target;
+    auto loss = residual.dot(residual);
     auto gradients =
         torch::autograd::grad({loss}, {inputs.prediction, inputs.target});
     benchmark::DoNotOptimize(gradients[0].data_ptr<float>());

--- a/benchmark/LibTorch/TorchOpsTest.cpp
+++ b/benchmark/LibTorch/TorchOpsTest.cpp
@@ -110,6 +110,11 @@ float method_loss(const torch::Tensor& lhs, const torch::Tensor& rhs) {
   return scalar.item<float>();
 }
 
+float partial_gradient_loss(const at::Tensor& lhs, const at::Tensor& rhs) {
+  auto product = at::mul(lhs, rhs);
+  return at::dot(product, lhs).item<float>();
+}
+
 void check_torch_alias_composition() {
   const auto options = torch::TensorOptions().dtype(torch::kFloat32);
   const auto input = torch::linspace(-2.0, 2.0, 17, options);
@@ -221,6 +226,34 @@ void check_method_composition() {
                 "Tensor method rhs gradient is incorrect");
 }
 
+void check_partial_gradients_do_not_alias_inputs() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto lhs = at::linspace(0.5, 2.0, 17, options);
+  const auto rhs = at::linspace(1.0, 3.0, 17, options);
+  const auto original_lhs = lhs.clone();
+  const auto original_rhs = rhs.clone();
+
+  auto lhs_gradient = at::zeros_like(lhs);
+  auto lhs_only = clad::gradient(partial_gradient_loss, "lhs");
+  lhs_only.execute(lhs, rhs, &lhs_gradient);
+  require_close(lhs_gradient, 2 * original_lhs * original_rhs,
+                "partial lhs gradient is incorrect");
+  require_close(lhs, original_lhs,
+                "partial lhs gradient modified the lhs input");
+  require_close(rhs, original_rhs,
+                "partial lhs gradient modified the rhs input");
+
+  auto rhs_gradient = at::zeros_like(rhs);
+  auto rhs_only = clad::gradient(partial_gradient_loss, "rhs");
+  rhs_only.execute(lhs, rhs, &rhs_gradient);
+  require_close(rhs_gradient, original_lhs * original_lhs,
+                "partial rhs gradient is incorrect");
+  require_close(lhs, original_lhs,
+                "partial rhs gradient modified the lhs input");
+  require_close(rhs, original_rhs,
+                "partial rhs gradient modified the rhs input");
+}
+
 void check_input_contract() {
   require_c10_error(
       [] {
@@ -265,6 +298,7 @@ int main() {
   check_namespace_alias_composition();
   check_operator_composition();
   check_method_composition();
+  check_partial_gradients_do_not_alias_inputs();
   check_input_contract();
   std::cout << "Clad Torch operator checks passed\n";
   return 0;

--- a/benchmark/LibTorch/TorchOpsTest.cpp
+++ b/benchmark/LibTorch/TorchOpsTest.cpp
@@ -5,7 +5,7 @@
 
 #include <iostream>
 #include <stdexcept>
-#include <type_traits>
+#include <vector>
 
 namespace {
 
@@ -115,6 +115,91 @@ float partial_gradient_loss(const at::Tensor& lhs, const at::Tensor& rhs) {
   return at::dot(product, lhs).item<float>();
 }
 
+float tensor_sum_loss(const at::Tensor& input) {
+  auto scalar = input.sum();
+  return scalar.item<float>();
+}
+
+float tensor_sum_dim_method_loss(const at::Tensor& input,
+                                 const at::Tensor& weights) {
+  auto reduced = input.sum(/*dim=*/1);
+  auto weighted = reduced.mul(weights);
+  return weighted.sum().item<float>();
+}
+
+float tensor_sum_dims_method_loss(const at::Tensor& input,
+                                  const at::Tensor& weights) {
+  auto reduced = input.sum({-3, -1}, /*keepdim=*/true);
+  auto weighted = reduced.mul(weights);
+  return weighted.sum().item<float>();
+}
+
+float tensor_sum_dims_loss(const at::Tensor& input, const at::Tensor& weights,
+                           at::OptionalIntArrayRef dims, bool keepdim) {
+  auto reduced = at::sum(input, dims, keepdim);
+  auto weighted = at::mul(reduced, weights);
+  return weighted.sum().item<float>();
+}
+
+float default_method_parameter_loss(const at::Tensor& input,
+                                    const at::Tensor& bias,
+                                    const at::Tensor& offset,
+                                    const at::Tensor& weights, int64_t dim) {
+  auto shifted = input.add(bias);
+  auto centered = shifted.sub(offset);
+  auto reduced = centered.sum(dim);
+  auto weighted = reduced.mul(weights);
+  auto scalar = weighted.sum();
+  return scalar.item<float>();
+}
+
+float default_function_parameter_loss(const at::Tensor& input,
+                                      const at::Tensor& weights,
+                                      at::OptionalIntArrayRef dims) {
+  auto reduced = at::sum(input, dims);
+  auto weighted = at::mul(reduced, weights);
+  auto scalar = at::sum(weighted);
+  return scalar.item<float>();
+}
+
+float explicit_sum_options_loss(const at::Tensor& input,
+                                const at::Tensor& weights,
+                                at::OptionalIntArrayRef dims, bool keepdim) {
+  auto reduced = input.sum(dims, keepdim, at::kFloat);
+  auto weighted = reduced.mul(weights);
+  auto scalar = weighted.sum(at::ScalarType::Float);
+  return scalar.item<float>();
+}
+
+float unsupported_sum_dtype_loss(const at::Tensor& input) {
+  auto scalar = input.sum(at::ScalarType::Double);
+  return scalar.item<float>();
+}
+
+float broadcast_add_loss(const at::Tensor& lhs, const at::Tensor& rhs) {
+  auto output = lhs + rhs;
+  auto scalar = output.sum();
+  return scalar.item<float>();
+}
+
+float broadcast_sub_loss(const at::Tensor& lhs, const at::Tensor& rhs) {
+  auto output = at::sub(lhs, rhs);
+  auto scalar = at::sum(output);
+  return scalar.item<float>();
+}
+
+float broadcast_mul_loss(const at::Tensor& lhs, const at::Tensor& rhs) {
+  auto output = lhs.mul(rhs);
+  auto scalar = output.sum();
+  return scalar.item<float>();
+}
+
+float broadcast_div_loss(const at::Tensor& lhs, const at::Tensor& rhs) {
+  auto output = at::div(lhs, rhs);
+  auto scalar = at::sum(output);
+  return scalar.item<float>();
+}
+
 void check_torch_alias_composition() {
   const auto options = torch::TensorOptions().dtype(torch::kFloat32);
   const auto input = torch::linspace(-2.0, 2.0, 17, options);
@@ -167,6 +252,37 @@ void check_direct_return_composition() {
       torch::autograd::grad({native_loss}, {native_input})[0];
   require_close(gradient, native_gradient,
                 "direct Tensor return gradient is incorrect");
+}
+
+void check_native_relu_vjp() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input = at::tensor({-2.0, -0.0, 0.0, 1.5}, options);
+  const auto d_output = at::tensor({0.5, 1.0, 1.5, 2.0}, options);
+  auto actual = at::full_like(input, 3.0);
+  const auto expected =
+      actual + at::threshold_backward(d_output, input, /*threshold=*/0);
+
+  clad::custom_derivatives::at::relu_pullback(input, d_output, &actual);
+  require_close(actual, expected, "native ReLU VJP accumulation is incorrect");
+}
+
+void check_partial_vjp_inputs() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto lhs = at::linspace(0.5, 2.0, 8, options).reshape({2, 1, 4});
+  const auto rhs = at::linspace(1.0, 3.0, 3, options).reshape({1, 3, 1});
+  const auto d_output = at::ones({2, 3, 4}, options);
+
+  auto lhs_gradient = at::zeros_like(lhs);
+  clad::custom_derivatives::at::mul_pullback(lhs, rhs, d_output, &lhs_gradient,
+                                             /*d_rhs=*/nullptr);
+  require_close(lhs_gradient, rhs.expand({2, 3, 4}).sum_to_size(lhs.sizes()),
+                "masked lhs VJP gradient is incorrect");
+
+  auto rhs_gradient = at::zeros_like(rhs);
+  clad::custom_derivatives::at::mul_pullback(lhs, rhs, d_output,
+                                             /*d_lhs=*/nullptr, &rhs_gradient);
+  require_close(rhs_gradient, lhs.expand({2, 3, 4}).sum_to_size(rhs.sizes()),
+                "masked rhs VJP gradient is incorrect");
 }
 
 void check_namespace_alias_composition() {
@@ -254,6 +370,354 @@ void check_partial_gradients_do_not_alias_inputs() {
                 "partial rhs gradient modified the rhs input");
 }
 
+void check_sum_shape_support() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  auto gradient = clad::gradient(tensor_sum_loss, "input");
+  auto check = [&](const at::Tensor& input) {
+    const auto original = input.clone();
+    auto actual = at::zeros_like(input);
+    gradient.execute(input, &actual);
+    require_close(actual, at::ones_like(input),
+                  "Tensor sum gradient is incorrect");
+    require_close(input, original, "Tensor sum modified its input");
+  };
+
+  check(at::scalar_tensor(2.0, options));
+  check(at::linspace(0.5, 3.0, 6, options).reshape({2, 3}));
+  check(at::linspace(0.5, 12.0, 24, options).reshape({2, 3, 4}));
+  check(at::empty({2, 0, 3}, options));
+}
+
+void check_sum_dim_method() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input = at::linspace(0.5, 12.0, 24, options).reshape({2, 3, 4});
+  const auto weights = at::linspace(0.5, 4.0, 8, options).reshape({2, 4});
+  auto actual = at::zeros_like(input);
+  auto gradient = clad::gradient(tensor_sum_dim_method_loss, "input");
+  gradient.execute(input, weights, &actual);
+
+  auto native_input = input.detach().clone().set_requires_grad(true);
+  auto native_loss = native_input.sum(/*dim=*/1).mul(weights).sum();
+  auto expected = torch::autograd::grad({native_loss}, {native_input})[0];
+  require_close(actual, expected,
+                "Tensor method sum(dim) gradient is incorrect");
+
+  const auto keepdim_weights =
+      at::linspace(0.5, 1.5, 3, options).reshape({1, 3, 1});
+  actual.zero_();
+  auto dims_gradient = clad::gradient(tensor_sum_dims_method_loss, "input");
+  dims_gradient.execute(input, keepdim_weights, &actual);
+
+  native_input = input.detach().clone().set_requires_grad(true);
+  native_loss =
+      native_input.sum({-3, -1}, /*keepdim=*/true).mul(keepdim_weights).sum();
+  expected = torch::autograd::grad({native_loss}, {native_input})[0];
+  require_close(actual, expected,
+                "Tensor method sum(dims, keepdim) gradient is incorrect");
+}
+
+void check_sum_dims_case(const at::Tensor& input, const at::Tensor& weights,
+                         at::OptionalIntArrayRef dims, bool keepdim) {
+  const auto original = input.clone();
+  auto actual = at::zeros_like(input);
+  auto gradient = clad::gradient(tensor_sum_dims_loss, "input");
+  gradient.execute(input, weights, dims, keepdim, &actual);
+
+  auto native_input = input.detach().clone().set_requires_grad(true);
+  auto native_loss =
+      at::mul(at::sum(native_input, dims, keepdim), weights).sum();
+  auto expected = torch::autograd::grad({native_loss}, {native_input})[0];
+  require_close(actual, expected, "Tensor sum(dim) gradient is incorrect");
+  require_close(input, original, "Tensor sum(dim) modified its input");
+}
+
+void check_sum_dims() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input = at::linspace(0.5, 12.0, 24, options).reshape({2, 3, 4});
+
+  const std::vector<int64_t> middle_dim{1};
+  check_sum_dims_case(input, at::linspace(0.5, 4.0, 8, options).reshape({2, 4}),
+                      middle_dim,
+                      /*keepdim=*/false);
+
+  const std::vector<int64_t> outer_dims{-1, -3};
+  check_sum_dims_case(input, at::linspace(0.5, 1.5, 3, options), outer_dims,
+                      /*keepdim=*/false);
+  check_sum_dims_case(
+      input, at::linspace(0.5, 1.5, 3, options).reshape({1, 3, 1}), outer_dims,
+      /*keepdim=*/true);
+
+  const std::vector<int64_t> all_dims;
+  check_sum_dims_case(input, at::scalar_tensor(2.0, options), all_dims,
+                      /*keepdim=*/false);
+  check_sum_dims_case(input, at::ones({1, 1, 1}, options), all_dims,
+                      /*keepdim=*/true);
+  check_sum_dims_case(input, at::scalar_tensor(3.0, options),
+                      at::OptionalIntArrayRef(), /*keepdim=*/false);
+
+  const auto scalar = at::scalar_tensor(2.0, options);
+  const std::vector<int64_t> scalar_dim{-1};
+  check_sum_dims_case(scalar, at::scalar_tensor(4.0, options), scalar_dim,
+                      /*keepdim=*/false);
+  check_sum_dims_case(scalar, at::scalar_tensor(5.0, options), scalar_dim,
+                      /*keepdim=*/true);
+
+  const auto empty = at::empty({2, 0, 3}, options);
+  check_sum_dims_case(empty, at::empty({0}, options), outer_dims,
+                      /*keepdim=*/false);
+  check_sum_dims_case(empty, at::ones({2, 3}, options), middle_dim,
+                      /*keepdim=*/false);
+}
+
+void check_sum_dim_contract() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input = at::ones({2, 3, 4}, options);
+  const auto weights = at::scalar_tensor(1.0, options);
+  auto gradient = clad::gradient(tensor_sum_dims_loss, "input");
+
+  require_c10_error(
+      [&] {
+        const std::vector<int64_t> dims{3};
+        auto actual = at::zeros_like(input);
+        gradient.execute(input, weights, dims, false, &actual);
+      },
+      "out-of-range sum dimension was not rejected");
+
+  require_c10_error(
+      [&] {
+        const std::vector<int64_t> dims{1, -2};
+        auto actual = at::zeros_like(input);
+        gradient.execute(input, weights, dims, false, &actual);
+      },
+      "duplicate sum dimensions were not rejected");
+}
+
+void check_default_method_parameters() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input =
+      at::linspace(-2.0, 3.0, 120, options).reshape({2, 3, 4, 5});
+  const auto bias = at::linspace(0.2, 1.0, 15, options).reshape({1, 3, 1, 5});
+  const auto offset = at::linspace(-0.5, 0.5, 8, options).reshape({2, 1, 4, 1});
+  const auto weights = at::linspace(0.5, 1.5, 15, options).reshape({1, 3, 5});
+  constexpr int64_t dim = -2;
+
+  auto input_gradient = at::zeros_like(input);
+  auto bias_gradient = at::zeros_like(bias);
+  auto offset_gradient = at::zeros_like(offset);
+  auto weights_gradient = at::zeros_like(weights);
+  auto gradient = clad::gradient(default_method_parameter_loss,
+                                 "input, bias, offset, weights");
+  gradient.execute(input, bias, offset, weights, dim, &input_gradient,
+                   &bias_gradient, &offset_gradient, &weights_gradient);
+
+  auto native_input = input.detach().clone().set_requires_grad(true);
+  auto native_bias = bias.detach().clone().set_requires_grad(true);
+  auto native_offset = offset.detach().clone().set_requires_grad(true);
+  auto native_weights = weights.detach().clone().set_requires_grad(true);
+  auto native_loss = native_input.add(native_bias)
+                         .sub(native_offset)
+                         .sum(dim)
+                         .mul(native_weights)
+                         .sum();
+  auto native_gradients =
+      torch::autograd::grad({native_loss}, {native_input, native_bias,
+                                            native_offset, native_weights});
+
+  require_close(input_gradient, native_gradients[0],
+                "default method input gradient is incorrect");
+  require_close(bias_gradient, native_gradients[1],
+                "default method bias gradient is incorrect");
+  require_close(offset_gradient, native_gradients[2],
+                "default method offset gradient is incorrect");
+  require_close(weights_gradient, native_gradients[3],
+                "default method weights gradient is incorrect");
+
+  require_c10_error(
+      [&] {
+        input_gradient.zero_();
+        bias_gradient.zero_();
+        offset_gradient.zero_();
+        weights_gradient.zero_();
+        gradient.execute(input, bias, offset, weights, /*dim=*/-5,
+                         &input_gradient, &bias_gradient, &offset_gradient,
+                         &weights_gradient);
+      },
+      "out-of-range scalar sum dimension was not rejected");
+}
+
+void check_default_function_parameters() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input = at::linspace(-1.5, 2.5, 24, options).reshape({2, 3, 4});
+  auto gradient =
+      clad::gradient(default_function_parameter_loss, "input, weights");
+
+  auto check = [&](const at::Tensor& weights, at::OptionalIntArrayRef dims) {
+    auto input_gradient = at::zeros_like(input);
+    auto weights_gradient = at::zeros_like(weights);
+    gradient.execute(input, weights, dims, &input_gradient, &weights_gradient);
+
+    auto native_input = input.detach().clone().set_requires_grad(true);
+    auto native_weights = weights.detach().clone().set_requires_grad(true);
+    auto native_loss =
+        at::mul(at::sum(native_input, dims), native_weights).sum();
+    auto native_gradients =
+        torch::autograd::grad({native_loss}, {native_input, native_weights});
+    require_close(input_gradient, native_gradients[0],
+                  "default function input gradient is incorrect");
+    require_close(weights_gradient, native_gradients[1],
+                  "default function weights gradient is incorrect");
+  };
+
+  const std::vector<int64_t> mixed_dims{-1, -3};
+  check(at::linspace(0.5, 1.5, 3, options), mixed_dims);
+
+  const std::vector<int64_t> empty_dims;
+  check(at::scalar_tensor(2.0, options), empty_dims);
+}
+
+void check_explicit_sum_options() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input = at::linspace(-1.0, 2.0, 24, options).reshape({2, 3, 4});
+  const std::vector<int64_t> dims{0, -1};
+  auto gradient = clad::gradient(explicit_sum_options_loss, "input, weights");
+
+  auto check = [&](const at::Tensor& weights, bool keepdim) {
+    auto input_gradient = at::zeros_like(input);
+    auto weights_gradient = at::zeros_like(weights);
+    gradient.execute(input, weights, dims, keepdim, &input_gradient,
+                     &weights_gradient);
+
+    auto native_input = input.detach().clone().set_requires_grad(true);
+    auto native_weights = weights.detach().clone().set_requires_grad(true);
+    auto native_loss = native_input.sum(dims, keepdim, at::kFloat)
+                           .mul(native_weights)
+                           .sum(at::ScalarType::Float);
+    auto native_gradients =
+        torch::autograd::grad({native_loss}, {native_input, native_weights});
+    require_close(input_gradient, native_gradients[0],
+                  "explicit sum options input gradient is incorrect");
+    require_close(weights_gradient, native_gradients[1],
+                  "explicit sum options weights gradient is incorrect");
+  };
+
+  check(at::linspace(0.5, 1.5, 3, options), /*keepdim=*/false);
+  check(at::linspace(0.5, 1.5, 3, options).reshape({1, 3, 1}),
+        /*keepdim=*/true);
+
+  require_c10_error(
+      [&] {
+        auto input_gradient = at::zeros_like(input);
+        auto dtype_gradient =
+            clad::gradient(unsupported_sum_dtype_loss, "input");
+        dtype_gradient.execute(input, &input_gradient);
+      },
+      "sum dtype conversion was not rejected");
+}
+
+template <typename Gradient, typename Operation>
+void check_binary_gradients(Gradient& gradient, Operation operation,
+                            const at::Tensor& lhs, const at::Tensor& rhs,
+                            const char* lhs_message, const char* rhs_message) {
+  const auto original_lhs = lhs.clone();
+  const auto original_rhs = rhs.clone();
+  auto lhs_gradient = at::zeros_like(lhs);
+  auto rhs_gradient = at::zeros_like(rhs);
+  gradient.execute(lhs, rhs, &lhs_gradient, &rhs_gradient);
+
+  auto native_lhs = lhs.detach().clone().set_requires_grad(true);
+  auto native_rhs = rhs.detach().clone().set_requires_grad(true);
+  auto native_loss = operation(native_lhs, native_rhs).sum();
+  auto native_gradients =
+      torch::autograd::grad({native_loss}, {native_lhs, native_rhs});
+
+  require_close(lhs_gradient, native_gradients[0], lhs_message);
+  require_close(rhs_gradient, native_gradients[1], rhs_message);
+  require_close(lhs, original_lhs, "broadcasting modified the lhs input");
+  require_close(rhs, original_rhs, "broadcasting modified the rhs input");
+}
+
+void check_broadcast_case(const at::Tensor& lhs, const at::Tensor& rhs) {
+  auto add_gradient = clad::gradient(broadcast_add_loss, "lhs, rhs");
+  check_binary_gradients(
+      add_gradient,
+      [](const at::Tensor& x, const at::Tensor& y) { return at::add(x, y); },
+      lhs, rhs, "broadcast add lhs gradient is incorrect",
+      "broadcast add rhs gradient is incorrect");
+
+  auto sub_gradient = clad::gradient(broadcast_sub_loss, "lhs, rhs");
+  check_binary_gradients(
+      sub_gradient,
+      [](const at::Tensor& x, const at::Tensor& y) { return at::sub(x, y); },
+      lhs, rhs, "broadcast sub lhs gradient is incorrect",
+      "broadcast sub rhs gradient is incorrect");
+
+  auto mul_gradient = clad::gradient(broadcast_mul_loss, "lhs, rhs");
+  check_binary_gradients(
+      mul_gradient,
+      [](const at::Tensor& x, const at::Tensor& y) { return at::mul(x, y); },
+      lhs, rhs, "broadcast mul lhs gradient is incorrect",
+      "broadcast mul rhs gradient is incorrect");
+
+  auto div_gradient = clad::gradient(broadcast_div_loss, "lhs, rhs");
+  check_binary_gradients(
+      div_gradient,
+      [](const at::Tensor& x, const at::Tensor& y) { return at::div(x, y); },
+      lhs, rhs, "broadcast div lhs gradient is incorrect",
+      "broadcast div rhs gradient is incorrect");
+}
+
+void check_broadcasting() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+
+  const auto matrix_lhs = at::linspace(0.5, 3.0, 6, options).reshape({2, 3});
+  const auto matrix_rhs = at::linspace(1.0, 2.0, 6, options).reshape({2, 3});
+  check_broadcast_case(matrix_lhs, matrix_rhs);
+
+  const auto lhs = at::linspace(0.5, 2.0, 8, options).reshape({2, 1, 4});
+  const auto rhs = at::linspace(1.0, 3.0, 3, options).reshape({1, 3, 1});
+  check_broadcast_case(lhs, rhs);
+  check_broadcast_case(rhs, lhs);
+
+  const auto scalar = at::scalar_tensor(1.5, options);
+  check_broadcast_case(lhs, scalar);
+  check_broadcast_case(scalar, lhs);
+
+  const auto empty = at::empty({2, 0, 3}, options);
+  const auto row = at::ones({1, 3}, options);
+  check_broadcast_case(empty, row);
+  check_broadcast_case(row, empty);
+}
+
+void check_partial_broadcast_gradients() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto lhs = at::linspace(0.5, 2.0, 8, options).reshape({2, 1, 4});
+  const auto rhs = at::linspace(1.0, 3.0, 3, options).reshape({1, 3, 1});
+  const auto original_lhs = lhs.clone();
+  const auto original_rhs = rhs.clone();
+
+  auto native_lhs = lhs.detach().clone().set_requires_grad(true);
+  auto native_rhs = rhs.detach().clone().set_requires_grad(true);
+  auto native_loss = at::mul(native_lhs, native_rhs).sum();
+  auto native_gradients =
+      torch::autograd::grad({native_loss}, {native_lhs, native_rhs});
+
+  auto lhs_gradient = at::zeros_like(lhs);
+  auto lhs_only = clad::gradient(broadcast_mul_loss, "lhs");
+  lhs_only.execute(lhs, rhs, &lhs_gradient);
+  require_close(lhs_gradient, native_gradients[0],
+                "partial broadcast lhs gradient is incorrect");
+
+  auto rhs_gradient = at::zeros_like(rhs);
+  auto rhs_only = clad::gradient(broadcast_mul_loss, "rhs");
+  rhs_only.execute(lhs, rhs, &rhs_gradient);
+  require_close(rhs_gradient, native_gradients[1],
+                "partial broadcast rhs gradient is incorrect");
+  require_close(lhs, original_lhs,
+                "partial broadcasting modified the lhs input");
+  require_close(rhs, original_rhs,
+                "partial broadcasting modified the rhs input");
+}
+
 void check_input_contract() {
   require_c10_error(
       [] {
@@ -267,13 +731,13 @@ void check_input_contract() {
   require_c10_error(
       [] {
         const auto input = torch::ones({4}, torch::kFloat);
-        const auto bias = torch::ones({1}, torch::kFloat);
+        const auto bias = torch::ones({2, 3}, torch::kFloat);
         auto input_gradient = torch::zeros_like(input);
         auto bias_gradient = torch::zeros_like(bias);
         auto clad_gradient = clad::gradient(torch_loss, "input, bias");
         clad_gradient.execute(input, bias, &input_gradient, &bias_gradient);
       },
-      "broadcasting input was not rejected");
+      "incompatible shapes were not rejected");
 
   require_c10_error(
       [] {
@@ -289,16 +753,26 @@ void check_input_contract() {
 } // namespace
 
 int main() {
-  static_assert(std::is_same_v<torch::Tensor, at::Tensor>);
   torch::set_num_threads(1);
   torch::set_num_interop_threads(1);
   check_torch_alias_composition();
   check_at_namespace_composition();
   check_direct_return_composition();
+  check_native_relu_vjp();
+  check_partial_vjp_inputs();
   check_namespace_alias_composition();
   check_operator_composition();
   check_method_composition();
   check_partial_gradients_do_not_alias_inputs();
+  check_sum_shape_support();
+  check_sum_dim_method();
+  check_sum_dims();
+  check_sum_dim_contract();
+  check_default_method_parameters();
+  check_default_function_parameters();
+  check_explicit_sum_options();
+  check_broadcasting();
+  check_partial_broadcast_gradients();
   check_input_contract();
   std::cout << "Clad Torch operator checks passed\n";
   return 0;

--- a/benchmark/LibTorch/TorchOpsTest.cpp
+++ b/benchmark/LibTorch/TorchOpsTest.cpp
@@ -1,0 +1,199 @@
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/TorchBuiltins.h" // IWYU pragma: keep
+
+#include <torch/torch.h> // IWYU pragma: keep
+
+#include <iostream>
+#include <stdexcept>
+#include <type_traits>
+
+namespace {
+
+namespace torch_api = torch;
+
+void require_close(const at::Tensor& actual, const at::Tensor& expected,
+                   const char* message) {
+  if (!at::allclose(actual, expected, 1.0e-5, 1.0e-6)) {
+    std::cerr << message << "\nactual: " << actual << "\nexpected: " << expected
+              << '\n';
+    throw std::runtime_error(message);
+  }
+}
+
+template <typename Callback>
+void require_c10_error(Callback callback, const char* message) {
+  try {
+    callback();
+  } catch (const c10::Error&) {
+    return;
+  }
+  throw std::runtime_error(message);
+}
+
+torch::Tensor torch_utility(const torch::Tensor& input,
+                            const torch::Tensor& bias) {
+  auto squared = torch::mul(input, input);
+  auto shifted = torch::add(squared, bias);
+  auto activated = torch::relu(shifted);
+  return activated;
+}
+
+float torch_loss(const torch::Tensor& input, const torch::Tensor& bias) {
+  auto output = torch_utility(input, bias);
+  auto residual = torch::sub(output, bias);
+  auto scalar = torch::dot(residual, input);
+  return scalar.item<float>();
+}
+
+at::Tensor at_utility(const at::Tensor& input) {
+  // Exercise at::Tensor's shallow copy constructor. Its adjoint must still use
+  // independent storage so reverse accumulation cannot alias the input buffer.
+  at::Tensor copied(input);
+  auto doubled = at::add(copied, input);
+  auto activated = at::relu(doubled);
+  return activated;
+}
+
+float at_loss(const at::Tensor& input) {
+  auto output = at_utility(input);
+  auto scalar = at::dot(output, input);
+  return scalar.item<float>();
+}
+
+torch::Tensor direct_utility(const torch::Tensor& input) {
+  return torch::relu(input);
+}
+
+float direct_loss(const torch::Tensor& input) {
+  auto output = direct_utility(input);
+  auto scalar = torch::dot(output, input);
+  return scalar.item<float>();
+}
+
+torch_api::Tensor namespace_alias_utility(const torch_api::Tensor& input) {
+  auto squared = torch_api::mul(input, input);
+  return squared;
+}
+
+float namespace_alias_loss(const torch_api::Tensor& input) {
+  auto output = namespace_alias_utility(input);
+  auto scalar = torch_api::dot(output, input);
+  return scalar.item<float>();
+}
+
+void check_torch_alias_composition() {
+  const auto options = torch::TensorOptions().dtype(torch::kFloat32);
+  const auto input = torch::linspace(-2.0, 2.0, 17, options);
+  const auto bias = torch::linspace(0.5, -0.5, 17, options);
+  auto input_gradient = torch::zeros_like(input);
+  auto bias_gradient = torch::zeros_like(bias);
+
+  auto clad_gradient = clad::gradient(torch_loss, "input, bias");
+  clad_gradient.execute(input, bias, &input_gradient, &bias_gradient);
+
+  auto native_input = input.detach().clone().set_requires_grad(true);
+  auto native_bias = bias.detach().clone().set_requires_grad(true);
+  auto native_output = torch_utility(native_input, native_bias);
+  auto native_loss =
+      torch::dot(torch::sub(native_output, native_bias), native_input);
+  auto native_gradients =
+      torch::autograd::grad({native_loss}, {native_input, native_bias});
+
+  require_close(input_gradient, native_gradients[0],
+                "torch::Tensor input gradient is incorrect");
+  require_close(bias_gradient, native_gradients[1],
+                "torch::Tensor bias gradient is incorrect");
+}
+
+void check_at_namespace_composition() {
+  const auto input =
+      at::linspace(-2.0, 2.0, 17, at::TensorOptions().dtype(at::kFloat));
+  auto gradient = at::zeros_like(input);
+  auto clad_gradient = clad::gradient(at_loss, "input");
+  clad_gradient.execute(input, &gradient);
+
+  auto native_input = input.detach().clone().set_requires_grad(true);
+  auto native_loss = at::dot(at_utility(native_input), native_input);
+  auto native_gradient =
+      torch::autograd::grad({native_loss}, {native_input})[0];
+  require_close(gradient, native_gradient,
+                "at::Tensor composition gradient is incorrect");
+}
+
+void check_direct_return_composition() {
+  const auto input = torch::linspace(
+      -2.0, 2.0, 17, torch::TensorOptions().dtype(torch::kFloat32));
+  auto gradient = torch::zeros_like(input);
+  auto clad_gradient = clad::gradient(direct_loss, "input");
+  clad_gradient.execute(input, &gradient);
+
+  auto native_input = input.detach().clone().set_requires_grad(true);
+  auto native_loss = torch::dot(direct_utility(native_input), native_input);
+  auto native_gradient =
+      torch::autograd::grad({native_loss}, {native_input})[0];
+  require_close(gradient, native_gradient,
+                "direct Tensor return gradient is incorrect");
+}
+
+void check_namespace_alias_composition() {
+  const auto input = torch_api::linspace(
+      -2.0, 2.0, 17, torch_api::TensorOptions().dtype(torch_api::kFloat32));
+  auto gradient = torch_api::zeros_like(input);
+  auto clad_gradient = clad::gradient(namespace_alias_loss, "input");
+  clad_gradient.execute(input, &gradient);
+
+  auto native_input = input.detach().clone().set_requires_grad(true);
+  auto native_loss =
+      torch_api::dot(namespace_alias_utility(native_input), native_input);
+  auto native_gradient =
+      torch::autograd::grad({native_loss}, {native_input})[0];
+  require_close(gradient, native_gradient,
+                "namespace-aliased Torch gradient is incorrect");
+}
+
+void check_input_contract() {
+  require_c10_error(
+      [] {
+        const auto input = at::ones({4}, at::kDouble);
+        auto gradient = at::zeros_like(input);
+        auto clad_gradient = clad::gradient(at_loss, "input");
+        clad_gradient.execute(input, &gradient);
+      },
+      "float64 input was not rejected");
+
+  require_c10_error(
+      [] {
+        const auto input = torch::ones({4}, torch::kFloat);
+        const auto bias = torch::ones({1}, torch::kFloat);
+        auto input_gradient = torch::zeros_like(input);
+        auto bias_gradient = torch::zeros_like(bias);
+        auto clad_gradient = clad::gradient(torch_loss, "input, bias");
+        clad_gradient.execute(input, bias, &input_gradient, &bias_gradient);
+      },
+      "broadcasting input was not rejected");
+
+  require_c10_error(
+      [] {
+        const auto input =
+            torch::ones({4, 2}, torch::kFloat).select(/*dim=*/1, /*index=*/0);
+        auto gradient = torch::zeros_like(input);
+        auto clad_gradient = clad::gradient(at_loss, "input");
+        clad_gradient.execute(input, &gradient);
+      },
+      "noncontiguous input was not rejected");
+}
+
+} // namespace
+
+int main() {
+  static_assert(std::is_same_v<torch::Tensor, at::Tensor>);
+  torch::set_num_threads(1);
+  torch::set_num_interop_threads(1);
+  check_torch_alias_composition();
+  check_at_namespace_composition();
+  check_direct_return_composition();
+  check_namespace_alias_composition();
+  check_input_contract();
+  std::cout << "Clad Torch operator checks passed\n";
+  return 0;
+}

--- a/benchmark/LibTorch/TorchOpsTest.cpp
+++ b/benchmark/LibTorch/TorchOpsTest.cpp
@@ -81,6 +81,35 @@ float namespace_alias_loss(const torch_api::Tensor& input) {
   return scalar.item<float>();
 }
 
+torch::Tensor operator_utility(const torch::Tensor& lhs,
+                               const torch::Tensor& rhs) {
+  auto added = lhs + rhs;
+  auto subtracted = lhs - rhs;
+  auto multiplied = added * subtracted;
+  return multiplied / rhs;
+}
+
+float operator_loss(const torch::Tensor& lhs, const torch::Tensor& rhs) {
+  auto output = operator_utility(lhs, rhs);
+  auto scalar = torch::dot(output, lhs);
+  return scalar.item<float>();
+}
+
+torch::Tensor method_utility(const torch::Tensor& lhs,
+                             const torch::Tensor& rhs) {
+  auto added = lhs.add(rhs, /*alpha=*/0.5);
+  auto subtracted = lhs.sub(rhs, /*alpha=*/0.25);
+  auto multiplied = added.mul(subtracted);
+  auto divided = multiplied.div(rhs);
+  return divided.relu();
+}
+
+float method_loss(const torch::Tensor& lhs, const torch::Tensor& rhs) {
+  auto output = method_utility(lhs, rhs);
+  auto scalar = output.dot(lhs);
+  return scalar.item<float>();
+}
+
 void check_torch_alias_composition() {
   const auto options = torch::TensorOptions().dtype(torch::kFloat32);
   const auto input = torch::linspace(-2.0, 2.0, 17, options);
@@ -151,6 +180,47 @@ void check_namespace_alias_composition() {
                 "namespace-aliased Torch gradient is incorrect");
 }
 
+void check_operator_composition() {
+  const auto options = torch::TensorOptions().dtype(torch::kFloat32);
+  const auto lhs = torch::linspace(0.5, 2.0, 17, options);
+  const auto rhs = torch::linspace(1.0, 3.0, 17, options);
+  auto lhs_gradient = torch::zeros_like(lhs);
+  auto rhs_gradient = torch::zeros_like(rhs);
+  auto clad_gradient = clad::gradient(operator_loss, "lhs, rhs");
+  clad_gradient.execute(lhs, rhs, &lhs_gradient, &rhs_gradient);
+
+  auto native_lhs = lhs.detach().clone().set_requires_grad(true);
+  auto native_rhs = rhs.detach().clone().set_requires_grad(true);
+  auto native_loss =
+      torch::dot(operator_utility(native_lhs, native_rhs), native_lhs);
+  auto native_gradients =
+      torch::autograd::grad({native_loss}, {native_lhs, native_rhs});
+  require_close(lhs_gradient, native_gradients[0],
+                "Tensor operator lhs gradient is incorrect");
+  require_close(rhs_gradient, native_gradients[1],
+                "Tensor operator rhs gradient is incorrect");
+}
+
+void check_method_composition() {
+  const auto options = torch::TensorOptions().dtype(torch::kFloat32);
+  const auto lhs = torch::linspace(0.5, 2.0, 17, options);
+  const auto rhs = torch::linspace(1.0, 3.0, 17, options);
+  auto lhs_gradient = torch::zeros_like(lhs);
+  auto rhs_gradient = torch::zeros_like(rhs);
+  auto clad_gradient = clad::gradient(method_loss, "lhs, rhs");
+  clad_gradient.execute(lhs, rhs, &lhs_gradient, &rhs_gradient);
+
+  auto native_lhs = lhs.detach().clone().set_requires_grad(true);
+  auto native_rhs = rhs.detach().clone().set_requires_grad(true);
+  auto native_loss = method_utility(native_lhs, native_rhs).dot(native_lhs);
+  auto native_gradients =
+      torch::autograd::grad({native_loss}, {native_lhs, native_rhs});
+  require_close(lhs_gradient, native_gradients[0],
+                "Tensor method lhs gradient is incorrect");
+  require_close(rhs_gradient, native_gradients[1],
+                "Tensor method rhs gradient is incorrect");
+}
+
 void check_input_contract() {
   require_c10_error(
       [] {
@@ -193,6 +263,8 @@ int main() {
   check_at_namespace_composition();
   check_direct_return_composition();
   check_namespace_alias_composition();
+  check_operator_composition();
+  check_method_composition();
   check_input_contract();
   std::cout << "Clad Torch operator checks passed\n";
   return 0;

--- a/benchmark/LibTorch/TorchOpsTest.cpp
+++ b/benchmark/LibTorch/TorchOpsTest.cpp
@@ -1,0 +1,271 @@
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/TorchBuiltins.h" // IWYU pragma: keep
+
+#include <torch/torch.h> // IWYU pragma: keep
+
+#include <iostream>
+#include <stdexcept>
+#include <type_traits>
+
+namespace {
+
+namespace torch_api = torch;
+
+void require_close(const at::Tensor& actual, const at::Tensor& expected,
+                   const char* message) {
+  if (!at::allclose(actual, expected, 1.0e-5, 1.0e-6)) {
+    std::cerr << message << "\nactual: " << actual << "\nexpected: " << expected
+              << '\n';
+    throw std::runtime_error(message);
+  }
+}
+
+template <typename Callback>
+void require_c10_error(Callback callback, const char* message) {
+  try {
+    callback();
+  } catch (const c10::Error&) {
+    return;
+  }
+  throw std::runtime_error(message);
+}
+
+torch::Tensor torch_utility(const torch::Tensor& input,
+                            const torch::Tensor& bias) {
+  auto squared = torch::mul(input, input);
+  auto shifted = torch::add(squared, bias);
+  auto activated = torch::relu(shifted);
+  return activated;
+}
+
+float torch_loss(const torch::Tensor& input, const torch::Tensor& bias) {
+  auto output = torch_utility(input, bias);
+  auto residual = torch::sub(output, bias);
+  auto scalar = torch::dot(residual, input);
+  return scalar.item<float>();
+}
+
+at::Tensor at_utility(const at::Tensor& input) {
+  // Exercise at::Tensor's shallow copy constructor. Its adjoint must still use
+  // independent storage so reverse accumulation cannot alias the input buffer.
+  at::Tensor copied(input);
+  auto doubled = at::add(copied, input);
+  auto activated = at::relu(doubled);
+  return activated;
+}
+
+float at_loss(const at::Tensor& input) {
+  auto output = at_utility(input);
+  auto scalar = at::dot(output, input);
+  return scalar.item<float>();
+}
+
+torch::Tensor direct_utility(const torch::Tensor& input) {
+  return torch::relu(input);
+}
+
+float direct_loss(const torch::Tensor& input) {
+  auto output = direct_utility(input);
+  auto scalar = torch::dot(output, input);
+  return scalar.item<float>();
+}
+
+torch_api::Tensor namespace_alias_utility(const torch_api::Tensor& input) {
+  auto squared = torch_api::mul(input, input);
+  return squared;
+}
+
+float namespace_alias_loss(const torch_api::Tensor& input) {
+  auto output = namespace_alias_utility(input);
+  auto scalar = torch_api::dot(output, input);
+  return scalar.item<float>();
+}
+
+torch::Tensor operator_utility(const torch::Tensor& lhs,
+                               const torch::Tensor& rhs) {
+  auto added = lhs + rhs;
+  auto subtracted = lhs - rhs;
+  auto multiplied = added * subtracted;
+  return multiplied / rhs;
+}
+
+float operator_loss(const torch::Tensor& lhs, const torch::Tensor& rhs) {
+  auto output = operator_utility(lhs, rhs);
+  auto scalar = torch::dot(output, lhs);
+  return scalar.item<float>();
+}
+
+torch::Tensor method_utility(const torch::Tensor& lhs,
+                             const torch::Tensor& rhs) {
+  auto added = lhs.add(rhs, /*alpha=*/0.5);
+  auto subtracted = lhs.sub(rhs, /*alpha=*/0.25);
+  auto multiplied = added.mul(subtracted);
+  auto divided = multiplied.div(rhs);
+  return divided.relu();
+}
+
+float method_loss(const torch::Tensor& lhs, const torch::Tensor& rhs) {
+  auto output = method_utility(lhs, rhs);
+  auto scalar = output.dot(lhs);
+  return scalar.item<float>();
+}
+
+void check_torch_alias_composition() {
+  const auto options = torch::TensorOptions().dtype(torch::kFloat32);
+  const auto input = torch::linspace(-2.0, 2.0, 17, options);
+  const auto bias = torch::linspace(0.5, -0.5, 17, options);
+  auto input_gradient = torch::zeros_like(input);
+  auto bias_gradient = torch::zeros_like(bias);
+
+  auto clad_gradient = clad::gradient(torch_loss, "input, bias");
+  clad_gradient.execute(input, bias, &input_gradient, &bias_gradient);
+
+  auto native_input = input.detach().clone().set_requires_grad(true);
+  auto native_bias = bias.detach().clone().set_requires_grad(true);
+  auto native_output = torch_utility(native_input, native_bias);
+  auto native_loss =
+      torch::dot(torch::sub(native_output, native_bias), native_input);
+  auto native_gradients =
+      torch::autograd::grad({native_loss}, {native_input, native_bias});
+
+  require_close(input_gradient, native_gradients[0],
+                "torch::Tensor input gradient is incorrect");
+  require_close(bias_gradient, native_gradients[1],
+                "torch::Tensor bias gradient is incorrect");
+}
+
+void check_at_namespace_composition() {
+  const auto input =
+      at::linspace(-2.0, 2.0, 17, at::TensorOptions().dtype(at::kFloat));
+  auto gradient = at::zeros_like(input);
+  auto clad_gradient = clad::gradient(at_loss, "input");
+  clad_gradient.execute(input, &gradient);
+
+  auto native_input = input.detach().clone().set_requires_grad(true);
+  auto native_loss = at::dot(at_utility(native_input), native_input);
+  auto native_gradient =
+      torch::autograd::grad({native_loss}, {native_input})[0];
+  require_close(gradient, native_gradient,
+                "at::Tensor composition gradient is incorrect");
+}
+
+void check_direct_return_composition() {
+  const auto input = torch::linspace(
+      -2.0, 2.0, 17, torch::TensorOptions().dtype(torch::kFloat32));
+  auto gradient = torch::zeros_like(input);
+  auto clad_gradient = clad::gradient(direct_loss, "input");
+  clad_gradient.execute(input, &gradient);
+
+  auto native_input = input.detach().clone().set_requires_grad(true);
+  auto native_loss = torch::dot(direct_utility(native_input), native_input);
+  auto native_gradient =
+      torch::autograd::grad({native_loss}, {native_input})[0];
+  require_close(gradient, native_gradient,
+                "direct Tensor return gradient is incorrect");
+}
+
+void check_namespace_alias_composition() {
+  const auto input = torch_api::linspace(
+      -2.0, 2.0, 17, torch_api::TensorOptions().dtype(torch_api::kFloat32));
+  auto gradient = torch_api::zeros_like(input);
+  auto clad_gradient = clad::gradient(namespace_alias_loss, "input");
+  clad_gradient.execute(input, &gradient);
+
+  auto native_input = input.detach().clone().set_requires_grad(true);
+  auto native_loss =
+      torch_api::dot(namespace_alias_utility(native_input), native_input);
+  auto native_gradient =
+      torch::autograd::grad({native_loss}, {native_input})[0];
+  require_close(gradient, native_gradient,
+                "namespace-aliased Torch gradient is incorrect");
+}
+
+void check_operator_composition() {
+  const auto options = torch::TensorOptions().dtype(torch::kFloat32);
+  const auto lhs = torch::linspace(0.5, 2.0, 17, options);
+  const auto rhs = torch::linspace(1.0, 3.0, 17, options);
+  auto lhs_gradient = torch::zeros_like(lhs);
+  auto rhs_gradient = torch::zeros_like(rhs);
+  auto clad_gradient = clad::gradient(operator_loss, "lhs, rhs");
+  clad_gradient.execute(lhs, rhs, &lhs_gradient, &rhs_gradient);
+
+  auto native_lhs = lhs.detach().clone().set_requires_grad(true);
+  auto native_rhs = rhs.detach().clone().set_requires_grad(true);
+  auto native_loss =
+      torch::dot(operator_utility(native_lhs, native_rhs), native_lhs);
+  auto native_gradients =
+      torch::autograd::grad({native_loss}, {native_lhs, native_rhs});
+  require_close(lhs_gradient, native_gradients[0],
+                "Tensor operator lhs gradient is incorrect");
+  require_close(rhs_gradient, native_gradients[1],
+                "Tensor operator rhs gradient is incorrect");
+}
+
+void check_method_composition() {
+  const auto options = torch::TensorOptions().dtype(torch::kFloat32);
+  const auto lhs = torch::linspace(0.5, 2.0, 17, options);
+  const auto rhs = torch::linspace(1.0, 3.0, 17, options);
+  auto lhs_gradient = torch::zeros_like(lhs);
+  auto rhs_gradient = torch::zeros_like(rhs);
+  auto clad_gradient = clad::gradient(method_loss, "lhs, rhs");
+  clad_gradient.execute(lhs, rhs, &lhs_gradient, &rhs_gradient);
+
+  auto native_lhs = lhs.detach().clone().set_requires_grad(true);
+  auto native_rhs = rhs.detach().clone().set_requires_grad(true);
+  auto native_loss = method_utility(native_lhs, native_rhs).dot(native_lhs);
+  auto native_gradients =
+      torch::autograd::grad({native_loss}, {native_lhs, native_rhs});
+  require_close(lhs_gradient, native_gradients[0],
+                "Tensor method lhs gradient is incorrect");
+  require_close(rhs_gradient, native_gradients[1],
+                "Tensor method rhs gradient is incorrect");
+}
+
+void check_input_contract() {
+  require_c10_error(
+      [] {
+        const auto input = at::ones({4}, at::kDouble);
+        auto gradient = at::zeros_like(input);
+        auto clad_gradient = clad::gradient(at_loss, "input");
+        clad_gradient.execute(input, &gradient);
+      },
+      "float64 input was not rejected");
+
+  require_c10_error(
+      [] {
+        const auto input = torch::ones({4}, torch::kFloat);
+        const auto bias = torch::ones({1}, torch::kFloat);
+        auto input_gradient = torch::zeros_like(input);
+        auto bias_gradient = torch::zeros_like(bias);
+        auto clad_gradient = clad::gradient(torch_loss, "input, bias");
+        clad_gradient.execute(input, bias, &input_gradient, &bias_gradient);
+      },
+      "broadcasting input was not rejected");
+
+  require_c10_error(
+      [] {
+        const auto input =
+            torch::ones({4, 2}, torch::kFloat).select(/*dim=*/1, /*index=*/0);
+        auto gradient = torch::zeros_like(input);
+        auto clad_gradient = clad::gradient(at_loss, "input");
+        clad_gradient.execute(input, &gradient);
+      },
+      "noncontiguous input was not rejected");
+}
+
+} // namespace
+
+int main() {
+  static_assert(std::is_same_v<torch::Tensor, at::Tensor>);
+  torch::set_num_threads(1);
+  torch::set_num_interop_threads(1);
+  check_torch_alias_composition();
+  check_at_namespace_composition();
+  check_direct_return_composition();
+  check_namespace_alias_composition();
+  check_operator_composition();
+  check_method_composition();
+  check_input_contract();
+  std::cout << "Clad Torch operator checks passed\n";
+  return 0;
+}

--- a/benchmark/LibTorch/TorchOpsTest.cpp
+++ b/benchmark/LibTorch/TorchOpsTest.cpp
@@ -5,11 +5,17 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace {
 
 namespace torch_api = torch;
+
+void require_true(bool condition, const char* message) {
+  if (!condition)
+    throw std::runtime_error(message);
+}
 
 void require_close(const at::Tensor& actual, const at::Tensor& expected,
                    const char* message) {
@@ -254,7 +260,210 @@ void check_direct_return_composition() {
                 "direct Tensor return gradient is incorrect");
 }
 
-void check_native_relu_vjp() {
+void check_tensor_adjoint_lifecycle() {
+  const auto input =
+      at::linspace(-2.0, 2.0, 17, at::TensorOptions().dtype(at::kFloat));
+
+  auto lazy_adjoint = clad::zero_like(input);
+  require_true(!lazy_adjoint.defined(),
+               "Tensor zero_like did not create a lazy zero adjoint");
+
+  const at::Tensor d_input;
+  auto copied =
+      clad::custom_derivatives::class_functions::constructor_reverse_forw(
+          clad::Tag<at::Tensor>{}, input, d_input);
+  require_true(copied.adjoint.defined(),
+               "Tensor copy adjoint storage was not materialized");
+  require_true(copied.adjoint.sizes() == input.sizes(),
+               "Tensor copy adjoint has the wrong shape");
+  require_close(copied.adjoint, at::zeros_like(input),
+                "Tensor copy adjoint is not zero");
+  require_true(!copied.adjoint.is_alias_of(input),
+               "Tensor copy adjoint aliases the primal input");
+}
+
+void check_lazy_accumulation() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  auto seed = at::scalar_tensor(2.0, options);
+  auto expanded = seed.expand({2, 3});
+  at::Tensor borrowed_destination;
+
+  clad::torch::detail::accumulate(&borrowed_destination, expanded);
+  require_true(borrowed_destination.defined(),
+               "borrowed contribution did not materialize its destination");
+  require_close(borrowed_destination, at::full({2, 3}, 2.0, options),
+                "borrowed contribution was accumulated incorrectly");
+  require_true(!borrowed_destination.is_alias_of(seed),
+               "borrowed contribution aliases its upstream adjoint");
+  borrowed_destination.add_(1.0);
+  require_close(seed, at::scalar_tensor(2.0, options),
+                "mutating a materialized adjoint changed its source view");
+
+  at::Tensor temporary_view_destination;
+  clad::torch::detail::accumulate(&temporary_view_destination,
+                                  seed.expand({2, 3}));
+  require_true(temporary_view_destination.is_contiguous(),
+               "temporary view contribution was not materialized");
+  require_true(!temporary_view_destination.is_alias_of(seed),
+               "temporary view contribution aliases its upstream adjoint");
+  temporary_view_destination.add_(1.0);
+  require_close(seed, at::scalar_tensor(2.0, options),
+                "mutating a temporary view contribution changed its source");
+
+  auto shared_contribution = at::linspace(1.0, 4.0, 4, options);
+  auto shared_alias = shared_contribution;
+  at::Tensor shared_destination;
+  clad::torch::detail::accumulate(&shared_destination,
+                                  ::std::move(shared_contribution));
+  require_true(!shared_destination.is_alias_of(shared_alias),
+               "shared Tensor handle was reused as an adjoint");
+
+  auto detached_source = at::linspace(1.0, 4.0, 4, options);
+  auto detached_contribution = detached_source.detach();
+  at::Tensor detached_destination;
+  clad::torch::detail::accumulate(&detached_destination,
+                                  ::std::move(detached_contribution));
+  require_true(!detached_destination.is_alias_of(detached_source),
+               "shared Tensor storage was reused as an adjoint");
+
+  auto owned_contribution = at::linspace(1.0, 4.0, 4, options);
+  const auto* owned_storage = owned_contribution.data_ptr<float>();
+  at::Tensor owned_destination;
+  clad::torch::detail::accumulate(&owned_destination,
+                                  ::std::move(owned_contribution));
+  require_true(owned_destination.data_ptr<float>() == owned_storage,
+               "unique Tensor contribution storage was not reused");
+
+  auto accumulated = at::full({4}, 3.0, options);
+  clad::torch::detail::accumulate(&accumulated, at::ones({4}, options));
+  require_close(accumulated, at::full({4}, 4.0, options),
+                "defined destination accumulation is incorrect");
+}
+
+void check_undefined_output_adjoint() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto lhs = at::linspace(1.0, 4.0, 4, options);
+  const auto rhs = at::linspace(2.0, 5.0, 4, options);
+  const at::Tensor d_output;
+  auto d_lhs = at::full_like(lhs, 3.0);
+  auto d_rhs = at::full_like(rhs, 4.0);
+  const auto expected_lhs = d_lhs.clone();
+  const auto expected_rhs = d_rhs.clone();
+  at::Scalar d_alpha = 0;
+
+  clad::custom_derivatives::at::add_pullback(lhs, rhs, /*alpha=*/1, d_output,
+                                             &d_lhs, &d_rhs, &d_alpha);
+  clad::custom_derivatives::at::sub_pullback(lhs, rhs, /*alpha=*/1, d_output,
+                                             &d_lhs, &d_rhs, &d_alpha);
+  clad::custom_derivatives::at::mul_pullback(lhs, rhs, d_output, &d_lhs,
+                                             &d_rhs);
+  clad::custom_derivatives::at::div_pullback(lhs, rhs, d_output, &d_lhs,
+                                             &d_rhs);
+  clad::custom_derivatives::at::relu_pullback(lhs, d_output, &d_lhs);
+  clad::custom_derivatives::at::dot_pullback(lhs, rhs, d_output, &d_lhs,
+                                             &d_rhs);
+
+  ::std::optional<at::ScalarType> dtype;
+  ::std::optional<at::ScalarType> d_dtype;
+  clad::custom_derivatives::at::sum_pullback(lhs, dtype, d_output, &d_lhs,
+                                             &d_dtype);
+
+  const ::std::vector<int64_t> dims{0};
+  at::OptionalIntArrayRef d_dims;
+  bool d_keepdim = false;
+  clad::custom_derivatives::at::sum_pullback(lhs, dims, /*keepdim=*/false,
+                                             dtype, d_output, &d_lhs, &d_dims,
+                                             &d_keepdim, &d_dtype);
+
+  require_close(d_lhs, expected_lhs,
+                "undefined output adjoint changed the lhs destination");
+  require_close(d_rhs, expected_rhs,
+                "undefined output adjoint changed the rhs destination");
+}
+
+void check_shared_pullback_destination() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto lhs = at::linspace(1.0, 4.0, 4, options);
+  const auto rhs = at::linspace(2.0, 5.0, 4, options);
+  const auto d_output = at::linspace(0.5, 2.0, 4, options);
+  const auto initial = at::full({4}, 0.25, options);
+  at::Scalar d_alpha = 0;
+
+  auto actual = initial.clone();
+  clad::custom_derivatives::at::add_pullback(lhs, rhs, /*alpha=*/2, d_output,
+                                             &actual, &actual, &d_alpha);
+  require_close(actual, initial + 3 * d_output,
+                "shared add destination was accumulated incorrectly");
+
+  actual = initial.clone();
+  clad::custom_derivatives::at::sub_pullback(lhs, rhs, /*alpha=*/2, d_output,
+                                             &actual, &actual, &d_alpha);
+  require_close(actual, initial - d_output,
+                "shared sub destination was accumulated incorrectly");
+
+  actual = initial.clone();
+  clad::custom_derivatives::at::mul_pullback(lhs, rhs, d_output, &actual,
+                                             &actual);
+  require_close(actual, initial + d_output * (lhs + rhs),
+                "shared mul destination was accumulated incorrectly");
+
+  actual = initial.clone();
+  clad::custom_derivatives::at::div_pullback(lhs, rhs, d_output, &actual,
+                                             &actual);
+  require_close(actual, initial + d_output / rhs - d_output * lhs / (rhs * rhs),
+                "shared div destination was accumulated incorrectly");
+
+  const auto d_dot = at::scalar_tensor(1.5, options);
+  actual = initial.clone();
+  clad::custom_derivatives::at::dot_pullback(lhs, rhs, d_dot, &actual, &actual);
+  require_close(actual, initial + 1.5 * (lhs + rhs),
+                "shared dot destination was accumulated incorrectly");
+
+  at::Tensor lazy_actual;
+  clad::custom_derivatives::at::dot_pullback(lhs, lhs, d_dot, &lazy_actual,
+                                             &lazy_actual);
+  require_close(lazy_actual, 3 * lhs,
+                "shared dot destination was not materialized correctly");
+}
+
+void check_lazy_generated_gradient() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input = at::linspace(0.5, 6.0, 6, options).reshape({2, 3});
+  const auto original = input.clone();
+  at::Tensor actual;
+
+  auto gradient = clad::gradient(tensor_sum_loss, "input");
+  gradient.execute(input, &actual);
+
+  require_true(actual.defined(),
+               "generated gradient did not materialize its output");
+  require_true(actual.is_contiguous(),
+               "generated gradient did not materialize an expanded view");
+  require_true(!actual.is_alias_of(input),
+               "generated gradient aliases its primal input");
+  require_close(actual, at::ones_like(input),
+                "lazy generated Tensor gradient is incorrect");
+  actual.add_(1.0);
+  require_close(input, original,
+                "mutating a lazy generated gradient changed its input");
+
+  const auto lhs = at::linspace(0.5, 2.0, 8, options).reshape({2, 1, 4});
+  const auto rhs = at::linspace(1.0, 3.0, 3, options).reshape({1, 3, 1});
+  at::Tensor d_lhs;
+  at::Tensor d_rhs;
+  auto broadcast_gradient = clad::gradient(broadcast_mul_loss, "lhs, rhs");
+  broadcast_gradient.execute(lhs, rhs, &d_lhs, &d_rhs);
+
+  const auto output_sizes = ::std::vector<int64_t>{2, 3, 4};
+  require_close(d_lhs, rhs.expand(output_sizes).sum_to_size(lhs.sizes()),
+                "lazy broadcast lhs gradient is incorrect");
+  require_close(d_rhs, lhs.expand(output_sizes).sum_to_size(rhs.sizes()),
+                "lazy broadcast rhs gradient is incorrect");
+  require_true(!d_lhs.is_alias_of(rhs) && !d_rhs.is_alias_of(lhs),
+               "lazy broadcast gradients alias their primal inputs");
+}
+
+void check_native_relu_backward() {
   const auto options = at::TensorOptions().dtype(at::kFloat);
   const auto input = at::tensor({-2.0, -0.0, 0.0, 1.5}, options);
   const auto d_output = at::tensor({0.5, 1.0, 1.5, 2.0}, options);
@@ -263,10 +472,11 @@ void check_native_relu_vjp() {
       actual + at::threshold_backward(d_output, input, /*threshold=*/0);
 
   clad::custom_derivatives::at::relu_pullback(input, d_output, &actual);
-  require_close(actual, expected, "native ReLU VJP accumulation is incorrect");
+  require_close(actual, expected,
+                "native ReLU backward accumulation is incorrect");
 }
 
-void check_partial_vjp_inputs() {
+void check_partial_pullback_inputs() {
   const auto options = at::TensorOptions().dtype(at::kFloat);
   const auto lhs = at::linspace(0.5, 2.0, 8, options).reshape({2, 1, 4});
   const auto rhs = at::linspace(1.0, 3.0, 3, options).reshape({1, 3, 1});
@@ -276,13 +486,13 @@ void check_partial_vjp_inputs() {
   clad::custom_derivatives::at::mul_pullback(lhs, rhs, d_output, &lhs_gradient,
                                              /*d_rhs=*/nullptr);
   require_close(lhs_gradient, rhs.expand({2, 3, 4}).sum_to_size(lhs.sizes()),
-                "masked lhs VJP gradient is incorrect");
+                "masked lhs pullback gradient is incorrect");
 
   auto rhs_gradient = at::zeros_like(rhs);
   clad::custom_derivatives::at::mul_pullback(lhs, rhs, d_output,
                                              /*d_lhs=*/nullptr, &rhs_gradient);
   require_close(rhs_gradient, lhs.expand({2, 3, 4}).sum_to_size(rhs.sizes()),
-                "masked rhs VJP gradient is incorrect");
+                "masked rhs pullback gradient is incorrect");
 }
 
 void check_namespace_alias_composition() {
@@ -758,8 +968,13 @@ int main() {
   check_torch_alias_composition();
   check_at_namespace_composition();
   check_direct_return_composition();
-  check_native_relu_vjp();
-  check_partial_vjp_inputs();
+  check_tensor_adjoint_lifecycle();
+  check_lazy_accumulation();
+  check_undefined_output_adjoint();
+  check_shared_pullback_destination();
+  check_lazy_generated_gradient();
+  check_native_relu_backward();
+  check_partial_pullback_inputs();
   check_namespace_alias_composition();
   check_operator_composition();
   check_method_composition();

--- a/benchmark/LibTorch/TorchOpsTest.cpp
+++ b/benchmark/LibTorch/TorchOpsTest.cpp
@@ -206,6 +206,45 @@ float broadcast_div_loss(const at::Tensor& lhs, const at::Tensor& rhs) {
   return scalar.item<float>();
 }
 
+float strided_input_loss(const at::Tensor& input, const at::Tensor& weights) {
+  auto scaled = input.mul(weights);
+  auto shifted = scaled.add(input);
+  return shifted.relu().sum().item<float>();
+}
+
+float transpose_method_loss(const at::Tensor& input, const at::Tensor& weights,
+                            int64_t dim0, int64_t dim1) {
+  auto transposed = input.transpose(dim0, dim1);
+  return transposed.mul(weights).sum().item<float>();
+}
+
+float transpose_function_loss(const at::Tensor& input,
+                              const at::Tensor& weights, int64_t dim0,
+                              int64_t dim1) {
+  auto transposed = at::transpose(input, dim0, dim1);
+  return at::sum(at::mul(transposed, weights)).item<float>();
+}
+
+float permute_method_loss(const at::Tensor& input, const at::Tensor& weights,
+                          at::IntArrayRef dims) {
+  auto permuted = input.permute(dims);
+  return permuted.mul(weights).sum().item<float>();
+}
+
+float permute_function_loss(const at::Tensor& input, const at::Tensor& weights,
+                            at::IntArrayRef dims) {
+  auto permuted = at::permute(input, dims);
+  return at::sum(at::mul(permuted, weights)).item<float>();
+}
+
+float chained_view_loss(const at::Tensor& input, const at::Tensor& weights,
+                        at::IntArrayRef dims, int64_t dim0, int64_t dim1) {
+  auto permuted = input.permute(dims);
+  auto transposed = at::transpose(permuted, dim0, dim1);
+  auto activated = transposed.mul(weights).relu();
+  return activated.sum().item<float>();
+}
+
 void check_torch_alias_composition() {
   const auto options = torch::TensorOptions().dtype(torch::kFloat32);
   const auto input = torch::linspace(-2.0, 2.0, 17, options);
@@ -928,6 +967,244 @@ void check_partial_broadcast_gradients() {
                 "partial broadcasting modified the rhs input");
 }
 
+template <typename Gradient, typename NativeLoss, typename... Args>
+void check_view_gradient(Gradient& gradient, NativeLoss native_loss,
+                         const at::Tensor& input, const char* message,
+                         const Args&... args) {
+  const auto original = input.clone();
+  at::Tensor actual;
+  gradient.execute(input, args..., &actual);
+
+  auto native_input = input.detach().set_requires_grad(true);
+  auto expected =
+      torch::autograd::grad({native_loss(native_input)}, {native_input})[0];
+  require_close(actual, expected, message);
+  require_close(input, original, "view differentiation modified its input");
+  require_true(!actual.is_alias_of(input),
+               "view gradient aliases its primal input");
+}
+
+void check_strided_inputs() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto base = at::linspace(-2.0, 3.0, 24, options).reshape({2, 3, 4});
+  const auto input = base.permute({2, 0, 1});
+  const auto weights = at::linspace(0.5, 1.5, 6, options).reshape({1, 2, 3});
+  require_true(!input.is_contiguous(),
+               "strided input test unexpectedly became contiguous");
+
+  auto gradient = clad::gradient(strided_input_loss, "input");
+  check_view_gradient(
+      gradient,
+      [&](const at::Tensor& native_input) {
+        return native_input.mul(weights).add(native_input).relu().sum();
+      },
+      input, "strided input gradient is incorrect", weights);
+
+  auto strided_destination = at::zeros_like(input);
+  require_true(!strided_destination.is_contiguous(),
+               "strided gradient destination unexpectedly became contiguous");
+  const auto destination_strides = strided_destination.strides().vec();
+  gradient.execute(input, weights, &strided_destination);
+  auto native_input = input.detach().set_requires_grad(true);
+  auto native_loss = native_input.mul(weights).add(native_input).relu().sum();
+  auto expected = torch::autograd::grad({native_loss}, {native_input})[0];
+  require_close(strided_destination, expected,
+                "preallocated strided gradient is incorrect");
+  require_true(strided_destination.strides().vec() == destination_strides,
+               "gradient accumulation changed destination strides");
+
+  const auto vector =
+      at::linspace(0.5, 8.0, 16, options).reshape({8, 2}).select(1, 0);
+  require_true(!vector.is_contiguous(),
+               "strided vector test unexpectedly became contiguous");
+  auto actual = at::zeros_like(vector);
+  auto dot_gradient = clad::gradient(at_loss, "input");
+  dot_gradient.execute(vector, &actual);
+
+  auto native_vector = vector.detach().set_requires_grad(true);
+  native_loss = at::dot(at_utility(native_vector), native_vector);
+  expected = torch::autograd::grad({native_loss}, {native_vector})[0];
+  require_close(actual, expected, "strided dot input gradient is incorrect");
+}
+
+void check_view_pullbacks() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input = at::zeros({2, 3, 4}, options);
+
+  const auto transpose_output_adjoint =
+      at::linspace(0.5, 12.0, 24, options).reshape({2, 3, 4}).transpose(0, 2);
+  require_true(!transpose_output_adjoint.is_contiguous(),
+               "transpose pullback seed unexpectedly became contiguous");
+  int64_t d_dim0 = 0;
+  int64_t d_dim1 = 0;
+  at::Tensor transpose_input_adjoint;
+  clad::custom_derivatives::at::transpose_pullback(
+      input, /*dim0=*/0, /*dim1=*/2, transpose_output_adjoint,
+      &transpose_input_adjoint, &d_dim0, &d_dim1);
+  require_close(transpose_input_adjoint,
+                transpose_output_adjoint.transpose(0, 2),
+                "transpose pullback did not invert the view");
+  require_true(!transpose_input_adjoint.is_alias_of(transpose_output_adjoint),
+               "transpose pullback gradient aliases its output adjoint");
+
+  const std::vector<int64_t> dims{-1, 0, 1};
+  const auto permute_output_adjoint =
+      at::linspace(0.5, 12.0, 24, options).reshape({2, 3, 4}).permute(dims);
+  require_true(!permute_output_adjoint.is_contiguous(),
+               "permute pullback seed unexpectedly became contiguous");
+  at::IntArrayRef d_dims;
+  at::Tensor permute_input_adjoint;
+  clad::custom_derivatives::at::permute_pullback(
+      input, dims, permute_output_adjoint, &permute_input_adjoint, &d_dims);
+  require_close(permute_input_adjoint,
+                permute_output_adjoint.permute({1, 2, 0}),
+                "permute pullback did not apply the inverse permutation");
+  require_true(!permute_input_adjoint.is_alias_of(permute_output_adjoint),
+               "permute pullback gradient aliases its output adjoint");
+
+  const at::Tensor zero_output_adjoint;
+  const auto initial = at::full_like(input, 2.0);
+  transpose_input_adjoint = initial.clone();
+  permute_input_adjoint = initial.clone();
+  clad::custom_derivatives::at::transpose_pullback(
+      input, /*dim0=*/0, /*dim1=*/2, zero_output_adjoint,
+      &transpose_input_adjoint, &d_dim0, &d_dim1);
+  clad::custom_derivatives::at::permute_pullback(
+      input, dims, zero_output_adjoint, &permute_input_adjoint, &d_dims);
+  require_close(transpose_input_adjoint, initial,
+                "undefined transpose adjoint was propagated");
+  require_close(permute_input_adjoint, initial,
+                "undefined permute adjoint was propagated");
+}
+
+void check_transpose_gradients() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input = at::linspace(-2.0, 3.0, 24, options).reshape({2, 3, 4});
+  const auto weights = at::linspace(0.5, 1.5, 24, options).reshape({4, 3, 2});
+  constexpr int64_t dim0 = -3;
+  constexpr int64_t dim1 = -1;
+
+  auto method_gradient = clad::gradient(transpose_method_loss, "input");
+  check_view_gradient(
+      method_gradient,
+      [&](const at::Tensor& native_input) {
+        return native_input.transpose(dim0, dim1).mul(weights).sum();
+      },
+      input, "Tensor method transpose gradient is incorrect", weights, dim0,
+      dim1);
+
+  auto function_gradient = clad::gradient(transpose_function_loss, "input");
+  check_view_gradient(
+      function_gradient,
+      [&](const at::Tensor& native_input) {
+        return at::transpose(native_input, dim0, dim1).mul(weights).sum();
+      },
+      input, "at::transpose gradient is incorrect", weights, dim0, dim1);
+}
+
+void check_permute_gradients() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input = at::linspace(-2.0, 3.0, 24, options).reshape({2, 3, 4});
+  const auto weights = at::linspace(0.5, 1.5, 24, options).reshape({4, 2, 3});
+  const std::vector<int64_t> dims{-1, 0, 1};
+
+  auto method_gradient = clad::gradient(permute_method_loss, "input");
+  check_view_gradient(
+      method_gradient,
+      [&](const at::Tensor& native_input) {
+        return native_input.permute(dims).mul(weights).sum();
+      },
+      input, "Tensor method permute gradient is incorrect", weights,
+      at::IntArrayRef(dims));
+
+  auto function_gradient = clad::gradient(permute_function_loss, "input");
+  check_view_gradient(
+      function_gradient,
+      [&](const at::Tensor& native_input) {
+        return at::permute(native_input, dims).mul(weights).sum();
+      },
+      input, "at::permute gradient is incorrect", weights,
+      at::IntArrayRef(dims));
+}
+
+void check_chained_view_gradients() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input =
+      at::linspace(-2.0, 3.0, 120, options).reshape({2, 3, 4, 5});
+  const std::vector<int64_t> dims{2, 0, 3, 1};
+  constexpr int64_t dim0 = 1;
+  constexpr int64_t dim1 = -1;
+  const auto weights =
+      at::linspace(0.25, 1.25, 120, options).reshape({4, 3, 5, 2});
+
+  auto gradient = clad::gradient(chained_view_loss, "input");
+  check_view_gradient(
+      gradient,
+      [&](const at::Tensor& native_input) {
+        return native_input.permute(dims)
+            .transpose(dim0, dim1)
+            .mul(weights)
+            .relu()
+            .sum();
+      },
+      input, "chained permute/transpose gradient is incorrect", weights,
+      at::IntArrayRef(dims), dim0, dim1);
+
+  const auto empty = at::empty({2, 0, 3}, options);
+  const std::vector<int64_t> empty_dims{2, 0, 1};
+  const auto empty_weights = at::empty({3, 2, 0}, options);
+  auto permute_gradient = clad::gradient(permute_method_loss, "input");
+  check_view_gradient(
+      permute_gradient,
+      [&](const at::Tensor& native_input) {
+        return native_input.permute(empty_dims).mul(empty_weights).sum();
+      },
+      empty, "empty permute gradient is incorrect", empty_weights,
+      at::IntArrayRef(empty_dims));
+
+  const auto scalar = at::scalar_tensor(2.0, options);
+  const std::vector<int64_t> scalar_dims;
+  check_view_gradient(
+      permute_gradient,
+      [&](const at::Tensor& native_input) {
+        return native_input.permute(scalar_dims).mul(3.0).sum();
+      },
+      scalar, "scalar permute gradient is incorrect",
+      at::scalar_tensor(3.0, options), at::IntArrayRef(scalar_dims));
+}
+
+void check_view_contract() {
+  const auto options = at::TensorOptions().dtype(at::kFloat);
+  const auto input = at::ones({2, 3, 4}, options);
+  const auto weights = at::ones({2, 3, 4}, options);
+  auto transpose_gradient = clad::gradient(transpose_method_loss, "input");
+
+  require_c10_error(
+      [&] {
+        at::Tensor actual;
+        transpose_gradient.execute(input, weights, /*dim0=*/0, /*dim1=*/3,
+                                   &actual);
+      },
+      "out-of-range transpose dimension was not rejected");
+
+  auto permute_gradient = clad::gradient(permute_method_loss, "input");
+  require_c10_error(
+      [&] {
+        const std::vector<int64_t> dims{0, 1};
+        at::Tensor actual;
+        permute_gradient.execute(input, weights, dims, &actual);
+      },
+      "short permutation was not rejected");
+
+  require_c10_error(
+      [&] {
+        const std::vector<int64_t> dims{0, 1, 1};
+        at::Tensor actual;
+        permute_gradient.execute(input, weights, dims, &actual);
+      },
+      "duplicate permutation dimensions were not rejected");
+}
+
 void check_input_contract() {
   require_c10_error(
       [] {
@@ -951,13 +1228,10 @@ void check_input_contract() {
 
   require_c10_error(
       [] {
-        const auto input =
-            torch::ones({4, 2}, torch::kFloat).select(/*dim=*/1, /*index=*/0);
-        auto gradient = torch::zeros_like(input);
-        auto clad_gradient = clad::gradient(at_loss, "input");
-        clad_gradient.execute(input, &gradient);
+        const auto input = at::ones({2, 3}, at::kFloat).to_sparse();
+        clad::torch::detail::validate_tensor(input);
       },
-      "noncontiguous input was not rejected");
+      "non-strided Tensor layout was not rejected");
 }
 
 } // namespace
@@ -988,6 +1262,12 @@ int main() {
   check_explicit_sum_options();
   check_broadcasting();
   check_partial_broadcast_gradients();
+  check_strided_inputs();
+  check_view_pullbacks();
+  check_transpose_gradients();
+  check_permute_gradients();
+  check_chained_view_gradients();
+  check_view_contract();
   check_input_contract();
   std::cout << "Clad Torch operator checks passed\n";
   return 0;

--- a/cmake/modules/AddClad.cmake
+++ b/cmake/modules/AddClad.cmake
@@ -1,4 +1,4 @@
-if (CLAD_ENABLE_BENCHMARKS)
+if (CLAD_ENABLE_BENCHMARKS OR CLAD_ENABLE_LIBTORCH_BENCHMARKS)
   # Find the current branch.
   execute_process(WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                   COMMAND git rev-parse HEAD
@@ -11,7 +11,7 @@ if (CLAD_ENABLE_BENCHMARKS)
 set_property(DIRECTORY APPEND PROPERTY
              CMAKE_CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/.git/HEAD")
 
-endif(CLAD_ENABLE_BENCHMARKS)
+endif()
 
 #-------------------------------------------------------------------------------
 # function ENABLE_CLAD_FOR_TARGET(<executable>

--- a/docs/userDocs/source/user/CustomDerivatives.rst
+++ b/docs/userDocs/source/user/CustomDerivatives.rst
@@ -79,6 +79,63 @@ directly in :code:`clad::custom_derivatives::class_functions` regardless of the 
   Non-templated free functions defined in a header file need to be marked :code:`inline`
   to avoid issues with symbol duplication just like any other C++ entity defined in a header file.
 
+Adjoint construction and initialization
+========================================
+
+Reverse-mode differentiation sometimes needs to construct an internal adjoint
+from an existing primal value. Clad provides two related customization points
+for this purpose:
+
+- :code:`clad::zero_init(x)` resets values in an already constructed adjoint in
+  place. Use it when the adjoint's required structure and storage already
+  exist. The default implementation recursively clears ranges and uses
+  byte-wise zeroing for supported non-range types; provide an overload when
+  that behavior would not preserve the structure required by the type.
+- :code:`clad::zero_like(x)` constructs and returns a new zero adjoint with the
+  same relevant runtime structure as the primal :code:`x`. Conceptually, it
+  returns a value structurally like :code:`x` with :code:`zero_init` applied.
+  This is the primary extension point for adjoint construction.
+
+The default :code:`zero_like` implementation value-initializes arithmetic and
+enum types. For resizable ranges, it resizes an empty result to the primal size
+and recursively resizes nested ranges directly in their corresponding result
+elements. Other copyable ranges use copy-then-zero to preserve their structure.
+Provide a type-specific :code:`zero_like` overload when neither strategy can
+create an independent, structurally correct adjoint. Common examples include
+owning or reference-counted storage, views that alias the primal, device memory,
+and types whose shape, allocator, device, or other runtime metadata requires
+special handling.
+
+For example, a device buffer may require a fresh allocation on the same device
+instead of a shallow copy::
+
+  struct DeviceBuffer {
+    DeviceBuffer(std::size_t size, int device);
+    std::size_t size() const;
+    int device() const;
+    void fill(double value);
+  };
+
+  namespace clad {
+
+  inline void zero_init(DeviceBuffer& buffer) {
+    buffer.fill(0.0);
+  }
+
+  inline DeviceBuffer zero_like(const DeviceBuffer& value) {
+    DeviceBuffer result(value.size(), value.device());
+    zero_init(result);
+    return result;
+  }
+
+  } // namespace clad
+
+Here :code:`zero_init` defines how to reset storage that already exists, while
+:code:`zero_like` defines how to allocate and construct that storage from the
+primal. The returned adjoint must not unintentionally alias mutable primal
+storage. Define these customizations after the differentiated type and before
+requesting its derivative.
+
 Pushforward custom derivatives
 ===============================
 

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -31,6 +31,9 @@
 #endif
 #include <type_traits>
 #include <utility>
+// Keep std::valarray's non-member begin/end overloads visible when is_range is
+// defined below.
+#include <valarray> // NOLINT(misc-include-cleaner)
 #ifndef __CUDACC__
 #include <mutex>
 #endif
@@ -207,25 +210,27 @@ CUDA_HOST_DEVICE auto back(TapeType& of) -> decltype(of.back()) {
   return of.back();
 }
 
-  /// The purpose of this function is to initialize adjoints
-  /// (or all of its iteratable elements) with 0.
-  namespace zero_init_detail {
-  template <class T> struct iterator_traits : std::iterator_traits<T> {};
-  template <> struct iterator_traits<void*> {};
-  template <> struct iterator_traits<const void*> {};
+/// Reset values in an already-constructed adjoint (or its iterable elements)
+/// to zero in place. This is the primitive used by the default zero_like
+/// implementation. Provide an overload when the default recursive or
+/// byte-wise zeroing would not preserve a type's required structure.
+namespace zero_init_detail {
+template <class T> struct iterator_traits : std::iterator_traits<T> {};
+template <> struct iterator_traits<void*> {};
+template <> struct iterator_traits<const void*> {};
 
-  template <class T, class It>
-  std::integral_constant<
-      bool, !std::is_same<typename std::remove_cv<T>::type,
-                          typename iterator_traits<It>::value_type>::value>
-  is_range_check(It first, It last);
+template <class T, class It>
+std::integral_constant<
+    bool, !std::is_same<typename std::remove_cv<T>::type,
+                        typename iterator_traits<It>::value_type>::value>
+is_range_check(It first, It last);
 
-  template <class T>
-  decltype(is_range_check<T>(std::begin(std::declval<const T&>()),
-                             std::end(std::declval<const T&>())))
-  is_range(int);
-  template <class T> std::false_type is_range(...);
-  } // namespace zero_init_detail
+template <class T>
+decltype(is_range_check<T>(std::begin(std::declval<const T&>()),
+                           std::end(std::declval<const T&>())))
+is_range(int);
+template <class T> std::false_type is_range(...);
+} // namespace zero_init_detail
 
   template <class T>
   struct is_range : decltype(zero_init_detail::is_range<T>(0)) {};
@@ -277,6 +282,124 @@ CUDA_HOST_DEVICE auto back(TapeType& of) -> decltype(of.back()) {
   }
 
   template <class T> CUDA_HOST_DEVICE void zero_init(T& t) { zero_impl(t); }
+
+  /// Construct a zero adjoint with the same relevant structure as \p value.
+  ///
+  /// Conceptually, zero_like(value) returns a value structurally like value
+  /// with zero_init applied. This is the adjoint-construction extension point;
+  /// provide an overload when copy-then-zero is incorrect, for example for
+  /// owning or reference-counted storage, device memory, or types whose shape,
+  /// allocator, or other runtime metadata needs special handling. The
+  /// reverse-mode visitor prefers this customization point when constructing
+  /// an internal adjoint from an existing primal value.
+  // Keep this header compatible with C++14; some Clad tests and clients include
+  // it in that language mode.
+  // NOLINTBEGIN(modernize-type-traits)
+  template <class T, std::enable_if_t<std::is_arithmetic<T>::value ||
+                                          std::is_enum<T>::value,
+                                      int> = 0>
+  CUDA_HOST_DEVICE T zero_like(const T&) {
+    return T();
+  }
+
+  namespace zero_like_detail {
+  template <class T>
+  auto has_resize_impl(int)
+      -> decltype(static_cast<void>(std::declval<const T&>().size()),
+                  static_cast<void>(T()),
+                  static_cast<void>(std::declval<T&>().resize(
+                      std::declval<typename T::size_type>())),
+                  std::true_type{});
+  template <class T> std::false_type has_resize_impl(...);
+
+  template <class T> struct has_resize : decltype(has_resize_impl<T>(0)) {};
+
+  // Implement these helpers after both range zero_like overloads so recursive
+  // fallback calls see the complete overload set.
+  template <class ResultRange, class PrimalRange>
+  void resize_and_zero(ResultRange& result, const PrimalRange& value);
+  template <class ResultElement, class PrimalElement>
+  void reconstruct_nested_range(ResultElement&& result,
+                                const PrimalElement& value, std::true_type);
+  template <class ResultElement, class PrimalElement>
+  void reconstruct_nested_range(ResultElement&& result,
+                                const PrimalElement& value, std::false_type);
+  template <class ResultRange, class PrimalRange>
+  void reconstruct_resizable_range(ResultRange&& result,
+                                   const PrimalRange& value, std::true_type);
+  template <class ResultRange, class PrimalRange>
+  void reconstruct_resizable_range(ResultRange&& result,
+                                   const PrimalRange& value, std::false_type);
+  } // namespace zero_like_detail
+
+  /// Default zero_like for a resizable range. Resize an empty result to the
+  /// primal size and recursively resize nested ranges directly in their result
+  /// positions, preserving rectangular and ragged shapes without copying
+  /// primal values or creating temporary nested containers.
+  template <class T,
+            std::enable_if_t<is_range<T>::value &&
+                                 std::is_copy_constructible<T>::value &&
+                                 zero_like_detail::has_resize<T>::value,
+                             int> = 0>
+  T zero_like(const T& value) {
+    T result;
+    zero_like_detail::resize_and_zero(result, value);
+    return result;
+  }
+
+  /// Fallback zero_like for copyable, non-resizable ranges: copy the primal
+  /// structure, then zero it.
+  template <class T,
+            std::enable_if_t<is_range<T>::value &&
+                                 std::is_copy_constructible<T>::value &&
+                                 !zero_like_detail::has_resize<T>::value,
+                             int> = 0>
+  T zero_like(const T& value) {
+    T result(value);
+    zero_init(result);
+    return result;
+  }
+
+  namespace zero_like_detail {
+  template <class ResultRange, class PrimalRange>
+  void resize_and_zero(ResultRange& result, const PrimalRange& value) {
+    result.resize(value.size());
+    auto resultIt = std::begin(result);
+    for (const auto& element : value) {
+      using Element = typename std::remove_cv<
+          typename std::remove_reference<decltype(element)>::type>::type;
+      reconstruct_nested_range(*resultIt, element, is_range<Element>{});
+      ++resultIt;
+    }
+  }
+
+  template <class ResultElement, class PrimalElement>
+  void reconstruct_nested_range(ResultElement&& result,
+                                const PrimalElement& value, std::true_type) {
+    reconstruct_resizable_range(
+        result, value,
+        has_resize<typename std::remove_cv<PrimalElement>::type>{});
+  }
+
+  template <class ResultElement, class PrimalElement>
+  void reconstruct_nested_range(ResultElement&& result, const PrimalElement&,
+                                std::false_type) {
+    zero_init(result);
+  }
+
+  template <class ResultRange, class PrimalRange>
+  void reconstruct_resizable_range(ResultRange&& result,
+                                   const PrimalRange& value, std::true_type) {
+    resize_and_zero(result, value);
+  }
+
+  template <class ResultRange, class PrimalRange>
+  void reconstruct_resizable_range(ResultRange&& result,
+                                   const PrimalRange& value, std::false_type) {
+    result = zero_like(value);
+  }
+  } // namespace zero_like_detail
+  // NOLINTEND(modernize-type-traits)
 
   /// Initialize a const sized array.
   // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays)

--- a/include/clad/Differentiator/TorchBuiltins.h
+++ b/include/clad/Differentiator/TorchBuiltins.h
@@ -4,5 +4,6 @@
 // Public umbrella header for Clad's ATen custom derivatives.
 #include "clad/Differentiator/TorchBuiltins/BasicOps.h" // IWYU pragma: export
 #include "clad/Differentiator/TorchBuiltins/TensorLifecycle.h" // IWYU pragma: export
+#include "clad/Differentiator/TorchBuiltins/TensorSyntax.h" // IWYU pragma: export
 
 #endif // CLAD_DIFFERENTIATOR_TORCHBUILTINS_H

--- a/include/clad/Differentiator/TorchBuiltins.h
+++ b/include/clad/Differentiator/TorchBuiltins.h
@@ -1,0 +1,8 @@
+#ifndef CLAD_DIFFERENTIATOR_TORCHBUILTINS_H
+#define CLAD_DIFFERENTIATOR_TORCHBUILTINS_H
+
+// Public umbrella header for Clad's ATen custom derivatives.
+#include "clad/Differentiator/TorchBuiltins/BasicOps.h" // IWYU pragma: export
+#include "clad/Differentiator/TorchBuiltins/TensorLifecycle.h" // IWYU pragma: export
+
+#endif // CLAD_DIFFERENTIATOR_TORCHBUILTINS_H

--- a/include/clad/Differentiator/TorchBuiltins.h
+++ b/include/clad/Differentiator/TorchBuiltins.h
@@ -5,5 +5,6 @@
 #include "clad/Differentiator/TorchBuiltins/BasicOps.h" // IWYU pragma: export
 #include "clad/Differentiator/TorchBuiltins/TensorLifecycle.h" // IWYU pragma: export
 #include "clad/Differentiator/TorchBuiltins/TensorSyntax.h" // IWYU pragma: export
+#include "clad/Differentiator/TorchBuiltins/ViewOps.h" // IWYU pragma: export
 
 #endif // CLAD_DIFFERENTIATOR_TORCHBUILTINS_H

--- a/include/clad/Differentiator/TorchBuiltins/BasicOps.h
+++ b/include/clad/Differentiator/TorchBuiltins/BasicOps.h
@@ -13,9 +13,16 @@ inline void add_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
                          const ::at::Scalar& alpha, ::at::Tensor d_output,
                          ::at::Tensor* d_lhs, ::at::Tensor* d_rhs,
                          ::at::Scalar* /*d_alpha*/) {
+  if ((!d_lhs && !d_rhs) || !::clad::torch::detail::should_propagate(d_output))
+    return;
   ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
-  ::clad::torch::detail::validate_tensor(d_output);
+  if (::clad::torch::detail::can_combine_adjoint_contributions(lhs, rhs, d_lhs,
+                                                               d_rhs)) {
+    ::clad::torch::detail::accumulate_to_shape(
+        d_lhs, ::at::add(d_output, d_output, alpha), lhs);
+    return;
+  }
   if (d_lhs)
     ::clad::torch::detail::accumulate_to_shape(d_lhs, d_output, lhs);
   if (d_rhs)
@@ -27,9 +34,16 @@ inline void sub_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
                          const ::at::Scalar& alpha, ::at::Tensor d_output,
                          ::at::Tensor* d_lhs, ::at::Tensor* d_rhs,
                          ::at::Scalar* /*d_alpha*/) {
+  if ((!d_lhs && !d_rhs) || !::clad::torch::detail::should_propagate(d_output))
+    return;
   ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
-  ::clad::torch::detail::validate_tensor(d_output);
+  if (::clad::torch::detail::can_combine_adjoint_contributions(lhs, rhs, d_lhs,
+                                                               d_rhs)) {
+    ::clad::torch::detail::accumulate_to_shape(
+        d_lhs, ::at::sub(d_output, d_output, alpha), lhs);
+    return;
+  }
   if (d_lhs)
     ::clad::torch::detail::accumulate_to_shape(d_lhs, d_output, lhs);
   if (d_rhs)
@@ -40,9 +54,18 @@ inline void sub_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
 inline void mul_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
                          ::at::Tensor d_output, ::at::Tensor* d_lhs,
                          ::at::Tensor* d_rhs) {
+  if ((!d_lhs && !d_rhs) || !::clad::torch::detail::should_propagate(d_output))
+    return;
   ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
-  ::clad::torch::detail::validate_tensor(d_output);
+  if (::clad::torch::detail::can_combine_adjoint_contributions(lhs, rhs, d_lhs,
+                                                               d_rhs)) {
+    auto contribution = ::at::mul(d_output, rhs);
+    contribution.addcmul_(d_output, lhs);
+    ::clad::torch::detail::accumulate_to_shape(d_lhs, ::std::move(contribution),
+                                               lhs);
+    return;
+  }
   if (d_lhs)
     ::clad::torch::detail::accumulate_to_shape(d_lhs, ::at::mul(d_output, rhs),
                                                lhs);
@@ -54,9 +77,20 @@ inline void mul_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
 inline void div_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
                          ::at::Tensor d_output, ::at::Tensor* d_lhs,
                          ::at::Tensor* d_rhs) {
+  if ((!d_lhs && !d_rhs) || !::clad::torch::detail::should_propagate(d_output))
+    return;
   ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
-  ::clad::torch::detail::validate_tensor(d_output);
+  if (::clad::torch::detail::can_combine_adjoint_contributions(lhs, rhs, d_lhs,
+                                                               d_rhs)) {
+    auto contribution = ::at::div(d_output, rhs);
+    auto numerator = ::at::mul(d_output, lhs);
+    auto denominator = ::at::mul(rhs, rhs);
+    contribution.addcdiv_(numerator, denominator, -1);
+    ::clad::torch::detail::accumulate_to_shape(d_lhs, ::std::move(contribution),
+                                               lhs);
+    return;
+  }
   if (d_lhs)
     ::clad::torch::detail::accumulate_to_shape(d_lhs, ::at::div(d_output, rhs),
                                                lhs);
@@ -70,23 +104,22 @@ inline void div_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
 
 inline void relu_pullback(const ::at::Tensor& input, ::at::Tensor d_output,
                           ::at::Tensor* d_input) {
+  if (!d_input || !::clad::torch::detail::should_propagate(d_output))
+    return;
   ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_tensor(input);
-  ::clad::torch::detail::validate_tensor(d_output);
-  if (d_input)
-    ::clad::torch::detail::accumulate(
-        d_input, ::at::threshold_backward(d_output, input, 0));
+  ::clad::torch::detail::accumulate(
+      d_input, ::at::threshold_backward(d_output, input, 0));
 }
 
 inline void sum_pullback(const ::at::Tensor& input,
                          ::std::optional<::at::ScalarType> dtype,
                          ::at::Tensor d_output, ::at::Tensor* d_input,
                          ::std::optional<::at::ScalarType>* /*d_dtype*/) {
+  if (!d_input || !::clad::torch::detail::should_propagate(d_output))
+    return;
   ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_reduction(input, dtype);
-  ::clad::torch::detail::validate_tensor(d_output);
-  if (!d_input)
-    return;
   auto contribution = ::clad::torch::detail::restore_reduced_adjoint(
       d_output, input, ::at::OptionalIntArrayRef(), /*keepdim=*/false);
   ::clad::torch::detail::accumulate(d_input, contribution);
@@ -99,11 +132,10 @@ inline void sum_pullback(const ::at::Tensor& input,
                          ::at::OptionalIntArrayRef* /*d_dims*/,
                          bool* /*d_keepdim*/,
                          ::std::optional<::at::ScalarType>* /*d_dtype*/) {
+  if (!d_input || !::clad::torch::detail::should_propagate(d_output))
+    return;
   ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_reduction(input, dtype);
-  ::clad::torch::detail::validate_tensor(d_output);
-  if (!d_input)
-    return;
   auto contribution = ::clad::torch::detail::restore_reduced_adjoint(
       d_output, input, dims, keepdim);
   ::clad::torch::detail::accumulate(d_input, contribution);
@@ -112,9 +144,21 @@ inline void sum_pullback(const ::at::Tensor& input,
 inline void dot_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
                          ::at::Tensor d_output, ::at::Tensor* d_lhs,
                          ::at::Tensor* d_rhs) {
+  if ((!d_lhs && !d_rhs) || !::clad::torch::detail::should_propagate(d_output))
+    return;
   ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_dot_inputs(lhs, rhs);
-  ::clad::torch::detail::validate_tensor(d_output);
+  if (::clad::torch::detail::can_combine_adjoint_contributions(lhs, rhs, d_lhs,
+                                                               d_rhs)) {
+    if (lhs.is_same(rhs)) {
+      ::clad::torch::detail::accumulate(
+          d_lhs, ::at::mul(lhs, 2.0F * d_output.item<float>()));
+    } else {
+      ::clad::torch::detail::accumulate(
+          d_lhs, ::at::mul(::at::add(lhs, rhs), d_output));
+    }
+    return;
+  }
   if (d_lhs)
     ::clad::torch::detail::accumulate(d_lhs, ::at::mul(rhs, d_output));
   if (d_rhs)
@@ -127,13 +171,13 @@ namespace clad::custom_derivatives::class_functions {
 
 inline void item_pullback(const ::at::Tensor* input, float d_output,
                           ::at::Tensor* d_input) {
+  if (!d_input)
+    return;
   ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_tensor(*input);
   TORCH_CHECK(input->numel() == 1,
               "Clad Torch item<float>() expects one tensor element");
-  if (d_input)
-    ::clad::torch::detail::accumulate(d_input,
-                                      ::at::full_like(*input, d_output));
+  ::clad::torch::detail::accumulate(d_input, ::at::full_like(*input, d_output));
 }
 
 } // namespace clad::custom_derivatives::class_functions

--- a/include/clad/Differentiator/TorchBuiltins/BasicOps.h
+++ b/include/clad/Differentiator/TorchBuiltins/BasicOps.h
@@ -3,7 +3,7 @@
 
 #include "clad/Differentiator/TorchBuiltins/TensorSupport.h" // IWYU pragma: export
 
-// First supported operator set: add, sub, mul, relu, dot, and item<float>.
+// First supported operator set: add, sub, mul, div, relu, dot, and item<float>.
 // Scalar options such as add/sub alpha are treated as non-differentiable.
 namespace clad::custom_derivatives::at {
 
@@ -71,6 +71,29 @@ inline void mul_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
   ::at::NoGradGuard guard;
   ::clad::torch::detail::accumulate(d_lhs, ::at::mul(d_output, rhs));
   ::clad::torch::detail::accumulate(d_rhs, ::at::mul(d_output, lhs));
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+div_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                 [[maybe_unused]] const ::at::Tensor& d_lhs,
+                 [[maybe_unused]] const ::at::Tensor& d_rhs) {
+  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
+  ::at::NoGradGuard guard;
+  return ::clad::torch::detail::make_value_and_zero_adjoint(
+      ::at::div(lhs, rhs));
+}
+
+inline void div_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                         ::at::Tensor d_output, ::at::Tensor* d_lhs,
+                         ::at::Tensor* d_rhs) {
+  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
+  ::clad::torch::detail::validate_tensor(d_output);
+  ::at::NoGradGuard guard;
+  ::clad::torch::detail::accumulate(d_lhs, ::at::div(d_output, rhs));
+  auto numerator = ::at::mul(d_output, lhs);
+  auto denominator = ::at::mul(rhs, rhs);
+  ::clad::torch::detail::accumulate(
+      d_rhs, ::at::neg(::at::div(numerator, denominator)));
 }
 
 inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>

--- a/include/clad/Differentiator/TorchBuiltins/BasicOps.h
+++ b/include/clad/Differentiator/TorchBuiltins/BasicOps.h
@@ -1,163 +1,139 @@
 #ifndef CLAD_DIFFERENTIATOR_TORCHBUILTINS_BASICOPS_H
 #define CLAD_DIFFERENTIATOR_TORCHBUILTINS_BASICOPS_H
 
-#include "clad/Differentiator/TorchBuiltins/TensorSupport.h" // IWYU pragma: export
+#include "clad/Differentiator/TorchBuiltins/TensorLifecycle.h" // IWYU pragma: export
 
-// First supported operator set: add, sub, mul, div, relu, dot, and item<float>.
-// Scalar options such as add/sub alpha are treated as non-differentiable.
+#include <ATen/ops/threshold_backward.h>
+
+// First supported operator set: add, sub, mul, div, relu, sum, dot, and
+// item<float>. Scalar options such as add/sub alpha are non-differentiable.
 namespace clad::custom_derivatives::at {
-
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-add_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
-                 const ::at::Scalar& alpha,
-                 [[maybe_unused]] const ::at::Tensor& d_lhs,
-                 [[maybe_unused]] const ::at::Tensor& d_rhs,
-                 [[maybe_unused]] const ::at::Scalar& d_alpha) {
-  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
-  ::at::NoGradGuard guard;
-  return ::clad::torch::detail::make_value_and_zero_adjoint(
-      ::at::add(lhs, rhs, alpha));
-}
 
 inline void add_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
                          const ::at::Scalar& alpha, ::at::Tensor d_output,
                          ::at::Tensor* d_lhs, ::at::Tensor* d_rhs,
-                         [[maybe_unused]] ::at::Scalar* d_alpha) {
+                         ::at::Scalar* /*d_alpha*/) {
+  ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
   ::clad::torch::detail::validate_tensor(d_output);
-  ::at::NoGradGuard guard;
-  ::clad::torch::detail::accumulate(d_lhs, d_output);
-  ::clad::torch::detail::accumulate(d_rhs, ::at::mul(d_output, alpha));
-}
-
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-sub_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
-                 const ::at::Scalar& alpha,
-                 [[maybe_unused]] const ::at::Tensor& d_lhs,
-                 [[maybe_unused]] const ::at::Tensor& d_rhs,
-                 [[maybe_unused]] const ::at::Scalar& d_alpha) {
-  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
-  ::at::NoGradGuard guard;
-  return ::clad::torch::detail::make_value_and_zero_adjoint(
-      ::at::sub(lhs, rhs, alpha));
+  if (d_lhs)
+    ::clad::torch::detail::accumulate_to_shape(d_lhs, d_output, lhs);
+  if (d_rhs)
+    ::clad::torch::detail::accumulate_to_shape(d_rhs,
+                                               ::at::mul(d_output, alpha), rhs);
 }
 
 inline void sub_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
                          const ::at::Scalar& alpha, ::at::Tensor d_output,
                          ::at::Tensor* d_lhs, ::at::Tensor* d_rhs,
-                         [[maybe_unused]] ::at::Scalar* d_alpha) {
+                         ::at::Scalar* /*d_alpha*/) {
+  ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
   ::clad::torch::detail::validate_tensor(d_output);
-  ::at::NoGradGuard guard;
-  ::clad::torch::detail::accumulate(d_lhs, d_output);
-  ::clad::torch::detail::accumulate(d_rhs, ::at::mul(d_output, -alpha));
-}
-
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-mul_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
-                 [[maybe_unused]] const ::at::Tensor& d_lhs,
-                 [[maybe_unused]] const ::at::Tensor& d_rhs) {
-  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
-  ::at::NoGradGuard guard;
-  return ::clad::torch::detail::make_value_and_zero_adjoint(
-      ::at::mul(lhs, rhs));
+  if (d_lhs)
+    ::clad::torch::detail::accumulate_to_shape(d_lhs, d_output, lhs);
+  if (d_rhs)
+    ::clad::torch::detail::accumulate_to_shape(
+        d_rhs, ::at::mul(d_output, -alpha), rhs);
 }
 
 inline void mul_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
                          ::at::Tensor d_output, ::at::Tensor* d_lhs,
                          ::at::Tensor* d_rhs) {
+  ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
   ::clad::torch::detail::validate_tensor(d_output);
-  ::at::NoGradGuard guard;
-  ::clad::torch::detail::accumulate(d_lhs, ::at::mul(d_output, rhs));
-  ::clad::torch::detail::accumulate(d_rhs, ::at::mul(d_output, lhs));
-}
-
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-div_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
-                 [[maybe_unused]] const ::at::Tensor& d_lhs,
-                 [[maybe_unused]] const ::at::Tensor& d_rhs) {
-  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
-  ::at::NoGradGuard guard;
-  return ::clad::torch::detail::make_value_and_zero_adjoint(
-      ::at::div(lhs, rhs));
+  if (d_lhs)
+    ::clad::torch::detail::accumulate_to_shape(d_lhs, ::at::mul(d_output, rhs),
+                                               lhs);
+  if (d_rhs)
+    ::clad::torch::detail::accumulate_to_shape(d_rhs, ::at::mul(d_output, lhs),
+                                               rhs);
 }
 
 inline void div_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
                          ::at::Tensor d_output, ::at::Tensor* d_lhs,
                          ::at::Tensor* d_rhs) {
+  ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
   ::clad::torch::detail::validate_tensor(d_output);
-  ::at::NoGradGuard guard;
-  ::clad::torch::detail::accumulate(d_lhs, ::at::div(d_output, rhs));
-  auto numerator = ::at::mul(d_output, lhs);
-  auto denominator = ::at::mul(rhs, rhs);
-  ::clad::torch::detail::accumulate(
-      d_rhs, ::at::neg(::at::div(numerator, denominator)));
-}
-
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-relu_reverse_forw(const ::at::Tensor& input,
-                  [[maybe_unused]] const ::at::Tensor& d_input) {
-  ::clad::torch::detail::validate_tensor(input);
-  ::at::NoGradGuard guard;
-  return ::clad::torch::detail::make_value_and_zero_adjoint(::at::relu(input));
+  if (d_lhs)
+    ::clad::torch::detail::accumulate_to_shape(d_lhs, ::at::div(d_output, rhs),
+                                               lhs);
+  if (d_rhs) {
+    auto numerator = ::at::mul(d_output, lhs);
+    auto denominator = ::at::mul(rhs, rhs);
+    ::clad::torch::detail::accumulate_to_shape(
+        d_rhs, ::at::neg(::at::div(numerator, denominator)), rhs);
+  }
 }
 
 inline void relu_pullback(const ::at::Tensor& input, ::at::Tensor d_output,
                           ::at::Tensor* d_input) {
+  ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_tensor(input);
   ::clad::torch::detail::validate_tensor(d_output);
-  ::at::NoGradGuard guard;
-  auto mask = ::at::gt(input, 0).to(input.scalar_type());
-  ::clad::torch::detail::accumulate(d_input, ::at::mul(d_output, mask));
+  if (d_input)
+    ::clad::torch::detail::accumulate(
+        d_input, ::at::threshold_backward(d_output, input, 0));
 }
 
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-dot_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
-                 [[maybe_unused]] const ::at::Tensor& d_lhs,
-                 [[maybe_unused]] const ::at::Tensor& d_rhs) {
-  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
-  TORCH_CHECK(lhs.dim() == 1,
-              "Clad Torch dot derivatives expect one-dimensional tensors");
+inline void sum_pullback(const ::at::Tensor& input,
+                         ::std::optional<::at::ScalarType> dtype,
+                         ::at::Tensor d_output, ::at::Tensor* d_input,
+                         ::std::optional<::at::ScalarType>* /*d_dtype*/) {
   ::at::NoGradGuard guard;
-  return ::clad::torch::detail::make_value_and_zero_adjoint(
-      ::at::dot(lhs, rhs));
+  ::clad::torch::detail::validate_reduction(input, dtype);
+  ::clad::torch::detail::validate_tensor(d_output);
+  if (!d_input)
+    return;
+  auto contribution = ::clad::torch::detail::restore_reduced_adjoint(
+      d_output, input, ::at::OptionalIntArrayRef(), /*keepdim=*/false);
+  ::clad::torch::detail::accumulate(d_input, contribution);
+}
+
+inline void sum_pullback(const ::at::Tensor& input,
+                         ::at::OptionalIntArrayRef dims, bool keepdim,
+                         ::std::optional<::at::ScalarType> dtype,
+                         ::at::Tensor d_output, ::at::Tensor* d_input,
+                         ::at::OptionalIntArrayRef* /*d_dims*/,
+                         bool* /*d_keepdim*/,
+                         ::std::optional<::at::ScalarType>* /*d_dtype*/) {
+  ::at::NoGradGuard guard;
+  ::clad::torch::detail::validate_reduction(input, dtype);
+  ::clad::torch::detail::validate_tensor(d_output);
+  if (!d_input)
+    return;
+  auto contribution = ::clad::torch::detail::restore_reduced_adjoint(
+      d_output, input, dims, keepdim);
+  ::clad::torch::detail::accumulate(d_input, contribution);
 }
 
 inline void dot_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
                          ::at::Tensor d_output, ::at::Tensor* d_lhs,
                          ::at::Tensor* d_rhs) {
-  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
-  ::clad::torch::detail::validate_tensor(d_output);
-  TORCH_CHECK(lhs.dim() == 1,
-              "Clad Torch dot derivatives expect one-dimensional tensors");
   ::at::NoGradGuard guard;
-  ::clad::torch::detail::accumulate(d_lhs, ::at::mul(rhs, d_output));
-  ::clad::torch::detail::accumulate(d_rhs, ::at::mul(lhs, d_output));
+  ::clad::torch::detail::validate_dot_inputs(lhs, rhs);
+  ::clad::torch::detail::validate_tensor(d_output);
+  if (d_lhs)
+    ::clad::torch::detail::accumulate(d_lhs, ::at::mul(rhs, d_output));
+  if (d_rhs)
+    ::clad::torch::detail::accumulate(d_rhs, ::at::mul(lhs, d_output));
 }
 
 } // namespace clad::custom_derivatives::at
 
 namespace clad::custom_derivatives::class_functions {
 
-inline ::clad::ValueAndAdjoint<float, float>
-item_reverse_forw(const ::at::Tensor* input,
-                  [[maybe_unused]] const ::at::Tensor* d_input) {
-  ::clad::torch::detail::validate_tensor(*input);
-  TORCH_CHECK(input->numel() == 1,
-              "Clad Torch item<float>() expects one tensor element");
-  ::at::NoGradGuard guard;
-  return {input->item<float>(), 0.0F};
-}
-
 inline void item_pullback(const ::at::Tensor* input, float d_output,
                           ::at::Tensor* d_input) {
+  ::at::NoGradGuard guard;
   ::clad::torch::detail::validate_tensor(*input);
   TORCH_CHECK(input->numel() == 1,
               "Clad Torch item<float>() expects one tensor element");
-  ::at::NoGradGuard guard;
-  ::clad::torch::detail::accumulate(d_input, ::at::full_like(*input, d_output));
+  if (d_input)
+    ::clad::torch::detail::accumulate(d_input,
+                                      ::at::full_like(*input, d_output));
 }
 
 } // namespace clad::custom_derivatives::class_functions

--- a/include/clad/Differentiator/TorchBuiltins/BasicOps.h
+++ b/include/clad/Differentiator/TorchBuiltins/BasicOps.h
@@ -1,0 +1,142 @@
+#ifndef CLAD_DIFFERENTIATOR_TORCHBUILTINS_BASICOPS_H
+#define CLAD_DIFFERENTIATOR_TORCHBUILTINS_BASICOPS_H
+
+#include "clad/Differentiator/TorchBuiltins/TensorSupport.h" // IWYU pragma: export
+
+// First supported operator set: add, sub, mul, relu, dot, and item<float>.
+// Scalar options such as add/sub alpha are treated as non-differentiable.
+namespace clad::custom_derivatives::at {
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+add_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                 const ::at::Scalar& alpha,
+                 [[maybe_unused]] const ::at::Tensor& d_lhs,
+                 [[maybe_unused]] const ::at::Tensor& d_rhs,
+                 [[maybe_unused]] const ::at::Scalar& d_alpha) {
+  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
+  ::at::NoGradGuard guard;
+  return ::clad::torch::detail::make_value_and_zero_adjoint(
+      ::at::add(lhs, rhs, alpha));
+}
+
+inline void add_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                         const ::at::Scalar& alpha, ::at::Tensor d_output,
+                         ::at::Tensor* d_lhs, ::at::Tensor* d_rhs,
+                         [[maybe_unused]] ::at::Scalar* d_alpha) {
+  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
+  ::clad::torch::detail::validate_tensor(d_output);
+  ::at::NoGradGuard guard;
+  ::clad::torch::detail::accumulate(d_lhs, d_output);
+  ::clad::torch::detail::accumulate(d_rhs, ::at::mul(d_output, alpha));
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+sub_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                 const ::at::Scalar& alpha,
+                 [[maybe_unused]] const ::at::Tensor& d_lhs,
+                 [[maybe_unused]] const ::at::Tensor& d_rhs,
+                 [[maybe_unused]] const ::at::Scalar& d_alpha) {
+  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
+  ::at::NoGradGuard guard;
+  return ::clad::torch::detail::make_value_and_zero_adjoint(
+      ::at::sub(lhs, rhs, alpha));
+}
+
+inline void sub_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                         const ::at::Scalar& alpha, ::at::Tensor d_output,
+                         ::at::Tensor* d_lhs, ::at::Tensor* d_rhs,
+                         [[maybe_unused]] ::at::Scalar* d_alpha) {
+  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
+  ::clad::torch::detail::validate_tensor(d_output);
+  ::at::NoGradGuard guard;
+  ::clad::torch::detail::accumulate(d_lhs, d_output);
+  ::clad::torch::detail::accumulate(d_rhs, ::at::mul(d_output, -alpha));
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+mul_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                 [[maybe_unused]] const ::at::Tensor& d_lhs,
+                 [[maybe_unused]] const ::at::Tensor& d_rhs) {
+  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
+  ::at::NoGradGuard guard;
+  return ::clad::torch::detail::make_value_and_zero_adjoint(
+      ::at::mul(lhs, rhs));
+}
+
+inline void mul_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                         ::at::Tensor d_output, ::at::Tensor* d_lhs,
+                         ::at::Tensor* d_rhs) {
+  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
+  ::clad::torch::detail::validate_tensor(d_output);
+  ::at::NoGradGuard guard;
+  ::clad::torch::detail::accumulate(d_lhs, ::at::mul(d_output, rhs));
+  ::clad::torch::detail::accumulate(d_rhs, ::at::mul(d_output, lhs));
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+relu_reverse_forw(const ::at::Tensor& input,
+                  [[maybe_unused]] const ::at::Tensor& d_input) {
+  ::clad::torch::detail::validate_tensor(input);
+  ::at::NoGradGuard guard;
+  return ::clad::torch::detail::make_value_and_zero_adjoint(::at::relu(input));
+}
+
+inline void relu_pullback(const ::at::Tensor& input, ::at::Tensor d_output,
+                          ::at::Tensor* d_input) {
+  ::clad::torch::detail::validate_tensor(input);
+  ::clad::torch::detail::validate_tensor(d_output);
+  ::at::NoGradGuard guard;
+  auto mask = ::at::gt(input, 0).to(input.scalar_type());
+  ::clad::torch::detail::accumulate(d_input, ::at::mul(d_output, mask));
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+dot_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                 [[maybe_unused]] const ::at::Tensor& d_lhs,
+                 [[maybe_unused]] const ::at::Tensor& d_rhs) {
+  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
+  TORCH_CHECK(lhs.dim() == 1,
+              "Clad Torch dot derivatives expect one-dimensional tensors");
+  ::at::NoGradGuard guard;
+  return ::clad::torch::detail::make_value_and_zero_adjoint(
+      ::at::dot(lhs, rhs));
+}
+
+inline void dot_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                         ::at::Tensor d_output, ::at::Tensor* d_lhs,
+                         ::at::Tensor* d_rhs) {
+  ::clad::torch::detail::validate_elementwise_inputs(lhs, rhs);
+  ::clad::torch::detail::validate_tensor(d_output);
+  TORCH_CHECK(lhs.dim() == 1,
+              "Clad Torch dot derivatives expect one-dimensional tensors");
+  ::at::NoGradGuard guard;
+  ::clad::torch::detail::accumulate(d_lhs, ::at::mul(rhs, d_output));
+  ::clad::torch::detail::accumulate(d_rhs, ::at::mul(lhs, d_output));
+}
+
+} // namespace clad::custom_derivatives::at
+
+namespace clad::custom_derivatives::class_functions {
+
+inline ::clad::ValueAndAdjoint<float, float>
+item_reverse_forw(const ::at::Tensor* input,
+                  [[maybe_unused]] const ::at::Tensor* d_input) {
+  ::clad::torch::detail::validate_tensor(*input);
+  TORCH_CHECK(input->numel() == 1,
+              "Clad Torch item<float>() expects one tensor element");
+  ::at::NoGradGuard guard;
+  return {input->item<float>(), 0.0F};
+}
+
+inline void item_pullback(const ::at::Tensor* input, float d_output,
+                          ::at::Tensor* d_input) {
+  ::clad::torch::detail::validate_tensor(*input);
+  TORCH_CHECK(input->numel() == 1,
+              "Clad Torch item<float>() expects one tensor element");
+  ::at::NoGradGuard guard;
+  ::clad::torch::detail::accumulate(d_input, ::at::full_like(*input, d_output));
+}
+
+} // namespace clad::custom_derivatives::class_functions
+
+#endif // CLAD_DIFFERENTIATOR_TORCHBUILTINS_BASICOPS_H

--- a/include/clad/Differentiator/TorchBuiltins/BasicOps.h
+++ b/include/clad/Differentiator/TorchBuiltins/BasicOps.h
@@ -5,8 +5,8 @@
 
 #include <ATen/ops/threshold_backward.h>
 
-// First supported operator set: add, sub, mul, div, relu, sum, dot, and
-// item<float>. Scalar options such as add/sub alpha are non-differentiable.
+// Basic operator set: add, sub, mul, div, relu, sum, dot, and item<float>.
+// Scalar options such as add/sub alpha are non-differentiable.
 namespace clad::custom_derivatives::at {
 
 inline void add_pullback(const ::at::Tensor& lhs, const ::at::Tensor& rhs,

--- a/include/clad/Differentiator/TorchBuiltins/TensorLifecycle.h
+++ b/include/clad/Differentiator/TorchBuiltins/TensorLifecycle.h
@@ -7,6 +7,12 @@
 
 namespace clad {
 
+inline ::at::Tensor zero_like(const ::at::Tensor& tensor) {
+  if (!tensor.defined())
+    return {};
+  return ::clad::torch::detail::zero_adjoint_like(tensor);
+}
+
 inline void zero_init(::at::Tensor& tensor) {
   if (tensor.defined()) {
     ::at::NoGradGuard guard;

--- a/include/clad/Differentiator/TorchBuiltins/TensorLifecycle.h
+++ b/include/clad/Differentiator/TorchBuiltins/TensorLifecycle.h
@@ -1,0 +1,51 @@
+#ifndef CLAD_DIFFERENTIATOR_TORCHBUILTINS_TENSORLIFECYCLE_H
+#define CLAD_DIFFERENTIATOR_TORCHBUILTINS_TENSORLIFECYCLE_H
+
+#include "clad/Differentiator/TorchBuiltins/TensorSupport.h" // IWYU pragma: export
+
+#include <utility>
+
+namespace clad {
+
+inline void zero_init(::at::Tensor& tensor) {
+  if (tensor.defined()) {
+    ::at::NoGradGuard guard;
+    tensor.zero_();
+  }
+}
+
+namespace custom_derivatives::class_functions {
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+constructor_reverse_forw(ConstructorPushforwardTag<::at::Tensor>,
+                         const ::at::Tensor& input,
+                         [[maybe_unused]] const ::at::Tensor& d_input) {
+  ::clad::torch::detail::validate_tensor(input);
+  // A local Tensor is a new reverse-mode node even though its primal copy
+  // shares storage. Its adjoint must start at zero and use independent storage.
+  return {input, ::clad::torch::detail::zero_adjoint_like(input)};
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+constructor_reverse_forw(ConstructorPushforwardTag<::at::Tensor>,
+                         ::at::Tensor&& input,
+                         [[maybe_unused]] ::at::Tensor&& d_input) {
+  ::clad::torch::detail::validate_tensor(input);
+  auto adjoint = ::clad::torch::detail::zero_adjoint_like(input);
+  return {::std::move(input), ::std::move(adjoint)};
+}
+
+inline void constructor_pullback([[maybe_unused]] const ::at::Tensor& input,
+                                 ::at::Tensor* d_this, ::at::Tensor* d_input) {
+  ::clad::torch::detail::propagate_adjoint(d_this, d_input);
+}
+
+inline void constructor_pullback([[maybe_unused]] ::at::Tensor&& input,
+                                 ::at::Tensor* d_this, ::at::Tensor* d_input) {
+  ::clad::torch::detail::propagate_adjoint(d_this, d_input);
+}
+
+} // namespace custom_derivatives::class_functions
+} // namespace clad
+
+#endif // CLAD_DIFFERENTIATOR_TORCHBUILTINS_TENSORLIFECYCLE_H

--- a/include/clad/Differentiator/TorchBuiltins/TensorLifecycle.h
+++ b/include/clad/Differentiator/TorchBuiltins/TensorLifecycle.h
@@ -8,11 +8,10 @@
 
 namespace clad {
 
-inline ::at::Tensor zero_like(const ::at::Tensor& tensor) {
-  if (!tensor.defined())
-    return {};
-  return ::clad::torch::detail::zero_adjoint_like(tensor);
-}
+// ATen uses an undefined Tensor as a lazy zero adjoint. Pullbacks materialize
+// its shape and storage from the first contribution. Copy and move lifecycle
+// hooks below still use zero_adjoint_like when independent storage is required.
+inline ::at::Tensor zero_like(const ::at::Tensor& /*tensor*/) { return {}; }
 
 // OptionalIntArrayRef is a non-owning reduction configuration, so its adjoint
 // carries neither dimension values nor borrowed storage.

--- a/include/clad/Differentiator/TorchBuiltins/TensorLifecycle.h
+++ b/include/clad/Differentiator/TorchBuiltins/TensorLifecycle.h
@@ -13,8 +13,10 @@ namespace clad {
 // hooks below still use zero_adjoint_like when independent storage is required.
 inline ::at::Tensor zero_like(const ::at::Tensor& /*tensor*/) { return {}; }
 
-// OptionalIntArrayRef is a non-owning reduction configuration, so its adjoint
-// carries neither dimension values nor borrowed storage.
+// ArrayRef configurations are non-owning, so their adjoints carry neither
+// dimension values nor borrowed storage.
+inline ::at::IntArrayRef zero_like(const ::at::IntArrayRef&) { return {}; }
+
 inline ::at::OptionalIntArrayRef zero_like(const ::at::OptionalIntArrayRef&) {
   return {};
 }
@@ -26,9 +28,15 @@ inline void zero_init(::at::Tensor& tensor) {
   }
 }
 
+inline void zero_init(::at::IntArrayRef& dims) { dims = {}; }
+
 inline void zero_init(::at::OptionalIntArrayRef& dims) { dims.reset(); }
 
 namespace custom_derivatives::class_functions {
+
+inline void constructor_pullback(const ::at::IntArrayRef& /*dims*/,
+                                 ::at::IntArrayRef* /*d_this*/,
+                                 ::at::IntArrayRef* /*d_dims*/) {}
 
 inline void constructor_pullback(const ::at::OptionalIntArrayRef& /*dims*/,
                                  ::at::OptionalIntArrayRef* /*d_this*/,

--- a/include/clad/Differentiator/TorchBuiltins/TensorLifecycle.h
+++ b/include/clad/Differentiator/TorchBuiltins/TensorLifecycle.h
@@ -3,6 +3,7 @@
 
 #include "clad/Differentiator/TorchBuiltins/TensorSupport.h" // IWYU pragma: export
 
+#include <optional>
 #include <utility>
 
 namespace clad {
@@ -13,6 +14,12 @@ inline ::at::Tensor zero_like(const ::at::Tensor& tensor) {
   return ::clad::torch::detail::zero_adjoint_like(tensor);
 }
 
+// OptionalIntArrayRef is a non-owning reduction configuration, so its adjoint
+// carries neither dimension values nor borrowed storage.
+inline ::at::OptionalIntArrayRef zero_like(const ::at::OptionalIntArrayRef&) {
+  return {};
+}
+
 inline void zero_init(::at::Tensor& tensor) {
   if (tensor.defined()) {
     ::at::NoGradGuard guard;
@@ -20,12 +27,32 @@ inline void zero_init(::at::Tensor& tensor) {
   }
 }
 
+inline void zero_init(::at::OptionalIntArrayRef& dims) { dims.reset(); }
+
 namespace custom_derivatives::class_functions {
+
+inline void constructor_pullback(const ::at::OptionalIntArrayRef& /*dims*/,
+                                 ::at::OptionalIntArrayRef* /*d_this*/,
+                                 ::at::OptionalIntArrayRef* /*d_dims*/) {}
+
+// Reduction dimensions and dtypes are configuration values. Their implicit
+// Torch wrapper constructions do not carry an adjoint.
+inline void constructor_pullback(const int64_t& /*dim*/,
+                                 ::at::OptionalIntArrayRef* /*d_this*/,
+                                 int64_t* /*d_dim*/) {}
+
+inline void constructor_pullback(::at::ScalarType&& /*dtype*/,
+                                 ::std::optional<::at::ScalarType>* /*d_this*/,
+                                 ::at::ScalarType* /*d_dtype*/) {}
+
+inline void constructor_pullback(const ::at::ScalarType& /*dtype*/,
+                                 ::std::optional<::at::ScalarType>* /*d_this*/,
+                                 ::at::ScalarType* /*d_dtype*/) {}
 
 inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
 constructor_reverse_forw(ConstructorPushforwardTag<::at::Tensor>,
                          const ::at::Tensor& input,
-                         [[maybe_unused]] const ::at::Tensor& d_input) {
+                         const ::at::Tensor& /*d_input*/) {
   ::clad::torch::detail::validate_tensor(input);
   // A local Tensor is a new reverse-mode node even though its primal copy
   // shares storage. Its adjoint must start at zero and use independent storage.
@@ -34,20 +61,19 @@ constructor_reverse_forw(ConstructorPushforwardTag<::at::Tensor>,
 
 inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
 constructor_reverse_forw(ConstructorPushforwardTag<::at::Tensor>,
-                         ::at::Tensor&& input,
-                         [[maybe_unused]] ::at::Tensor&& d_input) {
+                         ::at::Tensor&& input, ::at::Tensor&& /*d_input*/) {
   ::clad::torch::detail::validate_tensor(input);
   auto adjoint = ::clad::torch::detail::zero_adjoint_like(input);
   return {::std::move(input), ::std::move(adjoint)};
 }
 
-inline void constructor_pullback([[maybe_unused]] const ::at::Tensor& input,
+inline void constructor_pullback(const ::at::Tensor& /*input*/,
                                  ::at::Tensor* d_this, ::at::Tensor* d_input) {
   ::clad::torch::detail::propagate_adjoint(d_this, d_input);
 }
 
-inline void constructor_pullback([[maybe_unused]] ::at::Tensor&& input,
-                                 ::at::Tensor* d_this, ::at::Tensor* d_input) {
+inline void constructor_pullback(::at::Tensor&& /*input*/, ::at::Tensor* d_this,
+                                 ::at::Tensor* d_input) {
   ::clad::torch::detail::propagate_adjoint(d_this, d_input);
 }
 

--- a/include/clad/Differentiator/TorchBuiltins/TensorSupport.h
+++ b/include/clad/Differentiator/TorchBuiltins/TensorSupport.h
@@ -1,0 +1,68 @@
+#ifndef CLAD_DIFFERENTIATOR_TORCHBUILTINS_TENSORSUPPORT_H
+#define CLAD_DIFFERENTIATOR_TORCHBUILTINS_TENSORSUPPORT_H
+
+#include "clad/Differentiator/BuiltinDerivatives.h" // IWYU pragma: export
+
+#include <ATen/ATen.h>           // IWYU pragma: export
+#include <ATen/core/grad_mode.h> // IWYU pragma: export
+
+#include <utility>
+
+namespace clad::torch::detail {
+
+// The first operator set deliberately has a narrow, checked contract. Device,
+// dtype, layout, and broadcasting support can be added independently later.
+inline void validate_tensor(const ::at::Tensor& tensor) {
+  TORCH_CHECK(tensor.defined(),
+              "Clad Torch derivatives require a defined tensor");
+  TORCH_CHECK(tensor.device().is_cpu(),
+              "Clad Torch derivatives currently support CPU tensors only");
+  TORCH_CHECK(tensor.scalar_type() == ::at::kFloat,
+              "Clad Torch derivatives currently support float32 tensors only");
+  TORCH_CHECK(tensor.is_contiguous(),
+              "Clad Torch derivatives currently require contiguous tensors");
+}
+
+inline void validate_elementwise_inputs(const ::at::Tensor& lhs,
+                                        const ::at::Tensor& rhs) {
+  validate_tensor(lhs);
+  validate_tensor(rhs);
+  TORCH_CHECK(lhs.sizes() == rhs.sizes(),
+              "Clad Torch elementwise derivatives do not support broadcasting");
+}
+
+inline ::at::Tensor zero_adjoint_like(const ::at::Tensor& primal) {
+  ::at::NoGradGuard guard;
+  return ::at::zeros_like(primal);
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+make_value_and_zero_adjoint(::at::Tensor value) {
+  auto adjoint = zero_adjoint_like(value);
+  return {::std::move(value), ::std::move(adjoint)};
+}
+
+inline void accumulate(::at::Tensor* destination,
+                       const ::at::Tensor& contribution) {
+  ::at::NoGradGuard guard;
+  if (!destination->defined())
+    *destination = ::at::zeros_like(contribution);
+  destination->add_(contribution);
+}
+
+inline void propagate_adjoint(::at::Tensor* source, ::at::Tensor* destination) {
+  if (!source->defined())
+    return;
+  if (destination->defined() && source->is_alias_of(*destination))
+    return;
+
+  // Tensor copies share storage, while local adjoints must remain independent.
+  ::at::NoGradGuard guard;
+  auto contribution = source->clone();
+  accumulate(destination, contribution);
+  source->zero_();
+}
+
+} // namespace clad::torch::detail
+
+#endif // CLAD_DIFFERENTIATOR_TORCHBUILTINS_TENSORSUPPORT_H

--- a/include/clad/Differentiator/TorchBuiltins/TensorSupport.h
+++ b/include/clad/Differentiator/TorchBuiltins/TensorSupport.h
@@ -26,6 +26,20 @@ inline void validate_tensor(const ::at::Tensor& tensor) {
               "Clad Torch derivatives currently require contiguous tensors");
 }
 
+inline bool should_propagate(const ::at::Tensor& adjoint) {
+  if (!adjoint.defined())
+    return false;
+  validate_tensor(adjoint);
+  return true;
+}
+
+inline bool can_combine_adjoint_contributions(const ::at::Tensor& lhs,
+                                              const ::at::Tensor& rhs,
+                                              const ::at::Tensor* d_lhs,
+                                              const ::at::Tensor* d_rhs) {
+  return d_lhs && d_lhs == d_rhs && lhs.sizes() == rhs.sizes();
+}
+
 inline void validate_elementwise_inputs(const ::at::Tensor& lhs,
                                         const ::at::Tensor& rhs) {
   validate_tensor(lhs);
@@ -84,8 +98,27 @@ inline ::at::Tensor zero_adjoint_like(const ::at::Tensor& primal) {
 inline void accumulate(::at::Tensor* destination,
                        const ::at::Tensor& contribution) {
   ::at::NoGradGuard guard;
-  if (!destination->defined())
-    *destination = ::at::zeros_like(contribution);
+  if (!destination->defined()) {
+    // A borrowed contribution can be an expanded or strided view. Clone it so
+    // later accumulation cannot mutate the upstream adjoint through an alias.
+    *destination = contribution.clone();
+    return;
+  }
+  destination->add_(contribution);
+}
+
+inline void accumulate(::at::Tensor* destination, ::at::Tensor&& contribution) {
+  ::at::NoGradGuard guard;
+  if (!destination->defined()) {
+    // A unique, non-view temporary can become the adjoint directly. Clone
+    // views and shared handles so later accumulation cannot mutate an alias.
+    if (!contribution.is_view() && contribution.use_count() == 1 &&
+        contribution.storage().unique())
+      *destination = ::std::move(contribution);
+    else
+      *destination = contribution.clone();
+    return;
+  }
   destination->add_(contribution);
 }
 
@@ -99,16 +132,25 @@ inline void accumulate_to_shape(::at::Tensor* destination,
   accumulate(destination, contribution.sum_to_size(primal.sizes()));
 }
 
+inline void accumulate_to_shape(::at::Tensor* destination,
+                                ::at::Tensor&& contribution,
+                                const ::at::Tensor& primal) {
+  if (contribution.sizes() == primal.sizes()) {
+    accumulate(destination, ::std::move(contribution));
+    return;
+  }
+  accumulate(destination, contribution.sum_to_size(primal.sizes()));
+}
+
 inline void propagate_adjoint(::at::Tensor* source, ::at::Tensor* destination) {
-  if (!source->defined())
+  if (!source || !source->defined() || !destination)
     return;
   if (destination->defined() && source->is_alias_of(*destination))
     return;
 
   // Tensor copies share storage, while local adjoints must remain independent.
   ::at::NoGradGuard guard;
-  auto contribution = source->clone();
-  accumulate(destination, contribution);
+  accumulate(destination, source->clone());
   source->zero_();
 }
 

--- a/include/clad/Differentiator/TorchBuiltins/TensorSupport.h
+++ b/include/clad/Differentiator/TorchBuiltins/TensorSupport.h
@@ -14,7 +14,8 @@
 namespace clad::torch::detail {
 
 // The first operator set deliberately has a narrow, checked contract for
-// device, dtype, and layout. Elementwise operations follow ATen broadcasting.
+// device and dtype. Elementwise operations follow ATen broadcasting, while
+// ATen kernels preserve the logical semantics of strided Tensor views.
 inline void validate_tensor(const ::at::Tensor& tensor) {
   TORCH_CHECK(tensor.defined(),
               "Clad Torch derivatives require a defined tensor");
@@ -22,8 +23,8 @@ inline void validate_tensor(const ::at::Tensor& tensor) {
               "Clad Torch derivatives currently support CPU tensors only");
   TORCH_CHECK(tensor.scalar_type() == ::at::kFloat,
               "Clad Torch derivatives currently support float32 tensors only");
-  TORCH_CHECK(tensor.is_contiguous(),
-              "Clad Torch derivatives currently require contiguous tensors");
+  TORCH_CHECK(tensor.layout() == ::at::kStrided,
+              "Clad Torch derivatives currently support strided tensors only");
 }
 
 inline bool should_propagate(const ::at::Tensor& adjoint) {
@@ -75,6 +76,23 @@ canonicalize_reduction_dims(::at::IntArrayRef dims, int64_t input_rank) {
           canonical_dims.end(),
       "Clad Torch reduction dimensions must be unique");
   return canonical_dims;
+}
+
+inline ::std::vector<int64_t> inverse_permutation(::at::IntArrayRef dims,
+                                                  int64_t input_rank) {
+  TORCH_CHECK(static_cast<int64_t>(dims.size()) == input_rank,
+              "Clad Torch permute derivatives require one dimension per input "
+              "dimension");
+
+  ::std::vector<int64_t> inverse(input_rank, -1);
+  for (int64_t output_dim = 0; output_dim < input_rank; ++output_dim) {
+    const int64_t input_dim =
+        ::c10::maybe_wrap_dim(dims[output_dim], input_rank);
+    TORCH_CHECK(inverse[input_dim] == -1,
+                "Clad Torch permutation dimensions must be unique");
+    inverse[input_dim] = output_dim;
+  }
+  return inverse;
 }
 
 inline ::at::Tensor restore_reduced_adjoint(const ::at::Tensor& adjoint,

--- a/include/clad/Differentiator/TorchBuiltins/TensorSupport.h
+++ b/include/clad/Differentiator/TorchBuiltins/TensorSupport.h
@@ -5,13 +5,16 @@
 
 #include <ATen/ATen.h>           // IWYU pragma: export
 #include <ATen/core/grad_mode.h> // IWYU pragma: export
+#include <c10/core/WrapDimMinimal.h>
 
+#include <algorithm>
 #include <utility>
+#include <vector>
 
 namespace clad::torch::detail {
 
-// The first operator set deliberately has a narrow, checked contract. Device,
-// dtype, layout, and broadcasting support can be added independently later.
+// The first operator set deliberately has a narrow, checked contract for
+// device, dtype, and layout. Elementwise operations follow ATen broadcasting.
 inline void validate_tensor(const ::at::Tensor& tensor) {
   TORCH_CHECK(tensor.defined(),
               "Clad Torch derivatives require a defined tensor");
@@ -27,19 +30,55 @@ inline void validate_elementwise_inputs(const ::at::Tensor& lhs,
                                         const ::at::Tensor& rhs) {
   validate_tensor(lhs);
   validate_tensor(rhs);
+}
+
+inline void validate_dot_inputs(const ::at::Tensor& lhs,
+                                const ::at::Tensor& rhs) {
+  validate_elementwise_inputs(lhs, rhs);
   TORCH_CHECK(lhs.sizes() == rhs.sizes(),
-              "Clad Torch elementwise derivatives do not support broadcasting");
+              "Clad Torch dot derivatives require matching shapes");
+  TORCH_CHECK(lhs.dim() == 1,
+              "Clad Torch dot derivatives expect one-dimensional tensors");
+}
+
+inline void validate_reduction(const ::at::Tensor& input,
+                               ::std::optional<::at::ScalarType> dtype) {
+  validate_tensor(input);
+  TORCH_CHECK(!dtype || *dtype == input.scalar_type(),
+              "Clad Torch reduction derivatives do not support dtype "
+              "conversion");
+}
+
+inline ::std::vector<int64_t>
+canonicalize_reduction_dims(::at::IntArrayRef dims, int64_t input_rank) {
+  ::std::vector<int64_t> canonical_dims;
+  canonical_dims.reserve(dims.size());
+  for (int64_t dim : dims)
+    canonical_dims.push_back(::c10::maybe_wrap_dim(dim, input_rank));
+  ::std::sort(canonical_dims.begin(), canonical_dims.end());
+  TORCH_CHECK(
+      ::std::adjacent_find(canonical_dims.begin(), canonical_dims.end()) ==
+          canonical_dims.end(),
+      "Clad Torch reduction dimensions must be unique");
+  return canonical_dims;
+}
+
+inline ::at::Tensor restore_reduced_adjoint(const ::at::Tensor& adjoint,
+                                            const ::at::Tensor& input,
+                                            ::at::OptionalIntArrayRef dims,
+                                            bool keepdim) {
+  if (keepdim || input.dim() == 0 || !dims || dims->empty())
+    return adjoint.expand_as(input);
+
+  auto restored = adjoint;
+  for (int64_t dim : canonicalize_reduction_dims(*dims, input.dim()))
+    restored = restored.unsqueeze(dim);
+  return restored.expand_as(input);
 }
 
 inline ::at::Tensor zero_adjoint_like(const ::at::Tensor& primal) {
   ::at::NoGradGuard guard;
   return ::at::zeros_like(primal);
-}
-
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-make_value_and_zero_adjoint(::at::Tensor value) {
-  auto adjoint = zero_adjoint_like(value);
-  return {::std::move(value), ::std::move(adjoint)};
 }
 
 inline void accumulate(::at::Tensor* destination,
@@ -48,6 +87,16 @@ inline void accumulate(::at::Tensor* destination,
   if (!destination->defined())
     *destination = ::at::zeros_like(contribution);
   destination->add_(contribution);
+}
+
+inline void accumulate_to_shape(::at::Tensor* destination,
+                                const ::at::Tensor& contribution,
+                                const ::at::Tensor& primal) {
+  if (contribution.sizes() == primal.sizes()) {
+    accumulate(destination, contribution);
+    return;
+  }
+  accumulate(destination, contribution.sum_to_size(primal.sizes()));
 }
 
 inline void propagate_adjoint(::at::Tensor* source, ::at::Tensor* destination) {

--- a/include/clad/Differentiator/TorchBuiltins/TensorSyntax.h
+++ b/include/clad/Differentiator/TorchBuiltins/TensorSyntax.h
@@ -7,14 +7,6 @@
 // operator and Tensor method spellings onto the corresponding ATen functions.
 namespace clad::custom_derivatives::at {
 
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-operator_plus_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
-                           const ::at::Tensor& d_lhs,
-                           const ::at::Tensor& d_rhs) {
-  return add_reverse_forw(lhs, rhs, /*alpha=*/1, d_lhs, d_rhs,
-                          /*d_alpha=*/0);
-}
-
 inline void operator_plus_pullback(const ::at::Tensor& lhs,
                                    const ::at::Tensor& rhs,
                                    ::at::Tensor d_output, ::at::Tensor* d_lhs,
@@ -22,14 +14,6 @@ inline void operator_plus_pullback(const ::at::Tensor& lhs,
   ::at::Scalar d_alpha = 0;
   add_pullback(lhs, rhs, /*alpha=*/1, ::std::move(d_output), d_lhs, d_rhs,
                &d_alpha);
-}
-
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-operator_minus_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
-                            const ::at::Tensor& d_lhs,
-                            const ::at::Tensor& d_rhs) {
-  return sub_reverse_forw(lhs, rhs, /*alpha=*/1, d_lhs, d_rhs,
-                          /*d_alpha=*/0);
 }
 
 inline void operator_minus_pullback(const ::at::Tensor& lhs,
@@ -41,25 +25,11 @@ inline void operator_minus_pullback(const ::at::Tensor& lhs,
                &d_alpha);
 }
 
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-operator_star_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
-                           const ::at::Tensor& d_lhs,
-                           const ::at::Tensor& d_rhs) {
-  return mul_reverse_forw(lhs, rhs, d_lhs, d_rhs);
-}
-
 inline void operator_star_pullback(const ::at::Tensor& lhs,
                                    const ::at::Tensor& rhs,
                                    ::at::Tensor d_output, ::at::Tensor* d_lhs,
                                    ::at::Tensor* d_rhs) {
   mul_pullback(lhs, rhs, ::std::move(d_output), d_lhs, d_rhs);
-}
-
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-operator_slash_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
-                            const ::at::Tensor& d_lhs,
-                            const ::at::Tensor& d_rhs) {
-  return div_reverse_forw(lhs, rhs, d_lhs, d_rhs);
 }
 
 inline void operator_slash_pullback(const ::at::Tensor& lhs,
@@ -73,28 +43,12 @@ inline void operator_slash_pullback(const ::at::Tensor& lhs,
 
 namespace clad::custom_derivatives::class_functions {
 
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-add_reverse_forw(const ::at::Tensor* self, const ::at::Tensor& other,
-                 const ::at::Scalar& alpha, const ::at::Tensor* d_self,
-                 const ::at::Tensor& d_other, const ::at::Scalar& d_alpha) {
-  return ::clad::custom_derivatives::at::add_reverse_forw(
-      *self, other, alpha, *d_self, d_other, d_alpha);
-}
-
 inline void add_pullback(const ::at::Tensor* self, const ::at::Tensor& other,
                          const ::at::Scalar& alpha, ::at::Tensor d_output,
                          ::at::Tensor* d_self, ::at::Tensor* d_other,
                          ::at::Scalar* d_alpha) {
   ::clad::custom_derivatives::at::add_pullback(
       *self, other, alpha, ::std::move(d_output), d_self, d_other, d_alpha);
-}
-
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-sub_reverse_forw(const ::at::Tensor* self, const ::at::Tensor& other,
-                 const ::at::Scalar& alpha, const ::at::Tensor* d_self,
-                 const ::at::Tensor& d_other, const ::at::Scalar& d_alpha) {
-  return ::clad::custom_derivatives::at::sub_reverse_forw(
-      *self, other, alpha, *d_self, d_other, d_alpha);
 }
 
 inline void sub_pullback(const ::at::Tensor* self, const ::at::Tensor& other,
@@ -105,25 +59,11 @@ inline void sub_pullback(const ::at::Tensor* self, const ::at::Tensor& other,
       *self, other, alpha, ::std::move(d_output), d_self, d_other, d_alpha);
 }
 
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-mul_reverse_forw(const ::at::Tensor* self, const ::at::Tensor& other,
-                 const ::at::Tensor* d_self, const ::at::Tensor& d_other) {
-  return ::clad::custom_derivatives::at::mul_reverse_forw(*self, other, *d_self,
-                                                          d_other);
-}
-
 inline void mul_pullback(const ::at::Tensor* self, const ::at::Tensor& other,
                          ::at::Tensor d_output, ::at::Tensor* d_self,
                          ::at::Tensor* d_other) {
   ::clad::custom_derivatives::at::mul_pullback(
       *self, other, ::std::move(d_output), d_self, d_other);
-}
-
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-div_reverse_forw(const ::at::Tensor* self, const ::at::Tensor& other,
-                 const ::at::Tensor* d_self, const ::at::Tensor& d_other) {
-  return ::clad::custom_derivatives::at::div_reverse_forw(*self, other, *d_self,
-                                                          d_other);
 }
 
 inline void div_pullback(const ::at::Tensor* self, const ::at::Tensor& other,
@@ -133,22 +73,29 @@ inline void div_pullback(const ::at::Tensor* self, const ::at::Tensor& other,
       *self, other, ::std::move(d_output), d_self, d_other);
 }
 
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-relu_reverse_forw(const ::at::Tensor* self, const ::at::Tensor* d_self) {
-  return ::clad::custom_derivatives::at::relu_reverse_forw(*self, *d_self);
-}
-
 inline void relu_pullback(const ::at::Tensor* self, ::at::Tensor d_output,
                           ::at::Tensor* d_self) {
   ::clad::custom_derivatives::at::relu_pullback(*self, ::std::move(d_output),
                                                 d_self);
 }
 
-inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
-dot_reverse_forw(const ::at::Tensor* self, const ::at::Tensor& other,
-                 const ::at::Tensor* d_self, const ::at::Tensor& d_other) {
-  return ::clad::custom_derivatives::at::dot_reverse_forw(*self, other, *d_self,
-                                                          d_other);
+inline void sum_pullback(const ::at::Tensor* self,
+                         ::std::optional<::at::ScalarType> dtype,
+                         ::at::Tensor d_output, ::at::Tensor* d_self,
+                         ::std::optional<::at::ScalarType>* d_dtype) {
+  ::clad::custom_derivatives::at::sum_pullback(
+      *self, dtype, ::std::move(d_output), d_self, d_dtype);
+}
+
+inline void sum_pullback(const ::at::Tensor* self,
+                         ::at::OptionalIntArrayRef dims, bool keepdim,
+                         ::std::optional<::at::ScalarType> dtype,
+                         ::at::Tensor d_output, ::at::Tensor* d_self,
+                         ::at::OptionalIntArrayRef* d_dims, bool* d_keepdim,
+                         ::std::optional<::at::ScalarType>* d_dtype) {
+  ::clad::custom_derivatives::at::sum_pullback(*self, dims, keepdim, dtype,
+                                               ::std::move(d_output), d_self,
+                                               d_dims, d_keepdim, d_dtype);
 }
 
 inline void dot_pullback(const ::at::Tensor* self, const ::at::Tensor& other,

--- a/include/clad/Differentiator/TorchBuiltins/TensorSyntax.h
+++ b/include/clad/Differentiator/TorchBuiltins/TensorSyntax.h
@@ -1,0 +1,163 @@
+#ifndef CLAD_DIFFERENTIATOR_TORCHBUILTINS_TENSORSYNTAX_H
+#define CLAD_DIFFERENTIATOR_TORCHBUILTINS_TENSORSYNTAX_H
+
+#include "clad/Differentiator/TorchBuiltins/BasicOps.h" // IWYU pragma: export
+
+// Keep the derivative formulas in BasicOps.h. These adapters only map the
+// operator and Tensor method spellings onto the corresponding ATen functions.
+namespace clad::custom_derivatives::at {
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+operator_plus_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                           const ::at::Tensor& d_lhs,
+                           const ::at::Tensor& d_rhs) {
+  return add_reverse_forw(lhs, rhs, /*alpha=*/1, d_lhs, d_rhs,
+                          /*d_alpha=*/0);
+}
+
+inline void operator_plus_pullback(const ::at::Tensor& lhs,
+                                   const ::at::Tensor& rhs,
+                                   ::at::Tensor d_output, ::at::Tensor* d_lhs,
+                                   ::at::Tensor* d_rhs) {
+  ::at::Scalar d_alpha = 0;
+  add_pullback(lhs, rhs, /*alpha=*/1, ::std::move(d_output), d_lhs, d_rhs,
+               &d_alpha);
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+operator_minus_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                            const ::at::Tensor& d_lhs,
+                            const ::at::Tensor& d_rhs) {
+  return sub_reverse_forw(lhs, rhs, /*alpha=*/1, d_lhs, d_rhs,
+                          /*d_alpha=*/0);
+}
+
+inline void operator_minus_pullback(const ::at::Tensor& lhs,
+                                    const ::at::Tensor& rhs,
+                                    ::at::Tensor d_output, ::at::Tensor* d_lhs,
+                                    ::at::Tensor* d_rhs) {
+  ::at::Scalar d_alpha = 0;
+  sub_pullback(lhs, rhs, /*alpha=*/1, ::std::move(d_output), d_lhs, d_rhs,
+               &d_alpha);
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+operator_star_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                           const ::at::Tensor& d_lhs,
+                           const ::at::Tensor& d_rhs) {
+  return mul_reverse_forw(lhs, rhs, d_lhs, d_rhs);
+}
+
+inline void operator_star_pullback(const ::at::Tensor& lhs,
+                                   const ::at::Tensor& rhs,
+                                   ::at::Tensor d_output, ::at::Tensor* d_lhs,
+                                   ::at::Tensor* d_rhs) {
+  mul_pullback(lhs, rhs, ::std::move(d_output), d_lhs, d_rhs);
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+operator_slash_reverse_forw(const ::at::Tensor& lhs, const ::at::Tensor& rhs,
+                            const ::at::Tensor& d_lhs,
+                            const ::at::Tensor& d_rhs) {
+  return div_reverse_forw(lhs, rhs, d_lhs, d_rhs);
+}
+
+inline void operator_slash_pullback(const ::at::Tensor& lhs,
+                                    const ::at::Tensor& rhs,
+                                    ::at::Tensor d_output, ::at::Tensor* d_lhs,
+                                    ::at::Tensor* d_rhs) {
+  div_pullback(lhs, rhs, ::std::move(d_output), d_lhs, d_rhs);
+}
+
+} // namespace clad::custom_derivatives::at
+
+namespace clad::custom_derivatives::class_functions {
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+add_reverse_forw(const ::at::Tensor* self, const ::at::Tensor& other,
+                 const ::at::Scalar& alpha, const ::at::Tensor* d_self,
+                 const ::at::Tensor& d_other, const ::at::Scalar& d_alpha) {
+  return ::clad::custom_derivatives::at::add_reverse_forw(
+      *self, other, alpha, *d_self, d_other, d_alpha);
+}
+
+inline void add_pullback(const ::at::Tensor* self, const ::at::Tensor& other,
+                         const ::at::Scalar& alpha, ::at::Tensor d_output,
+                         ::at::Tensor* d_self, ::at::Tensor* d_other,
+                         ::at::Scalar* d_alpha) {
+  ::clad::custom_derivatives::at::add_pullback(
+      *self, other, alpha, ::std::move(d_output), d_self, d_other, d_alpha);
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+sub_reverse_forw(const ::at::Tensor* self, const ::at::Tensor& other,
+                 const ::at::Scalar& alpha, const ::at::Tensor* d_self,
+                 const ::at::Tensor& d_other, const ::at::Scalar& d_alpha) {
+  return ::clad::custom_derivatives::at::sub_reverse_forw(
+      *self, other, alpha, *d_self, d_other, d_alpha);
+}
+
+inline void sub_pullback(const ::at::Tensor* self, const ::at::Tensor& other,
+                         const ::at::Scalar& alpha, ::at::Tensor d_output,
+                         ::at::Tensor* d_self, ::at::Tensor* d_other,
+                         ::at::Scalar* d_alpha) {
+  ::clad::custom_derivatives::at::sub_pullback(
+      *self, other, alpha, ::std::move(d_output), d_self, d_other, d_alpha);
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+mul_reverse_forw(const ::at::Tensor* self, const ::at::Tensor& other,
+                 const ::at::Tensor* d_self, const ::at::Tensor& d_other) {
+  return ::clad::custom_derivatives::at::mul_reverse_forw(*self, other, *d_self,
+                                                          d_other);
+}
+
+inline void mul_pullback(const ::at::Tensor* self, const ::at::Tensor& other,
+                         ::at::Tensor d_output, ::at::Tensor* d_self,
+                         ::at::Tensor* d_other) {
+  ::clad::custom_derivatives::at::mul_pullback(
+      *self, other, ::std::move(d_output), d_self, d_other);
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+div_reverse_forw(const ::at::Tensor* self, const ::at::Tensor& other,
+                 const ::at::Tensor* d_self, const ::at::Tensor& d_other) {
+  return ::clad::custom_derivatives::at::div_reverse_forw(*self, other, *d_self,
+                                                          d_other);
+}
+
+inline void div_pullback(const ::at::Tensor* self, const ::at::Tensor& other,
+                         ::at::Tensor d_output, ::at::Tensor* d_self,
+                         ::at::Tensor* d_other) {
+  ::clad::custom_derivatives::at::div_pullback(
+      *self, other, ::std::move(d_output), d_self, d_other);
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+relu_reverse_forw(const ::at::Tensor* self, const ::at::Tensor* d_self) {
+  return ::clad::custom_derivatives::at::relu_reverse_forw(*self, *d_self);
+}
+
+inline void relu_pullback(const ::at::Tensor* self, ::at::Tensor d_output,
+                          ::at::Tensor* d_self) {
+  ::clad::custom_derivatives::at::relu_pullback(*self, ::std::move(d_output),
+                                                d_self);
+}
+
+inline ::clad::ValueAndAdjoint<::at::Tensor, ::at::Tensor>
+dot_reverse_forw(const ::at::Tensor* self, const ::at::Tensor& other,
+                 const ::at::Tensor* d_self, const ::at::Tensor& d_other) {
+  return ::clad::custom_derivatives::at::dot_reverse_forw(*self, other, *d_self,
+                                                          d_other);
+}
+
+inline void dot_pullback(const ::at::Tensor* self, const ::at::Tensor& other,
+                         ::at::Tensor d_output, ::at::Tensor* d_self,
+                         ::at::Tensor* d_other) {
+  ::clad::custom_derivatives::at::dot_pullback(
+      *self, other, ::std::move(d_output), d_self, d_other);
+}
+
+} // namespace clad::custom_derivatives::class_functions
+
+#endif // CLAD_DIFFERENTIATOR_TORCHBUILTINS_TENSORSYNTAX_H

--- a/include/clad/Differentiator/TorchBuiltins/TensorSyntax.h
+++ b/include/clad/Differentiator/TorchBuiltins/TensorSyntax.h
@@ -2,8 +2,9 @@
 #define CLAD_DIFFERENTIATOR_TORCHBUILTINS_TENSORSYNTAX_H
 
 #include "clad/Differentiator/TorchBuiltins/BasicOps.h" // IWYU pragma: export
+#include "clad/Differentiator/TorchBuiltins/ViewOps.h"  // IWYU pragma: export
 
-// Keep the derivative formulas in BasicOps.h. These adapters only map the
+// Keep derivative formulas in the operator headers. These adapters only map
 // operator and Tensor method spellings onto the corresponding ATen functions.
 namespace clad::custom_derivatives::at {
 
@@ -103,6 +104,21 @@ inline void dot_pullback(const ::at::Tensor* self, const ::at::Tensor& other,
                          ::at::Tensor* d_other) {
   ::clad::custom_derivatives::at::dot_pullback(
       *self, other, ::std::move(d_output), d_self, d_other);
+}
+
+inline void transpose_pullback(const ::at::Tensor* self, int64_t dim0,
+                               int64_t dim1, ::at::Tensor d_output,
+                               ::at::Tensor* d_self, int64_t* d_dim0,
+                               int64_t* d_dim1) {
+  ::clad::custom_derivatives::at::transpose_pullback(
+      *self, dim0, dim1, ::std::move(d_output), d_self, d_dim0, d_dim1);
+}
+
+inline void permute_pullback(const ::at::Tensor* self, ::at::IntArrayRef dims,
+                             ::at::Tensor d_output, ::at::Tensor* d_self,
+                             ::at::IntArrayRef* d_dims) {
+  ::clad::custom_derivatives::at::permute_pullback(
+      *self, dims, ::std::move(d_output), d_self, d_dims);
 }
 
 } // namespace clad::custom_derivatives::class_functions

--- a/include/clad/Differentiator/TorchBuiltins/ViewOps.h
+++ b/include/clad/Differentiator/TorchBuiltins/ViewOps.h
@@ -1,0 +1,36 @@
+#ifndef CLAD_DIFFERENTIATOR_TORCHBUILTINS_VIEWOPS_H
+#define CLAD_DIFFERENTIATOR_TORCHBUILTINS_VIEWOPS_H
+
+#include "clad/Differentiator/TorchBuiltins/TensorLifecycle.h" // IWYU pragma: export
+
+#include <ATen/ops/permute.h>
+#include <ATen/ops/transpose.h>
+
+namespace clad::custom_derivatives::at {
+
+inline void transpose_pullback(const ::at::Tensor& input, int64_t dim0,
+                               int64_t dim1, ::at::Tensor d_output,
+                               ::at::Tensor* d_input, int64_t* /*d_dim0*/,
+                               int64_t* /*d_dim1*/) {
+  if (!d_input || !::clad::torch::detail::should_propagate(d_output))
+    return;
+  ::at::NoGradGuard guard;
+  ::clad::torch::detail::validate_tensor(input);
+  ::clad::torch::detail::accumulate(d_input,
+                                    ::at::transpose(d_output, dim0, dim1));
+}
+
+inline void permute_pullback(const ::at::Tensor& input, ::at::IntArrayRef dims,
+                             ::at::Tensor d_output, ::at::Tensor* d_input,
+                             ::at::IntArrayRef* /*d_dims*/) {
+  if (!d_input || !::clad::torch::detail::should_propagate(d_output))
+    return;
+  ::at::NoGradGuard guard;
+  ::clad::torch::detail::validate_tensor(input);
+  auto inverse = ::clad::torch::detail::inverse_permutation(dims, input.dim());
+  ::clad::torch::detail::accumulate(d_input, ::at::permute(d_output, inverse));
+}
+
+} // namespace clad::custom_derivatives::at
+
+#endif // CLAD_DIFFERENTIATOR_TORCHBUILTINS_VIEWOPS_H

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -706,7 +706,10 @@ namespace clad {
     }
     /// Find declaration of clad::tape templated type.
     clang::TemplateDecl* GetCladTapeDecl();
-    /// Perform a lookup into clad namespace for an entity with given name.
+    /// Look up an entity with the given name in the clad namespace. The result
+    /// may be empty.
+    clang::LookupResult tryLookupCladMethod(llvm::StringRef name);
+    /// Look up a required clad function template with the given name.
     clang::LookupResult LookupCladTapeMethod(llvm::StringRef name);
     /// Perform lookup into clad namespace for push/pop/back. Returns
     /// LookupResult, which is will be resolved later (which is handy since they
@@ -735,6 +738,11 @@ namespace clad {
     clang::DeclRefExpr* GetCladTapePushDRE();
 
     clang::Stmt* GetCladZeroInit(llvm::MutableArrayRef<clang::Expr*> args);
+
+    /// Build `clad::zero_like(value)` if a viable overload is available.
+    /// Returns null when the customization point is not implemented for the
+    /// value's type.
+    clang::Expr* GetCladZeroLike(clang::Expr* value);
 
     /// Assigns the Init expression to VD after performing the necessary
     /// implicit conversion. This is required as clang doesn't add implicit

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -13,6 +13,7 @@
 #include "clang/AST/ParentMapContext.h"
 #include "clang/AST/QualTypeNames.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Stmt.h"
 #include "clang/AST/TemplateName.h"
 #include "clang/AST/Type.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
@@ -1717,6 +1718,10 @@ namespace clad {
         const Stmt* S = parents[0].get<Stmt>();
         // If the parent is a Stmt but not an Expr, then the result is not used.
         if (!S)
+          return false;
+        // A call returned directly is still consumed by the enclosing
+        // function, including its value and adjoint in reverse_forw mode.
+        if (isa<ReturnStmt>(S))
           return false;
         E = dyn_cast<Expr>(S);
         if (!E)

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1879,6 +1879,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       bool isCUDAKernel) {
     StmtDiff result;
     StmtDiff argDiff{};
+    const auto* defaultArg = dyn_cast<CXXDefaultArgExpr>(arg);
     // FIXME: We handle parameters with default values by setting them
     // explicitly. However, some of them have private types and cannot be set.
     // For this reason, we ignore std::__nat. We need to come up with a
@@ -1901,13 +1902,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // is done to reduce cloning complexity and only clone once. The type is
       // same as the call expression as it is the type used to declare the
       // _gradX array
-      QualType dArgTy =
-          utils::getNonConstType(CloneType(arg->getType()), m_Sema);
-      Expr* init = getStdInitListSizeExpr(arg);
+      QualType argType =
+          defaultArg ? utils::GetValueType(param->getType()) : arg->getType();
+      QualType dArgTy = utils::getNonConstType(CloneType(argType), m_Sema);
+      Expr* init = defaultArg ? nullptr : getStdInitListSizeExpr(arg);
       bool shouldCopyInitialize = false;
       if (!init) {
         if (const CXXRecordDecl* CRD = dArgTy->getAsCXXRecordDecl())
-          shouldCopyInitialize = utils::isCopyable(CRD);
+          shouldCopyInitialize = !defaultArg && utils::isCopyable(CRD);
         // Temporarily initialize the object with `*nullptr` to avoid
         // a potential error because of non-existing default constructor.
         if (shouldCopyInitialize) {
@@ -1993,8 +1995,11 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         dArgRef = BuildDeclRef(dArgDeclCUDA);
       }
       result.updateStmtDx(dArgRef);
-      // Visit using uninitialized reference.
-      argDiff = Visit(arg, BuildDeclRef(dArgDecl));
+      if (defaultArg)
+        argDiff = {Clone(defaultArg->getExpr()), getZeroInit(dArgTy)};
+      else
+        // Visit using uninitialized reference.
+        argDiff = Visit(arg, BuildDeclRef(dArgDecl));
       if (shouldCopyInitialize) {
         if (Expr* dInit = argDiff.getExpr_dx())
           SetDeclInit(dArgDecl, dInit);
@@ -2785,17 +2790,50 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       return StmtDiff(resValue, resAdjoint);
     } // Recreate the original call expression.
 
-    if (const auto* OCE = dyn_cast<CXXOperatorCallExpr>(CE)) {
+    if (const auto* OCE = dyn_cast<CXXOperatorCallExpr>(CE))
       call = BuildOperatorCall(OCE->getOperator(), CallArgs);
-      return StmtDiff(call);
+    else {
+      if (MD && MD->isInstance())
+        CallArgs.erase(CallArgs.begin());
+      call = m_Sema
+                 .ActOnCallExpr(getCurrentScope(), Clone(CE->getCallee()), Loc,
+                                CallArgs, Loc, CUDAExecConfig)
+                 .get();
     }
 
-    if (MD && MD->isInstance())
-      CallArgs.erase(CallArgs.begin());
-    call = m_Sema
-               .ActOnCallExpr(getCurrentScope(), Clone(CE->getCallee()), Loc,
-                              CallArgs, Loc, CUDAExecConfig)
-               .get();
+    // A value-returning call needs no handwritten reverse-forward helper when
+    // a zero_like customization exists: the original call supplies the primal
+    // and clad::zero_like supplies an independent, structurally correct
+    // adjoint.
+    // An explicit reverse_forw above still takes precedence when a call needs
+    // to save additional state or preserve reference/aliasing semantics.
+    bool needsDefaultAdjoint =
+        !nonDiff || m_DiffReq.Mode == DiffMode::reverse_mode_forward_pass;
+    if (needsDefaultAdjoint && needsForwPass &&
+        !returnType->isReferenceType() && !returnType->isPointerType()) {
+      Expr* callRef = nullptr;
+      if (isInsideLoop)
+        callRef = GlobalStoreAndRef(call, /*prefix=*/"_t", /*force=*/true);
+      else
+        callRef = StoreAndRef(call, direction::forward, /*prefix=*/"_t",
+                              /*forceDeclCreation=*/true);
+
+      if (Expr* zeroLike = GetCladZeroLike(CloneNode(callRef))) {
+        Expr* adjointRef = nullptr;
+        if (isInsideLoop)
+          adjointRef = GlobalStoreAndRef(zeroLike, /*prefix=*/"_r",
+                                         /*force=*/true);
+        else
+          adjointRef =
+              StoreAndRef(zeroLike, direction::forward, /*prefix=*/"_r",
+                          /*forceDeclCreation=*/true);
+        return StmtDiff(callRef, adjointRef);
+      }
+      call = callRef;
+    }
+
+    if (isa<CXXOperatorCallExpr>(CE))
+      return StmtDiff(call);
     return StmtDiff(call, getZeroInit(call->getType()));
   }
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -445,22 +445,31 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           return result;
         };
         bool isDirectInit = false;
-        if (isNonAggrClass && utils::isCopyable(RD) &&
-            !hasDangerousFields(RD)) {
-          ParmVarDecl* newFuncParam = nullptr;
-          for (auto* p : m_Derivative->parameters()) {
-            if (p->getName() == param->getName()) {
-              newFuncParam = p;
-              break;
-            }
+        bool needsZeroInit = false;
+        ParmVarDecl* newFuncParam = nullptr;
+        for (auto* p : m_Derivative->parameters()) {
+          if (p->getName() == param->getName()) {
+            newFuncParam = p;
+            break;
           }
-          assert(
-              newFuncParam &&
-              "Could not find corresponding parameter in derivative function");
+        }
+        assert(newFuncParam &&
+               "Could not find corresponding parameter in derivative function");
+
+        Expr* zeroLike = nullptr;
+        if (RD)
+          zeroLike =
+              GetCladZeroLike(BuildDeclRef(newFuncParam->getDefinition()));
+        if (zeroLike) {
+          initExpr = zeroLike;
+          isDirectInit = true;
+        } else if (isNonAggrClass && utils::isCopyable(RD) &&
+                   !hasDangerousFields(RD)) {
           initExpr = BuildDeclRef(newFuncParam->getDefinition());
           isDirectInit = true;
+          needsZeroInit = true;
         } else {
-          // If the type is not a tensor, we can use zero initialization.
+          // Preserve the legacy value-initialization fallback.
           initExpr = getZeroInit(VDDerivedType);
         }
         auto* VDDerived = BuildGlobalVarDecl(
@@ -468,6 +477,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             isDirectInit);
         m_Variables[param] = {VDDerived};
         addToBlock(BuildDeclStmt(VDDerived), m_Globals);
+        if (needsZeroInit) {
+          Expr* derivedRef = BuildDeclRef(VDDerived);
+          addToBlock(GetCladZeroInit(derivedRef), m_Globals);
+        }
       }
     }
 

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -702,13 +702,18 @@ namespace clad {
     return utils::LookupTemplateDeclInCladNamespace(m_Sema, "tape");
   }
 
-  LookupResult VisitorBase::LookupCladTapeMethod(llvm::StringRef name) {
+  LookupResult VisitorBase::tryLookupCladMethod(llvm::StringRef name) {
     NamespaceDecl* CladNS = utils::GetCladNamespace(m_Sema);
     CXXScopeSpec CSS;
     CSS.Extend(m_Context, CladNS, noLoc, noLoc);
     DeclarationName Name = &m_Context.Idents.get(name);
     LookupResult R(m_Sema, Name, noLoc, Sema::LookupOrdinaryName);
     m_Sema.LookupQualifiedName(R, CladNS, CSS);
+    return R;
+  }
+
+  LookupResult VisitorBase::LookupCladTapeMethod(llvm::StringRef name) {
+    LookupResult R = tryLookupCladMethod(name);
     assert(!R.empty() && isa<FunctionTemplateDecl>(R.getRepresentativeDecl()) &&
            "cannot find requested name");
     return R;
@@ -1243,6 +1248,35 @@ namespace clad {
         .get();
   }
 
+  Expr* VisitorBase::GetCladZeroLike(Expr* value) {
+    NamespaceDecl* CladNS = utils::GetCladNamespace(m_Sema);
+    CXXScopeSpec CSS;
+    CSS.Extend(m_Context, CladNS, noLoc, noLoc);
+
+    LookupResult R = tryLookupCladMethod("zero_like");
+    if (R.empty())
+      return nullptr; // LCOV_EXCL_LINE: version-mismatched runtime header
+
+    ExprResult NameExpr =
+        m_Sema.BuildDeclarationNameExpr(CSS, R, /*NeedsADL=*/false);
+    if (NameExpr.isInvalid())
+      return nullptr; // LCOV_EXCL_LINE: defensive Sema failure
+
+    Expr* UnresolvedLookup = NameExpr.get();
+    llvm::SmallVector<Expr*, 1> args{value};
+    auto ARargs = llvm::MutableArrayRef<Expr*>(args);
+
+    // A missing customization is an expected, silent fallback path. Reuse the
+    // same overload probe as custom derivatives instead of asking Sema to
+    // diagnose an invalid call.
+    if (m_Builder.noOverloadExists(UnresolvedLookup, ARargs))
+      return nullptr;
+
+    ExprResult Call = m_Sema.ActOnCallExpr(getCurrentScope(), UnresolvedLookup,
+                                           noLoc, ARargs, noLoc);
+    return Call.isInvalid() ? nullptr : Call.get();
+  }
+
   FunctionDecl*
   VisitorBase::CreateDerivativeOverload(FunctionDecl* derivative) {
     if (!derivative)
@@ -1427,6 +1461,10 @@ namespace clad {
   Expr* VisitorBase::BuildOperatorCall(OverloadedOperatorKind OOK,
                                        MutableArrayRef<Expr*> ArgExprs,
                                        SourceLocation OpLoc) {
+    // Sema requires a valid location for rebuilt operator calls.
+    if (!OpLoc.isValid())
+      OpLoc = utils::GetValidSLoc(m_Sema);
+
     // First check operator kinds that are not considered binary/unary.
 
     // FIXME: Currently, Clad never uses arrow operators, all of them

--- a/test/Gradient/Cladtorch.C
+++ b/test/Gradient/Cladtorch.C
@@ -66,6 +66,7 @@ float fn1(
 
 // CHECK: void fn1_grad_0(const cladtorch::Tensor &t, const cladtorch::Tensor &u, no_namespace o, decltype(anon) a, {{.*}}anon_namespace z, not_found::Tensor w, cladtorch::Tensor *_d_t) {
 // CHECK-NEXT:     {{.*}}cladtorch::Tensor _d_u(u);
+// CHECK-NEXT:     clad::zero_init(_d_u);
 // CHECK-NEXT:     no_namespace _d_o = {0.F};
 // CHECK-NEXT:     {{.*}} _d_a = {0.F};
 // CHECK-NEXT:     anon_namespace _d_z = {0.F};

--- a/test/Gradient/DefaultArgumentAdjoint.C
+++ b/test/Gradient/DefaultArgumentAdjoint.C
@@ -1,0 +1,43 @@
+// RUN: %cladclang %s -I%S/../../include -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+#include <optional>
+
+double configured_scale(double value,
+                        ::std::optional<int> factor = ::std::nullopt) {
+  return value * factor.value_or(2);
+}
+
+namespace clad::custom_derivatives {
+
+void configured_scale_pullback(
+    [[maybe_unused]] double value, ::std::optional<int> factor, double d_output,
+    double* d_value,
+    [[maybe_unused]] ::std::optional<int>* d_factor) {
+  *d_value += factor.value_or(2) * d_output;
+}
+
+} // namespace clad::custom_derivatives
+
+double use_default_factor(double value) { return configured_scale(value); }
+
+// CHECK: void use_default_factor_grad(double value, double *_d_value) {
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 0.;
+// CHECK-NEXT:         std::optional<int> _r1 = {};
+// CHECK-NEXT:         clad::custom_derivatives::configured_scale_pullback(value, ::std::nullopt, 1, &_r0, &_r1);
+// CHECK-NEXT:         *_d_value += _r0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+int main() {
+  auto gradient = clad::gradient(use_default_factor);
+  double derivative = 0.0;
+  gradient.execute(3.0, &derivative);
+  std::printf("%.1f\n", derivative);
+}
+
+// CHECK-EXEC: 2.0

--- a/test/Gradient/DirectMemoryReturn.C
+++ b/test/Gradient/DirectMemoryReturn.C
@@ -1,0 +1,51 @@
+// RUN: %cladclang %s -I%S/../../include -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+struct MemoryValue {
+  double value;
+  double* storage;
+};
+
+MemoryValue make_memory_value(double input) {
+  return {input * input, nullptr};
+}
+
+namespace clad::custom_derivatives {
+
+clad::ValueAndAdjoint<MemoryValue, MemoryValue>
+make_memory_value_reverse_forw(double input,
+                               [[maybe_unused]] double d_input) {
+  return {make_memory_value(input), {0.0, nullptr}};
+}
+
+void make_memory_value_pullback(double input, MemoryValue d_output,
+                                double* d_input) {
+  *d_input += 2.0 * input * d_output.value;
+}
+
+} // namespace clad::custom_derivatives
+
+MemoryValue direct_memory_value(double input) {
+  return make_memory_value(input);
+}
+
+double memory_loss(double input) {
+  auto result = direct_memory_value(input);
+  return result.value;
+}
+
+// CHECK: clad::ValueAndAdjoint<MemoryValue, MemoryValue> direct_memory_value_reverse_forw(double input, double _d_input) {
+// CHECK:     clad::ValueAndAdjoint<MemoryValue, MemoryValue> _t0 = clad::custom_derivatives::make_memory_value_reverse_forw(input, 0.);
+// CHECK:     return {_t0.value, _t0.adjoint};
+// CHECK: }
+
+int main() {
+  auto gradient = clad::gradient(memory_loss);
+  double d_input = 0.0;
+  gradient.execute(3.0, &d_input);
+  std::printf("%.1f\n", d_input); // CHECK-EXEC: 6.0
+}

--- a/test/Gradient/DirectMemoryReturn.C
+++ b/test/Gradient/DirectMemoryReturn.C
@@ -10,17 +10,24 @@ struct MemoryValue {
   double* storage;
 };
 
+int primalCalls = 0;
+int zeroLikeCalls = 0;
+
 MemoryValue make_memory_value(double input) {
+  ++primalCalls;
   return {input * input, nullptr};
 }
 
-namespace clad::custom_derivatives {
+namespace clad {
 
-clad::ValueAndAdjoint<MemoryValue, MemoryValue>
-make_memory_value_reverse_forw(double input,
-                               [[maybe_unused]] double d_input) {
-  return {make_memory_value(input), {0.0, nullptr}};
+MemoryValue zero_like(const MemoryValue& /*value*/) {
+  ++zeroLikeCalls;
+  return {0.0, nullptr};
 }
+
+} // namespace clad
+
+namespace clad::custom_derivatives {
 
 void make_memory_value_pullback(double input, MemoryValue d_output,
                                 double* d_input) {
@@ -39,8 +46,9 @@ double memory_loss(double input) {
 }
 
 // CHECK: clad::ValueAndAdjoint<MemoryValue, MemoryValue> direct_memory_value_reverse_forw(double input, double _d_input) {
-// CHECK:     clad::ValueAndAdjoint<MemoryValue, MemoryValue> _t0 = clad::custom_derivatives::make_memory_value_reverse_forw(input, 0.);
-// CHECK:     return {_t0.value, _t0.adjoint};
+// CHECK-NEXT:     MemoryValue _t0 = make_memory_value(input);
+// CHECK-NEXT:     MemoryValue _r0 = clad::zero_like(_t0);
+// CHECK-NEXT:     return {{.*}}_t0{{.*}}_r0{{.*}};
 // CHECK: }
 
 int main() {
@@ -48,4 +56,6 @@ int main() {
   double d_input = 0.0;
   gradient.execute(3.0, &d_input);
   std::printf("%.1f\n", d_input); // CHECK-EXEC: 6.0
+  std::printf("%d %d\n", primalCalls,
+              zeroLikeCalls); // CHECK-EXEC-NEXT: 2 2
 }

--- a/test/Gradient/STLNonIndependentAdjoint.C
+++ b/test/Gradient/STLNonIndependentAdjoint.C
@@ -1,0 +1,80 @@
+// RUN: %cladclang %s -I%S/../../include -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+// RUN: %cladclang -std=c++14 %s -I%S/../../include -o %t14
+// RUN: %t14 | %filecheck_exec %s
+// RUN: %cladclang -std=c++20 %s -I%S/../../include -o %t20
+// RUN: %t20 | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+
+#include <cstdio>
+#include <vector>
+
+double replace_and_square(std::vector<double> values, double x) {
+  values[0] = x;
+  return values[0] * values[0];
+}
+
+// CHECK: void replace_and_square_grad_1(std::vector<double> values, double x, double *_d_x) {
+// CHECK-NEXT:     std::vector<double> _d_values(clad::zero_like(values));
+
+struct PointerView {
+  explicit PointerView(std::size_t size) : storage(size), data(storage.data()) {}
+
+  std::vector<double> storage;
+  double* data;
+};
+
+namespace clad {
+PointerView zero_like(const PointerView& value) {
+  return PointerView(value.storage.size());
+}
+} // namespace clad
+
+double scale_view(const PointerView& values, double x) {
+  return values.data[0] * x;
+}
+
+// CHECK: void scale_view_grad_1(const PointerView &values, double x, double *_d_x) {
+// CHECK-NEXT:     PointerView _d_values(clad::zero_like(values));
+
+struct CopyFallback {
+  explicit CopyFallback(double value) : value(value) {}
+
+  double value;
+};
+
+double replace_fallback(CopyFallback values, double x) {
+  values.value = x;
+  return values.value * values.value;
+}
+
+// CHECK: void replace_fallback_grad_1(CopyFallback values, double x, double *_d_x) {
+// CHECK-NEXT:     CopyFallback _d_values(values);
+// CHECK-NEXT:     clad::zero_init(_d_values);
+
+int main() {
+  std::vector<double> values{10.0};
+  double d_x = 0.0;
+  auto gradient = clad::gradient(replace_and_square, "x");
+  gradient.execute(values, 3.0, &d_x);
+  std::printf("%.1f\n", d_x);
+
+  PointerView view(1);
+  view.storage[0] = 4.0;
+  double d_scale = 0.0;
+  auto scale_gradient = clad::gradient(scale_view, "x");
+  scale_gradient.execute(view, 3.0, &d_scale);
+  std::printf("%.1f\n", d_scale);
+
+  CopyFallback fallback(10.0);
+  double d_fallback = 0.0;
+  auto fallback_gradient = clad::gradient(replace_fallback, "x");
+  fallback_gradient.execute(fallback, 3.0, &d_fallback);
+  std::printf("%.1f\n", d_fallback);
+}
+
+// CHECK-EXEC: 6.0
+// CHECK-EXEC-NEXT: 4.0
+// CHECK-EXEC-NEXT: 6.0

--- a/test/Misc/ZeroLike.C
+++ b/test/Misc/ZeroLike.C
@@ -1,0 +1,109 @@
+// RUN: %cladclang %s -I%S/../../include -o %t
+// RUN: %t | %filecheck_exec %s
+// RUN: %cladclang -std=c++14 %s -I%S/../../include -o %t14
+// RUN: %t14 | %filecheck_exec %s
+// RUN: %cladclang -std=c++20 %s -I%S/../../include -o %t20
+// RUN: %t20 | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdio>
+#include <deque>
+#include <forward_list>
+#include <initializer_list>
+#include <list>
+#include <string>
+#include <valarray>
+#include <vector>
+
+namespace zero_like_test {
+struct Counted {
+  double value = 7.;
+  static long copies;
+
+  Counted() = default;
+  Counted(const Counted& other) : value(other.value) { ++copies; }
+  Counted& operator=(const Counted&) = default;
+};
+
+long Counted::copies = 0;
+
+void zero_init(Counted& value) { value.value = 0.; }
+} // namespace zero_like_test
+
+using zero_like_test::Counted;
+
+// Models containers such as unordered_map, where T(size_type) configures
+// buckets rather than constructing size() elements.
+class BucketCountRange {
+public:
+  using size_type = std::size_t;
+
+  BucketCountRange(std::initializer_list<double> values) : storage(values) {}
+  explicit BucketCountRange(size_type) {}
+
+  std::vector<double>::iterator begin() { return storage.begin(); }
+  std::vector<double>::iterator end() { return storage.end(); }
+  std::vector<double>::const_iterator begin() const { return storage.begin(); }
+  std::vector<double>::const_iterator end() const { return storage.end(); }
+  size_type size() const { return storage.size(); }
+
+private:
+  std::vector<double> storage;
+};
+
+template <class Range> bool is_zero(const Range& range) {
+  for (const auto& value : range)
+    if (value != 0)
+      return false;
+  return true;
+}
+
+int main() {
+  std::array<double, 2> array{{1., 2.}};
+  std::deque<double> deque{1., 2.};
+  std::forward_list<double> forwardList{1., 2.};
+  std::list<double> list{1., 2.};
+  std::vector<double> vector{1., 2.};
+  std::valarray<double> valarray{1., 2.};
+  std::string string{'a', 'b'};
+
+  std::printf("%d %d %d %d %d %d %d\n",
+              is_zero(clad::zero_like(array)),
+              is_zero(clad::zero_like(deque)),
+              is_zero(clad::zero_like(forwardList)),
+              is_zero(clad::zero_like(list)),
+              is_zero(clad::zero_like(vector)),
+              is_zero(clad::zero_like(valarray)),
+              is_zero(clad::zero_like(string)));
+
+  std::vector<std::vector<Counted>> ragged(3);
+  ragged[0].resize(2);
+  ragged[1].resize(1);
+  ragged[2].resize(3);
+  for (auto& row : ragged)
+    for (auto& value : row)
+      value.value = 3.14;
+
+  Counted::copies = 0;
+  auto dRagged = clad::zero_like(ragged);
+  bool sameShapeAndZero = dRagged.size() == ragged.size();
+  for (std::size_t i = 0; i < ragged.size(); ++i) {
+    sameShapeAndZero &= dRagged[i].size() == ragged[i].size();
+    for (const auto& value : dRagged[i])
+      sameShapeAndZero &= value.value == 0.;
+  }
+  std::printf("%d %ld\n", sameShapeAndZero, Counted::copies);
+
+  BucketCountRange bucketRange{1., 2.};
+  auto dBucketRange = clad::zero_like(bucketRange);
+  std::printf("%d\n", dBucketRange.size() == bucketRange.size() &&
+                              is_zero(dBucketRange));
+}
+
+// CHECK-EXEC: 1 1 1 1 1 1 1
+// CHECK-EXEC-NEXT: 1 0
+// CHECK-EXEC-NEXT: 1


### PR DESCRIPTION
## Status

Still in progress. The initial LibTorch integration is functional, but several TODO items remain.

### TODO
- [x] Accept native `torch::Tensor` / `at::Tensor` inputs without exposing raw storage pointers.
- [x] Support composition across user-defined `Tensor -> Tensor` helper functions.
- [x] Support scalar loss functions through `Tensor::item<float>()`.
- [x] Add custom derivatives for `add`, `sub`, `mul`, `div`, `relu`, and `dot`.
- [x] Support Tensor-Tensor operators `+`, `-`, `*`, and `/`.
- [x] Support `.add()`, `.sub()`, `.mul()`, `.div()`, `.relu()`, and `.dot()`.
- [x] Recognize `torch::`, `at::`, and namespace-alias API spellings.
- [x] Handle Tensor copy/move construction and independent adjoint storage.
- [x] Fix direct memory-return differentiation through `ReturnStmt`.
- [x] Compare generated gradients against `torch::autograd::grad`.
- [x] Add a Clad-versus-LibTorch autograd benchmark.
- [ ] Fix the Clad AST cloning crash for chained rvalue calls such as `return output.dot(lhs).item<float>();`.
- [x] Add Tensor-scalar and scalar-Tensor overloads for `+`, `-`, `*`, and `/`.
- [x] Add scalar overloads for `.add()`, `.sub()`, `.mul()`, and `.div()`.
- [x] Define and implement scalar-adjoint reduction semantics.
- [ ] Add in-place operators `+=`, `-=`, `*=`, and `/=`.
- [x] Add `.add_()`, `.sub_()`, `.mul_()`, and `.div_()` with correct mutation and tape semantics.
- [ ] Strengthen adjoint alias handling for distinct Tensor views sharing storage.
- [x] Add broadcasting support with reduction back to each input shape.
- [ ] Add support for additional dtypes, devices, layouts, and non-contiguous tensors.
- [ ] Make the Clad and autograd benchmark workloads fully symmetric, including scalar extraction.