### PR TITLE
Attach Enzyme where it belongs, and only where it is used.

### DIFF
--- a/patches/enzyme.patch
+++ b/patches/enzyme.patch
@@ -1,0 +1,42 @@
+Make Enzyme's module passes skippable.
+
+A pass reporting isRequired() cannot be declined: LLVM consults
+PassInstrumentationCallbacks::ShouldRunOptionalPassCallbacks only for
+optional passes. Marking them required is right for a standalone plugin,
+where every module the plugin sees is one the user asked it to handle.
+
+clad is in the other position. Its pass pipeline is built long after the
+point where it could have refused to register anything, and a session-based
+host such as clang-repl compiles many modules through a single plugin.
+Making these two optional lets clad decline them for a module that holds no
+__enzyme_autodiff call, so ordinary code is not routed through them.
+
+Nothing else declines them: clad registers the only such callback, and it
+answers yes for any module that does contain a request.
+
+diff --git a/enzyme/Enzyme/Enzyme.cpp b/enzyme/Enzyme/Enzyme.cpp
+index 1748a74f..10ffd933 100644
+--- a/enzyme/Enzyme/Enzyme.cpp
++++ b/enzyme/Enzyme/Enzyme.cpp
+@@ -3372,7 +3372,7 @@ public:
+                               : PreservedAnalyses::all();
+   }
+ 
+-  static bool isRequired() { return true; }
++  static bool isRequired() { return false; }
+ };
+ 
+ #undef DEBUG_TYPE
+diff --git a/enzyme/Enzyme/PreserveNVVM.h b/enzyme/Enzyme/PreserveNVVM.h
+index 46b5282d..ae3a85e5 100644
+--- a/enzyme/Enzyme/PreserveNVVM.h
++++ b/enzyme/Enzyme/PreserveNVVM.h
+@@ -51,7 +51,7 @@ public:
+ 
+   Result run(llvm::Module &M, llvm::ModuleAnalysisManager &MAM);
+ 
+-  static bool isRequired() { return true; }
++  static bool isRequired() { return false; }
+ };
+ 
+ #endif // ENZYME_PRESERVE_NVVM_H

--- a/test/Enzyme/GradientsComparisonWithClad.C
+++ b/test/Enzyme/GradientsComparisonWithClad.C
@@ -1,6 +1,10 @@
-// RUN: %cladclang %s  -I%S/../../include -oEnzymeGradients.out 2>&1 | %filecheck %s
+// RUN: %cladclang -O1 %s  -I%S/../../include -oEnzymeGradients.out 2>&1 | %filecheck %s
 // RUN: ./EnzymeGradients.out | %filecheck_exec %s
 // REQUIRES: Enzyme
+
+// Built at -O1: Enzyme does not run correctly at -O0. See
+// LoopsReverseModeComparisonWithClad.C for the details; at -O0 this file also
+// prints a negative zero where the expectations say 0.00.
 
 #include "clad/Differentiator/Differentiator.h"
 #include <cmath>

--- a/test/Enzyme/LoopsReverseModeComparisonWithClad.C
+++ b/test/Enzyme/LoopsReverseModeComparisonWithClad.C
@@ -1,6 +1,13 @@
-// RUN: %cladclang %s -I%S/../../include -oEnzymeLoops.out 2>&1 | %filecheck %s
+// RUN: %cladclang -O1 %s -I%S/../../include -oEnzymeLoops.out 2>&1 | %filecheck %s
 // RUN: ./EnzymeLoops.out | %filecheck_exec %s
 // REQUIRES: Enzyme
+
+// Built at -O1: Enzyme does not run correctly at -O0. It expects to see IR
+// that has been through its pre-simplification and the early optimizer, and
+// on unoptimized IR it silently returns a zero gradient for some control flow
+// -- fn13 below is one such case, and it reproduces with the standalone
+// ClangEnzyme plugin with no clad involved. -O0 is also the least
+// representative setting for a backend whose purpose is optimized code.
 
 #include "clad/Differentiator/Differentiator.h"
 #include <cmath>

