### PR TITLE
Parenthesize compound reverse-sweep exprs in the printed pullbacks

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3355,16 +3355,20 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         Rdiff = Visit(R, dr);
         Stmts RBlock = EndBlockWithoutCreatingCS(direction::reverse);
         // Rdiff.getRevSweepAsExpr() aliases the forward expr returned below;
-        // clone at each reverse-sweep use so they own distinct nodes.
+        // clone at each reverse-sweep use so they own distinct nodes. It can
+        // also be an un-stored compound expr (`l *= a + b`), so parenthesize
+        // it wherever it is embedded under a higher-precedence operator or
+        // the printed derivative mis-associates.
         addToCurrentBlock(
             BuildOp(BO_AddAssign, CloneNode(ResultRef),
                     BuildOp(BO_Mul, CloneNode(oldValue),
-                            CloneNode(Rdiff.getRevSweepAsExpr()))),
+                            BuildParens(CloneNode(Rdiff.getRevSweepAsExpr())))),
             direction::reverse);
         for (auto& S : RBlock)
           addToCurrentBlock(S, direction::reverse);
-        valueForRevPass = BuildOp(BO_Mul, CloneNode(Rdiff.getRevSweepAsExpr()),
-                                  CloneNode(Ldiff.getRevSweepAsExpr()));
+        valueForRevPass =
+            BuildOp(BO_Mul, BuildParens(CloneNode(Rdiff.getRevSweepAsExpr())),
+                    BuildParens(CloneNode(Ldiff.getRevSweepAsExpr())));
         std::tie(Ldiff, Rdiff) = std::make_pair(LCloned, Rdiff.getExpr());
       } else if (opCode == BO_DivAssign) {
         // Add the statement `dl = 0;`
@@ -3395,8 +3399,11 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         dr = StoreAndRef(dr, direction::reverse);
         Rdiff = Visit(R, dr);
         RDelayed.Finalize(Rdiff.getExpr());
-        valueForRevPass = BuildOp(BO_Div, Rdiff.getRevSweepAsExpr(),
-                                  Ldiff.getRevSweepAsExpr());
+        // Parenthesize: either side can be a compound expr, which would
+        // mis-associate under the division when the derivative is printed.
+        valueForRevPass =
+            BuildOp(BO_Div, BuildParens(Rdiff.getRevSweepAsExpr()),
+                    BuildParens(Ldiff.getRevSweepAsExpr()));
         std::tie(Ldiff, Rdiff) = std::make_pair(LCloned, RResult);
       } else
         llvm_unreachable("unknown assignment opCode");

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -620,10 +620,13 @@ namespace clad {
       return nullptr;
     Expr* ENoCasts = E->IgnoreCasts();
     // In our case, there is no reason to build parentheses around something
-    // that is not a binary or ternary operator.
+    // that is not a binary or ternary operator. An overloaded operator call
+    // with two arguments prints in binary form, except subscript and call,
+    // which are postfix and never need parentheses.
+    const auto* OCE = dyn_cast<CXXOperatorCallExpr>(ENoCasts);
     if (isa<BinaryOperator>(ENoCasts) ||
-        (isa<CXXOperatorCallExpr>(ENoCasts) &&
-         cast<CXXOperatorCallExpr>(ENoCasts)->getNumArgs() == 2) ||
+        (OCE && OCE->getNumArgs() == 2 && OCE->getOperator() != OO_Subscript &&
+         OCE->getOperator() != OO_Call) ||
         isa<ConditionalOperator>(ENoCasts) ||
         isa<CXXBindTemporaryExpr>(ENoCasts)) {
       return m_Sema.ActOnParenExpr(E->getBeginLoc(), E->getEndLoc(), E).get();

--- a/test/Arrays/ArrayInputsVectorForwardMode.C
+++ b/test/Arrays/ArrayInputsVectorForwardMode.C
@@ -11,7 +11,7 @@ double multiply(const double *arr) {
 // CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = _d_arr.size();
 // CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:   {
-// CHECK-NEXT:     clad::array<double> _d_vector_return((_d_vector_arr[0]) * arr[1] + arr[0] * (_d_vector_arr[1])); 
+// CHECK-NEXT:     clad::array<double> _d_vector_return(_d_vector_arr[0] * arr[1] + arr[0] * _d_vector_arr[1]); 
 // CHECK-NEXT:     _d_arr = _d_vector_return.slice({{0U|0UL|0ULL}}, _d_arr.size());
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
@@ -25,7 +25,7 @@ double divide(double *arr) {
 // CHECK-NEXT:   unsigned {{int|long|long long}} indepVarCount = _d_arr.size();
 // CHECK-NEXT:   clad::matrix<double> _d_vector_arr = clad::identity_matrix(_d_arr.size(), indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:   {
-// CHECK-NEXT:     _d_vector_return(((_d_vector_arr[0]) * arr[1] - arr[0] * (_d_vector_arr[1])) / (arr[1] * arr[1]));
+// CHECK-NEXT:     _d_vector_return((_d_vector_arr[0] * arr[1] - arr[0] * _d_vector_arr[1]) / (arr[1] * arr[1]));
 // CHECK-NEXT:     _d_arr = _d_vector_return.slice({{0U|0UL|0ULL}}, _d_arr.size());
 // CHECK-NEXT:     return;
 // CHECK-NEXT:   }
@@ -83,10 +83,10 @@ double maskedSum(const double *arr, int n, int *signedMask, double alpha, double
 // CHECK-NEXT:     clad::array<int> _d_vector_i(clad::zero_vector(indepVarCount));
 // CHECK-NEXT:     for (int i = 0; i < n; i++) {
 // CHECK-NEXT:       if (signedMask[i] > 0) {
-// CHECK-NEXT:         _d_vector_ret += _d_vector_alpha * arr[i] + alpha * (_d_vector_arr[i]);
+// CHECK-NEXT:         _d_vector_ret += _d_vector_alpha * arr[i] + alpha * _d_vector_arr[i];
 // CHECK-NEXT:         ret += alpha * arr[i];
 // CHECK-NEXT:       } else {
-// CHECK-NEXT:         _d_vector_ret -= _d_vector_beta * arr[i] + beta * (_d_vector_arr[i]);
+// CHECK-NEXT:         _d_vector_ret -= _d_vector_beta * arr[i] + beta * _d_vector_arr[i];
 // CHECK-NEXT:         ret -= beta * arr[i];
 // CHECK-NEXT:       }
 // CHECK-NEXT:     }

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -548,7 +548,7 @@ double f15(double i, double j) {
 // CHECK-NEXT:         d = _t2;
 // CHECK-NEXT:         double _r_d2 = _d_d;
 // CHECK-NEXT:         _d_d = 0.;
-// CHECK-NEXT:         _d_d += _r_d2 * 3 * j;
+// CHECK-NEXT:         _d_d += _r_d2 * (3 * j);
 // CHECK-NEXT:         *_d_j += 3 * d * _r_d2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -592,7 +592,7 @@ double f16(double i, double j) {
 // CHECK-NEXT:         c = _t0;
 // CHECK-NEXT:         double _r_d0 = _d_c;
 // CHECK-NEXT:         _d_c = 0.;
-// CHECK-NEXT:         _d_c += _r_d0 * 4 * j;
+// CHECK-NEXT:         _d_c += _r_d0 * (4 * j);
 // CHECK-NEXT:         *_d_j += 4 * c * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -855,6 +855,27 @@ double f26(double x, double y) {
 //CHECK-NEXT:    *_d_x += _d_l;
 //CHECK-NEXT:}
 
+// *= with a compound right-hand side, which reaches the pullback un-stored
+// and must be parenthesized in the `_r_d0 * (y + 1.)` product so the printed
+// derivative keeps the association of the built AST.
+double f27(double x, double y) {
+  x *= y + 1.;
+  return x;
+}
+
+//CHECK: void f27_grad(double x, double y, double *_d_x, double *_d_y) {
+//CHECK-NEXT:    double _t0 = x;
+//CHECK-NEXT:    x *= y + 1.;
+//CHECK-NEXT:    *_d_x += 1;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        x = _t0;
+//CHECK-NEXT:        double _r_d0 = *_d_x;
+//CHECK-NEXT:        *_d_x = 0.;
+//CHECK-NEXT:        *_d_x += _r_d0 * (y + 1.);
+//CHECK-NEXT:        *_d_y += x * _r_d0;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
 #define TEST(F, x, y)                                                          \
   {                                                                            \
     result[0] = 0;                                                             \
@@ -945,4 +966,5 @@ int main() {
   printf("{%d, %d}\n", grad_x, grad_y); // CHECK-EXEC: {4, 0}
 
   TEST(f26, 8, 2); // CHECK-EXEC: {0.50, -2.00}
+  TEST(f27, 3, 4); // CHECK-EXEC: {5.00, 3.00}
 }

--- a/test/Jacobian/Jacobian.C
+++ b/test/Jacobian/Jacobian.C
@@ -139,11 +139,11 @@ void f_6(double a[2], double b, double _clad_out_output[]) {
 // CHECK-NEXT:     *_d_vector_a = clad::identity_matrix(_d_vector_a->rows(), indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, _d_vector_a->rows() + {{1U|1UL|1ULL}});
 // CHECK-NEXT:     double _t0 = a[0] * a[0];
-// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = (((*_d_vector_a)[0]) * a[0] + a[0] * ((*_d_vector_a)[0])) * a[0] + _t0 * ((*_d_vector_a)[0]);
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((*_d_vector_a)[0] * a[0] + a[0] * (*_d_vector_a)[0]) * a[0] + _t0 * (*_d_vector_a)[0];
 // CHECK-NEXT:     _clad_out_output[0] = _t0 * a[0];
 // CHECK-NEXT:     double _t1 = a[0] * a[0];
 // CHECK-NEXT:     double _t2 = b * b;
-// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (((*_d_vector_a)[0]) * a[0] + a[0] * ((*_d_vector_a)[0])) * a[0] + _t1 * ((*_d_vector_a)[0]) + (_d_vector_b * b + b * _d_vector_b) * b + _t2 * _d_vector_b;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((*_d_vector_a)[0] * a[0] + a[0] * (*_d_vector_a)[0]) * a[0] + _t1 * (*_d_vector_a)[0] + (_d_vector_b * b + b * _d_vector_b) * b + _t2 * _d_vector_b;
 // CHECK-NEXT:     _clad_out_output[1] = _t1 * a[0] + _t2 * b;
 // CHECK-NEXT:     double _t3 = (a[0] + b);
 // CHECK-NEXT:     (*_d_vector__clad_out_output)[2] = (clad::zero_vector(indepVarCount)) * _t3 + 2 * ((*_d_vector_a)[0] + _d_vector_b);
@@ -202,7 +202,7 @@ void f_9(float a, double _clad_out_output[]){
 // CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount,  {{1U|1UL|1ULL}});
 // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = _d_vector_a * a + a * _d_vector_a;
 // CHECK-NEXT:     _clad_out_output[0] = a * a;
-// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((*_d_vector__clad_out_output)[0]) * 3 + _clad_out_output[0] * (clad::zero_vector(indepVarCount));
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (*_d_vector__clad_out_output)[0] * 3 + _clad_out_output[0] * (clad::zero_vector(indepVarCount));
 // CHECK-NEXT:     _clad_out_output[1] = _clad_out_output[0] * 3;
 // CHECK-NEXT: }
 
@@ -232,9 +232,9 @@ void f_11(double a[2], double b[1], double _clad_out_output[]) {
 // CHECK-NEXT:    *_d_vector_a = clad::identity_matrix(_d_vector_a->rows(), indepVarCount, 0UL);
 // CHECK-NEXT:    *_d_vector_b = clad::identity_matrix(_d_vector_b->rows(), indepVarCount, _d_vector_a->rows());
 // CHECK-NEXT:    *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, _d_vector_a->rows() + _d_vector_b->rows());
-// CHECK-NEXT:    (*_d_vector__clad_out_output)[0] = ((*_d_vector_a)[0]) * a[1] + a[0] * ((*_d_vector_a)[1]);
+// CHECK-NEXT:    (*_d_vector__clad_out_output)[0] = (*_d_vector_a)[0] * a[1] + a[0] * (*_d_vector_a)[1];
 // CHECK-NEXT:    _clad_out_output[0] = a[0] * a[1];
-// CHECK-NEXT:    (*_d_vector__clad_out_output)[1] = ((*_d_vector_a)[0]) * a[0] + a[0] * ((*_d_vector_a)[0]) + (*_d_vector_b)[0];
+// CHECK-NEXT:    (*_d_vector__clad_out_output)[1] = (*_d_vector_a)[0] * a[0] + a[0] * (*_d_vector_a)[0] + (*_d_vector_b)[0];
 // CHECK-NEXT:    _clad_out_output[1] = a[0] * a[0] + b[0];
 // CHECK-NEXT:    double _t0 = (a[0] + b[0]);
 // CHECK-NEXT:    (*_d_vector__clad_out_output)[2] = (clad::zero_vector(indepVarCount)) * _t0 + 2 * ((*_d_vector_a)[0] + (*_d_vector_b)[0]);

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -272,7 +272,7 @@
 // CHECK_VECTOR_FORWARD_MODE-NEXT    {
 // CHECK_VECTOR_FORWARD_MODE-NEXT        clad::array<int> _d_vector_i(clad::array<int>(indepVarCount, 0));
 // CHECK_VECTOR_FORWARD_MODE-NEXT        for (int i = 0; i < n; ++i) {
-// CHECK_VECTOR_FORWARD_MODE-NEXT            _d_vector_res += (_d_vector_weights[i]) * arr[i] + weights[i] * (_d_vector_arr[i]);
+// CHECK_VECTOR_FORWARD_MODE-NEXT            _d_vector_res += _d_vector_weights[i] * arr[i] + weights[i] * _d_vector_arr[i];
 // CHECK_VECTOR_FORWARD_MODE-NEXT            res += weights[i] * arr[i];
 // CHECK_VECTOR_FORWARD_MODE-NEXT        }
 // CHECK_VECTOR_FORWARD_MODE-NEXT    }


### PR DESCRIPTION
A compound assignment whose right-hand side StoreAndRef passes through un-stored (`l *= a + b` with an unchanging RHS) embeds that expression directly in the `_r_d * R` pullback product. The built AST is correct -- the product holds the sum as one operand -- but nothing inserts a ParenExpr, and Clang's printer only prints parentheses that exist as nodes, so the dumped derivative mis-associates:

  _d_C[0] += _r_d0 * alpha + beta;   // AST: _r_d0 * (alpha + beta)

Anything that recompiles printed derivatives (Derivatives.cpp generation, CladFunction::dump()-based workflows) gets wrong code. Wrap the reverse-sweep operands of the mul- and div-assign products and rev-pass values in BuildParens, which only parenthesizes exprs that print in binary/ternary form.

BuildParens itself treated any two-argument overloaded operator call as binary; subscript and call operators are postfix and never need parentheses, so stop wrapping those. This also drops the noise parens vector forward mode used to print around `_d_vector_arr[i]`.