### PR TITLE
Generate the clad::array element-wise assignments from macros

### DIFF
--- a/include/clad/Differentiator/Array.h
+++ b/include/clad/Differentiator/Array.h
@@ -18,6 +18,70 @@ template <typename T> class array_ref;
 #define PUREFUNC __attribute__((pure))
 #endif
 
+// The element-wise assignments of clad::array come in families that differ
+// only in the operator token, passed to these generators as `op`: one of `+=`,
+// `-=`, `*=`, `/=`, or `=` where plain assignment has the same shape.
+//
+// Three checks fire on the generators below and cannot be followed here:
+// cppcoreguidelines-macro-usage, because `op` is an operator token and each
+// expansion declares a different operator overload; bugprone-macro-parentheses,
+// because neither an operator token nor a function definition can be wrapped in
+// parentheses; and modernize-type-traits, because `std::is_arithmetic_v` is
+// C++17 while these headers are also included from C++14 code.
+// NOLINTBEGIN(cppcoreguidelines-macro-usage, bugprone-macro-parentheses,
+// modernize-type-traits)
+
+/// Applies `op` between every element and a scalar.
+#define CLAD_ARRAY_OP_SCALAR(op)                                               \
+  template <typename U,                                                        \
+            std::enable_if_t<std::is_arithmetic<U>::value, int> = 0>           \
+  CUDA_HOST_DEVICE array<T>& operator op(U n) {                                \
+    for (std::size_t i = 0; i < m_size; i++)                                   \
+      m_arr[i] op n;                                                           \
+    return *this;                                                              \
+  }
+
+/// Applies `op` element-wise with a raw array, which must be at least as long
+/// as this one -- there is no size to assert against.
+#define CLAD_ARRAY_OP_PTR(op)                                                  \
+  CUDA_HOST_DEVICE array<T>& operator op(T * arr) {                            \
+    for (std::size_t i = 0; i < m_size; i++)                                   \
+      m_arr[i] op arr[i];                                                      \
+    return *this;                                                              \
+  }
+
+/// Applies `op` element-wise with an array_ref of the same element type.
+#define CLAD_ARRAY_OP_ARRAY_REF(op)                                            \
+  CUDA_HOST_DEVICE array<T>& operator op(const array_ref<T>& arr) {            \
+    assert(arr.size() == m_size);                                              \
+    for (std::size_t i = 0; i < m_size; i++)                                   \
+      m_arr[i] op arr[i];                                                      \
+    return *this;                                                              \
+  }
+
+/// Applies `op` element-wise with an array of any element type.
+#define CLAD_ARRAY_OP_ARRAY(op)                                                \
+  template <typename U>                                                        \
+  CUDA_HOST_DEVICE array<T>& operator op(const array<U>& arr) {                \
+    assert(arr.size() == m_size);                                              \
+    for (std::size_t i = 0; i < m_size; i++)                                   \
+      m_arr[i] op static_cast<T>(arr[i]);                                      \
+    return *this;                                                              \
+  }
+
+/// Applies `op` element-wise with an unevaluated array expression.
+#define CLAD_ARRAY_OP_EXPR(op)                                                 \
+  template <typename L, typename BinaryOp, typename R>                         \
+  CUDA_HOST_DEVICE array<T>& operator op(                                      \
+      const array_expression<L, BinaryOp, R>& arr_exp) {                       \
+    assert(arr_exp.size() == m_size);                                          \
+    for (std::size_t i = 0; i < m_size; i++)                                   \
+      m_arr[i] op arr_exp[i];                                                  \
+    return *this;                                                              \
+  }
+// NOLINTEND(cppcoreguidelines-macro-usage, bugprone-macro-parentheses,
+// modernize-type-traits)
+
 /// This class is not meant to be used by user. It is used by clad internally
 /// only
 
@@ -135,76 +199,29 @@ public:
   CUDA_HOST_DEVICE PUREFUNC T& operator*() { return *m_arr; }
 
   // Arithmetic overloads
