### PR TITLE
Find LLD before Clang to support emscripten-built LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,15 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
 
   ## Find supported Clang
 
+  # Emscripten builds of clangInterpreter link lldWasm/lldCommon
+  # (clang/lib/Interpreter/CMakeLists.txt), so ClangTargets.cmake references
+  # LLD targets and find_package(Clang) fails unless LLD is found first.
+  if (DEFINED LLD_DIR)
+    find_package(LLD QUIET CONFIG PATHS ${LLD_DIR} "${LLD_DIR}/lib/cmake/lld" "${LLD_DIR}/cmake" NO_DEFAULT_PATH)
+  else()
+    find_package(LLD QUIET CONFIG HINTS "${LLVM_DIR}/../lld" "${LLVM_BINARY_DIR}/lib/cmake/lld")
+  endif()
+
   if (DEFINED CLANG_VERSION)
     message(FATAL_ERROR "Clang's configuration is not versioned. Please set LLVM_VERSION instead.")
   endif(DEFINED CLANG_VERSION)


### PR DESCRIPTION
Emscripten builds of the interpreter link `lldWasm/lldCommon`, so the generated ClangTargets.cmake references LLD targets and `find_package(Clang)` fails unless the LLD package is found first. Find LLD before Clang, honoring LLD_DIR when set and hinting off LLVM_DIR otherwise. The lookup is QUIET, so native builds without LLD are unaffected. This allows cross-compiling clad against an emscripten-built LLVM/Clang for wasm.