### PR TITLE
Reach past operator callees in the TBR dependency fallback.

### DIFF
--- a/lib/Differentiator/AnalysisBase.cpp
+++ b/lib/Differentiator/AnalysisBase.cpp
@@ -123,18 +123,23 @@ void AnalysisBase::getDependencySet(const clang::Expr* E,
   public:
     std::set<const clang::VarDecl*>& vars;
     DeclFinder(std::set<const clang::VarDecl*>& pvars) : vars(pvars) {}
+    // A Traverse* override returning false aborts the entire traversal, not
+    // just this subtree (see clang/AST/RecursiveASTVisitor.h); returning true
+    // without calling the base skips only this node's children.
     bool TraverseDeclRefExpr(DeclRefExpr* DRE) {
       if (auto* VD = dyn_cast<VarDecl>(DRE->getDecl()))
         vars.insert(VD);
-      return false;
+      return true;
     }
     bool TraverseArraySubscriptExpr(ArraySubscriptExpr* ASE) {
+      // The index is deliberately not visited: only the base contributes a
+      // storage dependency.
       TraverseStmt(ASE->getBase());
-      return false;
+      return true;
     }
     bool TraverseCXXThisExpr(CXXThisExpr* TE) {
       vars.insert(nullptr);
-      return false;
+      return true;
     }
   };
   DeclFinder finder(vars);

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3365,11 +3365,19 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       }
 
       // Store the value of the LHS of the assignment in the forward pass