--- a/test/Enzyme/PipelineOptIn.C
+++ b/test/Enzyme/PipelineOptIn.C
@@ -1,0 +1,32 @@
+// RUN: %cladclang -O1 -Xclang -fdebug-pass-manager %s -I%S/../../include \
+// RUN:   -oPipelineOptIn.out 2>&1 | %filecheck %s
+// RUN: ./PipelineOptIn.out | %filecheck_exec %s
+// REQUIRES: Enzyme
+
+// Enzyme's passes belong only in a translation unit that asked for them.
+// clad has finished deriving by the time clang builds the backend pipeline,
+// so the plugin registers Enzyme only when something here named the backend.
+// Compiling everything else through a third party pipeline is not clad's to
+// decide on the user's behalf.
+//
+// This file does ask, so the passes are expected. Nothing.C is the other half.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+double f(double x, double y) { return x * x * y; }
+
+// What is registered is Enzyme's canonical pipeline, not a bare pass spliced
+// in at pipeline start: its own pre-simplification runs with it. Order-free,
+// since where each lands in the pipeline is Enzyme's business, not clad's.
+// CHECK-DAG: Running pass: PreserveNVVM
+// CHECK-DAG: Running pass: EnzymeNewPM
+
+int main() {
+  auto g = clad::gradient<clad::opts::use_enzyme>(f);
+  double dx = 0, dy = 0;
+  g.execute(3, 4, &dx, &dy);
+  printf("{%.2f, %.2f}\n", dx, dy);
+  // CHECK-EXEC: {24.00, 9.00}
+}

--- a/test/Enzyme/PipelineOptOut.C
+++ b/test/Enzyme/PipelineOptOut.C
@@ -1,0 +1,26 @@
+// RUN: %cladclang -O1 -Xclang -fdebug-pass-manager %s -I%S/../../include \
+// RUN:   -oPipelineOptOut.out 2>&1 | %filecheck %s
+// RUN: ./PipelineOptOut.out | %filecheck_exec %s
+// REQUIRES: Enzyme
+
+// The other half of PipelineOptIn.C: an ordinary clad gradient in a build
+// that has the Enzyme backend compiled in. Nothing here names that backend,
+// so its passes are asked for and then declined -- the decision is made per
+// module, when the pass would run, rather than once per process.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+double f(double x, double y) { return x * x * y; }
+
+// CHECK: Skipping pass: EnzymeNewPM
+// CHECK-NOT: Running pass: EnzymeNewPM
+
+int main() {
+  auto g = clad::gradient(f);
+  double dx = 0, dy = 0;
+  g.execute(3, 4, &dx, &dy);
+  printf("{%.2f, %.2f}\n", dx, dy);
+  // CHECK-EXEC: {24.00, 9.00}
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -77,12 +77,6 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
 
     set(_enzyme_build_type ${CMAKE_CFG_INTDIR})
 
-    set(_enzyme_patch_command
-      ${CMAKE_COMMAND} -E copy_if_different
-      ${CMAKE_SOURCE_DIR}/patches/enzyme.patch <SOURCE_DIR> &&
-      git checkout <SOURCE_DIR> && git apply <SOURCE_DIR>/enzyme.patch
-      )
-
     # Set build byproducts only needed by Ninja.
     set(_enzyme_static_target EnzymeStatic-${LLVM_VERSION_MAJOR})
     set(_enzyme_static_archive_name ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}${CMAKE_STATIC_LIBRARY_PREFIX}${_enzyme_static_target}${CMAKE_STATIC_LIBRARY_SUFFIX})
@@ -99,11 +93,22 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
       Enzyme
       GIT_REPOSITORY https://github.com/EnzymeAD/Enzyme
       GIT_TAG v0.0.224
-      PATCH_COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_BINARY_DIR}/tools/Enzyme-prefix/src/Enzyme/enzyme/benchmarks
-      #PATCH_COMMAND #${_enzyme_patch_command}
       UPDATE_COMMAND ""
+      # The tag is pinned, so there is nothing to update, and leaving the step
+      # connected costs a great deal: an empty UPDATE_COMMAND never creates
+      # its stamp, so ninja finds it dirty and re-runs patch, configure, build
+      # and install on every single build -- 23s where there is no work to do.
+      # Disconnecting it also disconnects the patch step, so after editing
+      # patches/enzyme.patch run `ninja Enzyme-patch` to re-apply it.
+      UPDATE_DISCONNECTED 1
       EXTRA_CMAKE_ARGS ${EXTRA_CMAKE_ARGS}
       SOURCE_SUBDIR enzyme
