### PR TITLE
Index the delayed-calls planning loop to survive re-entrant appends

### DIFF
--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -638,9 +638,14 @@ void InitTimers();
       // In case of diagnostics, don't bother, just let the compiler finish.
       if (!m_CI.getDiagnostics().hasErrorOccurred()) {
         // Traverse all collected DeclGroupRef only once to create the static
-        // graph.
-        TimedAnalysisRegion R("Rest of TU");
-        for (auto DCI : m_DelayedCalls)
+        // graph. Planning can trigger implicit instantiations (e.g. clad::Tag
+        // when parsing the differentiate-call arguments) whose consumer
+        // notifications append to m_DelayedCalls mid-loop; deque::push_back
+        // keeps element references valid but invalidates iterators, so index
+        // instead of iterating (the appended groups are then planned too).
+        // NOLINTNEXTLINE(modernize-loop-convert)
+        for (size_t i = 0; i < m_DelayedCalls.size(); ++i) {
+          const DelayedCallInfo DCI = m_DelayedCalls[i];
           for (Decl* D : DCI.m_DGR) {
             if (const auto* FD = dyn_cast<FunctionDecl>(D))
               if (FD->isConstexpr())
@@ -648,6 +653,7 @@ void InitTimers();
             getScheduler().Plan(DCI.m_DGR);
             break;
           }
+        }
 
         if (m_CI.getFrontendOpts().ShowStats) {
           // Print the graph of the diff requests.


### PR DESCRIPTION
The TU-end planning loop iterated std::deque m_DelayedCalls with a range-for while its body can grow the container: Plan() can trigger an implicit instantiation (clad::Tag, while parsing the differentiate-call arguments) whose HandleTagDeclDefinition notification lands in AppendDelayed mid-loop. deque::push_back keeps element references valid but invalidates iterators, so whenever the push made the deque grow its block map the loop's cached iterators dangled and the next element read faulted. Whether that reallocation happens depends on the total number of delayed calls, which is why the crash only reproduced on the ubuntu-22.04 llvm-12/13 CI rows (deterministic there, at HandleTranslationUnit+137 on the movups copying the DelayedCallInfo) and nowhere else. Iterate by index instead; groups appended mid-loop are then planned as well, which is a no-op for decls outside the clad-activation interval.