-  /// Divides the number from every element in the array
-  template <typename U, typename std::enable_if<std::is_arithmetic<U>::value,
-                                                int>::type = 0>
-  CUDA_HOST_DEVICE array<T>& operator/=(U n) {
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] /= n;
-    return *this;
-  }
-  /// Multiplies the number to every element in the array
-  template <typename U, typename std::enable_if<std::is_arithmetic<U>::value,
-                                                int>::type = 0>
-  CUDA_HOST_DEVICE array<T>& operator*=(U n) {
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] *= n;
-    return *this;
-  }
-  /// Adds the number to every element in the array
-  template <typename U, typename std::enable_if<std::is_arithmetic<U>::value,
-                                                int>::type = 0>
-  CUDA_HOST_DEVICE array<T>& operator+=(U n) {
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] += n;
-    return *this;
-  }
-  /// Subtracts the number from every element in the array
-  template <typename U, typename std::enable_if<std::is_arithmetic<U>::value,
-                                                int>::type = 0>
-  CUDA_HOST_DEVICE array<T>& operator-=(U n) {
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] -= n;
-    return *this;
-  }
+  CLAD_ARRAY_OP_SCALAR(+=)
+  CLAD_ARRAY_OP_SCALAR(-=)
+  CLAD_ARRAY_OP_SCALAR(*=)
+  CLAD_ARRAY_OP_SCALAR(/=)
+
+  CLAD_ARRAY_OP_PTR(+=)
+  CLAD_ARRAY_OP_PTR(-=)
+  CLAD_ARRAY_OP_PTR(*=)
+  CLAD_ARRAY_OP_PTR(/=)
   /// Initializes the clad::array to the given array
   CUDA_HOST_DEVICE array<T>& operator=(T* arr) {
     for (std::size_t i = 0; i < m_size; i++)
       m_arr[i] = arr ? arr[i] : 0;
     return *this;
   }
-  /// Performs element wise addition
-  CUDA_HOST_DEVICE array<T>& operator+=(T* arr) {
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] += arr[i];
-    return *this;
-  }
-  /// Performs element wise subtraction
-  CUDA_HOST_DEVICE array<T>& operator-=(T* arr) {
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] -= arr[i];
-    return *this;
-  }
-  /// Performs element wise multiplication
-  CUDA_HOST_DEVICE array<T>& operator*=(T* arr) {
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] *= arr[i];
-    return *this;
-  }
-  /// Performs element wise division
-  CUDA_HOST_DEVICE array<T>& operator/=(T* arr) {
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] /= arr[i];
-    return *this;
-  }
-  /// Initializes the clad::array to the given clad::array_ref
-  CUDA_HOST_DEVICE array<T>& operator=(const array_ref<T>& arr) {
-    assert(arr.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] = arr[i];
-    return *this;
-  }
 
+  CLAD_ARRAY_OP_ARRAY_REF(=)
+  CLAD_ARRAY_OP_ARRAY_REF(+=)
+  CLAD_ARRAY_OP_ARRAY_REF(-=)
+  CLAD_ARRAY_OP_ARRAY_REF(*=)
+  CLAD_ARRAY_OP_ARRAY_REF(/=)
+  /// Initializes the clad::array to the given clad::array_ref. Only assignment
+  /// crosses element types; the compound operators above stay on array_ref<T>.
   template <typename U>
   CUDA_HOST_DEVICE array<T>& operator=(const array_ref<U>& arr) {
     assert(arr.size() == m_size);
@@ -213,119 +230,17 @@ public:
     return *this;
   }
 
