### PR TITLE
Discard delayed calls after a repl error or undo on clang < 22

### DIFF
--- a/test/Misc/Repl.cpp
+++ b/test/Misc/Repl.cpp
@@ -1,6 +1,8 @@
 // REQUIRES: clang-repl
-// UNSUPPORTED: clang-13, clang-14, clang-15, clang-17
-// RUN: cat %s | %clang-repl -Xcc -fplugin=%cladlib -Xcc -I%S/../../include | FileCheck %s
+// UNSUPPORTED: clang-13, clang-14, clang-15, clang-16, clang-17, clang-18
+// RUN: cat %s | %clang-repl -Xcc -fplugin=%cladlib                            \
+// RUN:             -Xcc -I%S/../../include -Xcc -Xclang -Xcc -verify |        \
+// RUN:                FileCheck %s
 
 double sq(double x) { return x*x; }
 extern "C" int printf(const char*,...);
@@ -8,3 +10,12 @@ extern "C" int printf(const char*,...);
 auto dsq = clad::differentiate(sq, "x");
 auto r1 = printf("dsq(1)=%f\n", dsq.execute(1));
 // CHECK: dsq(1)=2.00
+
+int x = 5;
+%undo
+int y = x; // expected-error {{use of undeclared identifier 'x'}}
+int x = 10;
+int e = undefined_sym, f = 1; // expected-error {{use of undeclared identifier 'undefined_sym'}}
+auto r2 = printf("dsq(2)=%f\n", dsq.execute(2));
+// CHECK: dsq(2)=4.00
+%quit

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -28,6 +28,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cassert>
 #include <deque>
 #include <map>
 #include <set>
@@ -263,6 +264,16 @@ struct DifferentiationOptions {
               m_CI.getPreprocessor().isIncrementalProcessingEnabled()) &&
              "Must start from index 0!");
       m_DelayedCalls.push_back(DCI);
+#if CLANG_VERSION_MAJOR < 22
+      // If we are in repl mode we might have an error or an undo operation
+      // which discards the set of declarations that were collected already.
+      // Clad should discard them, too, or it would replay them to the
+      // multiplexer over a broken AST. Clang >= 22 is not affected
+      // (llvm/llvm-project#182044).
+      if (m_CI.getPreprocessor().isIncrementalProcessingEnabled() &&
+          m_CI.getDiagnostics().hasErrorOccurred())
+        m_MultiplexerProcessedDelayedCallsIdx = m_DelayedCalls.size();
+#endif
     }
     void FinalizeTranslationUnit();
     void SendToMultiplexer();


### PR DESCRIPTION
in incremental mode a parse error or %undo discards the declarations of the current ptu, but clad's consumer has already queued delayed calls over them; replaying the queue to the multiplexer hands codegen a broken ast and crashes when run with CppInterOp + clang-repl (https://github.com/compiler-research/CppInterOp/pull/830). fast-forward delayed calls index past the queued calls when diagnostics report an error so they are never sent.

clang >= 22 is not affected (this was fixed by llvm/llvm-project#182044), so the workaround is gated on CLANG_VERSION_MAJOR < 22. Tested across LLVM 20, 21 and 22, all CppInterOp unittests pass.