### PR TITLE
Defer decl groups delivered while a planning traversal is in flight

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -405,14 +405,30 @@ struct RequestOptions {
 
     bool m_IsTraversingTopLevelDecl = true;
 
+    /// True while Walk is traversing a DeclGroupRef. A traversal can trigger
+    /// name lookups that make the ASTReader deserialize pending module decls
+    /// and hand them to the consumers, re-entering Walk; such groups are
+    /// parked in m_DeferredDGRs and traversed once the active walk finishes.
+    bool m_TraversalInFlight = false;
+
+    /// Decl groups delivered while a traversal was in flight (see
+    /// m_TraversalInFlight); drained at the end of the outermost Walk.
+    llvm::SmallVector<clang::DeclGroupRef, 4> m_DeferredDGRs;
+
   public:
     DiffCollector(DiffInterval& Interval,
                   clad::DynamicGraph<DiffRequest>& requestGraph, clang::Sema& S,
                   RequestOptions& opts, OwnedAnalysisContexts& AllAnalysisDC);
     /// Run the static planning pass over a group of top-level declarations,
     /// populating the request graph. A no-op when the clad-enabled interval is
-    /// empty.
+    /// empty. Re-entrant calls (e.g. module decls deserialized during a
+    /// lookup issued by an active traversal) defer their group until the
+    /// active traversal finishes.
     void Walk(clang::DeclGroupRef DGR);
+    /// True while Walk is traversing; see m_TraversalInFlight.
+    [[nodiscard]] bool isTraversalInFlight() const {
+      return m_TraversalInFlight;
+    }
     bool VisitCallExpr(clang::CallExpr* E);
     bool VisitDeclRefExpr(clang::DeclRefExpr* DRE);
     /// Record an in-place `p = realloc(p, n)` on the request whose body is

--- a/include/clad/Differentiator/DiffScheduler.h
+++ b/include/clad/Differentiator/DiffScheduler.h
@@ -39,6 +39,13 @@ public:
   /// Static planning pass over a group of top-level declarations.
   void Plan(clang::DeclGroupRef DGR) { m_Collector.Walk(DGR); }
 
+  /// True while a static planning traversal is on the stack; work that would
+  /// process requests (e.g. immediate constexpr differentiation) must not run
+  /// re-entrantly while this holds.
+  [[nodiscard]] bool isTraversalInFlight() const {
+    return m_Collector.isTraversalInFlight();
+  }
+
   /// Plan a single lazily-scheduled request (a nested or higher-order
   /// derivative) that the static walk never reached.
   void Plan(DiffRequest& R) { m_Collector.PlanNestedRequest(R); }

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -46,6 +46,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
@@ -329,10 +330,33 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     if (m_Interval.empty())
       return;
 
+    // A lookup issued mid-traversal (LookupCustomDerivativeDecl, analyses)
+    // can make the ASTReader deserialize pending module decls and hand them
+    // to the consumers, re-entering Walk while the active traversal -- and
+    // possibly a top-most request -- is still on the stack. Traversing them
+    // now would interleave collector state; park them until the active walk
+    // is done. (Deserialized decls lie outside the clad-activation interval,
+    // so the deferred traversal is a no-op for them beyond bookkeeping.)
+    if (m_TraversalInFlight) {
+      m_DeferredDGRs.push_back(DGR);
+      return;
+    }
+    llvm::SaveAndRestore<bool> InFlight(m_TraversalInFlight, true);
+
     assert(!m_TopMostReq && "Traversal already in flight!");
 
     for (Decl* D : DGR)
       TraverseDecl(D);
+
+    // Drain groups delivered during this walk (which may itself deliver
+    // more, growing the vector mid-loop -- hence indexed, not range-based).
+    // NOLINTNEXTLINE(modernize-loop-convert)
+    for (size_t i = 0; i < m_DeferredDGRs.size(); ++i) {
+      DeclGroupRef Deferred = m_DeferredDGRs[i];
+      for (Decl* D : Deferred)
+        TraverseDecl(D);
+    }
+    m_DeferredDGRs.clear();
   }
 
   bool DiffCollector::TraverseLambdaExpr(LambdaExpr* LE) {

--- a/test/Misc/CustomDerivativeFromModule.C
+++ b/test/Misc/CustomDerivativeFromModule.C
@@ -1,0 +1,41 @@
+// Tests that a custom derivative that lives in a C++ module is found and used:
+// the module decl is only deserialized by the lookup the planning traversal
+// issues, i.e. while the traversal is on the stack. This mirrors the setup in
+// which ROOT's runtime C++ modules re-enter CladPlugin::HandleTopLevelDecl
+// mid-traversal (there the deserialized decls are handed straight to the
+// consumers, so the delivered groups must be parked until the active walk
+// finishes). Under a plain clang plugin invocation the reader delivers them
+// through HandleInterestingDecl instead, which clad only queues -- so this
+// test cannot reproduce the re-entrant Walk itself; it pins down the lazy
+// module-deserialization path that leads up to it.
+//
+// The module map is passed explicitly, and -fno-implicit-module-maps is
+// required on top of that because -fmodules implies -fimplicit-module-maps:
+// implicit module-map discovery would also modularize the standard library on
+// some hosts (macOS), whose module builds emit diagnostics that this test's
+// FileCheck run forbids.
+//
+// RUN: rm -rf %t
+// RUN: %cladclang -fmodules -fimplicit-modules -fno-implicit-module-maps \
+// RUN:   -fmodule-map-file=%S/Inputs/CustomDerivativeFromModule/module.modulemap \
+// RUN:   -fmodules-cache-path=%t/cache -I%S/Inputs/CustomDerivativeFromModule \
+// RUN:   %s -I%S/../../include -o%t/CustomDerivativeFromModule.out 2>&1 | %filecheck %s
+// RUN: %t/CustomDerivativeFromModule.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include "custom.h"
+
+double opaque(double& x) { return 2. * x; }
+
+double fn(double x) { return opaque(x); }
+
+// CHECK: void fn_grad(double x, double *_d_x) {
+// CHECK-NEXT:     clad::custom_derivatives::opaque_pullback(x, 1, _d_x);
+// CHECK-NEXT: }
+
+int main() {
+  auto grad = clad::gradient(fn);
+  double dx = 0;
+  grad.execute(3.0, &dx);
+  printf("Result is:%.2f\n", dx); // CHECK-EXEC: Result is:2.00
+}

--- a/test/Misc/Inputs/CustomDerivativeFromModule/custom.h
+++ b/test/Misc/Inputs/CustomDerivativeFromModule/custom.h
@@ -1,0 +1,7 @@
+namespace clad {
+namespace custom_derivatives {
+inline void opaque_pullback(double& x, double _d_y, double* _d_x) {
+  *_d_x += 2. * _d_y;
+}
+} // namespace custom_derivatives
+} // namespace clad

--- a/test/Misc/Inputs/CustomDerivativeFromModule/module.modulemap
+++ b/test/Misc/Inputs/CustomDerivativeFromModule/module.modulemap
@@ -1,0 +1,1 @@
+module CustomDerivatives { header "custom.h" export * }

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -221,18 +221,27 @@ void InitTimers();
         }
       }
 
