### PR TITLE
Declare clad's derivatives inline

### DIFF
--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -80,6 +80,16 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
     if (R.Function && !R.Function->getPrimaryTemplate())
       S.LookupQualifiedName(Previous, dFD->getParent());
 
+    // Derivatives are declared inline, but a hand-written custom derivative may
+    // already define this name, and [dcl.inline]p6 forbids an inline
+    // declaration that follows a definition. Drop the specifier in that case.
+    auto definedNotInline = [](const NamedDecl* ND) {
+      const auto* PrevFD = dyn_cast<FunctionDecl>(ND);
+      return PrevFD && PrevFD->isDefined() && !PrevFD->isInlined();
+    };
+    if (std::any_of(Previous.begin(), Previous.end(), definedNotInline))
+      dFD->setInlineSpecified(false);
+
     // Check if we created a top-level decl with the same name for another
     // class.
     // FIXME: This case should be addressed by providing proper names and
@@ -134,7 +144,7 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
       returnedFD = CXXMethodDecl::Create(
           m_Context, CXXRD, noLoc, name, functionType, TSI,
           SC CLAD_COMPAT_FunctionDecl_UsesFPIntrin_Param(FD),
-          FD->isInlineSpecified(), FD->getConstexprKind(), noLoc);
+          /*isInlineSpecified=*/true, FD->getConstexprKind(), noLoc);
       // Generated member function should be called outside of class definitions
       // even if their original function had different access specifier.
       returnedFD->setAccess(AS_public);
@@ -153,13 +163,11 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
           m_Context, m_Sema.CurContext, noLoc, name, functionType, TSI,
           FD->getCanonicalDecl()->getStorageClass()
               CLAD_COMPAT_FunctionDecl_UsesFPIntrin_Param(FD),
-          FD->isInlineSpecified(), FD->hasWrittenPrototype(),
+          /*isInlineSpecified=*/true, FD->hasWrittenPrototype(),
           FD->getConstexprKind(), TrailingRequiresClause);
 
       returnedFD->setAccess(FD->getAccess());
     }
