### PR TITLE
Do not read an uninitialised variable in the activity test.

### DIFF
--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -465,8 +465,12 @@ double f13(double x, const double* obs){
 // CHECK-NEXT:    double g = f13_1(1, obs);
 // CHECK-NEXT:}
 
+// a and b are initialised because the loop below reads b before
+// assigning it. That read is undefined behaviour, and with TBR
+// disabled clad stores b unconditionally, which makes the
+// uninitialised value live and lets an optimising build trap on it.
 double f14(double x){
-  double a, b;
+  double a = 0, b = 0;
   double x1 = 0, x2 = 0, x3 = 0, x4 = 0;
   int i = 10;
   while(i){
@@ -493,7 +497,7 @@ double f14(double x){
 // CHECK-NEXT:     clad::tape<double> _t6 = {};
 // CHECK-NEXT:     clad::tape<double> _t7 = {};
 // CHECK-NEXT:     double _d_a = 0., _d_b = 0.;
-// CHECK-NEXT:     double a, b;
+// CHECK-NEXT:     double a = 0, b = 0;
 // CHECK-NEXT:     double _d_x1 = 0., _d_x2 = 0., _d_x3 = 0.;
 // CHECK-NEXT:     double x1 = 0, x2 = 0, x3 = 0, x4 = 0;
 // CHECK-NEXT:     int i = 10;


### PR DESCRIPTION
f14 declares `double a, b;` and its loop starts with `a = b;`, reading b before anything assigns it. That is undefined behaviour in the test's own source, and it has been hiding behind -O0: the suite compiles without an optimisation flag, where the garbage value is harmless.

At -O1 and above the same file traps with SIGILL. It needs -disable-tbr to show up, which is what the test runs with: with the analysis enabled clad never stores b, so the undefined read stays dead, while with it disabled b is stored unconditionally and the uninitialised value becomes live for the optimiser to act on.

Initialise both. The variables are still unvaried, so the analysis under test is unaffected, and the file now runs clean at -O0 through -O2.