### PR TITLE
Use CLAD_SOURCE_DIR and CLAD_BINARY_DIR in lib/Differentiator

### DIFF
--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -1,18 +1,16 @@
-# The VC revision include that we want to generate.
-if (LLVM_EXTERNAL_CLAD_SOURCE_DIR)
-  set(version_file ${LLVM_EXTERNAL_CLAD_SOURCE_DIR}/VERSION)
-else()
-  set(version_file ${CMAKE_SOURCE_DIR}/VERSION)
-endif(LLVM_EXTERNAL_CLAD_SOURCE_DIR)
+# The VC revision include that we want to generate. Note that CLAD_SOURCE_DIR
+# and CLAD_BINARY_DIR are ours also when clad is only a part of a bigger build,
+# whereas CMAKE_SOURCE_DIR and CMAKE_BINARY_DIR belong to whoever is on top.
+set(version_file ${CLAD_SOURCE_DIR}/VERSION)
 set(version_inc ${CMAKE_CURRENT_BINARY_DIR}/VCSVersion.inc)
 set(generate_vcs_version_script ${LLVM_CMAKE_DIR}/GenerateVersionFromVCS.cmake)
-find_first_existing_vc_file(${CMAKE_SOURCE_DIR} clad_vc)
+find_first_existing_vc_file(${CLAD_SOURCE_DIR} clad_vc)
 
 # Create the VCSVersion.inc
 add_custom_command(OUTPUT "${version_inc}"
   DEPENDS ${clad_vc} ${generate_vcs_version_script}
   COMMAND ${CMAKE_COMMAND} "-DNAMES=\"CLAD\""
-                           "-DCLAD_SOURCE_DIR=${CMAKE_SOURCE_DIR}"
+                           "-DCLAD_SOURCE_DIR=${CLAD_SOURCE_DIR}"
                            "-DLLVM_DIR=${LLVM_CMAKE_DIR}"
                            "-DCMAKE_MODULE_PATH=${LLVM_CMAKE_DIR}"
                            "-DHEADER_FILE=${version_inc}"
@@ -34,15 +32,9 @@ list(GET VERSION_LIST 0 CLAD_VERSION_MAJOR)
 list(GET VERSION_LIST 1 CLAD_VERSION_MINOR)
 list(GET VERSION_LIST 2 CLAD_VERSION_PATCH)
 
-if (LLVM_EXTERNAL_CLAD_SOURCE_DIR)
-  configure_file(
-    ${LLVM_EXTERNAL_CLAD_SOURCE_DIR}/include/clad/Differentiator/Version.inc.in
-    ${CMAKE_BINARY_DIR}/include/clad/Differentiator/Version.inc)
-else()
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/include/clad/Differentiator/Version.inc.in
-    ${CMAKE_BINARY_DIR}/include/clad/Differentiator/Version.inc)
-endif(LLVM_EXTERNAL_CLAD_SOURCE_DIR)
+configure_file(
+  ${CLAD_SOURCE_DIR}/include/clad/Differentiator/Version.inc.in
+  ${CLAD_BINARY_DIR}/include/clad/Differentiator/Version.inc)
 
 
 # (Ab)use llvm facilities for adding libraries.
@@ -77,3 +69,9 @@ llvm_add_library(cladDifferentiator
   VisitorBase.cpp
   ${version_inc}
   )
+
+# Version.cpp includes the generated VCSVersion.inc by its bare name, so the
+# directory it is generated into has to be on the include path. Do not rely on
+# CMAKE_INCLUDE_CURRENT_DIR here: a host project that adds us with
+# add_subdirectory() need not have it set.
+target_include_directories(cladDifferentiator PRIVATE ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
VERSION, the version control file and Version.inc were located relative to CMAKE_SOURCE_DIR and CMAKE_BINARY_DIR, which are clad's own directories only when clad happens to be the top level project. CLAD_SOURCE_DIR and CLAD_BINARY_DIR are ours in every configuration, so use those and drop the LLVM_EXTERNAL_CLAD_SOURCE_DIR special case they needed.

This changes where two generated files end up, on purpose:

Version.inc now goes to CLAD_BINARY_DIR/include instead of CMAKE_BINARY_DIR/include. Those are the same directory in a standalone build, but for a clad built as an external project of LLVM the old path was inside the LLVM binary directory. That is neither the directory clad puts on its include path nor the one it installs from, so clad was picking the header up only because LLVM happens to add its own binary include directory globally, and clad's install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/) never shipped it. Both now line up.

VCSVersion.inc now describes clad. find_first_existing_vc_file and the CLAD_SOURCE_DIR passed to GenerateVersionFromVCS.cmake were given CMAKE_SOURCE_DIR, so an external-project build searched the host checkout and stamped the host's git revision and remote into CLAD_REVISION and CLAD_REPOSITORY. clad::getCladRevision() and clad::getCladRepositoryPath() there reported the LLVM checkout instead of ours.

While the generated headers are being sorted out, give cladDifferentiator the directory VCSVersion.inc is generated into. Version.cpp includes it by its bare name and so far relied on CMAKE_INCLUDE_CURRENT_DIR, which clad only sets on the standalone path, so the include did not resolve once a host project added clad with add_subdirectory().