### PR TITLE
Clone the stored divisor into the div-assign pullback product

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3383,7 +3383,11 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         if (isInsideLoop)
           // Clone: LCloned is reused as the primal compound-assignment LHS.
           addToCurrentBlock(CloneNode(LCloned), direction::forward);
-        Expr* RxR = BuildParens(BuildOp(BO_Mul, RStored, CloneNode(RStored)));
+        // RStored may be the un-stored reverse-sweep expr itself (StoreAndRef
+        // passes simple refs through), which is reused as the primal RHS via
+        // RResult below; clone both factors so RxR shares nothing with it.
+        Expr* RxR = BuildParens(
+            BuildOp(BO_Mul, CloneNode(RStored), CloneNode(RStored)));
         // Clone LCloned (reused as the primal compound-assignment LHS below).
         Expr* dr = BuildOp(
             BO_Mul, CloneNode(oldValue),

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -829,6 +829,32 @@ short int f25(short int x, short int y) {
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
+// /= with a plain-variable divisor, which reaches the pullback un-stored and
+// must be cloned into the `(y * y)` denominator instead of being shared with
+// the rebuilt primal compound assignment.
+double f26(double x, double y) {
+  double l = x;
+  l /= y;
+  return l;
+}
+
+//CHECK: void f26_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK-NEXT:    double _d_l = 0.;
+//CHECK-NEXT:    double l = x;
+//CHECK-NEXT:    double _t0 = l;
+//CHECK-NEXT:    l /= y;
+//CHECK-NEXT:    _d_l += 1;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        l = _t0;
+//CHECK-NEXT:        double _r_d0 = _d_l;
+//CHECK-NEXT:        _d_l = 0.;
+//CHECK-NEXT:        _d_l += _r_d0 / y;
+//CHECK-NEXT:        double _r0 = _r_d0 * -l / (y * y);
+//CHECK-NEXT:        *_d_y += _r0;
+//CHECK-NEXT:    }
+//CHECK-NEXT:    *_d_x += _d_l;
+//CHECK-NEXT:}
+
 #define TEST(F, x, y)                                                          \
   {                                                                            \
     result[0] = 0;                                                             \
@@ -917,4 +943,6 @@ int main() {
   short int grad_x = 0, grad_y = 0;
   f25_grad.execute(x, y, &grad_x, &grad_y);
   printf("{%d, %d}\n", grad_x, grad_y); // CHECK-EXEC: {4, 0}
+
+  TEST(f26, 8, 2); // CHECK-EXEC: {0.50, -2.00}
 }


### PR DESCRIPTION
For `l /= r` with a divisor StoreAndRef passes through un-stored (a plain variable reference), RStored is the very expression RResult later places into the rebuilt primal compound assignment. Its first use in the `(r * r)` denominator of the pullback was not cloned, so the derivative held one DeclRefExpr under two parents:

  t19 /= t20;                          // primal, uses the node
  _d_t19 += _r_d6 / t20;               // cloned, fine
  _r26 = _r_d6 * -(t19 / (t20 * t20)); // first t20 shared with the primal

Seen with the RooFit codegen gradient in stressRooFit; trips the derivative integrity check. Clone both factors.