### PR TITLE
Share the lambda-introduction scaffolding between both builders

### DIFF
--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -13,6 +13,7 @@
 
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/StmtVisitor.h"
@@ -21,6 +22,7 @@
 #include "clang/Basic/Lambda.h"
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/Specifiers.h"
+#include "clang/Basic/Version.h"
 #include "clang/Sema/DeclSpec.h"
 #include "clang/Sema/Ownership.h"
 #include "clang/Sema/ParsedAttr.h"
@@ -30,6 +32,12 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/PrettyStackTrace.h"
+
+// For the LambdaBuilder
+#if CLANG_VERSION_MAJOR > 16
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/Support/SaveAndRestore.h"
+#endif // CLANG_VERSION_MAJOR > 16
 
 #include <array>
 #include <cassert>
@@ -304,6 +312,52 @@ namespace clad {
       void resolve(llvm::ArrayRef<clang::Stmt*> Body);
       bool contains(clang::VarDecl* VD) const { return m_Captures.count(VD); }
     };
+
+#if CLANG_VERSION_MAJOR > 16
+    /// Builds a new lambda closure with an explicit parameter list, following
+    /// the order Sema relies on while parsing one -- deviating from it leaves
+    /// Sema in a state that only crashes much later. Used by
+    /// `buildClonedLambda` and `ReverseModeVisitor::buildDerivedLambda`.
+    class LambdaBuilder {
+      VisitorBase& m_V;
+      // Sema keeps referring to the introducer and the declarator until
+      // ActOnLambdaExpr, so they outlive start(). m_DS is built from
+      // m_AttrFactory and m_D from m_DS, so declaration order matters.
+      clang::AttributeFactory m_AttrFactory;
+      const clang::DeclSpec m_DS;
+      clang::Declarator m_D;
+      clang::LambdaIntroducer m_Intro;
+      llvm::SaveAndRestore<clang::DeclContext*> m_SaveContext;
+      llvm::SaveAndRestore<clang::FunctionDecl*> m_SaveDerivative;
+      llvm::SaveAndRestore<clang::Scope*> m_SaveFnScope;
+      bool m_Started = false;
+      bool m_Finished = false;
+
+    public:
+      using ParamBuilder =
+          llvm::function_ref<void(llvm::SmallVectorImpl<clang::ParmVarDecl*>&)>;
+
+      explicit LambdaBuilder(VisitorBase& V);
+      LambdaBuilder(const LambdaBuilder&) = delete;
+      LambdaBuilder& operator=(const LambdaBuilder&) = delete;
+      LambdaBuilder(LambdaBuilder&&) = delete;
+      LambdaBuilder& operator=(LambdaBuilder&&) = delete;
+      /// Asserts that a started builder was also finished. The scopes and the
+      /// declaration context start() opens are only closed by finish(), so an
+      /// early return in between leaves Sema inside a half-built closure and
+      /// only crashes much later.
+      ~LambdaBuilder();
+      /// Without this the new closure is capture-less.
+      void cloneCaptures(const clang::LambdaExpr* LE);
+      /// Opens the body scope; on return the caller may begin a block and emit
+      /// into it. \p LE only supplies the declaration context to graft the
+      /// closure onto, \p BuildParams appends the call operator's parameters.
+      void start(const clang::LambdaExpr* LE, clang::QualType CallOpType,
+                 ParamBuilder BuildParams);
+      /// Closes the scopes start() opened.
+      clang::Expr* finish(clang::Stmt* Body);
+    };
+#endif // CLANG_VERSION_MAJOR > 16
 
     /// Build a lambda whose body is produced by `func`. Returns the
     /// LambdaExpr without invoking it, so the caller can bind it to a VarDecl

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2076,96 +2076,12 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
 #if CLANG_VERSION_MAJOR > 16
   clang::Expr* ReverseModeVisitor::buildDerivedLambda(const LambdaExpr* LE) {
-    LambdaIntroducer Intro;
-    Intro.Default = LCD_None;
-    Intro.Range.setBegin(noLoc);
-    Intro.Range.setEnd(noLoc);
-    AttributeFactory AttrFactory;
-    const DeclSpec DS(AttrFactory);
-    Declarator D(DS, clang::ParsedAttributesView::none(),
-                 clang::DeclaratorContext::LambdaExpr);
+    LambdaBuilder LBuilder(*this);
+    LBuilder.start(LE, GetLambdaDerivativeType(LE),
+                   [&](llvm::SmallVectorImpl<ParmVarDecl*>& params) {
+                     BuildParams(params, LE);
+                   });
 
-    QualType dFnType = GetLambdaDerivativeType(LE);
-
-    auto* DC =
-        const_cast<DeclContext*>(LE->getCallOperator()->getDeclContext());
-    llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
-    llvm::SaveAndRestore<FunctionDecl*> SaveDerivative(m_Derivative);
-
-    llvm::SaveAndRestore<Scope*> SaveFunctionScope(m_DerivativeFnScope);
-    beginScope(Scope::LambdaScope | Scope::DeclScope |
-               Scope::FunctionDeclarationScope | Scope::FunctionPrototypeScope);
-
-    m_Sema.PushLambdaScope();
-    m_Sema.ActOnLambdaExpressionAfterIntroducer(Intro, getCurrentScope());
-
-    beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
-               Scope::DeclScope);
-
-    llvm::SmallVector<DeclaratorChunk::ParamInfo> ParamInfoLambda;
-    llvm::SmallVector<ParmVarDecl*, 8> params;
-
-    m_Sema.ActOnLambdaClosureQualifiers(Intro, noLoc);
-
-    sema::LambdaScopeInfo* LSI = m_Sema.getCurLambda();
-    LSI->CallOperator->setType(dFnType);
-
-    m_Sema.PushDeclContext(getCurrentScope(), LSI->CallOperator);
-
-    LSI->Lambda->setDeclContext(DC);
-
-    m_Derivative = LSI->CallOperator;
-
-    BuildParams(params, LE);
-    m_Derivative->setBody(MakeCompoundStmt({}));
-
-    m_Sema.PopDeclContext();
-
-    for (auto* PVD : params)
-      ParamInfoLambda.emplace_back(PVD->getIdentifier(), PVD->getLocation(),
-                                   PVD, nullptr);
-    // ActOnStartOfLambdaDefinition uses LParenLoc.isValid() to flip
-    // LSI->ExplicitParams; an invalid LParen makes the lambda print
-    // without its parameter list (`[]{...}` instead of `[](T x){...}`).
-    // Use a real SourceLocation so the printer sees explicit params.
-    SourceLocation paramListLoc = utils::GetValidSLoc(m_Sema);
-    D.AddTypeInfo(DeclaratorChunk::getFunction(
-                      /*hasProto=*/true,
-                      /*isAmbiguous=*/false,
-                      /*LParenLoc=*/paramListLoc,
-                      /*Params=*/ParamInfoLambda.data(),
-                      /*NumParams=*/ParamInfoLambda.size(),
-                      /*EllipsisLoc=*/SourceLocation(),
-                      /*RParenLoc=*/paramListLoc,
-                      /*RefQualifierIsLValueRef=*/true,
-                      /*RefQualifierLoc=*/SourceLocation(),
-                      /*MutableLoc=*/SourceLocation(),
-                      /*ESpecType=*/EST_None,
-                      /*ESpecRange=*/SourceRange(),
-                      /*Exceptions=*/nullptr,
-                      /*ExceptionRanges=*/nullptr,
-                      /*NumExceptions=*/0,
-                      /*NoexceptExpr=*/nullptr,
-                      /*ExceptionSpecTokens=*/nullptr,
-                      /*DeclsInPrototype=*/{},
-                      /*LocalRangeBegin=*/noLoc,
-                      /*LocalRangeEnd=*/noLoc,
-                      /*Declarator=*/D,
-                      /*TrailingReturnType=*/ParsedType(),
-                      /*TrailingReturnTypeLoc=*/SourceLocation()),
-                  /*EndLoc=*/SourceLocation());
-
-    m_Sema.ActOnLambdaClosureParameters(getCurrentScope(), ParamInfoLambda);
-
-    beginScope(Scope::BlockScope | Scope::FnScope | Scope::DeclScope |
-               Scope::CompoundStmtScope);
-
-    m_Sema.ActOnStartOfLambdaDefinition(
-        Intro, D,
-        clad_compat::Sema_ActOnStartOfLambdaDefinition_ScopeOrDeclSpec(
-            getCurrentScope(), DS));
-
-    m_DerivativeFnScope = getCurrentScope();
     Stmts OuterGlobals;
     std::swap(m_Globals, OuterGlobals);
 
