### PR TITLE
Fix dangling tracker references in early-return recursive functions

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2751,9 +2751,15 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         } else {
           // Otherwise, generate the declaration
           // ``clad::restore_tracker _tracker0 = {};``
-          VarDecl* trackerDecl =
-              BuildVarDecl(trackerType, "_tracker", getZeroInit(trackerType));
-          addToCurrentBlock(BuildDeclStmt(trackerDecl));
+          VarDecl* trackerDecl = nullptr;
+          if (isInsideLoop || m_DiffReq.hasEarlyReturns()) {
+            trackerDecl = GlobalStoreImpl(trackerType, "_tracker",
+                                          getZeroInit(trackerType));
+          } else {
+            trackerDecl =
+                BuildVarDecl(trackerType, "_tracker", getZeroInit(trackerType));
+            addToCurrentBlock(BuildDeclStmt(trackerDecl));
+          }
           trackerExpr = BuildDeclRef(trackerDecl);
           Expr* restoreCall = BuildCallExprToMemFn(
               BuildDeclRef(trackerDecl), /*MemberFunctionName=*/"restore",
@@ -2772,28 +2778,25 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // synthesized for a function clad cannot actually differentiate (an
       // operation reached through an opaque type). Fall through to recreating
       // the original call rather than storing a null expression.
-      if (call) {
-        if (!needsForwPass ||
-            (!dfdx() && utils::hasUnusedReturnValue(m_Context, CE)))
-          return StmtDiff(call);
-        Expr* callRes = nullptr;
-        if (isInsideLoop)
-          callRes = GlobalStoreAndRef(call, /*prefix=*/"_t",
-                                      /*force=*/true);
-        else
-          callRes = StoreAndRef(call);
-        auto* resValue =
-            utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");
-        // Clone the base so `_t0.value` and `_t0.adjoint` own distinct nodes.
-        auto* resAdjoint = utils::BuildMemberExpr(
-            m_Sema, getCurrentScope(), CloneNode(callRes), "adjoint");
-        if (Expr* add_assign = BuildDiffIncrement(resAdjoint)) {
-          Stmts& block = getCurrentBlock(direction::reverse);
-          it = std::begin(block) + insertionPoint;
-          block.insert(it, add_assign);
-        }
-        return StmtDiff(resValue, resAdjoint);
+      if (!needsForwPass ||
+          (!dfdx() && utils::hasUnusedReturnValue(m_Context, CE)))
+        return StmtDiff(call);
+      Expr* callRes = nullptr;
+      if (isInsideLoop || m_DiffReq.hasEarlyReturns())
+        callRes = GlobalStoreAndRef(call, /*prefix=*/"_t", /*force=*/true);
+      else
+        callRes = StoreAndRef(call);
+      auto* resValue =
+          utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");
+      // Clone the base so `_t0.value` and `_t0.adjoint` own distinct nodes.
+      auto* resAdjoint = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                                CloneNode(callRes), "adjoint");
+      if (Expr* add_assign = BuildDiffIncrement(resAdjoint)) {
+        Stmts& block = getCurrentBlock(direction::reverse);
+        it = std::begin(block) + insertionPoint;
+        block.insert(it, add_assign);
       }
+      return StmtDiff(resValue, resAdjoint);
     } // Recreate the original call expression.
 
     if (const auto* OCE = dyn_cast<CXXOperatorCallExpr>(CE)) {
@@ -4207,8 +4210,16 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     assert(!isa<ArrayType>(Type) && "Array types cannot be stored.");
     if (!force && !UsefulToStoreGlobal(E))
       return E;
+    bool isValueAndAdjoint =
+        Type->getAsCXXRecordDecl() &&
+        Type->getAsCXXRecordDecl()->getName() == "ValueAndAdjoint";
 
-    if (isInsideLoop) {
+    bool requiresTape =
+        isInsideLoop ||
+        (m_DiffReq.hasEarlyReturns() &&
+         (isValueAndAdjoint || utils::IsCladValueAndPushforwardType(Type)));
+
+    if (requiresTape) {
       CladTapeResult CladTape = MakeCladTapeFor(E, prefix, Type);
       addToCurrentBlock(CladTape.Push, direction::forward);
       addToCurrentBlock(CladTape.Pop, direction::reverse);
@@ -4233,6 +4244,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // on for adjoints and loop counters.
       if (zeroInit)
         SetDeclInit(VD, getZeroInit(Type));
+
       addToBlock(decl, m_Globals);
       // Use a fresh ref for the store-back LHS; Ref is returned to the caller
       // and reused in the reverse pass, so sharing it here parents it twice.
@@ -4457,8 +4469,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
     bool isFnScope = getCurrentScope()->isFunctionScope() ||
                      m_DiffReq.Mode == DiffMode::reverse_mode_forward_pass;
-    VarDecl* VD = BuildGlobalVarDecl(
-        utils::getNonConstType(E->getType(), m_Sema), prefix);
+    QualType VarType = utils::getNonConstType(E->getType(), m_Sema);
+    VarDecl* VD = BuildGlobalVarDecl(VarType, prefix);
     Expr* Ref = BuildDeclRef(VD);
     if (!isFnScope)
       addToBlock(BuildDeclStmt(VD), m_Globals);
@@ -5407,7 +5419,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         diag(DiagnosticsEngine::Note, NoteL, "%0 is defined here")
             << constrForw << NoteL;
       }
-      Expr* callRes = StoreAndRef(customReverseForwFnCall);
+      Expr* callRes = nullptr;
+      if (isInsideLoop || m_DiffReq.hasEarlyReturns()) {
+        callRes = GlobalStoreAndRef(customReverseForwFnCall, /*prefix=*/"_t",
+                                    /*force=*/true);
+      } else {
+        callRes = StoreAndRef(customReverseForwFnCall);
+      }
       Expr* val =
           utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");
       // Clone the base so `_t0.value` and `_t0.adjoint` own distinct nodes.

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2751,9 +2751,15 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         } else {
           // Otherwise, generate the declaration
           // ``clad::restore_tracker _tracker0 = {};``
-          VarDecl* trackerDecl =
-              BuildVarDecl(trackerType, "_tracker", getZeroInit(trackerType));
-          addToCurrentBlock(BuildDeclStmt(trackerDecl));
+          VarDecl* trackerDecl = nullptr;
+          if (isInsideLoop || m_DiffReq.hasEarlyReturns()) {
+            trackerDecl = GlobalStoreImpl(trackerType, "_tracker",
+                                          getZeroInit(trackerType));
+          } else {
+            trackerDecl =
+                BuildVarDecl(trackerType, "_tracker", getZeroInit(trackerType));
+            addToCurrentBlock(BuildDeclStmt(trackerDecl));
+          }
           trackerExpr = BuildDeclRef(trackerDecl);
           Expr* restoreCall = BuildCallExprToMemFn(
               BuildDeclRef(trackerDecl), /*MemberFunctionName=*/"restore",
@@ -2772,28 +2778,25 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // synthesized for a function clad cannot actually differentiate (an
       // operation reached through an opaque type). Fall through to recreating
       // the original call rather than storing a null expression.
-      if (call) {
-        if (!needsForwPass ||
-            (!dfdx() && utils::hasUnusedReturnValue(m_Context, CE)))
-          return StmtDiff(call);
-        Expr* callRes = nullptr;
-        if (isInsideLoop)
-          callRes = GlobalStoreAndRef(call, /*prefix=*/"_t",
-                                      /*force=*/true);
-        else
-          callRes = StoreAndRef(call);
-        auto* resValue =
-            utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");
-        // Clone the base so `_t0.value` and `_t0.adjoint` own distinct nodes.
-        auto* resAdjoint = utils::BuildMemberExpr(
-            m_Sema, getCurrentScope(), CloneNode(callRes), "adjoint");
-        if (Expr* add_assign = BuildDiffIncrement(resAdjoint)) {
-          Stmts& block = getCurrentBlock(direction::reverse);
-          it = std::begin(block) + insertionPoint;
-          block.insert(it, add_assign);
-        }
-        return StmtDiff(resValue, resAdjoint);
+      if (!needsForwPass ||
+          (!dfdx() && utils::hasUnusedReturnValue(m_Context, CE)))
+        return StmtDiff(call);
+      Expr* callRes = nullptr;
+      if (isInsideLoop || m_DiffReq.hasEarlyReturns())
+        callRes = GlobalStoreAndRef(call, /*prefix=*/"_t", /*force=*/true);
+      else
+        callRes = StoreAndRef(call);
+      auto* resValue =
+          utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");
+      // Clone the base so `_t0.value` and `_t0.adjoint` own distinct nodes.
+      auto* resAdjoint = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                                CloneNode(callRes), "adjoint");
+      if (Expr* add_assign = BuildDiffIncrement(resAdjoint)) {
+        Stmts& block = getCurrentBlock(direction::reverse);
+        it = std::begin(block) + insertionPoint;
+        block.insert(it, add_assign);
       }
+      return StmtDiff(resValue, resAdjoint);
     } // Recreate the original call expression.
 
     if (const auto* OCE = dyn_cast<CXXOperatorCallExpr>(CE)) {
@@ -4214,8 +4217,16 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     assert(!isa<ArrayType>(Type) && "Array types cannot be stored.");
     if (!force && !UsefulToStoreGlobal(E))
       return E;
+    bool isValueAndAdjoint =
+        Type->getAsCXXRecordDecl() &&
+        Type->getAsCXXRecordDecl()->getName() == "ValueAndAdjoint";
 
-    if (isInsideLoop) {
+    bool requiresTape =
+        isInsideLoop ||
+        (m_DiffReq.hasEarlyReturns() &&
+         (isValueAndAdjoint || utils::IsCladValueAndPushforwardType(Type)));
+
+    if (requiresTape) {
       CladTapeResult CladTape = MakeCladTapeFor(E, prefix, Type);
       addToCurrentBlock(CladTape.Push, direction::forward);
       addToCurrentBlock(CladTape.Pop, direction::reverse);
@@ -4240,6 +4251,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // on for adjoints and loop counters.
       if (zeroInit)
         SetDeclInit(VD, getZeroInit(Type));
+
       addToBlock(decl, m_Globals);
       // Use a fresh ref for the store-back LHS; Ref is returned to the caller
       // and reused in the reverse pass, so sharing it here parents it twice.
@@ -4468,8 +4480,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
     bool isFnScope = getCurrentScope()->isFunctionScope() ||
                      m_DiffReq.Mode == DiffMode::reverse_mode_forward_pass;
-    VarDecl* VD = BuildGlobalVarDecl(
-        utils::getNonConstType(E->getType(), m_Sema), prefix);
+    QualType VarType = utils::getNonConstType(E->getType(), m_Sema);
+    VarDecl* VD = BuildGlobalVarDecl(VarType, prefix);
     Expr* Ref = BuildDeclRef(VD);
     if (!isFnScope)
       addToBlock(BuildDeclStmt(VD), m_Globals);
@@ -5418,7 +5430,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         diag(DiagnosticsEngine::Note, NoteL, "%0 is defined here")
             << constrForw << NoteL;
       }
-      Expr* callRes = StoreAndRef(customReverseForwFnCall);
+      Expr* callRes = nullptr;
+      if (isInsideLoop || m_DiffReq.hasEarlyReturns()) {
+        callRes = GlobalStoreAndRef(customReverseForwFnCall, /*prefix=*/"_t",
+                                    /*force=*/true);
+      } else {
+        callRes = StoreAndRef(customReverseForwFnCall);
+      }
       Expr* val =
           utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");
       // Clone the base so `_t0.value` and `_t0.adjoint` own distinct nodes.

--- a/test/Gradient/RecursiveFunctionEarlyReturn.C
+++ b/test/Gradient/RecursiveFunctionEarlyReturn.C
@@ -1,0 +1,62 @@
+// RUN: %cladclang -std=c++17 -O0 -I%S/../../include/ %s -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+#include <vector>
+
+struct CustomObj {
+  double v;
+  CustomObj() : v(0.0) {} 
+  CustomObj(double temp) {
+    v = temp * 2.0; 
+  }
+};
+
+double func1(double x, int n) {
+  if (n <= 0) {
+    CustomObj obj(x); 
+    return obj.v;
+  }
+  return x*2.0 + func1(x, n - 1);
+}
+
+double func(double* A, int n, std::vector<double>& v) {
+  if (n <= 1) {
+    return A[0] * v[0]; 
+  }
+  
+  double res = 0;
+  for (int i = 0; i < n; i++) {
+    v[0] += A[i]; 
+    res += func(A, n - 1, v); 
+  }
+  return res;
+}
+
+// CHECK: void func_grad_0_2(
+// CHECK: clad::restore_tracker _tracker0 = {};
+// CHECK: auto _rev0 = [&] {
+// CHECK: _tracker0.restore();
+
+int main() {
+  double A[] = {1.0, 2.0, 3.0};
+  std::vector<double> v = {1.0};
+  auto d_fn = clad::gradient(func, "A, v");
+  
+  double d_A[3] = {0, 0, 0};
+  std::vector<double> d_v = {0.0};
+  d_fn.execute(A, 3, v, d_A, &d_v);
+  printf("d_A = {%.2f, %.2f, %.2f}\n", d_A[0], d_A[1], d_A[2]);
+  // CHECK-EXEC: d_A = {74.00, 13.00, 2.00}
+  printf("d_v = {%.2f}\n", d_v[0]);
+  // CHECK-EXEC: d_v = {6.00}
+  
+  auto d_func1 = clad::gradient(func1, "x");
+  double d_x = 0;
+  d_func1.execute(2.0, 3, &d_x);
+  printf("d_x = %.2f\n", d_x); 
+  // CHECK-EXEC: d_x = 8.00
+  
+  return 0;
+}


### PR DESCRIPTION
This PR fixes a segmentation fault encountered while differentiating recursive functions with early returns (e.g., backtracking type functions). When differentiating such functions Clad wraps the reverse sweep in a lambda ```(auto _rev0 = [&])```. Previously, ```clad::restore_tracker``` declarations and ValueAndAdjoint temporaries generated for operator[] calls were emitted inside nested forward-sweep blocks and it leads to null pointer dereferencing, resulting in a segmentation fault.  
