### PR TITLE
Keep function-local state out of propagated restore trackers.

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -476,6 +476,14 @@ namespace clad {
     bool hasMemoryTypeParams(const clang::FunctionDecl* FD);
 
     bool shouldUseRestoreTracker(const clang::FunctionDecl* FD);
+    /// Returns true when E designates storage with automatic storage
+    /// duration in the current function, reached through subscripts,
+    /// members, dereferences or accessor calls. Such storage dies with the
+    /// function, so a caller must not try to restore it.
+    /// \param asPointerValue E is a pointer rvalue passed to a callee, so
+    /// the pointee is judged rather than the pointer variable's own slot.
+    bool designatesLocallyOwnedStorage(const clang::Expr* E,
+                                       bool asPointerValue = false);
 
     bool IsDifferentiableType(clang::QualType T);
 

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -117,6 +117,9 @@ namespace clad {
     clang::Expr* m_CurrentBreakFlagExpr;
 
     clang::Expr* m_RestoreTracker = nullptr;
+    /// A never-restored tracker handed to nested reverse_forw calls that only
+    /// mutate this reverse_forw's own locals; see VisitCallExpr.
+    clang::Expr* m_UnusedRestoreTracker = nullptr;
 
     unsigned outputArrayCursor = 0;
     unsigned numParams = 0;

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1203,6 +1203,56 @@ namespace clad {
       return false;
     }
 
+    bool designatesLocallyOwnedStorage(const clang::Expr* E,
+                                       bool asPointerValue) {
+      bool peeled = asPointerValue;
+      if (asPointerValue) {
+        // `&lvalue` passed as a pointer designates that lvalue directly.
+        const auto* UO =
+            dyn_cast<clang::UnaryOperator>(E->IgnoreParenImpCasts());
+        if (UO && UO->getOpcode() == clang::UO_AddrOf)
+          return designatesLocallyOwnedStorage(UO->getSubExpr());
+      }
+      while (true) {
+        E = E->IgnoreParenImpCasts();
+        if (const auto* UO = dyn_cast<clang::UnaryOperator>(E)) {
+          peeled |= UO->getOpcode() == clang::UO_Deref;
+          E = UO->getSubExpr();
+        } else if (const auto* ASE = dyn_cast<clang::ArraySubscriptExpr>(E)) {
+          peeled = true;
+          E = ASE->getBase();
+        } else if (const auto* OCE = dyn_cast<clang::CXXOperatorCallExpr>(E)) {
+          if (OCE->getNumArgs() == 0)
+            return false;
+          peeled = true;
+          E = OCE->getArg(0);
+        } else if (const auto* MCE = dyn_cast<clang::CXXMemberCallExpr>(E)) {
+          peeled = true;
+          E = MCE->getImplicitObjectArgument();
+        } else if (const auto* ME = dyn_cast<clang::MemberExpr>(E)) {
+          peeled |= ME->isArrow();
+          E = ME->getBase();
+        } else {
+          break;
+        }
+      }
+      const auto* DRE = dyn_cast<clang::DeclRefExpr>(E);
+      const auto* VD = DRE ? dyn_cast<clang::VarDecl>(DRE->getDecl()) : nullptr;
+      if (!VD || !VD->hasLocalStorage() || VD->getType()->isReferenceType())
+        return false;
+      // The variable's own slot (no indirection peeled) always has automatic
+      // storage duration, even for a pointer variable. Storage reached
+      // through the variable is only owned when the variable is not a
+      // pointer or reference into memory owned elsewhere.
+      // FIXME: a local pointer that provably holds the address of a local
+      // (`T* p = &t;`) reaches storage that does die with the function, but
+      // proving it needs points-to information, so such storage is still
+      // reported as caller-visible.
+      if (!peeled)
+        return true;
+      return !VD->getType()->isPointerType();
+    }
+
     bool hasMemoryTypeParams(const FunctionDecl* FD) {
       if (const auto* MD = dyn_cast<CXXMethodDecl>(FD))
         if (MD->isInstance() && !MD->isConst())

--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -222,11 +222,10 @@ StmtDiff ReverseModeForwPassVisitor::StoreAndRestore(clang::Expr* E,
                                                      bool moveToTape) {
   if (!m_RestoreTracker)
     return {};
-  if (const auto* DRE = dyn_cast<DeclRefExpr>(E->IgnoreCasts())) {
-    const auto* VD = cast<VarDecl>(DRE->getDecl());
-    if (!VD->getType()->isReferenceType())
-      return {};
-  }
+  // Storage owned by this function's locals is gone by the time the caller
+  // restores the tracker; recording it would replay bytes into freed memory.
+  if (utils::designatesLocallyOwnedStorage(E))
+    return {};
   // Clone both the tracker base (reused across every store call) and the stored
   // expression E (the caller passes the same node it emits into the primal), so
   // the store call is a distinct subtree.

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2733,7 +2733,40 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           // f_reverse_forw(..., clad::restore_tracker& _tracker0) {
           //   g_reverse_forw(..., _tracker0); // do not generate a new tracker
           // ```
-          trackerExpr = m_RestoreTracker;
+          // Do not propagate when every mutable argument is storage owned by
+          // one of this reverse_forw's locals: those addresses are dead by
+          // the time the caller restores, so a record of them would write
+          // into freed memory. Such state is caller-invisible, so a
+          // throwaway tracker is enough.
+          bool mutatesOnlyOwnLocals = true;
+          for (std::size_t i = 0, e = FD->getNumParams(); i < e; ++i) {
+            QualType parTy = FD->getParamDecl(i)->getType();
+            bool mayWrite = (parTy->isPointerType() &&
+                             !parTy->getPointeeType().isConstQualified()) ||
+                            (parTy->isLValueReferenceType() &&
+                             !parTy.getNonReferenceType().isConstQualified());
+            if (!mayWrite)
+              continue;
+            std::size_t argIdx =
+                i + static_cast<std::size_t>(isMethodOperatorCall);
+            if (argIdx >= CE->getNumArgs() ||
+                !utils::designatesLocallyOwnedStorage(
+                    CE->getArg(argIdx),
+                    /*asPointerValue=*/parTy->isPointerType())) {
+              mutatesOnlyOwnLocals = false;
+              break;
+            }
+          }
+          if (mutatesOnlyOwnLocals) {
+            if (!m_UnusedRestoreTracker) {
+              VarDecl* unusedDecl = GlobalStoreImpl(
+                  trackerType, "_tracker_unused", getZeroInit(trackerType));
+              m_UnusedRestoreTracker = BuildDeclRef(unusedDecl);
+            }
+            trackerExpr = m_UnusedRestoreTracker;
+          } else {
+            trackerExpr = m_RestoreTracker;
+          }
         } else {
           Expr* trackerPop = nullptr;
           if (isInsideLoop) {

--- a/test/Analyses/TrackerLocalStorage.C
+++ b/test/Analyses/TrackerLocalStorage.C
@@ -1,0 +1,99 @@
+// RUN: %cladclang %s -I%S/../../include -oTrackerLocalStorage.out 2>&1 \
+// RUN:   | %filecheck %s
+// RUN: ./TrackerLocalStorage.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s \
+// RUN:   -I%S/../../include -oTrackerLocalStorage.out
+// RUN: ./TrackerLocalStorage.out | %filecheck_exec %s
+
+// A reverse_forw that owns the storage a nested call mutates must not record
+// that storage in the tracker it received from its caller: those addresses
+// die with the reverse_forw, and the caller's restore would write into freed
+// memory. The shapes below reach that storage in every way the ownership
+// check has to see through -- address-of over a user operator[], an accessor
+// call, and a member array. Reaching a local through a pointer variable is
+// not recognized (see designatesLocallyOwnedStorage), so that shape is not
+// exercised here.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+// The nested call may not record into the tracker the caller passed in.
+// CHECK: void innerAddrOf_reverse_forw(
+// CHECK: clad::restore_tracker _tracker_unused0 = {};
+
+void twice(int n, const double* x, double* out) {
+  for (int i = 0; i < n; i++)
+    out[i] = 2 * x[i];
+}
+
+double squaresum(int n, const double* v) {
+  double t = 0;
+  for (int i = 0; i < n; i++)
+    t += v[i] * v[i];
+  return t;
+}
+
+struct Buf {
+  double vals[2];
+  double* data() { return vals; }
+  double& operator[](int i) { return vals[i]; }
+};
+
+struct Holder {
+  Buf b;
+};
+
+// Reached with `&buf[0]` -- address-of over a user operator[] on a local.
+void innerAddrOf(const double* x, double s, double* err) {
+  Buf buf;
+  twice(2, x, &buf[0]);
+  *err = s * squaresum(2, &buf[0]);
+}
+
+// Reached with a member accessor call on a local.
+void innerAccessor(const double* x, double s, double* err) {
+  Buf buf;
+  twice(2, x, buf.data());
+  *err = s * squaresum(2, buf.data());
+}
+
+// Reached through a member of a local, then a subscript.
+void innerMember(const double* x, double s, double* err) {
+  Holder h;
+  twice(2, x, &h.b.vals[0]);
+  *err = s * squaresum(2, &h.b.vals[0]);
+}
+
+#define OUTER(NAME, INNER)                                                     \
+  double NAME(const double* x) {                                               \
+    double t = 0;                                                              \
+    for (int k = 1; k <= 2; k++) {                                             \
+      double e = 0;                                                            \
+      INNER(x, k, &e);                                                         \
+      t += e;                                                                  \
+    }                                                                          \
+    return t;                                                                  \
+  }
+
+OUTER(outerAddrOf, innerAddrOf)
+OUTER(outerAccessor, innerAccessor)
+OUTER(outerMember, innerMember)
+
+int main() {
+  double x[2] = {1, 2};
+  double dx[2];
+
+#define TEST(fn)                                                               \
+  {                                                                            \
+    dx[0] = dx[1] = 0;                                                         \
+    auto grad = clad::gradient(fn, "x");                                       \
+    grad.execute(x, dx);                                                       \
+    printf(#fn ": dx={%.2f, %.2f}\n", dx[0], dx[1]);                           \
+  }
+
+  // f = sum_{k=1,2} k * |2x|^2 = 12 |x|^2 => df/dx_i = 24 x_i
+  TEST(outerAddrOf);   // CHECK-EXEC: outerAddrOf: dx={24.00, 48.00}
+  TEST(outerAccessor); // CHECK-EXEC: outerAccessor: dx={24.00, 48.00}
+  TEST(outerMember);   // CHECK-EXEC: outerMember: dx={24.00, 48.00}
+}

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -975,7 +975,8 @@ struct MyStructWrapper {
 };
 
 // CHECK:  inline constexpr clad::ValueAndAdjoint<MyStructWrapper &, MyStructWrapper &> operator_equal_reverse_forw(MyStructWrapper &&arg, MyStructWrapper *_d_this, MyStructWrapper &&_d_arg, clad::restore_tracker &_tracker0) noexcept {
-// CHECK-NEXT:      this->val.operator_equal_reverse_forw(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, std::move(_d_arg.val), _tracker0);
+// CHECK-NEXT:      clad::restore_tracker _tracker_unused0 = {};
+// CHECK-NEXT:      this->val.operator_equal_reverse_forw(static_cast<MyStructWrapper &&>(arg).val, &_d_this->val, std::move(_d_arg.val), _tracker_unused0);
 // CHECK-NEXT:      return {*this, *_d_this};
 // CHECK-NEXT:  }
 


### PR DESCRIPTION
A tracker propagated into a reverse_forw accumulates every store made in the callee subtree, keyed by raw address. Stores of storage owned by the reverse_forw itself -- its locals, by-value parameters, and heap owned by them -- record addresses that are dead by the time the caller restores, so the restore memcpy's the saved bytes into freed or reused memory.

Introduce utils::designatesLocallyOwnedStorage to recognize such storage, distinguishing a variable's own automatic slot from storage reached through a pointer or reference, and skip it at both recording sites: the reverse_forw's direct assignment stores (generalizing the existing plain-variable check to subscripts, members, and accessor-call lvalues) and the tracker propagation into nested reverse_forw calls, which now receive a never-restored local tracker when they can only mutate the enclosing function's own storage.