+      # Let Enzyme's own build decide what needs rebuilding, so editing its
+      # sources is picked up. A stamp cannot do that: it has no idea what the
+      # sub-project depends on. This is only affordable because the update
+      # step is disconnected -- left connected it drags patch, configure and
+      # install along with it on every build.
+      BUILD_ALWAYS 1
       BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${_enzyme_build_type} --target ${_enzyme_static_target} -- -j8
       #TEST_COMMAND ${CMAKE_COMMAND} --build . --config ${_enzyme_build_type} --target check-enzyme
       #TEST_BEFORE_INSTALL 1
@@ -111,6 +116,25 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
       BUILD_BYPRODUCTS ${ENZYME_BYPRODUCTS}
       DEPENDS LLVMSupport
     )
+
+    # Apply the patch from a step of our own rather than PATCH_COMMAND. The
+    # built-in patch step hangs off update, which CMake declares ALWAYS, so it
+    # is disconnected along with it and stops tracking anything. Hung off
+    # download instead it stays in the graph, and DEPENDS on the patch file
+    # rebuilds Enzyme whenever the patch changes.
+    ExternalProject_Add_Step(Enzyme clad-patch
+      COMMAND ${CMAKE_COMMAND} -E rm -rf <SOURCE_DIR>/enzyme/benchmarks
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              ${CMAKE_SOURCE_DIR}/patches/enzyme.patch <SOURCE_DIR>
+      # Reset first, so re-running the step is safe and editing the patch is
+      # all it takes to change what gets built.
+      COMMAND git -C <SOURCE_DIR> checkout -- enzyme
+      COMMAND git -C <SOURCE_DIR> apply enzyme.patch
+      DEPENDEES download
+      DEPENDERS configure
+      DEPENDS ${CMAKE_SOURCE_DIR}/patches/enzyme.patch
+      COMMENT "Applying clad's patch to Enzyme"
+      LOG 1)
 
     # Register LLVMEnzyme for our build system.
     add_library(LLVMEnzyme IMPORTED STATIC GLOBAL)

--- a/tools/ClangBackendPlugin.cpp
+++ b/tools/ClangBackendPlugin.cpp
@@ -8,6 +8,11 @@
 
 #include "ClangBackendPlugin.h"
 
+#include "clad/Differentiator/Compatibility.h"
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassInstrumentation.h"
+
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/llvm-config.h" // for CLANG_VERSION_MAJOR
 #include "llvm/IR/PassManager.h"
@@ -23,7 +28,8 @@
 #include <string>
 
 #ifdef CLAD_ENABLE_ENZYME_BACKEND