-  /// Performs element wise addition
-  CUDA_HOST_DEVICE array<T>& operator+=(const array_ref<T>& arr) {
-    assert(arr.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] += arr[i];
-    return *this;
-  }
-  /// Performs element wise subtraction
-  CUDA_HOST_DEVICE array<T>& operator-=(const array_ref<T>& arr) {
-    assert(arr.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] -= arr[i];
-    return *this;
-  }
-  /// Performs element wise multiplication
-  CUDA_HOST_DEVICE array<T>& operator*=(const array_ref<T>& arr) {
-    assert(arr.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] *= arr[i];
-    return *this;
-  }
-  /// Performs element wise division
-  CUDA_HOST_DEVICE array<T>& operator/=(const array_ref<T>& arr) {
-    assert(arr.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] /= arr[i];
-    return *this;
-  }
-  /// Initializes the clad::array to the given clad::array
-  template <typename U>
-  CUDA_HOST_DEVICE array<T>& operator=(const array<U>& arr) {
-    assert(arr.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] = static_cast<T>(arr[i]);
-    return *this;
-  }
-  /// Performs element wise addition
-  template <typename U>
-  CUDA_HOST_DEVICE array<T>& operator+=(const array<U>& arr) {
-    assert(arr.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] += static_cast<T>(arr[i]);
-    return *this;
-  }
-  /// Performs element wise subtraction
-  template <typename U>
-  CUDA_HOST_DEVICE array<T>& operator-=(const array<U>& arr) {
-    assert(arr.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] -= static_cast<T>(arr[i]);
-    return *this;
-  }
-  /// Performs element wise multiplication
-  template <typename U>
-  CUDA_HOST_DEVICE array<T>& operator*=(const array<U>& arr) {
-    assert(arr.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] *= static_cast<T>(arr[i]);
-    return *this;
-  }
-  /// Initializes the clad::array from the given clad::array_expression
-  template <typename L, typename BinaryOp, typename R>
-  CUDA_HOST_DEVICE array<T>&
-  operator=(const array_expression<L, BinaryOp, R>& arr_exp) {
-    assert(arr_exp.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] = arr_exp[i];
-    return *this;
-  }
-  /// Performs element wise division
-  template <typename U>
-  CUDA_HOST_DEVICE array<T>& operator/=(const array<U>& arr) {
-    assert(arr.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] /= static_cast<T>(arr[i]);
-    return *this;
-  }
-  /// Performs element wise addition with array_expression
-  template <typename L, typename BinaryOp, typename R>
-  CUDA_HOST_DEVICE array<T>&
-  operator+=(const array_expression<L, BinaryOp, R>& arr_exp) {
-    assert(arr_exp.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] += arr_exp[i];
-    return *this;
-  }
-  /// Performs element wise subtraction with array_expression
-  template <typename L, typename BinaryOp, typename R>
-  CUDA_HOST_DEVICE array<T>&
-  operator-=(const array_expression<L, BinaryOp, R>& arr_exp) {
-    assert(arr_exp.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] -= arr_exp[i];
-    return *this;
-  }
-  /// Performs element wise multiplication with array_expression
-  template <typename L, typename BinaryOp, typename R>
-  CUDA_HOST_DEVICE array<T>&
-  operator*=(const array_expression<L, BinaryOp, R>& arr_exp) {
-    assert(arr_exp.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] *= arr_exp[i];
-    return *this;
-  }
-  /// Performs element wise division with array_expression
-  template <typename L, typename BinaryOp, typename R>
-  CUDA_HOST_DEVICE array<T>&
-  operator/=(const array_expression<L, BinaryOp, R>& arr_exp) {
-    assert(arr_exp.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] /= arr_exp[i];
-    return *this;
-  }
+  CLAD_ARRAY_OP_ARRAY(=)
+  CLAD_ARRAY_OP_ARRAY(+=)
+  CLAD_ARRAY_OP_ARRAY(-=)
+  CLAD_ARRAY_OP_ARRAY(*=)
+  CLAD_ARRAY_OP_ARRAY(/=)
+
+  CLAD_ARRAY_OP_EXPR(=)
+  CLAD_ARRAY_OP_EXPR(+=)
+  CLAD_ARRAY_OP_EXPR(-=)
+  CLAD_ARRAY_OP_EXPR(*=)
+  CLAD_ARRAY_OP_EXPR(/=)
 
   /// Negate the array and return a new array.
   CUDA_HOST_DEVICE array_expression<T, BinarySub, const array<T>&>
@@ -356,5 +271,11 @@ template <typename T> CUDA_HOST_DEVICE array<T> zero_vector(std::size_t n) {
 }
 
 } // namespace clad
+
+#undef CLAD_ARRAY_OP_SCALAR
+#undef CLAD_ARRAY_OP_PTR
+#undef CLAD_ARRAY_OP_ARRAY_REF
+#undef CLAD_ARRAY_OP_ARRAY
+#undef CLAD_ARRAY_OP_EXPR
 
 #endif // CLAD_ARRAY_H

