### PR TITLE
Null check a tangent pointer at the root of its pointer arithmetic

### DIFF
--- a/include/clad/Differentiator/BaseForwardModeVisitor.h
+++ b/include/clad/Differentiator/BaseForwardModeVisitor.h
@@ -74,6 +74,27 @@ public:
                                     clang::Expr* tangent, clang::Expr* read,
                                     clang::Expr* zero);
 
+  /// \returns the declaration \p E is derived from by pointer arithmetic, or
+  /// null when \p E is not rooted in one. `xlArr + 1`, `xlArr += 1` and
+  /// `xlArr++` all yield `xlArr`; plain `q = xlArr + 1` does not, being rooted
+  /// in its right-hand side. A tangent pointer is null at its root, so the
+  /// root is what a null check has to test.
+  [[nodiscard]] static const clang::DeclRefExpr*
+  getPointerArithmeticRoot(const clang::Expr* E);
+
+  /// \returns \p tangent, the tangent of the primal pointer expression \p ptr,
+  /// rewritten to evaluate to a null pointer whenever the tangent it is derived
+  /// from is null. Returned unchanged unless \p ptr is rooted in a pointer
+  /// whose tangent may be null.
+  ///
+  /// A null tangent spells "the derivative of this argument is identically
+  /// zero" and readers null check it, but `nullptr + 1` is not null, so
+  /// arithmetic makes a reader sail past the check and dereference a small
+  /// integer. Callers apply this wherever a derived tangent outlives the
+  /// expression that built it.
+  clang::Expr* KeepTangentNullness(const clang::Expr* ptr,
+                                   clang::Expr* tangent);
+
   virtual StmtDiff
   VisitArraySubscriptExpr(const clang::ArraySubscriptExpr* ASE);
   StmtDiff VisitBinaryOperator(const clang::BinaryOperator* BinOp);

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -948,15 +948,63 @@ BaseForwardModeVisitor::VisitArraySubscriptExpr(const ArraySubscriptExpr* ASE) {
                   GuardNullTangentRead(base, adjoint, result_at_is, zero));
 }
 
+const DeclRefExpr*
+BaseForwardModeVisitor::getPointerArithmeticRoot(const Expr* E) {
+  while (E) {
+    E = E->IgnoreParenImpCasts();
+    if (const auto* BO = dyn_cast<BinaryOperator>(E)) {
+      BinaryOperatorKind opCode = BO->getOpcode();
+      bool isStep = opCode == BO_Add || opCode == BO_Sub ||
+                    opCode == BO_AddAssign || opCode == BO_SubAssign;
+      // Only a step that yields a pointer keeps the walk going; `ptr - ptr` is
+      // not one. Plain `ptr = q` is not one either, being rooted in `q`.
+      if (!isStep || !BO->getType()->isPointerType())
+        break;
+      // `ptr + n`, `ptr - n` and `ptr += n` step the pointer on the left,
+      // `n + ptr` the one on the right; a pointer result leaves no third case.
+      const Expr* LHS = BO->getLHS();
+      E = LHS->getType()->isPointerType() ? LHS : BO->getRHS();
+      continue;
+    }
+    const auto* UO = dyn_cast<UnaryOperator>(E);
+    if (!UO || !UO->isIncrementDecrementOp() || !UO->getType()->isPointerType())
+      break;
+    E = UO->getSubExpr();
+  }
+  return dyn_cast_or_null<DeclRefExpr>(E);
+}
+
 Expr* BaseForwardModeVisitor::GuardNullTangentRead(const Expr* ptr,
                                                    Expr* tangent, Expr* read,
                                                    Expr* zero) {
-  const auto* DRE = dyn_cast<DeclRefExpr>(ptr->IgnoreParenImpCasts());
+  // Test the root, not the expression being dereferenced: the two are null
+  // together, and the root repeats no pointer arithmetic. When the walk reaches
+  // no root the whole tangent becomes the condition, so callers have to hand
+  // over one that is safe to evaluate twice.
+  const DeclRefExpr* DRE = getPointerArithmeticRoot(ptr);
   if (!DRE || !m_DiffReq.mayHaveNullTangent(dyn_cast<VarDecl>(DRE->getDecl())))
     return read;
-  Expr* cond = CloneNode(tangent);
+  const DeclRefExpr* tangentRoot = getPointerArithmeticRoot(tangent);
+  Expr* cond = CloneNode(tangentRoot ? tangentRoot : tangent);
   return BuildParens(
       m_Sema.ActOnConditionalOp(noLoc, noLoc, cond, read, zero).get());
+}
+
+Expr* BaseForwardModeVisitor::KeepTangentNullness(const Expr* ptr,
+                                                  Expr* tangent) {
+  if (!tangent || !tangent->getType()->isPointerType())
+    return tangent;
+  // A bare root has no arithmetic to undo.
+  const DeclRefExpr* tangentRoot = getPointerArithmeticRoot(tangent);
+  if (!tangentRoot || tangentRoot == tangent->IgnoreParenImpCasts())
+    return tangent;
+  const DeclRefExpr* DRE = getPointerArithmeticRoot(ptr);
+  if (!DRE || !m_DiffReq.mayHaveNullTangent(dyn_cast<VarDecl>(DRE->getDecl())))
+    return tangent;
+  Expr* cond = CloneNode(tangentRoot);
+  Expr* null = getZeroInit(tangent->getType());
+  return BuildParens(
+      m_Sema.ActOnConditionalOp(noLoc, noLoc, cond, tangent, null).get());
 }
 
 StmtDiff BaseForwardModeVisitor::VisitDeclRefExpr(const DeclRefExpr* DRE) {
@@ -1279,6 +1327,8 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
         }
         dArg = getZeroInit(zeroTy);
       }
