### PR TITLE
Add support for WebAssembly build of clad

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,3 +607,40 @@ jobs:
         name: observes-change-summary
         path: observes-change-summary.json
         if-no-files-found: ignore
+
+  build-wasm:
+    timeout-minutes: 30
+    name: ubu24-emscr-runtime22
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Setup emsdk
+      uses: emscripten-core/setup-emsdk@v16
+      with:
+        # The emsdk pin must match the llvm-wasm cell.
+        version: '4.0.9'
+
+    - name: Setup LLVM/Clang/LLD built for wasm
+      uses: compiler-research/ci-workflows/actions/setup-recipe@main
+      with:
+        recipe: llvm-wasm
+        version: '22'
+        os: ubuntu-24.04
+        arch: x86_64
+
+    - name: Build Clad for wasm
+      run: |
+        LLVM_BUILD_DIR="$(pwd)/install/build"
+        mkdir obj && cd obj
+        emcmake cmake -DCMAKE_BUILD_TYPE=Release \
+          -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm \
+          -DClang_DIR=$LLVM_BUILD_DIR/lib/cmake/clang \
+          -DLLD_DIR=$LLVM_BUILD_DIR/lib/cmake/lld \
+          -DCLAD_BUILD_STATIC_ONLY=ON \
+          -DLLVM_ENABLE_WERROR=On \
+          $GITHUB_WORKSPACE
+        emmake make -j$(nproc)
+
+    - name: Run the unittests under node
+      run: emmake make -j$(nproc) -C obj check-clad

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,12 @@ add_definitions( -D_GNU_SOURCE
   -DCLAD_INSTDIR_INCL="${CLAD_BINARY_DIR}/include" )
 
 option(CLAD_BUILD_STATIC_ONLY "Does not build shared libraries. Useful when we have LLVM_ENABLE_PLUGINS=OFF (eg. Win or CYGWIN)" OFF)
+
+if (EMSCRIPTEN)
+  # For the test executables and googletest only; the LLVM-style archive
+  # targets append -fno-exceptions, which emcc >= 4 rejects alongside wasm-EH.
+  set(CLAD_EXTRA_WASM_FLAGS "-fwasm-exceptions" CACHE STRING "Extra flags for wasm")
+endif()
 if (NOT CLAD_BUILD_STATIC_ONLY AND NOT LLVM_ENABLE_PLUGINS)
   message(FATAL_ERROR "LLVM_ENABLE_PLUGINS is set to OFF. Please build clad with -DCLAD_BUILD_STATIC_ONLY=ON.")
 endif()
@@ -378,6 +384,8 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
     set(CMAKE_CXX_FLAGS ${stored_cxx_flags})
     set(CMAKE_C_FLAGS ${stored_c_flags})
   endif()
+elseif (EMSCRIPTEN AND NOT CLAD_DISABLE_TESTS)
+  add_subdirectory(unittests)
 endif()
 
 # Workaround for MSVS10 to avoid the Dialog Hell

--- a/cmake/modules/AddClad.cmake
+++ b/cmake/modules/AddClad.cmake
@@ -26,36 +26,40 @@ function(ENABLE_CLAD_FOR_TARGET executable)
     message(FATAL_ERROR "'${executable}' is not a valid target.")
   endif()
 
-  # Add the clad plugin
-  target_compile_options(${executable} PUBLIC -fplugin=$<TARGET_FILE:clad>)
+  if (TARGET clad)
+    # Add the clad plugin
+    target_compile_options(${executable} PUBLIC -fplugin=$<TARGET_FILE:clad>)
 
-  # Debugging. Emitting the derivatives' source code.
-  #target_compile_options(${executable} PUBLIC "SHELL:-Xclang -plugin-arg-clad"
-  #  "SHELL: -Xclang -fdump-derived-fn")
+    # Debugging. Emitting the derivatives' source code.
+    #target_compile_options(${executable} PUBLIC "SHELL:-Xclang -plugin-arg-clad"
+    #  "SHELL: -Xclang -fdump-derived-fn")
 
-  # Debugging. Emit llvm IR.
-  #target_compile_options(${executable} PUBLIC -S -emit-llvm)
+    # Debugging. Emit llvm IR.
+    #target_compile_options(${executable} PUBLIC -S -emit-llvm)
 
