### PR TITLE
Do not fabricate tangents for aliases of read-only data

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1609,17 +1609,28 @@ BaseForwardModeVisitor::DifferentiateVarDecl(const VarDecl* VD,
                                   initDiff.getExpr(), VD->isDirectInit());
   // FIXME: Create unique identifier for derivative.
   Expr* initDx = initDiff.getExpr_dx();
-  if (VD->getType()->isPointerType() && !initDx) {
+  QualType VDType = VD->getType();
+  // A reference tangent needs an lvalue to bind to; the literal 0 that e.g.
+  // `const double& r = 5.;` derives to is not one.
+  if (VDType->isLValueReferenceType() && initDx && !initDx->isLValue())
+    initDx = nullptr;
+  // References and pointers-to-const only alias storage they do not own, so
+  // without an initializer tangent there is nothing to alias. Fabricating one
+  // yields a null tangent that later gets dereferenced, or a reference bound
+  // to a temporary; leave them without a tangent and let uses derive to zero,
+  // as reverse mode does in ReverseModeVisitor::DifferentiateVarDecl.
+  bool isAlias =
+      VDType->isLValueReferenceType() ||
+      (VDType->isPointerType() && VDType->getPointeeType().isConstQualified());
+  if (VDType->isPointerType() && !initDx && !isAlias) {
     // initialize with nullptr.
-    // NOLINTBEGIN(cppcoreguidelines-owned-memory)
-    initDx =
-        new (m_Context) CXXNullPtrLiteralExpr(VD->getType(), VD->getBeginLoc());
-    // NOLINTEND(cppcoreguidelines-owned-memory)
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    initDx = new (m_Context) CXXNullPtrLiteralExpr(VDType, VD->getBeginLoc());
   }
   VarDecl* VDDerived = nullptr;
-  if (m_DiffReq.shouldHaveAdjointForw(VD))
-    VDDerived = BuildVarDecl(VD->getType(), "_d_" + VD->getNameAsString(),
-                             initDx, VD->isDirectInit());
+  if (m_DiffReq.shouldHaveAdjointForw(VD) && (initDx || !isAlias))
+    VDDerived = BuildVarDecl(VDType, "_d_" + VD->getNameAsString(), initDx,
+                             VD->isDirectInit());
 
   if (VDDerived)
     m_Variables.emplace(VDClone, AdjointInfo{VDDerived});

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3601,6 +3601,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         addToCurrentBlock(assignToZero, direction::reverse);
     }
 
+    // A reference adjoint aliases the referent's adjoint storage, so it needs
+    // an lvalue to bind to; the literal 0 that e.g. `const double& r = 5.;`
+    // derives to is not one. Drop the derivative to fall into the case below.
+    if (isRefType && initDiff.getExpr_dx() &&
+        !initDiff.getExpr_dx()->isLValue())
+      initDiff.updateStmtDx(nullptr);
+
     // If adjoint is a reference or a const pointer and derived expression is
     // not available, then we should not create a derived variable for it.
     bool constPointer =

