### PR TITLE
Recognize a constant-zero tangent that has been bound to a variable

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -446,6 +446,12 @@ namespace clad {
 
     bool IsZeroOrNullValue(const clang::Expr* E);
 
+    /// Like IsZeroOrNullValue(E), but also folds \p E as a constant
+    /// expression, so that a reference to a `const` variable initialized to
+    /// zero -- the shape a tangent takes once it has been bound to a
+    /// declaration -- is recognized as zero too.
+    bool IsZeroOrNullValue(const clang::Expr* E, const clang::ASTContext& C);
+
     bool IsMemoryDeallocationFunction(const clang::FunctionDecl* FD);
 
     /// Returns true if QT is a non-const reference type.

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1357,8 +1357,12 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
       for (unsigned i = 0, e = diffArgs.size(); i < e; ++i) {
         Expr* dArg = diffArgs[i];
         // If argDiff.expr_dx is nullptr or is a constant 0, then the derivative
-        // of the function call is 0.
-        if (!clad::utils::IsZeroOrNullValue(dArg)) {
+        // of the function call is 0. Constant-fold rather than pattern-match a
+        // literal: by the time a tangent reaches a call it has usually been
+        // bound to a `const` variable, and seeding one direction of a
+        // multi-directional request leaves every other tangent exactly that --
+        // a zero-initialized constant.
+        if (!clad::utils::IsZeroOrNullValue(dArg, m_Context)) {
           allArgsHaveZeroDerivatives = false;
           break;
         }

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -3,6 +3,7 @@
 
 #include "ConstantFolder.h"
 
+#include "clang/AST/APValue.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
@@ -26,6 +27,8 @@
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/TemplateDeduction.h"
 
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 
@@ -923,6 +926,26 @@ namespace clad {
         return IL->getValue() == 0;
       if (const auto* SL = dyn_cast<StringLiteral>(E))
         return SL->getLength() == 0;
+      return false;
+    }
+
+    bool IsZeroOrNullValue(const clang::Expr* E, const clang::ASTContext& C) {
+      // Handles a null E too, so the dereference below is safe.
+      if (IsZeroOrNullValue(E))
+        return true;
+      QualType T = E->getType();
+      // Evaluation is a whole-expression constant fold, so it is only correct
+      // to read the result as "this is zero" when the expression cannot
+      // observe or change anything on the way; EvaluateAs* refuse side
+      // effects by default.
+      if (T->isRealFloatingType()) {
+        llvm::APFloat F(0.);
+        return E->EvaluateAsFloat(F, C) && F.isZero();
+      }
+      if (T->isIntegralOrEnumerationType()) {
+        Expr::EvalResult R;
+        return E->EvaluateAsInt(R, C) && R.Val.getInt() == 0;
+      }
       return false;
     }
 

--- a/test/FirstDerivative/CallArguments.C
+++ b/test/FirstDerivative/CallArguments.C
@@ -112,12 +112,15 @@ float f_const_args_func_7(const float x, const float y) {
   return f_const_helper(x) + f_const_helper(y) - y;
 }
 
+// The tangent of y is a zero-initialized constant, so the call contributes
+// nothing and no pushforward is requested for it. f_const_args_func_8 below is
+// the same function with a non-const y, whose tangent can still be assigned to,
+// so there the pushforward stays.
 // CHECK: float f_const_args_func_7_darg0(const float x, const float y) {
 // CHECK-NEXT: const float _d_x = 1;
 // CHECK-NEXT: const float _d_y = 0;
 // CHECK-NEXT: clad::ValueAndPushforward<float, float> _t0 = f_const_helper_pushforward(x, _d_x);
-// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t1 = f_const_helper_pushforward(y, _d_y);
-// CHECK-NEXT: return _t0.pushforward + _t1.pushforward - _d_y;
+// CHECK-NEXT: return _t0.pushforward + 0.F - _d_y;
 // CHECK-NEXT: }
 
 float f_const_args_func_8(const float x, float y) {

--- a/test/Hessian/ZeroTangentCalls.C
+++ b/test/Hessian/ZeroTangentCalls.C
@@ -1,0 +1,58 @@
+// RUN: %cladclang %s -I%S/../../include -oZeroTangentCalls.out 2>&1 | %filecheck %s
+// RUN: ./ZeroTangentCalls.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oZeroTangentCalls.out
+// RUN: ./ZeroTangentCalls.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+double cube(double u) { return u * u * u; }
+
+// A hessian seeds one direction at a time, so in every row all tangents but
+// the seeded one are zero-initialized constants. A call handed such a tangent
+// contributes nothing, so no pushforward is requested for it: each direction
+// calls cube_pushforward once instead of twice. The parameters have to be
+// const for this -- a tangent that can still be assigned to is not folded.
+double sumOfCubes(const double x, const double y) {
+  return cube(x) + cube(y);
+}
+
+// CHECK: double sumOfCubes_darg0(const double x, const double y) {
+// CHECK-NEXT:     const double _d_x = 1;
+// CHECK-NEXT:     const double _d_y = 0;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = cube_pushforward(x, _d_x);
+// CHECK-NEXT:     return _t0.pushforward + 0.;
+// CHECK-NEXT: }
+
+// CHECK: double sumOfCubes_darg1(const double x, const double y) {
+// CHECK-NEXT:     const double _d_x = 0;
+// CHECK-NEXT:     const double _d_y = 1;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = cube_pushforward(y, _d_y);
+// CHECK-NEXT:     return 0. + _t0.pushforward;
+// CHECK-NEXT: }
+
+// The same holds one order up, where the hessian rows are differentiated.
+// CHECK: void sumOfCubes_darg0_grad(const double x, const double y, double *_d_x, double *_d_y) {
+// CHECK-NEXT:     double _d_d_x = 0.;
+// CHECK-NEXT:     const double _d_x0 = 1;
+// CHECK-NEXT:     double _d_d_y = 0.;
+// CHECK-NEXT:     const double _d_y0 = 0;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_t0 = {0., 0.};
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = cube_pushforward(x, _d_x0);
+// CHECK-NOT:      cube_pushforward(y
+
+// CHECK: void sumOfCubes_darg1_grad(const double x, const double y, double *_d_x, double *_d_y) {
+// CHECK-NEXT:     double _d_d_x = 0.;
+// CHECK-NEXT:     const double _d_x0 = 0;
+// CHECK-NEXT:     double _d_d_y = 0.;
+// CHECK-NEXT:     const double _d_y0 = 1;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_t0 = {0., 0.};
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = cube_pushforward(y, _d_y0);
+// CHECK-NOT:      cube_pushforward(x
+
+int main() {
+  auto hess = clad::hessian(sumOfCubes);
+  double matrix[4] = {0};
+  hess.execute(2, 3, matrix);
+  printf("[%.2f, %.2f, %.2f, %.2f]\n", matrix[0], matrix[1], matrix[2],
+         matrix[3]); // CHECK-EXEC: [12.00, 0.00, 0.00, 18.00]
+}

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -58,17 +58,17 @@ void TFormula_example_grad_1(const Double_t* x, Double_t* p, Double_t* _d_p);
 //CHECK-NEXT:       return 0. * _t0 + x[0] * (1. + 0. + 0.) + _t1.pushforward + 0.;
 //CHECK-NEXT:   }
 
+// Exp is called with a -0. tangent in the directions that do not seed p[0], so
+// it folds to zero and no pushforward is emitted for it.
 //CHECK:   Double_t TFormula_example_darg1_1(const Double_t *x, Double_t *p) {
 //CHECK-NEXT:       {{double|Double_t}} _t0 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives::TMath::Exp_pushforward(-p[0], -0.);
-//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t2 = clad::custom_derivatives::TMath::Abs_pushforward(p[1], 1.);
-//CHECK-NEXT:       return 0. * _t0 + x[0] * (0. + 1. + 0.) + _t1.pushforward + _t2.pushforward;
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives::TMath::Abs_pushforward(p[1], 1.);
+//CHECK-NEXT:       return 0. * _t0 + x[0] * (0. + 1. + 0.) + 0. + _t1.pushforward;
 //CHECK-NEXT:   }
 
 //CHECK:   Double_t TFormula_example_darg1_2(const Double_t *x, Double_t *p) {
 //CHECK-NEXT:       {{double|Double_t}} _t0 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives::TMath::Exp_pushforward(-p[0], -0.);
-//CHECK-NEXT:       return 0. * _t0 + x[0] * (0. + 0. + 1.) + _t1.pushforward + 0.;
+//CHECK-NEXT:       return 0. * _t0 + x[0] * (0. + 0. + 1.) + 0. + 0.;
 //CHECK-NEXT:   }
 
 Double_t TFormula_hess1(const Double_t *x, Double_t *p) {


### PR DESCRIPTION
VisitCallExpr already knows that a call whose argument tangents are all zero contributes nothing, and emits the plain call with a zero derivative instead of asking for a pushforward. The check went through IsZeroOrNullValue, which pattern-matches literals -- but a tangent has almost always been bound to a declaration by the time it reaches a call, so what the check actually sees is a reference to a `const double _d_t6 = 0;`.

This matters most when a request seeds one direction at a time, as a hessian does: there every tangent except the seeded one is exactly such a zero-initialized constant, and each direction was paying for the full chain of pushforwards anyway. The parameters have to be const-qualified for the fold to fire. A tangent that can still be assigned to is never folded, which is what stops a tangent that is reassigned later -- in a loop, say -- from being wrongly read as zero.

Add an IsZeroOrNullValue overload that constant-folds the expression and use it here. EvaluateAs* refuses side effects by default, so an expression that could observe or change anything on the way is not folded and the answer stays conservative.

Folding also widens an existing behavior that is worth stating plainly. The zero-derivative path keeps the primal call in the StmtDiff, but a _darg function returns only the derivative half, so the call is dropped along with it. That was already true of a literal-zero tangent; it now fires for every const-qualified parameter, so adding const to a signature can stop a side-effecting callee from running:

```c++
    int calls = 0;
    double g(double a) { ++calls; return a * a; }
    double f(const double x, const double y) { return g(y) + x * x; }
```

f_darg0 no longer calls g, and calls stays 0 where it used to reach 1. The derivative is unaffected -- an elided call contributes nothing to it -- and this is the intended trade for not differentiating through a term that cannot contribute.

Two tests change their expected output accordingly. CallArguments.C loses one pushforward in f_const_args_func_7_darg0; its non-const twin func_8 keeps both, which is exactly the distinction the fold draws. TFormula.C loses the Exp pushforward in the directions that do not seed p[0], where the tangent is `-0.` -- a UnaryOperator the literal matcher never caught. Hessian/ZeroTangentCalls.C is new and pins the hessian case.