### PR TITLE
Undo a shrinking in-place realloc in the reverse sweep.

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -12,6 +12,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
+#include <cstring>
 #include <functional>
 
 #define elidable_reverse_forw __attribute__((annotate("elidable_reverse_forw")))
@@ -1600,6 +1602,30 @@ void constructor_pullback(ValueAndPushforward<T, U> rhs,
 }
 } // namespace class_functions
 } // namespace custom_derivatives
+
+// Reverse-mode helper for an in-place realloc: resize `ptr` back to the byte
+// size it had before the forward realloc. When that regrows a buffer the
+// forward pass shrank, zero the re-grown tail for adjoint buffers so fresh
+// derivatives start at 0; primal buffers pass zeroGrownTail=false, their tail
+// being overwritten by value restores. Returns the possibly-moved pointer.
+// NOLINTBEGIN(cppcoreguidelines-no-malloc)
+// NOLINTBEGIN(cppcoreguidelines-owning-memory)
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+inline void* reverse_realloc(void* ptr, size_t oldBytes, size_t newBytes,
+                             bool zeroGrownTail) {
+  void* resized = ::realloc(ptr, oldBytes);
+  // realloc failed: keep the original buffer instead of leaking it.
+  if (!resized)
+    return ptr;
+  ptr = resized;
+  if (zeroGrownTail && oldBytes > newBytes)
+    ::memset(static_cast<char*>(ptr) + newBytes, 0, oldBytes - newBytes);
+  return ptr;
+}
+// NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+// NOLINTEND(cppcoreguidelines-owning-memory)
+// NOLINTEND(cppcoreguidelines-no-malloc)
+
 } // namespace clad
 
   // FIXME: These math functions depend on promote_2 just like pow:

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -9,6 +9,7 @@
 
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
+#include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
@@ -17,10 +18,13 @@
 
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstdint>
 #include <functional>
 #include <iterator>
 #include <map>