--- a/include/clad/Differentiator/ArrayRef.h
+++ b/include/clad/Differentiator/ArrayRef.h
@@ -8,6 +8,61 @@
 #include <type_traits>
 
 namespace clad {
+
+// As in clad::array, the element-wise assignments of clad::array_ref come in
+// families that differ only in the operator token, passed to these generators
+// as `op`: one of `+=`, `-=`, `*=`, `/=`, or `=` where plain assignment has the
+// same shape.
+//
+// The generators below suppress the same three checks as the ones in Array.h;
+// see the comment there for why none of them can be followed.
+// NOLINTBEGIN(cppcoreguidelines-macro-usage, bugprone-macro-parentheses,
+// modernize-type-traits)
+
+/// Applies `op` between every element and a scalar.
+#define CLAD_ARRAY_REF_OP_SCALAR(op)                                           \
+  template <typename U,                                                        \
+            std::enable_if_t<std::is_arithmetic<U>::value, int> = 0>           \
+  CUDA_HOST_DEVICE array_ref<T>& operator op(U a) {                            \
+    for (std::size_t i = 0; i < m_size; i++)                                   \
+      m_arr[i] op a;                                                           \
+    return *this;                                                              \
+  }
+
+/// Applies `op` element-wise with another array_ref.
+#define CLAD_ARRAY_REF_OP_ARRAY_REF(op)                                        \
+  template <typename U>                                                        \
+  CUDA_HOST_DEVICE array_ref<T>& operator op(const array_ref<U>& Ar) {         \
+    assert(m_size == Ar.size() && "Size of both the array_refs must be equal " \
+                                  "for carrying out compound assignment");     \
+    for (std::size_t i = 0; i < m_size; i++)                                   \
+      m_arr[i] op Ar[i];                                                       \
+    return *this;                                                              \
+  }
+
+/// Applies `op` element-wise with a clad::array.
+#define CLAD_ARRAY_REF_OP_ARRAY(op)                                            \
+  template <typename U>                                                        \
+  CUDA_HOST_DEVICE array_ref<T>& operator op(const array<U>& A) {              \
+    assert(m_size == A.size() && "Size of arrays must be equal");              \
+    for (std::size_t i = 0; i < m_size; i++)                                   \
+      m_arr[i] op A[i];                                                        \
+    return *this;                                                              \
+  }
+
+/// Applies `op` element-wise with an unevaluated array expression.
+#define CLAD_ARRAY_REF_OP_EXPR(op)                                             \
+  template <typename L, typename BinaryOp, typename R>                         \
+  CUDA_HOST_DEVICE array_ref<T>& operator op(                                  \
+      const array_expression<L, BinaryOp, R>& arr_exp) {                       \
+    assert(arr_exp.size() == m_size);                                          \
+    for (std::size_t i = 0; i < m_size; i++)                                   \
+      m_arr[i] op arr_exp[i];                                                  \
+    return *this;                                                              \
+  }
+// NOLINTEND(cppcoreguidelines-macro-usage, bugprone-macro-parentheses,
+// modernize-type-traits)
+
 /// Stores the pointer to and the size of an array and provides some helper
 /// functions for it. The array is supplied should have a life greater than
 /// that of the array_ref
@@ -39,14 +94,6 @@ public:
   /// Operator for conversion from array_ref<T> to const T*.
   constexpr CUDA_HOST_DEVICE operator const T*() const { return m_arr; }
 
-  template <typename U>
-  CUDA_HOST_DEVICE array_ref<T>& operator=(const array<U>& a) {
-    assert(m_size == a.size());
-    for (std::size_t i = 0; i < m_size; ++i)
-      m_arr[i] = a[i];
-    return *this;
-  }
-
   CLAD_CONSTEXPR_CXX14 CUDA_HOST_DEVICE array_ref<T>&
   operator=(const array_ref<T>& a) {
     if (this == &a)
@@ -57,14 +104,6 @@ public:
     return *this;
   }
 
-  template <typename L, typename BinaryOp, typename R>
-  CUDA_HOST_DEVICE array_ref<T>&
-  operator=(const array_expression<L, BinaryOp, R>& arr_exp) {
-    assert(arr_exp.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] = arr_exp[i];
-    return *this;
-  }
   /// Returns the size of the underlying array
   constexpr CUDA_HOST_DEVICE std::size_t size() const { return m_size; }
   constexpr CUDA_HOST_DEVICE PUREFUNC T* ptr() const { return m_arr; }
@@ -84,143 +123,29 @@ public:
   }
 
   // Arithmetic overloads
