### PR TITLE
Fix use-before-declaration in early-return reverse-mode lambda

### DIFF
--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -290,10 +290,14 @@ namespace clad {
       void collect(llvm::ArrayRef<clang::Stmt*> Body);
       /// A `[&]` capture binds a variable at the lambda's definition point, so
       /// every captured decl must precede the lambda. \p Prefix and \p Suffix
-      /// are the forward block split at the lambda's insertion point; move each
-      /// captured DeclStmt from Suffix to the end of Prefix when its
-      /// initializer references only names already live there -- the function's
-      /// parameters, \p AlreadyLive (decls emitted earlier), and Prefix.
+      /// are the forward block split at the lambda's insertion point. Each
+      /// captured decl in \p Suffix moves to the end of \p Prefix: whole, if
+      /// its initializer references only names already live there (the
+      /// function's parameters, \p AlreadyLive, and \p Prefix); otherwise
+      /// split into a zero-initialized declaration (moved) plus an assignment
+      /// left at the original spot, so the real value is still computed where
+      /// the original control flow put it. Array decls, which have no
+      /// whole-object assignment to split into, stay in \p Suffix.
       void orderCaptureDecls(llvm::SmallVectorImpl<clang::Stmt*>& Prefix,
                              llvm::SmallVectorImpl<clang::Stmt*>& Suffix,
                              llvm::ArrayRef<clang::Stmt*> AlreadyLive);

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -26,6 +26,7 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/TemplateBase.h"
+#include "clang/AST/Type.h"
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
@@ -419,20 +420,67 @@ namespace clad {
     llvm::SmallVector<Stmt*, 16> Remaining;
     for (Stmt* S : Suffix) {
       auto* DS = dyn_cast<DeclStmt>(S);
-      bool Move = DS != nullptr;
-      if (DS)
-        for (Decl* D : DS->decls()) {
-          auto* VD = dyn_cast<VarDecl>(D);
-          if (!VD || !contains(VD) || !selfContained(VD)) {
-            Move = false;
-            break;
-          }
-        }
-      if (Move) {
-        Prefix.push_back(S);
-        note(S);
-      } else
+      bool AnyCaptured = DS && llvm::any_of(DS->decls(), [&](Decl* D) {
+                           auto* VD = dyn_cast<VarDecl>(D);
+                           return VD && contains(VD);
+                         });
+      if (!AnyCaptured) {
         Remaining.push_back(S);
+        continue;
+      }
+
+      // At least one decl here is captured; rebuild the DeclStmt decl-by-decl.
+      // A captured decl with a self-contained initializer moves whole; one
+      // that isn't (e.g. `double y = n + x;`, reading a not-yet-hoisted `n`)
+      // is split: a zero-initialized declaration precedes the lambda and a
+      // plain assignment with the real value stays at the original spot.
+      // Referencing a local before any DeclStmt for it has run makes CodeGen
+      // treat it as a block-scope static instead of a real capture
+      // (vgvassilev/clad#1940); splitting avoids that while still computing
+      // the value -- and any side effects -- exactly where the original
+      // control flow put it. Decls that are neither (an uncaptured neighbour
+      // in `double a = n + x, c = 3.;`, or an array, which has no
+      // whole-object assignment to split into) stay behind, regrouped into a
+      // DeclStmt at the point their order requires.
+      llvm::SmallVector<Decl*, 4> KeptHere;
+      auto flushKept = [&]() {
+        if (KeptHere.empty())
+          return;
+        Remaining.push_back(m_V.BuildDeclStmt(KeptHere));
+        KeptHere.clear();
+      };
+      for (Decl* D : DS->decls()) {
+        auto* VD = dyn_cast<VarDecl>(D);
+        bool Hoistable = VD && contains(VD);
+        if (Hoistable && selfContained(VD)) {
+          flushKept();
+          Prefix.push_back(m_V.BuildDeclStmt(VD));
+          note(Prefix.back());
+          continue;
+        }
+        // Splitting needs a whole-object assignment, which an array type has
+        // no spelling for; an element-wise copy would need
+        // ReverseModeVisitor::BuildArrayAssignment, out of this shared
+        // VisitorBase utility's reach. Keep the decl -- findUseBeforeDecl
+        // still reports it if it really was captured.
+        if (!Hoistable || isa<ArrayType>(VD->getType())) {
+          KeptHere.push_back(D);
+          continue;
+        }
+        // selfContained() is true for an initializer-less decl, so reaching
+        // here means there is an initializer to move into the assignment.
+        Expr* Init = VD->getInit();
+        Expr* DeclRef = m_V.BuildDeclRef(VD);
+        m_V.SetDeclInit(VD, m_V.getZeroInit(VD->getType()));
+        flushKept();
+        Prefix.push_back(m_V.BuildDeclStmt(VD));
+        // Not noted: the hoisted decl only holds a placeholder until the
+        // assignment below runs, so a later decl reading VD (e.g. a
+        // `_t0 = y` snapshot of a split `y`) must go through this same split
+        // path rather than treat the placeholder as the real value.
+        Remaining.push_back(m_V.BuildOp(BO_Assign, DeclRef, Init));
+      }
+      flushKept();
     }
     Suffix = std::move(Remaining);
   }

--- a/test/Gradient/EarlyReturns.C
+++ b/test/Gradient/EarlyReturns.C
@@ -86,6 +86,30 @@ double recEarly(double x, double y) {
 
 double callsRec(double x, double y) { return recEarly(x, y); }
 
+// The early return is the very first statement, so the forward-sweep split
+// at the lambda's insertion point starts empty: n, a, b, and a's
+// pre-multiplication snapshot are all declared after it, yet the reverse
+// sweep (inside the lambda) reads them for the product rule on `a *= b`.
+// Those decls must still end up visible -- and correctly valued -- before
+// the lambda, not left behind it where CodeGen would mistake a captured-but-
+// not-yet-declared local for a block-scope static (vgvassilev/clad#1940).
+// `b, c` is one DeclStmt with mixed needs -- b is captured and must move, c
+// is not captured at all -- so the hoister has to take that statement apart
+// and leave c where it was.
+double declAfterEarly(double x, double y) {
+  if (y == 0)
+    return 1;
+  double n = y;
+  double a = n + x;
+  double b = n, c = 2 * x;
+  a *= b;
+  return a + c;
+}
+
+// CHECK-LABEL: void declAfterEarly_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: auto _rev0 = [&
+// CHECK-NOT: this is a clad bug
+
 int main() {
   double dx = 0, dy = 0;
 
@@ -127,4 +151,12 @@ int main() {
   dx = dy = 0;
   INIT_GRADIENT(callsRec);
   TEST_GRADIENT(callsRec, /*numOfDerivativeArgs=*/2, 3, 1, &dx, &dy); // CHECK-EXEC: {1.00, 1.00}
+
+  dx = dy = 0;
+  INIT_GRADIENT(declAfterEarly);
+  // y == 0 takes the early return: d(1) = {0, 0}.
+  TEST_GRADIENT(declAfterEarly, /*numOfDerivativeArgs=*/2, 3, 0, &dx, &dy); // CHECK-EXEC: {0.00, 0.00}
+  dx = dy = 0;
+  // y != 0 falls through: (y + x) * y + 2x, so d = {y + 2, x + 2y}.
+  TEST_GRADIENT(declAfterEarly, /*numOfDerivativeArgs=*/2, 3, 5, &dx, &dy); // CHECK-EXEC: {7.00, 13.00}
 }


### PR DESCRIPTION
When a differentiated function has early returns, the master reverse sweep is wrapped in a shared [&] lambda invoked from every return path. LambdaCaptures::orderCaptureDecls hoists any local the lambda reads to before that lambda, but it only handled captured decls whose initializer was already computable at the hoist point ("self-contained"); anything else (e.g. `double y = n + x;`, where `n` isn't itself captured) was left after the lambda while still being referenced inside it.

That is more than a diagnostic: Clang's CodeGen, given a lambda body referencing a local before any DeclStmt introduces it, silently emitted the variable as a disconnected `internal global` instead of a real by-reference capture, decoupling the lambda's view of the variable from its actual computed value and corrupting the gradient.

Regression introduced by https://github.com/vgvassilev/clad/commit/7514327a0c44ee037297e7596297b361f964dae1 ("Encode reverse-mode early returns with a named lambda"), which added orderCaptureDecls with this gap.

Fix: a captured decl that can't move whole is now split into a zero-initialized declaration hoisted before the lambda (giving it a real, in-scope binding) and a plain assignment left at the original program point (preserving control flow and side-effect order for the early return). A decl whose only "availability" comes from such a placeholder is not marked available for downstream decls, so a value snapshot depending on it also goes through the split path instead of capturing the placeholder.

Hoisting is now decided per decl rather than per DeclStmt, so a mixed statement like `double a = n + x, c = 3.;` no longer has to stay behind wholesale on account of its uncaptured neighbour: `a` is split out and `c` is regrouped into a DeclStmt at the point its order requires. An array decl is the one thing that cannot be split -- there is no whole-object assignment to split into, and an element-wise copy would need ReverseModeVisitor::BuildArrayAssignment, out of this shared VisitorBase utility's reach -- so it is kept in place, and only when it would otherwise be split: a captured array that can move whole (an adjoint's `double _d_arr[2] = {0}`) still does.

Fixes https://github.com/vgvassilev/clad/issues/1940