@@ -49,6 +53,84 @@ using ParamInfo = std::map<const clang::FunctionDecl*, ParamSet>;
 /// rediscovering them inside a visitor, keeps them available to every visitor
 /// and correct after a request is copied and re-pointed at another Function.
 struct DiffRequest {
+  /// Recognises a C heap-memory builtin call and centralises the invariants
+  /// reverse mode must preserve for it, so all memory-op reasoning goes through
+  /// one place instead of ad-hoc name checks scattered across the code base.
+  /// The planner uses it to record which pointers are reallocated in place; the
+  /// reverse-mode visitor uses it to emit and undo the resize.
+  class AllocCallInfo {
+  public:
+    enum class Kind : std::uint8_t { None, Malloc, Calloc, Realloc, Free };
+
+    AllocCallInfo() = default;
+
+    // Recognise E as a memory builtin; Kind::None if it is not one. Strips the
+    // C-style cast that wraps the call (e.g. `(double*)realloc(...)`), so
+    // IgnoreParenCasts, not IgnoreParenImpCasts, is required here.
+    [[nodiscard]] static AllocCallInfo recognize(clang::Expr* E) {
+      auto* CE = llvm::dyn_cast_or_null<clang::CallExpr>(
+          E ? E->IgnoreParenCasts() : nullptr);
+      if (!CE)
+        return {};
+      const clang::FunctionDecl* FD = CE->getDirectCallee();
+      // getName() asserts on non-identifier names (operators, constructors),
+      // which vector/STL code produces; the builtins are plain identifiers.
+      if (!FD || !FD->getDeclName().isIdentifier())
+        return {};
+      Kind k = llvm::StringSwitch<Kind>(FD->getName())
+                   .Case("malloc", Kind::Malloc)
+                   .Case("calloc", Kind::Calloc)
+                   .Case("realloc", Kind::Realloc)
+                   .Case("free", Kind::Free)
+                   .Default(Kind::None);
+      return AllocCallInfo(k, CE);
+    }
+
+    [[nodiscard]] Kind getKind() const { return m_Kind; }
+    [[nodiscard]] clang::CallExpr* getCall() const { return m_Call; }
+
+    // The number-of-bytes operand that a following memset must zero:
+    // malloc(n) -> n, realloc(p, n) -> n. calloc self-zeroes and needs no
+    // memset, so it (and free/none) report null here.
+    [[nodiscard]] clang::Expr* memsetByteSize() const {
+      switch (m_Kind) {
+      case Kind::Malloc:
+        return m_Call->getArg(0);
+      case Kind::Realloc:
+        return m_Call->getArg(1);
+      default:
+        return nullptr;
+      }
+    }
+
+    // True for an in-place `p = realloc(p, n)`: the LHS is realloc's own
+    // pointer argument. Only then may the reallocated pointer be kept across
+    // the call (realloc frees the old block, so a saved pointer would dangle).
+    [[nodiscard]] bool isInPlaceRealloc(const clang::Expr* LHS) const {
+      if (m_Kind != Kind::Realloc || m_Call->getNumArgs() == 0)
+        return false;
+      const auto* LDRE =
+          llvm::dyn_cast<clang::DeclRefExpr>(LHS->IgnoreParenCasts());
+      const auto* ArgDRE = llvm::dyn_cast<clang::DeclRefExpr>(
+          m_Call->getArg(0)->IgnoreParenCasts());
+      return LDRE && ArgDRE && LDRE->getDecl() == ArgDRE->getDecl();
+    }
+
+    // The pointer variable of an in-place `p = realloc(p, n)`, or null.
+    [[nodiscard]] const clang::VarDecl*
+    getInPlaceReallocPtr(const clang::Expr* LHS) const {
+      if (!isInPlaceRealloc(LHS))
+        return nullptr;
+      return llvm::dyn_cast<clang::VarDecl>(
+          llvm::cast<clang::DeclRefExpr>(LHS->IgnoreParenCasts())->getDecl());
+    }
+
+  private:
+    AllocCallInfo(Kind k, clang::CallExpr* c) : m_Kind(k), m_Call(c) {}
+    Kind m_Kind = Kind::None;
+    clang::CallExpr* m_Call = nullptr;
+  };
+
 private:
   /// Based on To-Be-Recorded analysis performed before differentiation, tells
   /// UsefulToStoreGlobal whether a variable with a given SourceLocation has to
@@ -109,6 +191,16 @@ public:
   const clang::Expr* Args = nullptr;
   /// Indexes of global GPU args of function as a subset of Args.
   std::vector<size_t> CUDAGlobalArgsIndexes;
+  /// Pointer variables that are the target of an in-place `p = realloc(p, n)`
+  /// in this function, collected by DiffCollector during planning. Reverse
+  /// mode gives exactly these an allocation-size shadow so the realloc can be
+  /// undone; other allocated pointers get none. Empty unless the body
+  /// reallocates in place.
+  std::set<const clang::VarDecl*> InPlaceReallocPtrs;
+  /// Whether VD is reallocated in place somewhere in this function.
+  bool isInPlaceReallocated(const clang::VarDecl* VD) const {
+    return InPlaceReallocPtrs.count(VD) != 0;
+  }
   /// Requested differentiation mode, forward or reverse.
   DiffMode Mode = DiffMode::unknown;
   /// If function appears in the call to clad::gradient/differentiate,
@@ -323,6 +415,10 @@ struct RequestOptions {
     void Walk(clang::DeclGroupRef DGR);
     bool VisitCallExpr(clang::CallExpr* E);
     bool VisitDeclRefExpr(clang::DeclRefExpr* DRE);
+    /// Record an in-place `p = realloc(p, n)` on the request whose body is
+    /// being traversed, so reverse mode knows p needs an allocation-size
+    /// shadow.
+    bool VisitBinaryOperator(clang::BinaryOperator* BO);
     bool VisitCXXConstructExpr(clang::CXXConstructExpr* e);
     bool shouldVisitImplicitCode() const { return true; }
     /// Here we use TraverseLambdaExpr and not VisitLambdaExpr to ensure the

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -591,6 +591,12 @@ namespace clad {
     /// @returns The call to memset if the condition is met, otherwise nullptr.
     clang::Expr* CheckAndBuildCallToMemset(clang::Expr* LHS, clang::Expr* RHS);
 
+    /// The byte-size operand of a malloc/calloc/realloc call, in the primal's
+    /// terms: malloc(n) -> n, calloc(k, s) -> k*s, realloc(p, n) -> n. Returns
+    /// null if `allocExpr` is not one of those. Used to track allocation sizes
+    /// so a realloc can be undone in the reverse sweep.
+    clang::Expr* buildAllocByteSize(clang::Expr* allocExpr);
+
     static DeclDiff<clang::StaticAssertDecl>
     DifferentiateStaticAssertDecl(const clang::StaticAssertDecl* SAD);
 

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -242,6 +242,11 @@ namespace clad {
     struct AdjointInfo {
       clang::VarDecl* Decl = nullptr;
       enum WrapKind : std::uint8_t { Plain, Deref, ParenDeref } Wrap = Plain;
+      /// For a pointer reallocated in place, the `size_t` variable tracking its
+      /// current allocation size in bytes: set where the pointer is allocated,
+      /// read where it is realloc'd to undo the resize in reverse. Null for
+      /// every other variable.
+      clang::VarDecl* AllocSize = nullptr;
     };
     /// Map used to keep track of variable declarations and match them
     /// with their derivatives.

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1569,6 +1569,18 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     return true;
   }
 
+  bool DiffCollector::VisitBinaryOperator(BinaryOperator* BO) {
+    // Runs while TraverseFunctionDeclOnce walks a request's body, with
+    // m_ParentReq pointing at that request (still local, added to the graph
+    // only after the walk) -- so this eagerly records into the very request
+    // reverse mode will consume. Outside a request body m_ParentReq is null.
+    if (m_ParentReq && BO->getOpcode() == BO_Assign)
+      if (const VarDecl* p = DiffRequest::AllocCallInfo::recognize(BO->getRHS())
+                                 .getInPlaceReallocPtr(BO->getLHS()))
+        m_ParentReq->InPlaceReallocPtrs.insert(p);
+    return true;
+  }
+
   bool DiffCollector::VisitDeclRefExpr(DeclRefExpr* DRE) {
     // m_TopMostReq is dereferenced below; it is null when PlanNestedRequest
     // walks a lazy request's body just to record its early-return flag, and no

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -80,6 +80,8 @@ using namespace clang;
 
 namespace clad {
 
+using AllocCallInfo = DiffRequest::AllocCallInfo;
+
 Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   if (E)
     if (const auto* CXXILE =
@@ -237,72 +239,6 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     return atomicAddCall;
   }
 
-  namespace {
-  // Recognises a C heap-memory builtin call and centralises the invariants
-  // reverse mode must preserve for it, so all memory-op reasoning goes through
-  // one place instead of ad-hoc name checks scattered across the visitor.
-  class AllocCallInfo {
-  public:
-    enum class Kind { None, Malloc, Calloc, Realloc, Free };
-
-    AllocCallInfo() = default;
-
-    // Recognise E as a memory builtin; Kind::None if it is not one. Strips the
-    // C-style cast that wraps the call (e.g. `(double*)realloc(...)`), so
-    // IgnoreParenCasts, not IgnoreParenImpCasts, is required here.
-    [[nodiscard]] static AllocCallInfo recognize(clang::Expr* E) {
-      auto* CE = llvm::dyn_cast_or_null<clang::CallExpr>(
-          E ? E->IgnoreParenCasts() : nullptr);
-      if (!CE)
-        return {};
-      const clang::FunctionDecl* FD = CE->getDirectCallee();
-      // getName() asserts on non-identifier names (operators, constructors),
-      // which vector/STL code produces; the builtins are plain identifiers.
-      if (!FD || !FD->getDeclName().isIdentifier())
-        return {};
-      Kind k = llvm::StringSwitch<Kind>(FD->getName())
-                   .Case("malloc", Kind::Malloc)
-                   .Case("calloc", Kind::Calloc)
-                   .Case("realloc", Kind::Realloc)
-                   .Case("free", Kind::Free)
-                   .Default(Kind::None);
-      return AllocCallInfo(k, CE);
-    }
-
-    // The number-of-bytes operand that a following memset must zero:
-    // malloc(n) -> n, realloc(p, n) -> n. calloc self-zeroes and needs no
-    // memset, so it (and free/none) report null here.
-    [[nodiscard]] clang::Expr* memsetByteSize() const {
-      switch (m_Kind) {
-      case Kind::Malloc:
-        return m_Call->getArg(0);
-      case Kind::Realloc:
-        return m_Call->getArg(1);
-      default:
-        return nullptr;
-      }
-    }
-
-    // True for an in-place `p = realloc(p, n)`: the LHS is realloc's own
-    // pointer argument. Only then may the reallocated pointer be kept across
-    // the call (realloc frees the old block, so a saved pointer would dangle).
-    [[nodiscard]] bool isInPlaceRealloc(const clang::Expr* LHS) const {
-      if (m_Kind != Kind::Realloc || m_Call->getNumArgs() == 0)
-        return false;
-      const auto* LDRE =
-          llvm::dyn_cast<clang::DeclRefExpr>(LHS->IgnoreParenCasts());
-      const auto* ArgDRE = llvm::dyn_cast<clang::DeclRefExpr>(
-          m_Call->getArg(0)->IgnoreParenCasts());
-      return LDRE && ArgDRE && LDRE->getDecl() == ArgDRE->getDecl();
-    }
-
-  private:
-    AllocCallInfo(Kind k, clang::CallExpr* c) : m_Kind(k), m_Call(c) {}
-    Kind m_Kind = Kind::None;
-    clang::CallExpr* m_Call = nullptr;
-  };
-  } // namespace
-
   // Both LHS (the memset destination) and the size expression are cloned here:
   // callers pass the derived pointer they also assign to and the malloc/realloc
   // size they also pass to that call, so cloning keeps the memset a distinct
@@ -316,6 +252,22 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
 
     return nullptr;
+  }
+
+  Expr* ReverseModeVisitor::buildAllocByteSize(Expr* allocExpr) {
+    // A pointer's initial allocation is malloc(n) or calloc(k, s); a realloc is
+    // a reassignment handled at the assignment, not a declaration initialiser.
+    // Report the byte size of the former two, null for anything else.
+    AllocCallInfo ac = AllocCallInfo::recognize(allocExpr);
+    CallExpr* call = ac.getCall();
+    switch (ac.getKind()) {
+    case AllocCallInfo::Kind::Malloc:
+      return call->getArg(0);
+    case AllocCallInfo::Kind::Calloc:
+      return BuildOp(BO_Mul, call->getArg(0), call->getArg(1));
+    default:
+      return nullptr;
+    }
   }
 
   ReverseModeVisitor::ReverseModeVisitor(DerivativeBuilder& builder,
@@ -3225,14 +3177,59 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // For an in-place `p = realloc(p, sz)`, realloc frees the old block, so
       // saving p to restore it in the reverse sweep would dangle (and be
       // double-freed at cleanup). Keep the reallocated pointer instead, for
-      // both p and its adjoint _d_p. This is sound for a growing or same-size
-      // realloc, where every reverse access stays in bounds. A shrinking
-      // in-place realloc is not handled -- its reverse sweep may read the
-      // freed tail out of bounds, as it did before this change; no test
-      // exercises it.
+      // both p and its adjoint _d_p.
       bool isReallocAssignment =
           opCode == BO_Assign &&
           AllocCallInfo::recognize(R).isInPlaceRealloc(L);
+
+      // For an in-place realloc whose buffer size we tracked at allocation,
+      // undo the resize in the reverse sweep: restore p and its adjoint _d_p to
+      // their pre-realloc byte size so statements that ran before the realloc
+      // access valid indices again (clad::reverse_realloc also zeroes the
+      // re-grown adjoint tail). Without a tracked size we fall back to keeping
+      // the reallocated pointer, which is correct only for grow/same-size.
+      if (isReallocAssignment) {
+        const auto* pDRE = cast<DeclRefExpr>(L->IgnoreParenCasts());
+        // Resolve the pointer to its adjoint record via the primal clone (the
+        // key m_Variables uses), then read the allocation-size shadow off it.
+        auto replIt = m_DeclReplacements.find(cast<VarDecl>(pDRE->getDecl()));
+        auto varIt = replIt == m_DeclReplacements.end()
+                         ? m_Variables.end()
+                         : m_Variables.find(replIt->second);
+        if (varIt != m_Variables.end() && varIt->second.AllocSize) {
+          VarDecl* sizeVar = varIt->second.AllocSize;
+          Expr* newBytes = AllocCallInfo::recognize(R).getCall()->getArg(1);
+          // Capture both sizes in the forward pass. The reverse sweep must use
+          // the sizes as they were at the realloc, but the operands may refer
+          // to variables whose values differ by the time the sweep runs, so
+          // neither can be re-evaluated there. oldBytes reads the shadow before
+          // it advances; newBytes is stored once and reused for the update.
+          Expr* oldBytes =
+              StoreAndRef(BuildDeclRef(sizeVar), direction::forward, "_t",
+                          /*forceDeclCreation=*/true);
+          Expr* newBytesRef = StoreAndRef(Clone(newBytes), direction::forward,
+                                          "_t", /*forceDeclCreation=*/true);
+          addToCurrentBlock(
+              BuildOp(BO_Assign, BuildDeclRef(sizeVar), Clone(newBytesRef)),
+              direction::forward);
+          auto buildReverseRealloc = [&](Expr* ptr, bool zeroTail) {
+            Expr* zt = new (m_Context)
+                CXXBoolLiteralExpr(zeroTail, m_Context.BoolTy, noLoc);
+            llvm::SmallVector<Expr*, 4> args = {Clone(ptr), Clone(oldBytes),
+                                                Clone(newBytesRef), zt};
+            Expr* call = GetFunctionCall("reverse_realloc", "clad", args);
+            // reverse_realloc returns void*; cast back to the pointer's type.
+            TypeSourceInfo* TSI =
+                m_Context.getTrivialTypeSourceInfo(ptr->getType(), noLoc);
+            call = m_Sema.BuildCStyleCastExpr(noLoc, TSI, noLoc, call).get();
+            return BuildOp(BO_Assign, Clone(ptr), call);
+          };
+          addToCurrentBlock(buildReverseRealloc(L, /*zeroTail=*/false),
+                            direction::reverse);
+          addToCurrentBlock(buildReverseRealloc(ResultRef, /*zeroTail=*/true),
+                            direction::reverse);
+        }
+      }
 
       // Store the value of the LHS of the assignment in the forward pass
       // and restore it in the reverse pass
@@ -3830,6 +3827,18 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                     BuildDeclRef(VDDerived),
                     VDDerived->getInit()->IgnoreCasts()))
               memsetCalls.push_back(memsetCall);
+            // Track this pointer's allocation size in bytes so an in-place
+            // realloc of it can be undone in the reverse sweep. The shadow is
+            // recorded on the pointer's adjoint entry, keyed like every other
+            // m_Variables record by the primal clone.
+            if (m_DiffReq.isInPlaceReallocated(VD))
+              if (Expr* bytes = buildAllocByteSize(VDDerived->getInit())) {
+                VarDecl* sizeVar = BuildVarDecl(
+                    m_Context.getSizeType(),
+                    "_" + VD->getNameAsString() + "_size", Clone(bytes));
+                memsetCalls.push_back(BuildDeclStmt(sizeVar));
+                m_Variables[VDDiff.getDecl()].AllocSize = sizeVar;
+              }
           }
         }
       } else if (auto* SAD = dyn_cast<StaticAssertDecl>(D)) {

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -331,29 +331,37 @@ double cStyleMemoryAlloc(double x, size_t n) {
 // CHECK-NEXT:     double _t0 = t->x;
 // CHECK-NEXT:     t->x = x;
 // CHECK-NEXT:     double *_d_p = (double *)calloc(1, sizeof(double));
+// CHECK-NEXT:     {{__size_t|size_t|unsigned long long|unsigned long|unsigned int}} _p_size0 = 1 * sizeof(double);
 // CHECK-NEXT:     double *p = (double *)calloc(1, sizeof(double));
 // CHECK-NEXT:     double _t1 = *p;
 // CHECK-NEXT:     *p = x;
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = t->x + *p;
+// CHECK-NEXT:     {{__size_t|size_t|unsigned long long|unsigned long|unsigned int}} _t2 = _p_size0;
+// CHECK-NEXT:     {{__size_t|size_t|unsigned long long|unsigned long|unsigned int}} _t3 = 2 * sizeof(double);
+// CHECK-NEXT:     _p_size0 = _t3;
 // CHECK-NEXT:     _d_p = (double *)realloc(_d_p, 2 * sizeof(double));
 // CHECK-NEXT:     memset(_d_p, 0, 2 * sizeof(double));
 // CHECK-NEXT:     p = (double *)realloc(p, 2 * sizeof(double));
-// CHECK-NEXT:     double _t2 = p[1];
+// CHECK-NEXT:     double _t4 = p[1];
 // CHECK-NEXT:     p[1] = 2 * x;
-// CHECK-NEXT:     double _t3 = res;
+// CHECK-NEXT:     double _t5 = res;
 // CHECK-NEXT:     res += p[1];
 // CHECK-NEXT:     _d_res += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         res = _t3;
+// CHECK-NEXT:         res = _t5;
 // CHECK-NEXT:         double _r_d3 = _d_res;
 // CHECK-NEXT:         _d_p[1] += _r_d3;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         p[1] = _t2;
+// CHECK-NEXT:         p[1] = _t4;
 // CHECK-NEXT:         double _r_d2 = _d_p[1];
 // CHECK-NEXT:         _d_p[1] = 0.;
 // CHECK-NEXT:         *_d_x += 2 * _r_d2;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         p = (double *)clad::reverse_realloc(p, _t2, _t3, false);
+// CHECK-NEXT:         _d_p = (double *)clad::reverse_realloc(_d_p, _t2, _t3, true);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_t->x += _d_res;

--- a/test/Gradient/ReallocShrink.C
+++ b/test/Gradient/ReallocShrink.C
@@ -1,0 +1,70 @@
+// RUN: %cladclang %s -I%S/../../include -oReallocShrink.out 2>&1 | %filecheck %s
+// RUN: ./ReallocShrink.out | %filecheck_exec %s
+
+// Shrinking in-place realloc: the reverse sweep must resize the buffer (and its
+// adjoint) back to the pre-realloc size so the pre-realloc reads stay in bounds
+// and the adjoint accumulates correctly. Runs Memcheck-clean under the valgrind
+// CI row.
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdlib>
+
+// res = (x + x*x) + x  ->  dres/dx = 2 + 2x ; at x = 3 -> 8
+double shrink_realloc(double x) {
+  double* p = (double*)malloc(2 * sizeof(double));
+  p[0] = x;
+  p[1] = x * x;
+  double res = p[0] + p[1];
+  p = (double*)realloc(p, 1 * sizeof(double)); // shrink 2 -> 1
+  res += p[0];
+  free(p);
+  return res;
+}
+
+// Two in-place reallocs on the same pointer, so each must restore the size the
+// buffer had before *it*: res = (x + x*x + x*x*x) + x + x -> x^3 + x^2 + 3x;
+// dres/dx = 3*x*x + 2*x + 3; at x = 2 -> 19.
+double chained_realloc(double x) {
+  double* p = (double*)malloc(3 * sizeof(double));
+  p[0] = x;
+  p[1] = x * x;
+  p[2] = x * x * x;
+  double res = p[0] + p[1] + p[2];
+  p = (double*)realloc(p, 1 * sizeof(double)); // shrink 3 -> 1
+  res += p[0];
+  p = (double*)realloc(p, 2 * sizeof(double)); // grow  1 -> 2
+  p[1] = x;
+  res += p[1];
+  free(p);
+  return res;
+}
+
+// realloc(NULL, n) grows an empty buffer (there is no prior allocation to size,
+// so no shadow is tracked and the reverse sweep keeps the reallocated pointer,
+// which is sound for a grow). res = x + x*x -> dres/dx = 1 + 2x; at x = 3 -> 7.
+double realloc_from_null(double x) {
+  double* p = nullptr;
+  p = (double*)realloc(p, 2 * sizeof(double));
+  p[0] = x;
+  p[1] = x * x;
+  double res = p[0] + p[1];
+  free(p);
+  return res;
+}
+
+int main() {
+  auto g = clad::gradient<clad::opts::disable_tbr>(shrink_realloc, "x");
+  double dx = 0;
+  g.execute(3.0, &dx);
+  printf("{%.2f}\n", dx); // CHECK-EXEC: {8.00}
+
+  auto gn = clad::gradient<clad::opts::disable_tbr>(realloc_from_null, "x");
+  double dxn = 0;
+  gn.execute(3.0, &dxn);
+  printf("{%.2f}\n", dxn); // CHECK-EXEC: {7.00}
+
+  auto gc = clad::gradient<clad::opts::disable_tbr>(chained_realloc, "x");
+  double dxc = 0;
+  gc.execute(2.0, &dxc);
+  printf("{%.2f}\n", dxc); // CHECK-EXEC: {19.00}
+}


### PR DESCRIPTION
Since #1925 an in-place `p = realloc(p, n)` keeps the reallocated pointer for both p and its adjoint instead of saving and restoring it, because realloc frees the old block and a saved pointer would dangle. That is correct only when the buffer grows or keeps its size: a shrinking realloc leaves the reverse sweep addressing a buffer smaller than the indices the forward pass wrote, reading past its end.

Track each differentiated pointer's allocation size in a size_t shadow, set at malloc/calloc/realloc. At an in-place realloc, save the pre-realloc size in the forward pass and, in the reverse sweep, call clad::reverse_realloc to resize both the primal and adjoint buffers back to it so the pre-realloc accesses stay in bounds; the adjoint's re-grown tail is zeroed so fresh derivatives start at 0. Without a tracked size the previous keep-the-pointer behaviour still applies.

Add Gradient/ReallocShrink.C, which is Memcheck-clean under the valgrind row only with this change; update Gradient/Pointers.C for the shadows.