### PR TITLE
Add an opt-in mechanism for non-differentiable types.

### DIFF
--- a/docs/userDocs/source/user/CustomDerivatives.rst
+++ b/docs/userDocs/source/user/CustomDerivatives.rst
@@ -467,10 +467,9 @@ to provide *and* the marker to declare instead:
           definition, descending into library internals
     note: to differentiate it, provide clad::custom_derivatives::scale_pullback
           with signature 'void (const Widget *, double, double, Widget *, double *)'
-    note: or declare it non-differentiable with
-          clad::custom_derivatives::nondifferentiable(clad::Tag<Widget>{})
+    note: or mark it non-differentiable with CLAD_NONDIFFERENTIABLE_TYPE(Widget)
 
-Each remark gives you the two ways to resolve the boundary:
+Each remark gives you the ways to resolve the boundary:
 
 - **Differentiate it semantically.** Copy the printed signature and implement
   the custom derivative (a pushforward, pullback, or reverse-forward -- see the
@@ -478,10 +477,15 @@ Each remark gives you the two ways to resolve the boundary:
   derivative that is simpler or more correct than clad cloning its
   implementation (a matrix product's adjoint, a container's element access, ...).
 - **Mark it non-differentiable.** If the type carries no differentiable data
-  (a stream, an allocator, a reference-count handle, ...), declare
-  :code:`clad::custom_derivatives::nondifferentiable(clad::Tag<T>{})` and clad
-  will treat every use of it as opaque. The marker note is emitted for member
-  functions and constructors, where the enclosing type is the thing to mark.
+  (a stream, an allocator, a reference-count handle, ...), mark it with
+  :code:`CLAD_NONDIFFERENTIABLE_TYPE(T)` (see :doc:`UsingClad`) and clad will
+  treat every construction of and call on it as opaque. The marker note is
+  emitted for member functions and constructors, where the enclosing type is
+  the thing to mark.
+- **Elide its reverse-forward pass.** For a reverse-forward-pass boundary whose
+  pass is a no-op (e.g. a shallow copy that shares its adjoint), declare the
+  printed :code:`..._reverse_forw` and mark it :code:`elidable_reverse_forw`;
+  clad then skips the call instead of cloning a body.
 
 Only functions outside the main file are reported, so differentiating your own
 code stays quiet; the remarks focus on the library edge you are porting. The

--- a/docs/userDocs/source/user/UsingClad.rst
+++ b/docs/userDocs/source/user/UsingClad.rst
@@ -598,13 +598,12 @@ The ``non_differentiable`` Attribute
 
 Occasionally, you may want to skip differentiating a specific variable or function call. For example, some variables might be used purely for logging, as constants, or as standalone metrics. Clad provides the ``non_differentiable`` annotation attribute to safely omit generating derivatives for these components.
 
-You can apply this attribute using Clang's annotation syntax. The most common approach is to define a macro alias:
+Clad ships the ``CLAD_NONDIFFERENTIABLE`` macro (defined in
+``clad/Differentiator/BuiltinDerivatives.h``, pulled in by ``Differentiator.h``)
+for this; it expands to ``__attribute__((annotate("non_differentiable")))``.
 
-.. code-block:: c++
-
-   #define non_differentiable __attribute__((annotate("non_differentiable")))
-
-If the ``non_differentiable`` attribute is applied to a variable, Clad skips generating a derivative counterpart for it:
+If ``CLAD_NONDIFFERENTIABLE`` is applied to a variable, Clad skips generating a
+derivative counterpart for it:
 
 .. code-block:: c++
 
@@ -612,21 +611,51 @@ If the ``non_differentiable`` attribute is applied to a variable, Clad skips gen
    public:
      double x;
      double y;
-     non_differentiable double weight; // Clad will not compute derivatives with respect to this member
+     CLAD_NONDIFFERENTIABLE double weight; // not differentiated
    };
 
 If the attribute is applied to a function declaration, Clad refrains from producing any derivative expressions for that specific function. Instead, calls to the primal function are injected directly, behaving as if the result has a zero derivative:
 
 .. code-block:: c++
 
