### PR TITLE
Do not plan clad derivatives for an Enzyme-backend request.

### DIFF
--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1699,7 +1699,13 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
         nonDiff = true;
     }
 
-    if (!(hasCustomPullback || nonDiff) || requestTBR) {
+    // Enzyme differentiates the emitted IR, so the only thing clad produces
+    // for such a request is the __enzyme_autodiff call. Analysing the body and
+    // recursing into the call graph would schedule pullbacks nothing consumes,
+    // and would fail on callees clad cannot differentiate but Enzyme can. The
+    // request itself is still scheduled below.
+    if (!request.use_enzyme &&
+        (!(hasCustomPullback || nonDiff) || requestTBR)) {
       clang::CFG::BuildOptions Options;
       std::unique_ptr<AnalysisDeclContext> AnalysisDC =
           std::make_unique<AnalysisDeclContext>(


### PR DESCRIPTION
A request marked use_enzyme produces one thing: a call to __enzyme_autodiff. Enzyme then differentiates the emitted IR, including everything the function calls. The planner nevertheless analysed the body and recursed into the call graph, scheduling a pullback for every callee.

None of that has a consumer. The scheduled derivatives are dead, the TBR and activity analyses inform nothing, and the recursion reaches callees clad cannot differentiate -- library bodies in particular -- turning a request Enzyme would have handled into a clad diagnostic.

Skip the analysis and the traversal for such a request. The request itself is still scheduled, so the wrapper is emitted as before.