### PR TITLE
Hoist reverse_forw scaffolding to function scope

### DIFF
--- a/include/clad/Differentiator/RestoreTracker.h
+++ b/include/clad/Differentiator/RestoreTracker.h
@@ -1,6 +1,10 @@
 #ifndef CLAD_DIFFERENTIATOR_RESTORETRACKER_H
 #define CLAD_DIFFERENTIATOR_RESTORETRACKER_H
 
+// CUDA_HOST_DEVICE is only used under __CUDACC__, so include-cleaner cannot
+// see the use in a non-CUDA parse.
+#include "clad/Differentiator/CladConfig.h" // IWYU pragma: keep
+
 #include <cassert>
 #include <cstdint>
 #include <cstring>
@@ -38,9 +42,9 @@ class restore_tracker {
   size_t m_cnt = 0, m_off = 0;
 
 public:
-  __host__ __device__ restore_tracker() = default;
+  CUDA_HOST_DEVICE restore_tracker() = default;
 
-  template <typename T> __host__ __device__ void store(const T& val) {
+  template <typename T> CUDA_HOST_DEVICE void store(const T& val) {
     for (size_t i = 0; i < m_cnt; ++i)
       if (m_meta[i].addr == (char*)&val)
         return;
@@ -56,11 +60,15 @@ public:
     m_cnt++;
   }
 
-  __host__ __device__ void restore() {
+  CUDA_HOST_DEVICE void restore() {
     for (size_t i = 0; i < m_cnt; ++i)
       std::memcpy(m_meta[i].addr, m_buf + m_meta[i].off, m_meta[i].size);
     m_cnt = m_off = 0;
   }
+
+  // Drop all records without writing anything back. Emitted where a
+  // block-local tracker declaration used to (re-)initialize the tracker.
+  CUDA_HOST_DEVICE void clear() { m_cnt = m_off = 0; }
 #else
   using RawMemory = std::vector<uint8_t>;
   using Address = char*;
@@ -88,6 +96,10 @@ public:
     }
     m_data.clear();
   }
+
+  // Drop all records without writing anything back. Emitted where a
+  // block-local tracker declaration used to (re-)initialize the tracker.
+  void clear() { m_data.clear(); }
 #endif
 };
 } // namespace clad

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2773,15 +2773,22 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         } else {
           // Otherwise, generate the declaration
           // ``clad::restore_tracker _tracker0 = {};``
-          VarDecl* trackerDecl = nullptr;
-          if (isInsideLoop || m_DiffReq.hasEarlyReturns()) {
-            trackerDecl = GlobalStoreImpl(trackerType, "_tracker",
-                                          getZeroInit(trackerType));
-          } else {
-            trackerDecl =
-                BuildVarDecl(trackerType, "_tracker", getZeroInit(trackerType));
-            addToCurrentBlock(BuildDeclStmt(trackerDecl));
-          }
+          // The declaration must live at function scope: the matching
+          // restore() below goes into the reverse sweep, which for a call
+          // inside a loop or branch is a different block than the forward
+          // one, so a block-local declaration would leave the reverse-sweep
+          // reference out of scope. A clear() at the former declaration
+          // point keeps the old per-visit semantics (only state recorded
+          // since the last forward visit is restored).
+          // FIXME: a single tracker serving all iterations of a reversed
+          // loop only restores the last iteration's state; full generality
+          // needs per-iteration taping of the tracker.
+          VarDecl* trackerDecl = GlobalStoreImpl(trackerType, "_tracker",
+                                                 getZeroInit(trackerType));
+          Expr* clearCall = BuildCallExprToMemFn(BuildDeclRef(trackerDecl),
+                                                 /*MemberFunctionName=*/"clear",
+                                                 /*ArgExprs=*/{}, Loc);
+          addToCurrentBlock(clearCall);
           trackerExpr = BuildDeclRef(trackerDecl);
           Expr* restoreCall = BuildCallExprToMemFn(
               BuildDeclRef(trackerDecl), /*MemberFunctionName=*/"restore",

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2807,25 +2807,72 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // synthesized for a function clad cannot actually differentiate (an
       // operation reached through an opaque type). Fall through to recreating
       // the original call rather than storing a null expression.
-      if (!needsForwPass ||
-          (!dfdx() && utils::hasUnusedReturnValue(m_Context, CE)))
-        return StmtDiff(call);
-      Expr* callRes = nullptr;
-      if (isInsideLoop || m_DiffReq.hasEarlyReturns())
-        callRes = GlobalStoreAndRef(call, /*prefix=*/"_t", /*force=*/true);
-      else
-        callRes = StoreAndRef(call);
-      auto* resValue =
-          utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes, "value");
-      // Clone the base so `_t0.value` and `_t0.adjoint` own distinct nodes.
-      auto* resAdjoint = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
-                                                CloneNode(callRes), "adjoint");
-      if (Expr* add_assign = BuildDiffIncrement(resAdjoint)) {
-        Stmts& block = getCurrentBlock(direction::reverse);
-        it = std::begin(block) + insertionPoint;
-        block.insert(it, add_assign);
+      if (call) {
+        if (!needsForwPass ||
+            (!dfdx() && utils::hasUnusedReturnValue(m_Context, CE)))
+          return StmtDiff(call);
+        Expr* callRes = nullptr;
+        Expr* resValue = nullptr;
+        Expr* resAdjoint = nullptr;
+        // The adjoint increment built below goes into the reverse sweep.
+        // For a call inside a sub-block that is a different block than the
+        // forward one, so a block-local store would be out of scope there.
+        // Early returns wrap the reverse sweep in lambdas, which must not
+        // capture block-locals either. In both cases hoist the store to
+        // function scope. A result with reference members cannot be hoisted
+        // whole: a reference cannot be declared unset and assigned later.
+        // Store it block-locally instead and hoist pointers to the
+        // referents, which outlive the block; both sweeps then go through
+        // the pointers. (With early returns GlobalStoreAndRef tapes the
+        // ValueAndAdjoint store, which also handles reference members.)
+        // FIXME: a result mixing reference and non-reference members (only
+        // producible by a custom reverse_forw) still emits the block-local
+        // form and trips the use-before-declaration integrity check: a
+        // pointer into the block-local struct would dangle.
+        bool anyRef = false;
+        bool allRefs = true;
+        if (const auto* RD = call->getType()->getAsCXXRecordDecl())
+          for (const FieldDecl* FD : RD->fields()) {
+            anyRef |= FD->getType()->isReferenceType();
+            allRefs &= FD->getType()->isReferenceType();
+          }
+        bool tapeStore = isInsideLoop || m_DiffReq.hasEarlyReturns();
+        if (!tapeStore &&
+            (getCurrentScope()->isFunctionScope() || (anyRef && !allRefs)))
+          callRes = StoreAndRef(call);
+        else if (tapeStore || !anyRef)
+          callRes = GlobalStoreAndRef(call, /*prefix=*/"_t",
+                                      /*force=*/true);
+        else {
+          callRes = StoreAndRef(call);
+          Expr* valueAddr = BuildOp(
+              UO_AddrOf, utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                                callRes, "value"));
+          Expr* adjointAddr = BuildOp(
+              UO_AddrOf, utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                                CloneNode(callRes), "adjoint"));
+          resValue = BuildOp(UO_Deref, GlobalStoreAndRef(valueAddr,
+                                                         /*prefix=*/"_t",
+                                                         /*force=*/true));
+          resAdjoint = BuildOp(UO_Deref, GlobalStoreAndRef(adjointAddr,
+                                                           /*prefix=*/"_t",
+                                                           /*force=*/true));
+        }
+        if (!resValue) {
+          resValue = utils::BuildMemberExpr(m_Sema, getCurrentScope(), callRes,
+                                            "value");
+          // Clone the base so `_t0.value` and `_t0.adjoint` own distinct
+          // nodes.
+          resAdjoint = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                              CloneNode(callRes), "adjoint");
+        }
+        if (Expr* add_assign = BuildDiffIncrement(resAdjoint)) {
+          Stmts& block = getCurrentBlock(direction::reverse);
+          it = std::begin(block) + insertionPoint;
+          block.insert(it, add_assign);
+        }
+        return StmtDiff(resValue, resAdjoint);
       }
