### PR TITLE
Let TBR run on dynamically scheduled reverse-mode requests

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -17,6 +17,7 @@
 #include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Basic/SourceLocation.h"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -424,6 +425,11 @@ struct RequestOptions {
     /// Essentially needed for prolonging the lifetime of
     /// unique_ptr<clang::AnalysisDeclContext>.
     OwnedAnalysisContexts& m_AllAnalysisDC;
+    /// The contexts PlanNestedRequest built, keyed by the function they
+    /// describe, so that repeated planning of the same lazily-scheduled
+    /// request reuses one context (and one CFG) instead of building another.
+    llvm::DenseMap<const clang::FunctionDecl*, clang::AnalysisDeclContext*>
+        m_NestedAnalysisDC;
     /// If set it means that we need to find the called functions and
     /// add them for implicit diff.
     ///

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -413,10 +413,13 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
     FunctionDecl* derivative = this->FindDerivedFunction(request);
     if (!derivative) {
       alreadyDerived = false;
-      // FIXME: Our analyses are closely tied to the DiffPlanner. Dynamic
-      // derivatives don't have m_AnalysisDC. We should either disable
-      // dynamic scheduling or build m_AnalysisDC here.
-      request.EnableTBRAnalysis = false;
+      // FIXME: Our analyses are closely tied to the DiffPlanner. The varied
+      // and useful analyses have to be run eagerly by the planner and it does
+      // not do so for dynamically scheduled requests, so they stay off. TBR
+      // runs lazily and only needs an m_AnalysisDC, which PlanNestedRequest
+      // above builds; keep it whenever we got one.
+      request.EnableTBRAnalysis =
+          request.EnableTBRAnalysis && request.m_AnalysisDC != nullptr;
       request.EnableVariedAnalysis = false;
       request.EnableUsefulAnalysis = false;
 

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -27,6 +27,7 @@
 #include "clang/AST/Stmt.h"
 #include "clang/AST/Type.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
+#include "clang/Analysis/CFG.h"
 #include "clang/Basic/DiagnosticSema.h"
 #include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LLVM.h" // isa, dyn_cast
@@ -381,12 +382,44 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     // records the early-return flag: m_TopMostReq is left null, so
     // VisitCallExpr and VisitDeclRefExpr bail and no sub-requests are spawned
     // -- only VisitReturnStmt runs over this request's body.
-    // FIXME: This is where a nested request should also get its m_AnalysisDC
-    // and the analyses currently force-disabled in HandleNestedDiffRequest.
+    // FIXME: The varied and useful analyses are still force-disabled in
+    // HandleNestedDiffRequest; only TBR is served here.
     const FunctionDecl* Def =
         request.Function ? request.Function->getDefinition() : nullptr;
     if (!Def || !Def->hasBody())
       return true;
+
+    // Give the request the analysis context TBR needs. DiffRequest runs TBR
+    // lazily out of shouldBeRecorded(), so building the context is all that is
+    // required for a dynamically scheduled reverse-mode request to drop the
+    // stores its reverse sweep never reads back. Hessian mode benefits most:
+    // its reverse pass runs once per direction over a first-order derivative.
+    //
+    // Only the reverse-mode family consults shouldBeRecorded(); a context built
+    // for, say, a pushforward would never be looked at. TBRAnalyzer::Analyze
+    // seeds its state from request.Function's parameters and matches them
+    // against the decls the CFG refers to, so the two must be the same
+    // FunctionDecl -- a redeclaration has its own ParmVarDecls, which would
+    // silently match nothing. shouldBeRecorded() refuses to analyze a lambda
+    // call operator for the same kind of reason, so do not arm TBR for one.
+    bool usesTBR = request.Mode == DiffMode::reverse ||
+                   request.Mode == DiffMode::pullback ||
+                   request.Mode == DiffMode::jacobian ||
+                   request.Mode == DiffMode::reverse_mode_forward_pass;
+    if (usesTBR && request.EnableTBRAnalysis && !request.m_AnalysisDC &&
+        request.Function == Def && !isLambdaCallOperator(Def)) {
+      // One context per function: the same nested request is planned again
+      // whenever another call site asks for its derivative.
+      AnalysisDeclContext*& ADC = m_NestedAnalysisDC[Def];
+      if (!ADC) {
+        clang::CFG::BuildOptions Options;
+        m_AllAnalysisDC.push_back(std::make_unique<AnalysisDeclContext>(
+            /*AnalysisDeclContextManager=*/nullptr, Def, Options));
+        ADC = m_AllAnalysisDC.back().get();
+      }
+      request.m_AnalysisDC = ADC;
+    }
+
     llvm::SaveAndRestore<DiffRequest*> Saved(m_ParentReq, &request);
     return TraverseStmt(Def->getBody());
   }

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -59,6 +59,11 @@ static FunctionDecl* DeriveUsingForwardAndReverseMode(
   ReverseModeRequest.BaseFunctionName = firstDerivative->getNameAsString();
   ReverseModeRequest.m_CladLoopCheckpoints =
       IndependentArgRequest.m_CladLoopCheckpoints;
+  // This reverse pass is the bulk of a hessian: it runs once per direction
+  // over a function the size of the first-order derivative. Let it use TBR so
+  // it only tapes what the reverse sweep reads back.
+  ReverseModeRequest.EnableTBRAnalysis =
+      IndependentArgRequest.EnableTBRAnalysis;
 
   FunctionDecl* secondDerivative =
       Builder.HandleNestedDiffRequest(ReverseModeRequest);

--- a/lib/Differentiator/TBRAnalyzer.cpp
+++ b/lib/Differentiator/TBRAnalyzer.cpp
@@ -125,10 +125,12 @@ void TBRAnalyzer::Analyze(const DiffRequest& request) {
 
   clang::SourceManager& SM = m_AnalysisDC->getASTContext().getSourceManager();
   for (const Stmt* S : m_TBRLocs) {
-    SourceLocation Loc = S->getBeginLoc();
-    unsigned line = SM.getPresumedLoc(Loc).getLine();
-    unsigned column = SM.getPresumedLoc(Loc).getColumn();
-    LLVM_DEBUG(llvm::dbgs() << line << ":" << column << "\n");
+    // Statements clad synthesized have no location to print. TBR runs on
+    // generated functions too, e.g. on a hessian's inner reverse pass.
+    PresumedLoc PL = SM.getPresumedLoc(S->getBeginLoc());
+    if (PL.isInvalid())
+      continue;
+    LLVM_DEBUG(llvm::dbgs() << PL.getLine() << ":" << PL.getColumn() << "\n");
   }
 #endif // NDEBUG
 }

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -1498,19 +1498,16 @@ double fn25_defined_later(double x) {
 // CHECK: inline void flexibleInterp_pullback(const double *params, const double *high, double _d_y, double *_d_params) {
 // CHECK-NEXT:     std::size_t _d_i = {{0U|0UL}};
 // CHECK-NEXT:     std::size_t i = {{0U|0UL}};
-// CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_total = 0.;
 // CHECK-NEXT:     double total = 1.;
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
 // CHECK-NEXT:     for (i = 0; i < 1; ++i) {
 // CHECK-NEXT:         _t0++;
-// CHECK-NEXT:         clad::push(_t1, total);
 // CHECK-NEXT:         total += params[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_total += _d_y;
 // CHECK-NEXT:     for (; _t0; _t0--) {
 // CHECK-NEXT:         --i;
-// CHECK-NEXT:         total = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_total;
 // CHECK-NEXT:         _d_params[i] += _r_d0;
 // CHECK-NEXT:     }

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -406,47 +406,41 @@ int main() {
 // CHECK-NEXT:     double _d_cond0;
 // CHECK-NEXT:     _d_cond0 = 0.;
 // CHECK-NEXT:     bool _cond1 = false;
-// CHECK-NEXT:     bool _t0 = false;
 // CHECK-NEXT:     bool _cond2 = false;
 // CHECK-NEXT:     bool _cond3 = false;
+// CHECK-NEXT:     float _t1 = 0.F;
 // CHECK-NEXT:     float _t2 = 0.F;
-// CHECK-NEXT:     float _t3 = 0.F;
-// CHECK-NEXT:     float _t4 = 0.F;
 // CHECK-NEXT:     float _d_val = 0.F;
 // CHECK-NEXT:     float val = ::std::pow(x, exponent);
-// CHECK-NEXT:     float _t1 = ::std::pow(x, exponent - 1);
+// CHECK-NEXT:     float _t0 = ::std::pow(x, exponent - 1);
 // CHECK-NEXT:     float _d_derivative = 0.F;
-// CHECK-NEXT:     float derivative = (exponent * _t1) * d_x;
 // CHECK-NEXT:     auto _rev0 = [&] {
 // CHECK-NEXT:         if (_cond3) {
-// CHECK-NEXT:             derivative = _t2;
 // CHECK-NEXT:             float _r4 = 0.F;
 // CHECK-NEXT:             float _r5 = 0.F;
-// CHECK-NEXT:             clad::custom_derivatives::std::pow_pullback(x, exponent, _d_derivative * d_exponent * _t3, &_r4, &_r5);
+// CHECK-NEXT:             clad::custom_derivatives::std::pow_pullback(x, exponent, _d_derivative * d_exponent * _t1, &_r4, &_r5);
 // CHECK-NEXT:             *_d_x += _r4;
 // CHECK-NEXT:             *_d_exponent += _r5;
 // CHECK-NEXT:             float _r6 = 0.F;
-// CHECK-NEXT:             _r6 += _t4 * _d_derivative * d_exponent * clad::custom_derivatives::std::log_pushforward(x, 1.F).pushforward;
+// CHECK-NEXT:             _r6 += _t2 * _d_derivative * d_exponent * clad::custom_derivatives::std::log_pushforward(x, 1.F).pushforward;
 // CHECK-NEXT:             *_d_x += _r6;
-// CHECK-NEXT:             *_d_d_exponent += (_t4 * _t3) * _d_derivative;
+// CHECK-NEXT:             *_d_d_exponent += (_t2 * _t1) * _d_derivative;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             *_d_exponent += _d_derivative * d_x * _t1;
+// CHECK-NEXT:             *_d_exponent += _d_derivative * d_x * _t0;
 // CHECK-NEXT:             float _r2 = 0.F;
 // CHECK-NEXT:             float _r3 = 0.F;
 // CHECK-NEXT:             clad::custom_derivatives::std::pow_pullback(x, exponent - 1, exponent * _d_derivative * d_x, &_r2, &_r3);
 // CHECK-NEXT:             *_d_x += _r2;
 // CHECK-NEXT:             *_d_exponent += _r3;
-// CHECK-NEXT:             *_d_d_x += (exponent * _t1) * _d_derivative;
+// CHECK-NEXT:             *_d_d_x += (exponent * _t0) * _d_derivative;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             if (_cond2)
 // CHECK-NEXT:                 _d_val += _d_y.value;
 // CHECK-NEXT:             {
-// CHECK-NEXT:                 if (_cond1) {
-// CHECK-NEXT:                     _cond0 = _t0;
+// CHECK-NEXT:                 if (_cond1)
 // CHECK-NEXT:                     _d_cond0 = 0.;
-// CHECK-NEXT:                 }
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
@@ -460,10 +454,8 @@ int main() {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _cond1 = exponent == static_cast<float>(0);
-// CHECK-NEXT:             if (_cond1) {
-// CHECK-NEXT:                 _t0 = _cond0;
+// CHECK-NEXT:             if (_cond1)
 // CHECK-NEXT:                 _cond0 = d_exponent == static_cast<float>(0);
-// CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _cond2 = _cond1 && _cond0;
 // CHECK-NEXT:         if (_cond2) {
@@ -471,13 +463,13 @@ int main() {
 // CHECK-NEXT:             return;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
+// CHECK-NEXT:     float derivative = (exponent * _t0) * d_x;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _cond3 = d_exponent;
 // CHECK-NEXT:         if (_cond3) {
-// CHECK-NEXT:             _t2 = derivative;
-// CHECK-NEXT:             _t4 = ::std::pow(x, exponent);
-// CHECK-NEXT:             _t3 = ::std::log(x);
-// CHECK-NEXT:             derivative += (_t4 * _t3) * d_exponent;
+// CHECK-NEXT:             _t2 = ::std::pow(x, exponent);
+// CHECK-NEXT:             _t1 = ::std::log(x);
+// CHECK-NEXT:             derivative += (_t2 * _t1) * d_exponent;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {

--- a/test/Hessian/TBR.C
+++ b/test/Hessian/TBR.C
@@ -1,0 +1,48 @@
+// RUN: %cladclang %s -I%S/../../include -oTBR.out 2>&1 | %filecheck %s
+// RUN: ./TBR.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oTBR.out
+// RUN: ./TBR.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include "../TestUtils.h"
+
+double mat4[4];
+clad::array_ref<double> mat4_ref(mat4, 4);
+
+// A hessian's inner reverse pass is scheduled lazily by
+// HandleNestedDiffRequest and never walked by the static planner, so it only
+// runs TBR if PlanNestedRequest built it an AnalysisDeclContext. Here that
+// shows up in the loop: `s = s + a` is linear, so neither s nor _d_s has to be
+// taped, while `a = a * x` is not and both a and _d_a do.
+double linearAndNonlinear(double x, double y) {
+  double a = x * y;
+  double s = a;
+  for (int i = 0; i < 3; ++i) {
+    s = s + a;
+    a = a * x;
+  }
+  return s * a;
+}
+
+// CHECK: void linearAndNonlinear_darg0_grad(double x, double y, double *_d_x, double *_d_y) {
+// Two tapes, for the nonlinear assignment only.
+// CHECK: clad::tape<double> _t1 = {};
+// CHECK-NEXT: clad::tape<double> _t2 = {};
+// CHECK-NOT: clad::tape<double> _t3 = {};
+// CHECK: for (i = 0; i < 3; ++i) {
+// CHECK-NEXT: _t0++;
+// CHECK-NEXT: _d_s = _d_s + _d_a;
+// CHECK-NEXT: s = s + a;
+// CHECK-NEXT: clad::push(_t1, _d_a);
+// CHECK-NEXT: _d_a = _d_a * x + a * _d_x0;
+// CHECK-NEXT: clad::push(_t2, a);
+// CHECK-NEXT: a = a * x;
+// CHECK-NEXT: }
+
+int main() {
+  INIT_HESSIAN(linearAndNonlinear);
+
+  TEST_HESSIAN(linearAndNonlinear, 1, 1.5, 2.5, mat4_ref);
+  // CHECK-EXEC: {3786.33, 879.61, 879.61, 87.33}
+}


### PR DESCRIPTION
HandleNestedDiffRequest force-disabled TBR, varied and useful analysis for every lazily-scheduled request, because such requests never pass through the static TU walk that builds an AnalysisDeclContext for them.

TBR does not need the planner to run it: DiffRequest::shouldBeRecorded() starts the analysis on demand and only needs m_AnalysisDC to be set. Build one in PlanNestedRequest -- which already exists to give these requests the planning information the TU walk never produced -- and keep TBR enabled whenever we got a context. The varied and useful analyses do have to be run eagerly by the planner, so they stay off and the FIXME shrinks to cover just them.

The context is built only for the reverse-mode family, the modes that consult shouldBeRecorded(), and only for a Function the analyzer will actually accept: TBRAnalyzer seeds its state from request.Function's parameters and matches them against the CFG, so the request's Function has to be the definition the CFG comes from -- a redeclaration's ParmVarDecls would silently match nothing -- and a lambda call operator, which shouldBeRecorded() refuses to analyze for the same kind of reason, is left alone. The context is cached per function, so planning the same nested request again from another call site reuses one CFG.

What this buys is dropping the stores the reverse sweep never reads back, so the size of the win depends on the function. Two existing tests show it: flexibleInterp_pullback loses the tape for its loop-carried 'total' entirely -- the accumulation is linear, so the old value is never needed -- and pow_pushforward_pullback loses three temporaries and two restores. The new hessian test tapes four values instead of eight. Hessians benefit most often, because their inner reverse pass runs once per requested direction over a function the size of the first-order derivative; HessianModeVisitor asks for TBR there by inheriting the flag from the hessian request.

Running TBR on lazily-scheduled requests also means running it on clad-generated functions, whose synthesized statements carry no source location. The debug-only location dump at the end of TBRAnalyzer::Analyze called PresumedLoc::getLine() unconditionally, which asserts on an invalid location and aborts the compiler in any assertions-enabled build; it took out Regressions/issue-1955.cpp. It now skips what it cannot print.

Verified with a full lit run (221 tests), and by checking that the new test fails again once HandleNestedDiffRequest force-disables TBR.