-      for (DiffRequest& request : getScheduler().getGraph().getNodes()) {
-        if (request.ImmediateMode && request.Function->isConstexpr()) {
-          getScheduler().getGraph().setCurrentProcessingNode(request);
-          ProcessDiffRequest(request);
-          getScheduler().getGraph().markCurrentNodeProcessed();
+      // This handler can be re-entered while a planning traversal is on the
+      // stack: a lookup issued by the traversal makes the ASTReader
+      // deserialize pending module decls and pass them to the consumers. The
+      // Plan call above then defers the group; processing requests here would
+      // interleave with the outer traversal (and clobber its current
+      // processing node), so leave them to the outer caller.
+      if (!getScheduler().isTraversalInFlight())
+        for (DiffRequest& request : getScheduler().getGraph().getNodes()) {
+          if (request.ImmediateMode && request.Function->isConstexpr()) {
+            getScheduler().getGraph().setCurrentProcessingNode(request);
+            ProcessDiffRequest(request);
+            getScheduler().getGraph().markCurrentNodeProcessed();
+          }
         }
-      }
 #endif
 
       // We could not delay the processing of derivatives, act as if each
       // call is final. That would still have vgvassilev/clad#248 unresolved.
-      if (!m_Multiplexer && !m_CI.getDiagnostics().hasErrorOccurred())
+      // Not on re-entry (see above): the outer traversal finalizes.
+      if (!m_CI.getDiagnostics().hasErrorOccurred() &&
+          !getScheduler().isTraversalInFlight() && !m_Multiplexer)
         FinalizeTranslationUnit();
     }
 


### PR DESCRIPTION
DiffCollector::Walk asserts that no traversal is already running, but it can be re-entered through the AST reader: a name lookup issued mid-traversal (LookupCustomDerivativeDecl, the analyses) makes the reader deserialize pending module decls and pass the interesting ones straight to the consumers, which lands in
CladPlugin::HandleTopLevelDecl -> Plan -> Walk while the outer walk -- and possibly its top-most request -- is still on the stack:

  DiffCollector::VisitCallExpr
    LookupCustomDerivativeDecl
      Sema::LookupQualifiedName
        ASTReader::FindExternalVisibleDeclsByName
          ASTReader::PassInterestingDeclsToConsumer
            CladPlugin::HandleTopLevelDecl
              DiffScheduler::Plan
                DiffCollector::Walk   // re-entered

Seen with ROOT's runtime C++ modules, where the second RooFit codegen fit in a process hits a lookup that flushes pending module decls. Traversing the group immediately would interleave collector state, so park it and drain it when the outermost walk finishes; deserialized decls lie outside the clad-activation interval, so the deferred traversal is a no-op for them beyond bookkeeping. The plugin's immediate constexpr processing and its no-multiplexer finalization are guarded the same way -- re-entrant ProcessDiffRequest would clobber the graph's current processing node.