-      return StmtDiff(resValue, resAdjoint);
     } // Recreate the original call expression.
 
     if (const auto* OCE = dyn_cast<CXXOperatorCallExpr>(CE)) {

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4297,8 +4297,16 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     VarDecl* VD = BuildGlobalVarDecl(Type, prefix);
     DeclStmt* decl = BuildDeclStmt(VD);
     Expr* Ref = BuildDeclRef(VD);
+    // The merged decl+init form is only valid when the decl lands in the
+    // function-body block: the returned Ref may be used from sibling or outer
+    // blocks (e.g. a short-circuit condition rebuilt outside the scaffolding
+    // block that evaluated it). In reverse_mode_forward_pass the Sema scope is
+    // not a reliable proxy -- an `if` scaffold opens a control scope while the
+    // store may still be requested for an outer-block consumer -- so require
+    // the forward block stack to actually be at the function body.
     bool isFnScope = getCurrentScope()->isFunctionScope() ||
-                     m_DiffReq.Mode == DiffMode::reverse_mode_forward_pass;
+                     (m_DiffReq.Mode == DiffMode::reverse_mode_forward_pass &&
+                      m_Blocks.size() == 1);
     if (isFnScope) {
       addToCurrentBlock(decl, direction::forward);
       SetDeclInit(VD, E);

--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -323,9 +323,10 @@ double f10(double x){
 // CHECK-NEXT: }
 
 // CHECK-NEXT: void f10_grad(double x, double *_d_x) {
+// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
 // CHECK-NEXT:     double _d_t[3] = {0};
 // CHECK-NEXT:     double t[3];
-// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     _tracker0.clear();
 // CHECK-NEXT:     f10_1_reverse_forw(x, t, 0., _d_t, _tracker0);
 // CHECK-NEXT:     _d_t[0] += 1;
 // CHECK-NEXT:     {

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -146,9 +146,10 @@ float sum(double* arr, int n) {
 }
 
 // CHECK: float sum_reverse_forw(double *arr, int n, double *_d_arr, int _d_n, clad::restore_tracker &_tracker0) {
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     float _d_res = 0;
 // CHECK-NEXT:     float res = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     _t0 = 0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     for (int i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
@@ -891,7 +892,8 @@ void mult(double* x, double y) {
 }
 
 // CHECK: void mult_reverse_forw(double *x, double y, double *_d_x, double _d_y, clad::restore_tracker &_tracker0) {
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
+// CHECK-NEXT:     _t0 = 0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     for (int i = 0; i < 3; ++i) {
 // CHECK-NEXT:         _t0++;

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -207,12 +207,13 @@ double fn4(double* arr, int n) {
 }
 
 // CHECK: void fn4_grad(double *arr, int n, double *_d_arr, int *_d_n) {
+// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     _tracker0.clear();
 // CHECK-NEXT:     res += sum_reverse_forw(arr, n, _d_arr, 0, _tracker0);
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
@@ -270,6 +271,7 @@ double fn5(double* arr, int n) {
 
 // CHECK: void fn5_grad(double *arr, int n, double *_d_arr, int *_d_n) {
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     _tracker0.clear();
 // CHECK-NEXT:     double _d_temp = 0.;
 // CHECK-NEXT:     double temp = modify2_reverse_forw(arr, _d_arr, _tracker0);
 // CHECK-NEXT:     _d_arr[0] += 1;
@@ -932,11 +934,12 @@ double fn27(double u, double v) {
 } // u * v + u
 
 // CHECK-NEXT: void fn27_grad(double u, double v, double *_d_u, double *_d_v) {
+// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
 // CHECK-NEXT:     double _d_arr[3] = {0};
 // CHECK-NEXT:     double arr[3] = {u, v, 1};
 // CHECK-NEXT:     double _d_sum = 0.;
 // CHECK-NEXT:     double sum0 = arr[0] * arr[1] * arr[2];
-// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     _tracker0.clear();
 // CHECK-NEXT:     mult_reverse_forw(arr, u, _d_arr, 0., _tracker0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_sum += 1;
@@ -973,8 +976,10 @@ double& nested(double* x, double y) {
 
 // CHECK-NEXT: void nested_pullback(double *x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
-// CHECK-NEXT:     mult_reverse_forw(x, y, _d_x, 0., _tracker0);
 // CHECK-NEXT:     clad::restore_tracker _tracker1 = {};
+// CHECK-NEXT:     _tracker0.clear();
+// CHECK-NEXT:     mult_reverse_forw(x, y, _d_x, 0., _tracker0);
+// CHECK-NEXT:     _tracker1.clear();
 // CHECK-NEXT:     mult_reverse_forw(x, 3, _d_x, 0, _tracker1);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _tracker1.restore();
@@ -997,9 +1002,10 @@ double fn28(double u, double v) {
 } // 3 * u * v + 2
 
 // CHECK-NEXT: void fn28_grad(double u, double v, double *_d_u, double *_d_v) {
+// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
 // CHECK-NEXT:     double _d_arr[3] = {0};
 // CHECK-NEXT:     double arr[3] = {u, v, 1};
-// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     _tracker0.clear();
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t0 = nested_reverse_forw(arr, u, _d_arr, 0., _tracker0);
 // CHECK-NEXT:     double &_d_ref = _t0.adjoint;
 // CHECK-NEXT:     double &ref = _t0.value;
@@ -1046,6 +1052,7 @@ double fn29(double *x) {
 
 // CHECK: void fn29_grad(double *x, double *_d_x) {
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     _tracker0.clear();
 // CHECK-NEXT:     foo_reverse_forw(x, _d_x, _tracker0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_x[0] += 1 * x[1];

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -460,6 +460,7 @@ double fn2(SimpleFunctions& sf, double i) {
 
 // CHECK: void fn2_grad(SimpleFunctions &sf, double i, SimpleFunctions *_d_sf, double *_d_i) {
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     _tracker0.clear();
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t0 = sf.ref_mem_fn_reverse_forw(i, _d_sf, 0., _tracker0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _t0.adjoint += 1;
@@ -498,6 +499,7 @@ double fn5(SimpleFunctions& v, double value) {
 
 // CHECK: void fn5_grad(SimpleFunctions &v, double value, SimpleFunctions *_d_v, double *_d_value) {
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     _tracker0.clear();
 // CHECK-NEXT:     v.operator_plus_equal_reverse_forw(value, _d_v, 0., _tracker0);
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
@@ -530,6 +532,7 @@ double fn4(SimpleFunctions& v) {
 
 // CHECK: void fn4_grad(SimpleFunctions &v, SimpleFunctions *_d_v) {
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     _tracker0.clear();
 // CHECK-NEXT:     v.operator_plus_plus_reverse_forw(_d_v, _tracker0);
 // CHECK-NEXT:     (*_d_v).x += 1;
 // CHECK-NEXT:     {
@@ -722,13 +725,14 @@ double fn11(double u, double v) {
 }
 
 // CHECK:  void fn11_grad(double u, double v, double *_d_u, double *_d_v) {
+// CHECK-NEXT:      clad::restore_tracker _tracker0 = {};
 // CHECK-NEXT:      double _d_res = 0.;
 // CHECK-NEXT:      double res = 0;
 // CHECK-NEXT:      A _d_a = {0.};
 // CHECK-NEXT:      A a;
 // CHECK-NEXT:      a.setData(u);
 // CHECK-NEXT:      res += a.data * v;
-// CHECK-NEXT:      clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:      _tracker0.clear();
 // CHECK-NEXT:      a.increment_reverse_forw(&_d_a, _tracker0);
 // CHECK-NEXT:      _d_res += 1;
 // CHECK-NEXT:      {

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -410,9 +410,10 @@ double nestedPtrFn (double x, double y) {
 }
 
 // CHECK: void nestedPtrFn_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
 // CHECK-NEXT:     double _d_arr[2] = {0};
 // CHECK-NEXT:     double arr[2] = {x, y};
-// CHECK-NEXT:     clad::restore_tracker _tracker0 = {}; 
+// CHECK-NEXT:     _tracker0.clear();
 // CHECK-NEXT:     clad::ValueAndAdjoint<double *, double *> _t0 = ptrValFn_reverse_forw(arr, 1, _d_arr, 0, _tracker0);
 // CHECK-NEXT:     double *_d_z = _t0.adjoint;
 // CHECK-NEXT:     double *z = _t0.value;

--- a/test/Gradient/ReverseForw.C
+++ b/test/Gradient/ReverseForw.C
@@ -198,6 +198,83 @@ double f4(double x) {
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
+// For a reverse_forw call inside a branch the ValueAndAdjoint store must also
+// be hoisted to function scope: the `.adjoint` use goes into the reverse
+// sweep, which is a different block than the forward `if`.
+double f5(double x, int flag) {
+  double r = x;
+  if (flag)
+    r += *mul2(&x);
+  return r;
+}
+
+//CHECK: void f5_grad_0(double x, int flag, double *_d_x) {
+//CHECK-NEXT:     int _d_flag = 0;
+//CHECK-NEXT:     bool _cond0;
+//CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+//CHECK-NEXT:     clad::ValueAndAdjoint<double *, double *> _t0;
+//CHECK-NEXT:     double _d_r = 0.;
+//CHECK-NEXT:     double r = x;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         _cond0 = flag;
+//CHECK-NEXT:         if (_cond0) {
+//CHECK-NEXT:             _tracker0.clear();
+//CHECK-NEXT:             _t0 = mul2_reverse_forw(&x, _d_x, _tracker0);
+//CHECK-NEXT:             r += *_t0.value;
+//CHECK-NEXT:         }
+//CHECK-NEXT:     }
+//CHECK-NEXT:     _d_r += 1;
+//CHECK-NEXT:     if (_cond0) {
+//CHECK-NEXT:         *_t0.adjoint += _d_r;
+//CHECK-NEXT:         _tracker0.restore();
+//CHECK-NEXT:         mul2_pullback(&x, _d_x);
+//CHECK-NEXT:     }
+//CHECK-NEXT:     *_d_x += _d_r;
+//CHECK-NEXT: }
+
+// A reference-typed ValueAndAdjoint cannot be hoisted whole (a reference
+// member cannot be declared unset and assigned afterwards); the store stays
+// block-local and pointers to the referents are hoisted instead, so the
+// reverse sweep stays in scope.
+double& amplify(double& x) {
+  x *= 2;
+  return x;
+}
+
+double f6(double x, int flag) {
+  double r = x;
+  if (flag)
+    r += amplify(x);
+  return r;
+}
+
+//CHECK: void f6_grad_0(double x, int flag, double *_d_x) {
+//CHECK-NEXT:     int _d_flag = 0;
+//CHECK-NEXT:     bool _cond0;
+//CHECK-NEXT:     double _t0;
+//CHECK-NEXT:     double *_t2;
+//CHECK-NEXT:     double *_t3;
+//CHECK-NEXT:     double _d_r = 0.;
+//CHECK-NEXT:     double r = x;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         _cond0 = flag;
+//CHECK-NEXT:         if (_cond0) {
+//CHECK-NEXT:             _t0 = x;
+//CHECK-NEXT:             clad::ValueAndAdjoint<double &, double &> _t1 = amplify_reverse_forw(x, *_d_x);
+//CHECK-NEXT:             _t2 = &_t1.value;
+//CHECK-NEXT:             _t3 = &_t1.adjoint;
+//CHECK-NEXT:             r += *_t2;
+//CHECK-NEXT:         }
+//CHECK-NEXT:     }
+//CHECK-NEXT:     _d_r += 1;
+//CHECK-NEXT:     if (_cond0) {
+//CHECK-NEXT:         *_t3 += _d_r;
+//CHECK-NEXT:         x = _t0;
+//CHECK-NEXT:         amplify_pullback(x, _d_x);
+//CHECK-NEXT:     }
+//CHECK-NEXT:     *_d_x += _d_r;
+//CHECK-NEXT: }
+
 int main() {
   double dx = 0;
   INIT_GRADIENT(f1);
@@ -214,4 +291,14 @@ int main() {
   dx = 0;
   INIT_GRADIENT(f4);
   TEST_GRADIENT(f4, /*numOfDerivativeArgs=*/1, 1, &dx); // CHECK-EXEC: 6.00
+
+  dx = 0;
+  INIT_GRADIENT(f5, "x");
+  TEST_GRADIENT(f5, /*numOfDerivativeArgs=*/1, 1, 1, &dx); // CHECK-EXEC: 3.00
+
+  dx = 0;
+  INIT_GRADIENT(f6, "x");
+  TEST_GRADIENT(f6, /*numOfDerivativeArgs=*/1, 1, 1, &dx); // CHECK-EXEC: 3.00
+  dx = 0;
+  TEST_GRADIENT(f6, /*numOfDerivativeArgs=*/1, 1, 0, &dx); // CHECK-EXEC: 1.00
 }

--- a/test/Gradient/ReverseForw.C
+++ b/test/Gradient/ReverseForw.C
@@ -64,6 +64,7 @@ double f1(double x) {
 
 //CHECK: void f1_grad(double x, double *_d_x) {
 //CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+//CHECK-NEXT:     _tracker0.clear();
 //CHECK-NEXT:     clad::ValueAndAdjoint<double *, double *> _t0 = nested_reverse_forw(&x, -6, _d_x, 0, _tracker0);
 //CHECK-NEXT:     {
 //CHECK-NEXT:         *_t0.adjoint += 1;
@@ -158,6 +159,45 @@ double f3(double x) {
   return arr[0];
 }
 
+// For a reverse_forw call inside a loop the tracker declaration must sit at
+// function scope: the matching restore() goes into the reverse sweep, which is
+// a different block. A clear() at the former declaration point keeps the
+// per-visit semantics.
+double* mul2(double* p) {
+  *p *= 2;
+  return p;
+}
+
+double f4(double x) {
+  double r = 0;
+  for (int i = 0; i < 2; ++i)
+    r += *mul2(&x);
+  return r;
+}
+
+//CHECK: void f4_grad(double x, double *_d_x) {
+//CHECK-NEXT:     int _d_i = 0;
+//CHECK-NEXT:     int i = 0;
+//CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+//CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double *, double *> > _t1 = {};
+//CHECK-NEXT:     double _d_r = 0.;
+//CHECK-NEXT:     double r = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     for (i = 0; i < 2; ++i) {
+//CHECK-NEXT:         _t0++;
+//CHECK-NEXT:         _tracker0.clear();
+//CHECK-NEXT:         clad::push(_t1, mul2_reverse_forw(&x, _d_x, _tracker0));
+//CHECK-NEXT:         r += *clad::back(_t1).value;
+//CHECK-NEXT:     }
+//CHECK-NEXT:     _d_r += 1;
+//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:         *clad::back(_t1).adjoint += _d_r;
+//CHECK-NEXT:         _tracker0.restore();
+//CHECK-NEXT:         mul2_pullback(&x, _d_x);
+//CHECK-NEXT:         clad::pop(_t1);
+//CHECK-NEXT:     }
+//CHECK-NEXT: }
+
 int main() {
   double dx = 0;
   INIT_GRADIENT(f1);
@@ -170,4 +210,8 @@ int main() {
   dx = 0;
   INIT_GRADIENT(f3);
   TEST_GRADIENT(f3, /*numOfDerivativeArgs=*/1, 1, &dx); // CHECK-EXEC: 6.00
+
+  dx = 0;
+  INIT_GRADIENT(f4);
+  TEST_GRADIENT(f4, /*numOfDerivativeArgs=*/1, 1, &dx); // CHECK-EXEC: 6.00
 }

--- a/test/Gradient/ReverseForw.C
+++ b/test/Gradient/ReverseForw.C
@@ -17,10 +17,11 @@ double* nested(double* p, int n) {
 }
 
 //CHECK: clad::ValueAndAdjoint<double *, double *> nested_reverse_forw(double *p, int n, double *_d_p, int _d_n, clad::restore_tracker &_tracker0) {
+//CHECK-NEXT:     bool _cond0;
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         bool _cond0 = n > 0;
+//CHECK-NEXT:         _cond0 = n > 0;
 //CHECK-NEXT:         if (_cond0)
 //CHECK-NEXT:             i = 1;
 //CHECK-NEXT:         else
@@ -84,8 +85,9 @@ double* filter(double* p, State s) {
 }
 
 //CHECK: clad::ValueAndAdjoint<double *, double *> filter_reverse_forw(double *p, State s, double *_d_p, State _d_s) {
+//CHECK-NEXT:     bool _cond0 = false;
 //CHECK-NEXT:     {
-//CHECK-NEXT:         bool _cond0 = s == State::should_return;
+//CHECK-NEXT:         _cond0 = s == State::should_return;
 //CHECK-NEXT:         if (_cond0)
 //CHECK-NEXT:             return {p, _d_p};
 //CHECK-NEXT:     }
@@ -121,6 +123,41 @@ double f2(double x) {
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
+// A short-circuit condition builds an `if (L) _cond = R` scaffold whose blocks
+// nest; the condition rebuilt from the stored flags is placed in the enclosing
+// block, so the flag stores must be hoisted instead of being declared inside
+// the scaffold block.
+void scale(double* C, double alpha, double beta) {
+  if (alpha != 0. || (beta != 0. && C != nullptr))
+    C[0] *= alpha * beta;
+}
+
+//CHECK: void scale_reverse_forw(double *C, double alpha, double beta, double *_d_C, double _d_alpha, double _d_beta, clad::restore_tracker &_tracker0) {
+//CHECK-NEXT:     bool _cond0;
+//CHECK-NEXT:     double _d_cond0;
+//CHECK-NEXT:     _d_cond0 = 0.;
+//CHECK-NEXT:     bool _cond1;
+//CHECK-NEXT:     bool _cond2;
+//CHECK-NEXT:     {
+//CHECK-NEXT:         {
+//CHECK-NEXT:             _cond1 = beta != 0.;
+//CHECK-NEXT:             if (_cond1)
+//CHECK-NEXT:                 _cond0 = C != nullptr;
+//CHECK-NEXT:         }
+//CHECK-NEXT:         _cond2 = alpha != 0. || (_cond1 && _cond0);
+//CHECK-NEXT:         if (_cond2) {
+//CHECK-NEXT:             _tracker0.store(C[0]);
+//CHECK-NEXT:             C[0] *= alpha * beta;
+//CHECK-NEXT:         }
+//CHECK-NEXT:     }
+//CHECK-NEXT: }
+
+double f3(double x) {
+  double arr[1] = {x};
+  scale(arr, 2., 3.);
+  return arr[0];
+}
+
 int main() {
   double dx = 0;
   INIT_GRADIENT(f1);
@@ -129,4 +166,8 @@ int main() {
   dx = 0;
   INIT_GRADIENT(f2);
   TEST_GRADIENT(f2, /*numOfDerivativeArgs=*/1, 3, &dx); // CHECK-EXEC: 1.00
+
+  dx = 0;
+  INIT_GRADIENT(f3);
+  TEST_GRADIENT(f3, /*numOfDerivativeArgs=*/1, 1, &dx); // CHECK-EXEC: 6.00
 }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -430,6 +430,7 @@ MyStruct fn12(MyStruct s) {  // expected-warning {{clad::gradient only supports 
 
 // CHECK: void fn12_grad(MyStruct s, MyStruct *_d_s) {
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     _tracker0.clear();
 // CHECK-NEXT:     s.operator_equal_reverse_forw({2 * s.a, 2 * s.b + 2}, _d_s, {0., 0.}, _tracker0);
 // CHECK-NEXT:    {
 // CHECK-NEXT:        _tracker0.restore();
@@ -711,6 +712,7 @@ void fn20(MyStruct s) {
 
 // CHECK: void fn20_grad(MyStruct s, MyStruct *_d_s) {
 // CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     _tracker0.clear();
 // CHECK-NEXT:     s.operator_equal_reverse_forw({2 * s.a, 2 * s.b + 2}, _d_s, {0., 0.}, _tracker0);
 // CHECK-NEXT:    {
 // CHECK-NEXT:        _tracker0.restore();
@@ -977,6 +979,7 @@ struct MyStructWrapper {
 
 // CHECK:  inline constexpr void operator_equal_pullback(MyStructWrapper &&arg, MyStructWrapper *_d_this, MyStructWrapper *_d_arg) noexcept {
 // CHECK-NEXT:      clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:      _tracker0.clear();
 // CHECK-NEXT:      this->val.operator_equal_reverse_forw(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, std::move((*_d_arg).val), _tracker0);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          _tracker0.restore();
@@ -991,9 +994,10 @@ double fn27(double x, double y) {
 }
 
 // CHECK:  void fn27_grad(double x, double y, double *_d_x, double *_d_y) {
+// CHECK-NEXT:      clad::restore_tracker _tracker0 = {};
 // CHECK-NEXT:      MyStructWrapper _d_s = {{.*0., 0..*}};
 // CHECK-NEXT:      MyStructWrapper s;
-// CHECK-NEXT:      clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:      _tracker0.clear();
 // CHECK-NEXT:      s.operator_equal_reverse_forw({{.*2 \* y, 3 \* x \+ 2.*}}, &_d_s, {{.*0., 0..*}}, _tracker0);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          _d_s.val.a += 1 * s.val.b;


### PR DESCRIPTION
Three fixes for the same bug shape: a variable that a `reverse_forw` call declares in the current forward block, while the matching statement in the reverse sweep lives in a different block. When the call sits inside a branch or a loop, the reverse-sweep reference names a variable that is out of scope there, which trips the use-before-declaration integrity check (assert in debug, warning in release) and produces uncompilable derivatives.

The three declarations, one commit each:

- **`GlobalStoreAndRef` in `reverse_mode_forward_pass`** assumed the current block is the function body and merged declaration with initializer. It isn't: a short-circuit condition builds a nested `if (L) _cond = R` scaffold, and the condition rebuilt from the stored flag is placed in the enclosing block. Take the shortcut only when the forward block stack is actually at the function body. Found via the `reverse_forw` of SOFIE's `Gemm_Call` pushforward.
- **The restore tracker** (`_tracker0`) is now declared at function scope, with a `clear()` at the former declaration point to preserve the per-visit semantics. Found via the pullback of SOFIE's `doInfer` helper.
- **The `ValueAndAdjoint` result store** is hoisted the same way, as an unset declaration plus an assignment at the call point. Results holding references cannot be declared unset, so for those we keep the struct store block-local and hoist pointers to the referents instead — member access through a reference field yields the referent, which outlives the block, and both sweeps go through the pointers.

New coverage in `test/Gradient/ReverseForw.C` for each case; the existing expectations there shift where the hoists changed the printed output.

Two limitations are left as FIXMEs in the code: a single hoisted tracker still restores only the last iteration's state for a reversed loop (unchanged from before this PR; full generality needs per-iteration taping), and a `reverse_forw` result mixing reference and non-reference members — only producible by a custom `reverse_forw` — keeps the block-local form, since a pointer into that struct would dangle.