### PR TITLE
Enable the constant folder in forward mode

### DIFF
--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1528,50 +1528,88 @@ BaseForwardModeVisitor::VisitBinaryOperator(const BinaryOperator* BinOp) {
   StmtDiff Ldiff = Visit(BinOp->getLHS());
   StmtDiff Rdiff = Visit(BinOp->getRHS());
 
+  // Fold the derivative expression algebraically. Forward mode carries one
+  // seeded direction, so most tangents reaching an operator are a constant
+  // zero and the product/quotient rules expand into `0 * b + a * 0` chains
+  // that keep the whole primal subtree alive. Folding them away is what stops
+  // an n-direction request (a hessian) from generating n copies of the parts
+  // of the function that the direction does not reach.
   ConstantFolder folder(m_Context);
   auto opCode = BinOp->getOpcode();
   Expr* opDiff = nullptr;
 
   // The operand primals are also parented by the forward value; clone each so
-  // the derivative expression owns a distinct subtree.
-  auto deriveMul = [this](StmtDiff& Ldiff, StmtDiff& Rdiff) {
-    Expr* LHS = BuildOp(BO_Mul, BuildParens(Ldiff.getExpr_dx()),
-                        BuildParens(CloneNode(Rdiff.getExpr())));
+  // the derivative expression owns a distinct subtree. A term whose tangent
+  // factor is a constant zero is not built at all rather than left for the
+  // folder to drop: the caller then skips storing the primal that term reads,
+  // and fold() may hand back its whole input unfolded, so the expression given
+  // to it must never contain a primal that is unsafe to re-evaluate.
+  auto mulTerm = [this](Expr* LHS, Expr* RHS) {
+    return BuildOp(BO_Mul, BuildParens(LHS), BuildParens(RHS));
+  };
 
-    Expr* RHS = BuildOp(BO_Mul, BuildParens(CloneNode(Ldiff.getExpr())),
-                        BuildParens(Rdiff.getExpr_dx()));
-
+  auto deriveMul = [this, &mulTerm](StmtDiff& Ldiff, StmtDiff& Rdiff,
+                                    bool dropsLTerm = false,
+                                    bool dropsRTerm = false) {
+    Expr* LHS = dropsLTerm
+                    ? nullptr
+                    : mulTerm(Ldiff.getExpr_dx(), CloneNode(Rdiff.getExpr()));
+    Expr* RHS = dropsRTerm
+                    ? nullptr
+                    : mulTerm(CloneNode(Ldiff.getExpr()), Rdiff.getExpr_dx());
+    if (!LHS)
+      return RHS;
+    if (!RHS)
+      return LHS;
     return BuildOp(BO_Add, LHS, RHS);
   };
 
-  auto deriveDiv = [this](StmtDiff& Ldiff, StmtDiff& Rdiff) {
-    Expr* LHS = BuildOp(BO_Mul, BuildParens(Ldiff.getExpr_dx()),
-                        BuildParens(CloneNode(Rdiff.getExpr())));
+  auto deriveDiv = [this, &mulTerm](StmtDiff& Ldiff, StmtDiff& Rdiff,
+                                    bool dropsRTerm = false) {
+    // The `dL * R` term is always built: when both tangents are zero the
+    // caller emits a plain zero instead of calling here, so the denominator
+    // survives and R is stored -- a zero dL term is then safe to keep for the
+    // folder.
+    Expr* nominator = mulTerm(Ldiff.getExpr_dx(), CloneNode(Rdiff.getExpr()));
+    if (!dropsRTerm)
+      nominator =
+          BuildOp(BO_Sub, nominator,
+                  mulTerm(CloneNode(Ldiff.getExpr()), Rdiff.getExpr_dx()));
 
-    Expr* RHS = BuildOp(BO_Mul, BuildParens(CloneNode(Ldiff.getExpr())),
-                        BuildParens(Rdiff.getExpr_dx()));
-
-    Expr* nominator = BuildOp(BO_Sub, LHS, RHS);
-
-    Expr* RParens = BuildParens(CloneNode(Rdiff.getExpr()));
     Expr* denominator =
-        BuildOp(BO_Mul, RParens, BuildParens(CloneNode(Rdiff.getExpr())));
-
+        mulTerm(CloneNode(Rdiff.getExpr()), CloneNode(Rdiff.getExpr()));
     return BuildOp(BO_Div, BuildParens(nominator), BuildParens(denominator));
   };
 
-  if (opCode == BO_Mul) {
-    // If Ldiff.getExpr() and Rdiff.getExpr() require evaluation, store the
-    // expressions in variables to avoid reevaluation.
-    Ldiff = {StoreAndRef(Ldiff.getExpr()), Ldiff.getExpr_dx()};
-    Rdiff = {StoreAndRef(Rdiff.getExpr()), Rdiff.getExpr_dx()};
+  if (opCode == BO_Mul || opCode == BO_Div) {
+    // A term of the product/quotient rule guarded by a constant-zero tangent
+    // is dead. Use the folder's own zero predicate to decide which terms to
+    // build, so this choice and the fold's identities cannot drift apart.
+    bool dropsLTerm =
+        ConstantFolder::evaluatesToZero(Ldiff.getExpr_dx(), m_Context);
+    bool dropsRTerm =
+        ConstantFolder::evaluatesToZero(Rdiff.getExpr_dx(), m_Context);
+    if (dropsLTerm && dropsRTerm) {
+      // Both tangents are zero: the numerator collapses to zero, and for
+      // division `0 / (R * R)` folds away the denominator with it, so no
+      // primal needs storing at all.
+      opDiff = getZeroInit(BinOp->getType());
+    } else {
+      // If Ldiff.getExpr() and Rdiff.getExpr() require evaluation, store the
+      // expressions in variables to avoid reevaluation. Only store an operand
+      // the derivative below will actually read -- storing it anyway would
+      // leave the primal alive as a dead temporary, the very thing the fold
+      // exists to remove. The left primal is only read by the `L * dR` term;
+      // the right primal by `dL * R` and, for division, by the denominator.
+      if (!dropsRTerm)
+        Ldiff = {StoreAndRef(Ldiff.getExpr()), Ldiff.getExpr_dx()};
+      if (!dropsLTerm || opCode == BO_Div)
+        Rdiff = {StoreAndRef(Rdiff.getExpr()), Rdiff.getExpr_dx()};
 
-    opDiff = deriveMul(Ldiff, Rdiff);
-  } else if (opCode == BO_Div) {
-    Ldiff = {StoreAndRef(Ldiff.getExpr()), Ldiff.getExpr_dx()};
-    Rdiff = {StoreAndRef(Rdiff.getExpr()), Rdiff.getExpr_dx()};
-
-    opDiff = deriveDiv(Ldiff, Rdiff);
+      opDiff = (opCode == BO_Mul)
+                   ? deriveMul(Ldiff, Rdiff, dropsLTerm, dropsRTerm)
+                   : deriveDiv(Ldiff, Rdiff, dropsRTerm);
+    }
   } else if (opCode == BO_Add || opCode == BO_Sub) {
     Expr* derivedL = nullptr;
     Expr* derivedR = nullptr;
@@ -1635,6 +1673,8 @@ BaseForwardModeVisitor::VisitBinaryOperator(const BinaryOperator* BinOp) {
       // _t1 *= 1;
       // ```
       //
+      // (The constant folder may collapse the derivative expression further;
+      // the ordering of the stored references is the point here.)
       auto LdiffExprDx = StoreAndRef(Ldiff.getExpr_dx());
       Ldiff = {StoreAndRef(Ldiff.getExpr()), LdiffExprDx};
       auto RdiffExprDx = StoreAndRef(Rdiff.getExpr_dx());

--- a/lib/Differentiator/ConstantFolder.cpp
+++ b/lib/Differentiator/ConstantFolder.cpp
@@ -10,13 +10,60 @@
 #include "clad/Differentiator/Compatibility.h"
 
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
+#include "clang/AST/OperationKinds.h"
+#include "clang/AST/Stmt.h"
+#include "clang/AST/Type.h"
+#include "clang/Basic/LLVM.h"
+#include "clang/Basic/SourceLocation.h"
+
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <cstdint>
 
 namespace clad {
   using namespace clang;
 
+  // `sizeof`, `alignof` and `offsetof` are constants, but their value belongs
+  // to the target ABI, while the folder evaluates on the host. Folding one
+  // into a numeric literal -- or folding an identity keyed on its host value
+  // -- bakes the host's answer into generated code that may be compiled for a
+  // different target (a CUDA derivative printing `n * 8UL` instead of
+  // `n * sizeof(double)`). Treat any expression containing one as opaque.
+  static bool containsTargetDependentConstant(const Expr* E) {
+    llvm::SmallVector<const Stmt*, 8> pending{E};
+    while (!pending.empty()) {
+      const Stmt* S = pending.pop_back_val();
+      // Null child slots (a ForStmt's empty init, ...) only occur on
+      // statements, which enter an expression tree via a GNU StmtExpr --
+      // and clad hoists those into temporaries before folding sees them.
+      if (!S)
+        continue; // LCOV_EXCL_LINE: defensive, see above
+      if (isa<UnaryExprOrTypeTraitExpr>(S) || isa<OffsetOfExpr>(S))
+        return true;
+      pending.append(S->child_begin(), S->child_end());
+    }
+    return false;
+  }
+
+  // The one evaluation gate for every folding decision. EvaluateAsRValue
+  // folds through side effects and only records them in HasSideEffects;
+  // without that check an operand like `(counter++, 0.)` reads as a plain
+  // zero and dropping or literalizing it deletes the increment from the
+  // derivative.
+  static bool evaluatesForFolding(Expr* E, ASTContext& C,
+                                  Expr::EvalResult& Result) {
+    return E->EvaluateAsRValue(Result, C) && !Result.HasSideEffects &&
+           !containsTargetDependentConstant(E);
+  }
+
   static bool evalsToN(Expr* E, ASTContext& C, uint64_t N = 0) {
     Expr::EvalResult result;
-    if (E->EvaluateAsRValue(result, C)) {
+    if (evaluatesForFolding(E, C, result)) {
       if (result.Val.isFloat()) {
         using namespace llvm;
         APFloat F = result.Val.getFloat();
@@ -30,15 +77,12 @@ namespace clad {
     return false;
   }
 
-  static bool evalsToZero(Expr* E, ASTContext& C) {
-    return evalsToN(E, C, /*N=*/0);
-  }
-
   static bool evalsToOne(Expr* E, ASTContext& C) {
     return evalsToN(E, C, /*N=*/1);
   }
 
-  static Expr* synthesizeLiteral(QualType QT, ASTContext& C, llvm::APInt val) {
+  static Expr* synthesizeLiteral(QualType QT, ASTContext& C,
+                                 const llvm::APInt& val) {
     assert(QT->isIntegralType(C) && "Not an integer type.");
     SourceLocation noLoc;
     return IntegerLiteral::Create(C, val, QT, noLoc);
@@ -63,15 +107,30 @@ namespace clad {
   }
 
   Expr* ConstantFolder::trivialFold(Expr* E) {
+    // Already a literal (possibly behind an implicit conversion): synthesizing
+    // a fresh one would only re-spell it at the converted type (`x *= 2`
+    // becoming `x *= 2.`), churning generated code without simplifying it.
+    const Expr* Inner = E->IgnoreImpCasts();
+    if (isa<IntegerLiteral>(Inner) || isa<FloatingLiteral>(Inner) ||
+        isa<CharacterLiteral>(Inner) || isa<CXXBoolLiteralExpr>(Inner) ||
+        isa<CXXNullPtrLiteralExpr>(Inner))
+      return E;
     Expr::EvalResult Result;
-    if (E->EvaluateAsRValue(Result, m_Context)) {
+    if (evaluatesForFolding(E, m_Context, Result)) {
       if (Result.Val.isFloat()) {
         llvm::APFloat F = Result.Val.getFloat();
         E = clad::synthesizeLiteral(E->getType(), m_Context, F);
       }
       else if (Result.Val.isInt()) {
         llvm::APSInt I = Result.Val.getInt();
-        E = clad::synthesizeLiteral(E->getType(), m_Context, I);
+        QualType QT = E->getType();
+        // A bool result needs a bool literal: an IntegerLiteral of boolean
+        // type is malformed and crashes the statement printer when it looks
+        // for an integer suffix.
+        if (QT->isBooleanType())
+          E = clad::synthesizeLiteral(QT, m_Context, I.getBoolValue());
+        else if (QT->isIntegralType(m_Context))
+          E = clad::synthesizeLiteral(QT, m_Context, I);
       }
     }
     return E;
@@ -88,30 +147,30 @@ namespace clad {
 
     if (opCode == BO_Mul) {
       // 0 * smth or smth * 0 == 0
-       if (evalsToZero(LHS, m_Context))
-         return LHS;
-       if (evalsToZero(RHS, m_Context))
-         return RHS;
+      if (evaluatesToZero(LHS, m_Context))
+        return LHS;
+      if (evaluatesToZero(RHS, m_Context))
+        return RHS;
 
-       // 1 * smth or smth * 1 == smth
-       if (evalsToOne(LHS, m_Context))
-         return RHS;
-       if (evalsToOne(RHS, m_Context))
-         return LHS;
+      // 1 * smth or smth * 1 == smth
+      if (evalsToOne(LHS, m_Context))
+        return RHS;
+      if (evalsToOne(RHS, m_Context))
+        return LHS;
     }
     else if (opCode == BO_Add || opCode == BO_Sub) {
       // smth +- 0 == smth
-      if (evalsToZero(RHS, m_Context))
+      if (evaluatesToZero(RHS, m_Context))
         return LHS;
 
       // 0 + smth == smth
       if (opCode == BO_Add)
-        if (evalsToZero(LHS, m_Context))
+        if (evaluatesToZero(LHS, m_Context))
           return RHS;
     }
     else if (opCode == BO_Div) {
       // 0 / smth == 0
-      if (evalsToZero(LHS, m_Context))
+      if (evaluatesToZero(LHS, m_Context))
         return LHS;
     }
 
@@ -120,21 +179,60 @@ namespace clad {
     return BinOp;
   }
 
+  /// True for expressions that never need parentheses around them: they bind
+  /// tighter than any operator clad builds around a folded subexpression.
+  static bool bindsTighterThanAnyOperator(const Expr* E) {
+    E = E->IgnoreImpCasts();
+    // An overloaded operator is a CallExpr in the AST but prints in operator
+    // syntax, which binds like the operator it names; conservatively keep the
+    // parentheses around it. Unreached today: every call that survives into a
+    // derivative has been rebuilt by the visitors in function-call syntax.
+    if (isa<CXXOperatorCallExpr>(E))
+      return false; // LCOV_EXCL_LINE: defensive, see above
+    return isa<DeclRefExpr>(E) || isa<IntegerLiteral>(E) ||
+           isa<FloatingLiteral>(E) || isa<CXXBoolLiteralExpr>(E) ||
+           isa<CXXNullPtrLiteralExpr>(E) || isa<MemberExpr>(E) ||
+           isa<ArraySubscriptExpr>(E) || isa<CallExpr>(E) || isa<ParenExpr>(E);
+  }
+
   Expr* ConstantFolder::VisitParenExpr(clang::ParenExpr* PE) {
     Expr* result = cast<Expr>(Visit(PE->getSubExpr()));
-    if (!isa<BinaryOperator>(result))
-      return result;
-    PE->setSubExpr(result);
-    return PE;
+    // Clang's printer relies on ParenExpr for precedence, so dropping one
+    // around anything that binds loosely makes -fdump-derived-fn print source
+    // that no longer reparses to the AST it came from -- a parenthesized
+    // conditional under a `*` prints as `a * c ? x : y`.
+    if (!bindsTighterThanAnyOperator(result)) {
+      PE->setSubExpr(result);
+      return PE;
+    }
+    return result;
+  }
+
+  bool ConstantFolder::evaluatesToZero(Expr* E, ASTContext& C) {
+    return E && evalsToN(E, C, /*N=*/0);
   }
 
   Expr* ConstantFolder::fold(Expr* E) {
-    if (!m_Enabled)
+    Expr* result = cast<Expr>(Visit(E));
+
+    // The identity rules (`x + 0`, `1 * x`) hand back an operand, and an
+    // operand can be an lvalue where the operator result was a prvalue. A
+    // folded tangent ends up in argument position next to its primal, and clad
+    // differentiates an lvalue argument w.r.t. the declaration it names while a
+    // prvalue argument only gets a temporary adjoint -- so a fold that changes
+    // the value category also changes which parameters the callee's pullback is
+    // requested for, and the tangent stops matching its primal. Keep the
+    // unfolded expression in that case. The check looks through the
+    // lvalue-to-rvalue conversion: it is the declaration underneath that the
+    // reverse pass keys on, not the cast. Because this hands the whole input
+    // back, callers must only pass expressions that are safe to re-evaluate
+    // in full -- see the term selection in
+    // BaseForwardModeVisitor::VisitBinaryOperator.
+    if (!E->IgnoreParenImpCasts()->isLValue() &&
+        result->IgnoreParenImpCasts()->isLValue())
       return E;
 
-    Expr* result = Visit(E);
-
-    return cast<Expr>(result);
+    return result;
   }
 
   Expr* ConstantFolder::synthesizeLiteral(QualType QT, ASTContext& C,

--- a/lib/Differentiator/ConstantFolder.h
+++ b/lib/Differentiator/ConstantFolder.h
@@ -11,10 +11,13 @@
 
 #include "clang/AST/StmtVisitor.h"
 
+#include <cstdint>
+
 namespace clang {
   class ASTContext;
   class BinaryOperator;
   class Expr;
+  class ParenExpr;
   class QualType;
 }
 
@@ -23,15 +26,20 @@ namespace clad {
     public clang::StmtVisitor<ConstantFolder, clang::Expr*> {
   private:
     clang::ASTContext& m_Context;
-    bool m_Enabled;
+
   public:
-    ConstantFolder(clang::ASTContext& C) : m_Context(C), m_Enabled(false) {}
+    explicit ConstantFolder(clang::ASTContext& C) : m_Context(C) {}
     clang::Expr* fold(clang::Expr* E);
     clang::Expr* VisitExpr(clang::Expr* E);
     clang::Expr* VisitBinaryOperator(clang::BinaryOperator* BinOp);
     clang::Expr* VisitParenExpr(clang::ParenExpr* PE);
     static clang::Expr* synthesizeLiteral(clang::QualType, clang::ASTContext &C,
                                           uint64_t val);
+    /// True when E is a constant zero that evaluates without side effects.
+    /// This is the predicate the identity rules use, exposed so a caller can
+    /// tell in advance which terms the fold is going to drop.
+    static bool evaluatesToZero(clang::Expr* E, clang::ASTContext& C);
+
   private:
     clang::Expr* trivialFold(clang::Expr* E);
   };

--- a/test/Arrays/ArrayInputsForwardMode.C
+++ b/test/Arrays/ArrayInputsForwardMode.C
@@ -8,7 +8,7 @@ double multiply(const double *arr) {
 }
 
 //CHECK:   double multiply_darg0_1(const double *arr) {
-//CHECK-NEXT:       return 0. * arr[1] + arr[0] * 1.;
+//CHECK-NEXT:       return arr[0] * 1.;
 //CHECK-NEXT:   }
 
 double divide(const double *arr) {
@@ -16,7 +16,7 @@ double divide(const double *arr) {
 }
 
 //CHECK:   double divide_darg0_1(const double *arr) {
-//CHECK-NEXT:       return (0. * arr[1] - arr[0] * 1.) / (arr[1] * arr[1]);
+//CHECK-NEXT:       return (0. - arr[0]) / (arr[1] * arr[1]);
 //CHECK-NEXT:   }
 
 double addArr(const double *arr, int n) {

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -88,7 +88,7 @@ float helper(float x) {
 }
 
 // CHECK: clad::ValueAndPushforward<float, float> helper_pushforward(float x, float _d_x) {
-// CHECK-NEXT:     return {2 * x, 0 * x + 2 * _d_x};
+// CHECK-NEXT:     return {2 * x, 2 * _d_x};
 // CHECK-NEXT: }
 
 float func2(float* a) {

--- a/test/CUDA/ForwardMode.cu
+++ b/test/CUDA/ForwardMode.cu
@@ -114,7 +114,7 @@ double fn1(double i, double j) {
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     double _t14 = 2 * sum;
-// CHECK-NEXT:     return _d_sum * i + sum * _d_i + (0 * sum + 2 * _d_sum) * j + _t14 * _d_j;
+// CHECK-NEXT:     return _d_sum * i + sum * _d_i + (2 * _d_sum) * j + _t14 * _d_j;
 // CHECK-NEXT: }
 
 int main() {

--- a/test/FirstDerivative/BasicArithmeticAddSub.C
+++ b/test/FirstDerivative/BasicArithmeticAddSub.C
@@ -21,7 +21,7 @@ int a_2(int x) {
 }
 // CHECK: int a_2_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: return 0 + 0;
+// CHECK-NEXT: return 0;
 // CHECK-NEXT: }
 
 int a_3(int x) {
@@ -40,7 +40,7 @@ int a_4(int x) {
 // CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
-// CHECK-NEXT: return _d_x + _d_y + _d_x + 0 + _d_x;
+// CHECK-NEXT: return _d_x + _d_y + _d_x + _d_x;
 // CHECK-NEXT: }
 
 int s_1(int x) {
@@ -59,7 +59,7 @@ int s_2(int x) {
 }
 // CHECK: int s_2_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: return 0 - 0;
+// CHECK-NEXT: return 0;
 // CHECK-NEXT: }
 
 int s_3(int x) {
@@ -78,7 +78,7 @@ int s_4(int x) {
 // CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
-// CHECK-NEXT: return _d_x - _d_y - _d_x - 0 - _d_x;
+// CHECK-NEXT: return _d_x - _d_y - _d_x - _d_x;
 // CHECK-NEXT: }
 
 int as_1(int x) {
@@ -89,7 +89,7 @@ int as_1(int x) {
 // CHECK-NEXT: int _d_x = 1;
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
-// CHECK-NEXT: return _d_x + _d_x - _d_x + _d_y - _d_y + 0 - 0;
+// CHECK-NEXT: return _d_x + _d_x - _d_x + _d_y - _d_y;
 // CHECK-NEXT: }
 
 float IntegerLiteralToFloatLiteral(float x, float y) {

--- a/test/FirstDerivative/BasicArithmeticAll.C
+++ b/test/FirstDerivative/BasicArithmeticAll.C
@@ -19,10 +19,9 @@ float basic_1(int x) {
 // CHECK-NEXT: int _t0 = (y + x);
 // CHECK-NEXT: int _t1 = (x - z);
 // CHECK-NEXT: int _t2 = x * y;
-// CHECK-NEXT: int _t3 = (_t2 * z);
-// CHECK-NEXT: int _t4 = _t0 / _t1;
-// CHECK-NEXT: int _t5 = (_t3 / 5);
-// CHECK-NEXT: return (((_d_y + _d_x) * _t1 - _t0 * (_d_x - _d_z)) / (_t1 * _t1)) * _t5 + _t4 * ((((_d_x * y + x * _d_y) * z + _t2 * _d_z) * 5 - _t3 * 0) / (5 * 5));
+// CHECK-NEXT: int _t3 = _t0 / _t1;
+// CHECK-NEXT: int _t4 = ((_t2 * z) / 5);
+// CHECK-NEXT: return (((_d_y + _d_x) * _t1 - _t0 * (_d_x - _d_z)) / (_t1 * _t1)) * _t4 + _t3 * ((((_d_x * y + x * _d_y) * z + _t2 * _d_z) * 5) / 25);
 // CHECK-NEXT: }
 
 float basic_1_darg0(int x);

--- a/test/FirstDerivative/BasicArithmeticMulDiv.C
+++ b/test/FirstDerivative/BasicArithmeticMulDiv.C
@@ -21,7 +21,7 @@ int m_2(int x) {
 }
 // CHECK: int m_2_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: return 0 * 1 + 1 * 0;
+// CHECK-NEXT: return 0;
 // CHECK-NEXT: }
 
 int m_3(int x) {
@@ -41,9 +41,8 @@ int m_4(int x) {
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
 // CHECK-NEXT: int _t0 = x * y;
-// CHECK-NEXT: int _t1 = _t0 * x;
-// CHECK-NEXT: int _t2 = _t1 * 3;
-// CHECK-NEXT: return (((_d_x * y + x * _d_y) * x + _t0 * _d_x) * 3 + _t1 * 0) * x + _t2 * _d_x;
+// CHECK-NEXT: int _t1 = _t0 * x * 3;
+// CHECK-NEXT: return (((_d_x * y + x * _d_y) * x + _t0 * _d_x) * 3) * x + _t1 * _d_x;
 // CHECK-NEXT: }
 
 double m_5(int x) {
@@ -51,7 +50,7 @@ double m_5(int x) {
 }
 // CHECK: double m_5_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: return 0. * x + 3.1400000000000001 * _d_x;
+// CHECK-NEXT: return 3.1400000000000001 * _d_x;
 // CHECK-NEXT: }
 
 float m_6(int x) {
@@ -59,7 +58,7 @@ float m_6(int x) {
 }
 // CHECK: float m_6_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: return 0.F * x + 3.F * _d_x;
+// CHECK-NEXT: return 3.F * _d_x;
 // CHECK-NEXT: }
 
 double m_7(double x) {
@@ -89,7 +88,7 @@ double m_9(double x) {
 }
 // CHECK: double m_9_darg0(double x) {
 // CHECK-NEXT:   double _d_x = 1;
-// CHECK-NEXT:   return (((_d_x = _d_x * 2 + x * 0) , (x *= 2)) , (_d_x * x + x * _d_x));
+// CHECK-NEXT:   return (((_d_x = _d_x * 2) , (x *= 2)) , (_d_x * x + x * _d_x));
 // CHECK-NEXT: }
 
 double m_10(double x, bool flag) {
@@ -99,7 +98,7 @@ double m_10(double x, bool flag) {
 // CHECK: double m_10_darg0(double x, bool flag) {
 // CHECK-NEXT:   double _d_x = 1;
 // CHECK-NEXT:   bool _d_flag = 0;
-// CHECK-NEXT:   return flag ? (((_d_x = _d_x * 2 + x * 0) , (x *= 2)) , (_d_x * x + x * _d_x)) : (((_d_x += 0) , (x += 1)) , (_d_x * x + x * _d_x));
+// CHECK-NEXT:   return flag ? (((_d_x = _d_x * 2) , (x *= 2)) , (_d_x * x + x * _d_x)) : (((_d_x += 0) , (x += 1)) , (_d_x * x + x * _d_x));
 // CHECK-NEXT: }
 
 template<size_t N>
@@ -135,7 +134,7 @@ int d_2(int x) {
 }
 // CHECK: int d_2_darg0(int x) {
 // CHECK-NEXT: int _d_x = 1;
-// CHECK-NEXT: return (0 * 1 - 1 * 0) / (1 * 1);
+// CHECK-NEXT: return 0;
 // CHECK-NEXT: }
 
 int d_3(int x) {
@@ -155,9 +154,8 @@ int d_4(int x) {
 // CHECK-NEXT: int _d_y = 0;
 // CHECK-NEXT: int y = 4;
 // CHECK-NEXT: int _t0 = x / y;
-// CHECK-NEXT: int _t1 = _t0 / x;
-// CHECK-NEXT: int _t2 = _t1 / 3;
-// CHECK-NEXT: return (((((((_d_x * y - x * _d_y) / (y * y)) * x - _t0 * _d_x) / (x * x)) * 3 - _t1 * 0) / (3 * 3)) * x - _t2 * _d_x) / (x * x);
+// CHECK-NEXT: int _t1 = _t0 / x / 3;
+// CHECK-NEXT: return (((((((_d_x * y - x * _d_y) / (y * y)) * x - _t0 * _d_x) / (x * x)) * 3) / 9) * x - _t1 * _d_x) / (x * x);
 // CHECK-NEXT: }
 
 double issue25(double x, double y) {
@@ -189,9 +187,7 @@ int md_1(int x) {
 // CHECK-NEXT: int _t0 = x * x;
 // CHECK-NEXT: int _t1 = _t0 / x;
 // CHECK-NEXT: int _t2 = _t1 * y;
-// CHECK-NEXT: int _t3 = _t2 / y;
-// CHECK-NEXT: int _t4 = _t3 * 3;
-// CHECK-NEXT: return ((((((((_d_x * x + x * _d_x) * x - _t0 * _d_x) / (x * x)) * y + _t1 * _d_y) * y - _t2 * _d_y) / (y * y)) * 3 + _t3 * 0) * 3 - _t4 * 0) / (3 * 3);
+// CHECK-NEXT: return ((((((((_d_x * x + x * _d_x) * x - _t0 * _d_x) / (x * x)) * y + _t1 * _d_y) * y - _t2 * _d_y) / (y * y)) * 3) * 3) / 9;
 // CHECK-NEXT: }
 
 

--- a/test/FirstDerivative/CallArguments.C
+++ b/test/FirstDerivative/CallArguments.C
@@ -43,7 +43,7 @@ float f_const_args_func_1(const float x, const float y) {
 // CHECK: float f_const_args_func_1_darg0(const float x, const float y) {
 // CHECK-NEXT: const float _d_x = 1;
 // CHECK-NEXT: const float _d_y = 0;
-// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
+// CHECK-NEXT: return x + x;
 // CHECK-NEXT: }
 
 float f_const_args_func_2(float x, const float y) {
@@ -53,7 +53,7 @@ float f_const_args_func_2(float x, const float y) {
 // CHECK: float f_const_args_func_2_darg0(float x, const float y) {
 // CHECK-NEXT: float _d_x = 1;
 // CHECK-NEXT: const float _d_y = 0;
-// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
+// CHECK-NEXT: return _d_x * x + x * _d_x;
 // CHECK-NEXT: }
 
 float f_const_args_func_3(const float x, float y) {
@@ -63,7 +63,7 @@ float f_const_args_func_3(const float x, float y) {
 // CHECK: float f_const_args_func_3_darg0(const float x, float y) {
 // CHECK-NEXT: const float _d_x = 1;
 // CHECK-NEXT: float _d_y = 0;
-// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - 0.F;
+// CHECK-NEXT: return x + x + _d_y * y + y * _d_y;
 // CHECK-NEXT: }
 
 struct Vec { float x=0, y=0, z=0; };
@@ -75,7 +75,7 @@ float f_const_args_func_4(float x, float y, const Vec v) {
 // CHECK-NEXT: float _d_x = 1;
 // CHECK-NEXT: float _d_y = 0;
 // CHECK-NEXT: const Vec _d_v;
-// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - _d_v.x;
+// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
 // CHECK-NEXT: }
 
 float f_const_args_func_5(float x, float y, const Vec &v) {
@@ -86,7 +86,7 @@ float f_const_args_func_5(float x, float y, const Vec &v) {
 // CHECK-NEXT: float _d_x = 1;
 // CHECK-NEXT: float _d_y = 0;
 // CHECK-NEXT: const Vec _d_v;
-// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - _d_v.x;
+// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y;
 // CHECK-NEXT: }
 
 float f_const_args_func_6(const float x, const float y, const Vec &v) {
@@ -97,7 +97,7 @@ float f_const_args_func_6(const float x, const float y, const Vec &v) {
 // CHECK-NEXT: const float _d_x = 1;
 // CHECK-NEXT: const float _d_y = 0;
 // CHECK-NEXT: const Vec _d_v;
-// CHECK-NEXT: return _d_x * x + x * _d_x + _d_y * y + y * _d_y - _d_v.x;
+// CHECK-NEXT: return x + x;
 // CHECK-NEXT: }
 
 float f_const_helper(const float x) {
@@ -185,7 +185,7 @@ float f_call_inline_fxn(float *params, float const *obs, float const *xlArr) {
 // CHECK-NEXT:     clad::ValueAndPushforward<unsigned int, unsigned int> _t0 = getBin_pushforward(0., 1., params[0], 1, 0., 0., 1.F, 0);
 // CHECK-NEXT:     const float _d_t116 = 0.F;
 // CHECK-NEXT:     const float t116 = *(xlArr + _t0.value);
-// CHECK-NEXT:     return _d_t116 * params[0] + t116 * 1.F;
+// CHECK-NEXT:     return t116 * 1.F;
 // CHECK-NEXT: }
 
 extern "C" int printf(const char* fmt, ...);

--- a/test/FirstDerivative/FunctionCallsWithResults.C
+++ b/test/FirstDerivative/FunctionCallsWithResults.C
@@ -253,7 +253,7 @@ double fn7(double i, double j) {
 // CHECK: double fn7_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = helperFn_pushforward(7 * i, 9 * j, 0 * i + 7 * _d_i, 0 * j + 9 * _d_j);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = helperFn_pushforward(7 * i, 9 * j, 7 * _d_i, 9 * _d_j);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = helperFn_pushforward(static_cast<double &&>(_t0.value), i + j, static_cast<double &&>(_t0.pushforward), _d_i + _d_j);
 // CHECK-NEXT:     return _t1.pushforward;
 // CHECK-NEXT: }
@@ -319,9 +319,8 @@ double fn8(double i, double j) {
 // CHECK-NEXT:     modifyArr_pushforward(arr, 5, i * j, _d_arr, 0, _d_i * j + i * _d_j);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = sum_pushforward(arr, 5, _d_arr, 0);
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = check_and_return_pushforward(_t0.value, 'a', _t0.pushforward, 0);
-// CHECK-NEXT:     double &_t2 = _t1.value;
-// CHECK-NEXT:     double _t3 = std::tanh(1.);
-// CHECK-NEXT:     return _t1.pushforward * _t3 + _t2 * 0.;
+// CHECK-NEXT:     double _t2 = std::tanh(1.);
+// CHECK-NEXT:     return _t1.pushforward * _t2;
 // CHECK-NEXT: }
 
 double g (double x) { return x; }

--- a/test/FirstDerivative/Loops.C
+++ b/test/FirstDerivative/Loops.C
@@ -22,7 +22,7 @@ double f1_darg0(double x, int y);
 // CHECK-NEXT:   double r = 1.;
 // CHECK-NEXT:   {
 // CHECK-NEXT:     int _d_i = 0;
-// CHECK-NEXT:     for (int i = 0; i < y; (_d_i = _d_i + 0) , (i = i + 1)) {
+// CHECK-NEXT:       for (int i = 0; i < y; (_d_i = _d_i) , (i = i + 1)) {
 // CHECK-NEXT:       _d_r = _d_r * x + r * _d_x;
 // CHECK-NEXT:       r = r * x;
 // CHECK-NEXT:     }
@@ -71,7 +71,7 @@ double f2_darg0(double x, int y);
 // CHECK-NEXT:   int _d_y = 0;
 // CHECK-NEXT:   {
 // CHECK-NEXT:     int _d_i = 0;
-// CHECK-NEXT:     for (int i = 0; i < y; (_d_i = _d_i + 0) , (i = i + 1)) {
+// CHECK-NEXT:       for (int i = 0; i < y; (_d_i = _d_i) , (i = i + 1)) {
 // CHECK-NEXT:       _d_x = _d_x * x + x * _d_x;
 // CHECK-NEXT:       x = x * x;
 // CHECK-NEXT:     } 
@@ -122,7 +122,7 @@ double f3_darg0(double x, int y);
 // CHECK-NEXT:   {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     for (int i = 0; i < y; (_d_r = _d_r * x + r * _d_x) , (r = r * x)) {
-// CHECK-NEXT:       _d_i = _d_i + 0;
+// CHECK-NEXT:           _d_i = _d_i;
 // CHECK-NEXT:       i = i + 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
@@ -177,7 +177,7 @@ double f4_darg0(double x, int y);
 // CHECK-NEXT:       r = r * _t3;
 // CHECK:        }
 // CHECK:        ()) {
-// CHECK-NEXT:          _d_i = _d_i + 0;
+// CHECK-NEXT:          _d_i = _d_i;
 // CHECK-NEXT:          i = i + 1;
 // CHECK-NEXT:        }
 // CHECK-NEXT:     }
@@ -517,7 +517,7 @@ double fn15_darg0(double u, double v);
 // CHECK-NEXT:      double res = 0;
 // CHECK-NEXT:      for (; (_d_res = _d_u * v + u * _d_v) , !(res = u * v);) {
 // CHECK-NEXT:      }
-// CHECK-NEXT:      return 0 * res + 2 * _d_res;
+// CHECK-NEXT:      return 2 * _d_res;
 // CHECK-NEXT:  }
 
 double fn16(double x) {
@@ -599,7 +599,7 @@ double fn19_darg0(double x, double y);
 // CHECK-NEXT:     double _d_res = 0;
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     double _t0 = 2 * x;
-// CHECK-NEXT:     double _d_f[5] = {_d_x * x + x * _d_x, (0 * x + 2 * _d_x) * y + _t0 * _d_y, _d_y * y + y * _d_y, _d_x, _d_y};
+// CHECK-NEXT:     double _d_f[5] = {_d_x * x + x * _d_x, (2 * _d_x) * y + _t0 * _d_y, _d_y * y + y * _d_y, _d_x, _d_y};
 // CHECK-NEXT:     double f[5] = {x * x, _t0 * y, y * y, x, y};
 // CHECK-NEXT:     double (&_d___range1)[5] = _d_f;
 // CHECK-NEXT:     double (&__range1)[5] = f;

--- a/test/FirstDerivative/Namespaces.C
+++ b/test/FirstDerivative/Namespaces.C
@@ -10,7 +10,7 @@ namespace A {
   double f_darg0(double x);
   //CHECK:   double f_darg0(double x) {
   //CHECK-NEXT:       double _d_x = 1;
-  //CHECK-NEXT:       return 0 * x + 1 * _d_x;
+  //CHECK-NEXT:       return 1 * _d_x;
   //CHECK-NEXT:   }
 }
 
@@ -20,7 +20,7 @@ namespace B {
   double f_darg0(double x);
   //CHECK:   double f_darg0(double x) {
   //CHECK-NEXT:       double _d_x = 1;
-  //CHECK-NEXT:       return 0 * x + 2 * _d_x;
+  //CHECK-NEXT:       return 2 * _d_x;
   //CHECK-NEXT:   }
 }
 
@@ -31,7 +31,7 @@ namespace C {
     double f_darg0(double x);
     //CHECK:   double f_darg0(double x) {
     //CHECK-NEXT:       double _d_x = 1;
-    //CHECK-NEXT:       return 0 * x + 3 * _d_x;
+    //CHECK-NEXT:       return 3 * _d_x;
     //CHECK-NEXT:   }
   }
   inline namespace E {
@@ -40,7 +40,7 @@ namespace C {
     double f_darg0(double x);
     //CHECK:   double f_darg0(double x) {
     //CHECK-NEXT:       double _d_x = 1;
-    //CHECK-NEXT:       return 0 * x + 4 * _d_x;
+    //CHECK-NEXT:       return 4 * _d_x;
     //CHECK-NEXT:   }
   }
 }
@@ -51,7 +51,7 @@ namespace {
   double f_darg0(double x);
   //CHECK:   double f_darg0(double x) {
   //CHECK-NEXT:       double _d_x = 1;
-  //CHECK-NEXT:       return 0 * x + 5 * _d_x;
+  //CHECK-NEXT:       return 5 * _d_x;
   //CHECK-NEXT:   }
 }
 

--- a/test/FirstDerivative/StructGlobalObjects.C
+++ b/test/FirstDerivative/StructGlobalObjects.C
@@ -18,7 +18,7 @@ double fn_complex(double i, double j) {
 // CHECK-NEXT: double _d_j = 0;
 // CHECK-NEXT: double &_t0 = c.real;
 // CHECK-NEXT: double &_t1 = c.im;
-// CHECK-NEXT: return 0. * i + _t0 * _d_i + 0. * j + _t1 * _d_j;
+// CHECK-NEXT: return _t0 * _d_i + _t1 * _d_j;
 // CHECK-NEXT: }
 
 struct Array {
@@ -36,7 +36,7 @@ double fn_array(double i, double j) {
 // CHECK-NEXT: double _d_j = 0;
 // CHECK-NEXT: double &_t0 = array.data[0];
 // CHECK-NEXT: double &_t1 = array.data[1];
-// CHECK-NEXT: return 0. * i + _t0 * _d_i + 0. * j + _t1 * _d_j;
+// CHECK-NEXT: return _t0 * _d_i + _t1 * _d_j;
 // CHECK-NEXT: }
 
 int main () {

--- a/test/FirstDerivative/Variables.C
+++ b/test/FirstDerivative/Variables.C
@@ -33,11 +33,11 @@ double f_ops1(double x) {
 // CHECK-NEXT:    double _d_x = 1;
 // CHECK-NEXT:    double _d_t0 = _d_x;
 // CHECK-NEXT:    double t0 = x;
-// CHECK-NEXT:    double _d_t1 = 0 * x + 2 * _d_x;
+// CHECK-NEXT:    double _d_t1 = 2 * _d_x;
 // CHECK-NEXT:    double t1 = 2 * x;
 // CHECK-NEXT:    double _d_t2 = 0;
 // CHECK-NEXT:    double t2 = 0;
-// CHECK-NEXT:    double _d_t3 = _d_t1 * 2 + t1 * 0 + _d_t2;
+// CHECK-NEXT:    double _d_t3 = _d_t1 * 2 + _d_t2;
 // CHECK-NEXT:    double t3 = t1 * 2 + t2;
 // CHECK-NEXT:    return _d_t3;
 // CHECK-NEXT: }
@@ -54,7 +54,7 @@ double f_ops2(double x) {
 // CHECK-NEXT:    double _d_x = 1;
 // CHECK-NEXT:    double _d_t0 = _d_x;
 // CHECK-NEXT:    double t0 = x;
-// CHECK-NEXT:    double _d_t1 = 0 * x + 2 * _d_x;
+// CHECK-NEXT:    double _d_t1 = 2 * _d_x;
 // CHECK-NEXT:    double t1 = 2 * x;
 // CHECK-NEXT:    double _d_t2 = 0;
 // CHECK-NEXT:    double t2 = 5;

--- a/test/ForwardMode/ConstantFolding.C
+++ b/test/ForwardMode/ConstantFolding.C
@@ -1,0 +1,164 @@
+// RUN: %cladclang %s -I%S/../../include -oConstantFolding.out 2>&1 | %filecheck %s
+// RUN: ./ConstantFolding.out | %filecheck_exec %s
+
+// Pins the algebraic folding of forward-mode derivative expressions and the
+// store-elision that goes with it: an operand read only by a dropped
+// product-rule term must not be kept alive as a dead temporary.
+
+#include "clad/Differentiator/Differentiator.h"
+
+extern "C" int printf(const char* fmt, ...);
+
+// Both tangents are literal zeros: the product rule collapses to a plain zero
+// and neither operand is stored.
+double fn_mul_both_zero(const double* arr) {
+  return arr[0] * arr[1];
+}
+// CHECK: double fn_mul_both_zero_darg0_2(const double *arr) {
+// CHECK-NEXT:     return 0.;
+// CHECK-NEXT: }
+
+// Same for the quotient rule: 0 / (R * R) folds away the denominator, so not
+// even the divisor is stored.
+double fn_div_both_zero(const double* arr) {
+  return arr[0] / arr[1];
+}
+// CHECK: double fn_div_both_zero_darg0_2(const double *arr) {
+// CHECK-NEXT:     return 0.;
+// CHECK-NEXT: }
+
+// The right tangent is zero, so the `L * dR` term is dropped and the left
+// primal (x + x) is not stored into a temporary.
+double fn_mul_skip_store(double x) {
+  return (x + x) * 3.14;
+}
+// CHECK: double fn_mul_skip_store_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     return (_d_x + _d_x) * 3.1400000000000001;
+// CHECK-NEXT: }
+
+// Division by a constant: the numerator keeps only the `dL * R` term.
+double fn_div_skip_store(double x) {
+  return (x + x) / 3.14;
+}
+// CHECK: double fn_div_skip_store_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     return ((_d_x + _d_x) * 3.1400000000000001) / 9.8596000000000004;
+// CHECK-NEXT: }
+
+// `_d_x * 1.` must not fold to the bare lvalue `_d_x`: the value category of
+// a tangent decides how a call it is passed to is differentiated.
+double fn_keep_value_category(double x) {
+  return x * 1.0;
+}
+// CHECK: double fn_keep_value_category_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     return _d_x * 1.;
+// CHECK-NEXT: }
+
+// A tangent with a side effect is never treated as a constant zero, even when
+// it evaluates to one: dropping it would drop the assignment.
+double fn_side_effect_tangent(double x) {
+  double y = 1;
+  return (y = 0.0) * x;
+}
+// CHECK: double fn_side_effect_tangent_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     double _d_y = 0;
+// CHECK-NEXT:     double y = 1;
+// CHECK-NEXT:     double &_t0 = (y = 0.);
+// CHECK-NEXT:     return (_d_y = 0.) * x + _t0 * _d_x;
+// CHECK-NEXT: }
+
+// A parenthesized conditional stays parenthesized when the fold hands it back
+// as an operand; without the parentheses the dump would reparse differently.
+double fn_paren_cond(double x, bool c) {
+  return (c ? x : 2.0) * 3.0;
+}
+// CHECK: double fn_paren_cond_darg0(double x, bool c) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     bool _d_c = 0;
+// CHECK-NEXT:     return (c ? _d_x : 0.) * 3.;
+// CHECK-NEXT: }
+
+// sizeof is a target-dependent constant: it must survive the fold spelled as
+// written, not literalized to the host's value (`x * 8UL`).
+double fn_sizeof_opaque(double x) {
+  return x * sizeof(double);
+}
+// CHECK: double fn_sizeof_opaque_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     unsigned {{(int|long)}} _t0 = sizeof(double);
+// CHECK-NEXT:     return _d_x * _t0 + x * sizeof(double);
+// CHECK-NEXT: }
+
+// Same for the identity rules: sizeof(char) evaluates to 1 on the host, but
+// `x * sizeof(char)` must not fold to `x` on its account.
+double fn_sizeof_one(double x) {
+  return x * sizeof(char);
+}
+// CHECK: double fn_sizeof_one_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     unsigned {{(int|long)}} _t0 = sizeof(char);
+// CHECK-NEXT:     return _d_x * _t0 + x * sizeof(char);
+// CHECK-NEXT: }
+
+// A literal operand keeps its source spelling: re-synthesizing it at the
+// implicitly converted type would print `x *= 2` as `x *= 2.`.
+double fn_keep_literal_spelling(double x) {
+  return x *= 2;
+}
+// CHECK: double fn_keep_literal_spelling_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     return _d_x = _d_x * 2;
+// CHECK-NEXT: }
+
+// A constant that folds to a boolean must be synthesized as a bool literal:
+// an IntegerLiteral of type bool crashes clang's statement printer.
+double fn_bool_constant(double x, bool b) {
+  return ((b = (2 > 1)), x * x);
+}
+// CHECK: double fn_bool_constant_darg0(double x, bool b) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     bool _d_b = 0;
+// CHECK-NEXT:     return (((_d_b = false) , (b = true)) , (_d_x * x + x * _d_x));
+// CHECK-NEXT: }
+
+int main() {
+  double arr[3] = {2.0, 4.0, 8.0};
+
+  auto d_mul = clad::differentiate(fn_mul_both_zero, "arr[2]");
+  printf("{%.2f}\n", d_mul.execute(arr)); // CHECK-EXEC: {0.00}
+
+  auto d_div = clad::differentiate(fn_div_both_zero, "arr[2]");
+  printf("{%.2f}\n", d_div.execute(arr)); // CHECK-EXEC: {0.00}
+
+  auto d_mul_skip = clad::differentiate(fn_mul_skip_store, "x");
+  printf("{%.2f}\n", d_mul_skip.execute(5)); // CHECK-EXEC: {6.28}
+
+  auto d_div_skip = clad::differentiate(fn_div_skip_store, "x");
+  printf("{%.2f}\n", d_div_skip.execute(5)); // CHECK-EXEC: {0.64}
+
+  auto d_keep = clad::differentiate(fn_keep_value_category, "x");
+  printf("{%.2f}\n", d_keep.execute(5)); // CHECK-EXEC: {1.00}
+
+  auto d_side = clad::differentiate(fn_side_effect_tangent, "x");
+  printf("{%.2f}\n", d_side.execute(5)); // CHECK-EXEC: {0.00}
+
+  auto d_cond = clad::differentiate(fn_paren_cond, "x");
+  printf("{%.2f}\n", d_cond.execute(5, true)); // CHECK-EXEC: {3.00}
+  printf("{%.2f}\n", d_cond.execute(5, false)); // CHECK-EXEC: {0.00}
+
+  auto d_sizeof = clad::differentiate(fn_sizeof_opaque, "x");
+  printf("{%.2f}\n", d_sizeof.execute(5)); // CHECK-EXEC: {48.00}
+
+  auto d_sizeof_one = clad::differentiate(fn_sizeof_one, "x");
+  printf("{%.2f}\n", d_sizeof_one.execute(5)); // CHECK-EXEC: {6.00}
+
+  auto d_literal = clad::differentiate(fn_keep_literal_spelling, "x");
+  printf("{%.2f}\n", d_literal.execute(5)); // CHECK-EXEC: {2.00}
+
+  auto d_bool = clad::differentiate(fn_bool_constant, "x");
+  printf("{%.2f}\n", d_bool.execute(5, false)); // CHECK-EXEC: {10.00}
+  return 0;
+}

--- a/test/ForwardMode/ConstevalTest.C
+++ b/test/ForwardMode/ConstevalTest.C
@@ -11,9 +11,8 @@ consteval double fn(double x, double y) {
 //CHECK: consteval double fn_darg0(double x, double y) {
 //CHECK-NEXT:    double _d_x = 1;
 //CHECK-NEXT:    double _d_y = 0;
-//CHECK-NEXT:    double _t0 = (x + y);
-//CHECK-NEXT:    return ((_d_x + _d_y) * 2 - _t0 * 0) / (2 * 2);
-//CHECK-NEXT:}
+//CHECK-NEXT:    return ((_d_x + _d_y) * 2) / 4.;
+//CHECK-NEXT:    }
 
 consteval double mul(double a, double b, double c) {
      double val = 99.00;
@@ -27,10 +26,10 @@ consteval double mul(double a, double b, double c) {
 //CHECK-NEXT:    double _d_c = 0;
 //CHECK-NEXT:    double _d_val = 0.;
 //CHECK-NEXT:    double val = 99.;
-//CHECK-NEXT:    double _d_result = _d_val * a + val * _d_a + 0 - _d_b + _d_c;
+//CHECK-NEXT:    double _d_result = _d_val * a + val * _d_a - _d_b + _d_c;
 //CHECK-NEXT:    double result = val * a + 100 - b + c;
 //CHECK-NEXT:    return _d_result;
-//CHECK-NEXT:}
+//CHECK-NEXT:    }
 
 consteval double fn_test() {
     auto dx = clad::differentiate<clad::immediate_mode>(fn, "x");

--- a/test/ForwardMode/ConstexprTest.C
+++ b/test/ForwardMode/ConstexprTest.C
@@ -11,9 +11,8 @@ constexpr double fn(double x, double y) {
 //CHECK: constexpr double fn_darg0(double x, double y) {
 //CHECK-NEXT:    double _d_x = 1;
 //CHECK-NEXT:    double _d_y = 0;
-//CHECK-NEXT:    double _t0 = (x + y);
-//CHECK-NEXT:    return ((_d_x + _d_y) * 2 - _t0 * 0) / (2 * 2);
-//CHECK-NEXT:}
+//CHECK-NEXT:    return ((_d_x + _d_y) * 2) / 4.;
+//CHECK-NEXT:    }
 
 constexpr double mul(double a, double b, double c) {
      double val = 99.00;
@@ -27,10 +26,10 @@ constexpr double mul(double a, double b, double c) {
 //CHECK-NEXT:    double _d_c = 0;
 //CHECK-NEXT:    double _d_val = 0.;
 //CHECK-NEXT:    double val = 99.;
-//CHECK-NEXT:    double _d_result = _d_val * a + val * _d_a + 0 - _d_b + _d_c;
+//CHECK-NEXT:    double _d_result = _d_val * a + val * _d_a - _d_b + _d_c;
 //CHECK-NEXT:    double result = val * a + 100 - b + c;
 //CHECK-NEXT:    return _d_result;
-//CHECK-NEXT:}
+//CHECK-NEXT:    }
 
 constexpr double fn_test() {
     if consteval {

--- a/test/ForwardMode/Functors.C
+++ b/test/ForwardMode/Functors.C
@@ -330,17 +330,14 @@ struct WidgetPointer {
   // CHECK-NEXT:       double &_t0 = this->arr[3];
   // CHECK-NEXT:       double &_t1 = this->arr[3];
   // CHECK-NEXT:       double &_t2 = this->i;
-  // CHECK-NEXT:       double _t3 = 1. * _t1 + _t0 * 1.;
+  // CHECK-NEXT:       double _t3 = _t1 + _t0;
   // CHECK-NEXT:       double _t4 = _t0 * _t1;
   // CHECK-NEXT:       _d_i = _d_i * _t4 + _t2 * _t3;
   // CHECK-NEXT:       _t2 *= _t4;
-  // CHECK-NEXT:       double &_t5 = this->arr[5];
-  // CHECK-NEXT:       double &_t6 = this->arr[5];
-  // CHECK-NEXT:       double &_t7 = this->j;
-  // CHECK-NEXT:       double _t8 = 0. * _t6 + _t5 * 0.;
-  // CHECK-NEXT:       double _t9 = _t5 * _t6;
-  // CHECK-NEXT:       _d_j = _d_j * _t9 + _t7 * _t8;
-  // CHECK-NEXT:       _t7 *= _t9;
+  // CHECK-NEXT:       double &_t5 = this->j;
+  // CHECK-NEXT:       double _t6 = this->arr[5] * this->arr[5];
+  // CHECK-NEXT:       _d_j = _d_j * _t6;
+  // CHECK-NEXT:       _t5 *= _t6;
   // CHECK-NEXT:       return _d_i + _d_j + _d_temp;
   // CHECK-NEXT:   }
 
@@ -359,20 +356,17 @@ struct WidgetPointer {
   // CHECK-NEXT:               temp += this->arr[k];
   // CHECK-NEXT:           }
   // CHECK-NEXT:       }
-  // CHECK-NEXT:       double &_t0 = this->arr[3];
-  // CHECK-NEXT:       double &_t1 = this->arr[3];
-  // CHECK-NEXT:       double &_t2 = this->i;
-  // CHECK-NEXT:       double _t3 = 0. * _t1 + _t0 * 0.;
-  // CHECK-NEXT:       double _t4 = _t0 * _t1;
-  // CHECK-NEXT:       _d_i = _d_i * _t4 + _t2 * _t3;
-  // CHECK-NEXT:       _t2 *= _t4;
-  // CHECK-NEXT:       double &_t5 = this->arr[5];
-  // CHECK-NEXT:       double &_t6 = this->arr[5];
-  // CHECK-NEXT:       double &_t7 = this->j;
-  // CHECK-NEXT:       double _t8 = 1. * _t6 + _t5 * 1.;
-  // CHECK-NEXT:       double _t9 = _t5 * _t6;
-  // CHECK-NEXT:       _d_j = _d_j * _t9 + _t7 * _t8;
-  // CHECK-NEXT:       _t7 *= _t9;
+  // CHECK-NEXT:       double &_t0 = this->i;
+  // CHECK-NEXT:       double _t1 = this->arr[3] * this->arr[3];
+  // CHECK-NEXT:       _d_i = _d_i * _t1;
+  // CHECK-NEXT:       _t0 *= _t1;
+  // CHECK-NEXT:       double &_t2 = this->arr[5];
+  // CHECK-NEXT:       double &_t3 = this->arr[5];
+  // CHECK-NEXT:       double &_t4 = this->j;
+  // CHECK-NEXT:       double _t5 = _t3 + _t2;
+  // CHECK-NEXT:       double _t6 = _t2 * _t3;
+  // CHECK-NEXT:       _d_j = _d_j * _t6 + _t4 * _t5;
+  // CHECK-NEXT:       _t4 *= _t6;
   // CHECK-NEXT:       return _d_i + _d_j + _d_temp;
   // CHECK-NEXT:   }
 
@@ -433,7 +427,7 @@ int main() {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_jj = 0;
   // CHECK-NEXT:     double _t0 = x * i;
-  // CHECK-NEXT:     return (0. * i + x * _d_i) * jj + _t0 * _d_jj;
+  // CHECK-NEXT:     return (x * _d_i) * jj + _t0 * _d_jj;
   // CHECK-NEXT: }
 
   auto lambdaNNS = outer::inner::lambdaNNS;

--- a/test/ForwardMode/NonDifferentiable.C
+++ b/test/ForwardMode/NonDifferentiable.C
@@ -127,13 +127,13 @@ int main() {
   // CHECK-NEXT:     SimpleFunctions1 *_d_this = &_d_this_obj;
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return (_d_this->x + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
+  // CHECK-NEXT:     return _d_this->x * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j;
   // CHECK-NEXT: }
 
   // CHECK: clad::ValueAndPushforward<double, double> mem_fn_1_pushforward(double i, double j, SimpleFunctions1 *_d_this, double _d_i, double _d_j) {
   // CHECK-NEXT:     double _t0 = (this->x + this->y);
   // CHECK-NEXT:     double _t1 = i * j;
-  // CHECK-NEXT:     return {_t0 * i + _t1 * j, (_d_this->x + 0.) * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j};
+  // CHECK-NEXT:     return {_t0 * i + _t1 * j, _d_this->x * i + _t0 * _d_i + (_d_i * j + i * _d_j) * j + _t1 * _d_j};
   // CHECK-NEXT: }
 
   // CHECK: double mem_fn_3_darg0(double i, double j) {
@@ -150,7 +150,7 @@ int main() {
   // CHECK-NEXT:     double _d_j = 0;
   // CHECK-NEXT:     SimpleFunctions1 _d_this_obj;
   // CHECK-NEXT:     SimpleFunctions1 *_d_this = &_d_this_obj;
-  // CHECK-NEXT:     return 0 + _d_i * j + i * _d_j;
+  // CHECK-NEXT:     return _d_i * j + i * _d_j;
   // CHECK-NEXT: }
 
   // CHECK: double mem_fn_5_darg0(double i, double j) {
@@ -160,9 +160,8 @@ int main() {
   // CHECK-NEXT:     SimpleFunctions1 *_d_this = &_d_this_obj;
   // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = this->mem_fn_1_pushforward(i, j, _d_this, _d_i, _d_j);
   // CHECK-NEXT:     double _t1 = this->mem_fn_2(i, j);
-  // CHECK-NEXT:     double &_t2 = _t0.value;
-  // CHECK-NEXT:     double _t3 = _t1 * _t2;
-  // CHECK-NEXT:     return (0 * _t2 + _t1 * _t0.pushforward) * i + _t3 * _d_i;
+  // CHECK-NEXT:     double _t2 = _t1 * _t0.value;
+  // CHECK-NEXT:     return (_t1 * _t0.pushforward) * i + _t2 * _d_i;
   // CHECK-NEXT: }
 
   // CHECK: double fn_s1_mem_fn_darg0(double i, double j) {
@@ -179,13 +178,12 @@ int main() {
   // CHECK-NEXT:     double _d_j = 0;
   // CHECK-NEXT:     SimpleFunctions1 _d_obj{0, 0};
   // CHECK-NEXT:     SimpleFunctions1 obj{2, 3};
-  // CHECK-NEXT:     double &_t0 = obj.x;
-  // CHECK-NEXT:     double &_t1 = obj.y;
-  // CHECK-NEXT:     return _d_obj.x * _t1 + _t0 * 0. + _d_i * j + i * _d_j;
+  // CHECK-NEXT:     double &_t0 = obj.y;
+  // CHECK-NEXT:     return _d_obj.x * _t0 + _d_i * j + i * _d_j;
   // CHECK-NEXT: }
 
   // CHECK: clad::ValueAndPushforward<SimpleFunctions1, SimpleFunctions1> operator_plus_pushforward(const SimpleFunctions1 &other, const SimpleFunctions1 *_d_this, const SimpleFunctions1 &_d_other) const {
-  // CHECK-NEXT:     return {SimpleFunctions1(this->x + other.x, this->y + other.y), SimpleFunctions1(_d_this->x + _d_other.x, 0. + 0.)};
+  // CHECK-NEXT:     return {SimpleFunctions1(this->x + other.x, this->y + other.y), SimpleFunctions1(_d_this->x + _d_other.x, 0.)};
   // CHECK-NEXT: }
 
   // CHECK: double fn_s1_operator_darg0(double i, double j) {
@@ -204,16 +202,14 @@ int main() {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
   // CHECK-NEXT:     SimpleFunctions2 obj(2, 3);
-  // CHECK-NEXT:     return 0 + _d_i * j + i * _d_j;
+  // CHECK-NEXT:     return _d_i * j + i * _d_j;
   // CHECK-NEXT: }
 
   // CHECK: double fn_s2_field_darg0(double i, double j) {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
   // CHECK-NEXT:     SimpleFunctions2 *obj0, obj(2, 3);
-  // CHECK-NEXT:     double &_t0 = obj.x;
-  // CHECK-NEXT:     double &_t1 = obj.y;
-  // CHECK-NEXT:     return 0. * _t1 + _t0 * 0. + _d_i * j + i * _d_j;
+  // CHECK-NEXT:     return _d_i * j + i * _d_j;
   // CHECK-NEXT: }
 
   // CHECK: double fn_s2_operator_darg0(double i, double j) {
@@ -227,6 +223,6 @@ int main() {
   // CHECK: double fn_non_diff_call_darg0(double i, double j) {
   // CHECK-NEXT:     double _d_i = 1;
   // CHECK-NEXT:     double _d_j = 0;
-  // CHECK-NEXT:     return 0 + _d_i * j + i * _d_j;
+  // CHECK-NEXT:     return _d_i * j + i * _d_j;
   // CHECK-NEXT: }
 }

--- a/test/ForwardMode/OpenMP.C
+++ b/test/ForwardMode/OpenMP.C
@@ -43,7 +43,7 @@ double sum_scaled_parallel_for(const double* x, int n, double scale) {
 // CHECK-NEXT:                 last = tmp;
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     _d_total += 0 * last + 0 * _d_last;
+// CHECK-NEXT:     _d_total += 0;
 // CHECK-NEXT:     total += 0 * last;
 // CHECK-NEXT:     return _d_total;
 // CHECK-NEXT: }
@@ -100,7 +100,7 @@ double accumulate_critical(const double *x, int n) {
 // CHECK-NEXT:         for (int i = 0; i < n; i++) {
 // CHECK-NEXT:             #pragma omp critical
 // CHECK-NEXT:                 {
-// CHECK-NEXT:                     _d_result += 1. * x[0] + x[0] * 1.;
+// CHECK-NEXT:                     _d_result += x[0] + x[0];
 // CHECK-NEXT:                     result += x[0] * x[0];
 // CHECK-NEXT:                 }
 // CHECK-NEXT:         }

--- a/test/ForwardMode/Pointer.C
+++ b/test/ForwardMode/Pointer.C
@@ -66,9 +66,9 @@ double fn4(double i, double j) {
 // CHECK: double fn4_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     double *_d_p = new double(0 * i + 7 * _d_i + _d_j);
+// CHECK-NEXT:     double *_d_p = new double(7 * _d_i + _d_j);
 // CHECK-NEXT:     double *p = new double(7 * i + j);
-// CHECK-NEXT:     double _d_q = *_d_p + 0 * i + 9 * _d_i;
+// CHECK-NEXT:     double _d_q = *_d_p + 9 * _d_i;
 // CHECK-NEXT:     double q = *p + 9 * i;
 // CHECK-NEXT:     delete _d_p;
 // CHECK-NEXT:     delete p;
@@ -90,9 +90,9 @@ double fn5(double i, double j) {
 // CHECK: double fn5_darg0(double i, double j) {
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     double _d_arr[2] = {0 * i + 7 * _d_i, 0 * i + 9 * _d_i};
+// CHECK-NEXT:     double _d_arr[2] = {7 * _d_i, 9 * _d_i};
 // CHECK-NEXT:     double arr[2] = {7 * i, 9 * i};
-// CHECK-NEXT:     *(_d_arr + 1) += 0 * i + 11 * _d_i;
+// CHECK-NEXT:     *(_d_arr + 1) += 11 * _d_i;
 // CHECK-NEXT:     *(arr + 1) += 11 * i;
 // CHECK-NEXT:     int _d_idx1 = 0, _d_idx2 = 0;
 // CHECK-NEXT:     int idx1 = 0, idx2 = 1;
@@ -100,11 +100,11 @@ double fn5(double i, double j) {
 // CHECK-NEXT:     double *p = arr;
 // CHECK-NEXT:     _d_p += 1;
 // CHECK-NEXT:     p += 1;
-// CHECK-NEXT:     _d_p = 0 + _d_p;
+// CHECK-NEXT:     _d_p = _d_p;
 // CHECK-NEXT:     p = 0 + p;
-// CHECK-NEXT:     *_d_p += 0 * i + 13 * _d_i;
+// CHECK-NEXT:     *_d_p += 13 * _d_i;
 // CHECK-NEXT:     *p += 13 * i;
-// CHECK-NEXT:     *(_d_p - 1) += 0 * i + 17 * _d_i;
+// CHECK-NEXT:     *(_d_p - 1) += 17 * _d_i;
 // CHECK-NEXT:     *(p - 1) += 17 * i;
 // CHECK-NEXT:     return *(_d_arr + idx1) + *(_d_arr + idx2);
 // CHECK-NEXT: }
@@ -160,11 +160,10 @@ double fn7(double i) {
 // CHECK-NEXT:     t->i = i;
 // CHECK-NEXT:     double _d_res = *_d_p + _d_t->i;
 // CHECK-NEXT:     double res = *p + t->i;
-// CHECK-NEXT:     unsigned {{(int|long)}} _t2 = sizeof(double);
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<void *, void *> _t3 = clad::custom_derivatives::realloc_pushforward(p, 2 * _t2, _d_p, 0 * _t2 + 2 * sizeof(double));
-// CHECK-NEXT:     _d_p = (double *)_t3.pushforward;
-// CHECK-NEXT:     p = (double *)_t3.value;
-// CHECK-NEXT:     _d_p[1] = 0 * i + 2 * _d_i;
+// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<void *, void *> _t2 = clad::custom_derivatives::realloc_pushforward(p, 2 * sizeof(double), _d_p, 2 * sizeof(double));
+// CHECK-NEXT:     _d_p = (double *)_t2.pushforward;
+// CHECK-NEXT:     p = (double *)_t2.value;
+// CHECK-NEXT:     _d_p[1] = 2 * _d_i;
 // CHECK-NEXT:     p[1] = 2 * i;
 // CHECK-NEXT:     _d_res += _d_p[1];
 // CHECK-NEXT:     res += p[1];
@@ -190,7 +189,7 @@ double fn8(double* params) {
 // CHECK-NEXT:     double _d_arr[1] = {0.};
 // CHECK-NEXT:     double arr[1] = {3.};
 // CHECK-NEXT:     clad::ValueAndPushforward<void *, void *> _t0 = cling_runtime_internal_throwIfInvalidPointer_pushforward((void *)0UL, (void *)0UL, arr, (void *)0UL, (void *)0UL, _d_arr);
-// CHECK-NEXT:     return 1. * params[0] + params[0] * 1. + *(double *)_t0.pushforward;
+// CHECK-NEXT:     return params[0] + params[0] + *(double *)_t0.pushforward;
 // CHECK-NEXT: }
 
 double fn9(double* params, const double *constants) {
@@ -201,7 +200,7 @@ double fn9(double* params, const double *constants) {
 // CHECK: double fn9_darg0_0(double *params, const double *constants) {
 // CHECK-NEXT:     double _d_c0 = 0.;
 // CHECK-NEXT:     double c0 = *constants;
-// CHECK-NEXT:     return 1. * c0 + params[0] * _d_c0;
+// CHECK-NEXT:     return c0 + params[0] * _d_c0;
 // CHECK-NEXT: }
 
 double fn10(double *params, const double *constants) {
@@ -212,7 +211,7 @@ double fn10(double *params, const double *constants) {
 // CHECK: double fn10_darg0_0(double *params, const double *constants) {
 // CHECK-NEXT:     double _d_c0 = 0.;
 // CHECK-NEXT:     double c0 = *(constants + 0);
-// CHECK-NEXT:     return 1. * c0 + params[0] * _d_c0;
+// CHECK-NEXT:     return c0 + params[0] * _d_c0;
 // CHECK-NEXT: }
 
 int main() {

--- a/test/ForwardMode/STLCustomDerivatives.C
+++ b/test/ForwardMode/STLCustomDerivatives.C
@@ -233,7 +233,7 @@ double fnVec6(double x, double y) {
 // CHECK-NEXT:          {{.*}}ValueAndPushforward<{{.*}}> _t23 = {{.*}}operator_subscript_pushforward(&w, 0, &_d_w, 0);
 // CHECK-NEXT:          {{.*}}ValueAndPushforward<{{.*}}> _t24 = {{.*}}operator_subscript_pushforward(&w, 1, &_d_w, 0);
 // CHECK-NEXT:          bool _t25 = ((_t23.value == y) && (_t24.value == y));
-// CHECK-NEXT:          _d_res += false * x + _t25 * _d_x;
+// CHECK-NEXT:          _d_res += _t25 * _d_x;
 // CHECK-NEXT:          res += _t25 * x;
 // CHECK-NEXT:          {{.*}}ValueAndPushforward<{{.*}}> _t26 = {{.*}}operator_subscript_pushforward(&v, 0, &_d_v, 0);
 // CHECK-NEXT:          _t26.pushforward = _d_x;
@@ -244,7 +244,7 @@ double fnVec6(double x, double y) {
 // CHECK-NEXT:          {{.*}}ValueAndPushforward<{{.*}}> _t29 = {{.*}}operator_subscript_pushforward(&w, 0, &_d_w, 0);
 // CHECK-NEXT:          _d_res += _t29.pushforward;
 // CHECK-NEXT:          res += _t29.value;
-// CHECK-NEXT:          {{.*}}assign_pushforward(&w, {3 * x, 2 * x, 4 * x}, &_d_w, {0 * x + 3 * _d_x, 0 * x + 2 * _d_x, 0 * x + 4 * _d_x});
+// CHECK-NEXT:          {{.*}}assign_pushforward(&w, {3 * x, 2 * x, 4 * x}, &_d_w, {3 * _d_x, 2 * _d_x, 4 * _d_x});
 // CHECK-NEXT:          {{.*}}ValueAndPushforward<{{.*}}> _t30 = {{.*}}operator_subscript_pushforward(&w, 1, &_d_w, 0);
 // CHECK-NEXT:          _d_res += _t30.pushforward;
 // CHECK-NEXT:          res += _t30.value;
@@ -390,14 +390,14 @@ double fnTuple1(double x, double y) {
 } // = 2x + 2y
 
 //CHECK:      clad::ValueAndPushforward<{{.*}}> pack_pushforward({{.*}}) {
-//CHECK-NEXT:          {{(clad::)?}}ValueAndPushforward<{{.*}}> _t0 = clad::custom_derivatives::std::make_tuple_pushforward(x, 2 * x, 3 * x, _d_x, 0 * x + 2 * _d_x, 0 * x + 3 * _d_x);
+//CHECK-NEXT:          {{(clad::)?}}ValueAndPushforward<{{.*}}> _t0 = clad::custom_derivatives::std::make_tuple_pushforward(x, 2 * x, 3 * x, _d_x, 2 * _d_x, 3 * _d_x);
 //CHECK-NEXT:          return {_t0.value, _t0.pushforward};
 //CHECK-NEXT:      }
 
 //CHECK:      double fnTuple1_darg0(double x, double y) {
 //CHECK-NEXT:          double _d_x = 1;
 //CHECK-NEXT:          double _d_y = 0;
-//CHECK-NEXT:          double _d_u, _d_v = 0 * x + 288 * _d_x, _d_w;
+//CHECK-NEXT:          double _d_u, _d_v = 288 * _d_x, _d_w;
 //CHECK-NEXT:          double u, v = 288 * x, w;
 //CHECK-NEXT:          {{(clad::)?}}ValueAndPushforward<{{.*}}> _t0 = clad::custom_derivatives::std::tie_pushforward(u, v, w, _d_u, _d_v, _d_w);
 //CHECK-NEXT:          {{(clad::)?}}ValueAndPushforward<{{.*}}> _t1 = pack_pushforward(x + y, _d_x + _d_y);

--- a/test/ForwardMode/SourceFnArg.C
+++ b/test/ForwardMode/SourceFnArg.C
@@ -25,7 +25,7 @@ double nonMemFn(double i) {
 
 // CHECK: double nonMemFn_darg0(double i) {
 // CHECK-NEXT:     double _d_i = 1;
-// CHECK-NEXT:     return 0 * i + 5 * _d_i;
+// CHECK-NEXT:     return 5 * _d_i;
 // CHECK-NEXT: }
 
 #define MEM_FN_TEST(var)\

--- a/test/ForwardMode/UserDefinedTypes.C
+++ b/test/ForwardMode/UserDefinedTypes.C
@@ -32,9 +32,9 @@ std::pair<double, double> fn1(double i, double j) {
 // CHECK-NEXT:     std::pair<double, double> e = d;
 // CHECK-NEXT:     _d_c.first += _d_i;
 // CHECK-NEXT:     c.first += i;
-// CHECK-NEXT:     _d_c.second += 0 * i + 2 * _d_i + _d_j;
+// CHECK-NEXT:     _d_c.second += 2 * _d_i + _d_j;
 // CHECK-NEXT:     c.second += 2 * i + j;
-// CHECK-NEXT:     _d_d.first += 0 * i + 2 * _d_i;
+// CHECK-NEXT:     _d_d.first += 2 * _d_i;
 // CHECK-NEXT:     d.first += 2 * i;
 // CHECK-NEXT:     _d_d.second += _d_i;
 // CHECK-NEXT:     d.second += i;
@@ -481,13 +481,12 @@ double fn6(TensorD5 t, double i) {
 // CHECK-NEXT:     TensorD5 _d_t;
 // CHECK-NEXT:     double _d_i = 1;
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = t.sum_pushforward(& _d_t);
-// CHECK-NEXT:     double &_t1 = _t0.value;
-// CHECK-NEXT:     double _d_res = 0 * _t1 + 3 * _t0.pushforward;
-// CHECK-NEXT:     double res = 3 * _t1;
+// CHECK-NEXT:     double _d_res = 3 * _t0.pushforward;
+// CHECK-NEXT:     double res = 3 * _t0.value;
 // CHECK-NEXT:     t.updateTo_pushforward(i * i, & _d_t, _d_i * i + i * _d_i);
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t2 = sum_pushforward(t, _d_t);
-// CHECK-NEXT:     _d_res += _t2.pushforward;
-// CHECK-NEXT:     res += _t2.value;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = sum_pushforward(t, _d_t);
+// CHECK-NEXT:     _d_res += _t1.pushforward;
+// CHECK-NEXT:     res += _t1.value;
 // CHECK-NEXT:     return _d_res;
 // CHECK-NEXT: }
 
@@ -503,7 +502,7 @@ TensorD5 fn7(double i, double j) {
 // CHECK-NEXT:     TensorD5 _d_t;
 // CHECK-NEXT:     TensorD5 t;
 // CHECK-NEXT:     double _t0 = 7 * i;
-// CHECK-NEXT:     t.updateTo_pushforward(_t0 * j, & _d_t, (0 * i + 7 * _d_i) * j + _t0 * _d_j);
+// CHECK-NEXT:     t.updateTo_pushforward(_t0 * j, & _d_t, (7 * _d_i) * j + _t0 * _d_j);
 // CHECK-NEXT:     return _d_t;
 // CHECK-NEXT: }
 
@@ -534,11 +533,9 @@ complexD fn8(double i, TensorD5 t) {
 // CHECK-NEXT:     complexD _d_c{0., 0.};
 // CHECK-NEXT:     complexD c{0., 0.};
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = t.sum_pushforward(& _d_t);
-// CHECK-NEXT:     double &_t1 = _t0.value;
-// CHECK-NEXT:     c.real_pushforward(7 * _t1, &_d_c, 0 * _t1 + 7 * _t0.pushforward);
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t2 = sum_pushforward(t, _d_t);
-// CHECK-NEXT:     double &_t3 = _t2.value;
-// CHECK-NEXT:     c.imag_pushforward(9 * _t3, &_d_c, 0 * _t3 + 9 * _t2.pushforward);
+// CHECK-NEXT:     c.real_pushforward(7 * _t0.value, &_d_c, 7 * _t0.pushforward);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = sum_pushforward(t, _d_t);
+// CHECK-NEXT:     c.imag_pushforward(9 * _t1.value, &_d_c, 9 * _t1.pushforward);
 // CHECK-NEXT:     return _d_c;
 // CHECK-NEXT: }
 
@@ -610,10 +607,10 @@ std::complex<double> fn10(double i, double j) {
 // CHECK-NEXT:     double _d_j = 0;
 // CHECK-NEXT:     std::complex<double> _d_c1{0., 0.}, _d_c2{0., 0.};
 // CHECK-NEXT:     std::complex<double> c1{0., 0.}, c2{0., 0.};
-// CHECK-NEXT:     c1.real_pushforward(2 * i, &_d_c1, 0 * i + 2 * _d_i);
-// CHECK-NEXT:     c1.imag_pushforward(5 * i, &_d_c1, 0 * i + 5 * _d_i);
-// CHECK-NEXT:     c2.real_pushforward(5 * i, &_d_c2, 0 * i + 5 * _d_i);
-// CHECK-NEXT:     c2.imag_pushforward(2 * i, &_d_c2, 0 * i + 2 * _d_i);
+// CHECK-NEXT:     c1.real_pushforward(2 * i, &_d_c1, 2 * _d_i);
+// CHECK-NEXT:     c1.imag_pushforward(5 * i, &_d_c1, 5 * _d_i);
+// CHECK-NEXT:     c2.real_pushforward(5 * i, &_d_c2, 5 * _d_i);
+// CHECK-NEXT:     c2.imag_pushforward(2 * i, &_d_c2, 2 * _d_i);
 // CHECK-NEXT:     clad::ValueAndPushforward<{{(std::)?}}complex<double>, {{(std::)?}}complex<double> > _t0 = std::operator_plus_pushforward(c1, c2, _d_c1, _d_c2);
 // CHECK-NEXT:     clad::ValueAndPushforward<{{(std::)?}}complex<double> &, {{(std::)?}}complex<double> &> _t1 = c1.operator_equal_pushforward({{(static_cast<std(::__1)?::complex<double> &&>\(_t0.value\))|(_t0.value)}}, &_d_c1, {{(static_cast<std(::__1)?::complex<double> &&>\(_t0.pushforward\))|(_t0.pushforward)}});
 // CHECK-NEXT:     clad::ValueAndPushforward<{{(std::)?}}complex<double> &, {{(std::)?}}complex<double> &> _t2 = c1.operator_plus_equal_pushforward(c2, &_d_c1, _d_c2);
@@ -803,13 +800,13 @@ TensorD5 fn11(double i, double j) {
 // CHECK-NEXT:     double _d_j = 0;
 // CHECK-NEXT:     TensorD5 _d_a, _d_b;
 // CHECK-NEXT:     TensorD5 a, b;
-// CHECK-NEXT:     a.operator_call_pushforward(7 * i, & _d_a, 0 * i + 7 * _d_i);
-// CHECK-NEXT:     b.operator_call_pushforward(9 * i, & _d_b, 0 * i + 9 * _d_i);
+// CHECK-NEXT:     a.operator_call_pushforward(7 * i, & _d_a, 7 * _d_i);
+// CHECK-NEXT:     b.operator_call_pushforward(9 * i, & _d_b, 9 * _d_i);
 // CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t0 = a.operator_subscript_pushforward(0, & _d_a, 0);
-// CHECK-NEXT:     _t0.pushforward += 0 * i + 11 * _d_i;
+// CHECK-NEXT:     _t0.pushforward += 11 * _d_i;
 // CHECK-NEXT:     _t0.value += 11 * i;
 // CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t1 = b.operator_subscript_pushforward(0, & _d_b, 0);
-// CHECK-NEXT:     _t1.pushforward += 0 * i + 13 * _d_i;
+// CHECK-NEXT:     _t1.pushforward += 13 * _d_i;
 // CHECK-NEXT:     _t1.value += 13 * i;
 // CHECK-NEXT:     TensorD5 _d_res1, _d_res2;
 // CHECK-NEXT:     TensorD5 res1, res2;
@@ -884,13 +881,13 @@ TensorD5 fn12(double i, double j) {
 // CHECK-NEXT:     double _d_j = 0;
 // CHECK-NEXT:     TensorD5 _d_a, _d_b;
 // CHECK-NEXT:     TensorD5 a, b;
-// CHECK-NEXT:     a.operator_call_pushforward(7 * i, & _d_a, 0 * i + 7 * _d_i);
-// CHECK-NEXT:     b.operator_call_pushforward(9 * i, & _d_b, 0 * i + 9 * _d_i);
+// CHECK-NEXT:     a.operator_call_pushforward(7 * i, & _d_a, 7 * _d_i);
+// CHECK-NEXT:     b.operator_call_pushforward(9 * i, & _d_b, 9 * _d_i);
 // CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t0 = a.operator_subscript_pushforward(0, & _d_a, 0);
-// CHECK-NEXT:     _t0.pushforward += 0 * i + 11 * _d_i;
+// CHECK-NEXT:     _t0.pushforward += 11 * _d_i;
 // CHECK-NEXT:     _t0.value += 11 * i;
 // CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t1 = b.operator_subscript_pushforward(0, & _d_b, 0);
-// CHECK-NEXT:     _t1.pushforward += 0 * i + 13 * _d_i;
+// CHECK-NEXT:     _t1.pushforward += 13 * _d_i;
 // CHECK-NEXT:     _t1.value += 13 * i;
 // CHECK-NEXT:     TensorD5 _d_res1;
 // CHECK-NEXT:     TensorD5 res1;
@@ -906,7 +903,7 @@ TensorD5 fn12(double i, double j) {
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}>, Tensor<double, 5{{U?}}> > _t7 = operator_slash_pushforward(_t6.value, a, _t6.pushforward, _d_a);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> _t8 = operator_plus_equal_pushforward(res1, _t7.value, _d_res1, _t7.pushforward);
 // CHECK-NEXT:     clad::ValueAndPushforward<double &, double &> _t9 = res1.operator_subscript_pushforward(1, & _d_res1, 0);
-// CHECK-NEXT:     _t9.pushforward += 0 * i + 17 * _d_i;
+// CHECK-NEXT:     _t9.pushforward += 17 * _d_i;
 // CHECK-NEXT:     _t9.value += 17 * i;
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5{{U?}}> &, Tensor<double, 5{{U?}}> &> _t10 = operator_caret_equal_pushforward(res1, one, _d_res1, _d_one);
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> &, Tensor<double, 5> &> _t11 = res1.operator_equal_pushforward(res1, & _d_res1, _d_res1);
@@ -1086,7 +1083,7 @@ TensorD5 fn13(double i, double j) {
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> *, Tensor<double, 5> *> _t11 = a.operator_amp_pushforward(& _d_a);
 // CHECK-NEXT:     Tensor<double, 5> *_d_ap = _t11.pushforward;
 // CHECK-NEXT:     Tensor<double, 5> *ap = _t11.value;
-// CHECK-NEXT:     _d_ap->data[1] = 0 * i + 7 * _d_i;
+// CHECK-NEXT:     _d_ap->data[1] = 7 * _d_i;
 // CHECK-NEXT:     ap->data[1] = 7 * i;
 // CHECK-NEXT:     clad::ValueAndPushforward<Tensor<double, 5> *, Tensor<double, 5> *> _t12 = b.operator_arrow_pushforward(& _d_b);
 // CHECK-NEXT:     double *_d_b_data = _t12.pushforward->data;
@@ -1140,10 +1137,10 @@ double fn14(double i, double j) {
 // CHECK-NEXT:     vectorD v;
 // CHECK-NEXT:     clad::custom_derivatives::class_functions::resize_pushforward(&v, 5, 0, &_d_v, 0, 0);
 // CHECK-NEXT:     {{.*}}ValueAndPushforward<{{.*}}, {{.*}}> _t0 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&v, 0, &_d_v, 0);
-// CHECK-NEXT:     _t0.pushforward = 0 * i + 9 * _d_i;
+// CHECK-NEXT:     _t0.pushforward = 9 * _d_i;
 // CHECK-NEXT:     _t0.value = 9 * i;
 // CHECK-NEXT:     {{.*}}ValueAndPushforward<{{.*}}, {{.*}}> _t1 = clad::custom_derivatives::class_functions::operator_subscript_pushforward(&v, 1, &_d_v, 0);
-// CHECK-NEXT:     _t1.pushforward = 0 * i + 11 * _d_i;
+// CHECK-NEXT:     _t1.pushforward = 11 * _d_i;
 // CHECK-NEXT:     _t1.value = 11 * i;
 // CHECK-NEXT:     clad::ValueAndPushforward<{{.*}}, {{.*}}> _t2 = std::begin_pushforward(v, _d_v);
 // CHECK-NEXT:     {{.*}} _d_b = _t2.pushforward;
@@ -1168,8 +1165,7 @@ double fn15(pairdd u, pairdd v) {
 // CHECK-NEXT:     pairdd _d_u;
 // CHECK-NEXT:     _d_u.first = 1;
 // CHECK-NEXT:     pairdd _d_v;
-// CHECK-NEXT:     double &_t0 = v.first;
-// CHECK-NEXT:     return _d_u.first + 0 * _t0 + 2 * _d_v.first;
+// CHECK-NEXT:     return _d_u.first + 2 * _d_v.first;
 // CHECK-NEXT: }
 
 double fn16(pair_of_pairdd u, pair_of_pairdd v) {
@@ -1180,8 +1176,7 @@ double fn16(pair_of_pairdd u, pair_of_pairdd v) {
 // CHECK-NEXT:     pair_of_pairdd _d_u;
 // CHECK-NEXT:     pair_of_pairdd _d_v;
 // CHECK-NEXT:     _d_v.second.second = 1;
-// CHECK-NEXT:     double &_t0 = v.second.second;
-// CHECK-NEXT:     return _d_u.first.first + 0 * _t0 + 2 * _d_v.second.second;
+// CHECK-NEXT:     return _d_u.first.first + 2 * _d_v.second.second;
 // CHECK-NEXT: }
 
 
@@ -1219,7 +1214,7 @@ double fn18(double i, double j) {
 // CHECK-NEXT:     double _d_j = 0;
 // CHECK-NEXT:     A _d_v[2] = {0, 0};
 // CHECK-NEXT:     A v[2] = {2, 3};
-// CHECK-NEXT:     clad::ValueAndPushforward<A &, A &> _t0 = v[0].operator_equal_pushforward(9 * i, &_d_v[0], 0 * i + 9 * _d_i);
+// CHECK-NEXT:     clad::ValueAndPushforward<A &, A &> _t0 = v[0].operator_equal_pushforward(9 * i, &_d_v[0], 9 * _d_i);
 // CHECK-NEXT:     return _d_v[0].mem;
 // CHECK-NEXT: }
 

--- a/test/Jacobian/Functors.C
+++ b/test/Jacobian/Functors.C
@@ -22,12 +22,12 @@ struct Experiment {
   // CHECK-NEXT:     double &_t0 = this->x;
   // CHECK-NEXT:     double _t1 = _t0 * i;
   // CHECK-NEXT:     double _t2 = _t1 * i;
-  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((_t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
   // CHECK-NEXT:     _clad_out_output[0] = _t2 * j;
   // CHECK-NEXT:     double &_t3 = this->y;
   // CHECK-NEXT:     double _t4 = _t3 * i;
   // CHECK-NEXT:     double _t5 = _t4 * j;
-  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((_t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
   // CHECK-NEXT:     _clad_out_output[1] = _t5 * j;
   // CHECK-NEXT: }
 
@@ -52,12 +52,12 @@ struct ExperimentConst {
   // CHECK-NEXT:     double &_t0 = this->x;
   // CHECK-NEXT:     double _t1 = _t0 * i;
   // CHECK-NEXT:     double _t2 = _t1 * i;
-  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((_t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
   // CHECK-NEXT:     _clad_out_output[0] = _t2 * j;
   // CHECK-NEXT:     double &_t3 = this->y;
   // CHECK-NEXT:     double _t4 = _t3 * i;
   // CHECK-NEXT:     double _t5 = _t4 * j;
-  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((_t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
   // CHECK-NEXT:     _clad_out_output[1] = _t5 * j;
   // CHECK-NEXT: }
 
@@ -82,12 +82,12 @@ struct ExperimentVolatile {
   // CHECK-NEXT:     volatile double &_t0 = this->x;
   // CHECK-NEXT:     double _t1 = _t0 * i;
   // CHECK-NEXT:     double _t2 = _t1 * i;
-  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((_t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
   // CHECK-NEXT:     _clad_out_output[0] = _t2 * j;
   // CHECK-NEXT:     volatile double &_t3 = this->y;
   // CHECK-NEXT:     double _t4 = _t3 * i;
   // CHECK-NEXT:     double _t5 = _t4 * j;
-  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((_t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
   // CHECK-NEXT:     _clad_out_output[1] = _t5 * j;
   // CHECK-NEXT: }
 
@@ -112,12 +112,12 @@ struct ExperimentConstVolatile {
   // CHECK-NEXT:     volatile double &_t0 = this->x;
   // CHECK-NEXT:     double _t1 = _t0 * i;
   // CHECK-NEXT:     double _t2 = _t1 * i;
-  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((_t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
   // CHECK-NEXT:     _clad_out_output[0] = _t2 * j;
   // CHECK-NEXT:     volatile double &_t3 = this->y;
   // CHECK-NEXT:     double _t4 = _t3 * i;
   // CHECK-NEXT:     double _t5 = _t4 * j;
-  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((_t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
   // CHECK-NEXT:     _clad_out_output[1] = _t5 * j;
   // CHECK-NEXT: }
 
@@ -144,12 +144,12 @@ namespace outer {
   // CHECK-NEXT:     double &_t0 = this->x;
   // CHECK-NEXT:     double _t1 = _t0 * i;
   // CHECK-NEXT:     double _t2 = _t1 * i;
-  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0 * i + _t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((_t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
   // CHECK-NEXT:     _clad_out_output[0] = _t2 * j;
   // CHECK-NEXT:     double &_t3 = this->y;
   // CHECK-NEXT:     double _t4 = _t3 * i;
   // CHECK-NEXT:     double _t5 = _t4 * j;
-  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((0 * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
+  // CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((_t3 * _d_vector_i) * j + _t4 * _d_vector_j) * j + _t5 * _d_vector_j;
   // CHECK-NEXT:     _clad_out_output[1] = _t5 * j;
   // CHECK-NEXT: }
 
@@ -232,11 +232,11 @@ int main() {
 // CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
 // CHECK-NEXT:     double _t0 = x * i;
 // CHECK-NEXT:     double _t1 = _t0 * i;
-// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0. * i + x * _d_vector_i) * i + _t0 * _d_vector_i) * jj + _t1 * _d_vector_jj;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((x * _d_vector_i) * i + _t0 * _d_vector_i) * jj + _t1 * _d_vector_jj;
 // CHECK-NEXT:     _clad_out_output[0] = _t1 * jj;
 // CHECK-NEXT:     double _t2 = y * i;
 // CHECK-NEXT:     double _t3 = _t2 * jj;
-// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((0. * i + y * _d_vector_i) * jj + _t2 * _d_vector_jj) * jj + _t3 * _d_vector_jj;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((y * _d_vector_i) * jj + _t2 * _d_vector_jj) * jj + _t3 * _d_vector_jj;
 // CHECK-NEXT:     _clad_out_output[1] = _t3 * jj;
 // CHECK-NEXT: }
 

--- a/test/Jacobian/TemplateFunctors.C
+++ b/test/Jacobian/TemplateFunctors.C
@@ -18,19 +18,16 @@ template <typename T> struct Experiment {
 // CHECK-NEXT:     clad::array<double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
-// CHECK-NEXT:     double &_t0 = this->x;
-// CHECK-NEXT:     double &_t1 = this->y;
-// CHECK-NEXT:     double _t2 = _t0 * _t1;
-// CHECK-NEXT:     double _t3 = _t2 * i;
-// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((0 * _t1 + _t0 * 0) * i + _t2 * _d_vector_i) * j + _t3 * _d_vector_j;
-// CHECK-NEXT:     _clad_out_output[0] = _t3 * j;
-// CHECK-NEXT:     double &_t4 = this->x;
-// CHECK-NEXT:     double _t5 = 2 * _t4;
-// CHECK-NEXT:     double &_t6 = this->y;
-// CHECK-NEXT:     double _t7 = _t5 * _t6;
-// CHECK-NEXT:     double _t8 = _t7 * i;
-// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((((clad::zero_vector(indepVarCount)) * _t4 + 2 * 0) * _t6 + _t5 * 0) * i + _t7 * _d_vector_i) * j + _t8 * _d_vector_j;
-// CHECK-NEXT:     _clad_out_output[1] = _t8 * j;
+// CHECK-NEXT:     double _t0 = this->x * this->y;
+// CHECK-NEXT:     double _t1 = _t0 * i;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = (_t0 * _d_vector_i) * j + _t1 * _d_vector_j;
+// CHECK-NEXT:     _clad_out_output[0] = _t1 * j;
+// CHECK-NEXT:     double &_t2 = this->x;
+// CHECK-NEXT:     double &_t3 = this->y;
+// CHECK-NEXT:     double _t4 = 2 * _t2 * _t3;
+// CHECK-NEXT:     double _t5 = _t4 * i;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = ((((clad::zero_vector(indepVarCount)) * _t2) * _t3) * i + _t4 * _d_vector_i) * j + _t5 * _d_vector_j;
+// CHECK-NEXT:     _clad_out_output[1] = _t5 * j;
 // CHECK-NEXT: }
 
 template <> struct Experiment<long double> {
@@ -48,21 +45,18 @@ template <> struct Experiment<long double> {
 // CHECK-NEXT:     clad::array<long double> _d_vector_i = clad::one_hot_vector(indepVarCount, {{0U|0UL|0ULL}});
 // CHECK-NEXT:     clad::array<long double> _d_vector_j = clad::one_hot_vector(indepVarCount, {{1U|1UL|1ULL}});
 // CHECK-NEXT:     *_d_vector__clad_out_output = clad::identity_matrix(_d_vector__clad_out_output->rows(), indepVarCount, {{2U|2UL|2ULL}});
-// CHECK-NEXT:     long double &_t0 = this->x;
-// CHECK-NEXT:     long double &_t1 = this->y;
-// CHECK-NEXT:     long double _t2 = _t0 * _t1;
-// CHECK-NEXT:     long double _t3 = _t2 * i;
-// CHECK-NEXT:     long double _t4 = _t3 * i;
-// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = (((0 * _t1 + _t0 * 0) * i + _t2 * _d_vector_i) * i + _t3 * _d_vector_i) * j + _t4 * _d_vector_j;
-// CHECK-NEXT:     _clad_out_output[0] = _t4 * j;
-// CHECK-NEXT:     long double &_t5 = this->x;
-// CHECK-NEXT:     long double _t6 = 2 * _t5;
-// CHECK-NEXT:     long double &_t7 = this->y;
-// CHECK-NEXT:     long double _t8 = _t6 * _t7;
-// CHECK-NEXT:     long double _t9 = _t8 * i;
-// CHECK-NEXT:     long double _t10 = _t9 * i;
-// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (((((clad::zero_vector(indepVarCount)) * _t5 + 2 * 0) * _t7 + _t6 * 0) * i + _t8 * _d_vector_i) * i + _t9 * _d_vector_i) * j + _t10 * _d_vector_j;
-// CHECK-NEXT:     _clad_out_output[1] = _t10 * j;
+// CHECK-NEXT:     long double _t0 = this->x * this->y;
+// CHECK-NEXT:     long double _t1 = _t0 * i;
+// CHECK-NEXT:     long double _t2 = _t1 * i;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[0] = ((_t0 * _d_vector_i) * i + _t1 * _d_vector_i) * j + _t2 * _d_vector_j;
+// CHECK-NEXT:     _clad_out_output[0] = _t2 * j;
+// CHECK-NEXT:     long double &_t3 = this->x;
+// CHECK-NEXT:     long double &_t4 = this->y;
+// CHECK-NEXT:     long double _t5 = 2 * _t3 * _t4;
+// CHECK-NEXT:     long double _t6 = _t5 * i;
+// CHECK-NEXT:     long double _t7 = _t6 * i;
+// CHECK-NEXT:     (*_d_vector__clad_out_output)[1] = (((((clad::zero_vector(indepVarCount)) * _t3) * _t4) * i + _t5 * _d_vector_i) * i + _t6 * _d_vector_i) * j + _t7 * _d_vector_j;
+// CHECK-NEXT:     _clad_out_output[1] = _t7 * j;
 // CHECK-NEXT: }
 
 #define INIT(E)                                                                \

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -74,20 +74,18 @@
 // CHECK_ROSENBROCK: double _d_y = 0;
 // CHECK_ROSENBROCK: double _t0 = (x - 1);
 // CHECK_ROSENBROCK: double _t1 = (x - 1);
-// CHECK_ROSENBROCK: double _t2 = (y - x * x);
-// CHECK_ROSENBROCK: double _t3 = 100 * _t2;
-// CHECK_ROSENBROCK: double _t4 = (y - x * x);
-// CHECK_ROSENBROCK: return (_d_x - 0) * _t1 + _t0 * (_d_x - 0) + (0 * _t2 + 100 * (_d_y - (_d_x * x + x * _d_x))) * _t4 + _t3 * (_d_y - (_d_x * x + x * _d_x));
+// CHECK_ROSENBROCK: double _t2 = 100 * (y - x * x);
+// CHECK_ROSENBROCK: double _t3 = (y - x * x);
+// CHECK_ROSENBROCK: return _d_x * _t1 + _t0 * _d_x + (100 * (_d_y - (_d_x * x + x * _d_x))) * _t3 + _t2 * (_d_y - (_d_x * x + x * _d_x));
 // CHECK_ROSENBROCK:}
 // CHECK_ROSENBROCK:double rosenbrock_func_darg1(double x, double y) {
 // CHECK_ROSENBROCK: double _d_x = 0;
 // CHECK_ROSENBROCK: double _d_y = 1;
 // CHECK_ROSENBROCK: double _t0 = (x - 1);
 // CHECK_ROSENBROCK: double _t1 = (x - 1);
-// CHECK_ROSENBROCK: double _t2 = (y - x * x);
-// CHECK_ROSENBROCK: double _t3 = 100 * _t2;
-// CHECK_ROSENBROCK: double _t4 = (y - x * x);
-// CHECK_ROSENBROCK: return (_d_x - 0) * _t1 + _t0 * (_d_x - 0) + (0 * _t2 + 100 * (_d_y - (_d_x * x + x * _d_x))) * _t4 + _t3 * (_d_y - (_d_x * x + x * _d_x));
+// CHECK_ROSENBROCK: double _t2 = 100 * (y - x * x);
+// CHECK_ROSENBROCK: double _t3 = (y - x * x);
+// CHECK_ROSENBROCK: return _d_x * _t1 + _t0 * _d_x + (100 * (_d_y - (_d_x * x + x * _d_x))) * _t3 + _t2 * (_d_y - (_d_x * x + x * _d_x));
 // CHECK_ROSENBROCK:}
 // RUN: ./RosenbrockFunction.out | FileCheck -check-prefix CHECK_ROSENBROCK_EXEC %s
 // CHECK_ROSENBROCK_EXEC: The result is -899.000000.

--- a/test/ROOT/TFormula.C
+++ b/test/ROOT/TFormula.C
@@ -53,22 +53,21 @@ void TFormula_example_grad_1(const Double_t* x, Double_t* p, Double_t* _d_p);
 //CHECK-NEXT:   }
 
 //CHECK:   Double_t TFormula_example_darg1_0(const Double_t *x, Double_t *p) {
-//CHECK-NEXT:       {{double|Double_t}} _t0 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives::TMath::Exp_pushforward(-p[0], -1.);
-//CHECK-NEXT:       return 0. * _t0 + x[0] * (1. + 0. + 0.) + _t1.pushforward + 0.;
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t0 = clad::custom_derivatives::TMath::Exp_pushforward(-p[0], -1.);
+//CHECK-NEXT:       return x[0] + _t0.pushforward;
 //CHECK-NEXT:   }
 
 // Exp is called with a -0. tangent in the directions that do not seed p[0], so
 // it folds to zero and no pushforward is emitted for it.
 //CHECK:   Double_t TFormula_example_darg1_1(const Double_t *x, Double_t *p) {
-//CHECK-NEXT:       {{double|Double_t}} _t0 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t1 = clad::custom_derivatives::TMath::Abs_pushforward(p[1], 1.);
-//CHECK-NEXT:       return 0. * _t0 + x[0] * (0. + 1. + 0.) + 0. + _t1.pushforward;
+//CHECK-NEXT:       clad::ValueAndPushforward<Double_t, Double_t> _t0 = clad::custom_derivatives::TMath::Abs_pushforward(p[1], 1.);
+//CHECK-NEXT:       return x[0] + _t0.pushforward;
 //CHECK-NEXT:   }
 
+// `x[0] * 1.` stays: the full fold would hand back the bare lvalue x[0], which
+// ConstantFolder::fold refuses because it would change the value category.
 //CHECK:   Double_t TFormula_example_darg1_2(const Double_t *x, Double_t *p) {
-//CHECK-NEXT:       {{double|Double_t}} _t0 = (p[0] + p[1] + p[2]);
-//CHECK-NEXT:       return 0. * _t0 + x[0] * (0. + 0. + 1.) + 0. + 0.;
+//CHECK-NEXT:       return x[0] * 1. + 0. + 0.;
 //CHECK-NEXT:   }
 
 Double_t TFormula_hess1(const Double_t *x, Double_t *p) {

--- a/test/ValidCodeGen/ValidCodeGen.C
+++ b/test/ValidCodeGen/ValidCodeGen.C
@@ -53,7 +53,7 @@ int main() {
 
 //CHECK:     double fn_darg0(double x) {
 //CHECK-NEXT:         double _d_x = 1;
-//CHECK-NEXT:         return _d_x * TN::coefficient + x * 0;
+//CHECK-NEXT:         return _d_x * TN::coefficient;
 //CHECK-NEXT:     }
 
 //CHECK:  int _d_coefficient = 0;


### PR DESCRIPTION
ConstantFolder has been dead code: its only caller constructed it with m_Enabled hardcoded to false. Forward mode carries one seeded direction, so most tangents reaching an operator are a constant zero, and the product/quotient rules expand into `0 * b + a * 0` chains that keep the whole primal subtree alive -- in a hessian, once per direction. Folding collapses them to a zero that cascades through the rest of the expression. This is 1.84x on hessian generation for a 41-parameter RooFit likelihood, and the generated code also evaluates faster.

Enabling the folder safely needs a set of accompanying fixes:

- Build only the product-rule terms whose tangent is not a constant zero, and store only the operands the surviving terms read; storing an operand only a dropped term reads would keep the primal alive as a dead temporary. When both tangents are zero, the whole rule -- for division including the denominator -- is a plain zero and nothing is stored. Term selection also keeps every fold() input safe to re-evaluate, which the bail-out below relies on.

- Refuse a fold whose result is an lvalue when the input was not. A tangent like `_d_x + 0` folding to the bare `_d_x` next to a prvalue primal argument changes which parameters the callee's pullback is requested for in reverse-over-forward; RooFit's poissonIntegral fails to build without this.

- Never treat an expression with side effects as a constant: a zero tangent with a side effect must not be dropped, and a constant-valued subexpression with a side effect must not be replaced by its value.

- Synthesize a bool literal when a folded constant is boolean. An IntegerLiteral of type bool is malformed and crashes clang's StmtPrinter (it finds no integer suffix for the type).

- Keep ParenExpr around any loosely binding subexpression the fold hands back (conditionals, overloaded operators), not just binary operators, so dumped source reparses to the AST it came from.

Test expectations are regenerated from the emitted derivatives, and ForwardMode/ConstantFolding.C pins each of the new branches. Verified with the full lit suite against both the release and the debug build (live AST-integrity asserts).