--- a/test/Regressions/issue-1955.cpp
+++ b/test/Regressions/issue-1955.cpp
@@ -1,0 +1,91 @@
+// RUN: %cladclang -std=c++17 -I%S/../../include %s -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+// A local alias of read-only data -- `const double* t = xlArr;` or
+// `const double& a = xlArr[0];` -- has no tangent, since the const pointer
+// parameter it aliases cannot have one either. Forward mode used to fabricate
+// one anyway: a null pointer typed `const double*`, later dereferenced, or a
+// reference bound to the literal 0. Both broke the Hessian, whose reverse pass
+// then built a `double*` adjoint out of a `const double*` initializer, or
+// bound a `double&` adjoint to a temporary.
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+double ptr_alias(double* params, double const* xlArr) {
+  double const* t = xlArr;
+  return params[0] * params[0] * t[0] + params[0] * params[1] * t[1];
+}
+
+// The alias gets no tangent of its own; uses of it derive to a plain 0.
+// CHECK: double ptr_alias_darg0_0(double *params, const double *xlArr) {
+// CHECK-NEXT: const double *t = xlArr;
+
+double ref_alias(double* params, double const* xlArr) {
+  double const& a = xlArr[0];
+  double const& b = 3.;
+  return params[0] * params[0] * a * b;
+}
+
+// CHECK: double ref_alias_darg0_0(double *params, const double *xlArr) {
+// CHECK-NEXT: const double &a = xlArr[0];
+// CHECK-NEXT: const double &b = 3.;
+
+// The shape this was reported with: RooFit's code generation emits such
+// aliases inside a checkpointed loop.
+double loop_alias(double* params, double const* xlArr) {
+  double sum = 0.;
+#pragma clad checkpoint loop
+  for (int i = 0; i < 2; i++) {
+    unsigned int idx = i;
+    double const* t = xlArr + 1 * idx;
+    sum += params[0] * params[0] * t[0];
+  }
+  return sum;
+}
+
+// CHECK: double loop_alias_darg0_0(double *params, const double *xlArr) {
+// CHECK: unsigned int idx = i;
+// CHECK-NEXT: const double *t = xlArr + 1 * idx;
+
+// A `const double&` bound to a literal broke plain reverse mode as well.
+double ref_to_literal(double* params) {
+  double const& r = 5.;
+  return params[0] * r;
+}
+
+// CHECK: void ref_to_literal_grad(double *params, double *_d_params) {
+// CHECK-NEXT: const double &r = 5.;
+// CHECK-NEXT: _d_params[0] += 1 * r;
+
+// CHECK: void ptr_alias_darg0_0_grad_0_0(double *params, const double *xlArr, double *_d_params) {
+// CHECK-NEXT: const double *t = xlArr;
+
+int main() {
+  double params[2] = {2., 3.};
+  double xlArr[2] = {5., 7.};
+
+  double m[4] = {};
+  clad::hessian(ptr_alias, "params[0:1]").execute(params, xlArr, m);
+  printf("ptr_alias %.2f %.2f %.2f %.2f\n", m[0], m[1], m[2], m[3]);
+  // CHECK-EXEC: ptr_alias 10.00 7.00 7.00 0.00
+
+  double m2[1] = {};
+  clad::hessian(ref_alias, "params[0]").execute(params, xlArr, m2);
+  printf("ref_alias %.2f\n", m2[0]);
+  // CHECK-EXEC: ref_alias 30.00
+
+  double m3[1] = {};
+  clad::hessian(loop_alias, "params[0]").execute(params, xlArr, m3);
+  printf("loop_alias %.2f\n", m3[0]);
+  // CHECK-EXEC: loop_alias 24.00
+
+  double d = 0.;
+  clad::gradient(ref_to_literal, "params[0]").execute(params, &d);
+  printf("ref_to_literal %.2f\n", d);
+  // CHECK-EXEC: ref_to_literal 5.00
+
+  printf("ptr_alias_darg %.2f\n",
+         clad::differentiate(ptr_alias, "params[0]").execute(params, xlArr));
+  // CHECK-EXEC: ptr_alias_darg 41.00
+}


### PR DESCRIPTION
A local `const double*` or `const double&` bound to a const pointer parameter has no tangent, because the parameter it aliases cannot have one. Forward mode fabricated one regardless: a null pointer literal typed `const double*`, or a reference bound to the literal 0.

The null tangent was then dereferenced in the generated derivative, and both shapes broke `clad::hessian()`, whose reverse pass builds adjoints without the const and so tried to initialize a `double*` from a `const double*`, or bind a `double&` to a temporary.

Leave such declarations without a tangent instead, matching what reverse mode already does, so uses of them derive to a plain zero. Reverse mode gets the same lvalue check for reference adjoints, which fixes `const double& r = 5.;` breaking `clad::gradient()` on its own.

Fixes #1955