### PR TITLE
[ci] Check that a change's tests fail without the change.

### DIFF
--- a/.github/actions/observes-change/action.yml
+++ b/.github/actions/observes-change/action.yml
@@ -1,0 +1,130 @@
+name: 'Tests observe the change'
+description: >
+  Check that the tests a change adds can actually fail without it, by
+  running only the touched test files against a build of the same tree with
+  the functional hunks reverted.
+
+# The work happens at two points in a job -- before the build, to revert,
+# and after it, to run the touched tests and restore -- so a single
+# composite action cannot wrap it. `mode` selects which half runs.
+# `verdict` is the third, for the job that aggregates across platforms.
+inputs:
+  mode:
+    description: 'revert | check | verdict'
+    required: true
+  base-sha:
+    description: >
+      Revision the change is measured against. Defaults to the merge-base
+      with the pull request's base, resolved once in revert mode and reused
+      by the later modes through the environment.
+    default: ''
+  build-dir:
+    description: 'configured build directory (check)'
+    default: 'obj'
+  rebuild-command:
+    description: >
+      Command that rebuilds after the hunks are restored (check). Required:
+      omitting it would leave every later step testing the baseline.
+    default: ''
+  platform:
+    description: 'name of the CI row this verdict comes from (check)'
+    default: ''
+  verdict-dir:
+    description: 'where per-platform verdicts are written or read'
+    default: 'observes'
+  summary-out:
+    description: 'path for the aggregated summary record (verdict)'
+    default: 'observes-change-summary.json'
+  test-dirs:
+    description: 'directories holding tests'
+    default: 'test'
+  test-suffixes:
+    description: 'suffixes of test sources'
+    default: '.C .cpp .cu'
+  functional-dirs:
+    description: 'directories holding the code tests exercise'
+    default: 'lib include tools'
+  functional-suffixes:
+    description: 'suffixes of functional sources'
+    default: '.h .cpp .inc'
+
+runs:
+  using: composite
+  steps:
+  - name: Revert the functional hunks
+    if: ${{ inputs.mode == 'revert' }}
+    shell: bash
+    run: |
+      cd "$GITHUB_WORKSPACE"
+      action=${{ github.action_path }}
+      base="${{ inputs.base-sha }}"
+      if [[ -z "$base" ]]; then
+        base=$(git merge-base HEAD "${{ github.event.pull_request.base.sha }}")
+      fi
+      echo "observes_base_sha=$base" >> $GITHUB_ENV
+      # Nothing to measure unless the change touches both tests and the
+      # code they would exercise.
+      touched=$("$action/test-observes-change.py" --list \
+        --base-rev "$base" \
+        --test-dirs ${{ inputs.test-dirs }} \
+        --test-suffixes ${{ inputs.test-suffixes }} \
+        --functional-dirs ${{ inputs.functional-dirs }} \
+        --functional-suffixes ${{ inputs.functional-suffixes }})
+      if [[ -z "$touched" ]]; then
+        echo "No touched tests -- skipping the baseline pass."
+        exit 0
+      fi
+      dirs="${{ inputs.functional-dirs }}"
+      echo "observes_dirs=$dirs" >> $GITHUB_ENV
+      # A reverse patch handles files the change adds or deletes, which
+      # `git checkout <base> -- <dirs>` would leave behind.
+      git diff "$base" HEAD -- $dirs > $RUNNER_TEMP/observes.diff
+      if [[ -s $RUNNER_TEMP/observes.diff ]] && git apply -R $RUNNER_TEMP/observes.diff; then
+        echo "observes_check=1" >> $GITHUB_ENV
+        echo "Reverted $(git diff --name-only "$base" HEAD -- $dirs | wc -l) file(s)."
+      else
+        echo "Could not revert cleanly -- skipping the baseline pass."
+      fi
+
+  - name: Run the touched tests against the baseline
+    if: ${{ inputs.mode == 'check' && env.observes_check == '1' }}
+    shell: bash
+    run: |
+      cd "$GITHUB_WORKSPACE"
+      mkdir -p "${{ inputs.verdict-dir }}"
+      "${{ github.action_path }}/test-observes-change.py" \
+        --build "${{ inputs.build-dir }}" \
+        --base-rev "$observes_base_sha" \
+        --platform "${{ inputs.platform }}" \
+        --test-dirs ${{ inputs.test-dirs }} \
+        --test-suffixes ${{ inputs.test-suffixes }} \
+        --functional-dirs ${{ inputs.functional-dirs }} \
+        --functional-suffixes ${{ inputs.functional-suffixes }} \
+        --verdict "${{ inputs.verdict-dir }}/${{ inputs.platform }}.json"
+
+  # Must run even if the baseline pass failed: leaving the tree reverted
+  # would make every later step test the baseline and report it as this
+  # change.
+  - name: Restore the change and rebuild
+    if: ${{ always() && inputs.mode == 'check' && env.observes_check == '1' }}
+    shell: bash
+    run: |
+      cd "$GITHUB_WORKSPACE"
+      if [[ -z "${{ inputs.rebuild-command }}" ]]; then
+        echo "::error::rebuild-command is required in check mode"
+        exit 1
+      fi
+      git apply $RUNNER_TEMP/observes.diff
+      git diff --quiet "$observes_base_sha" -- $observes_dirs && {
+        echo "::error::the tree still matches the baseline after restoring"
+        exit 1
+      }
+      ${{ inputs.rebuild-command }}
+
+  - name: Decide across platforms
+    if: ${{ inputs.mode == 'verdict' }}
+    shell: bash
+    run: |
+      cd "$GITHUB_WORKSPACE"
+      "${{ github.action_path }}/observes-change-verdict.py" \
+        "${{ inputs.verdict-dir }}" --out="${{ inputs.summary-out }}"

