### PR TITLE
Snapshot call state per loop iteration and survive the pullback replay.

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -431,6 +431,9 @@ namespace clad {
     clang::QualType GetCladArrayRefOfType(clang::Sema& S, clang::QualType T);
     /// Returns type clad::Tag<T>
     clang::QualType GetCladTagOfType(clang::Sema& S, clang::QualType T);
+    /// Builds a value-initialized temporary of type `T`, i.e. `T()`.
+    clang::Expr* BuildDefaultConstructExpr(clang::Sema& S, clang::QualType T);
+
     /// Returns type clad::Tag<T>()
     clang::Expr* GetCladTagExpr(clang::Sema& S, clang::QualType T);
 

--- a/include/clad/Differentiator/RestoreTracker.h
+++ b/include/clad/Differentiator/RestoreTracker.h
@@ -22,11 +22,14 @@ namespace clad {
 
 /// This class is used for bitwise storing/restoring variables.
 /// It is passed to reverse_forw to store the state of the program before the
-/// function call, for example,
+/// function call. restore() is non-destructive so it can re-establish the
+/// pre-call state both before the pullback (whose forward replay must start
+/// from it) and after it (the replay re-mutates the restored state):
 /// f_reverse_forw(..., _tracker0);
 /// ...
 /// _tracker0.restore();
 /// f_pullback(...);
+/// _tracker0.restore();
 /// We use it when we have to pass information between nested calls and
 /// clad::tape is not viable.
 class restore_tracker {
@@ -63,7 +66,6 @@ public:
   CUDA_HOST_DEVICE void restore() {
     for (size_t i = 0; i < m_cnt; ++i)
       std::memcpy(m_meta[i].addr, m_buf + m_meta[i].off, m_meta[i].size);
-    m_cnt = m_off = 0;
   }
 
   // Drop all records without writing anything back. Emitted where a
@@ -88,13 +90,14 @@ public:
     std::memcpy(buffer.data(), &val, sizeof(T));
     m_data.emplace((char*)&val, std::move(buffer));
   }
-  // Set all stored addresses to the corresponsing values bitwise.
+  // Set all stored addresses to the corresponding values bitwise. Keeps the
+  // stored values: the reverse sweep restores the same state again after the
+  // pullback's forward replay re-mutates it.
   void restore() {
     for (std::pair<const Address, RawMemory>& pair : m_data) {
       std::vector<uint8_t>& buffer = pair.second;
       std::memcpy(pair.first, buffer.data(), buffer.size());
     }
-    m_data.clear();
   }
 
   // Drop all records without writing anything back. Emitted where a

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1491,15 +1491,18 @@ namespace clad {
       return utils::InstantiateTemplate(S, CladTag, {T});
     }
 
-    Expr* GetCladTagExpr(Sema& S, QualType T) {
-      QualType CladTagTy = utils::GetCladTagOfType(S, T);
+    Expr* BuildDefaultConstructExpr(Sema& S, QualType T) {
+      SourceLocation Loc = utils::GetValidSLoc(S);
       return S
-          .BuildCXXTypeConstructExpr(S.getASTContext().getTrivialTypeSourceInfo(
-                                         CladTagTy, utils::GetValidSLoc(S)),
-                                     utils::GetValidSLoc(S), MultiExprArg{},
-                                     utils::GetValidSLoc(S),
-                                     /*ListInitialization=*/false)
+          .BuildCXXTypeConstructExpr(
+              S.getASTContext().getTrivialTypeSourceInfo(T, Loc), Loc,
+              MultiExprArg{}, Loc,
+              /*ListInitialization=*/false)
           .get();
+    }
+
+    Expr* GetCladTagExpr(Sema& S, QualType T) {
+      return BuildDefaultConstructExpr(S, utils::GetCladTagOfType(S, T));
     }
 
     bool canUsePushforwardInRevMode(const FunctionDecl* FD) {

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2717,7 +2717,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // f_reverse_forw(..., _tracker0);
       // ...
       // _tracker0.restore();
+      // f_pullback(...);
+      // _tracker0.restore();
       // ```
+      // The tracker restores the pre-call state twice: once so the pullback's
+      // forward replay starts from it, and once after the pullback, whose
+      // replay re-mutates the very state the first restore put back, so that
+      // earlier reverse-sweep consumers see pre-call values again.
       Expr* trackerExpr = nullptr;
       if (usingRestoreTracker) {
         if (m_RestoreTracker) {
@@ -2729,30 +2735,55 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           // ```
           trackerExpr = m_RestoreTracker;
         } else {
-          // Otherwise, generate the declaration
-          // ``clad::restore_tracker _tracker0 = {};``
-          // The declaration must live at function scope: the matching
-          // restore() below goes into the reverse sweep, which for a call
-          // inside a loop or branch is a different block than the forward
-          // one, so a block-local declaration would leave the reverse-sweep
-          // reference out of scope. A clear() at the former declaration
-          // point keeps the old per-visit semantics (only state recorded
-          // since the last forward visit is restored).
-          // FIXME: a single tracker serving all iterations of a reversed
-          // loop only restores the last iteration's state; full generality
-          // needs per-iteration taping of the tracker.
-          VarDecl* trackerDecl = GlobalStoreImpl(trackerType, "_tracker",
-                                                 getZeroInit(trackerType));
-          Expr* clearCall = BuildCallExprToMemFn(BuildDeclRef(trackerDecl),
-                                                 /*MemberFunctionName=*/"clear",
-                                                 /*ArgExprs=*/{}, Loc);
-          addToCurrentBlock(clearCall);
-          trackerExpr = BuildDeclRef(trackerDecl);
+          Expr* trackerPop = nullptr;
+          if (isInsideLoop) {
+            // Every iteration needs its own snapshot: one tracker shared by
+            // the whole loop keeps only the first iteration's values, since
+            // storing an address twice keeps the first store. Tape a fresh
+            // tracker per iteration and pop it once its reverse iteration is
+            // done.
+            Expr* freshTracker =
+                utils::BuildDefaultConstructExpr(m_Sema, trackerType);
+            auto CladTape =
+                MakeCladTapeFor(freshTracker, "_tracker", trackerType);
+            addToCurrentBlock(CladTape.Push, direction::forward);
+            trackerExpr = CladTape.Last();
+            trackerPop = CladTape.Pop;
+          } else {
+            // Otherwise, generate the declaration
+            // ``clad::restore_tracker _tracker0 = {};``
+            // The declaration must live at function scope: the matching
+            // restore() below goes into the reverse sweep, which for a call
+            // inside a branch is a different block than the forward one, so a
+            // block-local declaration would leave the reverse-sweep reference
+            // out of scope. A clear() at the former declaration point keeps
+            // the per-visit semantics (only state recorded since the last
+            // forward visit is restored).
+            VarDecl* trackerDecl = GlobalStoreImpl(trackerType, "_tracker",
+                                                   getZeroInit(trackerType));
+            Expr* clearCall =
+                BuildCallExprToMemFn(BuildDeclRef(trackerDecl),
+                                     /*MemberFunctionName=*/"clear",
+                                     /*ArgExprs=*/{}, Loc);
+            addToCurrentBlock(clearCall);
+            trackerExpr = BuildDeclRef(trackerDecl);
+          }
           Expr* restoreCall = BuildCallExprToMemFn(
-              BuildDeclRef(trackerDecl), /*MemberFunctionName=*/"restore",
+              CloneNode(trackerExpr), /*MemberFunctionName=*/"restore",
               /*ArgExprs=*/{}, Loc);
           it = std::begin(block) + insertionPoint;
           block.insert(it, restoreCall);
+          // Re-restore after the pullback's replay; then the loop tape can
+          // drop this iteration's tracker.
+          Expr* restoreCall2 = BuildCallExprToMemFn(
+              CloneNode(trackerExpr), /*MemberFunctionName=*/"restore",
+              /*ArgExprs=*/{}, Loc);
+          std::size_t postPullback = insertionPoint + 1 + PreCallStmts.size() +
+                                     (OverloadedDerivedFn ? 1 : 0);
+          it = std::begin(block) + postPullback;
+          it = block.insert(it, restoreCall2);
+          if (trackerPop)
+            block.insert(std::next(it), trackerPop);
         }
       }
       // Add the tracker as the last argument of the reverse_forw. A propagated

--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -333,6 +333,7 @@ double f10(double x){
 // CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         f10_1_pullback(x, t, &_r0, _d_t);
+// CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Analyses/TBRCalls.C
+++ b/test/Analyses/TBRCalls.C
@@ -106,6 +106,42 @@ double t8(const double* x) {
   return total;
 }
 
+double sqnorm(int d, const double* v) {
+  double t = 0;
+  for (int i = 0; i < d; i++)
+    t += v[i] * v[i];
+  return t;
+}
+
+void diffem(int d, const double* x, const double* y, double* out) {
+  for (int i = 0; i < d; i++)
+    out[i] = x[i] - y[i];
+}
+
+// The GradBench GMM loop: buf is overwritten through &buf[0] on every
+// iteration, and each iteration's values feed that iteration's nonlinear
+// read, so every iteration needs its own restore in the reverse sweep.
+double t9(const double* x, const double* m) {
+  Vec2 buf;
+  double total = 0;
+  for (int k = 0; k < 2; k++) {
+    diffem(2, x, m + 2 * k, &buf[0]);
+    total += sqnorm(2, &buf[0]);
+  }
+  return total;
+}
+
+// A value live across two mutating calls: squarer overwrites what the first
+// sqnorm's pullback still needs after squarer's own pullback replays.
+double t10(const double* x) {
+  double buf[2];
+  fillfrom(2, x, buf);
+  double t1 = sqnorm(2, buf);
+  squarer(2, buf);
+  double t2 = sqnorm(2, buf);
+  return t1 + t2;
+}
+
 // Nothing is read nonlinearly, so no pre-call state may be stored.
 double t7(const double* x) {
   double buf[2];
@@ -122,6 +158,15 @@ double t7(const double* x) {
 // CHECK-NOT: _tracker
 // CHECK-NOT: clad::push
 // CHECK: fillfrom_pullback(2, x, &buf[0]
+
+// In a loop each iteration gets its own tracker snapshot through a tape.
+// CHECK: void t9_grad(const double *x, const double *m, double *_d_x, double *_d_m) {
+// CHECK: clad::tape<clad::restore_tracker> _tracker0 = {};
+// CHECK: clad::push(_tracker0, clad::restore_tracker());
+// CHECK: clad::back(_tracker0).restore();
+// CHECK: diffem_pullback(2, x, m + 2 * k, &
+// CHECK-NEXT: clad::back(_tracker0).restore();
+// CHECK-NEXT: clad::pop(_tracker0);
 
 int main() {
   double x[2] = {1, 2};
@@ -145,4 +190,17 @@ int main() {
   TEST(t8); // CHECK-EXEC: t8: dx={10.00, 20.00}
   // f = x0 + x1
   TEST(t7); // CHECK-EXEC: t7: dx={1.00, 1.00}
+  {
+    double m[4] = {0.5, 1, 3, -1};
+    double dm[4] = {0, 0, 0, 0};
+    dx[0] = dx[1] = 0;
+    auto grad = clad::gradient(t9, "x, m");
+    grad.execute(x, m, dx, dm);
+    // f = sum_k sum_i (x_i - m_ki)^2
+    printf("t9: dx={%.2f, %.2f} dm={%.2f, %.2f, %.2f, %.2f}\n", dx[0], dx[1],
+           dm[0], dm[1], dm[2], dm[3]);
+    // CHECK-EXEC: t9: dx={-3.00, 8.00} dm={-1.00, -2.00, 4.00, -6.00}
+  }
+  // f = |x|^2 + |x^2|^2 => df/dx_i = 2 x_i + 4 x_i^3
+  TEST(t10); // CHECK-EXEC: t10: dx={6.00, 36.00}
 }

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -239,6 +239,7 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         int _r0 = 0;
 // CHECK-NEXT:         sum_pullback(arr, n, _r_d0, _d_arr, &_r0);
+// CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         *_d_n += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -278,6 +279,7 @@ double fn5(double* arr, int n) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:       _tracker0.restore();
 // CHECK-NEXT:       modify2_pullback(arr, _d_temp, _d_arr);
+// CHECK-NEXT:       _tracker0.restore();
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -953,6 +955,7 @@ double fn27(double u, double v) {
 // CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         mult_pullback(arr, u, _d_arr, &_r0);
+// CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         *_d_u += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -989,11 +992,13 @@ double& nested(double* x, double y) {
 // CHECK-NEXT:         _tracker1.restore();
 // CHECK-NEXT:         double _r1 = 0.;
 // CHECK-NEXT:         mult_pullback(x, 3, _d_x, &_r1);
+// CHECK-NEXT:         _tracker1.restore();
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         mult_pullback(x, y, _d_x, &_r0);
+// CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         *_d_y += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -1024,6 +1029,7 @@ double fn28(double u, double v) {
 // CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         nested_pullback(arr, u, _d_arr, &_r0);
+// CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         *_d_u += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -1069,6 +1075,7 @@ double fn29(double *x) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         foo_pullback(x, _d_x);
+// CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -467,6 +467,7 @@ double fn2(SimpleFunctions& sf, double i) {
 // CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         sf.ref_mem_fn_pullback(i, _d_sf, &_r0);
+// CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         *_d_i += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -506,6 +507,7 @@ double fn5(SimpleFunctions& v, double value) {
 // CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         v.operator_plus_equal_pullback(value, _d_v, &_r0);
+// CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         *_d_value += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -538,6 +540,7 @@ double fn4(SimpleFunctions& v) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         v.operator_plus_plus_pullback(_d_v);
+// CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -738,6 +741,7 @@ double fn11(double u, double v) {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          _tracker0.restore();
 // CHECK-NEXT:          a.increment_pullback(&_d_a);
+// CHECK-NEXT:          _tracker0.restore();
 // CHECK-NEXT:      }
 // CHECK-NEXT:      {
 // CHECK-NEXT:          double _r_d0 = _d_res;

--- a/test/Gradient/Pointers.C
+++ b/test/Gradient/Pointers.C
@@ -422,6 +422,7 @@ double nestedPtrFn (double x, double y) {
 // CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:         int _r0 = 0;
 // CHECK-NEXT:         ptrValFn_pullback(arr, 1, _d_arr, &_r0);
+// CHECK-NEXT:         _tracker0.restore();
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_x += _d_arr[0];

--- a/test/Gradient/RecordRestore.C
+++ b/test/Gradient/RecordRestore.C
@@ -36,13 +36,16 @@ double f(double x) {
 
 // CHECK: void f_grad(double x, double *_d_x) {
 // CHECK: clad::push(_t1, s);
-// CHECK: scale_reverse_forw(s, _d_s, _tracker0);
-// CHECK: _tracker0.restore();
+// CHECK-NEXT: clad::push(_tracker0, clad::restore_tracker());
+// CHECK-NEXT: scale_reverse_forw(s, _d_s, clad::back(_tracker0));
+// CHECK: clad::back(_tracker0).restore();
 // CHECK-NEXT: {
 // CHECK-NEXT:     s = clad::back(_t1);
 // CHECK-NEXT:     clad::pop(_t1);
 // CHECK-NEXT: }
 // CHECK-NEXT: scale_pullback(s, &_d_s);
+// CHECK-NEXT: clad::back(_tracker0).restore();
+// CHECK-NEXT: clad::pop(_tracker0);
 
 int main() {
   auto g = clad::gradient(f);

--- a/test/Gradient/RecursiveFunctionEarlyReturn.C
+++ b/test/Gradient/RecursiveFunctionEarlyReturn.C
@@ -35,9 +35,9 @@ double func(double* A, int n, std::vector<double>& v) {
 }
 
 // CHECK: void func_grad_0_2(
-// CHECK: clad::restore_tracker _tracker0 = {};
+// CHECK: clad::tape<clad::restore_tracker> _tracker0 = {};
 // CHECK: auto _rev0 = [&] {
-// CHECK: _tracker0.restore();
+// CHECK: clad::back(_tracker0).restore();
 
 int main() {
   double A[] = {1.0, 2.0, 3.0};

--- a/test/Gradient/ReverseForw.C
+++ b/test/Gradient/ReverseForw.C
@@ -71,6 +71,7 @@ double f1(double x) {
 //CHECK-NEXT:         _tracker0.restore();
 //CHECK-NEXT:         int _r0 = 0;
 //CHECK-NEXT:         nested_pullback(&x, -6, _d_x, &_r0);
+//CHECK-NEXT:         _tracker0.restore();
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
 
@@ -178,22 +179,24 @@ double f4(double x) {
 //CHECK: void f4_grad(double x, double *_d_x) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+//CHECK-NEXT:     clad::tape<clad::restore_tracker> _tracker0 = {};
 //CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double *, double *> > _t1 = {};
 //CHECK-NEXT:     double _d_r = 0.;
 //CHECK-NEXT:     double r = 0;
 //CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
 //CHECK-NEXT:     for (i = 0; i < 2; ++i) {
 //CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         _tracker0.clear();
-//CHECK-NEXT:         clad::push(_t1, mul2_reverse_forw(&x, _d_x, _tracker0));
+//CHECK-NEXT:         clad::push(_tracker0, clad::restore_tracker());
+//CHECK-NEXT:         clad::push(_t1, mul2_reverse_forw(&x, _d_x, clad::back(_tracker0)));
 //CHECK-NEXT:         r += *clad::back(_t1).value;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_r += 1;
 //CHECK-NEXT:     for (; _t0; _t0--) {
 //CHECK-NEXT:         *clad::back(_t1).adjoint += _d_r;
-//CHECK-NEXT:         _tracker0.restore();
+//CHECK-NEXT:         clad::back(_tracker0).restore();
 //CHECK-NEXT:         mul2_pullback(&x, _d_x);
+//CHECK-NEXT:         clad::back(_tracker0).restore();
+//CHECK-NEXT:         clad::pop(_tracker0);
 //CHECK-NEXT:         clad::pop(_t1);
 //CHECK-NEXT:     }
 //CHECK-NEXT: }
@@ -228,6 +231,7 @@ double f5(double x, int flag) {
 //CHECK-NEXT:         *_t0.adjoint += _d_r;
 //CHECK-NEXT:         _tracker0.restore();
 //CHECK-NEXT:         mul2_pullback(&x, _d_x);
+//CHECK-NEXT:         _tracker0.restore();
 //CHECK-NEXT:     }
 //CHECK-NEXT:     *_d_x += _d_r;
 //CHECK-NEXT: }

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -436,6 +436,7 @@ MyStruct fn12(MyStruct s) {  // expected-warning {{clad::gradient only supports 
 // CHECK-NEXT:        _tracker0.restore();
 // CHECK-NEXT:        MyStruct _r0 = {0., 0.};
 // CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, _d_s, &_r0);
+// CHECK-NEXT:        _tracker0.restore();
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;
 // CHECK-NEXT:    }
@@ -718,6 +719,7 @@ void fn20(MyStruct s) {
 // CHECK-NEXT:        _tracker0.restore();
 // CHECK-NEXT:        MyStruct _r0 = {0., 0.};
 // CHECK-NEXT:        s.operator_equal_pullback({2 * s.a, 2 * s.b + 2}, _d_s, &_r0);
+// CHECK-NEXT:        _tracker0.restore();
 // CHECK-NEXT:        (*_d_s).a += 2 * _r0.a;
 // CHECK-NEXT:        (*_d_s).b += 2 * _r0.b;
 // CHECK-NEXT:    }
@@ -984,6 +986,7 @@ struct MyStructWrapper {
 // CHECK-NEXT:      {
 // CHECK-NEXT:          _tracker0.restore();
 // CHECK-NEXT:          this->val.operator_equal_pullback(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, &(*_d_arg).val);
+// CHECK-NEXT:          _tracker0.restore();
 // CHECK-NEXT:      }
 // CHECK-NEXT:  }
 
@@ -1007,6 +1010,7 @@ double fn27(double x, double y) {
 // CHECK-NEXT:          _tracker0.restore();
 // CHECK-NEXT:          MyStructWrapper _r0 = {{.*0., 0..*}};
 // CHECK-NEXT:          s.operator_equal_pullback({{.*2 \* y, 3 \* x \+ 2.*}}, &_d_s, &_r0);
+// CHECK-NEXT:          _tracker0.restore();
 // CHECK-NEXT:          *_d_y += 2 * _r0.val.a;
 // CHECK-NEXT:          *_d_x += 3 * _r0.val.b;
 // CHECK-NEXT:      }


### PR DESCRIPTION
The restore_tracker protocol assumed one store/restore cycle per call site. Inside a loop that breaks twice over: the shared tracker's first-store-wins semantics keep only the first iteration's values (every later store hits an already-recorded address), and its destructive restore fires once, in the first reverse iteration, with those stale values. Even in straight-line code the single restore was consumed by the pullback, whose forward replay re-mutates the restored state, so every earlier reverse-sweep consumer read post-call values. Both defects produced silently wrong gradients for the GradBench GMM pattern -- a helper overwriting a caller buffer inside a loop, e.g. subtract(d, x, mu, &xcentered[0]).

Make restore() non-destructive and restore twice around every pullback: once so its replay starts from pre-call state and once because the replay just re-mutated it. Inside loops, keep a clad::tape of trackers -- push a fresh snapshot per iteration, pass clad::back to the reverse_forw, and pop after the matching reverse iteration -- so each iteration restores its own values, which is the per-iteration taping the function-scope tracker declaration left as a FIXME. Outside loops that declaration and its clear() are unchanged, and a tracker propagated into a nested reverse_forw still accumulates the callee subtree's stores into the current snapshot, which is exactly the state before the outer call.

Pushing a fresh tracker needs a value-initialized temporary, which GetCladTagExpr already knew how to build for clad::Tag<T>; that dance is named utils::BuildDefaultConstructExpr here and reused, since utils::getZeroInit's init-list cannot be deduced as a template call argument for a non-aggregate.

Analyses/TBRCalls.C gains the GMM loop shape and a value live across two mutating calls; the existing tracker expectations gain the second restore and the loop-tape form.