### PR TITLE
Thread per-call state from a reverse_forw to its pullback via pullback_state

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -2,6 +2,7 @@ set(CTEST_BUILD_NAME ${ROOT_ARCHITECTURE}-${CMAKE_BUILD_TYPE})
 enable_testing()
 
 CB_ADD_GBENCHMARK(Simple Simple.cpp)
+CB_ADD_GBENCHMARK(PullbackState PullbackState.cpp)
 CB_ADD_GBENCHMARK(AlgorithmicComplexity AlgorithmicComplexity.cpp)
 CB_ADD_GBENCHMARK(ArrayExpressionTemplates ArrayExpressionTemplates.cpp)
 if (CLAD_ENABLE_ENZYME_BACKEND)

--- a/benchmark/PullbackState.cpp
+++ b/benchmark/PullbackState.cpp
@@ -1,0 +1,76 @@
+#include "benchmark/benchmark.h"
+
+#include "clad/Differentiator/BuiltinDerivatives.h"
+#include "clad/Differentiator/Differentiator.h"
+
+// clad::pullback_state<clad::no_state> must be a zero-cost abstraction: an
+// empty payload, its per-call carrier, and the threading of that carrier into
+// both the reverse_forw and the pullback have to fold away entirely at -O1+.
+// These two benchmarks differentiate the same custom-derivative op -- one whose
+// reverse_forw/pullback carry no state, one whose reverse_forw/pullback carry
+// an empty pullback_state<no_state> -- and must report the same time within
+// noise. (At -O2 clad emits byte-identical assembly for the two gradients.)
+//
+// The custom derivatives take precedence over the primal bodies, so clad
+// routes through the reverse_forw for both variants, making the only
+// difference the empty carrier. (The primals still need definitions: taking
+// f_plain/f_state's address in clad::gradient odr-uses them, and their bodies
+// call the ops.)
+
+// Baseline: reverse_forw / pullback carry no state.
+void op_plain(double* p) { *p = *p * *p; }
+namespace clad::custom_derivatives {
+inline void op_plain_reverse_forw(double* p, double* /*d_p*/) { *p = *p * *p; }
+// NOLINTNEXTLINE(readability-non-const-parameter): clad matches a custom
+// derivative against the primal's exact parameter types; const here breaks it.
+inline void op_plain_pullback(double* p, double* d_p) { *d_p += 2.0 * *p; }
+} // namespace clad::custom_derivatives
+double f_plain(double x) {
+  double v = x;
+  op_plain(&v);
+  return v;
+}
+
+// Same op, but the reverse_forw / pullback carry pullback_state<no_state>.
+void op_state(double* p) { *p = *p * *p; }
+namespace clad::custom_derivatives {
+inline void op_state_reverse_forw(double* p, double* /*d_p*/,
+                                  clad::pullback_state<clad::no_state>&) {
+  *p = *p * *p;
+}
+// NOLINTNEXTLINE(readability-non-const-parameter): see op_plain_pullback.
+inline void op_state_pullback(double* p, double* d_p,
+                              clad::pullback_state<clad::no_state>) {
+  *d_p += 2.0 * *p;
+}
+} // namespace clad::custom_derivatives
+double f_state(double x) {
+  double v = x;
+  op_state(&v);
+  return v;
+}
+
+static void BM_PullbackNoStateOverhead_Plain(benchmark::State& state) {
+  auto grad = clad::gradient(f_plain, "x");
+  double dx = 0;
+  for (auto _ : state) {
+    dx = 0;
+    grad.execute(2.0, &dx);
+    benchmark::DoNotOptimize(dx);
+  }
+}
+BENCHMARK(BM_PullbackNoStateOverhead_Plain);
+
+static void BM_PullbackNoStateOverhead_State(benchmark::State& state) {
+  auto grad = clad::gradient(f_state, "x");
+  double dx = 0;
+  for (auto _ : state) {
+    dx = 0;
+    grad.execute(2.0, &dx);
+    benchmark::DoNotOptimize(dx);
+  }
+}
+BENCHMARK(BM_PullbackNoStateOverhead_State);
+
+// Define our main.
+BENCHMARK_MAIN();

--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -42,6 +42,26 @@ template <typename T, typename U> struct ValueAndAdjoint {
   U adjoint;
 };
 
+/// Empty payload for a pullback that carries no reverse-pass state.
+struct no_state {};
+
+/// Per-call state a custom `X_reverse_forw` hands to its matching `X_pullback`.
+/// The reverse_forw takes a trailing `pullback_state<Payload>&` out-parameter
+/// and fills it in the forward sweep; the pullback takes a trailing
+/// `pullback_state<Payload>` by value and reads it in the reverse sweep. clad
+/// declares one carrier and threads it into both calls -- the same out-param
+/// mechanism as `clad::restore_tracker`, and it composes with the
+/// `ValueAndAdjoint` a value-returning reverse_forw already returns. Use it to
+/// hand computed-in-forward data (e.g. a sort permutation) to the pullback
+/// without a shared or global stash.
+///
+/// `Payload` is author-owned; extend it by appending fields. An empty
+/// `pullback_state<no_state>` folds away at -O1+. When a reverse_forw also
+/// takes a `restore_tracker&`, the `pullback_state<Payload>&` comes first.
+template <typename Payload = no_state> struct pullback_state {
+  Payload data{};
+};
+
 /// It is used to identify constructor custom pushforwards. For
 /// constructor custom pushforward functions, we cannot use the same
 /// strategy which we use for custom pushforward for member

