### PR TITLE
Keep member calls with active args differentiable on a non-tangent base

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1077,15 +1077,44 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
         baseOriginalE = OCE->getArg(0);
       baseDiff = Visit(baseOriginalE);
       Expr* baseDerivative = baseDiff.getExpr_dx();
-      // A base that does not depend on the differentiation variable has no
-      // tangent, hence no pushforward to call, and contributes nothing to the
-      // directional derivative.
-      if (!baseDerivative || baseDerivative->getType()->isVoidType())
-        return StmtDiff(Clone(CE),
-                        getZeroInit(CE->getType().getNonReferenceType()));
-      if (!baseDerivative->getType()->isPointerType())
-        baseDerivative = BuildOp(UnaryOperatorKind::UO_AddrOf, baseDerivative);
-      diffArgs.push_back(baseDerivative);
+      if (!baseDerivative || baseDerivative->getType()->isVoidType()) {
+        // The base does not depend on the differentiation variable and has no
+        // tangent. The call may still contribute to the directional derivative
+        // through its arguments: consult the activity information of the
+        // DiffRequest to find out. If no argument is varied either, the call
+        // contributes nothing.
+        bool anyVariedArg = false;
+        for (unsigned i = isa<CXXOperatorCallExpr>(CE) ? 1 : 0,
+                      e = CE->getNumArgs();
+             i < e; ++i) {
+          const Expr* arg = CE->getArg(i);
+          if (utils::IsDifferentiableType(arg->getType()) &&
+              m_DiffReq.isVaried(arg)) {
+            anyVariedArg = true;
+            break;
+          }
+        }
+        if (!anyVariedArg)
+          return StmtDiff(Clone(CE),
+                          getZeroInit(CE->getType().getNonReferenceType()));
+        // The arguments drive the derivative through the pushforward, whose
+        // `_d_this` slot must stay filled: pass a zero-initialized
+        // placeholder, mirroring the zero adjoint reverse mode synthesizes
+        // for such a base.
+        QualType baseTy = baseOriginalE->getType();
+        if (baseTy->isPointerType())
+          baseTy = baseTy->getPointeeType();
+        baseTy = baseTy.getNonReferenceType().getUnqualifiedType();
+        VarDecl* dBaseVD = BuildVarDecl(baseTy, "_d_base", getZeroInit(baseTy));
+        addToCurrentBlock(BuildDeclStmt(dBaseVD));
+        diffArgs.push_back(
+            BuildOp(UnaryOperatorKind::UO_AddrOf, BuildDeclRef(dBaseVD)));
+      } else {
+        if (!baseDerivative->getType()->isPointerType())
+          baseDerivative =
+              BuildOp(UnaryOperatorKind::UO_AddrOf, baseDerivative);
+        diffArgs.push_back(baseDerivative);
+      }
     }
   }
 
@@ -1390,8 +1419,13 @@ StmtDiff BaseForwardModeVisitor::VisitUnaryOperator(const UnaryOperator* UnOp) {
         op, ConstantFolder::synthesizeLiteral(literalTy, m_Context, /*val=*/0));
   } else if (opKind == UnaryOperatorKind::UO_AddrOf) {
     Expr* derivedOp = diff.getExpr_dx();
-    if (derivedOp)
-      derivedOp = BuildOp(opKind, diff.getExpr_dx());
+    // A subexpression without a tangent of its own (e.g. an object that does
+    // not depend on the differentiation variable) yields a synthesized zero
+    // init, which is an rvalue and has no address.
+    if (derivedOp && !derivedOp->getType()->isVoidType())
+      derivedOp = BuildOp(opKind, derivedOp);
+    else
+      derivedOp = nullptr;
     return StmtDiff(op, derivedOp);
   } else if (opKind == UnaryOperatorKind::UO_LNot) {
     Expr* zero = getZeroInit(UnOp->getType());
@@ -1844,11 +1878,14 @@ BaseForwardModeVisitor::VisitCXXNamedCastExpr(const CXXNamedCastExpr* NCE) {
           .BuildCXXNamedCast(Loc, CastKind, TSI, subExprDiff.getExpr(),
                              Brackets, Range)
           .get();
-  Expr* castExprDiff =
-      m_Sema
-          .BuildCXXNamedCast(Loc, CastKind, TSI, subExprDiff.getExpr_dx(),
-                             Brackets, Range)
-          .get();
+  // A subexpression without a tangent (e.g. the address of an object that
+  // does not depend on the differentiation variable) has nothing to cast.
+  Expr* subExprDx = subExprDiff.getExpr_dx();
+  Expr* castExprDiff = nullptr;
+  if (subExprDx && !subExprDx->getType()->isVoidType())
+    castExprDiff =
+        m_Sema.BuildCXXNamedCast(Loc, CastKind, TSI, subExprDx, Brackets, Range)
+            .get();
   return StmtDiff(castExpr, castExprDiff);
 }
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2476,7 +2476,29 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             }
           }
         }
