### PR TITLE
Do not let a missing adjoint suppress a reverse_forw's stores.

### DIFF
--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2699,7 +2699,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // could otherwise call the primal directly: the pullback consumes state
     // only the reverse_forw produces, so eliding it would leave the carrier
     // empty and silently wrong.
-    if (calleeFnForwPassFD && !hasDynamicNonDiffParams &&
+    // A missing adjoint for a non-differentiated argument (a data pointer)
+    // must not suppress a reverse_forw that is only needed for its stores:
+    // suppressing it silently drops the pre-call state the reverse sweep
+    // relies on. The missing slot is filled with a null-pointer or zero
+    // literal, which is why this is restricted to calls whose returned
+    // ValueAndAdjoint is unused: those bodies only replay the primal.
+    if (calleeFnForwPassFD && (!hasDynamicNonDiffParams || !needsForwPass) &&
         (hasStoredParams || needsForwPass || !pullbackStateType.isNull())) {
       if (const auto* CD = dyn_cast<CXXConversionDecl>(FD))
         CallArgs.push_back(

--- a/test/Analyses/TBRChainedCalls.C
+++ b/test/Analyses/TBRChainedCalls.C
@@ -1,0 +1,97 @@
+// RUN: %cladclang %s -I%S/../../include -oTBRChainedCalls.out 2>&1 \
+// RUN:   | %filecheck %s
+// RUN: ./TBRChainedCalls.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s \
+// RUN:   -I%S/../../include -oTBRChainedCalls.out
+// RUN: ./TBRChainedCalls.out | %filecheck_exec %s
+
+// Two mutating calls chained through caller-owned buffers inside a loop,
+// where the second callee also reads a differentiated parameter it does not
+// write (`diag`). Its pullback recomputes from `centered`, so that buffer
+// must hold the values of the iteration being reversed; with only the second
+// call recorded, every reverse iteration reads the last iteration's values
+// and the read-only parameter's adjoint comes out wrong while the adjoints
+// flowing through the buffers still look right. This is the ADBench/GradBench
+// GMM inner loop in miniature.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+// CHECK: void chained_grad_0_1(
+// CHECK: sub_reverse_forw(
+
+void sub(int d, const double* x, const double* y, double* out) {
+  for (int i = 0; i < d; i++)
+    out[i] = x[i] - y[i];
+}
+
+void scale(int d, const double* diag, const double* x, double* out) {
+  for (int i = 0; i < d; i++)
+    out[i] = diag[i] * x[i];
+}
+
+// Non-linear read: its pullback needs the primal values of v.
+double sqnorm(int d, const double* v) {
+  double t = 0;
+  for (int i = 0; i < d; i++)
+    t += v[i] * v[i];
+  return t;
+}
+
+double chained(const double* diag, const double* mu, const double* x) {
+  double centered[2];
+  double scaled[2];
+  double s = 0;
+  for (int k = 0; k < 2; k++) {
+    sub(2, &x[k * 2], mu, centered);
+    scale(2, diag, centered, scaled);
+    s += sqnorm(2, scaled);
+  }
+  return s;
+}
+
+
+// The same defect without any chaining: `scale`'s output buffer is not
+// snapshotted per iteration because its `x` argument is not differentiated,
+// so the reverse sweep reads the last iteration's values. This is the shape
+// the GradBench GMM objective hits through its q/l blocks.
+double scaled_only(const double* q, const double* x) {
+  double g[2];
+  double out[2];
+  double s = 0;
+  for (int i = 0; i < 2; i++)
+    g[i] = q[i] * q[i];
+  for (int k = 0; k < 2; k++) {
+    scale(2, g, &x[k * 2], out);
+    s += sqnorm(2, out);
+  }
+  return s;
+}
+
+int main() {
+  double diag[2] = {1.5, 0.5};
+  double mu[2] = {0.25, 0.5};
+  double x[4] = {1., 2., 3., -1.};
+  double d_diag[2] = {};
+  double d_mu[2] = {};
+
+  auto grad = clad::gradient(chained, "diag, mu");
+  grad.execute(diag, mu, x, d_diag, d_mu);
+
+  // s = sum_k sum_i (diag_i * (x_ki - mu_i))^2
+  //   ds/ddiag_i = sum_k 2 diag_i (x_ki - mu_i)^2
+  //   ds/dmu_i   = sum_k -2 diag_i^2 (x_ki - mu_i)
+  printf("d_diag={%.4f, %.4f}\n", d_diag[0], d_diag[1]);
+  // CHECK-EXEC: d_diag={24.3750, 4.5000}
+  printf("d_mu={%.4f, %.4f}\n", d_mu[0], d_mu[1]);
+  // CHECK-EXEC: d_mu={-15.7500, 0.0000}
+
+  double q[2] = {0.5, 1.5};
+  double d_q[2] = {};
+  auto grad2 = clad::gradient(scaled_only, "q");
+  grad2.execute(q, x, d_q);
+  // s = sum_k sum_i (q_i^2 x_ki)^2 => ds/dq_i = sum_k 4 q_i^3 x_ki^2
+  printf("d_q={%.4f, %.4f}\n", d_q[0], d_q[1]);
+  // CHECK-EXEC: d_q={5.0000, 67.5000}
+}

--- a/test/Analyses/TBRComposition.C
+++ b/test/Analyses/TBRComposition.C
@@ -1,0 +1,92 @@
+// RUN: %cladclang %s -I%S/../../include -oTBRComposition.out 2>&1 \
+// RUN:   | %filecheck %s
+// RUN: ./TBRComposition.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s \
+// RUN:   -I%S/../../include -oTBRComposition.out
+// RUN: ./TBRComposition.out | %filecheck_exec %s
+
+// The GradBench/ADBench GMM objective in miniature: a differentiated function
+// with an out-parameter (so clad builds a reverse_forw carrying a restore
+// tracker), caller-owned local buffers, a non-differentiated data pointer,
+// and nested helpers that overwrite those buffers inside a loop whose
+// iterations are each read back non-linearly. Only that composition exercises the
+// per-call-instance state protocol; each mechanism in isolation stays correct
+// without it.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+// Both mutating calls must record their pre-call state, including the one
+// whose data pointer carries no adjoint.
+// CHECK: void objective_pullback(
+// CHECK: center_reverse_forw(
+// CHECK: scale_reverse_forw(
+
+// out[i] = x[i] - m[i]: overwrites caller storage through a pointer, with a
+// non-differentiated data pointer as one input.
+void center(int d, const double* x, const double* m, double* out) {
+  for (int i = 0; i < d; i++)
+    out[i] = x[i] - m[i];
+}
+
+// out[i] = s[i] * v[i]: reads the buffer written above and overwrites a
+// second one.
+void scale(int d, const double* s, const double* v, double* out) {
+  for (int i = 0; i < d; i++)
+    out[i] = s[i] * v[i];
+}
+
+// Non-linear read: its pullback needs the primal values of v.
+double sqnorm(int d, const double* v) {
+  double t = 0;
+  for (int i = 0; i < d; i++)
+    t += v[i] * v[i];
+  return t;
+}
+
+// err = sum_k (|diag_k * (x - m_k)|^2 + a_k), with x the fixed data.
+void objective(int d, int k, const double* a, const double* m,
+               const double* diag, const double* x, double* err) {
+  double centered[2];
+  double scaled[2];
+  double term[2];
+  for (int ik = 0; ik < k; ik++) {
+    center(d, x, &m[ik * d], &centered[0]);
+    scale(d, &diag[ik * d], &centered[0], &scaled[0]);
+    term[ik] = a[ik] + sqnorm(d, &scaled[0]);
+  }
+  double total = 0;
+  for (int ik = 0; ik < k; ik++)
+    total += term[ik];
+  *err = total;
+}
+
+double wrapper(const double* a, const double* m, const double* diag,
+               const double* x) {
+  double err = 0;
+  objective(2, 2, a, m, diag, x, &err);
+  return err;
+}
+
+int main() {
+  double a[2] = {0.5, -1.5};
+  double m[4] = {0.25, 0.5, -1., 2.};
+  double diag[4] = {2., 3., 0.5, 1.5};
+  double x[2] = {1., 2.};
+  double da[2] = {}, dm[4] = {}, dd[4] = {};
+
+  auto grad = clad::gradient(wrapper, "a, m, diag");
+  grad.execute(a, m, diag, x, da, dm, dd);
+
+  // f = sum_k sum_i (diag_ki * (x_i - m_ki))^2 + a_k
+  //   df/da_k     = 1
+  //   df/dm_ki    = -2 diag_ki^2 (x_i - m_ki)
+  //   df/ddiag_ki = 2 diag_ki (x_i - m_ki)^2
+  printf("da={%.2f, %.2f}\n", da[0], da[1]);
+  // CHECK-EXEC: da={1.00, 1.00}
+  printf("dm={%.2f, %.2f, %.2f, %.2f}\n", dm[0], dm[1], dm[2], dm[3]);
+  // CHECK-EXEC: dm={-6.00, -27.00, -1.00, 0.00}
+  printf("dd={%.2f, %.2f, %.2f, %.2f}\n", dd[0], dd[1], dd[2], dd[3]);
+  // CHECK-EXEC: dd={2.25, 13.50, 4.00, 0.00}
+}


### PR DESCRIPTION
A call mixing differentiated arguments with a non-differentiated data pointer (the GradBench GMM shape: subtract(d, x, mu, &xcentered[0]) where x is the dataset) has no adjoint for that argument, and the reverse_forw call was silently dropped for the whole call site. With it went the pre-call state snapshots, so the reverse sweep replayed pullbacks against last-iteration values. Two mutating calls chained through the same buffer show it clearly: the second call is recorded, the first is not, and the adjoint of a parameter the second callee only reads comes out wrong while the adjoints flowing through the buffer still look right.

Emit the reverse_forw whenever its returned ValueAndAdjoint is unused: such a body only replays the primal and records state, so the missing adjoint slot can be a null-pointer or zero literal. Calls that consume the returned adjoint keep the old requirement.

Analyses/TBRChainedCalls.C pins the chained-call shape against the analytic gradients. Analyses/TBRComposition.C is the acceptance test for the series: a miniature GMM objective -- out-parameter, caller-owned local buffers, a non-differentiated data pointer and nested helpers overwriting those buffers inside a loop read back non-linearly. Only that composition exercises the per-call-instance state protocol end to end, so it lands with the last commit of the series.