--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -272,6 +272,12 @@ namespace clad {
 
     bool IsCladValueAndPushforwardType(clang::QualType T);
 
+    /// If `T` is a `clad::pullback_state<Payload>` specialization, returns its
+    /// `Payload` argument; otherwise returns a null `QualType`. Used to thread
+    /// the payload a custom `reverse_forw` returns into its matching
+    /// `pullback`, and to diagnose a mismatched pullback signature.
+    clang::QualType GetPullbackStatePayload(clang::QualType T);
+
     /// Returns a valid `SourceRange` to be used in places where clang
     /// requires a valid `SourceRange`.
     clang::SourceRange GetValidSRange(clang::Sema& semaRef);

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -13,6 +13,7 @@
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
+#include "clang/AST/Type.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Basic/SourceLocation.h"
 
@@ -260,6 +261,18 @@ public:
   /// UnresolvedLookupExpr or DeclRefExpr representing the custom derivative
   /// overload
   clang::Expr* CustomDerivative = nullptr;
+
+  /// The trailing clad::pullback_state<S> parameter a custom reverse_forw /
+  /// pullback carries, already in argument form (by reference for a
+  /// reverse_forw, by value for a pullback), or null when none. clad does not
+  /// synthesize this parameter, so it is appended to the expected derivative
+  /// signature when matching the overload and when building its overload call.
+  clang::QualType PullbackStateParam;
+  // FIXME: First per-request fact communicated across the request graph. The
+  // finer call-site activity that would let a pullback early-exit inactive
+  // branches or narrow toward a directional call wants the same channel: rework
+  // DVI and the varied/useful structs into one composable, finer-grained
+  // activity model on the request (on the AST), propagated down each subgraph.
 
   /// A pointer to keep track of the prototype of the derived functions.
   /// For higher order derivatives, we store the entire sequence of

--- a/include/clad/Differentiator/DynamicGraph.h
+++ b/include/clad/Differentiator/DynamicGraph.h
@@ -110,6 +110,17 @@ public:
   const std::vector<T>& getNodes() const { return m_nodes; }
   std::vector<T>& getNodes() { return m_nodes; }
 
+  /// Returns the stored node equal to `node`, or nullptr if absent. The stored
+  /// copy may carry fields the lookup key does not, since node equality
+  /// intentionally ignores some annotations -- so this recovers what the
+  /// scheduler recorded on the node from a bare lookup key.
+  const T* getNode(const T& node) const {
+    auto it = m_nodeMap.find(node);
+    if (it == m_nodeMap.end())
+      return nullptr;
+    return &m_nodes[it->second.second];
+  }
+
   /// Dump the nodes and edges.
   void dump() const { print(std::cerr); }
 

--- a/include/clad/Differentiator/ThrustDerivatives.h
+++ b/include/clad/Differentiator/ThrustDerivatives.h
@@ -1232,18 +1232,16 @@ adjacent_difference_reverse_forw(InputIt first, InputIt last, OutputIt result,
   return {::thrust::adjacent_difference(first, last, result, op), {}};
 }
 
-namespace detail {
-inline ::std::vector<::thrust::device_vector<::std::size_t>>&
-permutation_stack() {
-  static ::std::vector<::thrust::device_vector<::std::size_t>> stack;
-  return stack;
-}
-} // namespace detail
-
+// The sort permutation (sorted position -> original index) is computed in the
+// reverse_forw and needed by the pullback to scatter adjoints back. It is
+// carried per call through clad::pullback_state, which clad threads from the
+// reverse_forw to its pullback -- replacing a static stack that was neither
+// reentrant nor thread-safe (see #1694).
 template <typename KeyIterator, typename ValueIterator>
-void sort_by_key_reverse_forw(KeyIterator keys_first, KeyIterator keys_last,
-                              ValueIterator values_first, KeyIterator,
-                              KeyIterator, ValueIterator) {
+void sort_by_key_reverse_forw(
+    KeyIterator keys_first, KeyIterator keys_last, ValueIterator values_first,
+    KeyIterator, KeyIterator, ValueIterator,
+    clad::pullback_state<::thrust::device_vector<::std::size_t>>& state) {
   const ::std::size_t n = ::thrust::distance(keys_first, keys_last);
   if (n > 0) {
     ::thrust::device_vector<::std::size_t> perm(n);
@@ -1255,16 +1253,16 @@ void sort_by_key_reverse_forw(KeyIterator keys_first, KeyIterator keys_last,
       }
     };
     ::thrust::sort(perm.begin(), perm.end(), index_comp_less{keys_first});
-    detail::permutation_stack().push_back(::std::move(perm));
+    state.data = ::std::move(perm);
   }
   ::thrust::sort_by_key(keys_first, keys_last, values_first);
 }
 
 template <typename KeyIterator, typename ValueIterator, typename Compare>
-void sort_by_key_reverse_forw(KeyIterator keys_first, KeyIterator keys_last,
-                              ValueIterator values_first, Compare comp,
-                              KeyIterator, KeyIterator, ValueIterator,
-                              Compare) {
+void sort_by_key_reverse_forw(
+    KeyIterator keys_first, KeyIterator keys_last, ValueIterator values_first,
+    Compare comp, KeyIterator, KeyIterator, ValueIterator, Compare,
+    clad::pullback_state<::thrust::device_vector<::std::size_t>>& state) {
   const ::std::size_t n = ::thrust::distance(keys_first, keys_last);
   if (n > 0) {
     ::thrust::device_vector<::std::size_t> perm(n);
@@ -1277,17 +1275,18 @@ void sort_by_key_reverse_forw(KeyIterator keys_first, KeyIterator keys_last,
       }
     };
     ::thrust::sort(perm.begin(), perm.end(), index_comp_with{keys_first, comp});
-    detail::permutation_stack().push_back(::std::move(perm));
+    state.data = ::std::move(perm);
   }
   ::thrust::sort_by_key(keys_first, keys_last, values_first, comp);
 }
 
 // pullback without comparator
 template <typename KeyIterator, typename ValueIterator>
-void sort_by_key_pullback(KeyIterator keys_first, KeyIterator keys_last,
-                          ValueIterator values_first, KeyIterator* d_keys_first,
-                          KeyIterator* d_keys_last,
-                          ValueIterator* d_values_first) {
+void sort_by_key_pullback(
+    KeyIterator keys_first, KeyIterator keys_last, ValueIterator values_first,
+    KeyIterator* d_keys_first, KeyIterator* d_keys_last,
+    ValueIterator* d_values_first,
+    clad::pullback_state<::thrust::device_vector<::std::size_t>> state) {
   using ValueConst = typename ::std::iterator_traits<ValueIterator>::value_type;
   using Value = ::std::remove_const_t<ValueConst>;
   using KeyConst = typename ::std::iterator_traits<KeyIterator>::value_type;
@@ -1297,10 +1296,9 @@ void sort_by_key_pullback(KeyIterator keys_first, KeyIterator keys_last,
   if (n == 0)
     return;
 
-  // Retrieve permutation mapping sorted position j -> original index i
-  auto& stack = detail::permutation_stack();
-  ::thrust::device_vector<::std::size_t> perm = ::std::move(stack.back());
-  stack.pop_back();
+  // Permutation (sorted position j -> original index i) produced by the
+  // matching reverse_forw and threaded in via pullback_state.
+  ::thrust::device_vector<::std::size_t> perm = ::std::move(state.data);
 
   // Build device pointers to adjoint buffers
   auto d_vals_const_ptr = ::thrust::raw_pointer_cast((*d_values_first).base());
@@ -1331,10 +1329,11 @@ void sort_by_key_pullback(KeyIterator keys_first, KeyIterator keys_last,
 
 // pullback with comparator
 template <typename KeyIterator, typename ValueIterator, typename Compare>
-void sort_by_key_pullback(KeyIterator keys_first, KeyIterator keys_last,
-                          ValueIterator values_first, Compare comp,
-                          KeyIterator* d_keys_first, KeyIterator* d_keys_last,
-                          ValueIterator* d_values_first, Compare* /*d_comp*/) {
+void sort_by_key_pullback(
+    KeyIterator keys_first, KeyIterator keys_last, ValueIterator values_first,
+    Compare comp, KeyIterator* d_keys_first, KeyIterator* d_keys_last,
+    ValueIterator* d_values_first, Compare* /*d_comp*/,
+    clad::pullback_state<::thrust::device_vector<::std::size_t>> state) {
   using ValueConst = typename ::std::iterator_traits<ValueIterator>::value_type;
   using Value = ::std::remove_const_t<ValueConst>;
   using KeyConst = typename ::std::iterator_traits<KeyIterator>::value_type;
@@ -1344,9 +1343,9 @@ void sort_by_key_pullback(KeyIterator keys_first, KeyIterator keys_last,
   if (n == 0)
     return;
 
-  auto& stack = detail::permutation_stack();
-  ::thrust::device_vector<::std::size_t> perm = ::std::move(stack.back());
-  stack.pop_back();
+  // Permutation produced by the matching reverse_forw, threaded in via
+  // pullback_state.
+  ::thrust::device_vector<::std::size_t> perm = ::std::move(state.data);
 
   auto d_vals_const_ptr = ::thrust::raw_pointer_cast((*d_values_first).base());
   auto d_vals_ptr = const_cast<Value*>(d_vals_const_ptr);

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -7,6 +7,7 @@
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/OperationKinds.h"
@@ -18,6 +19,7 @@
 #include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Analysis/CFG.h"
 #include "clang/Basic/Builtins.h"
+#include "clang/Basic/LLVM.h"
 #include "clang/Basic/PartialDiagnostic.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Sema/Lookup.h"
@@ -531,6 +533,21 @@ namespace clad {
     bool IsCladValueAndPushforwardType(clang::QualType T) {
       return T.getAsString().find("ValueAndPushforward") !=
              std::string::npos;
+    }
+
+    clang::QualType GetPullbackStatePayload(clang::QualType T) {
+      const auto* Spec = dyn_cast_or_null<ClassTemplateSpecializationDecl>(
+          T.getCanonicalType()->getAsCXXRecordDecl());
+      if (!Spec || Spec->getName() != "pullback_state")
+        return {};
+      // Guard against a same-named type in another namespace.
+      const auto* ND = dyn_cast_or_null<NamespaceDecl>(Spec->getDeclContext());
+      if (!ND || ND->getName() != "clad")
+        return {};
+      const TemplateArgumentList& Args = Spec->getTemplateArgs();
+      if (Args.size() == 0 || Args[0].getKind() != TemplateArgument::Type)
+        return {};
+      return Args[0].getAsType();
     }
 
     clang::SourceRange GetValidSRange(clang::Sema& semaRef) {

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -555,10 +555,18 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
         QualType DerivativeType =
             utils::GetDerivativeType(m_Sema, request.Function, request.Mode,
                                      diffParams, /*forCustomDerv=*/true);
-        // Generate dummy inits
+        // Generate dummy inits. A custom reverse_forw / pullback may carry a
+        // trailing clad::pullback_state<S> parameter that clad does not
+        // synthesize into DerivativeType; append it so the overload call has
+        // the right arity (see DiffRequest::PullbackStateParam).
+        llvm::ArrayRef<QualType> protoParamTypes =
+            cast<FunctionProtoType>(DerivativeType)->getParamTypes();
+        llvm::SmallVector<QualType, 8> paramTypes(protoParamTypes.begin(),
+                                                  protoParamTypes.end());
+        if (!request.PullbackStateParam.isNull())
+          paramTypes.push_back(request.PullbackStateParam);
         llvm::SmallVector<Expr*, 4> Inits;
-        for (QualType parTy :
-             cast<FunctionProtoType>(DerivativeType)->getParamTypes()) {
+        for (QualType parTy : paramTypes) {
           // Build dummy exprs of form ``static_cast<DesiredType>(*nullptr)``
           // to trick clang into thinking we use lvalues.
           QualType ptrType = m_Sema.getASTContext().getPointerType(

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1089,6 +1089,51 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     if (foundAnyDecl)
       *foundAnyDecl = true;
 
+    // A custom reverse_forw / pullback carries a trailing pullback_state<S>
+    // clad does not synthesize. Extend the expected signature with it before
+    // matching, or the declaration is rejected and the diagnostic omits the
+    // state the pullback must accept. S comes from the reverse_forw: the
+    // candidate itself, or -- for a pullback request -- its paired
+    // reverse_forw.
+    auto findStateParam = [](const LookupResult& LR) -> QualType {
+      for (const NamedDecl* ND : LR)
+        // getAsFunction sees through a FunctionTemplateDecl to its templated
+        // FunctionDecl -- a templated reverse_forw (e.g. the thrust
+        // derivatives) declares the state param there. The payload itself must
+        // still be non-dependent for GetPullbackStatePayload to recognize it.
+        if (const FunctionDecl* FD = ND->getUnderlyingDecl()->getAsFunction())
+          for (const ParmVarDecl* PVD : FD->parameters()) {
+            QualType PT = PVD->getType();
+            if (PT->isLValueReferenceType() &&
+                !utils::GetPullbackStatePayload(PT.getNonReferenceType())
+                     .isNull())
+              return PT.getNonReferenceType();
+          }
+      return {};
+    };
+    QualType stateParam;
+    if (R.Mode == DiffMode::reverse_mode_forward_pass)
+      stateParam = findStateParam(Found);
+    else if (R.Mode == DiffMode::pullback)
+      stateParam = findStateParam(
+          LookupPropagator(R.BaseFunctionName + "_reverse_forw"));
+    if (!stateParam.isNull())
+      if (const auto* FPT = dTy->getAs<FunctionProtoType>()) {
+        // The reverse_forw takes the state by reference (out-param); the
+        // pullback takes it by value.
+        QualType stateArg = R.Mode == DiffMode::reverse_mode_forward_pass
+                                ? C.getLValueReferenceType(stateParam)
+                                : stateParam;
+        llvm::SmallVector<QualType, 8> params(FPT->param_types().begin(),
+                                              FPT->param_types().end());
+        params.push_back(stateArg);
+        dTy = C.getFunctionType(FPT->getReturnType(), params,
+                                FPT->getExtProtoInfo());
+        // Remember it so Derive appends a matching argument when it builds the
+        // overload call for this custom derivative.
+        R.PullbackStateParam = stateArg;
+      }
+
     TemplateSpecCandidateSet FailedCandidates(R.CallContext->getBeginLoc(),
                                               /*ForTakingAddress=*/false);
     if (Expr* overload =

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1113,6 +1113,51 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     if (foundAnyDecl)
       *foundAnyDecl = true;
 
+    // A custom reverse_forw / pullback carries a trailing pullback_state<S>
+    // clad does not synthesize. Extend the expected signature with it before
+    // matching, or the declaration is rejected and the diagnostic omits the
+    // state the pullback must accept. S comes from the reverse_forw: the
+    // candidate itself, or -- for a pullback request -- its paired
+    // reverse_forw.
+    auto findStateParam = [](const LookupResult& LR) -> QualType {
+      for (const NamedDecl* ND : LR)
+        // getAsFunction sees through a FunctionTemplateDecl to its templated
+        // FunctionDecl -- a templated reverse_forw (e.g. the thrust
+        // derivatives) declares the state param there. The payload itself must
+        // still be non-dependent for GetPullbackStatePayload to recognize it.
+        if (const FunctionDecl* FD = ND->getUnderlyingDecl()->getAsFunction())
+          for (const ParmVarDecl* PVD : FD->parameters()) {
+            QualType PT = PVD->getType();
+            if (PT->isLValueReferenceType() &&
+                !utils::GetPullbackStatePayload(PT.getNonReferenceType())
+                     .isNull())
+              return PT.getNonReferenceType();
+          }
+      return {};
+    };
+    QualType stateParam;
+    if (R.Mode == DiffMode::reverse_mode_forward_pass)
+      stateParam = findStateParam(Found);
+    else if (R.Mode == DiffMode::pullback)
+      stateParam = findStateParam(
+          LookupPropagator(R.BaseFunctionName + "_reverse_forw"));
+    if (!stateParam.isNull())
+      if (const auto* FPT = dTy->getAs<FunctionProtoType>()) {
+        // The reverse_forw takes the state by reference (out-param); the
+        // pullback takes it by value.
+        QualType stateArg = R.Mode == DiffMode::reverse_mode_forward_pass
+                                ? C.getLValueReferenceType(stateParam)
+                                : stateParam;
+        llvm::SmallVector<QualType, 8> params(FPT->param_types().begin(),
+                                              FPT->param_types().end());
+        params.push_back(stateArg);
+        dTy = C.getFunctionType(FPT->getReturnType(), params,
+                                FPT->getExtProtoInfo());
+        // Remember it so Derive appends a matching argument when it builds the
+        // overload call for this custom derivative.
+        R.PullbackStateParam = stateArg;
+      }
+
     TemplateSpecCandidateSet FailedCandidates(R.CallContext->getBeginLoc(),
                                               /*ForTakingAddress=*/false);
     if (Expr* overload =

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2334,6 +2334,31 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       }
     }
 
+    // A custom reverse_forw may take a trailing clad::pullback_state<S>&
+    // out-param to hand per-call state to its pullback (like restore_tracker,
+    // but consumed by the pullback). The request records it at scheduling; the
+    // value type is the carrier clad threads into both calls.
+    QualType pullbackStateType;
+    if (!calleeFnForwPassReq.PullbackStateParam.isNull())
+      pullbackStateType =
+          calleeFnForwPassReq.PullbackStateParam.getNonReferenceType();
+    // A reverse_forw that fills a carrier cannot be elided in favour of the
+    // primal -- its pullback needs the state -- so force the full path.
+    if (!pullbackStateType.isNull())
+      elideReverseForw = false;
+    // Declared on first use and reused by both calls, so the reverse_forw's
+    // out-argument is present even if the pullback later fails to resolve.
+    Expr* pullbackStateRef = nullptr;
+    auto getPullbackStateRef = [&]() -> Expr* {
+      if (!pullbackStateRef && !pullbackStateType.isNull()) {
+        VarDecl* stateDecl = BuildVarDecl(pullbackStateType, "_state",
+                                          getZeroInit(pullbackStateType));
+        addToCurrentBlock(BuildDeclStmt(stateDecl));
+        pullbackStateRef = BuildDeclRef(stateDecl);
+      }
+      return pullbackStateRef;
+    };
+
     // FIXME: consider moving non-diff analysis to DiffPlanner.
     bool nonDiff = clad::utils::hasNonDifferentiableAttribute(CE) ||
                    clad::utils::callOperatesOnNonDifferentiableType(m_Sema, CE);
@@ -2553,6 +2578,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         if (arg)
           pullbackCallArgs.push_back(arg);
 
+      // Thread the reverse_forw's pullback_state into the pullback as its
+      // trailing by-value argument. The carrier is filled in the forward sweep
+      // (by the reverse_forw) and read here in the reverse sweep.
+      if (asGrad)
+        if (Expr* st = getPullbackStateRef())
+          pullbackCallArgs.push_back(CloneNode(st));
+
       if (!asGrad) {
         pullbackCallArgs.resize(1);
         pullbackCallArgs.push_back(ConstantFolder::synthesizeLiteral(
@@ -2724,13 +2756,22 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       return {call, call_dx};
     }
 
+    // A reverse_forw that carries pullback_state is mandatory even when clad
+    // could otherwise call the primal directly: the pullback consumes state
+    // only the reverse_forw produces, so eliding it would leave the carrier
+    // empty and silently wrong.
     if (calleeFnForwPassFD && !hasDynamicNonDiffParams &&
-        (hasStoredParams || needsForwPass)) {
+        (hasStoredParams || needsForwPass || !pullbackStateType.isNull())) {
       if (const auto* CD = dyn_cast<CXXConversionDecl>(FD))
         CallArgs.push_back(
             utils::GetCladTagExpr(m_Sema, CD->getConversionType()));
       CallArgs.insert(CallArgs.end(), revForwAdjointArgs.begin(),
                       revForwAdjointArgs.end());
+      // Pass the same _state carrier the pullback receives, so the reverse_forw
+      // fills it in the forward sweep. It precedes any restore_tracker, which
+      // remains the trailing argument.
+      if (Expr* st = getPullbackStateRef())
+        CallArgs.push_back(CloneNode(st));
       // Build the restore_tracker parameter
       // ```
       // clad::restore_tracker _tracker0 = {};

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2334,6 +2334,31 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       }
     }
 
+    // A custom reverse_forw may take a trailing clad::pullback_state<S>&
+    // out-param to hand per-call state to its pullback (like restore_tracker,
+    // but consumed by the pullback). The request records it at scheduling; the
+    // value type is the carrier clad threads into both calls.
+    QualType pullbackStateType;
+    if (!calleeFnForwPassReq.PullbackStateParam.isNull())
+      pullbackStateType =
+          calleeFnForwPassReq.PullbackStateParam.getNonReferenceType();
+    // A reverse_forw that fills a carrier cannot be elided in favour of the
+    // primal -- its pullback needs the state -- so force the full path.
+    if (!pullbackStateType.isNull())
+      elideReverseForw = false;
+    // Declared on first use and reused by both calls, so the reverse_forw's
+    // out-argument is present even if the pullback later fails to resolve.
+    Expr* pullbackStateRef = nullptr;
+    auto getPullbackStateRef = [&]() -> Expr* {
+      if (!pullbackStateRef && !pullbackStateType.isNull()) {
+        VarDecl* stateDecl = BuildVarDecl(pullbackStateType, "_state",
+                                          getZeroInit(pullbackStateType));
+        addToCurrentBlock(BuildDeclStmt(stateDecl));
+        pullbackStateRef = BuildDeclRef(stateDecl);
+      }
+      return pullbackStateRef;
+    };
+
     // FIXME: consider moving non-diff analysis to DiffPlanner.
     bool nonDiff = clad::utils::hasNonDifferentiableAttribute(CE) ||
                    clad::utils::callOperatesOnNonDifferentiableType(m_Sema, CE);
@@ -2575,6 +2600,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         if (arg)
           pullbackCallArgs.push_back(arg);
 
+      // Thread the reverse_forw's pullback_state into the pullback as its
+      // trailing by-value argument. The carrier is filled in the forward sweep
+      // (by the reverse_forw) and read here in the reverse sweep.
+      if (asGrad)
+        if (Expr* st = getPullbackStateRef())
+          pullbackCallArgs.push_back(CloneNode(st));
+
       if (!asGrad) {
         pullbackCallArgs.resize(1);
         pullbackCallArgs.push_back(ConstantFolder::synthesizeLiteral(
@@ -2746,13 +2778,22 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       return {call, call_dx};
     }
 
+    // A reverse_forw that carries pullback_state is mandatory even when clad
+    // could otherwise call the primal directly: the pullback consumes state
+    // only the reverse_forw produces, so eliding it would leave the carrier
+    // empty and silently wrong.
     if (calleeFnForwPassFD && !hasDynamicNonDiffParams &&
-        (hasStoredParams || needsForwPass)) {
+        (hasStoredParams || needsForwPass || !pullbackStateType.isNull())) {
       if (const auto* CD = dyn_cast<CXXConversionDecl>(FD))
         CallArgs.push_back(
             utils::GetCladTagExpr(m_Sema, CD->getConversionType()));
       CallArgs.insert(CallArgs.end(), revForwAdjointArgs.begin(),
                       revForwAdjointArgs.end());
+      // Pass the same _state carrier the pullback receives, so the reverse_forw
+      // fills it in the forward sweep. It precedes any restore_tracker, which
+      // remains the trailing argument.
+      if (Expr* st = getPullbackStateRef())
+        CallArgs.push_back(CloneNode(st));
       // Build the restore_tracker parameter
       // ```
       // clad::restore_tracker _tracker0 = {};

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -1420,7 +1420,14 @@ namespace clad {
     // Only definitions are differentiated
     if (request.Function->getDefinition())
       request.Function = request.Function->getDefinition();
-    // Look for the derivative
+    // This fresh request is only a lookup key, so it lacks the pullback_state
+    // the scheduler recorded (request equality ignores it). Restore it from the
+    // scheduled node for a reverse_forw, whose visitor reads it off the
+    // request.
+    if (request.Mode == DiffMode::reverse_mode_forward_pass)
+      if (const DiffRequest* scheduled =
+              m_Builder.m_Scheduler.getGraph().getNode(request))
+        request.PullbackStateParam = scheduled->PullbackStateParam;
     return m_Builder.FindDerivedFunction(request);
   }
 

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -1527,7 +1527,14 @@ namespace clad {
     // Only definitions are differentiated
     if (request.Function->getDefinition())
       request.Function = request.Function->getDefinition();
-    // Look for the derivative
+    // This fresh request is only a lookup key, so it lacks the pullback_state
+    // the scheduler recorded (request equality ignores it). Restore it from the
+    // scheduled node for a reverse_forw, whose visitor reads it off the
+    // request.
+    if (request.Mode == DiffMode::reverse_mode_forward_pass)
+      if (const DiffRequest* scheduled =
+              m_Builder.m_Scheduler.getGraph().getNode(request))
+        request.PullbackStateParam = scheduled->PullbackStateParam;
     return m_Builder.FindDerivedFunction(request);
   }
 

--- a/test/CUDA/ThrustSortByKey.cu
+++ b/test/CUDA/ThrustSortByKey.cu
@@ -26,12 +26,13 @@ void sort_by_key_simple(thrust::device_vector<int>& keys,
     thrust::sort_by_key(keys.begin(), keys.end(), vals.begin());
 }
 // CHECK: void sort_by_key_simple_grad(thrust::device_vector<int> &keys, thrust::device_vector<double> &vals, thrust::device_vector<int> *_d_keys, thrust::device_vector<double> *_d_vals) {
-// CHECK-NEXT: {{.*}}clad::custom_derivatives::thrust::sort_by_key_reverse_forw(std::begin(keys), std::end(keys), std::begin(vals), std::begin((*_d_keys)), std::end((*_d_keys)), std::begin((*_d_vals)));
+// CHECK-NEXT: {{.*pullback_state.*_state0.*}}
+// CHECK-NEXT: {{.*}}clad::custom_derivatives::thrust::sort_by_key_reverse_forw(std::begin(keys), std::end(keys), std::begin(vals), std::begin((*_d_keys)), std::end((*_d_keys)), std::begin((*_d_vals)), _state0);
 // CHECK-NEXT: {
 // CHECK-NEXT:     {{.*}}iterator _r0 = std::begin((*_d_keys));
 // CHECK-NEXT:     {{.*}}iterator _r1 = std::end((*_d_keys));
 // CHECK-NEXT:     {{.*}}iterator _r2 = std::begin((*_d_vals));
-// CHECK-NEXT:     clad::custom_derivatives::thrust::sort_by_key_pullback(std::begin(keys), std::end(keys), std::begin(vals), &_r0, &_r1, &_r2);
+// CHECK-NEXT:     clad::custom_derivatives::thrust::sort_by_key_pullback(std::begin(keys), std::end(keys), std::begin(vals), &_r0, &_r1, &_r2, _state0);
 // CHECK-NEXT: }
 // CHECK-NEXT: }
 
@@ -41,13 +42,14 @@ void sort_by_key_comp(thrust::device_vector<int>& keys,
     thrust::sort_by_key(keys.begin(), keys.end(), vals.begin(), thrust::greater<int>());
 }
 // CHECK: void sort_by_key_comp_grad(thrust::device_vector<int> &keys, thrust::device_vector<double> &vals, thrust::device_vector<int> *_d_keys, thrust::device_vector<double> *_d_vals) {
-// CHECK-NEXT: {{.*}}clad::custom_derivatives::thrust::sort_by_key_reverse_forw(std::begin(keys), std::end(keys), std::begin(vals), thrust::greater<int>(), std::begin((*_d_keys)), std::end((*_d_keys)), std::begin((*_d_vals)), {});
+// CHECK-NEXT: {{.*pullback_state.*_state0.*}}
+// CHECK-NEXT: {{.*}}clad::custom_derivatives::thrust::sort_by_key_reverse_forw(std::begin(keys), std::end(keys), std::begin(vals), thrust::greater<int>(), std::begin((*_d_keys)), std::end((*_d_keys)), std::begin((*_d_vals)), {}, _state0);
 // CHECK-NEXT: {
 // CHECK-NEXT:     {{.*}}iterator _r0 = std::begin((*_d_keys));
 // CHECK-NEXT:     {{.*}}iterator _r1 = std::end((*_d_keys));
 // CHECK-NEXT:     {{.*}}iterator _r2 = std::begin((*_d_vals));
 // CHECK-NEXT:     thrust::greater<int> _r3 = {};
-// CHECK-NEXT:     clad::custom_derivatives::thrust::sort_by_key_pullback(std::begin(keys), std::end(keys), std::begin(vals), thrust::greater<int>(), &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:     clad::custom_derivatives::thrust::sort_by_key_pullback(std::begin(keys), std::end(keys), std::begin(vals), thrust::greater<int>(), &_r0, &_r1, &_r2, &_r3, _state0);
 // CHECK-NEXT: }
 // CHECK-NEXT: }
 

--- a/test/Diagnostics/PullbackStateDiagnostics.C
+++ b/test/Diagnostics/PullbackStateDiagnostics.C
@@ -1,0 +1,78 @@
+// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1 | %filecheck %s
+//
+// A custom reverse_forw may declare a trailing clad::pullback_state<S>&
+// out-param to hand per-call state to its pullback; the pullback must then
+// accept the matching clad::pullback_state<S> by value. When it does not, clad
+// rejects the pullback and the "expected signature '...' does not match"
+// diagnostic spells out the required parameter -- i.e. it suggests the shape of
+// the forward declaration the author must write. This mirrors the existing
+// signature-mismatch machinery in CustomDerivativeDiagnostics.C.
+
+#include "clad/Differentiator/Differentiator.h"
+
+// Case 1: the pullback omits the trailing clad::pullback_state<double>.
+double* g(double* p);
+
+namespace clad::custom_derivatives {
+clad::ValueAndAdjoint<double*, double*>
+g_reverse_forw(double* p, double* d_p, clad::pullback_state<double>& state) {
+  return {p, d_p};
+}
+void g_pullback(double* p, double* d_p) { // expected-note {{candidate 'g_pullback' has different number of parameters (expected 3 but has 2)}}
+}
+} // namespace clad::custom_derivatives
+
+double f1(double x) {
+  return *g(&x);
+  // The expected signature names the clad::pullback_state<double> the pullback
+  // must accept -- the shape suggestion the author needs.
+  // expected-error-re@-3 {{expected signature{{.*}}clad::pullback_state<double>{{.*}}does not match}}
+  // expected-warning@-4 {{attempted differentiation of function 'g' without definition and no suitable overload was found in namespace 'custom_derivatives'}}
+  // expected-note@-5 {{numerical differentiation is not viable for 'g'; considering 'g' as 0}}
+}
+
+// Case 2: the pullback accepts a pullback_state of the WRONG payload type; the
+// suggestion must name the payload the reverse_forw actually produces (double).
+double* h(double* p);
+
+namespace clad::custom_derivatives {
+clad::ValueAndAdjoint<double*, double*>
+h_reverse_forw(double* p, double* d_p, clad::pullback_state<double>& state) {
+  return {p, d_p};
+}
+void h_pullback(double* p, double* d_p, // expected-note {{candidate 'h_pullback' has type mismatch at 3rd parameter (expected 'pullback_state<double>' but has 'pullback_state<int>')}}
+                clad::pullback_state<int> state) {
+}
+} // namespace clad::custom_derivatives
+
+double f2(double x) {
+  return *h(&x);
+  // expected-error-re@-1 {{expected signature{{.*}}clad::pullback_state<double>{{.*}}does not match}}
+  // expected-warning@-2 {{attempted differentiation of function 'h' without definition and no suitable overload was found in namespace 'custom_derivatives'}}
+  // expected-note@-3 {{numerical differentiation is not viable for 'h'; considering 'h' as 0}}
+}
+
+// Case 3: same mismatch, but the primal has a visible body. clad still uses the
+// matched reverse_forw, so the state carrier must be threaded even though the
+// pullback did not resolve -- otherwise the reverse_forw call is left an
+// argument short and clad crashes. This guards that recovery path.
+double* k(double* p) { return p; }
+
+namespace clad::custom_derivatives {
+clad::ValueAndAdjoint<double*, double*>
+k_reverse_forw(double* p, double* d_p, clad::pullback_state<double>& state) {
+  return {p, d_p};
+}
+void k_pullback(double* p, double* d_p) { // expected-note {{candidate 'k_pullback' has different number of parameters (expected 3 but has 2)}}
+}
+} // namespace clad::custom_derivatives
+
+double f3(double x) {
+  return *k(&x); // expected-error-re {{expected signature{{.*}}clad::pullback_state<double>{{.*}}does not match}}
+}
+
+int main() {
+  clad::gradient(f1, "x");
+  clad::gradient(f2, "x");
+  clad::gradient(f3, "x");
+}

--- a/test/Gradient/PullbackState.C
+++ b/test/Gradient/PullbackState.C
@@ -1,0 +1,147 @@
+// RUN: %cladclang %s -I%S/../../include -oPullbackState.out 2>&1 | %filecheck %s
+// RUN: ./PullbackState.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oPullbackState.out
+// RUN: ./PullbackState.out | %filecheck_exec %s
+
+// clad::pullback_state threading: a custom reverse_forw fills a trailing
+// pullback_state<Payload>& out-param in the forward sweep, and clad hands the
+// same carrier to the matching pullback (by value) in the reverse sweep. The
+// pullback here contributes state.data to the adjoint, so the gradient is
+// 1 + data if the carrier threads and 1 if it does not -- a direct check that
+// the value crosses from forward to reverse without a shared or global stash.
+
+#include "clad/Differentiator/Differentiator.h"
+#include "../TestUtils.h"
+
+// Pointer return makes clad route the call through a reverse_forw / pullback
+// pair (isMemoryType(return)), the seam pullback_state rides on.
+double* g(double* p) { return p; }
+
+namespace clad::custom_derivatives {
+clad::ValueAndAdjoint<double*, double*>
+g_reverse_forw(double* p, double* d_p, clad::pullback_state<double>& state) {
+  state.data = 10; // stash a sentinel only the pullback can observe
+  return {p, d_p};
+}
+void g_pullback(double* p, double* d_p, clad::pullback_state<double> state) {
+  *d_p += state.data; // adds the threaded sentinel on top of the seed
+}
+} // namespace clad::custom_derivatives
+
+double f(double x) { return *g(&x); }
+
+//CHECK: void f_grad(double x, double *_d_x) {
+//CHECK-NEXT:     clad::pullback_state<double> _state0 = {0.};
+//CHECK-NEXT:     clad::ValueAndAdjoint<double *, double *> _t0 = clad::custom_derivatives::g_reverse_forw(&x, _d_x, _state0);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         *_t0.adjoint += 1;
+//CHECK-NEXT:         clad::custom_derivatives::g_pullback(&x, _d_x, _state0);
+//CHECK-NEXT:     }
+//CHECK-NEXT: }
+
+// A void, in-place op whose primal clad could call directly. Because its
+// reverse_forw carries pullback_state, clad must still route through the
+// reverse_forw and never elide it -- otherwise the carrier is left empty and
+// the gradient is silently 1 instead of 8.
+void vop(double* p) {}
+
+namespace clad::custom_derivatives {
+void vop_reverse_forw(double* p, double* d_p, clad::pullback_state<double>& state) {
+  state.data = 7;
+}
+void vop_pullback(double* p, double* d_p, clad::pullback_state<double> state) {
+  *d_p += state.data;
+}
+} // namespace clad::custom_derivatives
+
+double fv(double x) {
+  double v = x;
+  vop(&v);
+  return v;
+}
+
+//CHECK: void fv_grad(double x, double *_d_x) {
+//CHECK-NEXT:     double _d_v = 0.;
+//CHECK-NEXT:     double v = x;
+//CHECK-NEXT:     clad::pullback_state<double> _state0 = {0.};
+//CHECK-NEXT:     clad::custom_derivatives::vop_reverse_forw(&v, &_d_v, _state0);
+//CHECK-NEXT:     _d_v += 1;
+//CHECK-NEXT:     clad::custom_derivatives::vop_pullback(&v, &_d_v, _state0);
+//CHECK-NEXT:     *_d_x += _d_v;
+//CHECK-NEXT: }
+
+// Reentrancy: two state-carrying calls in one gradient must each get their own
+// carrier -- the multi-call case the static stack this replaces got wrong. The
+// carriers stash different sentinels onto different inputs, so a shared or
+// crossed stash would swap the two gradients.
+void op3(double* p) {}
+
+namespace clad::custom_derivatives {
+void op3_reverse_forw(double* p, double* d_p, clad::pullback_state<double>& state) {
+  state.data = 3;
+}
+void op3_pullback(double* p, double* d_p, clad::pullback_state<double> state) {
+  *d_p += state.data;
+}
+} // namespace clad::custom_derivatives
+
+double f_two(double x, double y) {
+  double a = x;
+  double b = y;
+  vop(&a); // its carrier stashes 7 -> d/dx = 1 + 7 = 8
+  op3(&b); // a distinct carrier stashes 3 -> d/dy = 1 + 3 = 4
+  return a + b;
+}
+
+// Templated custom derivatives (the thrust sort_by_key shape): the state param
+// is declared on a FunctionTemplateDecl, which the scheduler must see through
+// when it extends the expected signature. If it does not, neither derivative
+// matches, clad differentiates the empty primal instead, and the gradient is
+// silently 1 instead of 6.
+template <typename T> void tvop(T* p) {}
+
+namespace clad::custom_derivatives {
+template <typename T>
+void tvop_reverse_forw(T* p, T* d_p, clad::pullback_state<double>& state) {
+  state.data = 5;
+}
+template <typename T>
+void tvop_pullback(T* p, T* d_p, clad::pullback_state<double> state) {
+  *d_p += state.data;
+}
+} // namespace clad::custom_derivatives
+
+double f_tmpl(double x) {
+  double v = x;
+  tvop(&v);
+  return v;
+}
+
+//CHECK: void f_tmpl_grad(double x, double *_d_x) {
+//CHECK-NEXT:     double _d_v = 0.;
+//CHECK-NEXT:     double v = x;
+//CHECK-NEXT:     clad::pullback_state<double> _state0 = {0.};
+//CHECK-NEXT:     clad::custom_derivatives::tvop_reverse_forw(&v, &_d_v, _state0);
+//CHECK-NEXT:     _d_v += 1;
+//CHECK-NEXT:     clad::custom_derivatives::tvop_pullback(&v, &_d_v, _state0);
+//CHECK-NEXT:     *_d_x += _d_v;
+//CHECK-NEXT: }
+
+int main() {
+  double dx = 0;
+  INIT_GRADIENT(f);
+  TEST_GRADIENT(f, /*numOfDerivativeArgs=*/1, 3, &dx); // CHECK-EXEC: 11.00
+
+  dx = 0;
+  INIT_GRADIENT(fv);
+  TEST_GRADIENT(fv, /*numOfDerivativeArgs=*/1, 3, &dx); // CHECK-EXEC: 8.00
+
+  dx = 0;
+  double dy = 0;
+  INIT_GRADIENT(f_two);
+  TEST_GRADIENT(f_two, /*numOfDerivativeArgs=*/2, 1, 1, &dx, &dy); // CHECK-EXEC: {8.00, 4.00}
+
+  dx = 0;
+  INIT_GRADIENT(f_tmpl);
+  TEST_GRADIENT(f_tmpl, /*numOfDerivativeArgs=*/1, 3, &dx); // CHECK-EXEC: 6.00
+}


### PR DESCRIPTION
A custom derivative that needs forward-sweep state in its pullback -- a sort permutation, a pivot vector -- had no typed channel for it. sort_by_key used a static std::vector stack, pushed by the reverse_forw and popped by the pullback: process-wide, not reentrant, and LIFO-wrong once differentiation nests or interleaves, scattering adjoints by the wrong permutation (#1694).

Introduce `clad::pullback_state<Payload>`: the `reverse_forw` takes a trailing `pullback_state<S>&` out-parameter, the pullback the matching `pullback_state<S>` by value, and clad declares one carrier per call site and threads it into both. It is the restore_tracker out-param mechanism, so it composes with the `ValueAndAdjoint` a `reverse_forw` already returns; the payload is author-owned, and an empty pullback_state<no_state> folds to zero cost.

clad does not synthesize the parameter, so the expected signature is extended with it before overload matching -- which also diagnoses a pullback that omits or mistypes it with a signature naming the required `pullback_state<S>`. The fact is recorded on the `DiffRequest` at scheduling and carried to the visitor through the request graph rather than re-derived, and a `reverse_forw` carrying it is never elided, so the carrier is always filled.

sort_by_key is ported off the static stack. Adds non-CUDA functional tests (threading, reentrancy, the no-elision rule), diagnostic tests for the mismatch messages, a benchmark asserting `pullback_state<no_state>` costs nothing, and the threaded carrier in the CUDA lit expectations.

Fixes #1694