### PR TITLE
Read a null tangent as an identically zero derivative

### DIFF
--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -65,20 +65,14 @@ public:
 
   virtual void ExecuteInsidePushforwardFunctionBlock() {}
 
-  /// Whether \p tangent is one clad itself may pass as a null pointer: the
-  /// derivative parameter standing for a const-qualified pointer parameter.
-  /// Clad cannot synthesize a tangent buffer for such a parameter, because its
-  /// size is unknown, so a pushforward call receives a null tangent for it,
-  /// spelling "the derivative of this argument is identically zero". Every
-  /// other tangent is either a local buffer or a pointer the caller has to
-  /// provide, and is therefore never null.
-  bool mayBeNullTangent(const clang::Expr* tangent) const;
-
   /// \returns \p read, the derivative expression dereferencing \p tangent,
   /// wrapped so that it evaluates to \p zero instead of dereferencing a null
-  /// \p tangent. Returns \p read unchanged when \p tangent cannot be null.
-  clang::Expr* GuardNullTangentRead(const clang::Expr* tangent,
-                                    clang::Expr* read, clang::Expr* zero);
+  /// \p tangent. \p ptr is the primal pointer expression \p tangent is the
+  /// tangent of; the request tells whether its tangent may be null, and \p read
+  /// is returned unchanged when it cannot be.
+  clang::Expr* GuardNullTangentRead(const clang::Expr* ptr,
+                                    clang::Expr* tangent, clang::Expr* read,
+                                    clang::Expr* zero);
 
   virtual StmtDiff
   VisitArraySubscriptExpr(const clang::ArraySubscriptExpr* ASE);

--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -3,6 +3,7 @@
 
 #include "Compatibility.h"
 #include "VisitorBase.h"
+#include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/OpenMPClause.h"
 #include "clang/AST/RecursiveASTVisitor.h"
@@ -63,6 +64,21 @@ public:
   }
 
   virtual void ExecuteInsidePushforwardFunctionBlock() {}
+
+  /// Whether \p tangent is one clad itself may pass as a null pointer: the
+  /// derivative parameter standing for a const-qualified pointer parameter.
+  /// Clad cannot synthesize a tangent buffer for such a parameter, because its
+  /// size is unknown, so a pushforward call receives a null tangent for it,
+  /// spelling "the derivative of this argument is identically zero". Every
+  /// other tangent is either a local buffer or a pointer the caller has to
+  /// provide, and is therefore never null.
+  bool mayBeNullTangent(const clang::Expr* tangent) const;
+
+  /// \returns \p read, the derivative expression dereferencing \p tangent,
+  /// wrapped so that it evaluates to \p zero instead of dereferencing a null
+  /// \p tangent. Returns \p read unchanged when \p tangent cannot be null.
+  clang::Expr* GuardNullTangentRead(const clang::Expr* tangent,
+                                    clang::Expr* read, clang::Expr* zero);
 
   virtual StmtDiff
   VisitArraySubscriptExpr(const clang::ArraySubscriptExpr* ASE);

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -161,6 +161,14 @@ private:
     bool HasAnalysisRun = false;
   } m_EarlyReturnInfo;
 
+  /// Cache for mayHaveNullTangent(): the primal's pointer variables that may
+  /// be given a null tangent. A property of the Function, computed once on
+  /// demand.
+  mutable struct NullTangentInfo {
+    std::set<const clang::VarDecl*> MaybeNullPtrs;
+    bool HasAnalysisRun = false;
+  } m_NullTangentInfo;
+
 public:
   /// The primal body's tail-position return -- the one an early-return encoder
   /// lets control fall through to, as opposed to an early return that needs a
@@ -175,6 +183,18 @@ public:
   /// lambdas belong to their own function and are skipped). A void function
   /// seeds no return value, so its returns skip the encoding.
   bool hasEarlyReturns() const;
+
+  /// Whether the tangent of the primal's pointer variable \p VD may be null at
+  /// run time. Clad cannot synthesize a tangent buffer for a const-qualified
+  /// pointer parameter, because its size is unknown, so a pushforward call
+  /// receives a null tangent for it, spelling "the derivative of this argument
+  /// is identically zero". A pointer of the body derived from such a parameter
+  /// -- and one clad has no tangent to give at all -- inherits that, so forward
+  /// mode has to guard the reads through their tangents. Every other tangent is
+  /// either a buffer clad allocated or a pointer the caller has to provide, and
+  /// is therefore never null. Answers false for a non-pointer, and for a
+  /// variable belonging to a function other than this request's.
+  bool mayHaveNullTangent(const clang::VarDecl* VD) const;
 
   /// Function to be differentiated.
   const clang::FunctionDecl* Function = nullptr;

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -944,23 +944,15 @@ BaseForwardModeVisitor::VisitArraySubscriptExpr(const ArraySubscriptExpr* ASE) {
     return StmtDiff(cloned, zero);
   Expr* adjoint = buildAdjoint(it->second);
   auto* result_at_is = BuildArraySubscript(adjoint, derivedIndices());
-  return StmtDiff(cloned, GuardNullTangentRead(adjoint, result_at_is, zero));
+  return StmtDiff(cloned,
+                  GuardNullTangentRead(base, adjoint, result_at_is, zero));
 }
 
