### PR TITLE
Support references and const locals across an early-return lambda

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -1028,6 +1028,12 @@ CUDA_HOST_DEVICE void pow_pullback(T1 x, T2 exponent, T3 d_y, T1* d_x,
   *d_exponent += t.pushforward * d_y;
 }
 
+// The min/max pushforwards return ValueAndPushforward<T, T> by value even
+// though std::min/max return `const T&`: with reference members the struct
+// is neither default-constructible nor assignable, which breaks
+// differentiating the generated code again at higher orders (issue #1872).
+// GetDerivedFunctionType in DiffPlanner relaxes the expected overload type
+// to match.
 template <typename T, class Compare>
 CUDA_HOST_DEVICE ValueAndPushforward<T, T>
 min_pushforward(const T& a, const T& b, Compare comp, const T& d_a,

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -696,6 +696,19 @@ namespace clad {
     /// Returns 0 for scalar types, otherwise {}.
     clang::Expr* getZeroInit(clang::QualType T);
 
+    /// The placeholder a moved pointer declaration of type \p PtrTy holds
+    /// until the forward sweep assigns it. Null would do, except with early
+    /// returns: the reverse sweep runs on every return path, so it reads and
+    /// writes through pointers the taken path never assigned. Those accesses
+    /// carry zero adjoints and cannot change the gradient, but they do have to
+    /// be defined -- so point the declaration at a fresh dummy of the pointee
+    /// type, declared into \p Block. Returns null when unneeded (no early
+    /// returns, not a pointer, or a pointee clad cannot zero-initialize),
+    /// leaving the placeholder to the caller.
+    clang::Expr*
+    BuildDereferenceablePlaceholder(clang::QualType PtrTy,
+                                    llvm::SmallVectorImpl<clang::Stmt*>& Block);
+
     /// Split an array subscript expression into a pair of base expr and
     /// a vector of all indices.
     std::pair<const clang::Expr*, llvm::SmallVector<const clang::Expr*, 4>>

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1095,10 +1095,16 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
             utils::MatchOverloadType(S, dTy, Found, FailedCandidates))
       return overload;
 
-    // Retry ValueAndPushforward<const T&, const T&> as
-    // ValueAndPushforward<T, T> after the exact match fails. This keeps
-    // reference-returning custom derivatives preferred while allowing
-    // assignable min/max results in higher-order differentiation.
+    // For an original that returns `const T&`, the expected pushforward
+    // returns ValueAndPushforward<const T&, const T&>. With two reference
+    // members that struct is neither default-constructible nor assignable,
+    // which breaks differentiating the generated code again at higher
+    // orders (issue #1872), so the min/max builtins return
+    // ValueAndPushforward<T, T> instead. Accept them by retrying the lookup
+    // with the expectation relaxed the same way. Retrying only after the
+    // exact match fails keeps genuinely reference-returning pushforwards
+    // (e.g. the STL builtins for operator[], at, front, back) matching as
+    // before.
     if (const auto* FPT = dTy->getAs<FunctionProtoType>()) {
       auto* CTSD = dyn_cast_or_null<ClassTemplateSpecializationDecl>(
           FPT->getReturnType()->getAsCXXRecordDecl());

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3498,15 +3498,31 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         !getCurrentScope()->isFunctionScope() &&
         m_DiffReq.Mode != DiffMode::reverse_mode_forward_pass && !keepLocal;
     QualType VDType = VD->getType();
+    // A function-scope declaration is not promoted, but with early returns
+    // LambdaCaptures::orderCaptureDecls may still split it -- declaration
+    // hoisted before the reverse-sweep lambda, initializer left behind as an
+    // assignment -- so it needs the same reassignable type. Except when it is
+    // a reference binding a temporary: the pointer that makes a reference
+    // reassignable has no lvalue to point at (clad supports neither encoding
+    // of one anyway).
+    bool bindsTemporary =
+        VDType->isLValueReferenceType() &&
+        (!VD->getInit() || !VD->getInit()->IgnoreImplicit()->isLValue());
+    bool mayBeSplitForLambda =
+        !promoteToFnScope && m_DiffReq.hasEarlyReturns() &&
+        getCurrentScope()->isFunctionScope() &&
+        m_DiffReq.Mode != DiffMode::reverse_mode_forward_pass && !keepLocal &&
+        !bindsTemporary;
     QualType VDCloneType = CloneType(VDType);
-    // If the cloned declaration is moved to the function global scope,
-    // change its type to make it reassignable.
-    if (promoteToFnScope) {
-      if (VDCloneType->isReferenceType())
-        VDCloneType =
-            m_Context.getPointerType(VDCloneType.getNonReferenceType());
+    // If the cloned declaration is moved to the function global scope, or may
+    // be split for the early-return lambda, change its type to make it
+    // reassignable. The split drops its own const, once it knows it happens;
+    // the pointer has to be decided here, as it changes how uses are spelled.
+    if ((promoteToFnScope || mayBeSplitForLambda) &&
+        VDCloneType->isReferenceType())
+      VDCloneType = m_Context.getPointerType(VDCloneType.getNonReferenceType());
+    if (promoteToFnScope)
       VDCloneType.removeLocalConst();
-    }
     // A variable-array type carries its size in a stored expression, so the
     // primal and adjoint declarations would otherwise share it. Re-clone the
     // type for such adjoints; other types keep the (possibly promoted)
@@ -3648,14 +3664,14 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     if (VDDerived)
       derivedVDE = BuildDeclRef(VDDerived);
 
-    // If a ref-type declaration is promoted to function global scope,
-    // it's replaced with a pointer and should be initialized with the
-    // address of the cloned init. e.g.
+    // If a ref-type declaration is promoted to function global scope (or may
+    // be split for the early-return lambda), it's replaced with a pointer and
+    // should be initialized with the address of the cloned init. e.g.
     // double& ref = x;
     // ->
     // double* ref;
     // ref = &x;
-    if (isRefType && promoteToFnScope) {
+    if (isRefType && (promoteToFnScope || mayBeSplitForLambda)) {
       // FIXME: Add extra parantheses if derived variable pointer is pointing to
       // a class type object.
       initDiff = {BuildOp(UnaryOperatorKind::UO_AddrOf, initDiff.getExpr()),
@@ -3698,7 +3714,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       Expr* assignDerivativeE = BuildOp(BinaryOperatorKind::BO_Assign,
                                         derivedVDE, initDiff.getExpr_dx());
       addToCurrentBlock(assignDerivativeE, direction::forward);
-      SetDeclInit(VDDerived, getZeroInit(VDDerivedType));
+      // An early return between this declaration and the assignment above
+      // leaves the reverse sweep writing through the placeholder.
+      Expr* placeholder =
+          BuildDereferenceablePlaceholder(VDDerivedType, m_Globals);
+      SetDeclInit(VDDerived,
+                  placeholder ? placeholder : getZeroInit(VDDerivedType));
       if (isInsideLoop) {
         StmtDiff pushPop = StoreAndRestore(derivedVDE);
         if (!keepLocal)
@@ -3848,7 +3869,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
               }
             }
             inits.push_back(assignment);
-            SetDeclInit(decl, getZeroInit(VD->getType()));
+            // Same care as for the adjoint in DifferentiateVarDecl: the
+            // reverse sweep reads this clone (a promoted reference is spelled
+            // as a pointer too) on a path taken before the assignment above.
+            Expr* placeholder =
+                BuildDereferenceablePlaceholder(decl->getType(), m_Globals);
+            SetDeclInit(decl,
+                        placeholder ? placeholder : getZeroInit(VD->getType()));
           }
         }
 

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -21,6 +21,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
 #include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/OperationKinds.h"
 #include "clang/AST/RecursiveASTVisitor.h"
@@ -454,6 +455,21 @@ namespace clad {
         bool Hoistable = VD && contains(VD);
         if (Hoistable && selfContained(VD)) {
           flushKept();
+          // Moved wholesale, the decl may still carry no real initial value:
+          // default init of a scalar or of a trivially-default-constructible
+          // record leaves indeterminate bits. In place that was fine -- the
+          // original program wrote them before any read -- but hoisted above
+          // the lambda they become readable by the reverse sweep on a path
+          // that returns before those writes. The adjoints there are zero, so
+          // only definedness is at stake; a zero initializer settles it.
+          const Expr* Init = VD->getInit();
+          bool Indeterminate = !Init;
+          if (const auto* CE = dyn_cast_or_null<CXXConstructExpr>(Init))
+            Indeterminate = CE->getConstructor()->isDefaultConstructor() &&
+                            CE->getConstructor()->isTrivial();
+          if (Indeterminate)
+            if (Expr* Zero = m_V.getZeroInit(VD->getType()))
+              m_V.SetDeclInit(VD, Zero);
           Prefix.push_back(m_V.BuildDeclStmt(VD));
           note(Prefix.back());
           continue;
@@ -470,8 +486,27 @@ namespace clad {
         // selfContained() is true for an initializer-less decl, so reaching
         // here means there is an initializer to move into the assignment.
         Expr* Init = VD->getInit();
+        // A const clone cannot take that assignment. Placeholder plus one
+        // assignment still leave the clone a single value for the rest of its
+        // lifetime, so dropping the qualifier costs nothing. (A decl promoted
+        // to the function global scope is split the same way and loses its
+        // const up front, in ReverseModeVisitor::DifferentiateVarDecl.)
+        QualType VDTy = VD->getType();
+        if (VDTy.isLocalConstQualified()) {
+          VDTy.removeLocalConst();
+          VD->setType(VDTy);
+          VD->setTypeSourceInfo(
+              m_V.m_Context.getTrivialTypeSourceInfo(VDTy, noLoc));
+        }
         Expr* DeclRef = m_V.BuildDeclRef(VD);
-        m_V.SetDeclInit(VD, m_V.getZeroInit(VD->getType()));
+        // The lambda reads the placeholder on a path that returns before the
+        // assignment below, so a pointer needs a dereferenceable one; its
+        // dummy declaration goes into Prefix ahead of VD's.
+        Expr* Placeholder =
+            m_V.BuildDereferenceablePlaceholder(VD->getType(), Prefix);
+        if (!Placeholder)
+          Placeholder = m_V.getZeroInit(VD->getType());
+        m_V.SetDeclInit(VD, Placeholder);
         flushKept();
         Prefix.push_back(m_V.BuildDeclStmt(VD));
         // Not noted: the hoisted decl only holds a placeholder until the
@@ -710,6 +745,26 @@ namespace clad {
 
   Expr* VisitorBase::getZeroInit(QualType T) {
     return utils::getZeroInit(T, m_Sema);
+  }
+
+  Expr* VisitorBase::BuildDereferenceablePlaceholder(
+      QualType PtrTy, llvm::SmallVectorImpl<Stmt*>& Block) {
+    const auto* PT = PtrTy->getAs<PointerType>();
+    if (!PT || !m_DiffReq.hasEarlyReturns())
+      return nullptr;
+    // Only for a pointee clad can bring into existence by itself: a scalar,
+    // or a record whose zero init cannot run into a user-provided or deleted
+    // default constructor.
+    QualType Pointee = PT->getPointeeType().getUnqualifiedType();
+    const CXXRecordDecl* RD = Pointee->getAsCXXRecordDecl();
+    bool conjurable =
+        Pointee->isScalarType() ||
+        (RD && RD->hasDefinition() && RD->hasTrivialDefaultConstructor());
+    if (!conjurable)
+      return nullptr;
+    VarDecl* Dummy = BuildVarDecl(Pointee, "_dummy", getZeroInit(Pointee));
+    Block.push_back(BuildDeclStmt(Dummy));
+    return BuildOp(UO_AddrOf, BuildDeclRef(Dummy));
   }
 
   std::pair<const clang::Expr*, llvm::SmallVector<const clang::Expr*, 4>>

--- a/test/Gradient/EarlyReturns.C
+++ b/test/Gradient/EarlyReturns.C
@@ -1,13 +1,12 @@
 // RUN: %cladclang %s -I%S/../../include -oEarlyReturns.out 2>&1 | %filecheck %s
 // RUN: ./EarlyReturns.out | %filecheck_exec %s
-// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oEarlyReturns.out
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oEarlyReturns.out 2>&1 | %filecheck --check-prefix=CHECK-NOTBR %s
 // RUN: ./EarlyReturns.out | %filecheck_exec %s
 //
-// The synthesized reverse lambda makes Clang's CodeGen emit a closure
-// constructor/destructor, whose exception landing-pad path
-// (EHScopeStack::requiresLandingPad) reads an uninitialized value inside
-// libclang on some runtimes. The read is Clang-internal and does not affect
-// the generated derivative; skip the run under Valgrind like the other tests.
+// The gradients must stay Memcheck-clean on every return path: the valgrind CI
+// row runs both executables, and the early path reads hoisted locals the
+// forward sweep never assigned, so their declarations may not leave
+// indeterminate bits behind.
 
 #include "clad/Differentiator/Differentiator.h"
 #include "../TestUtils.h"
@@ -126,6 +125,94 @@ double declAfterEarly(double x, double y) {
 // CHECK: auto _rev0 = [&
 // CHECK-NOT: this is a clad bug
 
+// `r` and `c` are read by the reverse sweep, so the hoister splits them:
+// declaration before the lambda, initializer left behind as an assignment.
+// Neither survives that as spelled -- a reference cannot be declared unbound
+// and re-seated, a const cannot be assigned -- so the clone of `r` is a
+// pointer (as for a reference promoted to the function global scope) and `c`
+// loses its const (vgvassilev/clad#1954).
+double refAfterEarly(double x, double y) {
+  if (y == 0)
+    return 1;
+  double a = x * y;
+  double& r = a;
+  const double c = r * r;
+  double d = c * c;
+  return d;
+}
+
+// CHECK-LABEL: void refAfterEarly_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: double *_d_r = &_d_a;
+// CHECK-NEXT: double _dummy0 = 0.;
+// CHECK-NEXT: double *r = &_dummy0;
+// CHECK-NEXT: double _d_c = 0.;
+// CHECK-NEXT: double c = 0.;
+// CHECK: auto _rev0 = [&
+// CHECK: r = &a;
+// CHECK-NEXT: c = *r * *r;
+// CHECK-NOT: this is a clad bug
+
+// The same split with a record referent: the hoisted pointer clone must still
+// point somewhere on the early path, so the placeholder is a fresh
+// zero-initialized dummy -- possible because zero init of Pair, whose default
+// constructor is trivial, cannot run into a user-provided one.
+struct Pair {
+  double a;
+  double b;
+};
+
+double structRefAfterEarly(double x, double y) {
+  if (y == 0)
+    return 1;
+  Pair p;
+  p.a = x * y;
+  p.b = x + y;
+  Pair& r = p;
+  double d = r.a * r.b;
+  return d;
+}
+
+// CHECK-LABEL: void structRefAfterEarly_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: Pair _dummy0 = {0., 0.};
+// CHECK-NEXT: Pair *r = &_dummy0;
+// CHECK: auto _rev0 = [&
+// CHECK: r = &p;
+// CHECK-NOT: this is a clad bug
+
+// Without TBR the sweep also restores p's members from snapshots, so `p`
+// itself is captured and hoisted -- moved wholesale, its default init would
+// leave indeterminate members for the early path's sweep (and for the
+// snapshots, taken right after the hoisted declaration) to read. The hoist
+// must add a zero initializer.
+// CHECK-NOTBR-LABEL: void structRefAfterEarly_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK-NOTBR: Pair p = {0., 0.};
+// CHECK-NOTBR: double _t0 = p.a;
+
+// A record whose member initializers make the default constructor non-trivial
+// is not one clad will conjure: the placeholder stays null, and only the
+// fall-through path is defined.
+struct Seeded {
+  double a = 1.;
+  double b = 0.;
+};
+
+double nontrivialRefAfterEarly(double x, double y) {
+  if (y == 0)
+    return 1;
+  Seeded s;
+  s.a = x * y;
+  s.b = x + y;
+  Seeded& r = s;
+  double d = r.a * r.b;
+  return d;
+}
+
+// CHECK-LABEL: void nontrivialRefAfterEarly_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: Seeded *r = nullptr;
+// CHECK: auto _rev0 = [&
+// CHECK: r = &s;
+// CHECK-NOT: this is a clad bug
+
 int main() {
   double dx = 0, dy = 0;
 
@@ -183,4 +270,28 @@ int main() {
   dx = dy = 0;
   // y != 0 falls through: (y + x) * y + 2x, so d = {y + 2, x + 2y}.
   TEST_GRADIENT(declAfterEarly, /*numOfDerivativeArgs=*/2, 3, 5, &dx, &dy); // CHECK-EXEC: {7.00, 13.00}
+
+  dx = dy = 0;
+  INIT_GRADIENT(refAfterEarly);
+  // y != 0 falls through: (x * y)^4, so d = {4(xy)^3 y, 4(xy)^3 x}.
+  TEST_GRADIENT(refAfterEarly, /*numOfDerivativeArgs=*/2, 1, 2, &dx, &dy); // CHECK-EXEC: {64.00, 32.00}
+  dx = dy = 0;
+  // y == 0 takes the early return: d(1) = {0, 0}. The sweep still dereferences
+  // `r`, which this path never bound, so its placeholder must point somewhere.
+  TEST_GRADIENT(refAfterEarly, /*numOfDerivativeArgs=*/2, 1, 0, &dx, &dy); // CHECK-EXEC: {0.00, 0.00}
+
+  dx = dy = 0;
+  INIT_GRADIENT(structRefAfterEarly);
+  // y != 0 falls through: (x * y) * (x + y), so d = {y * (2x + y), x * (x + 2y)}.
+  TEST_GRADIENT(structRefAfterEarly, /*numOfDerivativeArgs=*/2, 1, 2, &dx, &dy); // CHECK-EXEC: {8.00, 5.00}
+  dx = dy = 0;
+  // y == 0 takes the early return; the sweep dereferences the never-bound `r`,
+  // which is defined only because the placeholder points at the Pair dummy.
+  TEST_GRADIENT(structRefAfterEarly, /*numOfDerivativeArgs=*/2, 1, 0, &dx, &dy); // CHECK-EXEC: {0.00, 0.00}
+
+  dx = dy = 0;
+  INIT_GRADIENT(nontrivialRefAfterEarly);
+  // Fall-through path only: with the null placeholder, the early path's sweep
+  // would dereference the never-bound `r`.
+  TEST_GRADIENT(nontrivialRefAfterEarly, /*numOfDerivativeArgs=*/2, 1, 2, &dx, &dy); // CHECK-EXEC: {8.00, 5.00}
 }

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -1098,12 +1098,20 @@ double f_ref_in_rhs(double x, double y) {
   return 1;
 }
 
+// On the `x == 55` path the lambda dereferences the reference clones before
+// the branch binding them ran, so their placeholders point at a dummy each
+// instead of at null. One dummy per clone: sharing would let a dead
+// statement's write reach a later dead read, and from there a real adjoint.
 //CHECK: void f_ref_in_rhs_grad(double x, double y, double *_d_x, double *_d_y) {
 //CHECK-NEXT:     bool _cond0 = false;
-//CHECK-NEXT:     double *_d_ref_x = nullptr;
-//CHECK-NEXT:     double *ref_x = {};
-//CHECK-NEXT:     double *_d_ref_y = nullptr;
-//CHECK-NEXT:     double *ref_y = {};
+//CHECK-NEXT:     double _dummy0 = 0.;
+//CHECK-NEXT:     double _dummy1 = 0.;
+//CHECK-NEXT:     double *_d_ref_x = &_dummy0;
+//CHECK-NEXT:     double *ref_x = &_dummy1;
+//CHECK-NEXT:     double _dummy2 = 0.;
+//CHECK-NEXT:     double _dummy3 = 0.;
+//CHECK-NEXT:     double *_d_ref_y = &_dummy2;
+//CHECK-NEXT:     double *ref_y = &_dummy3;
 //CHECK-NEXT:     auto _rev0 = [&] {
 //CHECK-NEXT:         if (_cond0) {
 //CHECK-NEXT:             {
@@ -1316,6 +1324,8 @@ int main() {
 
   INIT_GRADIENT(f_ref_in_rhs);
   TEST_GRADIENT(f_ref_in_rhs, /*numOfDerivativeArgs=*/2, 3, 5, &d_i, &d_j);  // CHECK-EXEC: {5.00, 13.00}
+  // The tail return, where the sweep runs over clones this path never bound.
+  TEST_GRADIENT(f_ref_in_rhs, /*numOfDerivativeArgs=*/2, 55, 5, &d_i, &d_j);  // CHECK-EXEC: {0.00, 0.00}
 
   INIT_GRADIENT(f_reuse_global);
   TEST_GRADIENT(f_reuse_global, /*numOfDerivativeArgs=*/2, -3, 4, &d_i, &d_j);  // CHECK-EXEC: {-4.00, 3.00}


### PR DESCRIPTION
A function with early returns keeps its master reverse sweep in a shared [&] lambda, so every local the sweep reads must be declared before it. LambdaCaptures::orderCaptureDecls hoists such a local by splitting it: a placeholder declaration before the lambda plus an assignment left at the original program point. Two kinds of declaration do not survive that split as spelled, and clad emitted code that does not compile:

```c++
  double f(double x) {
     if (x <= 0) return 0.0;
     double y = x * x;
     double &t1 = y;      // -> double &t1 = {};
     double t2 = t1 * t1;
     return t2;
  }
```

A reference cannot be declared unbound and re-seated later; the same body with `const double t1 = y + 1;` cannot take the assignment either.

Fix: DifferentiateVarDecl clones a function-scope reference of an early-return function as a pointer -- the shape a reference promoted to the function global scope already gets -- and the split drops the const of the clone it hoists. A reference bound to a temporary keeps its reference type: there is no lvalue for the pointer to point at, and clad supports neither encoding of one.

That alone left the gradient crashing on the early path. The lambda runs the whole reverse sweep on every return path, including the part undoing statements the taken path never reached, so it reads and writes through pointers the forward sweep never assigned. Those accesses carry zero adjoints and cannot change the gradient, but a null placeholder makes them a null dereference. That is reachable on master already, through a reference promoted from a nested scope -- Gradients.C's f_ref_in_rhs carried it latent, executed on one path only. A moved pointer declaration now holds a fresh zero dummy of the pointee type (BuildDereferenceablePlaceholder), one dummy per declaration: sharing would let a dead statement's write reach a later dead read, and from there a real adjoint.

Fixes #1954