### PR TITLE
Add missing clone  of CXXBindTemporaryExpr in StmtClone

### DIFF
--- a/include/clad/Differentiator/StmtClone.h
+++ b/include/clad/Differentiator/StmtClone.h
@@ -120,6 +120,7 @@ namespace utils {
     DECLARE_CLONE_FN(CXXThrowExpr)
     DECLARE_CLONE_FN(CXXConstructExpr)
     DECLARE_CLONE_FN(CXXTemporaryObjectExpr)
+    DECLARE_CLONE_FN(CXXBindTemporaryExpr)
     DECLARE_CLONE_FN(MaterializeTemporaryExpr)
     DECLARE_CLONE_FN(PseudoObjectExpr)
     DECLARE_CLONE_FN(OpaqueValueExpr)

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -221,6 +221,9 @@ Stmt* StmtClone::VisitCXXTemporaryObjectExpr(CXXTemporaryObjectExpr* Node) {
   return result;
 }
 
+DEFINE_CREATE_EXPR(CXXBindTemporaryExpr,
+                   (Ctx, Node->getTemporary(), Clone(Node->getSubExpr())))
+
 DEFINE_CLONE_EXPR(MaterializeTemporaryExpr,
                   (CloneType(Node->getType()),
                    Node->getSubExpr() ? Clone(Node->getSubExpr()) : nullptr,

--- a/test/Gradient/TemporaryMemberCall.C
+++ b/test/Gradient/TemporaryMemberCall.C
@@ -1,0 +1,46 @@
+// RUN: %cladclang %s -I%S/../../include -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+
+#include <cstdio>
+#include <vector>
+
+struct Box {
+  double value;
+  // A non-trivial destructor makes Clang bind prvalues of this type in a
+  // CXXBindTemporaryExpr.
+  ~Box() {}
+
+  double get() const { return value; }
+};
+
+Box make_box(double x) { return {x * x}; }
+
+double temporary_method(double x) { return make_box(x).get(); }
+
+double vector_temporary_method(double x) {
+  return x + static_cast<double>(std::vector<double>().size());
+}
+
+// CHECK: void temporary_method_grad(double x, double *_d_x) {
+// CHECK:     make_box(x).get_pullback(1, &{{.*}});
+// CHECK:     make_box_pullback(x, {{.*}}, &{{.*}});
+// CHECK: }
+
+// CHECK: void vector_temporary_method_grad(double x, double *_d_x) {
+// CHECK:     *_d_x += 1;
+// CHECK: }
+
+int main() {
+  auto temporary_method_grad = clad::gradient(temporary_method);
+  double d_x = 0.0;
+  temporary_method_grad.execute(3.0, &d_x);
+  std::printf("box=%.1f\n", d_x); // CHECK-EXEC: box=6.0
+
+  auto vector_temporary_method_grad = clad::gradient(vector_temporary_method);
+  d_x = 0.0;
+  vector_temporary_method_grad.execute(3.0, &d_x);
+  std::printf("vector=%.1f\n", d_x); // CHECK-EXEC: vector=1.0
+}


### PR DESCRIPTION
 ### Add `CXXBindTemporaryExpr` support in `StmtClone`.

 Clang inserts this implicit AST node when a temporary object has a non-trivial destructor. Since `StmtClone` did not handle it, cloning nested member calls on such temporaries fell through to `VisitStmt` and could eventually crash while updating references.

  ### Possible follow-up

  StmtClone currently implements cloning by manually handling individual AST node kinds. This makes it possible to miss implicit nodes such as CXXBindTemporaryExpr.

  A longer-term solution could be to refactor cloning and declaration-reference replacement around Clang's TreeTransform. It already recursively transforms and rebuilds AST nodes through Sema, including the implicit temporary and cleanup machinery, and could address this class of missing-node failures more systematically.

  The main obstacle is that TreeTransform.h is currently a private, non-installed Clang header under clang/lib/Sema. It also depends on other private headers such as CoroutineStmtBuilder.h and TypeLocBuilder.h. Using it in Clad's standalone build would therefore require vendoring version-matched private headers, requiring a matching Clang source tree, or first making this infrastructure public in Clang.