### PR TITLE
Zero-initialize hoisted variables in GlobalStoreAndRef and StoreAndRef

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4231,7 +4231,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // this global there (a branch _cond flag) asks for zero-init so the
       // unreached case reads false -- the same zero-state clad already relies
       // on for adjoints and loop counters.
-      if (zeroInit)
+      if (zeroInit || m_DiffReq.hasEarlyReturns())
         SetDeclInit(VD, getZeroInit(Type));
       addToBlock(decl, m_Globals);
       // Use a fresh ref for the store-back LHS; Ref is returned to the caller
@@ -4291,6 +4291,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         Store = decl;
         SetDeclInit(VD, E);
       } else {
+        if (m_DiffReq.hasEarlyReturns())
+          SetDeclInit(VD, getZeroInit(Type));
         addToBlock(decl, m_Globals);
         Store = BuildOp(BO_Assign, Ref, Clone(E));
       }
@@ -4457,8 +4459,10 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     }
     bool isFnScope = getCurrentScope()->isFunctionScope() ||
                      m_DiffReq.Mode == DiffMode::reverse_mode_forward_pass;
-    VarDecl* VD = BuildGlobalVarDecl(
-        utils::getNonConstType(E->getType(), m_Sema), prefix);
+    QualType VarType = utils::getNonConstType(E->getType(), m_Sema);
+    VarDecl* VD = BuildGlobalVarDecl(VarType, prefix);
+    if (!isFnScope && m_DiffReq.hasEarlyReturns())
+      SetDeclInit(VD, getZeroInit(VarType));
     Expr* Ref = BuildDeclRef(VD);
     if (!isFnScope)
       addToBlock(BuildDeclStmt(VD), m_Globals);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4249,7 +4249,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // this global there (a branch _cond flag) asks for zero-init so the
       // unreached case reads false -- the same zero-state clad already relies
       // on for adjoints and loop counters.
-      if (zeroInit)
+      if (zeroInit || m_DiffReq.hasEarlyReturns())
         SetDeclInit(VD, getZeroInit(Type));
 
       addToBlock(decl, m_Globals);
@@ -4310,6 +4310,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         Store = decl;
         SetDeclInit(VD, E);
       } else {
+        if (m_DiffReq.hasEarlyReturns())
+          SetDeclInit(VD, getZeroInit(Type));
         addToBlock(decl, m_Globals);
         Store = BuildOp(BO_Assign, Ref, Clone(E));
       }
@@ -4482,6 +4484,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                      m_DiffReq.Mode == DiffMode::reverse_mode_forward_pass;
     QualType VarType = utils::getNonConstType(E->getType(), m_Sema);
     VarDecl* VD = BuildGlobalVarDecl(VarType, prefix);
+    if (!isFnScope && m_DiffReq.hasEarlyReturns())
+      SetDeclInit(VD, getZeroInit(VarType));
     Expr* Ref = BuildDeclRef(VD);
     if (!isFnScope)
       addToBlock(BuildDeclStmt(VD), m_Globals);

