### PR TITLE
Restore copy-pushed record state by copy in the reverse sweep.

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4422,8 +4422,19 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       Expr* moveCall = BuildArrayAssignment(Clone(E), Ref, direction::reverse);
       addToCurrentBlock(moveCall, direction::reverse);
       Restore = Pop;
-    } else if (E->isModifiableLvalue(m_Context) == Expr::MLV_Valid)
-      Restore = BuildOp(BO_Assign, Clone(E), Pop);
+    } else if (E->isModifiableLvalue(m_Context) == Expr::MLV_Valid) {
+      if (isInsideLoop && Type->isRecordType() && !moveToTape) {
+        // The restore must pair with the push: clad::pop moves the element
+        // out of its slot, and a move-assign replaces a record's heap buffer,
+        // dangling references handed out into it. Restore copy-pushed state
+        // by copy from clad::back so E keeps its buffer; move-pushed state
+        // must keep the move-assigning pop -- its buffer travels through the
+        // tape and back, which keeps that iteration's cached pointers valid.
+        Expr* assign = BuildOp(BO_Assign, Clone(E), Ref);
+        Restore = MakeCompoundStmt({assign, Pop});
+      } else
+        Restore = BuildOp(BO_Assign, Clone(E), Pop);
+    }
 
     return {Store, Restore};
   }

--- a/test/Gradient/RecordRestore.C
+++ b/test/Gradient/RecordRestore.C
@@ -1,0 +1,53 @@
+// RUN: %cladclang %s -I%S/../../include -oRecordRestore.out 2>&1 | %filecheck %s
+// RUN: ./RecordRestore.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s \
+// RUN:   -I%S/../../include -oRecordRestore.out
+// RUN: ./RecordRestore.out | %filecheck_exec %s
+
+// Verifies that a record stored on a tape by copy is also restored by copy
+// (clad::back then clad::pop). clad::pop returns the element moved out of its
+// slot, and a move-assigning restore would replace the record's heap storage,
+// dangling any reference previously handed out into it.
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+struct S {
+  double a;
+  double b;
+};
+
+void scale(S& s) {
+  s.a = 3 * s.a;
+  s.b = 3 * s.b;
+}
+
+double f(double x) {
+  S s;
+  s.a = x;
+  s.b = 2 * x;
+  double t = 0;
+  for (int i = 0; i < 1; i++) {
+    scale(s);
+    t += s.a * s.a + s.b;
+  }
+  return t;
+}
+
+// CHECK: void f_grad(double x, double *_d_x) {
+// CHECK: clad::push(_t1, s);
+// CHECK: scale_reverse_forw(s, _d_s, _tracker0);
+// CHECK: _tracker0.restore();
+// CHECK-NEXT: {
+// CHECK-NEXT:     s = clad::back(_t1);
+// CHECK-NEXT:     clad::pop(_t1);
+// CHECK-NEXT: }
+// CHECK-NEXT: scale_pullback(s, &_d_s);
+
+int main() {
+  auto g = clad::gradient(f);
+  double dx = 0;
+  g.execute(1.0, &dx);
+  // f = (3x)^2 + 6x => df/dx = 18x + 6
+  printf("dx=%.2f\n", dx); // CHECK-EXEC: dx=24.00
+}


### PR DESCRIPTION
clad::pop returns the tape element moved out of its slot, so the emitted restore `E = clad::pop(t)` move-assigns into E. For a record owning heap storage (std::vector) the move replaces E's buffer and dangles every reference previously handed out into it -- e.g. a cached operator_subscript_reverse_forw result the surrounding reverse sweep still writes through, corrupting the heap once the popped slot is destroyed.

Pair the restore with its push instead: state pushed by copy is restored by copy-assigning from clad::back before popping, preserving E's buffer identity, while state pushed with std::move keeps the move-assigning pop -- there the buffer travels into the tape and back, which is what keeps the element pointers cached in that iteration valid.

The new Gradient/RecordRestore.C pins the back-then-pop shape for a copy-pushed record in a loop; the move-push contract is already pinned by the `= clad::pop` expectations in Gradient/STLCustomDerivatives.C.