### PR TITLE
Clone CXXStdInitializerListExpr nodes

### DIFF
--- a/include/clad/Differentiator/StmtClone.h
+++ b/include/clad/Differentiator/StmtClone.h
@@ -122,6 +122,7 @@ namespace utils {
     DECLARE_CLONE_FN(CXXConstructExpr)
     DECLARE_CLONE_FN(CXXTemporaryObjectExpr)
     DECLARE_CLONE_FN(CXXBindTemporaryExpr)
+    DECLARE_CLONE_FN(CXXStdInitializerListExpr)
     DECLARE_CLONE_FN(MaterializeTemporaryExpr)
     DECLARE_CLONE_FN(PseudoObjectExpr)
     DECLARE_CLONE_FN(OpaqueValueExpr)

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -234,6 +234,9 @@ Stmt* StmtClone::VisitCXXTemporaryObjectExpr(CXXTemporaryObjectExpr* Node) {
 DEFINE_CREATE_EXPR(CXXBindTemporaryExpr,
                    (Ctx, Node->getTemporary(), Clone(Node->getSubExpr())))
 
+DEFINE_CLONE_EXPR(CXXStdInitializerListExpr,
+                  (CloneType(Node->getType()), Clone(Node->getSubExpr())))
+
 DEFINE_CLONE_EXPR(MaterializeTemporaryExpr,
                   (CloneType(Node->getType()),
                    Node->getSubExpr() ? Clone(Node->getSubExpr()) : nullptr,

--- a/test/Regressions/issue-1931.cpp
+++ b/test/Regressions/issue-1931.cpp
@@ -1,0 +1,32 @@
+// RUN: %cladclang %s -I%S/../../include -o %t
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+template <typename T>
+double helper(int n, T x) {
+  double result = 0.0;
+  for (int i = 0; i < n; ++i)
+    result += x[i] * x[i];
+  return result;
+}
+
+double fn(double* params) {
+  double sum = 0.0;
+  #pragma clad checkpoint loop
+  for (int i = 0; i < 3; i++) {
+    double arr[]{params[0], params[1]};
+    sum += helper(2, arr);
+  }
+  return sum;
+}
+
+int main() {
+  auto grad = clad::gradient(fn);
+  double params[] = {3.0, 4.0};
+  double d_params[] = {0.0, 0.0};
+  grad.execute(params, d_params);
+  printf("{%.2f, %.2f}\n", d_params[0], d_params[1]);
+  // CHECK-EXEC: {18.00, 24.00}
+  return 0;
+}


### PR DESCRIPTION
Brace initialized local arrays produce a CXXStdInitializerListExpr node that StmtClone had no visitor for and caused a crash. This PR adds the clone handler.

Fixes #1931 