### PR TITLE
Fix clad::array copy-assignment over-reading a shorter source.

### DIFF
--- a/include/clad/Differentiator/Array.h
+++ b/include/clad/Differentiator/Array.h
@@ -98,8 +98,11 @@ public:
       delete[] m_arr;
       // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
       m_arr = new T[arr.m_size];
-      m_size = arr.m_size;
     }
+    // Adopt the source size before delegating to operator=(T*): otherwise a
+    // larger destination keeps its old m_size and that overload reads
+    // arr.m_arr past its end (heap over-read on shrinking assignment).
+    m_size = arr.m_size;
     (*this) = arr.m_arr;
     return *this;
   }

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -1,7 +1,5 @@
 // RUN: %cladclang %s -I%S/../../include -oJacobian.out 2>&1 | %filecheck %s
 // RUN: ./Jacobian.out | %filecheck_exec %s
-// FIXME: real clad::array copy-assignment over-read; drop when the fix lands.
-// XFAIL: valgrind
 
 #include "clad/Differentiator/Differentiator.h"
 #include <cmath>

--- a/test/Jacobian/testUtility.C
+++ b/test/Jacobian/testUtility.C
@@ -1,7 +1,5 @@
 // RUN: %cladclang %s -I%S/../../include -otestUtility.out 2>&1 | %filecheck %s
 // RUN: ./testUtility.out | %filecheck_exec %s
-// FIXME: real clad::array copy-assignment over-read; drop when the fix lands.
-// XFAIL: valgrind
 
 #include "clad/Differentiator/Differentiator.h"
 


### PR DESCRIPTION
array<T>::operator=(const array<T>&) only reallocated when the destination was smaller than the source, so a larger destination kept its old m_size and then copied that many elements from the shorter source -- a heap over-read Valgrind flags in Jacobian/Jacobian.C and Jacobian/testUtility.C once the clang false positives are suppressed.

Adopt the source size before copying so the loop is bounded by the source. The buffer may exceed m_size after a shrink, which is harmless: m_size bounds every access and the destructor frees the whole buffer.