--- a/.github/actions/observes-change/observes-change-verdict.py
+++ b/.github/actions/observes-change/observes-change-verdict.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Combine what every platform reported into one verdict.
+
+A test counts as observing the change if it failed at baseline on any row,
+since a defect can be invisible everywhere but under valgrind. The check
+fails only for a touched test that failed nowhere.
+
+How many rows saw it is reported rather than collapsed: failing everywhere
+is an ordinary regression test, while failing on exactly one is either the
+most valuable kind of test in the suite or a flake, and a pass/fail bit
+cannot tell a reviewer which.
+
+The per-platform matrix is also written out. Accumulated across changes, a
+test that is never the only one to fail is a candidate for merging -- a
+claim about defects caught rather than lines executed.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def load(vdir):
+    out = []
+    for p in sorted(Path(vdir).rglob("*.json")):
+        try:
+            out.append(json.loads(p.read_text()))
+        except (json.JSONDecodeError, OSError):
+            print(f"skipping unreadable verdict {p}", file=sys.stderr)
+    return out
+
+
+def main(vdir, out=None):
+    verdicts = load(vdir)
+    if not verdicts:
+        print("No verdicts reported -- nothing to decide.")
+        return 0
+    applicable = [v for v in verdicts if v.get("applicable")]
+    if not applicable:
+        print("No touched lit tests on any platform -- check not applicable.")
+        return 0
+
+    total = len(applicable)
+    # test -> [(platform, kind)] for the rows where it failed at baseline
+    seen, every = {}, set()
+    for v in applicable:
+        for name, r in v.get("tests", {}).items():
+            every.add(name)
+            if not r.get("passed"):
+                seen.setdefault(name, []).append((v["platform"], r.get("kind")))
+
+    rows, narrow, blind = [], [], []
+    for name in sorted(every):
+        where = seen.get(name, [])
+        n = len(where)
+        if n == 0:
+            rows.append((name, f"passes at baseline on all {total}"))
+            blind.append(name)
+        else:
+            rows.append((name, f"observes the change on {n}/{total}"))
+            # One row out of many is the interesting end of the range.
+            if n == 1 and total > 1:
+                narrow.append((name, where[0]))
+
+    width = max(len(r[0]) for r in rows)
+    lines = [f"Baseline pass reported by {total} platform(s), "
+             f"{len(every)} touched test file(s).", ""]
+    lines += [f"  {n:<{width + 2}}{s}" for n, s in rows]
+
+    if narrow:
+        lines += ["", f"Evidence from a single platform:", ""]
+        for name, (plat, kind) in narrow:
+            lines.append(f"  {name} -- only {plat} ({kind})")
+        lines += ["", "That is the expected shape for a defect that only "
+                  "manifests under one", "row's checking, such as valgrind or "
+                  "a sanitizer. If this test is not", "about such a defect, "
+                  "the result is more likely flaky than meaningful."]
+
+    if blind:
+        lines += ["", "No platform saw these fail with the change reverted, "
+                  "so they cannot be", "its regression test:", ""]
+        lines += [f"  {b}" for b in blind]
+        lines += ["", "Either the shape they use does not reach the changed "
+                  "code, or they pin", "behavior this change does not affect "
+                  "-- in which case they belong in", "their own commit."]
+
+    report = "\n".join(lines)
+    print(report)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        title = "Tests do not observe the change" if blind else \
+                "Tests observe the change"
+        md = [f"### {title}", "", "| test | baseline |", "| --- | --- |"]
+        md += [f"| `{n}` | {s} |" for n, s in rows]
+        if narrow:
+            md += ["", "**Evidence from a single platform**", ""]
+            md += [f"- `{n}` -- only `{p}` ({k})" for n, (p, k) in narrow]
+        if blind:
+            md += ["", "**No platform saw these fail with the change "
+                   "reverted**", ""]
+            md += [f"- `{b}`" for b in blind]
+        with open(summary, "a") as f:
+            f.write("\n".join(md) + "\n")
+
+    if out:
+        record = {
+            "schema": 1,
+            "pull_request": os.environ.get("PR_NUMBER"),
+            "head_sha": os.environ.get("HEAD_SHA"),
+            "base_sha": next((v.get("base_sha") for v in applicable
+                              if v.get("base_sha")), None),
+            "platforms": sorted(v["platform"] for v in applicable),
+            "tests": {
+                name: {
+                    "observed_on": sorted(p for p, _ in seen.get(name, [])),
+                    "kinds": sorted({k for _, k in seen.get(name, []) if k}),
+                    "observed": len(seen.get(name, [])),
+                    "of": total,
+                }
+                for name in sorted(every)
+            },
+            "blind": blind,
+            "single_platform": [n for n, _ in narrow],
+            "verdict": "blind" if blind else "observed",
+        }
+        Path(out).write_text(json.dumps(record, indent=2))
+        print(f"\nWrote {out}")
+    return 1 if blind else 0
+
+
+if __name__ == "__main__":
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    flags = {a.split("=")[0]: a.split("=", 1)[-1]
+             for a in sys.argv[1:] if a.startswith("--")}
+    sys.exit(main(args[0], flags.get("--out")))