-   non_differentiable double get_scaling_factor(double i, double j) { 
-       return i * j; 
+   CLAD_NONDIFFERENTIABLE double get_scaling_factor(double i, double j) {
+       return i * j;
    }
 
-   double compute(double i, double j) { 
-       // get_scaling_factor will skip differentiation completely. 
-       return get_scaling_factor(i, j) + i * j; 
+   double compute(double i, double j) {
+       // get_scaling_factor will skip differentiation completely.
+       return get_scaling_factor(i, j) + i * j;
    }
+
+Marking a type you do not own
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The attribute must sit on the declaration you want to mark, so it cannot be
+attached to a library type declared in a header you do not control (a stream, an
+allocator, a third-party handle). For those, mark the type from the outside with
+``CLAD_NONDIFFERENTIABLE_TYPE`` at global scope; Clad then treats every
+construction of and call on that type as opaque:
+
+.. code-block:: c++
+
+   CLAD_NONDIFFERENTIABLE_TYPE(ThirdParty::Handle);
+   // template arguments (and commas) are fine:
+   CLAD_NONDIFFERENTIABLE_TYPE(std::map<int, double>);
+
+It expands to a ``clad::Tag`` specialization carrying
+``CLAD_NONDIFFERENTIABLE``. A concrete type is marked as written; a *template
+family* (e.g. every ``Boxed<T>``) needs a partial specialization the macro
+cannot express -- write it directly:
+
+.. code-block:: c++
+
+   namespace clad {
+   template <class T> class CLAD_NONDIFFERENTIABLE Tag<Boxed<T>> {};
+   }
+
+The standard-library primitives Clad already knows are non-differentiable
+(``std::string``, ``std::allocator``, the stream family) are marked this way in
+``STLBuiltins.h``.
 
 Specifying Custom Derivatives
 -------------------------------

--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -60,6 +60,21 @@ template <typename T, typename U> struct ValueAndAdjoint {
 /// We do the same for constructor_reverse_forw.
 template <class T> class Tag {};
 
+/// Marks an entity non-differentiable: clad treats it as opaque and never
+/// clones its body to synthesize a derivative. Apply at the declaration of a
+/// variable, member, function, or type you own, e.g.
+///   struct CLAD_NONDIFFERENTIABLE Handle { double* data; };
+#define CLAD_NONDIFFERENTIABLE __attribute__((annotate("non_differentiable")))
+
+/// Marks a type you do NOT own -- a library type you cannot annotate at its own
+/// declaration -- non-differentiable, by specializing clad::Tag for it. Use at
+/// global scope. The type may contain commas, e.g.
+///   CLAD_NONDIFFERENTIABLE_TYPE(std::map<int, double>);
+#define CLAD_NONDIFFERENTIABLE_TYPE(...)                                       \
+  namespace clad {                                                             \
+  template <> class CLAD_NONDIFFERENTIABLE Tag<__VA_ARGS__> {};                \
+  }
+
 /// We have aliases with for old tags for backwards compatibility.
 template <class T> using ConstructorPushforwardTag = Tag<T>;
 

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -381,6 +381,26 @@ namespace clad {
 
     bool hasNonDifferentiableAttribute(const clang::Expr* E);
 
+    /// Returns true if \p RD is marked non-differentiable (opaque) by a
+    /// clad::custom_derivatives::nondifferentiable(clad::Tag<T>) declaration:
+    /// clad must not clone its member bodies to synthesize a derivative. The
+    /// built-in standard-library markers live in STLBuiltins.h; users extend
+    /// the set by declaring their own.
+    bool isNonDifferentiableType(clang::Sema& S,
+                                 const clang::CXXRecordDecl* RD);
+
+    /// Returns true if the type \p CE fundamentally operates on -- the object
+    /// of a member call, or the first argument of a free operator (`os << x`)
+    /// -- is non-differentiable (Tag-aware, so it honors clad::Tag<T> markers).
+    /// Deliberately narrower than hasNonDifferentiableAttribute(Expr): it looks
+    /// only at the operated-on type, so a differentiable call that merely
+    /// passes a marked value is unaffected. Callers use it to skip the call
+    /// outright (an early return) rather than to set the weaker nonDiff flag,
+    /// which in reverse mode would still schedule a pullback and descend into
+    /// the type's machinery.
+    bool callOperatesOnNonDifferentiableType(clang::Sema& S,
+                                             const clang::CallExpr* CE);
+
     /// Collects every DeclRefExpr, MemberExpr, ArraySubscriptExpr in an
     /// assignment operator or a ternary if operator. This is useful to when we
     /// need to decide what needs to be stored on tape in reverse mode.
@@ -429,8 +449,17 @@ namespace clad {
     bool isLinearConstructor(const clang::CXXConstructorDecl* CD,
                              const clang::ASTContext& C);
 
-    bool isElidableConstructor(const clang::CXXConstructorDecl* CD,
-                               const clang::ASTContext& C);
+    /// Returns true if the reverse-forward propagator for constructor \p CD is
+    /// structurally elidable -- clad need not synthesize one because the plain
+    /// construction plus the normal member-wise adjoint handling already covers
+    /// it. This holds for a trivial copy/move constructor (a shallow share of
+    /// pointer/handle members), an aggregate, and a memberwise zero-or-copy
+    /// initializer. A non-trivial constructor can additionally opt in with the
+    /// elidable_reverse_forw attribute on its custom reverse_forw (see
+    /// hasElidableReverseForwAttribute) -- both paths are combined where the
+    /// propagator is consumed.
+    bool constructorReverseForwIsElidable(const clang::CXXConstructorDecl* CD,
+                                          const clang::ASTContext& C);
 
     /// Returns true if T allows to edit any memory.
     bool isMemoryType(clang::QualType T);

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -7,8 +7,10 @@
 #include <clad/Differentiator/FunctionTraits.h>
 #include <functional>
 #include <initializer_list>
+#include <iosfwd>
 #include <iterator>
 #include <memory>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <vector>
@@ -29,6 +31,30 @@ template <class T1, class T2> void zero_init(std::pair<T1, T2>& p) {
 template <class T> void zero_init(typename std::allocator<T>&) {
   // do nothing, unclear if allocators have differentiable properties.
 }
+
+// Mark a library type non-differentiable (opaque) by specializing clad::Tag for
+// it and annotating the specialization: the `non_differentiable` attribute
+// cannot be attached to a type declared in a header we do not own. clad then
+// treats the type as opaque and never clones its member bodies to synthesize a
+// derivative -- which for these primitives would be ill-formed. A custom
+// derivative, if present, still wins. Add your own non-differentiable library
+// types the same way.
+template <class C, class Tr, class A>
+class CLAD_NONDIFFERENTIABLE Tag<::std::basic_string<C, Tr, A>> {};
+template <class T> class CLAD_NONDIFFERENTIABLE Tag<::std::allocator<T>> {};
+// The stream family is non-differentiable I/O. Marking it lets clad treat a
+// stream operation (`os << x`, a streambuf method) as opaque instead of
+// descending into sentry/streambuf/scope_guard/char_traits machinery. Only
+// forward declarations (<iosfwd>) are needed to name the templates.
+template <class C, class Tr>
+class CLAD_NONDIFFERENTIABLE Tag<::std::basic_ostream<C, Tr>> {};
+template <class C, class Tr>
+class CLAD_NONDIFFERENTIABLE Tag<::std::basic_istream<C, Tr>> {};
+template <class C, class Tr>
+class CLAD_NONDIFFERENTIABLE Tag<::std::basic_streambuf<C, Tr>> {};
+template <class C, class Tr>
+class CLAD_NONDIFFERENTIABLE Tag<::std::basic_ios<C, Tr>> {};
+template <> class CLAD_NONDIFFERENTIABLE Tag<::std::ios_base> {};
 
 namespace custom_derivatives {
 

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -359,8 +359,8 @@ namespace clad {
       return true;
     }
 
-    bool isElidableConstructor(const clang::CXXConstructorDecl* CD,
-                               const clang::ASTContext& C) {
+    bool constructorReverseForwIsElidable(const clang::CXXConstructorDecl* CD,
+                                          const clang::ASTContext& C) {
       const CXXRecordDecl* RD = CD->getParent();
       if (CD->isCopyOrMoveConstructor() && CD->isTrivial())
         return true;
@@ -684,6 +684,51 @@ namespace clad {
         QualType VDElemTy = utils::GetValueType(VD->getType());
         const CXXRecordDecl* RD = VDElemTy->getAsCXXRecordDecl();
         if (RD && clad::utils::hasNonDifferentiableAttribute(RD))
+          return true;
+      }
+      return false;
+    }
+
+    bool isNonDifferentiableType(clang::Sema& S,
+                                 const clang::CXXRecordDecl* RD) {
+      // A type is non-differentiable (opaque) when it carries the
+      // `non_differentiable` annotation. For a type the user owns the attribute
+      // sits on the type itself; for a foreign type it cannot, so the opt-out
+      // is expressed on a clad::Tag<T> specialization instead (see
+      // STLBuiltins.h). Either way clad never clones the type's member bodies
+      // to synthesize a derivative, which for library internals is ill-formed
+      // (see DiffCollector::VisitCXXConstructExpr). A custom derivative, if
+      // present, still wins: it is looked up first, so the marker only
+      // suppresses the body-clone fallback.
+      if (!RD)
+        return false;
+      if (hasNonDifferentiableAttribute(RD))
+        return true;
+      // Out-of-line opt-out: the attribute lives on clad::Tag<RD>. Completing
+      // the specialization instantiates a matching partial specialization's
+      // attribute onto it (Tag's primary template is an empty class, so
+      // completion never fails); then read the attribute off it.
+      QualType TagTy = GetCladTagOfType(
+          S, clad_compat::getRecordType(S.getASTContext(), RD));
+      S.isCompleteType(GetValidSLoc(S), TagTy);
+      const auto* TagRD = TagTy->getAsCXXRecordDecl();
+      return TagRD && hasNonDifferentiableAttribute(TagRD);
+    }
+
+    bool callOperatesOnNonDifferentiableType(clang::Sema& S,
+                                             const clang::CallExpr* CE) {
+      // Extract the type the call operates on -- the declaring class of a
+      // member call, or the first argument of a free operator (`os << x`) --
+      // and ask whether it is non-differentiable. See the header for why this
+      // is narrower than hasNonDifferentiableAttribute(Expr) and why callers
+      // skip on it rather than set the nonDiff flag.
+      const clang::FunctionDecl* FD = CE->getDirectCallee();
+      if (const auto* MD = dyn_cast_or_null<clang::CXXMethodDecl>(FD))
+        if (isNonDifferentiableType(S, MD->getParent()))
+          return true;
+      if (FD && FD->isOverloadedOperator() && CE->getNumArgs() >= 1) {
+        QualType T = CE->getArg(0)->getType().getNonReferenceType();
+        if (isNonDifferentiableType(S, T->getAsCXXRecordDecl()))
           return true;
       }
       return false;

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -476,8 +476,12 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
     const FunctionDecl* FD = request.Function;
     // A custom derivative already covers this call; nothing to port. Only a
     // function whose *definition* clad is about to clone is a porting gap.
+    // Constructors have a non-identifier name (a constructor name) but are a
+    // primary porting case (e.g. std::string's constructor), so let them
+    // through; other non-identifier names (operators) have no clean suggested
+    // custom-derivative spelling, so skip them.
     if (!FD || request.CustomDerivative || !FD->isDefined() ||
-        !FD->getDeclName().isIdentifier())
+        (!FD->getDeclName().isIdentifier() && !isa<CXXConstructorDecl>(FD)))
       return;
     // Hint only at a library boundary: a function defined outside the main
     // source file (an included header), where the user decides "differentiate
@@ -502,11 +506,36 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
          "to differentiate it, provide clad::custom_derivatives::%0 with "
          "signature %1")
         << request.ComputeDerivativeName() << DerivativeType;
-    if (const auto* MD = dyn_cast<CXXMethodDecl>(FD))
+    if (const auto* MD = dyn_cast<CXXMethodDecl>(FD)) {
+      const CXXRecordDecl* RD = MD->getParent();
+      // Print the qualified name WITH template arguments
+      // (getQualifiedNameAsString drops them, yielding an ill-formed Tag<Boxed>
+      // for a Boxed<double>).
+      clang::PrintingPolicy Policy = m_Sema.getPrintingPolicy();
+      Policy.SuppressTagKeyword = true;
+      std::string TypeName =
+          clad_compat::getRecordType(m_Context, RD).getAsString(Policy);
       diag(DiagnosticsEngine::Note, Loc,
-           "or declare it non-differentiable with "
-           "clad::custom_derivatives::nondifferentiable(clad::Tag<%0>{})")
-          << MD->getParent()->getQualifiedNameAsString();
+           "or mark it non-differentiable with CLAD_NONDIFFERENTIABLE_TYPE(%0)")
+          << TypeName;
+      // The value-level macro marks a single type; a template instantiation is
+      // only that specialization. Marking the whole family needs a clad::Tag
+      // partial specialization the macro cannot express.
+      if (isa<clang::ClassTemplateSpecializationDecl>(RD))
+        diag(DiagnosticsEngine::Note, Loc,
+             "this marks only this specialization; to mark the whole template, "
+             "add a clad::Tag partial specialization carrying "
+             "CLAD_NONDIFFERENTIABLE");
+    }
+    // A reverse-forward pass that is a no-op (e.g. a shallow copy that shares
+    // its adjoint) need not be cloned: declare it and mark it elidable so clad
+    // skips the call. Point at the existing mechanism rather than a new one.
+    if (request.Mode == DiffMode::reverse_mode_forward_pass)
+      diag(DiagnosticsEngine::Note, Loc,
+           "or, if its reverse-forward pass is a no-op (e.g. a shallow copy "
+           "that shares its adjoint), declare %0 with signature %1 and mark it "
+           "elidable_reverse_forw")
+          << request.ComputeDerivativeName() << DerivativeType;
   }
 
   DerivativeAndOverload

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1252,6 +1252,15 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       if (clad::utils::hasNonDifferentiableAttribute(E))
         nonDiff = true;
 
+      // A call whose object is a marked non-differentiable type -- a stream
+      // operation (`os << x`) or a std::streambuf method -- is opaque. Do not
+      // schedule a derivative for it or recurse into its body; otherwise clad
+      // descends into the whole non-differentiable I/O machinery
+      // (sentry/streambuf/scope_guard/char_traits). The primal call is emitted
+      // as-is in the derivative.
+      if (clad::utils::callOperatesOnNonDifferentiableType(m_Sema, E))
+        return true;
+
       request.VerboseDiags = false;
       request.EnableTBRAnalysis = m_TopMostReq->EnableTBRAnalysis;
       request.EnableVariedAnalysis = m_TopMostReq->EnableVariedAnalysis;
@@ -1614,10 +1623,21 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     forwPassRequest.BaseFunctionName = "constructor";
     forwPassRequest.Mode = DiffMode::reverse_mode_forward_pass;
     forwPassRequest.CallContext = E;
+    forwPassRequest.EmitPortingHints = m_TopMostReq->EmitPortingHints;
     QualType recordTy = CD->getThisType()->getPointeeType();
     bool elideRevForw =
-        utils::isElidableConstructor(CD, m_Sema.getASTContext());
-    if (LookupCustomDerivativeDecl(forwPassRequest) || !elideRevForw)
+        utils::constructorReverseForwIsElidable(CD, m_Sema.getASTContext());
+    // Cloning the body of a non-differentiable constructor yields an ill-formed
+    // reverse-forward propagator: e.g. std::string's char-pointer constructor
+    // (reached through a Kokkos::View label) delegates to a private member
+    // (this->__init(...)), but the propagator is a static function with no
+    // `this`, so CodeGen crashes. Build a propagator for a marked type only
+    // when the user supplied a custom derivative, never by cloning the library
+    // body.
+    bool cloneBodyUnsafe =
+        utils::isNonDifferentiableType(m_Sema, CD->getParent());
+    if (LookupCustomDerivativeDecl(forwPassRequest) ||
+        (!elideRevForw && !cloneBodyUnsafe))
       m_DiffRequestGraph.addNode(forwPassRequest, /*isSource=*/true);
 
     // Don't build propagators for calls that do not contribute in

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1996,10 +1996,18 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     if (isNonDiff)
       result.updateStmtDx(nullptr);
     QualType paramTy = param->getType();
-    if (Expr* adjointArg = result.getExpr_dx())
-      if (!(isNonDiff || utils::isArrayOrPointerType(paramTy) || isCUDAKernel))
+    if (Expr* adjointArg = result.getExpr_dx()) {
+      // An argument of an opaque (non-differentiable) type carries no adjoint,
+      // so its adjoint expression has void type. Taking its address for the
+      // pullback (`&<void>`) is ill-formed, so drop it rather than thread it
+      // through.
+      if (adjointArg->getType()->isVoidType())
+        result.updateStmtDx(nullptr);
+      else if (!(isNonDiff || utils::isArrayOrPointerType(paramTy) ||
+                 isCUDAKernel))
         result.updateStmtDx(
             BuildOp(UO_AddrOf, adjointArg, m_DiffReq->getLocation()));
+    }
 
     // If a function returns an object by value, there
     // are an implicit move constructor and an implicit
@@ -2318,7 +2326,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
 
     // FIXME: consider moving non-diff analysis to DiffPlanner.
-    bool nonDiff = clad::utils::hasNonDifferentiableAttribute(CE);
+    bool nonDiff = clad::utils::hasNonDifferentiableAttribute(CE) ||
+                   clad::utils::callOperatesOnNonDifferentiableType(m_Sema, CE);
     // If the result does not depend on the result of the call, just clone
     // the call and visit arguments (since they may contain side-effects like
     // f(x = y))
@@ -2750,26 +2759,32 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         CallArgs.push_back(CloneNode(trackerExpr));
       call =
           BuildCallExprToFunction(calleeFnForwPassFD, CallArgs, CUDAExecConfig);
-      if (!needsForwPass ||
-          (!dfdx() && utils::hasUnusedReturnValue(m_Context, CE)))
-        return StmtDiff(call);
-      Expr* callRes = nullptr;
-      if (isInsideLoop)
-        callRes = GlobalStoreAndRef(call, /*prefix=*/"_t",
-                                    /*force=*/true);
-      else
-        callRes = StoreAndRef(call);
-      auto* resValue =
-          utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");
-      // Clone the base so `_t0.value` and `_t0.adjoint` own distinct nodes.
-      auto* resAdjoint = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
-                                                CloneNode(callRes), "adjoint");
-      if (Expr* add_assign = BuildDiffIncrement(resAdjoint)) {
-        Stmts& block = getCurrentBlock(direction::reverse);
-        it = std::begin(block) + insertionPoint;
-        block.insert(it, add_assign);
+      // Sema can reject the reverse-forward call -- e.g. its signature was
+      // synthesized for a function clad cannot actually differentiate (an
+      // operation reached through an opaque type). Fall through to recreating
+      // the original call rather than storing a null expression.
+      if (call) {
+        if (!needsForwPass ||
+            (!dfdx() && utils::hasUnusedReturnValue(m_Context, CE)))
+          return StmtDiff(call);
+        Expr* callRes = nullptr;
+        if (isInsideLoop)
+          callRes = GlobalStoreAndRef(call, /*prefix=*/"_t",
+                                      /*force=*/true);
+        else
+          callRes = StoreAndRef(call);
+        auto* resValue =
+            utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");
+        // Clone the base so `_t0.value` and `_t0.adjoint` own distinct nodes.
+        auto* resAdjoint = utils::BuildMemberExpr(
+            m_Sema, getCurrentScope(), CloneNode(callRes), "adjoint");
+        if (Expr* add_assign = BuildDiffIncrement(resAdjoint)) {
+          Stmts& block = getCurrentBlock(direction::reverse);
+          it = std::begin(block) + insertionPoint;
+          block.insert(it, add_assign);
+        }
+        return StmtDiff(resValue, resAdjoint);
       }
-      return StmtDiff(resValue, resAdjoint);
     } // Recreate the original call expression.
 
     if (const auto* OCE = dyn_cast<CXXOperatorCallExpr>(CE)) {
@@ -5330,9 +5345,15 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       }
       return {val, adjoint};
     }
-    assert((elideReverseForw ||
-            utils::isElidableConstructor(CD, m_Sema.getASTContext())) &&
-           "No reverse_forw for a non-elidable constructor.");
+    // A non-differentiable (marked) library-type constructor is scheduled
+    // without a reverse-forward propagator (see DiffPlanner), so `constrForw`
+    // is legitimately null here even for a non-elidable constructor; fall
+    // through to the plain construction clone.
+    assert(
+        (elideReverseForw ||
+         utils::isNonDifferentiableType(m_Sema, CD->getParent()) ||
+         utils::constructorReverseForwIsElidable(CD, m_Sema.getASTContext())) &&
+        "No reverse_forw for a non-elidable constructor.");
 
     // Aggregate constructors are always element-wise initializers.
     if (RD->isAggregate() && CD->isDefaultConstructor())

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -1316,6 +1316,20 @@ void print(T* arr, int n) {
   F##_grad.execute(__VA_ARGS__, result, &d_n);\
   print(result, 5);
 
+// Calls the reference-returning identity() inside a loop. clad stores each
+// identity_reverse_forw result in a tape -- the in-loop reverse-forward store
+// (GlobalStoreAndRef), as opposed to the straight-line store fn7 exercises.
+double fnIdLoop(double x, double y) {
+  double a = x;
+  double s = 0;
+  for (int c = 0; c < 3; ++c)
+    s += identity(a);
+  return s + y;
+} // 3x + y
+
+// CHECK-LABEL: void fnIdLoop_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: clad::push(_t{{[0-9]+}}, identity_reverse_forw(a, _d_a));
+
 int main() {
   double result[7];
   float fresult[7];
@@ -1438,6 +1452,8 @@ int main() {
 
   INIT(fn35);
   TEST2(fn35, 10, 1);  // CHECK-EXEC: {-3.00, 2.00}
+  INIT(fnIdLoop);
+  TEST2(fnIdLoop, 2, 5);  // CHECK-EXEC: {3.00, 1.00}
 }
 
 double sq_defined_later(double x) {

--- a/test/Gradient/NonDifferentiableMarkedType.cpp
+++ b/test/Gradient/NonDifferentiableMarkedType.cpp
@@ -1,0 +1,59 @@
+// RUN: %cladclang %s -I%S/../../include -oNonDifferentiableMarkedType.out -Xclang -verify 2>&1 | %filecheck %s
+// RUN: ./NonDifferentiableMarkedType.out | %filecheck_exec %s
+//
+// A user type marked non-differentiable with CLAD_NONDIFFERENTIABLE_TYPE is
+// opaque: callOperatesOnNonDifferentiableType makes clad treat a call that
+// operates on it as carrying no derivative instead of descending into it. The
+// "type the call operates on" is the object of a member call (Meter::read
+// below) or the first argument of a free operator (operator<< on Logger).
+
+#include "clad/Differentiator/Differentiator.h"
+
+struct Meter {
+  double v;
+  double read() const { return v; }
+};
+CLAD_NONDIFFERENTIABLE_TYPE(Meter);
+
+double f(double x) {
+  Meter m{5.0};
+  return x * x + m.read(); // m.read() is opaque -> zero derivative contribution
+}
+
+// CHECK: void f_grad(double x, double *_d_x) {
+// CHECK-NOT: read
+// CHECK: *_d_x += 1 * x;
+// CHECK-NEXT: *_d_x += x * 1;
+
+struct Logger {};
+CLAD_NONDIFFERENTIABLE_TYPE(Logger);
+// Free operator whose first argument is the marked type -- the arg0 branch of
+// callOperatesOnNonDifferentiableType, distinct from the member-call branch
+// above.
+Logger& operator<<(Logger& l, double) { return l; }
+
+double g(double x) {
+  Logger log;
+  log << (x * x); // opaque -> emitted as-is, feeds nothing into the adjoint
+  return x * x * x;
+}
+
+// The operator call survives verbatim in the derivative and gets no pullback;
+// only the return contributes to the adjoint (d/dx x^3 = 3x^2 = 12 at x = 2).
+// CHECK: void g_grad(double x, double *_d_x) {
+// CHECK: {{.*}} << (x * x);
+// CHECK-NOT: pullback
+
+int main() {
+  auto df = clad::gradient(f);
+  double dx = 0;
+  df.execute(3.0, &dx);
+  printf("%.2f\n", dx); // CHECK-EXEC: 6.00
+
+  auto dg = clad::gradient(g);
+  dx = 0;
+  dg.execute(2.0, &dx);
+  printf("%.2f\n", dx); // CHECK-EXEC: 12.00
+}
+
+// expected-no-diagnostics

--- a/test/Gradient/StringConstructor.cpp
+++ b/test/Gradient/StringConstructor.cpp
@@ -1,0 +1,46 @@
+// RUN: %cladclang %s -I%S/../../include -oStringConstructor.out -Xclang -verify 2>&1 | %filecheck %s
+// RUN: ./StringConstructor.out | %filecheck_exec %s
+//
+// Constructing a std::string inside a differentiated function used to crash
+// clad: it synthesized a reverse-forward propagator for the constructor by
+// cloning the body, which delegates to a private member (`this->__init(...)`),
+// but the propagator is a static function with no `this`, so CodeGen
+// dereferenced a null `this`. Str reproduces that shape without <string> -- a
+// constructor that delegates to a member function. Removing the marker below
+// makes clang segfault in CodeGen generating Str::constructor_reverse_forw
+// (verified against this clang). The defaulted constructor matters: without it
+// clad's generated adjoint fails earlier at Sema ("no matching constructor"),
+// masking the CodeGen crash the marker actually prevents. With the marker the
+// construction is opaque, so the body is never cloned.
+
+#include "clad/Differentiator/Differentiator.h"
+
+struct Str {
+  const char* Data = nullptr;
+  Str() = default; // reach CodeGen, not an earlier Sema error
+  Str(const char* P) { init(P); } // body needs `this`; unsafe as a static clone
+private:
+  void init(const char* P) { Data = P; }
+};
+CLAD_NONDIFFERENTIABLE_TYPE(Str);
+
+double f(double x) {
+  Str s("a"); // opaque -> not differentiated, no `init` clone
+  return x * x;
+}
+
+// CHECK: void f_grad(double x, double *_d_x) {
+// CHECK-NEXT: Str s("a");
+// CHECK-NEXT: Str _d_s({{.*}});
+// CHECK-NOT: init
+// CHECK: *_d_x += 1 * x;
+// CHECK-NEXT: *_d_x += x * 1;
+
+int main() {
+  auto g = clad::gradient(f);
+  double x = 3, d_x = 0;
+  g.execute(x, &d_x);
+  printf("%.2f\n", d_x); // CHECK-EXEC: 6.00
+}
+
+// expected-no-diagnostics

--- a/test/Misc/PortingHints.cpp
+++ b/test/Misc/PortingHints.cpp
@@ -33,7 +33,7 @@ int main() {
 // CHECK-NOT: no custom derivative for 'f'
 // CHECK: remark: clad has no custom derivative for 'scale' and is differentiating its definition, descending into library internals
 // CHECK: note: to differentiate it, provide clad::custom_derivatives::scale_{{.*}} with signature
-// CHECK: note: or declare it non-differentiable with clad::custom_derivatives::nondifferentiable(clad::Tag<Widget>{})
+// CHECK: note: or mark it non-differentiable with CLAD_NONDIFFERENTIABLE_TYPE(Widget)
 
 // CHECK-QUIET-NOT: remark:
 

--- a/test/Misc/PortingHintsBoxed.h
+++ b/test/Misc/PortingHintsBoxed.h
@@ -1,0 +1,9 @@
+// Companion "library" header for PortingHintsTemplate.cpp: a class template
+// whose instantiation is the differentiation boundary, exercising the
+// template-argument spelling of the porting hints.
+#pragma once
+
+template <class T> struct Boxed {
+  T v;
+  T scale(T x) const { return x * v; }
+};

--- a/test/Misc/PortingHintsConstructor.cpp
+++ b/test/Misc/PortingHintsConstructor.cpp
@@ -1,0 +1,29 @@
+// A library constructor clad would clone triggers -fclad-porting-hints for BOTH
+// its reverse-forward pass and its pullback. The reverse-forward one, in
+// addition to the custom-derivative signature and the non-differentiable
+// marker, offers the elidable_reverse_forw route -- for a constructor whose
+// reverse pass is a no-op (e.g. a shallow copy that shares its adjoint).
+// RUN: clang -std=c++17 -fsyntax-only -fplugin=%cladlib -Xclang -plugin-arg-clad \
+// RUN:   -Xclang -fclad-porting-hints %s -I%S/../../include 2>&1 | %filecheck %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "PortingHintsGadget.h"
+
+double f(double x) {
+  Gadget g(x);
+  return g.v; // clones Gadget's constructor -> reverse_forw + pullback hints
+}
+
+int main() {
+  auto grad = clad::gradient(f);
+  double dx = 0;
+  grad.execute(2, &dx);
+}
+
+// CHECK: remark: clad has no custom derivative for 'Gadget' and is differentiating its definition, descending into library internals
+// CHECK: note: to differentiate it, provide clad::custom_derivatives::constructor_reverse_forw with signature
+// CHECK: note: or mark it non-differentiable with CLAD_NONDIFFERENTIABLE_TYPE(Gadget)
+// CHECK: note: or, if its reverse-forward pass is a no-op {{.*}}mark it elidable_reverse_forw
+// CHECK: remark: clad has no custom derivative for 'Gadget' and is differentiating its definition, descending into library internals
+// CHECK: note: to differentiate it, provide clad::custom_derivatives::constructor_pullback with signature
+// CHECK: note: or mark it non-differentiable with CLAD_NONDIFFERENTIABLE_TYPE(Gadget)

--- a/test/Misc/PortingHintsGadget.h
+++ b/test/Misc/PortingHintsGadget.h
@@ -1,0 +1,10 @@
+// Companion "library" header for PortingHintsConstructor.cpp. Its constructor is
+// non-elidable (a computing member initializer), so clad schedules and clones a
+// reverse-forward propagator for it -- the case that offers the
+// elidable_reverse_forw porting route.
+#pragma once
+
+struct Gadget {
+  double v;
+  Gadget(double s) : v(s * 2.0) {}
+};

--- a/test/Misc/PortingHintsTemplate.cpp
+++ b/test/Misc/PortingHintsTemplate.cpp
@@ -1,0 +1,26 @@
+// A boundary method on a TEMPLATE INSTANTIATION. The marker suggestion must
+// carry the template arguments -- CLAD_NONDIFFERENTIABLE_TYPE(Boxed<double>),
+// not Boxed, which getQualifiedNameAsString drops and which would expand to an
+// ill-formed Tag<Boxed>. clad additionally notes that a full specialization
+// marks only this instantiation; the whole family needs a partial one.
+// RUN: clang -std=c++17 -fsyntax-only -fplugin=%cladlib -Xclang -plugin-arg-clad \
+// RUN:   -Xclang -fclad-porting-hints %s -I%S/../../include 2>&1 | %filecheck %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "PortingHintsBoxed.h"
+
+double f(double x) {
+  Boxed<double> b{2.0};
+  return b.scale(x);
+}
+
+int main() {
+  auto g = clad::gradient(f);
+  double dx = 0;
+  g.execute(2, &dx);
+}
+
+// CHECK: remark: clad has no custom derivative for 'scale' and is differentiating its definition, descending into library internals
+// CHECK: note: to differentiate it, provide clad::custom_derivatives::scale_pullback with signature {{.*}}Boxed<double>
+// CHECK: note: or mark it non-differentiable with CLAD_NONDIFFERENTIABLE_TYPE(Boxed<double>)
+// CHECK: note: this marks only this specialization; to mark the whole template, {{.*}}CLAD_NONDIFFERENTIABLE


### PR DESCRIPTION
When clad has no custom derivative for a called function it synthesizes one by cloning the function's body. For a type whose internals are not meant to be differentiated -- a standard-library primitive, an I/O stream -- that clone is at best wasteful and at worst ill-formed: cloning std::string's char-pointer constructor emits a static reverse-forward propagator that dereferences a null `this` and crashes CodeGen.

A type is now non-differentiable when it carries the `non_differentiable` annotation -- on the type itself for code the user owns (CLAD_NONDIFFERENTIABLE), or on a clad::Tag<T> specialization for a foreign type the user cannot annotate at its declaration (CLAD_NONDIFFERENTIABLE_TYPE). utils::isNonDifferentiableType detects it, so clad never clones such a type's constructor or member bodies, and callOperatesOnNonDifferentiableType extends the treatment to a call whose object is opaque (e.g. a std::ostream operation). Seed std::string, std::allocator and the stream family in STLBuiltins.h.

-fclad-porting-hints prints the paste-able CLAD_NONDIFFERENTIABLE_TYPE spelling and, for a reverse-forward pass, the elidable_reverse_forw route with its signature -- pointing at existing mechanisms rather than inventing new ones. isElidableConstructor is renamed to constructorReverseForwIsElidable and documented so its "a trivial copy is a shallow share" coverage is discoverable; that made a separate data-less-copy heuristic unnecessary.

The user guide documents both macros; tests cover marker-based construction opacity (StringConstructor) and a marked-type call (NonDifferentiableMarkedType).