### PR TITLE
Allow safe qualification conversions in custom derivative lookup

### DIFF
--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1031,6 +1031,37 @@ namespace clad {
       return cast<TemplateDecl>(TapeR.getFoundDecl());
     }
 
+    static bool MatchFunctionTypeWithQualifiedParams(Sema& S,
+                                                     QualType ExpectedFnTy,
+                                                     QualType CandidateFnTy) {
+      ASTContext& C = S.getASTContext();
+      if (C.hasSameFunctionTypeIgnoringExceptionSpec(ExpectedFnTy,
+                                                     CandidateFnTy))
+        return true;
+
+      const auto* Expected = ExpectedFnTy->getAs<FunctionProtoType>();
+      const auto* Candidate = CandidateFnTy->getAs<FunctionProtoType>();
+      if (!Expected || !Candidate ||
+          Expected->getNumParams() != Candidate->getNumParams())
+        return false;
+
+      for (unsigned I = 0; I < Expected->getNumParams(); ++I) {
+        QualType From = Expected->getParamType(I);
+        QualType To = Candidate->getParamType(I);
+        bool ObjCLifetimeConversion = false;
+        if (!C.hasSameType(From, To) &&
+            !S.IsQualificationConversion(From, To, /*CStyle=*/false,
+                                         ObjCLifetimeConversion))
+          return false;
+      }
+
+      QualType CandidateWithExpectedParams = C.getFunctionType(
+          Candidate->getReturnType(), Expected->getParamTypes(),
+          Candidate->getExtProtoInfo());
+      return C.hasSameFunctionTypeIgnoringExceptionSpec(
+          ExpectedFnTy, CandidateWithExpectedParams);
+    }
+
     Expr* MatchOverloadType(Sema& S, QualType FnTy, LookupResult& Overloads,
                             TemplateSpecCandidateSet& FailedCandidates) {
       CXXScopeSpec SS;
@@ -1072,7 +1103,7 @@ namespace clad {
         if (!FD)
           continue;
         // Overload is just a FunctionDecl, check if the signature matches.
-        if (C.hasSameFunctionTypeIgnoringExceptionSpec(FD->getType(), FnTy))
+        if (MatchFunctionTypeWithQualifiedParams(S, FnTy, FD->getType()))
           return S.BuildDeclarationNameExpr(SS, Overloads, /*ADL=*/false).get();
       }
       return nullptr;

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -582,9 +582,11 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
                        .ActOnCallExpr(m_Sema.TUScope, request.CustomDerivative,
                                       {}, Inits, {})
                        .get();
+        auto* Call = CE ? dyn_cast<CallExpr>(CE->IgnoreImplicit()) : nullptr;
+        if (!Call)
+          return {};
         DerivativeAndOverload result{};
-        result.derivative =
-            cast<CallExpr>(CE->IgnoreImplicit())->getDirectCallee();
+        result.derivative = Call->getDirectCallee();
 
         // reverse and jacobian modes require overloads, even if the derivatives
         // are custom

--- a/test/Diagnostics/CustomDerivativeDiagnostics.C
+++ b/test/Diagnostics/CustomDerivativeDiagnostics.C
@@ -1,5 +1,4 @@
 // RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify 2>&1 | %filecheck %s
-
 #include "clad/Differentiator/Differentiator.h"
 
 namespace helpers {
@@ -56,6 +55,58 @@ double f2(double x, double y) {
   return h(x, y); // expected-error {{user-defined derivative for 'h' was provided but not used;}}
 }
 
+void alias_op(double* x) {}
+
+namespace clad::custom_derivatives {
+  void alias_op_pullback(double x, double* _d_x) { // expected-note {{candidate 'alias_op_pullback' has type mismatch at 1st parameter (expected 'double *' but has 'double')}}
+    *_d_x += x;
+  }
+}
+
+double aliasing_mismatch(double x) {
+  alias_op(&x); // expected-error {{user-defined derivative for 'alias_op' was provided but not used;}}
+  return x;
+}
+
+void const_op(const double* x) {}
+
+namespace clad::custom_derivatives {
+  void const_op_pullback(double* x, double* _d_x) { // expected-note {{candidate 'const_op_pullback' has type mismatch at 1st parameter (expected 'const double *' but has 'double *')}}
+    *_d_x += *x;
+  }
+}
+
+double qualification_removal(double x) {
+  const_op(&x); // expected-error {{user-defined derivative for 'const_op' was provided but not used;}}
+  return x;
+}
+
+void deep_op(double** x) {}
+
+namespace clad::custom_derivatives {
+  void deep_op_pullback(const double** x, double** _d_x) { // expected-note {{candidate 'deep_op_pullback' has type mismatch at 1st parameter (expected 'double **' but has 'const double **')}}
+    **_d_x += **x;
+  }
+}
+
+double unsafe_deep_qualification(double x) {
+  double* p = &x;
+  deep_op(&p); // expected-error {{user-defined derivative for 'deep_op' was provided but not used;}}
+  return x;
+}
+
+void ambiguous_op(double* x) {}
+
+namespace clad::custom_derivatives {
+  void ambiguous_op_pullback(const double* x, double* _d_x) {} // expected-note {{candidate function}}
+  void ambiguous_op_pullback(volatile double* x, double* _d_x) {} // expected-note {{candidate function}}
+}
+
+double ambiguous_qualification(double x) {
+  ambiguous_op(&x);
+  return x;
+}
+
 double sq(double x);
 
 namespace clad::custom_derivatives {
@@ -96,6 +147,10 @@ double f4(double x) {
 int main() {
     clad::gradient(f1);
     clad::differentiate(f2, "x");
+    clad::gradient(aliasing_mismatch);
+    clad::gradient(qualification_removal);
+    clad::gradient(unsafe_deep_qualification);
+    clad::gradient(ambiguous_qualification); // expected-error@* {{call to 'ambiguous_op_pullback' is ambiguous}}
     clad::gradient(f3);
     clad::gradient(f4);
 }

--- a/test/Regressions/issue-1947.cpp
+++ b/test/Regressions/issue-1947.cpp
@@ -1,0 +1,98 @@
+// RUN: %cladclang -std=c++17 %s -I%S/../../include -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+void vop(double*) {}
+void nested_op(double**) {}
+void volatile_op(double*) {}
+void overload_op(double*) {}
+double read_op(double* p) { return *p; }
+
+namespace clad::custom_derivatives {
+void vop_pullback(const double*, double* d_p) { *d_p += 5.; }
+// The intermediate const makes this safe, unlike double** -> const double**.
+void nested_op_pullback(const double* const*, double** d_p) { **d_p += 2.; }
+void volatile_op_pullback(volatile double*, double* d_p) { *d_p += 3.; }
+void overload_op_pullback(double*, double* d_p) { *d_p += 4.; }
+void overload_op_pullback(const double*, double* d_p) { *d_p += 9.; }
+ValueAndPushforward<double, double> read_op_pushforward(const double* p,
+                                                       double* d_p) {
+  return {*p, *d_p + 5.};
+}
+} // namespace clad::custom_derivatives
+
+double free_function(double x) {
+  double value = x;
+  vop(&value);
+  return value;
+}
+
+struct Box {
+  void stash(double*) {}
+};
+
+namespace clad::custom_derivatives::class_functions {
+void stash_pullback(Box*, const double*, Box*, double* d_p) { *d_p += 5.; }
+} // namespace clad::custom_derivatives::class_functions
+
+double member_function(double x) {
+  Box box;
+  double value = x;
+  box.stash(&value);
+  return value;
+}
+
+double nested_pointer(double x) {
+  double* p = &x;
+  nested_op(&p);
+  return x;
+}
+
+double volatile_pointer(double x) {
+  volatile_op(&x);
+  return x;
+}
+
+double overload_preference(double x) {
+  overload_op(&x);
+  return x;
+}
+
+double custom_pushforward(double x) { return read_op(&x); }
+
+int main() {
+  auto freeGrad = clad::gradient(free_function, "x");
+  double freeDx = 0.;
+  freeGrad.execute(3., &freeDx);
+
+  auto memberGrad = clad::gradient(member_function, "x");
+  double memberDx = 0.;
+  memberGrad.execute(3., &memberDx);
+
+  std::printf("{%.2f, %.2f}\n", freeDx, memberDx);
+
+  double nestedDx = 0.;
+  clad::gradient(nested_pointer).execute(3., &nestedDx);
+  double volatileDx = 0.;
+  clad::gradient(volatile_pointer).execute(3., &volatileDx);
+  double overloadDx = 0.;
+  clad::gradient(overload_preference).execute(3., &overloadDx);
+  auto pushforward = clad::differentiate(custom_pushforward, "x");
+  std::printf("{%.2f, %.2f, %.2f, %.2f}\n", nestedDx, volatileDx,
+              overloadDx, pushforward.execute(3.));
+}
+
+// CHECK: void free_function_grad(double x, double *_d_x) {
+// CHECK: clad::custom_derivatives::vop_pullback(&value, &_d_value);
+// CHECK: void member_function_grad(double x, double *_d_x) {
+// CHECK: clad::custom_derivatives::class_functions::stash_pullback(&box, &value, &_d_box, &_d_value);
+// CHECK: clad::custom_derivatives::nested_op_pullback(&p, &_d_p);
+// CHECK: clad::custom_derivatives::volatile_op_pullback(&x, _d_x);
+// CHECK: clad::custom_derivatives::overload_op_pullback(&x, _d_x);
+// CHECK: clad::custom_derivatives::read_op_pushforward(&x, &_d_x);
+
+// CHECK-EXEC: {6.00, 6.00}
+// CHECK-EXEC-NEXT: {3.00, 4.00, 5.00, 6.00}


### PR DESCRIPTION
## Problem

Custom derivative lookup required exact function type identity. A pullback that safely adds `const` to a pointer parameter was therefore unusable: the free-function case emitted a hard error, while the method case silently ignored the custom pullback and produced `1.00` instead of `6.00`.

## Fix

For non-template candidates, accept a parameter difference only when Clang recognizes the expected-to-candidate change as a qualification conversion. Reconstructing the candidate type with the expected parameter list keeps the return type, arity, variadic state, calling convention, and other function properties exact. Template deduction and reference binding remain unchanged.

This intentionally follows Clang qualification-conversion semantics rather than being const-only: safe nested-pointer qualification and adding `volatile` are accepted, while unsafe `double**` to `const double**`, qualifier removal, and pointer-to-value changes remain rejected. Reference parameters stay exact because reference binding uses separate compatibility rules and is outside this issue-specific change.

Clang still performs normal overload resolution. If equally ranked qualified candidates are ambiguous, Clad now preserves the ambiguity diagnostic and returns cleanly instead of assuming overload resolution produced a `CallExpr` and asserting.

The regression checks generated calls and executes free-function, method, safe nested-pointer, volatile, exact-overload-preference, and pushforward cases. Diagnostics pin the unsafe and ambiguous boundaries.

## Testing

- untouched-upstream RED: const pointer, safe nested-pointer, volatile, and pushforward candidates are rejected; patched runtime output is `{6.00, 6.00}` and `{3.00, 4.00, 5.00, 6.00}`
- unsafe deep-pointer qualification is rejected on both untouched upstream and the patch
- plain Clang confirms `double**` to `const double**` is invalid and `double**` to `const double* const*` is valid
- const and volatile candidates with no exact overload now emit `call to ambiguous_op_pullback is ambiguous` without a Clad assertion; untouched upstream rejects both as mismatched
- focused lit coverage: 10/10 passed (issue regression, custom derivative diagnostics, function calls, member functions, and error estimation)
- unit binaries: 5/5 tests passed
- `clang-format-18 --dry-run --Werror` and `git diff --check` passed
- `clang-tidy-18` with changed-line filters: no diagnostics in either changed production file
- full `check-clad`: 178 passed, 1 expected failure, 24 unsupported, and 2 failures (`issue-1815`, `issue-1855`) that reproduce with the saved untouched-upstream plugin at `b59b4439`; both assert in unrelated loop-checkpoint code at `ClangPlugin.cpp:312`

Fixes: #1947