-bool BaseForwardModeVisitor::mayBeNullTangent(const Expr* tangent) const {
-  const auto* DRE = dyn_cast<DeclRefExpr>(tangent->IgnoreParenImpCasts());
-  if (!DRE)
-    return false;
-  const auto* PVD = dyn_cast<ParmVarDecl>(DRE->getDecl());
-  if (!PVD || PVD->getDeclContext() != m_Derivative)
-    return false;
-  QualType T = PVD->getType();
-  return T->isPointerType() && T->getPointeeType().isConstQualified();
-}
-
-Expr* BaseForwardModeVisitor::GuardNullTangentRead(const Expr* tangent,
-                                                   Expr* read, Expr* zero) {
-  if (!mayBeNullTangent(tangent))
+Expr* BaseForwardModeVisitor::GuardNullTangentRead(const Expr* ptr,
+                                                   Expr* tangent, Expr* read,
+                                                   Expr* zero) {
+  const auto* DRE = dyn_cast<DeclRefExpr>(ptr->IgnoreParenImpCasts());
+  if (!DRE || !m_DiffReq.mayHaveNullTangent(dyn_cast<VarDecl>(DRE->getDecl())))
     return read;
   Expr* cond = CloneNode(tangent);
   return BuildParens(
@@ -1436,7 +1428,8 @@ StmtDiff BaseForwardModeVisitor::VisitUnaryOperator(const UnaryOperator* UnOp) {
     Expr* zero =
         ConstantFolder::synthesizeLiteral(literalTy, m_Context, /*val=*/0);
     if (Expr* dx = diff.getExpr_dx())
-      return StmtDiff(op, GuardNullTangentRead(dx, BuildOp(opKind, dx), zero));
+      return StmtDiff(op, GuardNullTangentRead(UnOp->getSubExpr(), dx,
+                                               BuildOp(opKind, dx), zero));
     return StmtDiff(op, zero);
   } else if (opKind == UnaryOperatorKind::UO_AddrOf) {
     Expr* derivedOp = diff.getExpr_dx();

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -942,24 +942,29 @@ BaseForwardModeVisitor::VisitArraySubscriptExpr(const ArraySubscriptExpr* ASE) {
   // so the decl's type is the adjoint's -- check it before building anything.
   if (!isArrayOrPointerType(it->second.Decl->getType().getNonReferenceType()))
     return StmtDiff(cloned, zero);
-  auto* result_at_is =
-      BuildArraySubscript(buildAdjoint(it->second), derivedIndices());
-  // Guard nullable tangent for pointer-to-const inputs: the outer
-  // derivative represents inactive const T* parameters as nullptr, so
-  // dereferencing _d_obs[i] without a check would be invalid at runtime.
-  if (it->second.Decl->getType().getNonReferenceType()->isPointerType()) {
-    QualType origBaseTy = base->getType();
-    if (origBaseTy->isPointerType() &&
-        origBaseTy->getPointeeType().isConstQualified()) {
-      // Build: (_d_obs != nullptr ? _d_obs[idx] : 0)
-      Expr* cond = BuildOp(BO_NE, buildAdjoint(it->second),
-                           m_Sema.ActOnCXXNullPtrLiteral(noLoc).get());
-      result_at_is = BuildParens(
-          m_Sema.ActOnConditionalOp(noLoc, noLoc, cond, result_at_is, zero)
-              .get());
-    }
-  }
-  return StmtDiff(cloned, result_at_is);
+  Expr* adjoint = buildAdjoint(it->second);
+  auto* result_at_is = BuildArraySubscript(adjoint, derivedIndices());
+  return StmtDiff(cloned, GuardNullTangentRead(adjoint, result_at_is, zero));
+}
+
+bool BaseForwardModeVisitor::mayBeNullTangent(const Expr* tangent) const {
+  const auto* DRE = dyn_cast<DeclRefExpr>(tangent->IgnoreParenImpCasts());
+  if (!DRE)
+    return false;
+  const auto* PVD = dyn_cast<ParmVarDecl>(DRE->getDecl());
+  if (!PVD || PVD->getDeclContext() != m_Derivative)
+    return false;
+  QualType T = PVD->getType();
+  return T->isPointerType() && T->getPointeeType().isConstQualified();
+}
+
+Expr* BaseForwardModeVisitor::GuardNullTangentRead(const Expr* tangent,
+                                                   Expr* read, Expr* zero) {
+  if (!mayBeNullTangent(tangent))
+    return read;
+  Expr* cond = CloneNode(tangent);
+  return BuildParens(
+      m_Sema.ActOnConditionalOp(noLoc, noLoc, cond, read, zero).get());
 }
 
 StmtDiff BaseForwardModeVisitor::VisitDeclRefExpr(const DeclRefExpr* DRE) {
@@ -1426,12 +1431,13 @@ StmtDiff BaseForwardModeVisitor::VisitUnaryOperator(const UnaryOperator* UnOp) {
       derivedOp = BuildOp(opKind, diff.getExpr_dx());
     return StmtDiff(op, derivedOp);
   } else if (opKind == UnaryOperatorKind::UO_Deref) {
-    if (Expr* dx = diff.getExpr_dx())
-      return StmtDiff(op, BuildOp(opKind, dx));
     QualType literalTy =
         utils::GetValueType(UnOp->getSubExpr()->getType()->getPointeeType());
-    return StmtDiff(
-        op, ConstantFolder::synthesizeLiteral(literalTy, m_Context, /*val=*/0));
+    Expr* zero =
+        ConstantFolder::synthesizeLiteral(literalTy, m_Context, /*val=*/0);
+    if (Expr* dx = diff.getExpr_dx())
+      return StmtDiff(op, GuardNullTangentRead(dx, BuildOp(opKind, dx), zero));
+    return StmtDiff(op, zero);
   } else if (opKind == UnaryOperatorKind::UO_AddrOf) {
     Expr* derivedOp = diff.getExpr_dx();
     // A subexpression without a tangent of its own (e.g. an object that does

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -49,6 +49,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <utility>
 
@@ -441,6 +442,94 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     F.TraverseStmt(Def->getBody());
     m_EarlyReturnInfo = {F.Found, /*HasAnalysisRun=*/true};
     return F.Found;
+  }
+
+  namespace {
+  /// Propagates "the tangent of this pointer may be null" along the pointer
+  /// initializations and assignments of a function body, to a fixpoint. Runs on
+  /// the primal, so that the classification does not depend on the order in
+  /// which the derivative code is generated: a read may precede the assignment
+  /// that makes the tangent null, as it does across loop iterations.
+  class MaybeNullPointerPropagator
+      : public RecursiveASTVisitor<MaybeNullPointerPropagator> {
+    std::set<const VarDecl*>* m_MaybeNull;
+    bool m_Changed = false;
+
+    /// Whether \p E reads a pointer whose tangent may be null. Pointer
+    /// arithmetic and casts keep such a tangent null, so the whole expression
+    /// is searched.
+    bool readsMaybeNull(const Expr* E) const {
+      if (!E)
+        return false;
+      if (const auto* DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts()))
+        if (const auto* VD = dyn_cast<VarDecl>(DRE->getDecl()))
+          if (m_MaybeNull->count(VD) != 0)
+            return true;
+      for (const Stmt* child : E->children())
+        if (const auto* childExpr = dyn_cast_or_null<Expr>(child))
+          if (readsMaybeNull(childExpr))
+            return true;
+      return false;
+    }
+
+    void taint(const VarDecl* VD) {
+      if (VD && VD->getType()->isPointerType() &&
+          m_MaybeNull->insert(VD).second)
+        m_Changed = true;
+    }
+
+  public:
+    explicit MaybeNullPointerPropagator(std::set<const VarDecl*>& maybeNull)
+        : m_MaybeNull(&maybeNull) {}
+
+    bool VisitVarDecl(VarDecl* VD) {
+      // A pointer clad has no tangent for is given a null one.
+      if (VD->getType()->isPointerType() &&
+          (!VD->getInit() || readsMaybeNull(VD->getInit())))
+        taint(VD);
+      return true;
+    }
+
+    bool VisitBinaryOperator(BinaryOperator* BO) {
+      if (BO->getOpcode() != BO_Assign || !BO->getType()->isPointerType() ||
+          !readsMaybeNull(BO->getRHS()))
+        return true;
+      const auto* DRE =
+          dyn_cast<DeclRefExpr>(BO->getLHS()->IgnoreParenImpCasts());
+      if (DRE)
+        taint(dyn_cast<VarDecl>(DRE->getDecl()));
+      return true;
+    }
+
+    void runToFixpoint(Stmt* Body) {
+      m_Changed = true;
+      while (m_Changed) {
+        m_Changed = false;
+        TraverseStmt(Body);
+      }
+    }
+  };
+  } // namespace
+
+  bool DiffRequest::mayHaveNullTangent(const VarDecl* VD) const {
+    if (!VD || !VD->getType()->isPointerType())
+      return false;
+    if (!m_NullTangentInfo.HasAnalysisRun) {
+      m_NullTangentInfo.HasAnalysisRun = true;
+      const FunctionDecl* Def = Function ? Function->getDefinition() : nullptr;
+      if (Def && Def->hasBody()) {
+        std::set<const VarDecl*>& MaybeNull = m_NullTangentInfo.MaybeNullPtrs;
+        // Clad has no tangent buffer to pass for a const-qualified pointer
+        // parameter; the pointers of the body derived from one inherit that.
+        for (const ParmVarDecl* PVD : Def->parameters()) {
+          QualType T = PVD->getType();
+          if (T->isPointerType() && T->getPointeeType().isConstQualified())
+            MaybeNull.insert(PVD);
+        }
+        MaybeNullPointerPropagator(MaybeNull).runToFixpoint(Def->getBody());
+      }
+    }
+    return m_NullTangentInfo.MaybeNullPtrs.count(VD) != 0;
   }
 
   void DiffRequest::UpdateDiffParamsInfo(Sema& semaRef) {

--- a/test/Regressions/issue-1804.cpp
+++ b/test/Regressions/issue-1804.cpp
@@ -32,6 +32,29 @@ double g_outer(double *params, double const *obs) { return g_inner(params, obs);
 // CHECK: clad::ValueAndPushforward<double, double> g_inner_pushforward(double *params, const double *obs, double *_d_params, const double *_d_obs) {
 // CHECK-NEXT:     return {*obs * params[0], (_d_obs ? *_d_obs : 0.) * params[0] + *obs * _d_params[0]};
 
+// A local pointer inherits the null tangent of the one it is derived from. The
+// classification runs over the whole function at once, so that a read that
+// precedes the assignment making the tangent null -- as `p[0]` does here from
+// the second iteration on -- is guarded too.
+double h_inner(double *params, double const *obs) {
+   const double *q = obs;
+   double buf[1] = {params[0]};
+   const double *p = buf;
+   double s = q[0] * params[0];
+   for (int i = 0; i < 2; ++i) {
+      s += p[0] * params[0];
+      p = obs;
+   }
+   return s;
+}
+
+double h_outer(double *params, double const *obs) { return h_inner(params, obs); }
+
+// CHECK: clad::ValueAndPushforward<double, double> h_inner_pushforward(double *params, const double *obs, double *_d_params, const double *_d_obs) {
+// CHECK-NEXT:     const double *_d_q = _d_obs;
+// CHECK: double _d_s = (_d_q ? _d_q[0] : 0.) * params[0] + q[0] * _d_params[0];
+// CHECK: _d_s += (_d_p ? _d_p[0] : 0.) * params[0] + p[0] * _d_params[0];
+
 // Clang prints the type of a compound literal as `double [3]` up to clang 13
 // and as `double[3]` from clang 14 on, so accept either spelling.
 // CHECK: f_inner_pushforward_pullback(params, obs, (double{{ ?}}[3]){1., 0., 0.}, nullptr, _d_t0, _d_params, (double{{ ?}}[3]){0., 0., 0.}, nullptr);
@@ -60,4 +83,9 @@ int main() {
    auto d = clad::differentiate(g_outer, "params[0]");
    printf("%.5g\n", d.execute(params, obs));
    // CHECK-EXEC: -9.9
+
+   // s = obs0 * p0 + p0 * p0 + obs0 * p0, so ds/dp0 = 2 * obs0 + 2 * p0.
+   auto d2 = clad::differentiate(h_outer, "params[0]");
+   printf("%.5g\n", d2.execute(params, obs));
+   // CHECK-EXEC: -18.8
 }

--- a/test/Regressions/issue-1804.cpp
+++ b/test/Regressions/issue-1804.cpp
@@ -1,6 +1,15 @@
-// RUN: %cladclang -c -std=c++17 -I%S/../../include %s
+// RUN: %cladclang %s -I%S/../../include -o%t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
 
 #include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+// `obs` is a const-qualified pointer parameter, so clad cannot synthesize a
+// tangent buffer for it -- its size is unknown -- and passes a null tangent
+// instead, meaning "the derivative of this argument is identically zero".
+// Reads through it have to yield that zero rather than dereference the null
+// pointer.
 
 double f_inner(double *params, double const *obs) {
    double arg = (obs[0] - params[1]) / params[2];
@@ -11,8 +20,44 @@ double f_outer(double *params, double const *obs) {
    return f_inner(params, obs) + params[0];
 }
 
-void check() {
-   auto hess = clad::hessian(f_outer, "params[0:2]");
-}
+// CHECK: clad::ValueAndPushforward<double, double> f_inner_pushforward(double *params, const double *obs, double *_d_params, const double *_d_obs) {
+// CHECK-NEXT:     double _t0 = (obs[0] - params[1]);
+// CHECK-NEXT:     double _d_arg = (((_d_obs ? _d_obs[0] : 0.) - _d_params[1]) * params[2] - _t0 * _d_params[2]) / (params[2] * params[2]);
 
-// CHECK: f_inner_pushforward_pullback(params, obs, (double[3]){1., 0., 0.}, nullptr, _d_t0, _d_params, (double[3]){0., 0., 0.}, nullptr);
+// The same holds for a dereference spelled without a subscript.
+double g_inner(double *params, double const *obs) { return *obs * params[0]; }
+
+double g_outer(double *params, double const *obs) { return g_inner(params, obs); }
+
+// CHECK: clad::ValueAndPushforward<double, double> g_inner_pushforward(double *params, const double *obs, double *_d_params, const double *_d_obs) {
+// CHECK-NEXT:     return {*obs * params[0], (_d_obs ? *_d_obs : 0.) * params[0] + *obs * _d_params[0]};
+
+// Clang prints the type of a compound literal as `double [3]` up to clang 13
+// and as `double[3]` from clang 14 on, so accept either spelling.
+// CHECK: f_inner_pushforward_pullback(params, obs, (double{{ ?}}[3]){1., 0., 0.}, nullptr, _d_t0, _d_params, (double{{ ?}}[3]){0., 0., 0.}, nullptr);
+
+// The pullback of the guarded read is guarded by the same condition, so the
+// null adjoint of the null tangent is never written to either.
+// CHECK: void f_inner_pushforward_pullback(double *params, const double *obs, double *_d_params, const double *_d_obs, clad::ValueAndPushforward<double, double> _d_y, double *_d_params0, double *_d_d_params, double *_d_d_obs) {
+// CHECK: bool _cond0 = _d_obs;
+// CHECK: if (_cond0)
+// CHECK-NEXT: _d_d_obs[0] += _d_d_arg / _t0 * params[2];
+
+int main() {
+   double params[3] = {0.5, -1, 2};
+   double obs[1] = {-9.9};
+
+   auto hess = clad::hessian(f_outer, "params[0:2]");
+   double matrix[9] = {};
+   hess.execute(params, obs, matrix);
+   for (int i = 0; i < 3; ++i)
+      printf("%.5g %.5g %.5g\n", matrix[3 * i], matrix[3 * i + 1],
+             matrix[3 * i + 2]);
+   // CHECK-EXEC: 0 0 0
+   // CHECK-EXEC: 0 0.5 -4.45
+   // CHECK-EXEC: 0 -4.45 29.704
+
+   auto d = clad::differentiate(g_outer, "params[0]");
+   printf("%.5g\n", d.execute(params, obs));
+   // CHECK-EXEC: -9.9
+}


### PR DESCRIPTION
Forward mode has to supply a tangent for every argument of a call it differentiates. For a const-qualified pointer parameter it cannot synthesize one, because the size is unknown, so it passes a null tangent instead:

  inner_func_pushforward(params, obs, (double[3]){1., 0., 0.}, nullptr);

The pushforward then read `_d_obs[0]` unconditionally and dereferenced the null pointer. #1805 fixed the type mismatch that used to mask this, leaving the null dereference behind; at -O0 it segfaults, and with optimizations the undefined behaviour lets the derivative bodies be deleted outright, which is why hessians silently came out all zeros.

Guard such reads so they produce the zero the null tangent stands for. The guard is limited to derivative parameters standing for const- qualified pointer parameters, which are exactly the ones clad nulls out: a non-const pointer parameter is either the independent variable or a hard error, and so is never null and generates no guard.

The reverse sweep needs no change of its own. The pullback of `cond ? A : 0` is `if (cond) <pullback of A>`, so the accumulation into the null adjoint of a null tangent ends up guarded by the same condition, and no existing generated code changes.

The regression test only compiled its input, and its CHECK line never ran for want of a FileCheck pipe, so the crash went unnoticed. Run it and check the hessian against the analytic values.

Fixes #1804