--- a/test/Gradient/EarlyReturns.C
+++ b/test/Gradient/EarlyReturns.C
@@ -86,6 +86,22 @@ double recEarly(double x, double y) {
 
 double callsRec(double x, double y) { return recEarly(x, y); }
 
+double nested_early_return(double x, double y) {
+  if (x > 0) {
+    x = x * y; 
+  }
+  if (x < 0) {
+    return 0;  
+  }
+  return x;
+}
+
+// CHECK-LABEL: void nested_early_return_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK-NEXT:     bool _cond0 = false;
+// CHECK-NEXT:     double _t0 = 0.;
+// CHECK-NEXT:     bool _cond1 = false;
+
+
 int main() {
   double dx = 0, dy = 0;
 
@@ -127,4 +143,12 @@ int main() {
   dx = dy = 0;
   INIT_GRADIENT(callsRec);
   TEST_GRADIENT(callsRec, /*numOfDerivativeArgs=*/2, 3, 1, &dx, &dy); // CHECK-EXEC: {1.00, 1.00}
+
+  dx = dy = 0;
+  INIT_GRADIENT(nested_early_return);
+  // x > 0 triggers x = x * y, falling through to return x. 
+  TEST_GRADIENT(nested_early_return, /*numOfDerivativeArgs=*/2, 5, 3, &dx, &dy); // CHECK-EXEC: {3.00, 5.00}
+  dx = dy = 0;
+  // x < 0 takes the early return 0. 
+  TEST_GRADIENT(nested_early_return, /*numOfDerivativeArgs=*/2, -5, 3, &dx, &dy); // CHECK-EXEC: {0.00, 0.00}
 }

--- a/test/Gradient/EarlyReturns.C
+++ b/test/Gradient/EarlyReturns.C
@@ -86,6 +86,22 @@ double recEarly(double x, double y) {
 
 double callsRec(double x, double y) { return recEarly(x, y); }
 
+double nested_early_return(double x, double y) {
+  if (x > 0) {
+    x = x * y; 
+  }
+  if (x < 0) {
+    return 0;  
+  }
+  return x;
+}
+
+// CHECK-LABEL: void nested_early_return_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK-NEXT:     bool _cond0 = false;
+// CHECK-NEXT:     double _t0 = 0.;
+// CHECK-NEXT:     bool _cond1 = false;
+
+
 // The early return is the very first statement, so the forward-sweep split
 // at the lambda's insertion point starts empty: n, a, b, and a's
 // pre-multiplication snapshot are all declared after it, yet the reverse
@@ -151,6 +167,14 @@ int main() {
   dx = dy = 0;
   INIT_GRADIENT(callsRec);
   TEST_GRADIENT(callsRec, /*numOfDerivativeArgs=*/2, 3, 1, &dx, &dy); // CHECK-EXEC: {1.00, 1.00}
+
+  dx = dy = 0;
+  INIT_GRADIENT(nested_early_return);
+  // x > 0 triggers x = x * y, falling through to return x. 
+  TEST_GRADIENT(nested_early_return, /*numOfDerivativeArgs=*/2, 5, 3, &dx, &dy); // CHECK-EXEC: {3.00, 5.00}
+  dx = dy = 0;
+  // x < 0 takes the early return 0. 
+  TEST_GRADIENT(nested_early_return, /*numOfDerivativeArgs=*/2, -5, 3, &dx, &dy); // CHECK-EXEC: {0.00, 0.00}
 
   dx = dy = 0;
   INIT_GRADIENT(declAfterEarly);

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -406,12 +406,12 @@ int main() {
 // CHECK-NEXT:     double _d_cond0;
 // CHECK-NEXT:     _d_cond0 = 0.;
 // CHECK-NEXT:     bool _cond1 = false;
-// CHECK-NEXT:     bool _t0;
+// CHECK-NEXT:     bool _t0 = false;
 // CHECK-NEXT:     bool _cond2 = false;
 // CHECK-NEXT:     bool _cond3 = false;
-// CHECK-NEXT:     float _t2;
-// CHECK-NEXT:     float _t3;
-// CHECK-NEXT:     float _t4;
+// CHECK-NEXT:     float _t2 = 0.F;
+// CHECK-NEXT:     float _t3 = 0.F;
+// CHECK-NEXT:     float _t4 = 0.F;
 // CHECK-NEXT:     float _d_val = 0.F;
 // CHECK-NEXT:     float val = ::std::pow(x, exponent);
 // CHECK-NEXT:     float _t1 = ::std::pow(x, exponent - 1);


### PR DESCRIPTION
When early returns are present, variables assigned inside nested scopes  are hoisted to the top level so they can be safely captured by the lambda. Previously, these variables were left uninitialized, which could lead to capturing garbage memory if an early return triggered before their assignment ultimately leading to crash
.