### PR TITLE
Fix uninitialized record assignment in reverse mode

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3794,12 +3794,18 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           auto* decl = VDDiff.getDecl();
           if (VD->getInit()) {
             auto* declRef = BuildDeclRef(decl);
+            Expr* init = decl->getInit();
+            const auto* CE = dyn_cast_or_null<CXXConstructExpr>(
+                init ? init->IgnoreImplicit() : nullptr);
+            if (!init ||
+                (CE && !CE->getNumArgs() && !CE->isListInitialization()))
+              init = getZeroInit(VD->getType());
             Expr* assignment = nullptr;
             if (isa<ArrayType>(VD->getType()))
-              assignment = BuildArrayAssignment(declRef, decl->getInit(),
-                                                direction::forward);
+              assignment =
+                  BuildArrayAssignment(declRef, init, direction::forward);
             else
-              assignment = BuildOp(BO_Assign, declRef, decl->getInit());
+              assignment = BuildOp(BO_Assign, declRef, init);
             if (isInsideLoop) {
               if (m_DiffReq.shouldBeRecorded(DS)) {
                 auto pushPop = StoreAndRestore(declRef, /*prefix=*/"_t",

--- a/test/Regressions/issue-1283.cpp
+++ b/test/Regressions/issue-1283.cpp
@@ -1,0 +1,41 @@
+// RUN: %cladclang %s -I%S/../../include -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+extern "C" int printf(const char*, ...);
+
+struct Struct {
+  double val;
+};
+
+double fn(double a) {
+  double result = 0;
+  for (int i = 0; i < 3; ++i) {
+    Struct s;
+    s.val = a * (i + 1);
+    result += s.val;
+  }
+  return result;
+}
+
+int main() {
+  auto grad = clad::gradient(fn);
+  double d_a = 0;
+  grad.execute(3, &d_a);
+  printf("%.2f\n", d_a); // CHECK-EXEC: 6.00
+}
+
+// CHECK: void fn_grad(double a, double *_d_a) {
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     Struct _d_s = {0.};
+// CHECK-NEXT:     Struct s = {0.};
+// CHECK-NEXT:     double _d_result = 0.;
+// CHECK-NEXT:     double result = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     for (i = 0; i < 3; ++i) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         s = {0.};
+// CHECK-NEXT:         s.val = a * (i + 1);
+// CHECK-NEXT:         result += s.val;


### PR DESCRIPTION
## Summary

- replace declaration-only empty constructor expressions with Clad’s existing zero initializer before building promoted assignments
- preserve explicit list initialization and constructor calls with arguments
- add regression coverage for record declarations inside loops

## Testing

- verified the issue #1283 reproducer fails on `origin/master` and passes with this change
- manually A/B tested implicit aggregates, default member initializers, explicitly defaulted records, explicit list initialization, and user-defined constructors
- ran the full lit suite: 174 passed, 1 expected platform failure, 25 unsupported, and 2 failures independently reproduced on `origin/master`
- ran `DifferentiatorHTests` and `MiscTests`: 5/5 passed
- ran `git-clang-format-18`: no changes
- ran `clang-tidy-18` on the changed production-code range: no diagnostics
- ran `git diff --check`

Fixes: #1283