@@ -2192,19 +2108,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     m_Globals.clear();
     std::swap(m_Globals, OuterGlobals);
 
-    Expr* lambda =
-        m_Sema
-            .ActOnLambdaExpr(
-                noLoc,
-                DerivedBody /*,*/
-                    CLAD_COMPAT_CLANG17_ActOnLambdaExpr_getCurrentScope_ExtraParam(
-                        *this))
-            .get();
-
-    endScope();
-    endScope();
-    endScope();
-    return lambda;
+    return LBuilder.finish(DerivedBody);
   }
 
   StmtDiff ReverseModeVisitor::VisitLambdaExpr(const LambdaExpr* LE) {

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -28,6 +28,8 @@
 #include "clang/AST/Stmt.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/Type.h"
+#include "clang/Basic/ExceptionSpecificationType.h"
+#include "clang/Basic/Lambda.h"
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
@@ -50,6 +52,7 @@
 #include "llvm/Support/SaveAndRestore.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <numeric>
 #include <utility>
@@ -1152,6 +1155,131 @@ namespace clad {
   }
 #endif // CLANG_VERSION_MAJOR >= 17
 
+#if CLANG_VERSION_MAJOR > 16
+  VisitorBase::LambdaBuilder::LambdaBuilder(VisitorBase& V)
+      : m_V(V), m_DS(m_AttrFactory),
+        m_D(m_DS, clang::ParsedAttributesView::none(),
+            clang::DeclaratorContext::LambdaExpr),
+        m_SaveContext(V.m_Sema.CurContext), m_SaveDerivative(V.m_Derivative),
+        m_SaveFnScope(V.m_DerivativeFnScope) {
+    m_Intro.Default = LCD_None;
+    m_Intro.Range.setBegin(noLoc);
+    m_Intro.Range.setEnd(noLoc);
+  }
+
+  void VisitorBase::LambdaBuilder::cloneCaptures(const LambdaExpr* LE) {
+    m_Intro.Default = LE->getCaptureDefault();
+    for (const clang::LambdaCapture& Cap : LE->explicit_captures())
+      m_Intro.addCapture(Cap.getCaptureKind(), Cap.getLocation(),
+                         Cap.getCapturedVar()->getIdentifier(), /*EllipsisLoc=*/
+                         noLoc, clang::LambdaCaptureInitKind::NoInit,
+                         clang::ExprResult(), clang::ParsedType(),
+                         SourceRange());
+    m_Intro.Range.setBegin(LE->getBeginLoc());
+    m_Intro.Range.setEnd(LE->getEndLoc());
+  }
+
+  void VisitorBase::LambdaBuilder::start(const LambdaExpr* LE,
+                                         QualType CallOpType,
+                                         ParamBuilder BuildParams) {
+    DeclContext* DC = LE->getCallOperator()->getDeclContext();
+
+    m_Started = true;
+    m_V.beginScope(Scope::LambdaScope | Scope::DeclScope |
+                   Scope::FunctionDeclarationScope |
+                   Scope::FunctionPrototypeScope);
+    m_V.m_Sema.PushLambdaScope();
+    m_V.m_Sema.ActOnLambdaExpressionAfterIntroducer(m_Intro,
+                                                    m_V.getCurrentScope());
+
+    m_V.beginScope(Scope::FunctionPrototypeScope |
+                   Scope::FunctionDeclarationScope | Scope::DeclScope);
+
+    m_V.m_Sema.ActOnLambdaClosureQualifiers(m_Intro, noLoc);
+
+    sema::LambdaScopeInfo* LSI = m_V.m_Sema.getCurLambda();
+    LSI->CallOperator->setType(CallOpType);
+    m_V.m_Sema.PushDeclContext(m_V.getCurrentScope(), LSI->CallOperator);
+    LSI->Lambda->setDeclContext(DC);
+    m_V.m_Derivative = LSI->CallOperator;
+
+    llvm::SmallVector<ParmVarDecl*, 8> params;
+    BuildParams(params);
+    m_V.m_Derivative->setBody(m_V.MakeCompoundStmt({}));
+
+    m_V.m_Sema.PopDeclContext();
+
+    llvm::SmallVector<DeclaratorChunk::ParamInfo> ParamInfoLambda;
+    for (auto* PVD : params)
+      ParamInfoLambda.emplace_back(PVD->getIdentifier(), PVD->getLocation(),
+                                   PVD, nullptr);
+    // ActOnStartOfLambdaDefinition uses LParenLoc.isValid() to flip
+    // LSI->ExplicitParams; an invalid LParen makes the lambda print without
+    // its parameter list (`[]{...}` instead of `[](T x){...}`).
+    SourceLocation paramListLoc = utils::GetValidSLoc(m_V.m_Sema);
+    m_D.AddTypeInfo(DeclaratorChunk::getFunction(
+                        /*hasProto=*/true,
+                        /*isAmbiguous=*/false,
+                        /*LParenLoc=*/paramListLoc,
+                        /*Params=*/ParamInfoLambda.data(),
+                        /*NumParams=*/ParamInfoLambda.size(),
+                        /*EllipsisLoc=*/SourceLocation(),
+                        /*RParenLoc=*/paramListLoc,
+                        /*RefQualifierIsLValueRef=*/true,
+                        /*RefQualifierLoc=*/SourceLocation(),
+                        /*MutableLoc=*/SourceLocation(),
+                        /*ESpecType=*/EST_None,
+                        /*ESpecRange=*/SourceRange(),
+                        /*Exceptions=*/nullptr,
+                        /*ExceptionRanges=*/nullptr,
+                        /*NumExceptions=*/0,
+                        /*NoexceptExpr=*/nullptr,
+                        /*ExceptionSpecTokens=*/nullptr,
+                        /*DeclsInPrototype=*/{},
+                        /*LocalRangeBegin=*/noLoc,
+                        /*LocalRangeEnd=*/noLoc,
+                        /*Declarator=*/m_D,
+                        /*TrailingReturnType=*/ParsedType(),
+                        /*TrailingReturnTypeLoc=*/SourceLocation()),
+                    /*EndLoc=*/SourceLocation());
+
+    m_V.m_Sema.ActOnLambdaClosureParameters(m_V.getCurrentScope(),
+                                            ParamInfoLambda);
+
+    m_V.beginScope(Scope::BlockScope | Scope::FnScope | Scope::DeclScope |
+                   Scope::CompoundStmtScope);
+
+    m_V.m_Sema.ActOnStartOfLambdaDefinition(
+        m_Intro, m_D,
+        clad_compat::Sema_ActOnStartOfLambdaDefinition_ScopeOrDeclSpec(
+            m_V.getCurrentScope(), m_DS));
+
+    m_V.m_DerivativeFnScope = m_V.getCurrentScope();
+  }
+
+  Expr* VisitorBase::LambdaBuilder::finish(Stmt* Body) {
+    Expr* lambda =
+        m_V.m_Sema
+            .ActOnLambdaExpr(
+                noLoc,
+                Body /*,*/
+                    CLAD_COMPAT_CLANG17_ActOnLambdaExpr_getCurrentScope_ExtraParam(
+                        m_V))
+            .get();
+    m_V.endScope();
+    m_V.endScope();
+    m_V.endScope();
+    m_Finished = true;
+    return lambda;
+  }
+
+  VisitorBase::LambdaBuilder::~LambdaBuilder() {
+    assert((!m_Started || m_Finished) &&
+           "a started LambdaBuilder must be finished: bailing out in between "
+           "leaves Sema inside a half-built closure");
+  }
+#endif // CLANG_VERSION_MAJOR > 16
+
   Expr* VisitorBase::buildClonedLambda(const LambdaExpr* LE) {
     // A primal copy needs a *fresh* closure type; a plain StmtClone reuses the
     // original closure, so two clones share the operator() body -- both a
@@ -1175,100 +1303,23 @@ namespace clad {
 
     const CXXMethodDecl* CallOp = LE->getCallOperator();
 
-    // Mirror the lambda-introduction dance performed while parsing a lambda;
-    // see buildDerivedLambda for the differentiating counterpart.
-    LambdaIntroducer Intro;
-    Intro.Default = LE->getCaptureDefault();
-    for (const clang::LambdaCapture& Cap : LE->explicit_captures())
-      Intro.addCapture(Cap.getCaptureKind(), Cap.getLocation(),
-                       Cap.getCapturedVar()->getIdentifier(), /*EllipsisLoc=*/
-                       noLoc, clang::LambdaCaptureInitKind::NoInit,
-                       clang::ExprResult(), clang::ParsedType(), SourceRange());
-    Intro.Range.setBegin(LE->getBeginLoc());
-    Intro.Range.setEnd(LE->getEndLoc());
-    AttributeFactory AttrFactory;
-    const DeclSpec DS(AttrFactory);
-    Declarator D(DS, clang::ParsedAttributesView::none(),
-                 clang::DeclaratorContext::LambdaExpr);
-
-    auto* DC = const_cast<DeclContext*>(CallOp->getDeclContext());
-    llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
-    llvm::SaveAndRestore<FunctionDecl*> SaveDerivative(m_Derivative);
-    llvm::SaveAndRestore<Scope*> SaveFnScope(m_DerivativeFnScope);
-
-    beginScope(Scope::LambdaScope | Scope::DeclScope |
-               Scope::FunctionDeclarationScope | Scope::FunctionPrototypeScope);
-    m_Sema.PushLambdaScope();
-    m_Sema.ActOnLambdaExpressionAfterIntroducer(Intro, getCurrentScope());
-
-    beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
-               Scope::DeclScope);
-
-    llvm::SmallVector<DeclaratorChunk::ParamInfo> ParamInfoLambda;
-    llvm::SmallVector<ParmVarDecl*, 8> params;
-
-    m_Sema.ActOnLambdaClosureQualifiers(Intro, noLoc);
-
-    sema::LambdaScopeInfo* LSI = m_Sema.getCurLambda();
-    // The clone keeps the original call operator's signature (unlike the
-    // derivative, which gets adjoint parameters).
-    LSI->CallOperator->setType(CallOp->getType());
-    m_Sema.PushDeclContext(getCurrentScope(), LSI->CallOperator);
-    LSI->Lambda->setDeclContext(DC);
-    m_Derivative = LSI->CallOperator;
-
-    for (const ParmVarDecl* PVD : CallOp->parameters()) {
-      IdentifierInfo* II = PVD->getIdentifier();
-      if (!PVD->getDeclName())
-        II = CreateUniqueIdentifier("arg");
-      auto* newPVD = CloneParmVarDecl(PVD, II, /*pushOnScopeChains=*/true,
-                                      /*cloneDefaultArg=*/false);
-      // Remap references in the cloned body to the new parameters.
-      m_DeclReplacements[PVD] = newPVD;
-      params.push_back(newPVD);
-    }
-    m_Derivative->setBody(MakeCompoundStmt({}));
-    m_Sema.PopDeclContext();
-
-    for (auto* PVD : params)
-      ParamInfoLambda.emplace_back(PVD->getIdentifier(), PVD->getLocation(),
-                                   PVD, nullptr);
-    SourceLocation paramListLoc = utils::GetValidSLoc(m_Sema);
-    D.AddTypeInfo(DeclaratorChunk::getFunction(
-                      /*hasProto=*/true,
-                      /*isAmbiguous=*/false,
-                      /*LParenLoc=*/paramListLoc,
-                      /*Params=*/ParamInfoLambda.data(),
-                      /*NumParams=*/ParamInfoLambda.size(),
-                      /*EllipsisLoc=*/SourceLocation(),
-                      /*RParenLoc=*/paramListLoc,
-                      /*RefQualifierIsLValueRef=*/true,
-                      /*RefQualifierLoc=*/SourceLocation(),
-                      /*MutableLoc=*/SourceLocation(),
-                      /*ESpecType=*/EST_None,
-                      /*ESpecRange=*/SourceRange(),
-                      /*Exceptions=*/nullptr,
-                      /*ExceptionRanges=*/nullptr,
-                      /*NumExceptions=*/0,
-                      /*NoexceptExpr=*/nullptr,
-                      /*ExceptionSpecTokens=*/nullptr,
-                      /*DeclsInPrototype=*/{},
-                      /*LocalRangeBegin=*/noLoc,
-                      /*LocalRangeEnd=*/noLoc,
-                      /*Declarator=*/D,
-                      /*TrailingReturnType=*/ParsedType(),
-                      /*TrailingReturnTypeLoc=*/SourceLocation()),
-                  /*EndLoc=*/SourceLocation());
-
-    m_Sema.ActOnLambdaClosureParameters(getCurrentScope(), ParamInfoLambda);
-
-    beginScope(Scope::BlockScope | Scope::FnScope | Scope::DeclScope |
-               Scope::CompoundStmtScope);
-    m_Sema.ActOnStartOfLambdaDefinition(
-        Intro, D,
-        clad_compat::Sema_ActOnStartOfLambdaDefinition_ScopeOrDeclSpec(
-            getCurrentScope(), DS));
-    m_DerivativeFnScope = getCurrentScope();
+    LambdaBuilder LBuilder(*this);
+    LBuilder.cloneCaptures(LE);
+    LBuilder.start(LE, CallOp->getType(),
+                   [&](llvm::SmallVectorImpl<ParmVarDecl*>& params) {
+                     for (const ParmVarDecl* PVD : CallOp->parameters()) {
+                       IdentifierInfo* II = PVD->getIdentifier();
+                       if (!PVD->getDeclName())
+                         II = CreateUniqueIdentifier("arg");
+                       auto* newPVD =
+                           CloneParmVarDecl(PVD, II, /*pushOnScopeChains=*/true,
+                                            /*cloneDefaultArg=*/false);
+                       // Remap references in the cloned body to the new
+                       // parameters.
+                       m_DeclReplacements[PVD] = newPVD;
+                       params.push_back(newPVD);
+                     }
+                   });
 
     beginBlock();
     const auto* Body = cast<CompoundStmt>(CallOp->getBody());
@@ -1307,20 +1358,7 @@ namespace clad {
       up.TraverseStmt(clonedS);
       addToCurrentBlock(clonedS);
     }
-    CompoundStmt* ClonedBody = endBlock();
-
-    Expr* lambda =
-        m_Sema
-            .ActOnLambdaExpr(
-                noLoc,
-                ClonedBody /*,*/
-                    CLAD_COMPAT_CLANG17_ActOnLambdaExpr_getCurrentScope_ExtraParam(
-                        *this))
-            .get();
-    endScope();
-    endScope();
-    endScope();
-    return lambda;
+    return LBuilder.finish(endBlock());
 #endif // CLANG_VERSION_MAJOR < 17
   }
 

--- a/test/Gradient/Lambdas.C
+++ b/test/Gradient/Lambdas.C
@@ -173,6 +173,33 @@ double f6(double i) {
 // CHECK-NEXT: }
 
 
+double f7(double i, double j) {
+  // The unnamed parameter needs a synthesized name in the cloned primal.
+  auto _f = [](double t, double) {
+    return t * t;
+  };
+  return _f(i, j);
+}
+
+// CHECK: void f7_grad(double i, double j, double *_d_i, double *_d_j) {
+// CHECK-NEXT:     auto _f0 = [](double t, double arg) {
+// CHECK-NEXT:         return t * t;
+// CHECK-NEXT:     };
+// CHECK-NEXT:     auto _d__f = [](double t, double arg, double _d_y, double *_d_t, double *_d_arg) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             *_d_t += _d_y * t;
+// CHECK-NEXT:             *_d_t += t * _d_y;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     };
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 0.;
+// CHECK-NEXT:         double _r1 = 0.;
+// CHECK-NEXT:         _d__f(i, j, 1, &_r0, &_r1);
+// CHECK-NEXT:         *_d_i += _r0;
+// CHECK-NEXT:         *_d_j += _r1;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
 int main() {
   auto df1 = clad::gradient(f1);
   double di = 0, dj = 0;
@@ -203,4 +230,9 @@ int main() {
   di = 0;
   df6.execute(3, &di);
   printf("%.2f\n", di);                       // CHECK-EXEC: 8.00
+
+  auto df7 = clad::gradient(f7);
+  di = 0, dj = 0;
+  df7.execute(3, 4, &di, &dj);
+  printf("%.2f %.2f\n", di, dj);              // CHECK-EXEC: 6.00 0.00
 }


### PR DESCRIPTION
buildDerivedLambda and buildClonedLambda each carried their own copy of the sequence Sema performs while parsing a lambda: introduce the closure, push its call operator as the current declaration context, describe the parameter list through a Declarator, then open the body scope. The two copies were identical for ~50 lines, most of it the 25-argument DeclaratorChunk::getFunction call, and they only diverge in the closure's captures, the type of its call operator, how the parameters are produced, and how the body is filled.

Move the shared part into a VisitorBase::LambdaScaffold helper that also owns the parser-level state Sema keeps referring to until ActOnLambdaExpr. Each builder is now its introducer setup, a parameter-building callback, and its own body construction. No functional change.

**This is a code consolidation commit, no functional changes**