-extern "C" void registerEnzyme(llvm::PassBuilder& PB);
+extern "C" void registerEnzymeAndPassPipeline(llvm::PassBuilder& PB,
+                                              bool augment);
 #endif // CLAD_ENABLE_ENZYME_BACKEND
 
 namespace clad {
@@ -32,26 +38,39 @@ void ClangBackendPluginPass::registerCallbacks(PassBuilder& PB) {
 // Enable backend plugins only with the new pass manager.
 #if CLANG_VERSION_MAJOR > 15
 #ifdef CLAD_ENABLE_ENZYME_BACKEND
-  registerEnzyme(PB);
+  // Register Enzyme's canonical pipeline: pre-simplification (loop rotation,
+  // GVN, SROA), EnzymeNewPM at the optimizer-early extension point, and the
+  // post cleanup. Splicing a bare "enzyme" pass at pipeline start hands
+  // Enzyme unoptimized IR, which it is neither designed nor tuned for.
+  registerEnzymeAndPassPipeline(PB, /*augment=*/true);
+
+  // Enzyme's passes are registered for every compilation, but only a module
+  // that actually contains a request needs them. Decide per module rather
+  // than per process: a session-based host compiles many modules through one
+  // plugin, so anything remembered across them would be wrong for all but the
+  // one that set it.
+  //
+  // Skipping requires the passes to be optional, which they are not upstream;
+  // patches/enzyme.patch makes them so. Without that patch the callback is
+  // simply never consulted and every module keeps the passes, as before.
+  if (PassInstrumentationCallbacks* PIC = PB.getPassInstrumentationCallbacks())
+    PIC->registerShouldRunOptionalPassCallback([](llvm::StringRef PassID,
+                                                  llvm::Any IR) {
+      if (!PassID.contains("Enzyme") && !PassID.contains("PreserveNVVM"))
+        return true;
+      // Both are module passes, so anything else is not ours to skip.
+      // The name is mangled -- clad declares the callee in C++ -- so
+      // look for it inside the symbol rather than at its start.
+      const auto* const* M = llvm::any_cast<const llvm::Module*>(&IR);
+      return !M || llvm::any_of((*M)->functions(), [](const llvm::Function& F) {
+        return F.getName().contains("__enzyme_autodiff");
+      });
+    });
 #endif // CLAD_ENABLE_ENZYME_BACKEND
-  // Pre
-  PB.registerPipelineStartEPCallback([&](llvm::ModulePassManager& MPM,
-                                         llvm::OptimizationLevel) {
-    MPM.addPass(ClangBackendPluginPass());
-    // registerEnzyme adds enzyme via registerPipelineParsingCallback,
-    // however, clang does not trigger this callback unless
-    // parsePassPipeline is called.
-#if CLAD_ENABLE_ENZYME_BACKEND
-    std::string Pipeline = "enzyme";
-    if (auto Err = PB.parsePassPipeline(MPM, Pipeline))
-      report_fatal_error(Twine("unable to parse pass pipeline description '") +
-                         Pipeline + "': " + toString(std::move(Err)));
-#endif // CLAD_ENABLE_ENZYME_BACKEND
-  });
-  // Post
-  // PB.registerOptimizerEarlyEPCallback(
-  //     [](ModulePassManager &MPM, OptimizationLevel) {
-  //     });
+  PB.registerPipelineStartEPCallback(
+      [&](llvm::ModulePassManager& MPM, llvm::OptimizationLevel) {
+        MPM.addPass(ClangBackendPluginPass());
+      });
 #endif // CLANG_VERSION_MAJOR > 15
 }
 } // namespace clad


### PR DESCRIPTION
clad spliced a bare "enzyme" pass in at PipelineStart, which hands Enzyme completely unoptimized IR. Enzyme is neither designed nor tuned for that: it expects to run after its own pre-simplification -- loop rotation, GVN, SROA -- and before the optimizer proper, so that the code it differentiates is already in the shape its analyses assume. Registering the canonical pipeline instead takes the GradBench GMM gradient from 22.1x the hand-written gradient to 2.64x, with the result unchanged to 2.3e-15.

Driving Enzyme the way it expects also means inheriting how it behaves: at -O0 it returns a zero gradient for some control flow, which reproduces with the standalone ClangEnzyme plugin and no clad involved. The two comparison tests therefore build at -O1, which is in any case the least artificial setting for a backend whose purpose is optimized code.

Registration alone would put Enzyme's passes in front of every translation unit the build compiles, whether or not it asks for them, and that should follow from what someone's code says rather than from how clad was configured. Registration cannot make that call -- the pipeline is built long after clad could refuse, and a session-based host such as clang-repl compiles many modules through one plugin, so anything remembered across them would be wrong for all but the module that set it. Decide when the pass would run instead, from the module in front of it, through LLVM's ShouldRunOptionalPass callback. That callback is only consulted for optional passes and Enzyme marks both of its module passes required, which is the right default for a standalone plugin; patches/enzyme.patch makes them optional here. Without the patch the callback is never consulted and every module keeps the passes, as before.

Carrying a patch means the build has to notice when it, or Enzyme's sources, change. Neither was true: an empty UPDATE_COMMAND never creates its stamp, so ninja found that step dirty forever and re-ran patch, configure, build and install behind it -- 23 seconds to rebuild nothing. Disconnecting it fixes that but also disconnects the built-in patch step, which hangs off update, so the patch is applied from a step of our own that hangs off download and depends on the patch file. Sources are covered by BUILD_ALWAYS, which hands the decision to Enzyme's own build and is affordable only once update is disconnected.

An ordinary gradient now runs none of Enzyme's passes rather than 190.