### PR TITLE
Clone the callee and arguments into the numerical-diff fallback call

### DIFF
--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -1018,9 +1018,12 @@ namespace clad {
     bool isSupported = argType->isArithmeticType();
     if (!isSupported)
       return nullptr;
-    // Build function args.
+    // Build function args. The callee and argument expressions the caller
+    // hands in may still be parented by the rebuilt primal call (the forward
+    // mode passes them straight out of it), so clone every expression that is
+    // embedded in the numerical-diff call.
     llvm::SmallVector<Expr*, 16U> NumDiffArgs;
-    NumDiffArgs.push_back(targetFuncCall);
+    NumDiffArgs.push_back(CloneNode(targetFuncCall));
     // targetArg is also the value passed through `args` below (and embedded in
     // targetFuncCall); clone it so the numerical-diff call does not share it.
     NumDiffArgs.push_back(CloneNode(targetArg));
@@ -1030,7 +1033,8 @@ namespace clad {
     NumDiffArgs.push_back(ConstantFolder::synthesizeLiteral(m_Context.IntTy,
                                                             m_Context,
                                                             printErrorInf));
-    NumDiffArgs.insert(NumDiffArgs.end(), args.begin(), args.begin() + numArgs);
+    for (unsigned i = 0; i < numArgs; ++i)
+      NumDiffArgs.push_back(CloneNode(args[i]));
     // Return the found overload.
     std::string Name = "forward_central_difference";
     return m_Builder.BuildCallToCustomDerivativeOrNumericalDiff(

--- a/test/NumericalDiff/NumDiff.C
+++ b/test/NumericalDiff/NumDiff.C
@@ -17,11 +17,27 @@ double test_1(double x){
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
+// In forward mode the primal call is rebuilt and returned next to the
+// numerical-diff call, which must clone the callee and arguments instead of
+// sharing them with the rebuilt call.
+double test_2(double x){
+  return x * std::tgamma(x); // expected-warning {{attempted differentiation of function 'tgamma' without definition and no suitable overload was found in namespace 'custom_derivatives'}}
+  // expected-note@-1 {{falling back to numerical differentiation for 'tgamma'}}
+}
+
+//CHECK: double test_2_darg0(double x) {
+//CHECK-NEXT:     double _d_x = 1;
+//CHECK-NEXT:     double _t0 = std::tgamma(x);
+//CHECK-NEXT:     return _d_x * _t0 + x * (numerical_diff::forward_central_difference(std::tgamma, x, 0, 0, x) * _d_x);
+//CHECK-NEXT: }
+
 int main(){
   auto df = clad::gradient(test_1);
 
   double x = 0.5, dx = 0;
   df.execute(x, &dx);
-  printf("Result is:%f", dx); // CHECK-EXEC: Result is:-3.480231
-  
+  printf("Result is:%f\n", dx); // CHECK-EXEC: Result is:-3.480231
+
+  auto df2 = clad::differentiate(test_2, "x");
+  printf("Result is:%f\n", df2.execute(3.0)); // CHECK-EXEC: Result is:7.536706
 }


### PR DESCRIPTION
When forward mode cannot derive a call (e.g. one whose arguments are all literals, for which the planner schedules no pushforward), it rebuilds the primal call and asks GetSingleArgCentralDiffCall for a forward_central_difference call to use as the derivative. The callee it passes is taken straight out of the rebuilt primal call, and the primal argument expressions are appended as the trailing call arguments, so the generated pushforward held the same callee ImplicitCastExpr and the same argument subtree under two parents:

  double _t6 = std::sqrt(2 * M_PI);   // primal
  ... numerical_diff::forward_central_difference(
          std::sqrt /*shared*/, 2 * M_PI /*clone*/, 0, 0,
          2 * M_PI /*shared*/) * 0 ...

Seen with clad::hessian of RooFit's lognormal likelihoods; the shared nodes trip the derivative integrity check (and any later in-place edit of one user would corrupt the other). Clone the callee and every forwarded argument; the middle targetArg was already cloned.