### PR TITLE
Do not iterate the delayed calls while planning grows them

### DIFF
--- a/test/Misc/DelayedCallsGrowth.C
+++ b/test/Misc/DelayedCallsGrowth.C
@@ -1,0 +1,46 @@
+// RUN: %cladclang -I%S/../../include %s -oDelayedCallsGrowth.out
+// RUN: ./DelayedCallsGrowth.out | %filecheck_exec %s
+
+// Planning a request whose target is a constructor (or a conversion operator)
+// makes clad instantiate a clad::Tag<T> specialization -- see
+// utils::GetDerivativeType -- and Sema reports that new tag back through the
+// plugin's HandleTagDeclDefinition, which appends to m_DelayedCalls. The
+// planning loop in CladPlugin::HandleTranslationUnit walks that very deque, so
+// differentiating a constructor grows the container mid-iteration.
+//
+// Inserting into a deque invalidates every iterator to it, though not
+// references to its elements ([deque.modifiers]/1,
+// https://eel.is/c++draft/deque.modifiers#1). The loop used to be a range-for,
+// whose end() is computed once up front, so from the first such append onwards
+// it walked invalidated iterators and eventually dereferenced a DeclGroupRef
+// read out of bounds.
+//
+// Note this test pins the code path; it cannot reliably reproduce the crash.
+// Whether the stale iterator faults depends on the deque reallocating its block
+// map at that moment, which is a function of how many delayed calls precede the
+// append and of the standard library's map slack -- not of anything this
+// source can control.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+struct S {
+  double x;
+  // Differentiating through this constructor is what triggers the
+  // planning-time clad::Tag<S> instantiation.
+  S(double v) : x(v) {}
+};
+
+double f(double u) {
+  S s(u);
+  return s.x * s.x;
+}
+
+int main() {
+  auto g = clad::gradient(f);
+  double dx = 0;
+  g.execute(3, &dx);
+  printf("%.2f\n", dx); // CHECK-EXEC: 6.00
+  return 0;
+}

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -640,14 +640,24 @@ void InitTimers();
         // Traverse all collected DeclGroupRef only once to create the static
         // graph.
         TimedAnalysisRegion R("Rest of TU");
-        for (auto DCI : m_DelayedCalls)
-          for (Decl* D : DCI.m_DGR) {
+        // Plan() appends to m_DelayedCalls: planning instantiates templates,
+        // which re-enters this plugin's HandleTopLevelDecl. Inserting into a
+        // deque invalidates every iterator to it, though not references to its
+        // elements (see [deque.modifiers]/1,
+        // https://eel.is/c++draft/deque.modifiers#1), so a range-for -- whose
+        // end() is computed once, up front -- walks invalidated iterators from
+        // the first such append onwards. Index and re-read size() instead, as
+        // SendToMultiplexer already does.
+        for (size_t i = 0; i < m_DelayedCalls.size(); ++i) {
+          const DeclGroupRef DGR = m_DelayedCalls[i].m_DGR;
+          for (Decl* D : DGR) {
             if (const auto* FD = dyn_cast<FunctionDecl>(D))
               if (FD->isConstexpr())
                 continue;
-            getScheduler().Plan(DCI.m_DGR);
+            getScheduler().Plan(DGR);
             break;
           }
+        }
 
         if (m_CI.getFrontendOpts().ShowStats) {
           // Print the graph of the diff requests.


### PR DESCRIPTION
Planning a request that targets a constructor or a conversion operator
instantiates a `clad::Tag<T>` specialization, which Sema reports back through
the plugin's `HandleTagDeclDefinition` and so appends to `m_DelayedCalls`.
`CladPlugin::HandleTranslationUnit` walks that same deque with a range-for,
whose `end()` is computed once, so from the first append onwards it advances
and compares iterators the insertion invalidated ([deque.modifiers]/1,
https://eel.is/c++draft/deque.modifiers#1). It then reads a `DeclGroupRef`
past the valid range and dereferences it, crashing at end of file.

Index the deque and re-read `size()` on each step, as `SendToMultiplexer`
already does for the same reason. Groups appended while the loop runs are then
planned as well, instead of being skipped.

Whether the stale iterator actually faults depends on the deque reallocating
its block map at that point, which no test input controls — that is why this
fails on some hosts and not others. This is what breaks #1946's
`ubu24-clang20-runtime21` job: compiling `test/ForwardMode/UserDefinedTypes.C`
grows `m_DelayedCalls` mid-loop (11366 → 11371 entries on current master,
verified with temporary instrumentation), and on the Linux runner's libstdc++
the block map moves, producing the segfault in
`CladPlugin::HandleTranslationUnit` at `<eof>`. The growth is identical on
master without #1946 — that PR only perturbs the allocation pattern enough to
expose the latent bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
