### PR TITLE
Give each delayed-store placeholder a distinct value

### DIFF
--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -120,6 +120,7 @@ namespace clad {
 
     unsigned outputArrayCursor = 0;
     unsigned numParams = 0;
+    unsigned m_PlaceholderCount = 0;
     llvm::SmallVector<clang::Expr*, 1> m_Pullback;
     const char* funcPostfix() const {
       if (m_DiffReq.Mode == DiffMode::jacobian)

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4430,11 +4430,15 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // VISITED forward value at every occurrence -- so a stored condition
       // `_cond0` (not the raw operand) is used, preserving correctness. The
       // placeholder may be cloned by de-sharing callsites; PlaceholderReplacer
-      // matches it structurally (by value) so clones are replaced too.
-      // Its value is arbitrary but distinctive to aid
-      // debugging if one ever leaks.
+      // matches it structurally (by value) so clones are replaced too. Its
+      // value is arbitrary but distinctive to aid debugging if one ever leaks,
+      // but it must not be shared among placeholder: nested multiplications
+      // keep the outer placeholder live while the inner one is finalized. The
+      // base stays below 2^24 so that base + serial is exact in `float` too.
+      constexpr unsigned placeholderBase = 0xBAD000;
       Expr* PH = ConstantFolder::synthesizeLiteral(E->getType(), m_Context,
-                                                   /*val=*/~0U);
+                                                   /*val=*/placeholderBase +
+                                                       m_PlaceholderCount++);
       return DelayedStoreResult{*this,
                                 StmtDiff{PH, /*diff=*/nullptr, PH},
                                 /*Declaration=*/nullptr,

--- a/test/Regressions/issue-1941.cpp
+++ b/test/Regressions/issue-1941.cpp
@@ -1,0 +1,78 @@
+// RUN: %cladclang -std=c++17 -I%S/../../include %s -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+// A nested product keeps the outer operand's placeholder live while the inner
+// one is finalized. The two used to be value-equal, so the inner Finalize
+// spliced its operand into the outer placeholder's occurrences as well,
+// yielding `_d_x += 1 * c[i * 2] * c[i * 2]` for compound_index below. A plain
+// `c[i]` subscript is stored rather than recomputed, so it never hit this.
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+double compound_index(double x, const double* c, int i) {
+  return (x + 1.) * c[i * 2] * (x + 1.);
+}
+
+// CHECK: void compound_index_grad_0(double x, const double *c, int i, double *_d_x) {
+// CHECK: *_d_x += 1 * (x + 1.) * c[i * 2];
+// CHECK-NEXT: *_d_x += (x + 1.) * c[i * 2] * 1;
+
+double plain_index(double x, const double* c, int i) {
+  return (x + 1.) * c[i] * (x + 1.);
+}
+
+// Placeholders are literals of the operand type, so they must stay far enough
+// apart to survive `float`'s 24-bit mantissa.
+float compound_index_f(float x, const float* c, int i) {
+  return (x + 1.F) * c[i * 2] * (x + 1.F);
+}
+
+double nested_products(double x, const double* c, int i) {
+  return ((x * x + 1.) * c[i * 2]) * ((x + 3.) * c[i * 2 + 1]) * (x + 1.);
+}
+
+double mixed_div(double x, const double* c, int i) {
+  return (x + 1.) / c[i * 2] * (x + 1.) / c[i * 2 + 1];
+}
+
+// The RooFit::Detail::MathFuncs::multiVarGaussian() shape this was found with.
+double multi_var(double x, const double* c, int n) {
+  double result = 0.;
+  for (int i = 0; i < n; ++i)
+    for (int j = 0; j < n; ++j)
+      result += (x - c[i]) * c[i * n + j] * (x - c[j]);
+  return result;
+}
+
+#define CHECK_GRAD(F, ARG)                                                     \
+  do {                                                                         \
+    auto grad = clad::gradient(F, "x");                                        \
+    double d = 0.;                                                             \
+    grad.execute(5., c, ARG, &d);                                              \
+    printf(#F " %.6f\n", d);                                                   \
+  } while (0)
+
+int main() {
+  double c[8];
+  for (int k = 0; k < 8; ++k)
+    c[k] = 1.5 + 0.25 * k;
+
+  // d/dx of (x+1)^2 * c[2] at x = 5 is 2 * 6 * 2 == 24.
+  CHECK_GRAD(compound_index, 1); // CHECK-EXEC: compound_index 24.000000
+  CHECK_GRAD(plain_index, 2);    // CHECK-EXEC: plain_index 24.000000
+  CHECK_GRAD(nested_products, 1); // CHECK-EXEC: nested_products 3798.000000
+  CHECK_GRAD(mixed_div, 1);       // CHECK-EXEC: mixed_div 2.666667
+  CHECK_GRAD(multi_var, 2);       // CHECK-EXEC: multi_var 50.437500
+
+  {
+    float cf[8];
+    for (int k = 0; k < 8; ++k)
+      cf[k] = 1.5F + 0.25F * k;
+    auto grad = clad::gradient(compound_index_f, "x");
+    float d = 0.F;
+    grad.execute(5.F, cf, 1, &d);
+    printf("compound_index_f %.6f\n", (double)d);
+    // CHECK-EXEC: compound_index_f 24.000000
+  }
+}


### PR DESCRIPTION
DelayedGlobalStoreAndRef breaks the circular dependency in `x * y` -- each operand's adjoint needs the other's value -- by returning a placeholder literal that DelayedStoreResult::Finalize later splices out.

b75bba2c ("Do not reuse AST nodes in generated derivatives.") made de-sharing callsites CloneNode the placeholder, so PlaceholderReplacer started matching it by value rather than by pointer. Every placeholder was synthesized with the same value, ~0U, so value-equal placeholders became indistinguishable. In a nested product the outer placeholder is still live when the inner one is finalized, and the inner Finalize then spliced its operand into the outer placeholder's occurrences too:

```c++
double f(double x, const double* c, int i) {
  return (x + 1.) * c[i * 2] * (x + 1.);
}

*_d_x += 1 * c[i * 2] * c[i * 2];   // wrong, left operand clobbered
```

Hand each placeholder a serial number so no two are ever value-equal. The base is kept below 2^24 so that base + serial is exactly representable in `float` as well -- values near 2^32 round consecutive placeholders back together, which left the `float` case broken.

A plain `c[i]` subscript is not UsefulToStore, so it never takes the placeholder path; that is why only compound indices were affected. Found via RooFit's multiVarGaussian(), which sums
`(x[i] - mu[i]) * covI[i * n + j] * (x[j] - mu[j])`.

Fixes #1941

**It was confirmed that with this commit, Clad `master` works again for the RooFit usecase, modulo the problem reported in #1940.**