-  /// Divides the arrays element wise
-  template <typename U>
-  CUDA_HOST_DEVICE array_ref<T>& operator/=(const array_ref<U>& Ar) {
-    assert(m_size == Ar.size() && "Size of both the array_refs must be equal "
-                                  "for carrying out addition assignment");
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] /= Ar[i];
-    return *this;
-  }
-  /// Multiplies the arrays element wise
-  template <typename U>
-  CUDA_HOST_DEVICE array_ref<T>& operator*=(const array_ref<U>& Ar) {
-    assert(m_size == Ar.size() && "Size of both the array_refs must be equal "
-                                  "for carrying out addition assignment");
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] *= Ar[i];
-    return *this;
-  }
-  /// Adds the arrays element wise
-  template <typename U>
-  CUDA_HOST_DEVICE array_ref<T>& operator+=(const array_ref<U>& Ar) {
-    assert(m_size == Ar.size() && "Size of both the array_refs must be equal "
-                                  "for carrying out addition assignment");
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] += Ar[i];
-    return *this;
-  }
-  /// Subtracts the arrays element wise
-  template <typename U>
-  CUDA_HOST_DEVICE array_ref<T>& operator-=(const array_ref<U>& Ar) {
-    assert(m_size == Ar.size() && "Size of both the array_refs must be equal "
-                                  "for carrying out addition assignment");
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] -= Ar[i];
-    return *this;
-  }
-  /// Divides the elements of the array_ref by elements of the array
-  template <typename U>
-  CUDA_HOST_DEVICE array_ref<T>& operator/=(const array<U>& A) {
-    assert(m_size == A.size() && "Size of arrays must be equal");
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] /= A[i];
-    return *this;
-  }
-  /// Multiplies the elements of the array_ref by elements of the array
-  template <typename L, typename BinaryOp, typename R>
-  CUDA_HOST_DEVICE array_ref<T>&
-  operator*=(const array_expression<L, BinaryOp, R>& arr_exp) {
-    assert(arr_exp.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] *= arr_exp[i];
-    return *this;
-  }
-  /// Adds the elements of the array_ref by elements of the array
-  template <typename L, typename BinaryOp, typename R>
-  CUDA_HOST_DEVICE array_ref<T>&
-  operator+=(const array_expression<L, BinaryOp, R>& arr_exp) {
-    assert(arr_exp.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] += arr_exp[i];
-    return *this;
-  }
-  /// Subtracts the elements of the array_ref by elements of the array
-  template <typename L, typename BinaryOp, typename R>
-  CUDA_HOST_DEVICE array_ref<T>&
-  operator-=(const array_expression<L, BinaryOp, R>& arr_exp) {
-    assert(arr_exp.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] -= arr_exp[i];
-    return *this;
-  }
-  /// Divides the elements of the array_ref by elements of the array
-  template <typename L, typename BinaryOp, typename R>
-  CUDA_HOST_DEVICE array_ref<T>&
-  operator/=(const array_expression<L, BinaryOp, R>& arr_exp) {
-    assert(arr_exp.size() == m_size);
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] /= arr_exp[i];
-    return *this;
-  }
-  /// Multiplies the elements of the array_ref by elements of the array
-  template <typename U>
-  CUDA_HOST_DEVICE array_ref<T>& operator*=(const array<U>& A) {
-    assert(m_size == A.size() && "Size of arrays must be equal");
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] *= A[i];
-    return *this;
-  }
-  /// Adds the elements of the array_ref by elements of the array
-  template <typename U>
-  CUDA_HOST_DEVICE array_ref<T>& operator+=(const array<U>& A) {
-    assert(m_size == A.size() && "Size of arrays must be equal");
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] += A[i];
-    return *this;
-  }
-  /// Subtracts the elements of the array_ref by elements of the array
-  template <typename U>
-  CUDA_HOST_DEVICE array_ref<T>& operator-=(const array<U>& A) {
-    assert(m_size == A.size() && "Size of arrays must be equal");
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] -= A[i];
-    return *this;
-  }
-  /// Divides the array by a scalar
-  template <typename U, typename std::enable_if<std::is_arithmetic<U>::value,
-                                                int>::type = 0>
-  CUDA_HOST_DEVICE array_ref<T>& operator/=(U a) {
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] /= a;
-    return *this;
-  }
-  /// Multiplies the array by a scalar
-  template <typename U, typename std::enable_if<std::is_arithmetic<U>::value,
-                                                int>::type = 0>
-  CUDA_HOST_DEVICE array_ref<T>& operator*=(U a) {
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] *= a;
-    return *this;
-  }
-  /// Adds the array by a scalar
-  template <typename U, typename std::enable_if<std::is_arithmetic<U>::value,
-                                                int>::type = 0>
-  CUDA_HOST_DEVICE array_ref<T>& operator+=(U a) {
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] += a;
-    return *this;
-  }
+  CLAD_ARRAY_REF_OP_SCALAR(+=)
+  CLAD_ARRAY_REF_OP_SCALAR(-=)
+  CLAD_ARRAY_REF_OP_SCALAR(*=)
+  CLAD_ARRAY_REF_OP_SCALAR(/=)
 
