### PR TITLE
Zero-initialize non-independent parameter adjoints and introduce `clad::zero_like`

### DIFF
--- a/docs/userDocs/source/user/CustomDerivatives.rst
+++ b/docs/userDocs/source/user/CustomDerivatives.rst
@@ -79,6 +79,62 @@ directly in :code:`clad::custom_derivatives::class_functions` regardless of the 
   Non-templated free functions defined in a header file need to be marked :code:`inline`
   to avoid issues with symbol duplication just like any other C++ entity defined in a header file.
 
+Adjoint construction and initialization
+========================================
+
+Reverse-mode differentiation sometimes needs to construct an internal adjoint
+from an existing primal value. Clad provides two related customization points
+for this purpose:
+
+- :code:`clad::zero_init(x)` resets values in an already constructed adjoint in
+  place. Use it when the adjoint's required structure and storage already
+  exist. The default implementation recursively clears ranges and uses
+  byte-wise zeroing for supported non-range types; provide an overload when
+  that behavior would not preserve the structure required by the type.
+- :code:`clad::zero_like(x)` constructs and returns a new zero adjoint with the
+  same relevant runtime structure as the primal :code:`x`. Conceptually, it
+  returns a value structurally like :code:`x` with :code:`zero_init` applied.
+  This is the primary extension point for adjoint construction.
+
+The default :code:`zero_like` implementation value-initializes arithmetic and
+enum types. For copyable ranges, it copies the primal to preserve its structure
+and then calls :code:`zero_init` on the copy. Provide a type-specific
+:code:`zero_like` overload when copy-then-zero cannot create an independent,
+structurally correct adjoint. Common examples include owning or
+reference-counted storage, views that alias the primal, device memory, and types
+whose shape, allocator, device, or other runtime metadata requires special
+handling.
+
+For example, a device buffer may require a fresh allocation on the same device
+instead of a shallow copy::
+
+  struct DeviceBuffer {
+    DeviceBuffer(std::size_t size, int device);
+    std::size_t size() const;
+    int device() const;
+    void fill(double value);
+  };
+
+  namespace clad {
+
+  inline void zero_init(DeviceBuffer& buffer) {
+    buffer.fill(0.0);
+  }
+
+  inline DeviceBuffer zero_like(const DeviceBuffer& value) {
+    DeviceBuffer result(value.size(), value.device());
+    zero_init(result);
+    return result;
+  }
+
+  } // namespace clad
+
+Here :code:`zero_init` defines how to reset storage that already exists, while
+:code:`zero_like` defines how to allocate and construct that storage from the
+primal. The returned adjoint must not unintentionally alias mutable primal
+storage. Define these customizations after the differentiated type and before
+requesting its derivative.
+
 Pushforward custom derivatives
 ===============================
 

--- a/docs/userDocs/source/user/CustomDerivatives.rst
+++ b/docs/userDocs/source/user/CustomDerivatives.rst
@@ -79,6 +79,63 @@ directly in :code:`clad::custom_derivatives::class_functions` regardless of the 
   Non-templated free functions defined in a header file need to be marked :code:`inline`
   to avoid issues with symbol duplication just like any other C++ entity defined in a header file.
 
+Adjoint construction and initialization
+========================================
+
+Reverse-mode differentiation sometimes needs to construct an internal adjoint
+from an existing primal value. Clad provides two related customization points
+for this purpose:
+
+- :code:`clad::zero_init(x)` resets values in an already constructed adjoint in
+  place. Use it when the adjoint's required structure and storage already
+  exist. The default implementation recursively clears ranges and uses
+  byte-wise zeroing for supported non-range types; provide an overload when
+  that behavior would not preserve the structure required by the type.
+- :code:`clad::zero_like(x)` constructs and returns a new zero adjoint with the
+  same relevant runtime structure as the primal :code:`x`. Conceptually, it
+  returns a value structurally like :code:`x` with :code:`zero_init` applied.
+  This is the primary extension point for adjoint construction.
+
+The default :code:`zero_like` implementation value-initializes arithmetic and
+enum types. For resizable ranges, it resizes an empty result to the primal size
+and recursively resizes nested ranges directly in their corresponding result
+elements. Other copyable ranges use copy-then-zero to preserve their structure.
+Provide a type-specific :code:`zero_like` overload when neither strategy can
+create an independent, structurally correct adjoint. Common examples include
+owning or reference-counted storage, views that alias the primal, device memory,
+and types whose shape, allocator, device, or other runtime metadata requires
+special handling.
+
+For example, a device buffer may require a fresh allocation on the same device
+instead of a shallow copy::
+
+  struct DeviceBuffer {
+    DeviceBuffer(std::size_t size, int device);
+    std::size_t size() const;
+    int device() const;
+    void fill(double value);
+  };
+
+  namespace clad {
+
+  inline void zero_init(DeviceBuffer& buffer) {
+    buffer.fill(0.0);
+  }
+
+  inline DeviceBuffer zero_like(const DeviceBuffer& value) {
+    DeviceBuffer result(value.size(), value.device());
+    zero_init(result);
+    return result;
+  }
+
+  } // namespace clad
+
+Here :code:`zero_init` defines how to reset storage that already exists, while
+:code:`zero_like` defines how to allocate and construct that storage from the
+primal. The returned adjoint must not unintentionally alias mutable primal
+storage. Define these customizations after the differentiated type and before
+requesting its derivative.
+
 Pushforward custom derivatives
 ===============================
 

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -210,8 +210,10 @@ CUDA_HOST_DEVICE auto back(TapeType& of) -> decltype(of.back()) {
   return of.back();
 }
 