-  # Debugging. Optimization misses.
-  #target_compile_options(${executable} PUBLIC "SHELL:-Xclang -Rpass-missed=.*inline.*")
+    # Debugging. Optimization misses.
+    #target_compile_options(${executable} PUBLIC "SHELL:-Xclang -Rpass-missed=.*inline.*")
+
+    add_dependencies(${executable} clad)
+
+    # If clad.so changes we don't need to relink but to rebuild the source files.
+    # $<TARGET_FILE:clad> does not work for OBJECT_DEPENDS.
+    set (CLAD_SO_PATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/clad${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    set_source_files_properties(${source_files} PROPERTY OBJECT_DEPENDS ${CLAD_SO_PATH})
+  endif()
 
   # Clad requires us to link against these libraries.
-  target_link_libraries(${executable} PUBLIC stdc++ pthread m)
+  if (NOT EMSCRIPTEN)
+    target_link_libraries(${executable} PUBLIC stdc++ pthread m)
+  endif()
 
   target_include_directories(${executable} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
   set_property(TARGET ${executable} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-
-  add_dependencies(${executable} clad)
 
   if (NOT CLAD_BUILT_STANDALONE)
     # We are probably building clad with clang. Make sure we've built clang.
     add_dependencies(${executable} clang)
   endif()
-
-  # If clad.so changes we don't need to relink but to rebuild the source files.
-  # $<TARGET_FILE:clad> does not work for OBJECT_DEPENDS.
-  set (CLAD_SO_PATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/clad${CMAKE_SHARED_LIBRARY_SUFFIX}")
-  set_source_files_properties(${source_files} PROPERTY OBJECT_DEPENDS ${CLAD_SO_PATH})
 
   # Add dependencies to executable
   if(ARG_DEPENDS)
@@ -274,6 +278,10 @@ function(clad_externalproject_add NAME)
 
   # Everything EXCEPT EXTRA_CMAKE_ARGS gets forwarded unchanged
   set(FORWARDED_ARGS ${ARG_UNPARSED_ARGUMENTS})
+
+  if (DEFINED CMAKE_TOOLCHAIN_FILE)
+    list(APPEND ARG_EXTRA_CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
+  endif()
 
   ExternalProject_Add(${NAME}
     GIT_SHALLOW ON # Do not clone the history

--- a/cmake/modules/CladGoogleTest.cmake
+++ b/cmake/modules/CladGoogleTest.cmake
@@ -17,14 +17,24 @@ if(MSVC)
 elseif(APPLE)
   set(EXTRA_GTEST_OPTS -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
                        -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES})
+elseif(EMSCRIPTEN)
+  set(EXTRA_GTEST_OPTS -Dgtest_disable_pthreads=ON)
 endif()
 
 set(EXTRA_CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} ${EXTRA_GTEST_OPTS}")
+
+set(_gtest_build_command ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release -- -j6)
+if(EMSCRIPTEN)
+  # gtest appends -fexceptions, which resolves the EH scheme to emscripten JS
+  # exceptions; EMCC_CFLAGS lands after it, as in the llvm-wasm build.
+  set(_gtest_build_command ${CMAKE_COMMAND} -E env "EMCC_CFLAGS=${CLAD_EXTRA_WASM_FLAGS}"
+      ${_gtest_build_command})
+endif()
 clad_externalproject_add(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG v1.17.0
-  BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release -- -j6
+  BUILD_COMMAND ${_gtest_build_command}
   # Disable install step
   INSTALL_COMMAND cmake -E echo "Skipping install step."
   BUILD_BYPRODUCTS ${_gtest_byproducts}

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,6 +1,13 @@
 add_custom_target(CladUnitTests)
 set_target_properties(CladUnitTests PROPERTIES FOLDER "Clad tests")
 
+if (EMSCRIPTEN)
+  enable_testing()
+  add_custom_target(check-clad COMMAND ${CMAKE_CTEST_COMMAND} -V
+    DEPENDS CladUnitTests WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  set_target_properties(check-clad PROPERTIES FOLDER "Clad tests")
+endif()
+
 # LLVM builds (not installed llvm) provides gtest.
 if (NOT TARGET gtest)
   include(CladGoogleTest)
@@ -39,15 +46,25 @@ function(add_clad_unittest test_dirname)
   endif()
 
   target_link_libraries(${test_dirname} PUBLIC ${gtest_libs})
+
+  if (EMSCRIPTEN)
+    target_compile_options(${test_dirname} PUBLIC "SHELL:${CLAD_EXTRA_WASM_FLAGS}")
+    target_link_options(${test_dirname} PUBLIC "SHELL:${CLAD_EXTRA_WASM_FLAGS}")
+    add_test(NAME clad-${test_dirname} COMMAND $ENV{EMSDK_NODE} ${test_dirname}.js)
+    set_tests_properties(clad-${test_dirname} PROPERTIES TIMEOUT 240)
+  endif()
 endfunction()
 
 add_subdirectory(Basic)
 
-find_package(Kokkos)
-if (Kokkos_FOUND)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-  add_subdirectory(Kokkos)
-endif(Kokkos_FOUND)
+# Misc and Kokkos compile with -fplugin=clad.so; only Basic is header-only.
+if (NOT EMSCRIPTEN)
+  find_package(Kokkos)
+  if (Kokkos_FOUND)
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+    add_subdirectory(Kokkos)
+  endif(Kokkos_FOUND)
 
-add_subdirectory(Misc)
+  add_subdirectory(Misc)
+endif()


### PR DESCRIPTION
Emscripten builds are static-only (emscripten LLVM has LLVM_ENABLE_PLUGINS=OFF), so there is no clad
MODULE to drive the lit suite or the plugin-compiled unittests and the test tree was skipped entirely.
The Basic unittests exercise only the headers, so they now cross-compile and run under node; Misc and
Kokkos stay native-only.

Adds a ubuntu-24.04 job that builds clad against a prebuilt emscripten LLVM 22 (the llvm-wasm artifact
CppInterOp's emscripten CI uses, emsdk 4.0.9) with LLVM_ENABLE_WERROR=On and runs the Basic unittests
under node. Also verified against an emscripten-built LLVM 20.1.8 locally; the native suites are
unaffected (LLVM 21).