-  /// Subtracts the array by a scalar
-  template <typename U, typename std::enable_if<std::is_arithmetic<U>::value,
-                                                int>::type = 0>
-  CUDA_HOST_DEVICE array_ref<T>& operator-=(U a) {
-    for (std::size_t i = 0; i < m_size; i++)
-      m_arr[i] -= a;
-    return *this;
-  }
+  /// Assignment from an array_ref is not generated here: the array_ref<T>
+  /// overload above has to stay non-templated to catch self-assignment.
+  CLAD_ARRAY_REF_OP_ARRAY_REF(+=)
+  CLAD_ARRAY_REF_OP_ARRAY_REF(-=)
+  CLAD_ARRAY_REF_OP_ARRAY_REF(*=)
+  CLAD_ARRAY_REF_OP_ARRAY_REF(/=)
+
+  CLAD_ARRAY_REF_OP_ARRAY(=)
+  CLAD_ARRAY_REF_OP_ARRAY(+=)
+  CLAD_ARRAY_REF_OP_ARRAY(-=)
+  CLAD_ARRAY_REF_OP_ARRAY(*=)
+  CLAD_ARRAY_REF_OP_ARRAY(/=)
+
+  CLAD_ARRAY_REF_OP_EXPR(=)
+  CLAD_ARRAY_REF_OP_EXPR(+=)
+  CLAD_ARRAY_REF_OP_EXPR(-=)
+  CLAD_ARRAY_REF_OP_EXPR(*=)
+  CLAD_ARRAY_REF_OP_EXPR(/=)
 };
 
   /// `array_ref<void>` specialisation is created to be used as a placeholder
@@ -268,5 +193,10 @@ public:
   };
   // NOLINTEND(*-pointer-arithmetic)
 } // namespace clad
+
+#undef CLAD_ARRAY_REF_OP_SCALAR
+#undef CLAD_ARRAY_REF_OP_ARRAY_REF
+#undef CLAD_ARRAY_REF_OP_ARRAY
+#undef CLAD_ARRAY_REF_OP_EXPR
 
 #endif // CLAD_ARRAY_REF_H


### PR DESCRIPTION
clad::array and clad::array_ref each carry a family of compound assignment operators per operand kind: a scalar, a raw pointer, an array_ref, an array of a different element type, and an unevaluated array_expression. Within a family the four operators differ in exactly one token -- the loop body, the assert, the enable_if and the return are copied verbatim -- so the two headers spent ~340 lines saying the same thing 38 times. The copies had already started to drift: array_ref's four array_ref overloads all assert "for carrying out addition assignment", including the three that are not addition.

Replace each family with a generator macro taking the operator token, so a family reads as one body plus a list of the tokens it is instantiated for. The macros are #undef'd at the end of the header that defines them. The resulting overload set is unchanged; only the shared assert message is reworded to "compound assignment".

Three overloads stay written out because they do not fit their family: array's operator=(T*), which treats a null pointer as all-zero; array's operator= from an array_ref of a different element type, the one assignment that crosses element types; and array_ref's operator=(const array_ref<T>&), which has to stay non-templated to catch self-assignment.

Verified by AST-printing both headers before and after and diffing the declared operator signatures (identical up to one parameter name), and by running test/Misc/CladArray.C, test/Misc/CladMatrix.C and a TU exercising every overload under clang and gcc, C++17 and C++20, with asserts on -- byte-identical output in every case.

**This is a code consolidation commit, no functional changes**