### PR TITLE
Track the independent-variable offset in one place

### DIFF
--- a/include/clad/Differentiator/VectorForwardModeVisitor.h
+++ b/include/clad/Differentiator/VectorForwardModeVisitor.h
@@ -4,6 +4,9 @@
 #include "BaseForwardModeVisitor.h"
 #include "DerivativeBuilder.h"
 
+#include "clang/AST/Expr.h"
+
+#include <cstddef>
 #include <unordered_map>
 
 namespace clad {
@@ -11,6 +14,33 @@ namespace clad {
 /// Used to compute derivatives by clad::vector_forward_differentiate.
 class VectorForwardModeVisitor : public BaseForwardModeVisitor {
 protected:
+  /// Tracks where the next independent variable starts in the flat vector of
+  /// all of them: the sizes of the array parameters seen so far plus the
+  /// number of scalar ones. Array sizes are only known at run time, so that
+  /// half is an accumulated expression; the scalar half is a counter folded
+  /// into a literal on demand.
+  ///
+  /// The tracker clones every expression it takes in and hands out. The sum
+  /// keeps growing after an offset is taken, and each offset goes into a
+  /// different part of the derivative; every AST node has exactly one parent.
+  class IndVarOffsetTracker {
+    VectorForwardModeVisitor* m_V;
+    /// Sum of the sizes of the array parameters seen so far, null until the
+    /// first one.
+    clang::Expr* m_ArrayCount = nullptr;
+    /// Number of scalar parameters seen so far.
+    std::size_t m_ScalarCount = 0;
+
+  public:
+    explicit IndVarOffsetTracker(VectorForwardModeVisitor& V) : m_V(&V) {}
+    /// Build a fresh expression for the offset of the current parameter.
+    [[nodiscard]] clang::Expr* buildOffset() const;
+    /// Account for an array parameter of the given size.
+    void advanceByArray(const clang::Expr* size);
+    /// Account for a scalar parameter.
+    void advanceByScalar() { ++m_ScalarCount; }
+  };
+
   llvm::SmallVector<const clang::ValueDecl*, 16> m_IndependentVars;
   /// Map used to keep track of parameter variables w.r.t which the
   /// the derivative is being computed. This is separate from the

--- a/lib/Differentiator/JacobianModeVisitor.cpp
+++ b/lib/Differentiator/JacobianModeVisitor.cpp
@@ -165,13 +165,8 @@ DerivativeAndOverload JacobianModeVisitor::Derive() {
   for (DeclStmt* decl : adjointDecls)
     addToCurrentBlock(decl);
 
-  // Expression for maintaining the number of independent variables processed
-  // till now present as array elements. This will be sum of sizes of all such
-  // arrays.
-  Expr* arrayIndVarCountExpr = nullptr;
-
-  // Number of non-array independent variables processed till now.
-  nonArrayIndVarCount = 0;
+  // Offset of the next independent variable into the vector of all of them.
+  IndVarOffsetTracker offsetTracker(*this);
 
   // Current Index of independent variable in the param list of the function.
   size_t independentVarIndex = 0;
@@ -188,16 +183,7 @@ DerivativeAndOverload JacobianModeVisitor::Derive() {
     if (m_DiffReq.DVI.size() > independentVarIndex &&
         m_DiffReq.DVI[independentVarIndex].param ==
             m_DiffReq->getParamDecl(i)) {
-      // Current offset for independent variable. arrayIndVarCountExpr keeps
-      // accumulating below, so clone it for this offset use.
-      Expr* offsetExpr = CloneNode(arrayIndVarCountExpr);
-      Expr* nonArrayIndVarCountExpr = ConstantFolder::synthesizeLiteral(
-          m_Context.UnsignedLongTy, m_Context, nonArrayIndVarCount);
-      if (!offsetExpr)
-        offsetExpr = nonArrayIndVarCountExpr;
-      else if (nonArrayIndVarCount != 0)
-        offsetExpr = BuildOp(BinaryOperatorKind::BO_Add, offsetExpr,
-                             nonArrayIndVarCountExpr);
+      Expr* offsetExpr = offsetTracker.buildOffset();
 
       if (is_array) {
         // The adjoint is `(*_d_p)`; the array whose size we need is the bare
@@ -213,20 +199,13 @@ DerivativeAndOverload JacobianModeVisitor::Derive() {
                                             offsetExpr};
         dVectorParam = BuildIdentityMatrixExpr(dParamType, args, loc);
 
-        // Update the array independent expression. getSize is already used by
-        // the identity matrix above; clone it so the two do not share.
-        if (!arrayIndVarCountExpr)
-          arrayIndVarCountExpr = CloneNode(getSize);
-        else
-          arrayIndVarCountExpr =
-              BuildOp(BinaryOperatorKind::BO_Add, arrayIndVarCountExpr,
-                      CloneNode(getSize));
+        offsetTracker.advanceByArray(getSize);
       } else {
         // Create a one hot vector for the parameter.
         llvm::SmallVector<Expr*, 2> args = {buildIndVarCountRef(), offsetExpr};
         dVectorParam = BuildCallExprToCladFunction("one_hot_vector", args,
                                                    {dParamType}, loc);
-        ++nonArrayIndVarCount;
+        offsetTracker.advanceByScalar();
       }
       ++independentVarIndex;
     } else {

--- a/lib/Differentiator/VectorForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorForwardModeVisitor.cpp
@@ -6,6 +6,7 @@
 #include "clad/Differentiator/ParseDiffArgsTypes.h"
 
 #include "clang/AST/Decl.h"
+#include "clang/AST/OperationKinds.h"
 #include "clang/AST/TemplateName.h"
 #include "clang/Sema/Lookup.h"
 
@@ -19,6 +20,29 @@ VectorForwardModeVisitor::VectorForwardModeVisitor(DerivativeBuilder& builder,
     : BaseForwardModeVisitor(builder, request) {}
 
 VectorForwardModeVisitor::~VectorForwardModeVisitor() {}
+
+Expr* VectorForwardModeVisitor::IndVarOffsetTracker::buildOffset() const {
+  // The running sum keeps growing after this call, so hand out a clone.
+  Expr* offset = m_V->CloneNode(m_ArrayCount);
+  if (offset && m_ScalarCount == 0)
+    return offset;
+  Expr* scalars = ConstantFolder::synthesizeLiteral(
+      m_V->m_Context.UnsignedLongTy, m_V->m_Context, m_ScalarCount);
+  if (!offset)
+    return scalars;
+  return m_V->BuildOp(BinaryOperatorKind::BO_Add, offset, scalars);
+}
+
+void VectorForwardModeVisitor::IndVarOffsetTracker::advanceByArray(
+    const Expr* size) {
+  // The caller splices `size` itself into the derivative, so keep a clone.
+  Expr* clonedSize = m_V->CloneNode(size);
+  if (!m_ArrayCount)
+    m_ArrayCount = clonedSize;
+  else
+    m_ArrayCount =
+        m_V->BuildOp(BinaryOperatorKind::BO_Add, m_ArrayCount, clonedSize);
+}
 
 std::string VectorForwardModeVisitor::GetPushForwardFunctionSuffix() {
   return "_vector_pushforward";
@@ -87,13 +111,8 @@ DerivativeAndOverload VectorForwardModeVisitor::Derive() {
   addToCurrentBlock(BuildDeclStmt(totalIndVars));
   m_IndVarCountDecl = totalIndVars;
 
-  // Expression for maintaining the number of independent variables processed
-  // till now present as array elements. This will be sum of sizes of all such
-  // arrays.
-  Expr* arrayIndVarCountExpr = nullptr;
-
-  // Number of non-array independent variables processed till now.
-  size_t nonArrayIndVarCount = 0;
+  // Offset of the next independent variable into the vector of all of them.
+  IndVarOffsetTracker offsetTracker(*this);
 
   // Current Index of independent variable in the param list of the function.
   size_t independentVarIndex = 0;
@@ -108,16 +127,7 @@ DerivativeAndOverload VectorForwardModeVisitor::Derive() {
     if (m_IndependentVars.size() > independentVarIndex &&
         m_IndependentVars[independentVarIndex] == m_DiffReq->getParamDecl(i)) {
 
-      // Current offset for independent variable. arrayIndVarCountExpr keeps
-      // accumulating below, so clone it for this offset use.
-      Expr* offsetExpr = CloneNode(arrayIndVarCountExpr);
-      Expr* nonArrayIndVarCountExpr = ConstantFolder::synthesizeLiteral(
-          m_Context.UnsignedLongTy, m_Context, nonArrayIndVarCount);
-      if (!offsetExpr)
-        offsetExpr = nonArrayIndVarCountExpr;
-      else if (nonArrayIndVarCount != 0)
-        offsetExpr = BuildOp(BinaryOperatorKind::BO_Add, offsetExpr,
-                             nonArrayIndVarCountExpr);
+      Expr* offsetExpr = offsetTracker.buildOffset();
 
       if (is_array) {
         // Get size of the array.
@@ -131,22 +141,13 @@ DerivativeAndOverload VectorForwardModeVisitor::Derive() {
                                             offsetExpr};
         dVectorParam = BuildIdentityMatrixExpr(dParamType, args, loc);
 
-        // Update the array independent expression. getSize is already used by
-        // the identity matrix above and arrayIndVarCountExpr flows into later
-        // slice/subscript expressions, so clone it here to avoid sharing.
-        if (!arrayIndVarCountExpr) {
-          arrayIndVarCountExpr = CloneNode(getSize);
-        } else {
-          arrayIndVarCountExpr =
-              BuildOp(BinaryOperatorKind::BO_Add, arrayIndVarCountExpr,
-                      CloneNode(getSize));
-        }
+        offsetTracker.advanceByArray(getSize);
       } else {
         // Create a one hot vector for the parameter.
         llvm::SmallVector<Expr*, 2> args = {buildIndVarCountRef(), offsetExpr};
         dVectorParam = BuildCallExprToCladFunction("one_hot_vector", args,
                                                    {dParamType}, loc);
-        ++nonArrayIndVarCount;
+        offsetTracker.advanceByScalar();
       }
       ++independentVarIndex;
     } else {
@@ -477,28 +478,15 @@ StmtDiff VectorForwardModeVisitor::VisitReturnStmt(const ReturnStmt* RS) {
   // parameters.
   auto dVectorRef = BuildDeclRef(dVectorParamDecl);
 
-  // Expression for maintaining the number of independent variables processed
-  // till now present as array elements. This will be sum of sizes of all such
-  // arrays.
-  Expr* arrayIndVarCountExpr = nullptr;
-  // Number of non-array independent variables processed till now.
-  size_t nonArrayIndVarCount = 0;
+  // Offset of the next independent variable into the vector of all of them.
+  IndVarOffsetTracker offsetTracker(*this);
 
   for (size_t i = 0; i < m_IndependentVars.size(); ++i) {
     // Get the derivative of the ith parameter.
     auto dParam = m_ParamVariables[m_IndependentVars[i]];
     Expr* dParamValue = nullptr;
 
-    // Current offset for independent variable.
-    // arrayIndVarCountExpr keeps accumulating below; clone it for this offset.
-    Expr* offsetExpr = CloneNode(arrayIndVarCountExpr);
-    Expr* nonArrayIndVarCountExpr = ConstantFolder::synthesizeLiteral(
-        m_Context.UnsignedLongTy, m_Context, nonArrayIndVarCount);
-    if (!offsetExpr)
-      offsetExpr = nonArrayIndVarCountExpr;
-    else if (nonArrayIndVarCount != 0)
-      offsetExpr = BuildOp(BinaryOperatorKind::BO_Add, offsetExpr,
-                           nonArrayIndVarCountExpr);
+    Expr* offsetExpr = offsetTracker.buildOffset();
 
     if (isCladArrayType(dParam->getType())) {
       // Get the size of the array.
@@ -510,22 +498,14 @@ StmtDiff VectorForwardModeVisitor::VisitReturnStmt(const ReturnStmt* RS) {
       llvm::SmallVector<Expr*, 2> args = {offsetExpr, getSize};
       dParamValue = BuildArrayRefSliceExpr(CloneNode(dVectorRef), args);
 
-      // Update the array independent expression. getSize is used by the slice
-      // above; clone so the two do not share.
-      if (!arrayIndVarCountExpr) {
-        arrayIndVarCountExpr = CloneNode(getSize);
-      } else {
-        arrayIndVarCountExpr =
-            BuildOp(BinaryOperatorKind::BO_Add, arrayIndVarCountExpr,
-                    CloneNode(getSize));
-      }
+      offsetTracker.advanceByArray(getSize);
     } else {
       dParamValue = m_Sema
                         .ActOnArraySubscriptExpr(
                             getCurrentScope(), CloneNode(dVectorRef),
                             dVectorRef->getExprLoc(), offsetExpr, noLoc)
                         .get();
-      ++nonArrayIndVarCount;
+      offsetTracker.advanceByScalar();
     }
     // Create an assignment expression to assign the ith element of the
     // return vector to the derivative of the ith parameter.


### PR DESCRIPTION
Vector forward mode and Jacobian mode each computed the offset of a parameter into the flat vector of independent variables by hand, three times over: in VectorForwardModeVisitor::Derive, in its VisitReturnStmt, and in JacobianModeVisitor::Derive. Every copy accumulated the running sum of array sizes, folded the scalar count into a literal, combined the two, and cloned expressions on both sides before splicing them into the derivative.

The clones are what made the duplication expensive. The running sum keeps growing after an offset is taken from it, and each offset is spliced into a different part of the derivative, so handing out the accumulator itself would give an AST node two parents. The same applies to the size expression: it is already used by the identity matrix or array slice built for that parameter, so the accumulator has to take a copy. Each of the three sites had to know all of this independently.

Replace them with an IndVarOffsetTracker that owns the accumulation and clones on the way in and on the way out, so the one-parent invariant is structural instead of restated at each site.

The tracker stores a VectorForwardModeVisitor* rather than a VisitorBase*, because m_Context and BuildOp are protected in VisitorBase and cannot be reached through a base pointer. Its methods are defined in the .cpp so ConstantFolder.h stays out of the public header.

The two sites that compute the *total* independent-variable count (VectorForwardModeVisitor.cpp and JacobianModeVisitor.cpp) use the same combine formula but hand the accumulated expression off instead of cloning it, so they are left alone; routing them through the tracker would orphan a node per array parameter.

No functional change: the Jacobian, VectorMode and ArrayInputsVectorForwardMode tests check the generated derivative source line by line with FileCheck and pass unmodified, so the emitted AST is identical. Verified against a debug build, where the AST-integrity checks assert rather than warn.

**This is a refactor to consolidate the code, no functional changes**