### PR TITLE
Add zero pullbacks for std::vector size() and capacity()

### DIFF
--- a/include/clad/Differentiator/STLBuiltins.h
+++ b/include/clad/Differentiator/STLBuiltins.h
@@ -628,6 +628,19 @@ void shrink_to_fit_reverse_forw(::std::vector<T>* v,
   v->shrink_to_fit();
 }
 
+// The element count does not depend on the element values, so these mirror
+// size_pushforward/capacity_pushforward, which report a zero derivative.
+// Without them clad differentiates the standard library implementation of
+// size()/capacity(), which is pointer arithmetic over the internal members and
+// whose pullback is only empty by accident of how the header is written.
+template <typename T, typename P>
+void size_pullback(const ::std::vector<T>* /*v*/, P /*d_y*/,
+                   ::std::vector<T>* /*d_v*/) noexcept;
+
+template <typename T, typename P>
+void capacity_pullback(const ::std::vector<T>* /*v*/, P /*d_y*/,
+                       ::std::vector<T>* /*d_v*/) noexcept;
+
 // array reverse mode
 
 template <typename T, ::std::size_t N>


### PR DESCRIPTION
STLBuiltins.h declares size_pushforward and capacity_pushforward, both reporting a zero derivative since the element count does not depend on the element values, but it had no reverse mode counterparts. Reverse mode therefore fell through to differentiating the standard library implementation of size()/capacity(), which is pointer arithmetic over the internal _M_impl members.

That emitted no call only by accident. ReverseModeVisitor elides a call whose pullback comes out with an empty body, and up to libstdc++ 14 both observers were a single return statement, so the pullback clad generated for them was empty. libstdc++ 15 rewrote them to introduce a local ptrdiff_t and an __builtin_unreachable guard, the generated pullback is no longer empty, and fn11_grad in Gradient/STLCustomDerivatives.C started carrying v.capacity_pullback() and v.size_pullback() calls into libstdc++ internals.

Declare size_pullback and capacity_pullback without a definition, the idiom reserve_pullback and shrink_to_fit_pullback already use: a declaration with a valid location counts as an empty body, so the call is dropped no matter how the standard library spells the observer. The incoming adjoint is a template parameter because clad passes it at the type the result was used at rather than the size_type returned.

The generated code is unchanged on libstdc++ 13 and 14, so no test expectations move; Gradient/STLCustomDerivatives.C now also passes on libstdc++ 15.