-  /// The purpose of this function is to initialize adjoints
-  /// (or all of its iteratable elements) with 0.
+  /// Reset values in an already-constructed adjoint (or its iterable elements)
+  /// to zero in place. This is the primitive used by the default zero_like
+  /// implementation. Provide an overload when the default recursive or
+  /// byte-wise zeroing would not preserve a type's required structure.
   namespace zero_init_detail {
   template <class T> struct iterator_traits : std::iterator_traits<T> {};
   template <> struct iterator_traits<void*> {};
@@ -281,13 +283,15 @@ CUDA_HOST_DEVICE auto back(TapeType& of) -> decltype(of.back()) {
 
   template <class T> CUDA_HOST_DEVICE void zero_init(T& t) { zero_impl(t); }
 
-  /// Create a zero adjoint with the same relevant structure as \p value.
+  /// Construct a zero adjoint with the same relevant structure as \p value.
   ///
-  /// Record and container types should provide an overload when constructing
-  /// their zero adjoint requires preserving runtime structure such as shape,
-  /// size, allocator, or device information. The reverse-mode visitor prefers
-  /// this customization point when it must create an internal adjoint from an
-  /// existing primal value.
+  /// Conceptually, zero_like(value) returns a value structurally like value
+  /// with zero_init applied. This is the adjoint-construction extension point;
+  /// provide an overload when copy-then-zero is incorrect, for example for
+  /// owning or reference-counted storage, device memory, or types whose shape,
+  /// allocator, or other runtime metadata needs special handling. The
+  /// reverse-mode visitor prefers this customization point when constructing
+  /// an internal adjoint from an existing primal value.
   // Keep this header compatible with C++14; some Clad tests and clients include
   // it in that language mode.
   // NOLINTBEGIN(modernize-type-traits)

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -31,6 +31,9 @@
 #endif
 #include <type_traits>
 #include <utility>
+// Keep std::valarray's non-member begin/end overloads visible when is_range is
+// defined below.
+#include <valarray>
 #ifndef __CUDACC__
 #include <mutex>
 #endif

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -31,6 +31,9 @@
 #endif
 #include <type_traits>
 #include <utility>
+// Keep std::valarray's non-member begin/end overloads visible when is_range is
+// defined below.
+#include <valarray> // NOLINT(misc-include-cleaner)
 #ifndef __CUDACC__
 #include <mutex>
 #endif
@@ -207,25 +210,27 @@ CUDA_HOST_DEVICE auto back(TapeType& of) -> decltype(of.back()) {
   return of.back();
 }
 
-  /// The purpose of this function is to initialize adjoints
-  /// (or all of its iteratable elements) with 0.
-  namespace zero_init_detail {
-  template <class T> struct iterator_traits : std::iterator_traits<T> {};
-  template <> struct iterator_traits<void*> {};
-  template <> struct iterator_traits<const void*> {};
+/// Reset values in an already-constructed adjoint (or its iterable elements)
+/// to zero in place. This is the primitive used by the default zero_like
+/// implementation. Provide an overload when the default recursive or
+/// byte-wise zeroing would not preserve a type's required structure.
+namespace zero_init_detail {
+template <class T> struct iterator_traits : std::iterator_traits<T> {};
+template <> struct iterator_traits<void*> {};
+template <> struct iterator_traits<const void*> {};
 
-  template <class T, class It>
-  std::integral_constant<
-      bool, !std::is_same<typename std::remove_cv<T>::type,
-                          typename iterator_traits<It>::value_type>::value>
-  is_range_check(It first, It last);
+template <class T, class It>
+std::integral_constant<
+    bool, !std::is_same<typename std::remove_cv<T>::type,
+                        typename iterator_traits<It>::value_type>::value>
+is_range_check(It first, It last);
 
-  template <class T>
-  decltype(is_range_check<T>(std::begin(std::declval<const T&>()),
-                             std::end(std::declval<const T&>())))
-  is_range(int);
-  template <class T> std::false_type is_range(...);
-  } // namespace zero_init_detail
+template <class T>
+decltype(is_range_check<T>(std::begin(std::declval<const T&>()),
+                           std::end(std::declval<const T&>())))
+is_range(int);
+template <class T> std::false_type is_range(...);
+} // namespace zero_init_detail
 
   template <class T>
   struct is_range : decltype(zero_init_detail::is_range<T>(0)) {};
@@ -277,6 +282,124 @@ CUDA_HOST_DEVICE auto back(TapeType& of) -> decltype(of.back()) {
   }
 
   template <class T> CUDA_HOST_DEVICE void zero_init(T& t) { zero_impl(t); }
+
+  /// Construct a zero adjoint with the same relevant structure as \p value.
+  ///
+  /// Conceptually, zero_like(value) returns a value structurally like value
+  /// with zero_init applied. This is the adjoint-construction extension point;
+  /// provide an overload when copy-then-zero is incorrect, for example for
+  /// owning or reference-counted storage, device memory, or types whose shape,
+  /// allocator, or other runtime metadata needs special handling. The
+  /// reverse-mode visitor prefers this customization point when constructing
+  /// an internal adjoint from an existing primal value.
+  // Keep this header compatible with C++14; some Clad tests and clients include
+  // it in that language mode.
+  // NOLINTBEGIN(modernize-type-traits)
+  template <class T, std::enable_if_t<std::is_arithmetic<T>::value ||
+                                          std::is_enum<T>::value,
+                                      int> = 0>
+  CUDA_HOST_DEVICE T zero_like(const T&) {
+    return T();
+  }
+
+  namespace zero_like_detail {
+  template <class T>
+  auto has_resize_impl(int)
+      -> decltype(static_cast<void>(std::declval<const T&>().size()),
+                  static_cast<void>(T()),
+                  static_cast<void>(std::declval<T&>().resize(
+                      std::declval<typename T::size_type>())),
+                  std::true_type{});
+  template <class T> std::false_type has_resize_impl(...);
+
+  template <class T> struct has_resize : decltype(has_resize_impl<T>(0)) {};
+
+  // Implement these helpers after both range zero_like overloads so recursive
+  // fallback calls see the complete overload set.
+  template <class ResultRange, class PrimalRange>
+  void resize_and_zero(ResultRange& result, const PrimalRange& value);
+  template <class ResultElement, class PrimalElement>
+  void reconstruct_nested_range(ResultElement&& result,
+                                const PrimalElement& value, std::true_type);
+  template <class ResultElement, class PrimalElement>
+  void reconstruct_nested_range(ResultElement&& result,
+                                const PrimalElement& value, std::false_type);
+  template <class ResultRange, class PrimalRange>
+  void reconstruct_resizable_range(ResultRange&& result,
+                                   const PrimalRange& value, std::true_type);
+  template <class ResultRange, class PrimalRange>
+  void reconstruct_resizable_range(ResultRange&& result,
+                                   const PrimalRange& value, std::false_type);
+  } // namespace zero_like_detail
+
+  /// Default zero_like for a resizable range. Resize an empty result to the
+  /// primal size and recursively resize nested ranges directly in their result
+  /// positions, preserving rectangular and ragged shapes without copying
+  /// primal values or creating temporary nested containers.
+  template <class T,
+            std::enable_if_t<is_range<T>::value &&
+                                 std::is_copy_constructible<T>::value &&
+                                 zero_like_detail::has_resize<T>::value,
+                             int> = 0>
+  T zero_like(const T& value) {
+    T result;
+    zero_like_detail::resize_and_zero(result, value);
+    return result;
+  }
+
+  /// Fallback zero_like for copyable, non-resizable ranges: copy the primal
+  /// structure, then zero it.
+  template <class T,
+            std::enable_if_t<is_range<T>::value &&
+                                 std::is_copy_constructible<T>::value &&
+                                 !zero_like_detail::has_resize<T>::value,
+                             int> = 0>
+  T zero_like(const T& value) {
+    T result(value);
+    zero_init(result);
+    return result;
+  }
+
+  namespace zero_like_detail {
+  template <class ResultRange, class PrimalRange>
+  void resize_and_zero(ResultRange& result, const PrimalRange& value) {
+    result.resize(value.size());
+    auto resultIt = std::begin(result);
+    for (const auto& element : value) {
+      using Element = typename std::remove_cv<
+          typename std::remove_reference<decltype(element)>::type>::type;
+      reconstruct_nested_range(*resultIt, element, is_range<Element>{});
+      ++resultIt;
+    }
+  }
+
+  template <class ResultElement, class PrimalElement>
+  void reconstruct_nested_range(ResultElement&& result,
+                                const PrimalElement& value, std::true_type) {
+    reconstruct_resizable_range(
+        result, value,
+        has_resize<typename std::remove_cv<PrimalElement>::type>{});
+  }
+
+  template <class ResultElement, class PrimalElement>
+  void reconstruct_nested_range(ResultElement&& result, const PrimalElement&,
+                                std::false_type) {
+    zero_init(result);
+  }
+
+  template <class ResultRange, class PrimalRange>
+  void reconstruct_resizable_range(ResultRange&& result,
+                                   const PrimalRange& value, std::true_type) {
+    resize_and_zero(result, value);
+  }
+
+  template <class ResultRange, class PrimalRange>
+  void reconstruct_resizable_range(ResultRange&& result,
+                                   const PrimalRange& value, std::false_type) {
+    result = zero_like(value);
+  }
+  } // namespace zero_like_detail
+  // NOLINTEND(modernize-type-traits)
 
   /// Initialize a const sized array.
   // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays)

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -33,7 +33,7 @@
 #include <utility>
 // Keep std::valarray's non-member begin/end overloads visible when is_range is
 // defined below.
-#include <valarray>
+#include <valarray> // NOLINT(misc-include-cleaner)
 #ifndef __CUDACC__
 #include <mutex>
 #endif

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -278,6 +278,34 @@ CUDA_HOST_DEVICE auto back(TapeType& of) -> decltype(of.back()) {
 
   template <class T> CUDA_HOST_DEVICE void zero_init(T& t) { zero_impl(t); }
 
+  /// Create a zero adjoint with the same relevant structure as \p value.
+  ///
+  /// Record and container types should provide an overload when constructing
+  /// their zero adjoint requires preserving runtime structure such as shape,
+  /// size, allocator, or device information. The reverse-mode visitor prefers
+  /// this customization point when it must create an internal adjoint from an
+  /// existing primal value.
+  // Keep this header compatible with C++14; some Clad tests and clients include
+  // it in that language mode.
+  // NOLINTBEGIN(modernize-type-traits)
+  template <class T, std::enable_if_t<std::is_arithmetic<T>::value ||
+                                          std::is_enum<T>::value,
+                                      int> = 0>
+  CUDA_HOST_DEVICE T zero_like(const T&) {
+    return T();
+  }
+
+  /// Default zero_like implementation for copyable ranges.
+  template <class T, std::enable_if_t<is_range<T>::value &&
+                                          std::is_copy_constructible<T>::value,
+                                      int> = 0>
+  T zero_like(const T& value) {
+    T result(value);
+    zero_init(result);
+    return result;
+  }
+  // NOLINTEND(modernize-type-traits)
+
   /// Initialize a const sized array.
   // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays)
   template <typename T> CUDA_HOST_DEVICE void zero_init(T* x, std::size_t N) {

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -11,11 +11,14 @@
 #include <memory>
 #include <tuple>
 #include <type_traits>
+#include <valarray>
 #include <vector>
 
 #define elidable_reverse_forw __attribute__((annotate("elidable_reverse_forw")))
 
 namespace clad {
+
+template <class T> struct is_range;
 
 // zero_init specializations
 
@@ -24,6 +27,11 @@ template <class T1, class T2> void zero_init(std::pair<T1, T2>& p) {
   zero_init(p.first);
   zero_init(p.second);
 }
+
+// Unlike the other standard owning sequences, std::valarray has no member
+// begin()/end(). Its non-member overloads may not be visible when the generic
+// range detector in Differentiator.h is defined, depending on the STL.
+template <class T> struct is_range<std::valarray<T>> : std::true_type {};
 
 //  is almost trivially copyable. Specialize it.
 template <class T> void zero_init(typename std::allocator<T>&) {

--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -11,14 +11,11 @@
 #include <memory>
 #include <tuple>
 #include <type_traits>
-#include <valarray>
 #include <vector>
 
 #define elidable_reverse_forw __attribute__((annotate("elidable_reverse_forw")))
 
 namespace clad {
-
-template <class T> struct is_range;
 
 // zero_init specializations
 
@@ -27,11 +24,6 @@ template <class T1, class T2> void zero_init(std::pair<T1, T2>& p) {
   zero_init(p.first);
   zero_init(p.second);
 }
-
-// Unlike the other standard owning sequences, std::valarray has no member
-// begin()/end(). Its non-member overloads may not be visible when the generic
-// range detector in Differentiator.h is defined, depending on the STL.
-template <class T> struct is_range<std::valarray<T>> : std::true_type {};
 
 //  is almost trivially copyable. Specialize it.
 template <class T> void zero_init(typename std::allocator<T>&) {

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -736,6 +736,11 @@ namespace clad {
 
     clang::Stmt* GetCladZeroInit(llvm::MutableArrayRef<clang::Expr*> args);
 
+    /// Build `clad::zero_like(value)` if a viable overload is available.
+    /// Returns null when the customization point is not implemented for the
+    /// value's type.
+    clang::Expr* GetCladZeroLike(clang::Expr* value);
+
     /// Assigns the Init expression to VD after performing the necessary
     /// implicit conversion. This is required as clang doesn't add implicit
     /// conversions while assigning values to variables which are initialized

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -728,7 +728,10 @@ namespace clad {
     }
     /// Find declaration of clad::tape templated type.
     clang::TemplateDecl* GetCladTapeDecl();
-    /// Perform a lookup into clad namespace for an entity with given name.
+    /// Look up an entity with the given name in the clad namespace. The result
+    /// may be empty.
+    clang::LookupResult tryLookupCladMethod(llvm::StringRef name);
+    /// Look up a required clad function template with the given name.
     clang::LookupResult LookupCladTapeMethod(llvm::StringRef name);
     /// Perform lookup into clad namespace for push/pop/back. Returns
     /// LookupResult, which is will be resolved later (which is handy since they
@@ -757,6 +760,11 @@ namespace clad {
     clang::DeclRefExpr* GetCladTapePushDRE();
 
     clang::Stmt* GetCladZeroInit(llvm::MutableArrayRef<clang::Expr*> args);
+
+    /// Build `clad::zero_like(value)` if a viable overload is available.
+    /// Returns null when the customization point is not implemented for the
+    /// value's type.
+    clang::Expr* GetCladZeroLike(clang::Expr* value);
 
     /// Assigns the Init expression to VD after performing the necessary
     /// implicit conversion. This is required as clang doesn't add implicit

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -706,7 +706,10 @@ namespace clad {
     }
     /// Find declaration of clad::tape templated type.
     clang::TemplateDecl* GetCladTapeDecl();
-    /// Perform a lookup into clad namespace for an entity with given name.
+    /// Look up an entity with the given name in the clad namespace. The result
+    /// may be empty.
+    clang::LookupResult tryLookupCladMethod(llvm::StringRef name);
+    /// Look up a required clad function template with the given name.
     clang::LookupResult LookupCladTapeMethod(llvm::StringRef name);
     /// Perform lookup into clad namespace for push/pop/back. Returns
     /// LookupResult, which is will be resolved later (which is handy since they

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -453,22 +453,31 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           return result;
         };
         bool isDirectInit = false;
-        if (isNonAggrClass && utils::isCopyable(RD) &&
-            !hasDangerousFields(RD)) {
-          ParmVarDecl* newFuncParam = nullptr;
-          for (auto* p : m_Derivative->parameters()) {
-            if (p->getName() == param->getName()) {
-              newFuncParam = p;
-              break;
-            }
+        bool needsZeroInit = false;
+        ParmVarDecl* newFuncParam = nullptr;
+        for (auto* p : m_Derivative->parameters()) {
+          if (p->getName() == param->getName()) {
+            newFuncParam = p;
+            break;
           }
-          assert(
-              newFuncParam &&
-              "Could not find corresponding parameter in derivative function");
+        }
+        assert(newFuncParam &&
+               "Could not find corresponding parameter in derivative function");
+
+        Expr* zeroLike = nullptr;
+        if (RD)
+          zeroLike =
+              GetCladZeroLike(BuildDeclRef(newFuncParam->getDefinition()));
+        if (zeroLike) {
+          initExpr = zeroLike;
+          isDirectInit = true;
+        } else if (isNonAggrClass && utils::isCopyable(RD) &&
+                   !hasDangerousFields(RD)) {
           initExpr = BuildDeclRef(newFuncParam->getDefinition());
           isDirectInit = true;
+          needsZeroInit = true;
         } else {
-          // If the type is not a tensor, we can use zero initialization.
+          // Preserve the legacy value-initialization fallback.
           initExpr = getZeroInit(VDDerivedType);
         }
         auto* VDDerived = BuildGlobalVarDecl(
@@ -476,6 +485,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             isDirectInit);
         m_Variables[param] = {VDDerived};
         addToBlock(BuildDeclStmt(VDDerived), m_Globals);
+        if (needsZeroInit) {
+          Expr* derivedRef = BuildDeclRef(VDDerived);
+          addToBlock(GetCladZeroInit(derivedRef), m_Globals);
+        }
       }
     }
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -445,22 +445,31 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           return result;
         };
         bool isDirectInit = false;
-        if (isNonAggrClass && utils::isCopyable(RD) &&
-            !hasDangerousFields(RD)) {
-          ParmVarDecl* newFuncParam = nullptr;
-          for (auto* p : m_Derivative->parameters()) {
-            if (p->getName() == param->getName()) {
-              newFuncParam = p;
-              break;
-            }
+        bool needsZeroInit = false;
+        ParmVarDecl* newFuncParam = nullptr;
+        for (auto* p : m_Derivative->parameters()) {
+          if (p->getName() == param->getName()) {
+            newFuncParam = p;
+            break;
           }
-          assert(
-              newFuncParam &&
-              "Could not find corresponding parameter in derivative function");
+        }
+        assert(newFuncParam &&
+               "Could not find corresponding parameter in derivative function");
+
+        Expr* zeroLike = nullptr;
+        if (RD)
+          zeroLike =
+              GetCladZeroLike(BuildDeclRef(newFuncParam->getDefinition()));
+        if (zeroLike) {
+          initExpr = zeroLike;
+          isDirectInit = true;
+        } else if (isNonAggrClass && utils::isCopyable(RD) &&
+                   !hasDangerousFields(RD)) {
           initExpr = BuildDeclRef(newFuncParam->getDefinition());
           isDirectInit = true;
+          needsZeroInit = true;
         } else {
-          // If the type is not a tensor, we can use zero initialization.
+          // Preserve the legacy value-initialization fallback.
           initExpr = getZeroInit(VDDerivedType);
         }
         auto* VDDerived = BuildGlobalVarDecl(
@@ -468,7 +477,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             isDirectInit);
         m_Variables[param] = {VDDerived};
         addToBlock(BuildDeclStmt(VDDerived), m_Globals);
-        if (isDirectInit) {
+        if (needsZeroInit) {
           Expr* derivedRef = BuildDeclRef(VDDerived);
           addToBlock(GetCladZeroInit(derivedRef), m_Globals);
         }

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -468,6 +468,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             isDirectInit);
         m_Variables[param] = {VDDerived};
         addToBlock(BuildDeclStmt(VDDerived), m_Globals);
+        if (isDirectInit) {
+          Expr* derivedRef = BuildDeclRef(VDDerived);
+          addToBlock(GetCladZeroInit(derivedRef), m_Globals);
+        }
       }
     }
 

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -21,13 +21,11 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/Expr.h"
-#include "clang/AST/ExprCXX.h"
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/OperationKinds.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/TemplateBase.h"
-#include "clang/AST/Type.h"
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
@@ -704,13 +702,18 @@ namespace clad {
     return utils::LookupTemplateDeclInCladNamespace(m_Sema, "tape");
   }
 
-  LookupResult VisitorBase::LookupCladTapeMethod(llvm::StringRef name) {
+  LookupResult VisitorBase::tryLookupCladMethod(llvm::StringRef name) {
     NamespaceDecl* CladNS = utils::GetCladNamespace(m_Sema);
     CXXScopeSpec CSS;
     CSS.Extend(m_Context, CladNS, noLoc, noLoc);
     DeclarationName Name = &m_Context.Idents.get(name);
     LookupResult R(m_Sema, Name, noLoc, Sema::LookupOrdinaryName);
     m_Sema.LookupQualifiedName(R, CladNS, CSS);
+    return R;
+  }
+
+  LookupResult VisitorBase::LookupCladTapeMethod(llvm::StringRef name) {
+    LookupResult R = tryLookupCladMethod(name);
     assert(!R.empty() && isa<FunctionTemplateDecl>(R.getRepresentativeDecl()) &&
            "cannot find requested name");
     return R;
@@ -1250,10 +1253,7 @@ namespace clad {
     CXXScopeSpec CSS;
     CSS.Extend(m_Context, CladNS, noLoc, noLoc);
 
-    DeclarationName Name = &m_Context.Idents.get("zero_like");
-    LookupResult R(m_Sema, Name, noLoc, Sema::LookupOrdinaryName);
-    R.suppressDiagnostics();
-    m_Sema.LookupQualifiedName(R, CladNS, CSS);
+    LookupResult R = tryLookupCladMethod("zero_like");
     if (R.empty())
       return nullptr;
 
@@ -1266,27 +1266,11 @@ namespace clad {
     llvm::SmallVector<Expr*, 1> args{value};
     auto ARargs = llvm::MutableArrayRef<Expr*>(args);
 
-    // Test overload viability before asking Sema to build the call. A failed
-    // optional customization must quietly fall back to the legacy adjoint
-    // construction path instead of producing a diagnostic.
-    if (UnresolvedLookup->hasPlaceholderType(BuiltinType::Overload)) {
-      OverloadExpr::FindResult Find = OverloadExpr::find(UnresolvedLookup);
-      if (!Find.HasFormOfMemberPointer &&
-          isa<UnresolvedLookupExpr>(Find.Expression)) {
-        ExprResult Result;
-        OverloadCandidateSet CandidateSet(noLoc,
-                                          OverloadCandidateSet::CSK_Normal);
-        Scope* S = m_Sema.getScopeForContext(m_Sema.CurContext);
-        auto* ULE = cast<UnresolvedLookupExpr>(Find.Expression);
-        m_Sema.buildOverloadedCallSet(S, UnresolvedLookup, ULE, ARargs, noLoc,
-                                      &CandidateSet, &Result);
-        OverloadCandidateSet::iterator Best = nullptr;
-        OverloadingResult OverloadResult =
-            CandidateSet.BestViableFunction(m_Sema, noLoc, Best);
-        if (OverloadResult != 0U)
-          return nullptr;
-      }
-    }
+    // A missing customization is an expected, silent fallback path. Reuse the
+    // same overload probe as custom derivatives instead of asking Sema to
+    // diagnose an invalid call.
+    if (m_Builder.noOverloadExists(UnresolvedLookup, ARargs))
+      return nullptr;
 
     ExprResult Call = m_Sema.ActOnCallExpr(getCurrentScope(), UnresolvedLookup,
                                            noLoc, ARargs, noLoc);

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -808,13 +808,18 @@ namespace clad {
     return utils::LookupTemplateDeclInCladNamespace(m_Sema, "tape");
   }
 
-  LookupResult VisitorBase::LookupCladTapeMethod(llvm::StringRef name) {
+  LookupResult VisitorBase::tryLookupCladMethod(llvm::StringRef name) {
     NamespaceDecl* CladNS = utils::GetCladNamespace(m_Sema);
     CXXScopeSpec CSS;
     CSS.Extend(m_Context, CladNS, noLoc, noLoc);
     DeclarationName Name = &m_Context.Idents.get(name);
     LookupResult R(m_Sema, Name, noLoc, Sema::LookupOrdinaryName);
     m_Sema.LookupQualifiedName(R, CladNS, CSS);
+    return R;
+  }
+
+  LookupResult VisitorBase::LookupCladTapeMethod(llvm::StringRef name) {
+    LookupResult R = tryLookupCladMethod(name);
     assert(!R.empty() && isa<FunctionTemplateDecl>(R.getRepresentativeDecl()) &&
            "cannot find requested name");
     return R;
@@ -1353,6 +1358,35 @@ namespace clad {
         .get();
   }
 
+  Expr* VisitorBase::GetCladZeroLike(Expr* value) {
+    NamespaceDecl* CladNS = utils::GetCladNamespace(m_Sema);
+    CXXScopeSpec CSS;
+    CSS.Extend(m_Context, CladNS, noLoc, noLoc);
+
+    LookupResult R = tryLookupCladMethod("zero_like");
+    if (R.empty())
+      return nullptr; // LCOV_EXCL_LINE: version-mismatched runtime header
+
+    ExprResult NameExpr =
+        m_Sema.BuildDeclarationNameExpr(CSS, R, /*NeedsADL=*/false);
+    if (NameExpr.isInvalid())
+      return nullptr; // LCOV_EXCL_LINE: defensive Sema failure
+
+    Expr* UnresolvedLookup = NameExpr.get();
+    llvm::SmallVector<Expr*, 1> args{value};
+    auto ARargs = llvm::MutableArrayRef<Expr*>(args);
+
+    // A missing customization is an expected, silent fallback path. Reuse the
+    // same overload probe as custom derivatives instead of asking Sema to
+    // diagnose an invalid call.
+    if (m_Builder.noOverloadExists(UnresolvedLookup, ARargs))
+      return nullptr;
+
+    ExprResult Call = m_Sema.ActOnCallExpr(getCurrentScope(), UnresolvedLookup,
+                                           noLoc, ARargs, noLoc);
+    return Call.isInvalid() ? nullptr : Call.get();
+  }
+
   FunctionDecl*
   VisitorBase::CreateDerivativeOverload(FunctionDecl* derivative) {
     if (!derivative)
@@ -1544,6 +1578,10 @@ namespace clad {
   Expr* VisitorBase::BuildOperatorCall(OverloadedOperatorKind OOK,
                                        MutableArrayRef<Expr*> ArgExprs,
                                        SourceLocation OpLoc) {
+    // Sema requires a valid location for rebuilt operator calls.
+    if (!OpLoc.isValid())
+      OpLoc = utils::GetValidSLoc(m_Sema);
+
     // First check operator kinds that are not considered binary/unary.
 
     // FIXME: Currently, Clad never uses arrow operators, all of them

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -21,11 +21,13 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/OperationKinds.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/TemplateBase.h"
+#include "clang/AST/Type.h"
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
@@ -1241,6 +1243,54 @@ namespace clad {
         m_Sema.BuildDeclarationNameExpr(CSS, init, false).getAs<DeclRefExpr>();
     return m_Sema.ActOnCallExpr(getCurrentScope(), pushDRE, noLoc, args, noLoc)
         .get();
+  }
+
+  Expr* VisitorBase::GetCladZeroLike(Expr* value) {
+    NamespaceDecl* CladNS = utils::GetCladNamespace(m_Sema);
+    CXXScopeSpec CSS;
+    CSS.Extend(m_Context, CladNS, noLoc, noLoc);
+
+    DeclarationName Name = &m_Context.Idents.get("zero_like");
+    LookupResult R(m_Sema, Name, noLoc, Sema::LookupOrdinaryName);
+    R.suppressDiagnostics();
+    m_Sema.LookupQualifiedName(R, CladNS, CSS);
+    if (R.empty())
+      return nullptr;
+
+    ExprResult NameExpr =
+        m_Sema.BuildDeclarationNameExpr(CSS, R, /*NeedsADL=*/false);
+    if (NameExpr.isInvalid())
+      return nullptr;
+
+    Expr* UnresolvedLookup = NameExpr.get();
+    llvm::SmallVector<Expr*, 1> args{value};
+    auto ARargs = llvm::MutableArrayRef<Expr*>(args);
+
+    // Test overload viability before asking Sema to build the call. A failed
+    // optional customization must quietly fall back to the legacy adjoint
+    // construction path instead of producing a diagnostic.
+    if (UnresolvedLookup->hasPlaceholderType(BuiltinType::Overload)) {
+      OverloadExpr::FindResult Find = OverloadExpr::find(UnresolvedLookup);
+      if (!Find.HasFormOfMemberPointer &&
+          isa<UnresolvedLookupExpr>(Find.Expression)) {
+        ExprResult Result;
+        OverloadCandidateSet CandidateSet(noLoc,
+                                          OverloadCandidateSet::CSK_Normal);
+        Scope* S = m_Sema.getScopeForContext(m_Sema.CurContext);
+        auto* ULE = cast<UnresolvedLookupExpr>(Find.Expression);
+        m_Sema.buildOverloadedCallSet(S, UnresolvedLookup, ULE, ARargs, noLoc,
+                                      &CandidateSet, &Result);
+        OverloadCandidateSet::iterator Best = nullptr;
+        OverloadingResult OverloadResult =
+            CandidateSet.BestViableFunction(m_Sema, noLoc, Best);
+        if (OverloadResult != 0U)
+          return nullptr;
+      }
+    }
+
+    ExprResult Call = m_Sema.ActOnCallExpr(getCurrentScope(), UnresolvedLookup,
+                                           noLoc, ARargs, noLoc);
+    return Call.isInvalid() ? nullptr : Call.get();
   }
 
   FunctionDecl*

--- a/test/Gradient/Cladtorch.C
+++ b/test/Gradient/Cladtorch.C
@@ -66,6 +66,7 @@ float fn1(
 
 // CHECK: void fn1_grad_0(const cladtorch::Tensor &t, const cladtorch::Tensor &u, no_namespace o, decltype(anon) a, {{.*}}anon_namespace z, not_found::Tensor w, cladtorch::Tensor *_d_t) {
 // CHECK-NEXT:     {{.*}}cladtorch::Tensor _d_u(u);
+// CHECK-NEXT:     clad::zero_init(_d_u);
 // CHECK-NEXT:     no_namespace _d_o = {0.F};
 // CHECK-NEXT:     {{.*}} _d_a = {0.F};
 // CHECK-NEXT:     anon_namespace _d_z = {0.F};

--- a/test/Gradient/STLNonIndependentAdjoint.C
+++ b/test/Gradient/STLNonIndependentAdjoint.C
@@ -1,0 +1,27 @@
+// RUN: %cladclang %s -I%S/../../include -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+
+#include <cstdio>
+#include <vector>
+
+double replace_and_square(std::vector<double> values, double x) {
+  values[0] = x;
+  return values[0] * values[0];
+}
+
+// CHECK: void replace_and_square_grad_1(std::vector<double> values, double x, double *_d_x) {
+// CHECK-NEXT:     std::vector<double> _d_values(values);
+// CHECK-NEXT:     clad::zero_init(_d_values);
+
+int main() {
+  std::vector<double> values{10.0};
+  double d_x = 0.0;
+  auto gradient = clad::gradient(replace_and_square, "x");
+  gradient.execute(values, 3.0, &d_x);
+  std::printf("%.1f\n", d_x);
+}
+
+// CHECK-EXEC: 6.0

--- a/test/Gradient/STLNonIndependentAdjoint.C
+++ b/test/Gradient/STLNonIndependentAdjoint.C
@@ -13,8 +13,27 @@ double replace_and_square(std::vector<double> values, double x) {
 }
 
 // CHECK: void replace_and_square_grad_1(std::vector<double> values, double x, double *_d_x) {
-// CHECK-NEXT:     std::vector<double> _d_values(values);
-// CHECK-NEXT:     clad::zero_init(_d_values);
+// CHECK-NEXT:     std::vector<double> _d_values(clad::zero_like(values));
+
+struct PointerView {
+  explicit PointerView(std::size_t size) : storage(size), data(storage.data()) {}
+
+  std::vector<double> storage;
+  double* data;
+};
+
+namespace clad {
+PointerView zero_like(const PointerView& value) {
+  return PointerView(value.storage.size());
+}
+} // namespace clad
+
+double scale_view(const PointerView& values, double x) {
+  return values.data[0] * x;
+}
+
+// CHECK: void scale_view_grad_1(const PointerView &values, double x, double *_d_x) {
+// CHECK-NEXT:     PointerView _d_values(clad::zero_like(values));
 
 int main() {
   std::vector<double> values{10.0};
@@ -22,6 +41,14 @@ int main() {
   auto gradient = clad::gradient(replace_and_square, "x");
   gradient.execute(values, 3.0, &d_x);
   std::printf("%.1f\n", d_x);
+
+  PointerView view(1);
+  view.storage[0] = 4.0;
+  double d_scale = 0.0;
+  auto scale_gradient = clad::gradient(scale_view, "x");
+  scale_gradient.execute(view, 3.0, &d_scale);
+  std::printf("%.1f\n", d_scale);
 }
 
 // CHECK-EXEC: 6.0
+// CHECK-EXEC-NEXT: 4.0

--- a/test/Gradient/STLNonIndependentAdjoint.C
+++ b/test/Gradient/STLNonIndependentAdjoint.C
@@ -1,5 +1,9 @@
 // RUN: %cladclang %s -I%S/../../include -o %t 2>&1 | %filecheck %s
 // RUN: %t | %filecheck_exec %s
+// RUN: %cladclang -std=c++14 %s -I%S/../../include -o %t14
+// RUN: %t14 | %filecheck_exec %s
+// RUN: %cladclang -std=c++20 %s -I%S/../../include -o %t20
+// RUN: %t20 | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
 #include "clad/Differentiator/STLBuiltins.h"

--- a/test/Gradient/STLNonIndependentAdjoint.C
+++ b/test/Gradient/STLNonIndependentAdjoint.C
@@ -1,0 +1,80 @@
+// RUN: %cladclang %s -I%S/../../include -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+// RUN: %cladclang -std=c++14 %s -I%S/../../include -o %t14
+// RUN: %t14 | %filecheck_exec %s
+// RUN: %cladclang -std=c++20 %s -I%S/../../include -o %t20
+// RUN: %t20 | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+
+#include <cstdio>
+#include <vector>
+
+double replace_and_square(std::vector<double> values, double x) {
+  values[0] = x;
+  return values[0] * values[0];
+}
+
+// CHECK: void replace_and_square_grad_1(std::vector<double> values, double x, double *_d_x) {
+// CHECK-NEXT:     std::vector<double> _d_values(clad::zero_like(values));
+
+struct PointerView {
+  explicit PointerView(std::size_t size) : storage(size), data(storage.data()) {}
+
+  std::vector<double> storage;
+  double* data;
+};
+
+namespace clad {
+PointerView zero_like(const PointerView& value) {
+  return PointerView(value.storage.size());
+}
+} // namespace clad
+
+double scale_view(const PointerView& values, double x) {
+  return values.data[0] * x;
+}
+
+// CHECK: void scale_view_grad_1(const PointerView &values, double x, double *_d_x) {
+// CHECK-NEXT:     PointerView _d_values(clad::zero_like(values));
+
+struct CopyFallback {
+  explicit CopyFallback(double value) : value(value) {}
+
+  double value;
+};
+
+double replace_fallback(CopyFallback values, double x) {
+  values.value = x;
+  return values.value * values.value;
+}
+
+// CHECK: void replace_fallback_grad_1(CopyFallback values, double x, double *_d_x) {
+// CHECK-NEXT:     CopyFallback _d_values(values);
+// CHECK-NEXT:     clad::zero_init(_d_values);
+
+int main() {
+  std::vector<double> values{10.0};
+  double d_x = 0.0;
+  auto gradient = clad::gradient(replace_and_square, "x");
+  gradient.execute(values, 3.0, &d_x);
+  std::printf("%.1f\n", d_x);
+
+  PointerView view(1);
+  view.storage[0] = 4.0;
+  double d_scale = 0.0;
+  auto scale_gradient = clad::gradient(scale_view, "x");
+  scale_gradient.execute(view, 3.0, &d_scale);
+  std::printf("%.1f\n", d_scale);
+
+  CopyFallback fallback(10.0);
+  double d_fallback = 0.0;
+  auto fallback_gradient = clad::gradient(replace_fallback, "x");
+  fallback_gradient.execute(fallback, 3.0, &d_fallback);
+  std::printf("%.1f\n", d_fallback);
+}
+
+// CHECK-EXEC: 6.0
+// CHECK-EXEC-NEXT: 4.0
+// CHECK-EXEC-NEXT: 6.0

--- a/test/Misc/ZeroLike.C
+++ b/test/Misc/ZeroLike.C
@@ -1,0 +1,42 @@
+// RUN: %cladclang %s -I%S/../../include -o %t
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+
+#include <array>
+#include <cstdio>
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <string>
+#include <valarray>
+#include <vector>
+
+template <class Range> bool is_zero(const Range& range) {
+  for (const auto& value : range)
+    if (value != 0)
+      return false;
+  return true;
+}
+
+int main() {
+  std::array<double, 2> array{{1., 2.}};
+  std::deque<double> deque{1., 2.};
+  std::forward_list<double> forwardList{1., 2.};
+  std::list<double> list{1., 2.};
+  std::vector<double> vector{1., 2.};
+  std::valarray<double> valarray{1., 2.};
+  std::string string{'a', 'b'};
+
+  std::printf("%d %d %d %d %d %d %d\n",
+              is_zero(clad::zero_like(array)),
+              is_zero(clad::zero_like(deque)),
+              is_zero(clad::zero_like(forwardList)),
+              is_zero(clad::zero_like(list)),
+              is_zero(clad::zero_like(vector)),
+              is_zero(clad::zero_like(valarray)),
+              is_zero(clad::zero_like(string)));
+}
+
+// CHECK-EXEC: 1 1 1 1 1 1 1

--- a/test/Misc/ZeroLike.C
+++ b/test/Misc/ZeroLike.C
@@ -1,0 +1,109 @@
+// RUN: %cladclang %s -I%S/../../include -o %t
+// RUN: %t | %filecheck_exec %s
+// RUN: %cladclang -std=c++14 %s -I%S/../../include -o %t14
+// RUN: %t14 | %filecheck_exec %s
+// RUN: %cladclang -std=c++20 %s -I%S/../../include -o %t20
+// RUN: %t20 | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "clad/Differentiator/STLBuiltins.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdio>
+#include <deque>
+#include <forward_list>
+#include <initializer_list>
+#include <list>
+#include <string>
+#include <valarray>
+#include <vector>
+
+namespace zero_like_test {
+struct Counted {
+  double value = 7.;
+  static long copies;
+
+  Counted() = default;
+  Counted(const Counted& other) : value(other.value) { ++copies; }
+  Counted& operator=(const Counted&) = default;
+};
+
+long Counted::copies = 0;
+
+void zero_init(Counted& value) { value.value = 0.; }
+} // namespace zero_like_test
+
+using zero_like_test::Counted;
+
+// Models containers such as unordered_map, where T(size_type) configures
+// buckets rather than constructing size() elements.
+class BucketCountRange {
+public:
+  using size_type = std::size_t;
+
+  BucketCountRange(std::initializer_list<double> values) : storage(values) {}
+  explicit BucketCountRange(size_type) {}
+
+  std::vector<double>::iterator begin() { return storage.begin(); }
+  std::vector<double>::iterator end() { return storage.end(); }
+  std::vector<double>::const_iterator begin() const { return storage.begin(); }
+  std::vector<double>::const_iterator end() const { return storage.end(); }
+  size_type size() const { return storage.size(); }
+
+private:
+  std::vector<double> storage;
+};
+
+template <class Range> bool is_zero(const Range& range) {
+  for (const auto& value : range)
+    if (value != 0)
+      return false;
+  return true;
+}
+
+int main() {
+  std::array<double, 2> array{{1., 2.}};
+  std::deque<double> deque{1., 2.};
+  std::forward_list<double> forwardList{1., 2.};
+  std::list<double> list{1., 2.};
+  std::vector<double> vector{1., 2.};
+  std::valarray<double> valarray{1., 2.};
+  std::string string{'a', 'b'};
+
+  std::printf("%d %d %d %d %d %d %d\n",
+              is_zero(clad::zero_like(array)),
+              is_zero(clad::zero_like(deque)),
+              is_zero(clad::zero_like(forwardList)),
+              is_zero(clad::zero_like(list)),
+              is_zero(clad::zero_like(vector)),
+              is_zero(clad::zero_like(valarray)),
+              is_zero(clad::zero_like(string)));
+
+  std::vector<std::vector<Counted>> ragged(3);
+  ragged[0].resize(2);
+  ragged[1].resize(1);
+  ragged[2].resize(3);
+  for (auto& row : ragged)
+    for (auto& value : row)
+      value.value = 3.14;
+
+  Counted::copies = 0;
+  auto dRagged = clad::zero_like(ragged);
+  bool sameShapeAndZero = dRagged.size() == ragged.size();
+  for (std::size_t i = 0; i < ragged.size(); ++i) {
+    sameShapeAndZero &= dRagged[i].size() == ragged[i].size();
+    for (const auto& value : dRagged[i])
+      sameShapeAndZero &= value.value == 0.;
+  }
+  std::printf("%d %ld\n", sameShapeAndZero, Counted::copies);
+
+  BucketCountRange bucketRange{1., 2.};
+  auto dBucketRange = clad::zero_like(bucketRange);
+  std::printf("%d\n", dBucketRange.size() == bucketRange.size() &&
+                              is_zero(dBucketRange));
+}
+
+// CHECK-EXEC: 1 1 1 1 1 1 1
+// CHECK-EXEC-NEXT: 1 0
+// CHECK-EXEC-NEXT: 1

--- a/test/Misc/ZeroLike.C
+++ b/test/Misc/ZeroLike.C
@@ -1,5 +1,9 @@
 // RUN: %cladclang %s -I%S/../../include -o %t
 // RUN: %t | %filecheck_exec %s
+// RUN: %cladclang -std=c++14 %s -I%S/../../include -o %t14
+// RUN: %t14 | %filecheck_exec %s
+// RUN: %cladclang -std=c++20 %s -I%S/../../include -o %t20
+// RUN: %t20 | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
 #include "clad/Differentiator/STLBuiltins.h"


### PR DESCRIPTION
While investigating the following case:

```cpp
double replace_and_square(std::vector<double> values, double x) {
  values[0] = x;
  return values[0] * values[0];
}

auto gradient = clad::gradient(replace_and_square, "x");
```

I found that even though `values` is not selected as an independent parameter, Clad still needs an internal `_d_values` to propagate the derivative through the assignment.

For `values = {10.0}` and `x = 3.0`, the expected derivative is `6.0`. However, `_d_values` was initialized by copying the primal value and was never cleared, so its initial value leaked into the reverse pass and produced `16.0`.

This means that every internal adjoint created by Clad, including adjoints for non-independent parameters, must represent a valid zero tangent before the reverse pass starts.

While fixing this, I found that the current API does not have enough expressive power to construct such an adjoint correctly for every type.

For a record parameter of type `T`, the existing logic is roughly:

```cpp
// T has direct pointer or reference fields:
T _d_param = T{};

// Otherwise, if T is copyable:
T _d_param(param);
clad::zero_init(_d_param);
```

Neither option is generally correct.

For example, libc++ implements `std::vector` using direct pointer fields. The field-based check therefore selects:

```cpp
std::vector<double> _d_values{};
```

but this loses the vector’s runtime structure: `_d_values` is empty while `values` may contain several elements.

At the same time, simply ignoring pointer fields and always copying is also unsafe. A user-defined type may contain an internal pointer referring to its own storage, and its copy constructor may leave the copied pointer referring to the primal object.

In other words, field layout alone cannot tell us whether copying a type creates a valid, independently owned adjoint.

`clad::zero_init` cannot fully solve this either. Its current purpose is to reset an already existing adjoint while preserving its structure. It is also used for arrays, loop resets, and user-provided specializations. Changing it into an adjoint-construction operation would change its existing semantics and break backward compatibility.

This PR therefore introduces a separate customization point:

```cpp
auto adjoint = clad::zero_like(primal);
```

The intended contract of `zero_like` is:

- create a new adjoint with independent storage;
- preserve runtime structure relevant to differentiation, such as size, shape, allocator, device, and internal invariants;
- initialize all differentiable values to zero;
- never modify or alias mutable storage from the primal.

Types can provide their own overload:

```cpp
namespace clad {

MyType zero_like(const MyType& value) {
  // Construct an independently owned zero adjoint.
}

} // namespace clad
```

For `std::vector`, the implementation copies the vector to obtain independent storage and preserve its size, then applies `zero_init` to its elements:

```cpp
template <class T, class Allocator>
std::vector<T, Allocator>
zero_like(const std::vector<T, Allocator>& value) {
  std::vector<T, Allocator> result(value);
  zero_init(result);
  return result;
}
```

A Tensor backend can similarly implement this by delegating to an operation such as `at::zeros_like`.

When Clad creates an internal adjoint from an existing primal value, it now tries a viable `clad::zero_like` overload first. If no overload is available, it preserves the previous copy/value-initialization logic as a backward-compatible fallback.

This also removes the need for a `std::vector`-specific exception in `ReverseModeVisitor`: knowledge about how to construct a vector adjoint now lives in `STLBuiltins.h`, where it belongs.

Finally, this API provides an important building block for improving `clad::gradient`. Currently, users must allocate zero adjoints themselves and pass `_d_xxx` pointers to `execute`. With `zero_like`, Clad can eventually construct those terminal adjoints from the primal arguments and return them directly:

```cpp
auto gradients = gradient.execute(args...);
```

This PR does not change that interface yet, but it provides the missing construction operation needed to implement it correctly for vectors, tensors, and user-defined structured types.