--- a/.github/actions/observes-change/test-observes-change.py
+++ b/.github/actions/observes-change/test-observes-change.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Check that the tests a change adds can actually fail without it.
+
+A test that still passes with the change's functional hunks reverted is not
+evidence about that change. Coverage does not show this, because every clad
+test drags the whole pipeline through: on a sample batch seven of eight
+tests executed a one-line patch only two of them could observe.
+
+The caller reverts and rebuilds; this runs the touched test files against
+the result and records, per test, whether each still passes. A failure to
+build is reported apart from a FileCheck mismatch, since it usually means
+the test needs a new API rather than that it pins a behavior.
+
+Exits 0 either way. One platform cannot decide the question -- a defect can
+be invisible everywhere but under valgrind -- so it writes a verdict and
+observes-change-verdict.py combines them.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# A clang diagnostic and a FileCheck diagnostic share this shape; only the
+# message tells them apart.
+DIAG = re.compile(r"^[^\s].*?:\d+:\d+: error: (.*)$", re.M)
+# Project convention, not anything intrinsic; each is overridable so a
+# project laid out differently configures rather than forks.
+TEST_DIRS = ("test",)
+TEST_SUFFIXES = (".C", ".cpp", ".cu")
+FUNCTIONAL_DIRS = ("lib", "include", "tools")
+FUNCTIONAL_SUFFIXES = (".h", ".cpp", ".inc")
+
+
+def git(*args):
+    return subprocess.run(["git", *args], capture_output=True, text=True,
+                          check=True).stdout.split()
+
+
+def changed(base_rev, test_dirs, test_suffixes, func_dirs, func_suffixes):
+    # --diff-filter=d drops deletions: a test the change removes, or the old
+    # path of a renamed one, no longer exists to run, and handing it to lit
+    # would fail and be miscounted as evidence.
+    files = git("diff", "--name-only", "--diff-filter=d", f"{base_rev}...HEAD")
+    tests = [f for f in files
+             if f.startswith(tuple(d + "/" for d in test_dirs))
+             and Path(f).suffix in test_suffixes and Path(f).exists()]
+    functional = [f for f in files
+                  if f.startswith(tuple(d + "/" for d in func_dirs))
+                  and Path(f).suffix in func_suffixes]
+    return tests, functional
+
+
+def clad_obj_root(build: Path):
+    """Use the value lit was configured with rather than guessing paths."""
+    cfg = build / "test" / "lit.site.cfg"
+    if not cfg.exists():
+        sys.exit(f"{cfg} not found -- is {build} a configured clad build?")
+    m = re.search(r'^config\.clad_obj_root = "(.*)"$', cfg.read_text(), re.M)
+    if not m:
+        sys.exit(f"clad_obj_root not set in {cfg}")
+    return Path(m.group(1))
+
+
+def annotate(level, test, message):
+    """Report this row's own result while the rest of the suite still runs.
+
+    The aggregate cannot decide before every platform reports, but one
+    row's result is known much earlier and belongs on the test file in the
+    pull request rather than at the bottom of a log.
+    """
+    if os.environ.get("GITHUB_ACTIONS"):
+        print(f"::{level} file={test},line=1::{message}")
+
+
+def classify(output):
+    diags = DIAG.findall(output)
+    if any(not d.startswith("CHECK") for d in diags):
+        return "COMPILE", "does not build at baseline -- needs a new API"
+    if diags:
+        return "CHECK", "clad generates different code at baseline"
+    return "FAIL", "fails at baseline"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--build", help="configured clad build directory")
+    ap.add_argument("--base-rev", default="origin/master",
+                    help="revision the change is measured against")
+    ap.add_argument("--platform", default="local",
+                    help="name of the CI row this verdict comes from")
+    ap.add_argument("--verdict", help="write the verdict as JSON here")
+    ap.add_argument("--lit", default=shutil.which("lit"))
+    ap.add_argument("--list", action="store_true",
+                    help="print the touched test files and exit")
+    ap.add_argument("--test-dirs", nargs="+", default=list(TEST_DIRS))
+    ap.add_argument("--test-suffixes", nargs="+", default=list(TEST_SUFFIXES))
+    ap.add_argument("--functional-dirs", nargs="+",
+                    default=list(FUNCTIONAL_DIRS))
+    ap.add_argument("--functional-suffixes", nargs="+",
+                    default=list(FUNCTIONAL_SUFFIXES))
+    ap.add_argument("tests", nargs="*",
+                    help="test files to check (default: those the change touches)")
+    a = ap.parse_args()
+
+    tests, functional = ((a.tests, ["(explicit)"]) if a.tests
+                         else changed(a.base_rev, a.test_dirs, a.test_suffixes,
+                                      a.functional_dirs,
+                                      a.functional_suffixes))
+    # A change touching no functional code has nothing for its tests to
+    # observe, and tests that pin existing behavior are expected to pass.
+    if not functional:
+        tests = []
+    if a.list:
+        print("\n".join(tests))
+        return 0
+
+    verdict = {"platform": a.platform, "base_sha": a.base_rev, "tests": {},
+               "applicable": bool(tests)}
+    if not tests:
+        print("No touched lit tests to check.")
+    else:
+        if not a.build:
+            sys.exit("--build is required unless --list is given")
+        if not a.lit:
+            sys.exit("lit not found; pass --lit or pip install lit")
+        obj_root = clad_obj_root(Path(a.build))
+
+        print(f"Running {len(tests)} touched test file(s) against clad built "
+              f"from {a.base_rev}:\n")
+        width = max(len(t) for t in tests)
+        print(f"{'test':<{width + 2}}{'at baseline':<13}evidence")
+        print("-" * (width + 55))
+        for t in tests:
+            # lit discovers tests through the build tree, so address them there.
+            p = subprocess.run([a.lit, "-v", "--no-progress-bar",
+                                str(obj_root / t)],
+                               capture_output=True, text=True)
+            if p.returncode == 0:
+                verdict["tests"][t] = {"passed": True, "kind": None}
+                print(f"{t:<{width + 2}}{'PASS':<13}none -- cannot fail for "
+                      f"this change")
+                annotate("warning", t, f"Passes on {a.platform} with this "
+                         "change reverted, so it cannot be its regression "
+                         "test. Another platform may still observe it.")
+                continue
+            kind, note = classify(p.stdout + p.stderr)
+            verdict["tests"][t] = {"passed": False, "kind": kind}
+            print(f"{t:<{width + 2}}{'FAIL':<13}{kind} -- {note}")
+            annotate("notice", t, f"Observes this change on {a.platform} "
+                     f"({kind}).")
+
+    if a.verdict:
+        Path(a.verdict).write_text(json.dumps(verdict, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,15 @@ jobs:
         echo "Use Clang/LLVM in $env:PATH_TO_LLVM_BUILD"
         echo "Building clad in $env:BUILD_TYPE"
         python3 --version
+    # Build the baseline first, so the touched tests can be run against a
+    # clad that does not have the change. Restoring the hunks afterwards
+    # rebuilds only what they touch, so this costs one incremental build
+    # rather than a second full one.
+    - name: Revert functional hunks for the baseline
+      if: ${{ runner.os != 'windows' && matrix.cuda != true && github.event_name == 'pull_request' }}
+      uses: ./.github/actions/observes-change
+      with:
+        mode: revert
     - name: Build Clad on *nix
       if: ${{ runner.os != 'windows' }}
       run: |
@@ -387,6 +396,20 @@ jobs:
           ${{ matrix.extra_cmake_options }}
 
         cmake --build . -- -j${{ env.ncpus }}
+    - name: Check the touched tests against the baseline
+      if: ${{ always() && runner.os != 'windows' && matrix.cuda != true && env.observes_check == '1' }}
+      uses: ./.github/actions/observes-change
+      with:
+        mode: check
+        platform: ${{ matrix.name }}
+        build-dir: obj
+        rebuild-command: cmake --build obj -- -j${{ env.ncpus }}
+    - name: Upload the baseline verdict
+      if: ${{ runner.os != 'windows' && env.observes_check == '1' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: observes-change-${{ matrix.name }}
+        path: observes/
     - name: Build Clad on Windows
       if: ${{ runner.os == 'windows' }}
       run: |
@@ -549,3 +572,35 @@ jobs:
             cuda: true
 
     steps: *build_steps
+
+  observes-change:
+    name: Tests observe the change
+    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+    needs: [build]
+    runs-on: ubuntu-24.04
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: observes-change-*
+        path: verdicts
+        merge-multiple: false
+      continue-on-error: true
+    - name: Decide
+      uses: ./.github/actions/observes-change
+      with:
+        mode: verdict
+        verdict-dir: verdicts
+    # Keep the per-platform matrix even when the check passes: a test that
+    # is never the only one to fail across many changes is a candidate for
+    # merging, which is a claim about defects caught rather than lines run.
+    - name: Upload the summary record
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: observes-change-summary
+        path: observes-change-summary.json
+        if-no-files-found: ignore


### PR DESCRIPTION
A test that still passes with the change's functional hunks reverted is not evidence about that change, yet nothing in review distinguishes it from one that is. Coverage cannot: every clad test drags the whole pipeline through, so on a sample batch seven of eight tests executed a one-line patch only two of them could observe.

Each build row reverts the functional hunks before its build, runs the touched test files against that baseline, then restores and rebuilds incrementally before the full suite. The answer therefore costs one incremental rebuild rather than a second full build, and it comes from every platform rather than one: a defect can be invisible everywhere but under valgrind, so a touched test counts if any row saw it fail and the check fails only for one that failed nowhere. How many rows saw it is reported rather than collapsed, since failing on exactly one is either the most valuable kind of test in the suite or a flake.

It is a composite action taking the directory and suffix conventions as inputs, so nothing about clad's layout is baked in and it can move to ci-workflows once it has proven itself here.