-        if (Expr* baseDerivative = baseDiff.getExpr_dx()) {
+        Expr* baseDerivative = baseDiff.getExpr_dx();
+        // A synthesized zero init (e.g. the `0` a pointer base without an
+        // adjoint differentiates to) is an rvalue whose address cannot be
+        // taken; treat it as an absent adjoint.
+        if (baseDerivative && !baseDerivative->getType()->isPointerType() &&
+            !baseDerivative->isLValue())
+          baseDerivative = nullptr;
+        if (!baseDerivative && !nonDiff) {
+          // The base has no adjoint of its own -- e.g. a read-only global, or
+          // an object reached through a cast address. The `_d_this` slot of
+          // the pullback must stay filled nonetheless: pass a zero-initialized
+          // placeholder whose contribution is discarded.
+          QualType dBaseTy = baseOriginalE->getType();
+          if (dBaseTy->isPointerType())
+            dBaseTy = dBaseTy->getPointeeType();
+          dBaseTy =
+              utils::getNonConstType(dBaseTy.getNonReferenceType(), m_Sema);
+          VarDecl* dBaseDecl =
+              BuildVarDecl(dBaseTy, "_r", getZeroInit(dBaseTy));
+          PreCallStmts.push_back(BuildDeclStmt(dBaseDecl));
+          baseDerivative = BuildDeclRef(dBaseDecl);
+        }
+        if (baseDerivative) {
           if (!baseDerivative->getType()->isPointerType())
             baseDerivative = BuildOp(UO_AddrOf, baseDerivative);
           CallArgDx.push_back(baseDerivative);

--- a/test/ForwardMode/NonActiveCallBase.cpp
+++ b/test/ForwardMode/NonActiveCallBase.cpp
@@ -38,8 +38,58 @@ double reads_nonactive(double x) {
 
 // CHECK: double reads_nonactive_darg0(double x) {
 
+// A base without a tangent must not zero out the whole call when an argument
+// is active: the pushforward still has to run, with a zero placeholder
+// filling the `_d_this` slot (issue #1960).
+struct Sq {
+  double operator()(double v) const { return v * v; }
+};
+
+static Sq sq;
+
+double active_arg(double x) { return sq(x); }
+
+// CHECK: double active_arg_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     Sq _d_base = {};
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = sq.operator_call_pushforward(x, &_d_base, _d_x);
+// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT: }
+
+// The same shape reached through a cast address, as JIT-generated wrappers
+// produce when referring to an object living in the host process.
+double cast_base(double x) {
+  return reinterpret_cast<Sq const*>(&sq)->operator()(x);
+}
+
+// CHECK: double cast_base_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     Sq _d_base = {};
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = reinterpret_cast<const Sq *>(&sq)->operator_call_pushforward(x, &_d_base, _d_x);
+// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT: }
+
+// When neither the base nor any argument is varied, the call really does
+// contribute nothing: a zero derivative is returned and no pushforward is
+// emitted.
+double inactive_arg(double x) { return x + sq(2.0); }
+
+// CHECK: double inactive_arg_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     return _d_x + 0.;
+// CHECK-NEXT: }
+
 int main() {
   auto dx = clad::differentiate(reads_nonactive, "x");
   // d/dx sum_i x * g(i) = sum_i g(i) = 9
   printf("%.2f\n", dx.execute(1.5)); // CHECK-EXEC: 9.00
+
+  auto dsq = clad::differentiate(active_arg, "x");
+  printf("%.2f\n", dsq.execute(3.)); // CHECK-EXEC: 6.00
+
+  auto dcast = clad::differentiate(cast_base, "x");
+  printf("%.2f\n", dcast.execute(3.)); // CHECK-EXEC: 6.00
+
+  auto dinactive = clad::differentiate(inactive_arg, "x");
+  printf("%.2f\n", dinactive.execute(3.)); // CHECK-EXEC: 1.00
 }

--- a/test/Gradient/NonActiveCallBase.C
+++ b/test/Gradient/NonActiveCallBase.C
@@ -1,0 +1,36 @@
+// RUN: %cladclang %s -I%S/../../include -oNonActiveCallBase.out 2>&1 | %filecheck %s
+// RUN: ./NonActiveCallBase.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oNonActiveCallBase.out
+// RUN: ./NonActiveCallBase.out | %filecheck_exec %s
+
+// Reverse mode over a member call whose base is a pointer baked into the
+// source as an integer literal, as JIT-generated wrappers do for objects
+// living in the host process. Such a base differentiates to a plain `0` -- an
+// rvalue whose address cannot be taken -- which must count as an absent
+// adjoint: a zero-initialized placeholder fills the `_d_this` slot of the
+// pullback instead (issue #1960).
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+struct Sq {
+  double operator()(double v) const { return v * v; }
+};
+
+// The method reads no object state, so the baked-in address is never
+// dereferenced -- the call only routes the active argument.
+double addr_lit(double x) {
+  return reinterpret_cast<Sq const *>(0x40)->operator()(x);
+}
+
+// CHECK: void addr_lit_grad(double x, double *_d_x) {
+// CHECK: Sq _r0 = {};
+// CHECK: reinterpret_cast<const Sq *>(64)->operator_call_pullback(x, 1, &_r0, &_r1);
+// CHECK: *_d_x += _r1;
+
+int main() {
+  double dx = 0;
+  clad::gradient(addr_lit, "x").execute(3., &dx);
+  printf("%.2f\n", dx); // CHECK-EXEC: 6.00
+}

--- a/test/Hessian/NonActiveCallBase.C
+++ b/test/Hessian/NonActiveCallBase.C
@@ -1,0 +1,50 @@
+// RUN: %cladclang %s -I%S/../../include -oNonActiveCallBase.out 2>&1 | %filecheck %s
+// RUN: ./NonActiveCallBase.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oNonActiveCallBase.out
+// RUN: ./NonActiveCallBase.out | %filecheck_exec %s
+
+// Regression test for issue #1960: a Hessian routed through the pushforward of
+// a member call whose base object has no tangent. The forward pass must call
+// the pushforward with a zero placeholder for `_d_this` instead of yielding a
+// zero derivative, and the reverse pass over that pushforward must keep the
+// adjoint-of-`this` slot of the pullback filled even though the base has no
+// adjoint of its own.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+struct Functor {
+  double operator()(double x) const { return x * x; }
+};
+
+// gFunc is only read, never differentiated with respect to.
+Functor gFunc;
+
+double helper(double x) { return gFunc(x); }
+double func(double *p) { return helper(p[0]) * p[1]; }
+
+// CHECK: void helper_pushforward_pullback(double x, double _d_x, clad::ValueAndPushforward<double, double> _d_y, double *_d_x0, double *_d_d_x) {
+// CHECK: Functor _r0 = {};
+// CHECK: gFunc.operator_call_pushforward_pullback(x, &_d_base, _d_x, _d_t0, &_r0, &_r1, &_d_d_base, &_r2);
+
+// The same shape reached through a cast address, as JIT-generated wrappers
+// produce when referring to an object living in the host process.
+double helperCast(double x) {
+  return reinterpret_cast<Functor const *>(&gFunc)->operator()(x);
+}
+double funcCast(double *p) { return helperCast(p[0]) * p[1]; }
+
+int main() {
+  double p[2] = {3., 5.};
+
+  double h[4] = {0., 0., 0., 0.};
+  clad::hessian(func, "p[0:1]").execute(p, h);
+  printf("%.2f %.2f %.2f %.2f\n", h[0], h[1], h[2], h[3]);
+  // CHECK-EXEC: 10.00 6.00 6.00 0.00
+
+  double hCast[4] = {0., 0., 0., 0.};
+  clad::hessian(funcCast, "p[0:1]").execute(p, hCast);
+  printf("%.2f %.2f %.2f %.2f\n", hCast[0], hCast[1], hCast[2], hCast[3]);
+  // CHECK-EXEC: 10.00 6.00 6.00 0.00
+}


### PR DESCRIPTION
Since c18a748a, forward mode yields a zero derivative as soon as the base object of a member/operator call has no tangent, before the call arguments are even visited. That is only correct when no argument is active either: gFunc(x) with a read-only global gFunc still depends on x, so the derivative was silently zeroed, hessians lost the rows routed through a pushforward, and no custom pushforward was ever looked up (issue #1960).

Defer the bail-out until the arguments have been visited. If none of them has a tangent, keep returning zero. Otherwise call the pushforward with a zero-initialized placeholder filling the _d_this slot, mirroring the zero adjoint reverse mode synthesizes for a read-only base.

The reverse pass over such a pushforward hit the second half of the bug: when the base has no adjoint -- as in hessians, where global-adjoint discovery does not run over the clad-generated pushforward -- the adjoint-of-this argument was dropped from the pullback call, emitting ill-formed code ("too few arguments to function call") and skewing the CallArgDx indexing used to classify differentiable params. Synthesize the same kind of zero placeholder there, and treat a non-addressable zero literal (the int 0 a cast pointer base differentiates to) as an absent adjoint instead of taking its address.

Also guard the forward-mode UO_AddrOf and CXXNamedCastExpr visitors against subexpressions without a tangent: they used to build &<void rvalue> and feed a null Expr* into Sema::BuildCXXNamedCast, which emitted "cannot take the address of an rvalue" and could segfault on
reinterpret_cast<T*>(&global)->call(x).

Fixes #1960.