-      // and restore it in the reverse pass
+      // and restore it in the reverse pass.
       if (m_DiffReq.shouldBeRecorded(L) && !isReallocAssignment) {
-        // Clone: LCloned is also consumed by the forward reconstruction, so the
-        // store/restore must not share it.
-        StmtDiff pushPop = StoreAndRestore(CloneNode(LCloned));
+        // In a loop a call-shaped LHS (`v[i]` through a user-defined
+        // operator[] or at()) is restored by re-evaluating the lvalue rather
+        // than through the call's cached result pointer, whose per-iteration
+        // target the reverse sweep may already have destroyed. The accessor
+        // therefore runs once more per stored assignment.
+        bool callLValue = isa<CallExpr>(L->IgnoreParenImpCasts());
+        // Clone: LCloned is also consumed by the forward reconstruction, so
+        // the store/restore must not share it.
+        Expr* storeE =
+            (isInsideLoop && callLValue) ? Clone(L) : CloneNode(LCloned);
+        StmtDiff pushPop = StoreAndRestore(storeE);
         addToCurrentBlock(pushPop.getStmt(), direction::forward);
         addToCurrentBlock(pushPop.getStmt_dx(), direction::reverse);
         if (isInsideOMPBlock) {

--- a/test/Analyses/TBRCalls.C
+++ b/test/Analyses/TBRCalls.C
@@ -1,0 +1,148 @@
+// RUN: %cladclang %s -I%S/../../include -oTBRCalls.out 2>&1 | %filecheck %s
+// RUN: ./TBRCalls.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s \
+// RUN:   -I%S/../../include -oTBRCalls.out
+// RUN: ./TBRCalls.out | %filecheck_exec %s
+
+// Verifies that TBR analysis records caller state mutated through a call even
+// when the argument does not resolve to a storage location -- the GradBench
+// GMM shape `f(..., &v[0])`, where the address-of wraps a user-defined
+// operator[] call. The dependency fallback used to come back empty for such
+// arguments, so no pre-call state was stored and the pullback replayed from
+// post-call values.
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+void fillfrom(int d, const double* x, double* out) {
+  for (int i = 0; i < d; i++)
+    out[i] = x[i];
+}
+
+// Reads and overwrites out in place; its pullback needs the primal values.
+void squarer(int d, double* out) {
+  for (int i = 0; i < d; i++)
+    out[i] = out[i] * out[i];
+}
+
+struct Vec2 {
+  double vals[2];
+  double& operator[](int i) { return vals[i]; }
+  const double& operator[](int i) const { return vals[i]; }
+  double& at(int i) { return vals[i]; }
+  const double& at(int i) const { return vals[i]; }
+  double* data() { return vals; }
+  const double* data() const { return vals; }
+};
+
+struct W {
+  double* ptr;
+};
+
+// The mutated buffer is reached through &buf[0] over a user-defined
+// operator[].
+double t1(const double* x) {
+  Vec2 buf;
+  fillfrom(2, x, &buf[0]);
+  squarer(2, &buf[0]);
+  return buf[0] + buf[1];
+}
+
+// The mutated buffer is reached through a data() accessor.
+double t2(const double* x) {
+  Vec2 buf;
+  fillfrom(2, x, buf.data());
+  squarer(2, buf.data());
+  return buf[0] + buf[1];
+}
+
+// The mutated buffer is reached through &buf[0] on a raw array.
+double t3(const double* x) {
+  double buf[2];
+  fillfrom(2, x, &buf[0]);
+  squarer(2, &buf[0]);
+  return buf[0] + buf[1];
+}
+
+// The mutated buffer is reached through a struct-carried pointer.
+double t4(const double* x) {
+  double buf[2];
+  W w{buf};
+  fillfrom(2, x, buf);
+  squarer(2, w.ptr);
+  return buf[0] + buf[1];
+}
+
+// A call-shaped assignment lvalue overwritten after a nonlinear read: the
+// element must be stored and restored so the read's adjoint sees its primal.
+double t5(const double* x) {
+  Vec2 buf;
+  buf.at(0) = x[0];
+  buf.at(1) = x[1];
+  double t = buf.at(0) * buf.at(0) + buf.at(1) * buf.at(1);
+  buf.at(0) = 3 * x[1];
+  return t + buf.at(0);
+}
+
+double t6(const double* x) {
+  Vec2 buf;
+  buf[0] = x[0];
+  buf[1] = x[1];
+  double t = buf[0] * buf[0] + buf[1] * buf[1];
+  buf[0] = 3 * x[1];
+  return t + buf[0];
+}
+
+// An in-loop overwrite through operator[] results: each reverse iteration
+// must see its own element values, restored by re-evaluating the lvalue.
+double t8(const double* x) {
+  Vec2 v;
+  double total = 0;
+  for (int k = 1; k <= 2; k++) {
+    for (int j = 0; j < 2; j++)
+      v[j] = k * x[j];
+    total += v[0] * v[0] + v[1] * v[1];
+  }
+  return total;
+}
+
+// Nothing is read nonlinearly, so no pre-call state may be stored.
+double t7(const double* x) {
+  double buf[2];
+  fillfrom(2, x, &buf[0]);
+  return buf[0] + buf[1];
+}
+
+// CHECK: void t1_grad(const double *x, double *_d_x) {
+// CHECK: squarer_reverse_forw(2, &{{.*}}, 0, &{{.*}}, _tracker0);
+// CHECK: _tracker0.restore();
+// CHECK: squarer_pullback(2, &{{.*}});
+
+// CHECK: void t7_grad(const double *x, double *_d_x) {
+// CHECK-NOT: _tracker
+// CHECK-NOT: clad::push
+// CHECK: fillfrom_pullback(2, x, &buf[0]
+
+int main() {
+  double x[2] = {1, 2};
+  double dx[2];
+#define TEST(fn)                                                               \
+  {                                                                            \
+    dx[0] = dx[1] = 0;                                                         \
+    auto grad = clad::gradient(fn, "x");                                       \
+    grad.execute(x, dx);                                                       \
+    printf(#fn ": dx={%.2f, %.2f}\n", dx[0], dx[1]);                           \
+  }
+  // f = x0^2 + x1^2 => df/dx_i = 2 x_i
+  TEST(t1); // CHECK-EXEC: t1: dx={2.00, 4.00}
+  TEST(t2); // CHECK-EXEC: t2: dx={2.00, 4.00}
+  TEST(t3); // CHECK-EXEC: t3: dx={2.00, 4.00}
+  TEST(t4); // CHECK-EXEC: t4: dx={2.00, 4.00}
+  // f = x0^2 + x1^2 + 3 x1 => df/dx0 = 2 x0, df/dx1 = 2 x1 + 3
+  TEST(t5); // CHECK-EXEC: t5: dx={2.00, 7.00}
+  TEST(t6); // CHECK-EXEC: t6: dx={2.00, 7.00}
+  // f = sum_k k^2 |x|^2 = 5 |x|^2 => df/dx_i = 10 x_i
+  TEST(t8); // CHECK-EXEC: t8: dx={10.00, 20.00}
+  // f = x0 + x1
+  TEST(t7); // CHECK-EXEC: t7: dx={1.00, 1.00}
+}

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -353,7 +353,9 @@ double fn7(double i, double j) {
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t2 = {{.*}}custom_derivatives::custom_identity_reverse_forw(i, *_d_i);
 // CHECK-NEXT:     double &_d_temp = _t2.adjoint;
 // CHECK-NEXT:     double &temp = _t2.value;
+// CHECK-NEXT:     double _t3 = k;
 // CHECK-NEXT:     k += 7 * j;
+// CHECK-NEXT:     double _t4 = l;
 // CHECK-NEXT:     l += 9 * i;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_i += 1;
@@ -361,10 +363,12 @@ double fn7(double i, double j) {
 // CHECK-NEXT:         _d_temp += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
+// CHECK-NEXT:         l = _t4;
 // CHECK-NEXT:         double _r_d1 = _d_l;
 // CHECK-NEXT:         *_d_i += 9 * _r_d1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
+// CHECK-NEXT:         k = _t3;
 // CHECK-NEXT:         double _r_d0 = _d_k;
 // CHECK-NEXT:         *_d_j += 7 * _r_d0;
 // CHECK-NEXT:     }
@@ -1009,9 +1013,13 @@ double fn28(double u, double v) {
 // CHECK-NEXT:     clad::ValueAndAdjoint<double &, double &> _t0 = nested_reverse_forw(arr, u, _d_arr, 0., _tracker0);
 // CHECK-NEXT:     double &_d_ref = _t0.adjoint;
 // CHECK-NEXT:     double &ref = _t0.value;
+// CHECK-NEXT:     double _t1 = ref;
 // CHECK-NEXT:     ref += 2;
 // CHECK-NEXT:     _d_ref += 1;
-// CHECK-NEXT:     double _r_d0 = _d_ref; 
+// CHECK-NEXT:     {
+// CHECK-NEXT:         ref = _t1;
+// CHECK-NEXT:         double _r_d0 = _d_ref;
+// CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         double _r0 = 0.;

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -409,12 +409,14 @@ int main() {
 // CHECK-NEXT:     {{.*}}class_functions::push_back_reverse_forw(&vec, v, &_d_vec, *_d_v);
 // CHECK-NEXT:     double &_d_ref = _d_vec[0];
 // CHECK-NEXT:     double &ref = vec[0];
+// CHECK-NEXT:     double _t2 = ref;
 // CHECK-NEXT:     ref += u;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_vec[0] += 1;
 // CHECK-NEXT:         _d_vec[1] += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
+// CHECK-NEXT:         ref = _t2;
 // CHECK-NEXT:         double _r_d0 = _d_ref;
 // CHECK-NEXT:         *_d_u += _r_d0;
 // CHECK-NEXT:     }
@@ -435,10 +437,15 @@ int main() {
 // CHECK-NEXT:     double *ref1 = {};
 // CHECK-NEXT:     double *_d_ref2 = nullptr;
 // CHECK-NEXT:     double *ref2 = {};
+// CHECK-NEXT:     double _t1;
+// CHECK-NEXT:     double _t2;
+// CHECK-NEXT:     double _t3;
 // CHECK-NEXT:     double *_d_ref00 = nullptr;
 // CHECK-NEXT:     double *ref00 = {};
 // CHECK-NEXT:     double *_d_ref10 = nullptr;
 // CHECK-NEXT:     double *ref10 = {};
+// CHECK-NEXT:     double _t6;
+// CHECK-NEXT:     double _t7;
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     std::vector<double> vec;
@@ -452,21 +459,26 @@ int main() {
 // CHECK-NEXT:         ref1 = &vec[1];
 // CHECK-NEXT:         _d_ref2 = &_d_vec[2];
 // CHECK-NEXT:         ref2 = &vec[2];
+// CHECK-NEXT:         _t1 = *ref0;
 // CHECK-NEXT:         *ref0 = u;
+// CHECK-NEXT:         _t2 = *ref1;
 // CHECK-NEXT:         *ref1 = v;
+// CHECK-NEXT:         _t3 = *ref2;
 // CHECK-NEXT:         *ref2 = u + v;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     res = vec[0] + vec[1] + vec[2];
-// CHECK-NEXT:     std::vector<double> _t1 = vec;
+// CHECK-NEXT:     std::vector<double> _t4 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::clear_reverse_forw(&vec, &_d_vec);
-// CHECK-NEXT:     std::vector<double> _t2 = vec;
+// CHECK-NEXT:     std::vector<double> _t5 = vec;
 // CHECK-NEXT:     {{.*}}class_functions::resize_reverse_forw(&vec, 2, &_d_vec, 0);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_ref00 = &_d_vec[0];
 // CHECK-NEXT:         ref00 = &vec[0];
 // CHECK-NEXT:         _d_ref10 = &_d_vec[1];
 // CHECK-NEXT:         ref10 = &vec[1];
+// CHECK-NEXT:         _t6 = *ref00;
 // CHECK-NEXT:         *ref00 = u;
+// CHECK-NEXT:         _t7 = *ref10;
 // CHECK-NEXT:         *ref10 = u;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     res += vec[0] + vec[1];
@@ -478,23 +490,25 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
+// CHECK-NEXT:             *ref10 = _t7;
 // CHECK-NEXT:             double _r_d5 = *_d_ref10;
 // CHECK-NEXT:             *_d_ref10 = 0.;
 // CHECK-NEXT:             *_d_u += _r_d5;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
+// CHECK-NEXT:             *ref00 = _t6;
 // CHECK-NEXT:             double _r_d4 = *_d_ref00;
 // CHECK-NEXT:             *_d_ref00 = 0.;
 // CHECK-NEXT:             *_d_u += _r_d4;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         vec = _t2;
+// CHECK-NEXT:         vec = _t5;
 // CHECK-NEXT:         {{.*}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:         {{.*}}class_functions::resize_pullback(&vec, 2, &_d_vec, &_r1);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         vec = _t1;
+// CHECK-NEXT:         vec = _t4;
 // CHECK-NEXT:         clad::custom_derivatives::class_functions::clear_pullback(&vec, &_d_vec);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -506,17 +520,20 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
+// CHECK-NEXT:             *ref2 = _t3;
 // CHECK-NEXT:             double _r_d2 = *_d_ref2;
 // CHECK-NEXT:             *_d_ref2 = 0.;
 // CHECK-NEXT:             *_d_u += _r_d2;
 // CHECK-NEXT:             *_d_v += _r_d2;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
+// CHECK-NEXT:             *ref1 = _t2;
 // CHECK-NEXT:             double _r_d1 = *_d_ref1;
 // CHECK-NEXT:             *_d_ref1 = 0.;
 // CHECK-NEXT:             *_d_v += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
+// CHECK-NEXT:             *ref0 = _t1;
 // CHECK-NEXT:             double _r_d0 = *_d_ref0;
 // CHECK-NEXT:             *_d_ref0 = 0.;
 // CHECK-NEXT:             *_d_u += _r_d0;
@@ -559,9 +576,11 @@ int main() {
 // CHECK-NEXT:          std::vector<double> _t1 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, x, &_d_a, *_d_x);
 // CHECK-NEXT:          {{.*}}value_type *_t2 = &a[1];
-// CHECK-NEXT:          _t2 = x * x;
+// CHECK-NEXT:          {{.*}}value_type _t3 = *_t2;
+// CHECK-NEXT:          *_t2 = x * x;
 // CHECK-NEXT:          _d_a[1] += 1;
 // CHECK-NEXT:          {
+// CHECK-NEXT:              *_t2 = _t3;
 // CHECK-NEXT:              {{.*}}value_type _r_d0 = _d_a[1];
 // CHECK-NEXT:              _d_a[1] = 0.;
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
@@ -609,54 +628,64 @@ int main() {
 // CHECK-NEXT:         std::array<double, 2> _d_a = {{.*}};
 // CHECK-NEXT:         std::array<double, 2> a;
 // CHECK-NEXT:         {{.*}}value_type *_t0 = &a[0];
+// CHECK-NEXT:         {{.*}}value_type _t1 = *_t0;
 // CHECK-NEXT:         *_t0 = 5;
-// CHECK-NEXT:         {{.*}}value_type *_t1 = &a[1];
-// CHECK-NEXT:         *_t1 = y;
+// CHECK-NEXT:         {{.*}}value_type *_t2 = &a[1];
+// CHECK-NEXT:         {{.*}}value_type _t3 = *_t2;
+// CHECK-NEXT:         *_t2 = y;
 // CHECK-NEXT:         std::array<double, 3> _d_b = {{.*}};
 // CHECK-NEXT:         std::array<double, 3> _b0;
-// CHECK-NEXT:         {{.*}}value_type *_t2 = &_b0[0];
-// CHECK-NEXT:         *_t2 = x;
-// CHECK-NEXT:         {{.*}}value_type *_t3 = &_b0[1];
-// CHECK-NEXT:         *_t3 = 0;
-// CHECK-NEXT:         {{.*}}value_type *_t4 = &_b0[2];
-// CHECK-NEXT:         *_t4 = x * x;
+// CHECK-NEXT:         {{.*}}value_type *_t4 = &_b0[0];
+// CHECK-NEXT:         {{.*}}value_type _t5 = *_t4;
+// CHECK-NEXT:         *_t4 = x;
+// CHECK-NEXT:         {{.*}}value_type *_t6 = &_b0[1];
+// CHECK-NEXT:         {{.*}}value_type _t7 = *_t6;
+// CHECK-NEXT:         *_t6 = 0;
+// CHECK-NEXT:         {{.*}}value_type *_t8 = &_b0[2];
+// CHECK-NEXT:         {{.*}}value_type _t9 = *_t8;
+// CHECK-NEXT:         *_t8 = x * x;
 // CHECK-NEXT:         std::array<double, 3> _d_b0 = {{.*}};
 // CHECK-NEXT:         const std::array<double, 3> b = _b0;
-// CHECK:              {{.*}}value_type _t{{7|8}} = a.back();
-// CHECK-NEXT:         {{.*}}value_type _t6 = b.front();
-// CHECK-NEXT:         {{.*}}value_type _t5 = b.at(2);
+// CHECK:              {{.*}}value_type [[T_BACK:_t[0-9]+]] = a.back();
+// CHECK-NEXT:         {{.*}}value_type [[T_FRONT:_t[0-9]+]] = b.front();
+// CHECK-NEXT:         {{.*}}value_type [[T_AT:_t[0-9]+]] = b.at(2);
 // CHECK-NEXT:         {
-// CHECK-NEXT:             _d_a.back() += 1 * _t5 * _t6;
-// CHECK:                  {{.*}}front_pullback(&b, _t{{7|8}} * 1 * _t5, &_d_b0);
+// CHECK-NEXT:             _d_a.back() += 1 * [[T_AT]] * [[T_FRONT]];
+// CHECK:                  {{.*}}front_pullback(&b, [[T_BACK]] * 1 * [[T_AT]], &_d_b0);
 // CHECK-NEXT:             {{.*size_type|size_t}} _r0 = {{0U|0UL}};
-// CHECK-NEXT:             {{.*}}at_pullback(&b, 2, _t{{7|8}} * _t6 * 1, &_d_b0, &_r0);
+// CHECK-NEXT:             {{.*}}at_pullback(&b, 2, [[T_BACK]] * [[T_FRONT]] * 1, &_d_b0, &_r0);
 // CHECK-NEXT:             {{.*size_type|size_t}} _r1 = {{0U|0UL}};
 // CHECK-NEXT:             {{.*}}operator_subscript_pullback(&b, 1, 1, &_d_b0, &_r1);
 // CHECK-NEXT:         }
-// CHECK-NEXT:         {{.*}}constructor_pullback(_b0, &_d_b0, &_d_b);
-// CHECK-NEXT:         {
+// CHECK:              {{.*}}constructor_pullback(_b0, &_d_b0, &_d_b);
+// CHECK:                  {
+// CHECK-NEXT:             *_t8 = _t9;
 // CHECK-NEXT:             {{.*}}value_type _r_d4 = _d_b[2];
 // CHECK-NEXT:             _d_b[2] = 0.;
 // CHECK-NEXT:             *_d_x += _r_d4 * x;
 // CHECK-NEXT:             *_d_x += x * _r_d4;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
+// CHECK-NEXT:             *_t6 = _t7;
 // CHECK-NEXT:             {{.*}}value_type _r_d3 = _d_b[1];
 // CHECK-NEXT:             _d_b[1] = 0.;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
+// CHECK-NEXT:             *_t4 = _t5;
 // CHECK-NEXT:             {{.*}}value_type _r_d2 = _d_b[0];
 // CHECK-NEXT:             _d_b[0] = 0.;
 // CHECK-NEXT:             *_d_x += _r_d2;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
+// CHECK-NEXT:             *_t2 = _t3;
 // CHECK-NEXT:             {{.*}}value_type _r_d1 = _d_a[1];
 // CHECK-NEXT:             _d_a[1] = 0.;
 // CHECK-NEXT:             *_d_y += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
+// CHECK-NEXT:             *_t0 = _t1;
 // CHECK-NEXT:             {{.*}}value_type _r_d0 = _d_a[0];
-// CHECK-NEXT:             d_a[0] = 0.;
+// CHECK-NEXT:             _d_a[0] = 0.;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 
@@ -683,9 +712,11 @@ int main() {
 // CHECK-NEXT:         std::array<double, 2> _d_a = {{.*}};
 // CHECK-NEXT:         std::array<double, 2> a;
 // CHECK-NEXT:         {{.*}}value_type *_t0 = &a[1];
+// CHECK-NEXT:         {{.*}}value_type _t1 = *_t0;
 // CHECK-NEXT:         *_t0 = 2 * x;
 // CHECK-NEXT:         _d_a[1] += 1;
 // CHECK-NEXT:         {
+// CHECK-NEXT:             *_t0 = _t1;
 // CHECK-NEXT:             {{.*}} _r_d0 = _d_a[1];
 // CHECK-NEXT:             _d_a[1] = 0.;
 // CHECK-NEXT:             *_d_x += 2 * _r_d0;
@@ -786,9 +817,11 @@ int main() {
 // CHECK-NEXT:          std::vector<double> _t0 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, 0, &_d_a, 0);
 // CHECK-NEXT:          {{.*}}value_type *_t1 = &a[0];
+// CHECK-NEXT:          {{.*}}value_type _t2 = *_t1;
 // CHECK-NEXT:          *_t1 = x * x;
 // CHECK-NEXT:          _d_a[0] += 1;
 // CHECK-NEXT:          {
+// CHECK-NEXT:              *_t1 = _t2;
 // CHECK-NEXT:              {{.*}}value_type _r_d0 = _d_a[0];
 // CHECK-NEXT:              _d_a[0] = 0{{.*}};
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
@@ -827,6 +860,7 @@ int main() {
 // CHECK-NEXT:      std::vector<double> ls = {};
 // CHECK-NEXT:      std::vector<double> _d_ls{};
 // CHECK-NEXT:      clad::tape<{{.*}}value_type *> _t3 = {};
+// CHECK-NEXT:      clad::tape<{{.*}}value_type> _t4 = {};
 // CHECK-NEXT:      {{.*}}allocator_type alloc;
 // CHECK-NEXT:      {{.*}}allocator_type _d_alloc;
 // CHECK-NEXT:      unsigned {{int|long|long long}} _t0 = 0;
@@ -836,6 +870,7 @@ int main() {
 // CHECK-NEXT:          clad::push(_t2, std::move(ls)) , ls = {u, v}, alloc;
 // CHECK-NEXT:          _d_ls = {0., 0.}, _d_alloc;
 // CHECK-NEXT:          clad::push(_t3, &ls[1]);
+// CHECK-NEXT:          clad::push(_t4, ls[1]);
 // CHECK-NEXT:          *clad::back(_t3) += ls[0];
 // CHECK-NEXT:          u = ls[1];
 // CHECK-NEXT:      }
@@ -847,6 +882,7 @@ int main() {
 // CHECK-NEXT:              _d_ls[1] += _r_d1;
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
+// CHECK-NEXT:              ls[1] = clad::pop(_t4);
 // CHECK-NEXT:              {{.*}}value_type _r_d0 = _d_ls[1];
 // CHECK-NEXT:              _d_ls[0] += _r_d0;
 // CHECK-NEXT:              clad::pop(_t3);
@@ -931,6 +967,7 @@ int main() {
 // CHECK-NEXT:     std::vector<double> ls = {};
 // CHECK-NEXT:     std::vector<double> _d_ls{};
 // CHECK-NEXT:     clad::tape<value_type *> _t3 = {};
+// CHECK-NEXT:     clad::tape<value_type> _t4 = {};
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
 // CHECK-NEXT:     for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:         _t0++;
@@ -938,6 +975,7 @@ int main() {
 // CHECK-NEXT:         clad::push(_t2, std::move(ls)) , ls = {{.*{u, v}.*}};
 // CHECK-NEXT:         _d_ls = {{.*}}{0., 0.}{{.*}};
 // CHECK-NEXT:         clad::push(_t3, &ls[1]);
+// CHECK-NEXT:         clad::push(_t4, ls[1]);
 // CHECK-NEXT:         *clad::back(_t3) += ls[0];
 // CHECK-NEXT:         u = ls[1];
 // CHECK-NEXT:     }
@@ -949,6 +987,7 @@ int main() {
 // CHECK-NEXT:             _d_ls[1] += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
+// CHECK-NEXT:             ls[1] = clad::pop(_t4);
 // CHECK-NEXT:             {{.*}}value_type _r_d0 = _d_ls[1];
 // CHECK-NEXT:             _d_ls[0] += _r_d0;
 // CHECK-NEXT:             clad::pop(_t3);


### PR DESCRIPTION
getDependencySet's DeclFinder returned false from its Traverse* overrides, but in RecursiveASTVisitor a false return aborts the entire traversal, not just the current subtree. The first DeclRefExpr in an operator call names the operator itself, so the walk ended before any variable was found and the dependency set of an expression like `&v[0]` or `v[i] = x` came back empty. The conservative fallbacks built on it (findReq, setIsRequired) then silently no-oped: state mutated through such expressions was never marked to-be-recorded, no pre-call value was stored, and the reverse sweep read post-overwrite values -- the GradBench GMM shape #1964 papered over with hardcoded function names.

Return true so the walk continues with the siblings while still not descending into the handled node. The wider marks reach the visitor's element store for assignments through operator[]/at() results. In a loop such an element is restored by re-evaluating the lvalue rather than through the call's cached result pointer, whose per-iteration target the reverse sweep may already have destroyed; the reverse sweep maintains the loop induction variables, so the fresh call designates this iteration's element in whatever buffer the object currently owns. The accessor consequently runs once more per stored assignment, which is observable for accessors with side effects.

The new Analyses/TBRCalls.C pins the mutating-callee shapes (&v[0] over a user operator[], data(), raw arrays, a struct-carried pointer), the straight-line and in-loop operator[]/at() overwrite-after-read shapes, and one no-store elision guard, with TBR on and off; the FunctionCalls and STLCustomDerivatives expectations gain the stores the widened fallback now correctly records.