+      // The callee null checks the tangent it is handed.
+      dArg = KeepTangentNullness(arg, dArg);
       // pointer/array arguments are dynamically synthesized above
       diffArgs.push_back(dArg);
     }
@@ -1412,8 +1462,12 @@ StmtDiff BaseForwardModeVisitor::VisitUnaryOperator(const UnaryOperator* UnOp) {
   else if (opKind == UO_PostInc || opKind == UO_PostDec ||
            opKind == UO_PreInc || opKind == UO_PreDec) {
     Expr* derivedOp = diff.getExpr_dx();
-    if (derivedOp && diff.getExpr_dx()->getType()->isPointerType())
+    if (derivedOp && diff.getExpr_dx()->getType()->isPointerType()) {
       derivedOp = BuildOp(opKind, diff.getExpr_dx());
+      // The stepped tangent outlives this expression, so skip the step while
+      // it is null.
+      derivedOp = KeepTangentNullness(UnOp->getSubExpr(), derivedOp);
+    }
     return StmtDiff(op, derivedOp);
   } /* For supporting complex types */
   else if (opKind == UnaryOperatorKind::UO_Real ||
@@ -1427,9 +1481,15 @@ StmtDiff BaseForwardModeVisitor::VisitUnaryOperator(const UnaryOperator* UnOp) {
         utils::GetValueType(UnOp->getSubExpr()->getType()->getPointeeType());
     Expr* zero =
         ConstantFolder::synthesizeLiteral(literalTy, m_Context, /*val=*/0);
-    if (Expr* dx = diff.getExpr_dx())
+    if (Expr* dx = diff.getExpr_dx()) {
+      // The guard tests the tangent and reads through it. A tangent that steps
+      // a pointer (`_d_q++`) would take that step once per occurrence, so give
+      // the two occurrences a single evaluation to share.
+      if (dx->HasSideEffects(m_Context))
+        dx = StoreAndRef(dx);
       return StmtDiff(op, GuardNullTangentRead(UnOp->getSubExpr(), dx,
                                                BuildOp(opKind, dx), zero));
+    }
     return StmtDiff(op, zero);
   } else if (opKind == UnaryOperatorKind::UO_AddrOf) {
     Expr* derivedOp = diff.getExpr_dx();
@@ -1544,7 +1604,13 @@ BaseForwardModeVisitor::VisitBinaryOperator(const BinaryOperator* BinOp) {
         derivedL = CloneNode(derivedL);
       if (derivedR == Rdiff.getExpr())
         derivedR = CloneNode(derivedR);
+      // `q = xlArr + 1` carries the arithmetic on the right; `q += 1` performs
+      // it on the tangent itself, so there the whole update is guarded.
+      if (opCode == BO_Assign)
+        derivedR = KeepTangentNullness(BinOp->getRHS(), derivedR);
       opDiff = BuildOp(opCode, derivedL, derivedR);
+      if (opCode != BO_Assign)
+        opDiff = KeepTangentNullness(BinOp->getLHS(), opDiff);
     } else if (opCode == BO_MulAssign || opCode == BO_DivAssign) {
       // if both original expression and derived expression and evaluatable,
       // then derived expression reference needs to be stored before
@@ -1662,6 +1728,9 @@ BaseForwardModeVisitor::DifferentiateVarDecl(const VarDecl* VD,
   // `const double& r = 5.;` derives to is not one.
   if (VDType->isLValueReferenceType() && initDx && !initDx->isLValue())
     initDx = nullptr;
+  // The tangent outlives the initializer that built it.
+  if (init && initDx)
+    initDx = KeepTangentNullness(init, initDx);
   // References and pointers-to-const only alias storage they do not own, so
   // without an initializer tangent there is nothing to alias. Fabricating one
   // yields a null tangent that later gets dereferenced, or a reference bound

--- a/test/Regressions/null-tangent-pointer-arithmetic.cpp
+++ b/test/Regressions/null-tangent-pointer-arithmetic.cpp
@@ -1,0 +1,197 @@
+// RUN: %cladclang -std=c++17 -I%S/../../include %s -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+// Clad cannot size a tangent buffer for a `const double*` parameter, so a
+// pushforward is handed a null tangent for it and null checks the reads through
+// it. Pointer arithmetic used to lose that encoding: `_d_xlArr + 1` is 0x8
+// rather than null, so the check sailed through and the derivative dereferenced
+// a small integer. Reads written on the arithmetic itself were not checked at
+// all, only bare declaration references were.
+//
+// These are the shapes RooFit's code generation emits for a multi-channel
+// likelihood, so every such hessian crashed at run time.
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+// Initializer: the derived pointer outlives the expression that built it.
+double indexed(double* params, double const* xlArr) {
+  double const* q = xlArr + 1;
+  return params[0] * params[0] * q[0] + params[0] * params[1] * xlArr[0];
+}
+double stored_ptr(double* params, double const* xlArr) {
+  return indexed(params, xlArr);
+}
+
+// CHECK: clad::ValueAndPushforward<double, double> indexed_pushforward(double *params, const double *xlArr, double *_d_params, const double *_d_xlArr) {
+// CHECK-NEXT: const double *_d_q = (_d_xlArr ? _d_xlArr + 1 : nullptr);
+// CHECK-NEXT: const double *q = xlArr + 1;
+
+// A read on the arithmetic itself is guarded on the root, so the check does
+// not repeat the arithmetic.
+double deref(double* params, double const* xlArr) {
+  unsigned int i = 1;
+  return params[0] * params[0] * *(xlArr + i);
+}
+double deref_arith(double* params, double const* xlArr) {
+  return deref(params, xlArr);
+}
+
+// CHECK: clad::ValueAndPushforward<double, double> deref_pushforward(double *params, const double *xlArr, double *_d_params, const double *_d_xlArr) {
+// CHECK: _d_xlArr ? *(_d_xlArr + i) : 0.
+
+// Assignment, compound assignment and increment. The last two step the tangent
+// in place, so the step itself is what gets skipped while it is null.
+double reassigned(double* params, double const* xlArr) {
+  double const* q = xlArr;
+  q = xlArr + 1;
+  return params[0] * params[0] * q[0];
+}
+double assign_ptr(double* params, double const* xlArr) {
+  return reassigned(params, xlArr);
+}
+
+// CHECK: clad::ValueAndPushforward<double, double> reassigned_pushforward(double *params, const double *xlArr, double *_d_params, const double *_d_xlArr) {
+// CHECK: _d_q = (_d_xlArr ? _d_xlArr + 1 : nullptr);
+// CHECK-NEXT: q = xlArr + 1;
+
+double advanced(double* params, double const* xlArr) {
+  double const* q = xlArr;
+  q += 1;
+  return params[0] * params[0] * q[0];
+}
+double compound_ptr(double* params, double const* xlArr) {
+  return advanced(params, xlArr);
+}
+
+// CHECK: clad::ValueAndPushforward<double, double> advanced_pushforward(double *params, const double *xlArr, double *_d_params, const double *_d_xlArr) {
+// CHECK: (_d_q ? _d_q += 1 : nullptr);
+// CHECK-NEXT: q += 1;
+
+double stepped(double* params, double const* xlArr) {
+  double const* q = xlArr;
+  q++;
+  return params[0] * params[0] * q[0];
+}
+double incr_ptr(double* params, double const* xlArr) {
+  return stepped(params, xlArr);
+}
+
+// CHECK: clad::ValueAndPushforward<double, double> stepped_pushforward(double *params, const double *xlArr, double *_d_params, const double *_d_xlArr) {
+// CHECK: (_d_q ? _d_q++ : nullptr);
+// CHECK-NEXT: q++;
+
+// A derived pointer has to reach a further callee null, so that the callee's
+// own check answers truthfully.
+double leaf(double const* v) { return v[0]; }
+double forwarded(double* params, double const* xlArr) {
+  double const* q = xlArr + 1;
+  return params[0] * params[0] * leaf(q);
+}
+double pass_ptr(double* params, double const* xlArr) {
+  return forwarded(params, xlArr);
+}
+
+// Passing the arithmetic itself is what reaches the call-argument guard; a
+// pointer bound to a variable first was already nulled by its initializer.
+double forwarded_arith(double* params, double const* xlArr) {
+  return params[0] * params[0] * leaf(xlArr + 1);
+}
+double pass_arith(double* params, double const* xlArr) {
+  return forwarded_arith(params, xlArr);
+}
+
+// CHECK: clad::ValueAndPushforward<double, double> forwarded_arith_pushforward(double *params, const double *xlArr, double *_d_params, const double *_d_xlArr) {
+// CHECK: leaf_pushforward(xlArr + 1, (_d_xlArr ? _d_xlArr + 1 : nullptr));
+
+// An assignment is not a step, so the walk ends there instead of reaching
+// `xlArr` through it. The tangent it hands on is already null when `_d_xlArr`
+// is, and the outer assignment has to pass that on rather than test `_d_p`,
+// which the same statement is still writing.
+double chained(double* params, double const* xlArr) {
+  double const* p = xlArr;
+  double const* q = xlArr;
+  q = p = xlArr + 1;
+  return params[0] * params[0] * q[0];
+}
+double chain_ptr(double* params, double const* xlArr) {
+  return chained(params, xlArr);
+}
+
+// CHECK: clad::ValueAndPushforward<double, double> chained_pushforward(double *params, const double *xlArr, double *_d_params, const double *_d_xlArr) {
+// CHECK: _d_q = _d_p = (_d_xlArr ? _d_xlArr + 1 : nullptr);
+// CHECK-NEXT: q = p = xlArr + 1;
+
+// A tangent that steps a pointer is both tested and read through, so it has to
+// be evaluated once. Guarding the step in place stepped it twice, which reads
+// past the end of the tangent buffer.
+double stepped_read(double* x) {
+  double* q; // no initializer, so the planner marks its tangent maybe-null
+  q = x;     // ... while at run time it is the real tangent of `x`
+  return *(q += 1);
+}
+double step_read(double* x) { return stepped_read(x); }
+
+double stepped_read_post(double* x) {
+  double* q;
+  q = x;
+  return *(q++);
+}
+double step_read_post(double* x) { return stepped_read_post(x); }
+
+// CHECK: clad::ValueAndPushforward<double, double> stepped_read_pushforward(double *x, double *_d_x) {
+// CHECK: double *_t0 = (_d_q ? _d_q += 1 : nullptr);
+// CHECK-NEXT: return {*(q += 1), (_t0 ? *_t0 : 0.)};
+
+int main() {
+  double params[2] = {2., 3.};
+  double xlArr[2] = {5., 7.};
+
+  double m[4] = {};
+  clad::hessian(stored_ptr, "params[0:1]").execute(params, xlArr, m);
+  printf("stored_ptr %.2f %.2f %.2f %.2f\n", m[0], m[1], m[2], m[3]);
+  // CHECK-EXEC: stored_ptr 14.00 5.00 5.00 0.00
+
+  double m2[1] = {};
+  clad::hessian(deref_arith, "params[0]").execute(params, xlArr, m2);
+  printf("deref_arith %.2f\n", m2[0]);
+  // CHECK-EXEC: deref_arith 14.00
+
+  double m3[1] = {};
+  clad::hessian(pass_ptr, "params[0]").execute(params, xlArr, m3);
+  printf("pass_ptr %.2f\n", m3[0]);
+  // CHECK-EXEC: pass_ptr 14.00
+
+  double m4[1] = {};
+  clad::hessian(assign_ptr, "params[0]").execute(params, xlArr, m4);
+  printf("assign_ptr %.2f\n", m4[0]);
+  // CHECK-EXEC: assign_ptr 14.00
+
+  double m5[1] = {};
+  clad::hessian(compound_ptr, "params[0]").execute(params, xlArr, m5);
+  printf("compound_ptr %.2f\n", m5[0]);
+  // CHECK-EXEC: compound_ptr 14.00
+
+  double m6[1] = {};
+  clad::hessian(incr_ptr, "params[0]").execute(params, xlArr, m6);
+  printf("incr_ptr %.2f\n", m6[0]);
+  // CHECK-EXEC: incr_ptr 14.00
+
+  double m7[1] = {};
+  clad::hessian(pass_arith, "params[0]").execute(params, xlArr, m7);
+  printf("pass_arith %.2f\n", m7[0]);
+  // CHECK-EXEC: pass_arith 14.00
+
+  double m8[1] = {};
+  clad::hessian(chain_ptr, "params[0]").execute(params, xlArr, m8);
+  printf("chain_ptr %.2f\n", m8[0]);
+  // CHECK-EXEC: chain_ptr 14.00
+
+  double v[3] = {2., 3., 5.};
+  printf("step_read %.2f\n",
+         clad::differentiate(step_read, "x[1]").execute(v));
+  // CHECK-EXEC: step_read 1.00
+  printf("step_read_post %.2f\n",
+         clad::differentiate(step_read_post, "x[0]").execute(v));
+  // CHECK-EXEC: step_read_post 1.00
+}


### PR DESCRIPTION
Clad cannot size a tangent buffer for a `const double*` parameter, so a pushforward is handed a null tangent for it. Null spells "the derivative of this argument is identically zero", and forward mode null checks the reads through it.

Pointer arithmetic destroys that encoding, because `nullptr + 1` is 0x8 rather than null. The guard was still emitted -- the planner does mark the variable as possibly having a null tangent -- it just tested a pointer the arithmetic had already made non-null, so the read went ahead and dereferenced a small integer. That is what made the failure quiet rather than loud. These are the shapes RooFit's code generation emits for a multi-channel likelihood, so every such hessian crashed at run time.

Add getPointerArithmeticRoot, which walks an expression back to the declaration its pointer value originates in, and KeepTangentNullness, which rebuilds a derived tangent to evaluate to null whenever the tangent it came from is null. Guard the five places a tangent outlives the expression that built it: variable initializers, call arguments, assignments, compound assignments and increments.

Null-ness originates at the root and pointer arithmetic preserves it, so the root is what the check has to test. Testing it there also keeps the condition free of the arithmetic, which matters because the condition is cloned. `p += n` and `p++` update the pointer they are rooted in and are walked through; plain `p = q` is rooted in `q` instead, so the assignment case guards the derived right-hand side while the in-place cases guard the whole update.

Widening the walk also makes the pre-existing read guard fire on `*(p++)`, where the tangent already carries a step. Such a tangent is both tested and read through, so it is stored first and the guard tests the stored value -- one step, one test.