-
-    returnedFD->setImplicitlyInline(FD->isInlined());
 
     for (const FunctionDecl* NFD : FD->redecls()) {
       for (const auto* Attr : NFD->attrs()) {

--- a/test/CUDA/ForwardMode.cu
+++ b/test/CUDA/ForwardMode.cu
@@ -17,7 +17,7 @@ __global__ void add(double *a, double *b, double *c, int n) {
     c[idx] = a[idx] + b[idx];
 }
 
-// CHECK:  __attribute__((global)) void add_pushforward(double *a, double *b, double *c, int n, double *_d_a, double *_d_b, double *_d_c, int _d_n) {
+// CHECK:  __attribute__((global)) inline void add_pushforward(double *a, double *b, double *c, int n, double *_d_a, double *_d_b, double *_d_c, int _d_n) {
 // CHECK-NEXT:     int _d_idx = 0;
 // CHECK-NEXT:     int idx = threadIdx.x;
 // CHECK-NEXT:     if (idx < n) {

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -28,7 +28,7 @@ __device__ __host__ double gauss(const double* x, double* p, double sigma, int d
 }
 
 
-// CHECK: __attribute__((device)) __attribute__((host)) void gauss_grad_1(const double *x, double *p, double sigma, int dim, double *_d_p) {
+// CHECK: __attribute__((device)) __attribute__((host)) inline void gauss_grad_1(const double *x, double *p, double sigma, int dim, double *_d_p) {
 //CHECK-NEXT:     double _d_sigma = 0.;
 //CHECK-NEXT:     int _d_dim = 0;
 //CHECK-NEXT:     int _d_i = 0;

--- a/test/CUDA/GradientKernels.cu
+++ b/test/CUDA/GradientKernels.cu
@@ -262,7 +262,7 @@ __global__ void kernel_with_device_call(double *out, const double *in, double va
   out[index] = device_fn(in[index], val);
 }
 
-// CHECK: __attribute__((device)) void device_fn_pullback_1(const double in, double val, double _d_y, double *_d_in, double *_d_val) {
+// CHECK: __attribute__((device)) inline void device_fn_pullback_1(const double in, double val, double _d_y, double *_d_in, double *_d_val) {
 //CHECK-NEXT:    {
 //CHECK-NEXT:                *_d_in += _d_y;
 //CHECK-NEXT:                *_d_val += _d_y;
@@ -300,7 +300,7 @@ __global__ void dup_kernel_with_device_call_2(double *out, const double *in, dou
   out[index] = device_fn_2(in, val);
 } 
 
-//CHECK: __attribute__((device)) void device_fn_2_pullback_1(const double *in, double val, double _d_y, double *_d_val) {
+//CHECK: __attribute__((device)) inline void device_fn_2_pullback_1(const double *in, double val, double _d_y, double *_d_val) {
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:    *_d_val += _d_y;
@@ -321,7 +321,7 @@ __global__ void dup_kernel_with_device_call_2(double *out, const double *in, dou
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
-// CHECK: __attribute__((device)) void device_fn_2_pullback_0(const double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+// CHECK: __attribute__((device)) inline void device_fn_2_pullback_0(const double *in, double val, double _d_y, double *_d_in, double *_d_val) {
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:    {
@@ -356,7 +356,7 @@ __global__ void kernel_with_device_call_3(double *out, double *in, double *val) 
   out[index] = device_fn_3(in, val);
 } 
 
-// CHECK: __attribute__((device)) void device_fn_3_pullback_0_1(double *in, double *val, double _d_y, double *_d_in, double *_d_val) {
+// CHECK: __attribute__((device)) inline void device_fn_3_pullback_0_1(double *in, double *val, double _d_y, double *_d_in, double *_d_val) {
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:    {
@@ -392,7 +392,7 @@ __global__ void kernel_with_nested_device_call(double *out, double *in, double v
   out[index] = device_with_device_call(in, val);
 }
 
-// CHECK: __attribute__((device)) void device_fn_4_pullback_0_1(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+// CHECK: __attribute__((device)) inline void device_fn_4_pullback_0_1(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
 //CHECK-NEXT:    int _d_index = 0;
 //CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
 //CHECK-NEXT:    {
@@ -401,7 +401,7 @@ __global__ void kernel_with_nested_device_call(double *out, double *in, double v
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
-// CHECK: __attribute__((device)) void device_with_device_call_pullback_0(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+// CHECK: __attribute__((device)) inline void device_with_device_call_pullback_0(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
 //CHECK-NEXT:    {
 //CHECK-NEXT:        double _r0 = 0.;
 //CHECK-NEXT:        device_fn_4_pullback_0_1(in, val, _d_y, _d_in, &_r0);
@@ -551,7 +551,7 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
   cudaFree(out_dev);
 }
 
-// CHECK: __attribute__((global)) void add_kernel_4_pullback(int *out, int *in, int N, int *_d_out, int *_d_in, int *_d_N) {
+// CHECK: __attribute__((global)) inline void add_kernel_4_pullback(int *out, int *in, int N, int *_d_out, int *_d_in, int *_d_N) {
 // CHECK-NEXT:     bool _cond0;
 // CHECK-NEXT:     int _d_sum = 0;
 // CHECK-NEXT:     int sum = 0;
@@ -770,7 +770,7 @@ __global__ void kernel_device_injective(int *a) {
   device_injective_index(a);
 }
 
-// CHECK: __attribute__((device)) void device_injective_index_pullback_0(int *a, int *_d_a) {
+// CHECK: __attribute__((device)) inline void device_injective_index_pullback_0(int *a, int *_d_a) {
 // CHECK-NEXT:     int _d_index1 = 0;
 // CHECK-NEXT:     int index1 = threadIdx.x + blockIdx.x * blockDim.x;
 // CHECK-NEXT:     int _d_index2 = 0;

--- a/test/Enzyme/GradientsComparisonWithClad.C
+++ b/test/Enzyme/GradientsComparisonWithClad.C
@@ -11,7 +11,7 @@ __attribute__((always_inline)) double f_add1(double x, double y) {
   return x + y;
 }
 
-// CHECK: __attribute__((always_inline)) void f_add1_grad_enzyme(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: __attribute__((always_inline)) inline void f_add1_grad_enzyme(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     clad::EnzymeGradient<2> grad = __enzyme_autodiff_f_add1(f_add1, x, y);
 // CHECK-NEXT:     *_d_x = grad.d_arr[0U];
 // CHECK-NEXT:     *_d_y = grad.d_arr[1U];

--- a/test/FirstDerivative/FunctionCalls.C
+++ b/test/FirstDerivative/FunctionCalls.C
@@ -177,7 +177,7 @@ double test_9(double x) {
   return A::static_method(x);
 }
 
-// CHECK: static clad::ValueAndPushforward<double, double> static_method_pushforward(double x, double _d_x) {
+// CHECK: static inline clad::ValueAndPushforward<double, double> static_method_pushforward(double x, double _d_x) {
 // CHECK-NEXT: return {x, _d_x};
 // CHECK-NEXT: }
 

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -28,7 +28,7 @@ double fn1(double x, double y) {
     return y + g.y;
 } // x + x^2
 
-// CHECK: static clad::ValueAndAdjoint<argByVal, argByVal> constructor_reverse_forw(clad::Tag<argByVal>, double val, double _d_val) {
+// CHECK: static inline clad::ValueAndAdjoint<argByVal, argByVal> constructor_reverse_forw(clad::Tag<argByVal>, double val, double _d_val) {
 // CHECK-NEXT:     argByVal *_this = (argByVal *)malloc(sizeof(argByVal));
 // CHECK-NEXT:     argByVal *_d_this = (argByVal *)malloc(sizeof(argByVal));
 // CHECK-NEXT:     memset(_d_this, 0, sizeof(argByVal));
@@ -38,7 +38,7 @@ double fn1(double x, double y) {
 // CHECK-NEXT:     return {*_this, *_d_this};
 // CHECK-NEXT: }
 
-// CHECK:  static void constructor_pullback(double val, argByVal *_d_this, double *_d_val) {
+// CHECK:  static inline void constructor_pullback(double val, argByVal *_d_this, double *_d_val) {
 // CHECK-NEXT:      argByVal *_this = (argByVal *)malloc(sizeof(argByVal));
 // CHECK-NEXT:      _this->x = val;
 // CHECK-NEXT:      double _t0 = val;
@@ -128,7 +128,7 @@ double fn2(double u, double v) {
   return 1;
 }
 
-// CHECK:  static clad::ValueAndAdjoint<S1, S1> constructor_reverse_forw(clad::Tag<S1>, double x, double _d_x) {
+// CHECK:  static inline clad::ValueAndAdjoint<S1, S1> constructor_reverse_forw(clad::Tag<S1>, double x, double _d_x) {
 // CHECK-NEXT:      S1 *_this = (S1 *)malloc(sizeof(S1));
 // CHECK-NEXT:      S1 *_d_this = (S1 *)malloc(sizeof(S1));
 // CHECK-NEXT:      memset(_d_this, 0, sizeof(S1));
@@ -137,7 +137,7 @@ double fn2(double u, double v) {
 // CHECK-NEXT:      return {*_this, *_d_this};
 // CHECK-NEXT:  }
 
-// CHECK:  static void constructor_pullback(double x, S1 *_d_this, double *_d_x) {
+// CHECK:  static inline void constructor_pullback(double x, S1 *_d_this, double *_d_x) {
 // CHECK-NEXT:      _d_this->d = 0.;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          *_d_x += _d_this->p;
@@ -145,7 +145,7 @@ double fn2(double u, double v) {
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
-// CHECK: static clad::ValueAndAdjoint<S2, S2> constructor_reverse_forw(clad::Tag<S2>, double x, double _d_x) {
+// CHECK: static inline clad::ValueAndAdjoint<S2, S2> constructor_reverse_forw(clad::Tag<S2>, double x, double _d_x) {
 // CHECK-NEXT:     S2 *_this = (S2 *)malloc(sizeof(S2));
 // CHECK-NEXT:     S2 *_d_this = (S2 *)malloc(sizeof(S2));
 // CHECK-NEXT:     memset(_d_this, 0, sizeof(S2));
@@ -155,7 +155,7 @@ double fn2(double u, double v) {
 // CHECK-NEXT:     return {*_this, *_d_this};
 // CHECK-NEXT: }
 
-// CHECK:  static void constructor_pullback(double x, S2 *_d_this, double *_d_x) {
+// CHECK:  static inline void constructor_pullback(double x, S2 *_d_this, double *_d_x) {
 // CHECK-NEXT:      S2 *_this = (S2 *)malloc(sizeof(S2));
 // CHECK-NEXT:      _this->p = x;
 // CHECK-NEXT:      _this->i = 1.;
@@ -169,7 +169,7 @@ double fn2(double u, double v) {
 // CHECK-NEXT:      free(_this);
 // CHECK-NEXT:  }
 
-// CHECK: static clad::ValueAndAdjoint<S3, S3> constructor_reverse_forw(clad::Tag<S3>, double x, double _d_x) {
+// CHECK: static inline clad::ValueAndAdjoint<S3, S3> constructor_reverse_forw(clad::Tag<S3>, double x, double _d_x) {
 // CHECK-NEXT:     S3 *_this = (S3 *)malloc(sizeof(S3));
 // CHECK-NEXT:     S3 *_d_this = (S3 *)malloc(sizeof(S3));
 // CHECK-NEXT:     memset(_d_this, 0, sizeof(S3));
@@ -177,7 +177,7 @@ double fn2(double u, double v) {
 // CHECK-NEXT:     return {*_this, *_d_this};
 // CHECK-NEXT: }
 
-// CHECK:  static void constructor_pullback(double x, S3 *_d_this, double *_d_x) {
+// CHECK:  static inline void constructor_pullback(double x, S3 *_d_this, double *_d_x) {
 // CHECK-NEXT:      S3 *_this = (S3 *)malloc(sizeof(S3));
 // CHECK-NEXT:      _this->p = x * x;
 // CHECK-NEXT:      {
@@ -189,14 +189,14 @@ double fn2(double u, double v) {
 // CHECK-NEXT:      free(_this);
 // CHECK-NEXT:  }
 
-// CHECK: static clad::ValueAndAdjoint<S5, S5> constructor_reverse_forw(clad::Tag<S5>, double x, double _d_x) {
+// CHECK: static inline clad::ValueAndAdjoint<S5, S5> constructor_reverse_forw(clad::Tag<S5>, double x, double _d_x) {
 // CHECK-NEXT:     S5 *_this = (S5 *)malloc(sizeof(S5));
 // CHECK-NEXT:     S5 *_d_this = (S5 *)malloc(sizeof(S5));
 // CHECK-NEXT:     memset(_d_this, 0, sizeof(S5));
 // CHECK-NEXT:     return {*_this, *_d_this};
 // CHECK-NEXT: }
 
-// CHECK:  static void constructor_pullback(double x, S5 *_d_this, double *_d_x) {
+// CHECK:  static inline void constructor_pullback(double x, S5 *_d_this, double *_d_x) {
 // CHECK-NEXT:      S5 *_this = (S5 *)malloc(sizeof(S5));
 // CHECK-NEXT:      free(_this);
 // CHECK-NEXT:  }
@@ -241,7 +241,7 @@ double fn3(double u, double v) {
   return s.i * s.p;
 }
 
-// CHECK: static clad::ValueAndAdjoint<S4, S4> constructor_reverse_forw(clad::Tag<S4>, double x, double _d_x) {
+// CHECK: static inline clad::ValueAndAdjoint<S4, S4> constructor_reverse_forw(clad::Tag<S4>, double x, double _d_x) {
 // CHECK-NEXT:    S4 *_this = (S4 *)malloc(sizeof(S4));
 // CHECK-NEXT:    S4 *_d_this = (S4 *)malloc(sizeof(S4));
 // CHECK-NEXT:    memset(_d_this, 0, sizeof(S4));
@@ -250,7 +250,7 @@ double fn3(double u, double v) {
 // CHECK-NEXT:    return {*_this, *_d_this};
 // CHECK-NEXT:}
 
-// CHECK: static void constructor_pullback(double x, S4 *_d_this, double *_d_x) {
+// CHECK: static inline void constructor_pullback(double x, S4 *_d_this, double *_d_x) {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        *_d_x += _d_this->p;
 // CHECK-NEXT:        _d_this->p = 0.;
@@ -296,7 +296,7 @@ double fn4(double i, double j) {
   return 2 + SimpleFunctions1(i);
 }
 
-// CHECK: static void constructor_pullback(double px, SimpleFunctions1 *_d_this, double *_d_px) {
+// CHECK: static inline void constructor_pullback(double px, SimpleFunctions1 *_d_this, double *_d_px) {
 // CHECK-NEXT:      _d_this->y = 0.;
 // CHECK-NEXT:      {
 // CHECK-NEXT:          *_d_px += _d_this->x;
@@ -332,7 +332,7 @@ double fn5(double x, double y) {
     return y + g.y;
 } // x + x^2
 
-// CHECK:  static void constructor_pullback(double v, argByValWrapper *_d_this, double *_d_v) {
+// CHECK:  static inline void constructor_pullback(double v, argByValWrapper *_d_this, double *_d_v) {
 // CHECK-NEXT:      clad::ValueAndAdjoint<argByVal, argByVal> _t0 = argByVal::constructor_reverse_forw(clad::Tag<argByVal>(), v, 0.);
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r0 = 0.;
@@ -365,7 +365,7 @@ double fn6(double x, double y) {
     return g.z;
 } // x^2 * y
 
-// CHECK: static clad::ValueAndAdjoint<argByValWrapper, argByValWrapper> constructor_reverse_forw(clad::Tag<argByValWrapper>, double v, double u, double _d_v, double _d_u) {
+// CHECK: static inline clad::ValueAndAdjoint<argByValWrapper, argByValWrapper> constructor_reverse_forw(clad::Tag<argByValWrapper>, double v, double u, double _d_v, double _d_u) {
 // CHECK-NEXT:     argByValWrapper *_this = (argByValWrapper *)malloc(sizeof(argByValWrapper));
 // CHECK-NEXT:     argByValWrapper *_d_this = (argByValWrapper *)malloc(sizeof(argByValWrapper));
 // CHECK-NEXT:     memset(_d_this, 0, sizeof(argByValWrapper));
@@ -374,7 +374,7 @@ double fn6(double x, double y) {
 // CHECK-NEXT:     return {*_this, *_d_this};
 // CHECK-NEXT: }
 
-// CHECK:  static void constructor_pullback(double v, double u, argByValWrapper *_d_this, double *_d_v, double *_d_u) {
+// CHECK:  static inline void constructor_pullback(double v, double u, argByValWrapper *_d_this, double *_d_v, double *_d_u) {
 // CHECK-NEXT:      argByValWrapper *_this = (argByValWrapper *)malloc(sizeof(argByValWrapper));
 // CHECK-NEXT:      new (_this) argByValWrapper(v);
 // CHECK-NEXT:      _this->z = _this->y * u;
@@ -411,7 +411,7 @@ double fn7(double x, double y) {
     return g.z;
 } // x^3
 
-// CHECK: static clad::ValueAndAdjoint<argByValWrapper, argByValWrapper> constructor_reverse_forw(clad::Tag<argByValWrapper>, double v, bool arg, double _d_v, bool _d_arg) {
+// CHECK: static inline clad::ValueAndAdjoint<argByValWrapper, argByValWrapper> constructor_reverse_forw(clad::Tag<argByValWrapper>, double v, bool arg, double _d_v, bool _d_arg) {
 // CHECK-NEXT:     argByValWrapper *_this = (argByValWrapper *)malloc(sizeof(argByValWrapper));
 // CHECK-NEXT:     argByValWrapper *_d_this = (argByValWrapper *)malloc(sizeof(argByValWrapper));
 // CHECK-NEXT:     memset(_d_this, 0, sizeof(argByValWrapper));
@@ -421,7 +421,7 @@ double fn7(double x, double y) {
 // CHECK-NEXT:     return {*_this, *_d_this};
 // CHECK-NEXT: }
 
-// CHECK:  static void constructor_pullback(double v, bool arg, argByValWrapper *_d_this, double *_d_v, bool *_d_arg) {
+// CHECK:  static inline void constructor_pullback(double v, bool arg, argByValWrapper *_d_this, double *_d_v, bool *_d_arg) {
 // CHECK-NEXT:      argByValWrapper *_this = (argByValWrapper *)malloc(sizeof(argByValWrapper));
 // CHECK-NEXT:      clad::ValueAndAdjoint<argByVal, argByVal> _t0 = argByVal::constructor_reverse_forw(clad::Tag<argByVal>(), v, 0.);
 // CHECK-NEXT:      new (static_cast<argByVal *>(_this)) argByVal(_t0.value);
@@ -586,7 +586,7 @@ struct cust_double {
     double val;
 };
 
-// CHECK:  static void constructor_pullback(double x, cust_double *_d_this, double *_d_x) {
+// CHECK:  static inline void constructor_pullback(double x, cust_double *_d_this, double *_d_x) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          *_d_x += _d_this->val;
 // CHECK-NEXT:          _d_this->val = 0.;
@@ -646,7 +646,7 @@ class ptrConstr {
   }
 };
 
-// CHECK:  static clad::ValueAndAdjoint<ptrConstr, ptrConstr> constructor_reverse_forw(clad::Tag<ptrConstr>, double &x, const double &y, double &_d_x, const double &_d_y) {
+// CHECK:  static inline clad::ValueAndAdjoint<ptrConstr, ptrConstr> constructor_reverse_forw(clad::Tag<ptrConstr>, double &x, const double &y, double &_d_x, const double &_d_y) {
 // CHECK-NEXT:      ptrConstr *_this = (ptrConstr *)malloc(sizeof(ptrConstr));
 // CHECK-NEXT:      ptrConstr *_d_this = (ptrConstr *)malloc(sizeof(ptrConstr));
 // CHECK-NEXT:      memset(_d_this, 0, sizeof(ptrConstr));
@@ -656,7 +656,7 @@ class ptrConstr {
 // CHECK-NEXT:      return {*_this, *_d_this};
 // CHECK-NEXT:  }
 
-// CHECK:  static void constructor_pullback(double &x, const double &y, ptrConstr *_d_this, double *_d_x, double *_d_y) {
+// CHECK:  static inline void constructor_pullback(double &x, const double &y, ptrConstr *_d_this, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      ptrConstr *_this = (ptrConstr *)malloc(sizeof(ptrConstr));
 // CHECK-NEXT:      _this->ptr = &x;
 // CHECK-NEXT:      _this->val = y * y;

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -367,7 +367,7 @@ public:
 
   static double static_mem_fn(double u, double v) { return u + v; }
   
-  // CHECK: static void static_mem_fn_grad(double u, double v, double *_d_u, double *_d_v) {
+  // CHECK: static inline void static_mem_fn_grad(double u, double v, double *_d_u, double *_d_v) {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         *_d_u += 1;
   // CHECK-NEXT:         *_d_v += 1;
@@ -574,7 +574,7 @@ double fn6(double u, double v) {
     return v;
 }
 
-// CHECK: static void constructor_pullback(double x, double *y, SafeTestClass *_d_this, double *_d_x, double *_d_y) {
+// CHECK: static inline void constructor_pullback(double x, double *y, SafeTestClass *_d_this, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     SafeTestClass *_this = (SafeTestClass *)malloc(sizeof(SafeTestClass));
 // CHECK-NEXT:     *y = x;
 // CHECK-NEXT:     {
@@ -906,7 +906,7 @@ int main() {
   d_fn3.execute(2, 3, 4, 5, &result[0], &result[1]);
   printf("%.2f %.2f", result[0], result[1]); // CHECK-EXEC: 10.00 4.00
 
-// CHECK: static void constructor_pullback(double p_x, double p_y, SimpleFunctions *_d_this, double *_d_p_x, double *_d_p_y) {
+// CHECK: static inline void constructor_pullback(double p_x, double p_y, SimpleFunctions *_d_this, double *_d_p_x, double *_d_p_y) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_p_y += _d_this->y;
 // CHECK-NEXT:         _d_this->y = 0.;

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -1169,7 +1169,7 @@ int main() {
 // CHECK-NEXT:     foo_pullback(x, _d_y, _d_x);
 // CHECK-NEXT: }
 
-// CHECK: {{.*}}static constexpr void constructor_pullback(double &{{.*}}, int &&{{.*}}, std::pair<double, double> *_d_this, double *{{.*}}, int *{{.*}}){{.*}}{
+// CHECK: {{.*}}static inline constexpr void constructor_pullback(double &{{.*}}, int &&{{.*}}, std::pair<double, double> *_d_this, double *{{.*}}, int *{{.*}}){{.*}}{
 // CHECK-NEXT:     std::pair<double, double> *_this = (std::pair<double, double> *)malloc(sizeof(std::pair<double, double>));
 // CHECK:    _this->first = {{.*}};
 // CHECK-NEXT:   _this->second = std::move({{.*}});

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -555,7 +555,7 @@ public:
   }
 };
 
-// CHECK: static void constructor_pullback(double p_x, double p_y, SimpleFunctions1 *_d_this, double *_d_p_x, double *_d_p_y) noexcept {
+// CHECK: static inline void constructor_pullback(double p_x, double p_y, SimpleFunctions1 *_d_this, double *_d_p_x, double *_d_p_y) noexcept {
 // CHECK-NEXT:    {
 // CHECK-NEXT:        *_d_p_y += _d_this->y;
 // CHECK-NEXT:        _d_this->y = 0.;
@@ -833,7 +833,7 @@ struct Vector3 {
     }
 };
 
-// CHECK: static void constructor_pullback(double px, double py, double pz, Vector3 *_d_this, double *_d_px, double *_d_py, double *_d_pz) {
+// CHECK: static inline void constructor_pullback(double px, double py, double pz, Vector3 *_d_this, double *_d_px, double *_d_py, double *_d_pz) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          *_d_pz += _d_this->z;
 // CHECK-NEXT:          _d_this->z = 0.;
@@ -1300,7 +1300,7 @@ public:
   }
 };
 
-// CHECK:  static void constructor_pullback(size_t n, PrivClass *_d_this, size_t *_d_n) {
+// CHECK:  static inline void constructor_pullback(size_t n, PrivClass *_d_this, size_t *_d_n) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          *_d_n += _d_this->n_;
 // CHECK-NEXT:          _d_this->n_ = {{0U|0UL|0ULL}};

--- a/test/Regressions/hessian-intermediate-codegen.cpp
+++ b/test/Regressions/hessian-intermediate-codegen.cpp
@@ -1,0 +1,35 @@
+// RUN: %cladclang -std=c++17 -I%S/../../include %s -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+// Derivatives are generated into every translation unit that needs them, so
+// clad declares them inline. That also makes them discardable: CodeGen defers
+// each until a DeclRefExpr asks for it. Hessian mode derives fn once in forward
+// mode per direction and only reverse-differentiates the result, so nothing
+// references fn_darg0 and it never reaches the backend.
+//
+// Derivatives are cached per request, so the clad::differentiate below reuses
+// that same declaration rather than building its own. Its call is the
+// DeclRefExpr that makes CodeGen emit fn_darg0 after all; were the intermediate
+// undiscardable instead (internal linkage, or held back from CodeGen), the
+// symbol would stay undefined and this would not link.
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+double fn(double x, double y) { return x * x * y; }
+
+// CHECK: {{^}}inline double fn_darg0(double x, double y) {
+// CHECK: {{^}}inline void fn_hessian(double x, double y, double *hessianMatrix) {
+
+int main() {
+  auto h = clad::hessian(fn);
+  auto d = clad::differentiate(fn, "x");
+
+  double matrix[4] = {0, 0, 0, 0};
+  h.execute(3, 5, matrix);
+  printf("%.2f %.2f %.2f %.2f\n", matrix[0], matrix[1], matrix[2], matrix[3]);
+  // CHECK-EXEC: 10.00 6.00 6.00 0.00
+
+  printf("%.2f\n", d.execute(3, 5));
+  // CHECK-EXEC: 30.00
+}

--- a/unittests/Misc/CallDeclOnly.cpp
+++ b/unittests/Misc/CallDeclOnly.cpp
@@ -23,7 +23,7 @@ TEST(CallDeclOnly, CheckNumDiff) {
 
   // Check the generated code from grad.dump()
   std::string expected = R"(The code is: 
-void wrapper1_grad(double *params, double *_d_params) {
+inline void wrapper1_grad(double *params, double *_d_params) {
     double _d_ix = 0.;
     const double ix = 1 + params[0];
     {


### PR DESCRIPTION
Hessian mode derives the function once in forward mode per direction and reverse-differentiates each of those, cloning the first-order body into the second. Nothing ever calls `f_darg0_<i>` afterwards, yet the backend got one dead function per direction, each roughly the size of the primal -- on a 41-parameter RooFit likelihood, 17% of all emitted derivative AST and 1.19x on the time to produce the hessian.

CodeGen defers a function until a DeclRefExpr asks for it, so why were these exempt? clad cloned the primal's inline-ness, and a plain `double f(...)` yields a strong external definition, which ASTContext::DeclMustBeEmitted requires this TU to emit.

But a derivative is not the primal. It is a small function clad regenerates in every translation unit that asks for it, and the handwritten pushforwards and pullbacks in BuiltinDerivatives.h are already inline for that reason. So clone every derivative inline at the FunctionDecl::Create and CXXMethodDecl::Create calls instead of carrying the primal's specifier over, and no mode needs a case of its own. Being discardable, CodeGen drops whatever nothing references, and a later clad::differentiate(f, "x") reusing the cached declaration brings its definition back through the DeclRefExpr in its own call.

The user-facing f_darg0, f_grad, f_hessian and f_jacobian are inline as well. The CladFunction that names one sits in the same translation unit, so its DeclRefExpr keeps the definition alive.

The exception is a derivative whose name a user already defined by hand: [dcl.inline]p6 makes an inline declaration that follows a definition ill-formed, and Hessian/BuiltinDerivatives.C does exactly that with clad::custom_derivatives::f7_darg1_grad. registerDerivative already looks the name up for Sema's redeclaration merge, so drop the specifier there when that lookup finds a non-inline definition.