### PR TITLE
Assemble hessians from hessian-vector products

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -171,6 +171,18 @@ namespace clad {
     /// Returns true if `QT` is Array or Pointer Type, otherwise returns false.
     bool isArrayOrPointerType(clang::QualType QT);
 
+    /// \returns whether a hessian of \p FD can be assembled from
+    /// hessian-vector products rather than derived once per direction.
+    ///
+    /// The vector-product wrapper hands the pushforward its tangents and the
+    /// pullback its adjoints by position, so it needs the generated shape of
+    /// one tangent per parameter and nothing else in between. An instance
+    /// method also carries `this` and its adjoint, which the hessian matrix
+    /// has no place for. Both the planner and the hessian visitor ask this,
+    /// so that the derivatives the planner schedules are the ones the visitor
+    /// goes looking for.
+    bool canUseHessianVectorProducts(const clang::FunctionDecl* FD);
+
     /// Returns true if `T` is auto or auto* type, otherwise returns false.
     bool IsAutoOrAutoPtrType(clang::QualType T);
 

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -250,6 +250,12 @@ public:
   /// A flag specifying whether this differentiation is to be used
   /// for error estimation.
   bool EnableErrorEstimation = false;
+  /// Assemble the hessian from hessian-vector products -- one pushforward of
+  /// the function and one pullback of it -- instead of one second-order
+  /// function per direction. The planner decides this (and schedules the
+  /// pushforward); HessianModeVisitor only consumes the decision. Derived
+  /// from Function, Mode and Args, so excluded from request equality.
+  bool UseHessianVectorProducts = false;
   /// Puts the derived function and its code in the diff call
   void updateCall(clang::FunctionDecl* FD, clang::FunctionDecl* OverloadedFD,
                   clang::Sema& SemaRef);
@@ -325,6 +331,13 @@ public:
   ///   3) If no argument is provided, a default argument is used. The
   ///      function will be differentiated w.r.t. to its every parameter.
   void UpdateDiffParamsInfo(clang::Sema& semaRef);
+
+  /// The pushforward request a hessian assembled from hessian-vector products
+  /// consumes. One factory serves both sides: the planner schedules the
+  /// request this builds, and HessianModeVisitor builds it again to find that
+  /// scheduled derivative, so the two must stay structurally identical.
+  [[nodiscard]] DiffRequest
+  pushforwardRequestForHessian(clang::Sema& semaRef) const;
 
   /// Allow comparing DiffRequests.
   bool operator==(const DiffRequest& other) const {

--- a/include/clad/Differentiator/HessianModeVisitor.h
+++ b/include/clad/Differentiator/HessianModeVisitor.h
@@ -9,13 +9,20 @@
 
 #include "Compatibility.h"
 #include "VisitorBase.h"
+#include "clad/Differentiator/ParseDiffArgsTypes.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Sema/Sema.h"
 
+#include "llvm/ADT/SmallVector.h"
+
 #include <array>
+#include <cstddef>
 #include <stack>
+#include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace clad {
   /// A visitor for processing the function code to generate hessians
@@ -32,6 +39,36 @@ namespace clad {
           llvm::SmallVector<size_t, 16> IndependentArgsSize,
           size_t TotalIndependentArgsSize, const std::string& hessianFuncName,
           clang::DeclContext* FD, clang::QualType hessianFuncType);
+
+    /// Derives the pair of functions a hessian-vector product is built from:
+    /// a pushforward of the function, whose direction is a run-time argument,
+    /// and a pullback of that pushforward that takes adjoints for the
+    /// parameters in \p args. Only called when the planner committed to the
+    /// scheme (DiffRequest::UseHessianVectorProducts) and scheduled the
+    /// pushforward.
+    ///
+    /// \returns both, or a pair of nulls when either could not be built --
+    /// an error, since no per-direction derivatives were scheduled to fall
+    /// back on.
+    std::pair<clang::FunctionDecl*, clang::FunctionDecl*>
+    DeriveVectorProductFunctions(const DiffParams& args);
+
+    /// Builds `f_hessian` as a sequence of hessian-vector products.
+    ///
+    /// One pushforward of the function carries the direction as a run-time
+    /// argument, and one pullback of that pushforward, seeded with
+    /// `{.value = 0, .pushforward = 1}`, turns a direction into the matching
+    /// row of the hessian. So two derivatives serve every direction, and the
+    /// wrapper only has to seed a tangent and call. \p IndependentArgsSize
+    /// holds the number of requested directions per independent parameter, in
+    /// parameter order, and \p TotalIndependentArgsSize their sum -- the row
+    /// length of the hessian matrix.
+    DerivativeAndOverload BuildHessianFromVectorProducts(
+        clang::FunctionDecl* pushforwardFD, clang::FunctionDecl* pullbackFD,
+        const DiffParams& args, const IndexIntervalTable& indexIntervalTable,
+        llvm::SmallVector<size_t, 16> IndependentArgsSize,
+        size_t TotalIndependentArgsSize, const std::string& hessianFuncName,
+        clang::DeclContext* DC, clang::QualType hessianFunctionType);
 
   public:
     HessianModeVisitor(DerivativeBuilder& builder, const DiffRequest& request);

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -342,6 +342,27 @@ namespace clad {
       return QT->isArrayType() || QT->isPointerType();
     }
 
+    bool canUseHessianVectorProducts(const clang::FunctionDecl* FD) {
+      // The wrapper passes tangents and adjoints by position and the hessian
+      // matrix has no place for `this`.
+      if (const auto* MD = dyn_cast<CXXMethodDecl>(FD))
+        if (MD->isInstance())
+          return false;
+      for (const ParmVarDecl* PVD : FD->parameters()) {
+        QualType T = PVD->getType();
+        // The wrapper needs one tangent per parameter: a parameter the
+        // pushforward's signature filter skips leaves the wrapper and the
+        // pushforward disagreeing on positions.
+        if (!IsDifferentiableType(T))
+          return false;
+        // A reference tangent can be neither reseeded between directions nor
+        // zero-initialized for a parameter no direction runs through.
+        if (T->isReferenceType())
+          return false;
+      }
+      return true;
+    }
+
     bool isLinearConstructor(const clang::CXXConstructorDecl* CD,
                              const clang::ASTContext& C) {
       // Trivial constructors are linear

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -11,6 +11,7 @@
 #include "clad/Differentiator/Compatibility.h"
 #include "clad/Differentiator/DerivativeBuilder.h"
 #include "clad/Differentiator/DerivedFnCollector.h"
+#include "clad/Differentiator/ParseDiffArgsTypes.h"
 #include "clad/Differentiator/Timers.h"
 
 #include "clang/AST/ASTContext.h"
@@ -42,6 +43,7 @@
 #include "clang/Sema/SemaDiagnostic.h"
 #include "clang/Sema/TemplateDeduction.h"
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -563,6 +565,16 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       }
     }
     return m_NullTangentInfo.MaybeNullPtrs.count(VD) != 0;
+  }
+
+  DiffRequest DiffRequest::pushforwardRequestForHessian(Sema& semaRef) const {
+    DiffRequest pushforwardRequest = *this;
+    pushforwardRequest.Mode = DiffMode::pushforward;
+    pushforwardRequest.Args = nullptr;
+    pushforwardRequest.CallUpdateRequired = false;
+    pushforwardRequest.UseHessianVectorProducts = false;
+    pushforwardRequest.UpdateDiffParamsInfo(semaRef);
+    return pushforwardRequest;
   }
 
   void DiffRequest::UpdateDiffParamsInfo(Sema& semaRef) {
@@ -1367,6 +1379,26 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       } else if (const auto* CtorExpr = dyn_cast<CXXConstructExpr>(callSite)) {
         fnDecl = CtorExpr->getConstructor();
       }
+      // A synthesized request -- the pushforward of a hessian assembled from
+      // vector products -- carries the clad::hessian call as its context. Its
+      // callee is clad's own template, not the function being differentiated,
+      // and must not anchor the namespace lookup.
+      bool anchorsRequestFn = false;
+      if (const auto* ND = dyn_cast_or_null<NamedDecl>(fnDecl)) {
+        const Decl* underlying = ND->getUnderlyingDecl();
+        if (const auto* FTD = dyn_cast<FunctionTemplateDecl>(underlying))
+          underlying = FTD->getTemplatedDecl();
+        if (const auto* UFD = dyn_cast<FunctionDecl>(underlying)) {
+          const FunctionDecl* pattern =
+              request.Function->getTemplateInstantiationPattern();
+          anchorsRequestFn =
+              UFD->getCanonicalDecl() == request.Function->getCanonicalDecl() ||
+              (pattern &&
+               UFD->getCanonicalDecl() == pattern->getCanonicalDecl());
+        }
+      }
+      if (!anchorsRequestFn)
+        fnDecl = request.Function;
     } else
       fnDecl = request.Function;
     assert(request.Mode != DiffMode::unknown &&
@@ -1746,6 +1778,45 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
 
       if (request.Mode == DiffMode::hessian ||
           request.Mode == DiffMode::hessian_diagonal) {
+        // A hessian assembled from hessian-vector products needs one
+        // pushforward of the function, whose direction is a run-time
+        // argument. Schedule it here so that it is derived, and not merely
+        // declared, by the time HessianModeVisitor asks for its pullback: a
+        // pullback of a function whose body does not exist yet comes out
+        // empty. The decision is recorded on the request: the visitor
+        // consumes it and does not decide again, so the two sides cannot
+        // disagree.
+        request.UseHessianVectorProducts =
+            request.Mode == DiffMode::hessian &&
+            utils::canUseHessianVectorProducts(request.Function);
+
+        // A pointer parameter outside the requested set would get a null
+        // tangent, which forward mode only reads as zero through a const
+        // pointee. Derive per direction instead, which diagnoses the
+        // dependent non-const pointer rather than dereferencing null at run
+        // time.
+        if (request.UseHessianVectorProducts && request.Args)
+          for (const ParmVarDecl* PVD : request.Function->parameters()) {
+            QualType T = PVD->getType();
+            if (!utils::isArrayOrPointerType(T) ||
+                utils::GetValueType(T).isConstQualified())
+              continue;
+            bool requested = std::any_of(request.DVI.begin(), request.DVI.end(),
+                                         [PVD](const DiffInputVarInfo& dVar) {
+                                           return dVar.param == PVD;
+                                         });
+            if (!requested) {
+              request.UseHessianVectorProducts = false;
+              break;
+            }
+          }
+
+        // Build the per-direction forward requests up front: deriving per
+        // direction consumes them, and the vector-product scheme must first
+        // know that none of them resolves to a custom forward derivative,
+        // which only the per-direction scheme honors.
+        llvm::SmallVector<DiffRequest, 8> forwRequests;
+        bool hasCustomForwardDerivative = false;
         DiffRequest forwRequest = request;
         forwRequest.Mode = DiffMode::forward;
         forwRequest.CallUpdateRequired = false;
@@ -1768,18 +1839,37 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
               // writes on success; without this reset a direction with a
               // custom derivative leaks it into every direction after it.
               forwRequest.CustomDerivative = nullptr;
-              LookupCustomDerivativeDecl(forwRequest);
-              m_DiffRequestGraph.addNode(forwRequest, /*isSource=*/true);
+              hasCustomForwardDerivative |=
+                  LookupCustomDerivativeDecl(forwRequest);
+              forwRequests.push_back(forwRequest);
             }
           } else {
             forwRequest.Args = utils::CreateStringLiteral(
                 m_Sema.getASTContext(), PVD->getNameAsString());
             forwRequest.UpdateDiffParamsInfo(m_Sema);
             forwRequest.CustomDerivative = nullptr;
-            LookupCustomDerivativeDecl(forwRequest);
-            m_DiffRequestGraph.addNode(forwRequest, /*isSource=*/true);
+            hasCustomForwardDerivative |=
+                LookupCustomDerivativeDecl(forwRequest);
+            forwRequests.push_back(forwRequest);
           }
         }
+        if (hasCustomForwardDerivative)
+          request.UseHessianVectorProducts = false;
+
+        if (request.UseHessianVectorProducts) {
+          DiffRequest pushforwardRequest =
+              request.pushforwardRequestForHessian(m_Sema);
+          // A custom pushforward is free to take any shape, and the wrapper
+          // builds its calls by position; derive per direction instead.
+          if (LookupCustomDerivativeDecl(pushforwardRequest))
+            request.UseHessianVectorProducts = false;
+          else
+            m_DiffRequestGraph.addNode(pushforwardRequest, /*isSource=*/true);
+        }
+
+        if (!request.UseHessianVectorProducts)
+          for (DiffRequest& fr : forwRequests)
+            m_DiffRequestGraph.addNode(fr, /*isSource=*/true);
       }
     }
 

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -6,14 +6,20 @@
 
 #include "clad/Differentiator/HessianModeVisitor.h"
 
+#include "ConstantFolder.h"
+
 #include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/Compatibility.h"
+#include "clad/Differentiator/DerivativeBuilder.h"
 #include "clad/Differentiator/DiffPlanner.h"
 #include "clad/Differentiator/ErrorEstimator.h"
+#include "clad/Differentiator/ParseDiffArgsTypes.h"
 #include "clad/Differentiator/StmtClone.h"
 
 #include "clang/AST/Decl.h"
+#include "clang/AST/DeclarationName.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/OperationKinds.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/LLVM.h"
@@ -24,6 +30,7 @@
 #include "clang/Sema/SemaInternal.h"
 #include "clang/Sema/Template.h"
 
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -34,6 +41,7 @@
 #include <cstddef>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 using namespace clang;
@@ -94,6 +102,255 @@ static FunctionDecl* DeriveUsingForwardModeTwice(
   FunctionDecl* secondDerivative =
       Builder.FindDerivedFunction(IndependentArgRequest);
   return secondDerivative;
+}
+
+std::pair<FunctionDecl*, FunctionDecl*>
+HessianModeVisitor::DeriveVectorProductFunctions(const DiffParams& args) {
+  const FunctionDecl* FD = m_DiffReq.Function;
+
+  // The same factory built the request the planner scheduled, so this finds
+  // that derivative rather than starting a second one.
+  DiffRequest pushforwardReq = m_DiffReq.pushforwardRequestForHessian(m_Sema);
+  FunctionDecl* pushforwardFD = m_Builder.FindDerivedFunction(pushforwardReq);
+  // The wrapper builds its calls by position: one tangent per parameter.
+  if (!pushforwardFD || pushforwardFD->getNumParams() != 2 * FD->getNumParams())
+    return {nullptr, nullptr}; // LCOV_EXCL_LINE
+
+  DiffRequest pullbackReq{};
+  pullbackReq.Function = pushforwardFD;
+  pullbackReq.BaseFunctionName = pushforwardFD->getNameAsString();
+  pullbackReq.Mode = DiffMode::pullback;
+  pullbackReq.EnableTBRAnalysis = m_DiffReq.EnableTBRAnalysis;
+  pullbackReq.EnableVariedAnalysis = m_DiffReq.EnableVariedAnalysis;
+  // The user's checkpointing pragmas address the reverse pass, which in this
+  // scheme is the pullback; the per-direction scheme forwarded them to its
+  // reverse requests just the same.
+  pullbackReq.m_CladLoopCheckpoints = m_DiffReq.m_CladLoopCheckpoints;
+  // Adjoints for the parameters the hessian was requested for, in parameter
+  // order: those are the rows the wrapper fills in.
+  size_t numAdjoints = 0;
+  std::string subsetSuffix;
+  for (unsigned i = 0, e = FD->getNumParams(); i != e; ++i)
+    if (std::find(args.begin(), args.end(), FD->getParamDecl(i)) !=
+        args.end()) {
+      pullbackReq.DVI.push_back(pushforwardFD->getParamDecl(i));
+      ++numAdjoints;
+      subsetSuffix += "_" + std::to_string(i);
+    }
+  // A pullback w.r.t. a subset of the parameters is its own function: two
+  // subsets of equal size would otherwise produce two inline definitions
+  // with one signature and different bodies, of which the linker silently
+  // keeps one for both. Encode the subset the way restricted grads and
+  // hessians encode theirs.
+  if (numAdjoints != FD->getNumParams())
+    pullbackReq.BaseFunctionName += subsetSuffix;
+
+  FunctionDecl* pullbackFD = m_Builder.HandleNestedDiffRequest(pullbackReq);
+  // The wrapper builds the call by position, so anything but
+  // `(pushforward parameters..., _d_y, adjoints...)` is not ours to call.
+  if (!pullbackFD || pullbackFD->getNumParams() !=
+                         pushforwardFD->getNumParams() + 1 + numAdjoints)
+    return {nullptr, nullptr}; // LCOV_EXCL_LINE
+  return {pushforwardFD, pullbackFD};
+}
+
+DerivativeAndOverload HessianModeVisitor::BuildHessianFromVectorProducts(
+    FunctionDecl* pushforwardFD, FunctionDecl* pullbackFD,
+    const DiffParams& args, const IndexIntervalTable& indexIntervalTable,
+    llvm::SmallVector<size_t, 16> IndependentArgsSize,
+    size_t TotalIndependentArgsSize, const std::string& hessianFuncName,
+    DeclContext* DC, QualType hessianFunctionType) {
+  const FunctionDecl* FD = m_DiffReq.Function;
+  const unsigned numParams = FD->getNumParams();
+
+  // Where each parameter sits in the request: its place in `args` (which
+  // `indexIntervalTable` is keyed by) and its place among the requested
+  // parameters (which `IndependentArgsSize` is keyed by, in parameter order).
+  llvm::SmallVector<int, 8> posInArgs(numParams, -1);
+  llvm::SmallVector<int, 8> posInRequested(numParams, -1);
+  int requested = 0;
+  for (unsigned i = 0; i != numParams; ++i) {
+    const auto* it = std::find(args.begin(), args.end(), FD->getParamDecl(i));
+    if (it == args.end())
+      continue;
+    posInArgs[i] = static_cast<int>(it - args.begin());
+    posInRequested[i] = requested++;
+  }
+
+  IdentifierInfo* II = &m_Context.Idents.get(hessianFuncName);
+  DeclarationNameInfo name(II, noLoc);
+
+  llvm::SaveAndRestore<DeclContext*> SaveContext(m_Sema.CurContext);
+  llvm::SaveAndRestore<Scope*> SaveScope(getCurrentScope(),
+                                         getEnclosingNamespaceOrTUScope());
+  m_Sema.CurContext = DC;
+
+  // `result` owns the namespace Scopes cloneFunction opens; its destructor
+  // pops them before SaveScope restores.
+  ClonedFunction result = m_Builder.cloneFunction(
+      m_DiffReq.Function, *this, DC, noLoc, name, hessianFunctionType);
+  FunctionDecl* hessianFD = result.fd;
+
+  beginScope(Scope::FunctionPrototypeScope | Scope::FunctionDeclarationScope |
+             Scope::DeclScope);
+  m_Sema.PushFunctionScope();
+  m_Sema.PushDeclContext(getCurrentScope(), hessianFD);
+
+  llvm::ArrayRef<QualType> paramTypes =
+      llvm::cast<FunctionProtoType>(hessianFunctionType)->getParamTypes();
+  llvm::SmallVector<ParmVarDecl*, 4> params(paramTypes.size());
+  std::transform(m_DiffReq->param_begin(), m_DiffReq->param_end(),
+                 std::begin(params), [&](const ParmVarDecl* PVD) {
+                   auto* VD = ParmVarDecl::Create(
+                       m_Context, hessianFD, noLoc, noLoc, PVD->getIdentifier(),
+                       PVD->getType(), PVD->getTypeSourceInfo(),
+                       PVD->getStorageClass(),
+                       /*DefArg=*/nullptr);
+                   if (VD->getIdentifier())
+                     m_Sema.PushOnScopeChains(VD, getCurrentScope(),
+                                              /*AddToContext=*/false);
+                   return VD;
+                 });
+  params.back() = ParmVarDecl::Create(
+      m_Context, hessianFD, noLoc, noLoc,
+      &m_Context.Idents.get("hessianMatrix"), paramTypes.back(),
+      m_Context.getTrivialTypeSourceInfo(paramTypes.back(), noLoc),
+      params.front()->getStorageClass(), /*DefArg=*/nullptr);
+  if (params.back()->getIdentifier())
+    m_Sema.PushOnScopeChains(params.back(), getCurrentScope(),
+                             /*AddToContext=*/false);
+  hessianFD->setParams(clad_compat::makeArrayRef(params.data(), params.size()));
+  Expr* Result = BuildDeclRef(params.back());
+
+  beginScope(Scope::FnScope | Scope::DeclScope);
+  m_DerivativeFnScope = getCurrentScope();
+
+  std::vector<Stmt*> block;
+
+  // The seed that picks the pushforward out of the returned pair: the adjoint
+  // of the value is zero, the adjoint of the directional derivative is one, so
+  // the pullback returns the derivative of the directional derivative.
+  QualType seedType = pullbackFD->getParamDecl(2 * numParams)->getType();
+  VarDecl* seedVD = BuildVarDecl(seedType, "_d_y", getZeroInit(seedType),
+                                 /*DirectInit=*/true);
+  block.push_back(BuildDeclStmt(seedVD));
+  Expr* seedRef = BuildDeclRef(seedVD);
+  QualType dblType = m_Context.DoubleTy;
+  block.push_back(BuildOp(
+      BO_Assign,
+      utils::BuildMemberExpr(m_Sema, getCurrentScope(), seedRef, "pushforward"),
+      ConstantFolder::synthesizeLiteral(dblType, m_Context, /*val=*/1)));
+
+  // One tangent per parameter, reused across directions: the loop seeds a
+  // single entry and clears it again. A parameter no direction runs through
+  // keeps a zero tangent -- for a pointer that is a null tangent, which
+  // forward mode reads as an identically zero derivative.
+  llvm::SmallVector<Expr*, 8> tangents(numParams);
+  for (unsigned i = 0; i != numParams; ++i) {
+    QualType tangentType =
+        pushforwardFD->getParamDecl(numParams + i)->getType();
+    if (posInArgs[i] < 0) {
+      tangents[i] = getZeroInit(tangentType);
+      continue;
+    }
+    QualType paramType = FD->getParamDecl(i)->getType();
+    // The seeding assignments below need the variable mutable even when the
+    // parameter (and with it the pushforward's tangent) is const.
+    QualType storageType = utils::GetNonConstValueType(tangentType);
+    if (utils::isArrayOrPointerType(paramType)) {
+      // Indices are seeded in place, so the buffer has to reach the last
+      // requested one.
+      QualType elemType = utils::GetNonConstValueType(paramType);
+      QualType sizeType = clad_compat::getSizeType(m_Context);
+      storageType = m_Context.getConstantArrayType(
+          elemType,
+          llvm::APInt(m_Context.getIntWidth(sizeType),
+                      indexIntervalTable[posInArgs[i]].Finish),
+          /*SizeExpr=*/nullptr, clad_compat::ArraySizeModifier_Normal,
+          /*IndexTypeQuals=*/0);
+    }
+    // Named after the parameter it is the tangent of, as elsewhere in clad.
+    VarDecl* VD = BuildVarDecl(storageType,
+                               "_d_" + FD->getParamDecl(i)->getNameAsString(),
+                               getZeroInit(storageType), /*DirectInit=*/true);
+    block.push_back(BuildDeclStmt(VD));
+    tangents[i] = BuildDeclRef(VD);
+  }
+
+  auto sizeType = clad_compat::getSizeType(m_Context);
+  auto sizeTypeBits = m_Context.getIntWidth(sizeType);
+
+  // Row `d` of the hessian is the pullback seeded with the direction `e_d`.
+  // Unrolling keeps the mixed scalar-and-array case simple; each direction
+  // costs three statements rather than a function of its own.
+  size_t row = 0;
+  for (unsigned i = 0; i != numParams; ++i) {
+    if (posInArgs[i] < 0)
+      continue;
+    bool isArray = utils::isArrayOrPointerType(FD->getParamDecl(i)->getType());
+    size_t start = isArray ? indexIntervalTable[posInArgs[i]].Start : 0;
+    size_t finish = isArray ? indexIntervalTable[posInArgs[i]].Finish : 1;
+
+    for (size_t idx = start; idx != finish; ++idx, ++row) {
+      // The tangent entry this direction seeds.
+      Expr* seeded = CloneNode(tangents[i]);
+      if (isArray) {
+        Expr* idxExpr = ConstantFolder::synthesizeLiteral(sizeType, m_Context,
+                                                          /*val=*/idx);
+        seeded = BuildArraySubscript(seeded, idxExpr);
+      }
+      block.push_back(BuildOp(
+          BO_Assign, seeded,
+          ConstantFolder::synthesizeLiteral(dblType, m_Context, /*val=*/1)));
+
+      llvm::SmallVector<Expr*, 16> callArgs;
+      for (unsigned p = 0; p != numParams; ++p)
+        callArgs.push_back(BuildDeclRef(params[p]));
+      for (unsigned p = 0; p != numParams; ++p)
+        callArgs.push_back(CloneNode(tangents[p]));
+      callArgs.push_back(CloneNode(seedRef));
+      // The adjoints are the row itself: each requested parameter owns the
+      // stretch of the row that the per-direction scheme gives it, so the
+      // pullback can accumulate straight into the matrix.
+      size_t column = 0;
+      for (unsigned p = 0; p != numParams; ++p) {
+        if (posInRequested[p] < 0)
+          continue;
+        llvm::APInt offset(sizeTypeBits,
+                           row * TotalIndependentArgsSize + column);
+        Expr* offsetArg =
+            IntegerLiteral::Create(m_Context, offset, sizeType, noLoc);
+        callArgs.push_back(BuildOp(BO_Add, CloneNode(Result), offsetArg));
+        column += IndependentArgsSize[posInRequested[p]];
+      }
+      block.push_back(BuildCallExprToFunction(pullbackFD, callArgs));
+
+      // Clear the seed so the next direction starts from e_0.
+      Expr* cleared = CloneNode(tangents[i]);
+      if (isArray) {
+        Expr* idxExpr = ConstantFolder::synthesizeLiteral(sizeType, m_Context,
+                                                          /*val=*/idx);
+        cleared = BuildArraySubscript(cleared, idxExpr);
+      }
+      block.push_back(BuildOp(
+          BO_Assign, cleared,
+          ConstantFolder::synthesizeLiteral(dblType, m_Context, /*val=*/0)));
+    }
+  }
+
+  auto stmtsRef = clad_compat::makeArrayRef(block.data(), block.size());
+  CompoundStmt* CS = clad_compat::CompoundStmt_Create(
+      m_Context,
+      stmtsRef /**/ CLAD_COMPAT_CLANG15_CompoundStmt_Create_ExtraParam2(
+          clang::FPOptionsOverride()),
+      noLoc, noLoc);
+  hessianFD->setBody(CS);
+  endScope(); // Function body scope
+  m_Sema.PopFunctionScopeInfo();
+  m_Sema.PopDeclContext();
+  endScope(); // Function decl scope
+
+  return DerivativeAndOverload{result.fd, /*OverloadFunctionDecl=*/nullptr};
 }
 
 DerivativeAndOverload HessianModeVisitor::Derive() {
@@ -185,6 +442,31 @@ DerivativeAndOverload HessianModeVisitor::Derive() {
       IndependentArgsSize.push_back(1);
       TotalIndependentArgsSize++;
     }
+  }
+
+  // Deriving per direction emits one second-order function per direction, each
+  // the size of a gradient, so the code grows as the square of the parameter
+  // count. A hessian-vector product carries the direction at run time instead
+  // and needs the same two derivatives however many directions are requested.
+  // The planner made that choice and scheduled the pushforward accordingly;
+  // per-direction derivatives were not scheduled, so there is no falling back.
+  if (m_DiffReq.UseHessianVectorProducts) {
+    FunctionDecl* pushforwardFD = nullptr;
+    FunctionDecl* pullbackFD = nullptr;
+    std::tie(pushforwardFD, pullbackFD) = DeriveVectorProductFunctions(args);
+    if (!pullbackFD) {
+      // LCOV_EXCL_START
+      diag(DiagnosticsEngine::Error, m_DiffReq.CallContext->getBeginLoc(),
+           "failed to assemble the hessian of '%0' from hessian-vector "
+           "products")
+          << FD->getNameAsString();
+      return {};
+      // LCOV_EXCL_STOP
+    }
+    return BuildHessianFromVectorProducts(
+        pushforwardFD, pullbackFD, args, indexIntervalTable,
+        IndependentArgsSize, TotalIndependentArgsSize, hessianFuncName, DC,
+        hessianFunctionType);
   }
 
   // Ascertains the independent arguments and differentiates the function

--- a/test/Hessian/Arrays.C
+++ b/test/Hessian/Arrays.C
@@ -6,17 +6,37 @@
 #include "clad/Differentiator/Differentiator.h"
 
 double f(double i, double j[2]) { return i * j[0] * j[1]; }
-// CHECK: void f_hessian(double i, double j[2], double *hessianMatrix) {
-// CHECK-NEXT:     f_darg0_grad(i, j, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-// CHECK-NEXT:     f_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL|3ULL}}, hessianMatrix + {{4U|4UL|4ULL}});
-// CHECK-NEXT:     f_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL|6ULL}}, hessianMatrix + {{7U|7UL|7ULL}});
+// CHECK: inline void f_hessian(double i, double j[2], double *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     double _d_i(0.);
+// CHECK-NEXT:     double _d_j[2]{0};
+// CHECK-NEXT:     _d_i = 1.;
+// CHECK-NEXT:     f_pushforward_pullback(i, j, _d_i, _d_j, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     _d_i = 0.;
+// CHECK-NEXT:     _d_j[{{0U|0UL|0ULL}}] = 1.;
+// CHECK-NEXT:     f_pushforward_pullback(i, j, _d_i, _d_j, _d_y, hessianMatrix + {{3U|3UL|3ULL}}, hessianMatrix + {{4U|4UL|4ULL}});
+// CHECK-NEXT:     _d_j[{{0U|0UL|0ULL}}] = 0.;
+// CHECK-NEXT:     _d_j[{{1U|1UL|1ULL}}] = 1.;
+// CHECK-NEXT:     f_pushforward_pullback(i, j, _d_i, _d_j, _d_y, hessianMatrix + {{6U|6UL|6ULL}}, hessianMatrix + {{7U|7UL|7ULL}});
+// CHECK-NEXT:     _d_j[{{1U|1UL|1ULL}}] = 0.;
 // CHECK-NEXT: }
 
 double g(double i, double j[2]) { return i * (j[0] + j[1]); }
-// CHECK: void g_hessian(double i, double j[2], double *hessianMatrix) {
-// CHECK-NEXT:   g_darg0_grad(i, j, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-// CHECK-NEXT:   g_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL|3ULL}}, hessianMatrix + {{4U|4UL|4ULL}});
-// CHECK-NEXT:   g_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL|6ULL}}, hessianMatrix + {{7U|7UL|7ULL}});
+// CHECK: inline void g_hessian(double i, double j[2], double *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     double _d_i(0.);
+// CHECK-NEXT:     double _d_j[2]{0};
+// CHECK-NEXT:     _d_i = 1.;
+// CHECK-NEXT:     g_pushforward_pullback(i, j, _d_i, _d_j, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     _d_i = 0.;
+// CHECK-NEXT:     _d_j[{{0U|0UL|0ULL}}] = 1.;
+// CHECK-NEXT:     g_pushforward_pullback(i, j, _d_i, _d_j, _d_y, hessianMatrix + {{3U|3UL|3ULL}}, hessianMatrix + {{4U|4UL|4ULL}});
+// CHECK-NEXT:     _d_j[{{0U|0UL|0ULL}}] = 0.;
+// CHECK-NEXT:     _d_j[{{1U|1UL|1ULL}}] = 1.;
+// CHECK-NEXT:     g_pushforward_pullback(i, j, _d_i, _d_j, _d_y, hessianMatrix + {{6U|6UL|6ULL}}, hessianMatrix + {{7U|7UL|7ULL}});
+// CHECK-NEXT:     _d_j[{{1U|1UL|1ULL}}] = 0.;
 // CHECK-NEXT: }
 
 double h(double arr[3], double weights[3], double multiplier) {
@@ -27,14 +47,14 @@ double h(double arr[3], double weights[3], double multiplier) {
   weightedSum *= multiplier;
   return weightedSum * weightedSum;
 }
-// CHECK: void h_hessian_diagonal(double arr[3], double weights[3], double multiplier, double *diagonalHessianVector) {
-// CHECK-NEXT:   *(diagonalHessianVector + 0{{U|UL}}) = h_d2arg0_0(arr, weights, multiplier);
-// CHECK-NEXT:   *(diagonalHessianVector + 1{{U|UL}}) = h_d2arg0_1(arr, weights, multiplier);
-// CHECK-NEXT:   *(diagonalHessianVector + 2{{U|UL}}) = h_d2arg0_2(arr, weights, multiplier);
-// CHECK-NEXT:   *(diagonalHessianVector + 3{{U|UL}}) = h_d2arg1_0(arr, weights, multiplier);
-// CHECK-NEXT:   *(diagonalHessianVector + 4{{U|UL}}) = h_d2arg1_1(arr, weights, multiplier);
-// CHECK-NEXT:   *(diagonalHessianVector + 5{{U|UL}}) = h_d2arg1_2(arr, weights, multiplier);
-// CHECK-NEXT:   *(diagonalHessianVector + 6{{U|UL}}) = h_d2arg2(arr, weights, multiplier);
+// CHECK: inline void h_hessian_diagonal(double arr[3], double weights[3], double multiplier, double *diagonalHessianVector) {
+// CHECK-NEXT:     *(diagonalHessianVector + {{0U|0UL|0ULL}}) = h_d2arg0_0(arr, weights, multiplier);
+// CHECK-NEXT:     *(diagonalHessianVector + {{1U|1UL|1ULL}}) = h_d2arg0_1(arr, weights, multiplier);
+// CHECK-NEXT:     *(diagonalHessianVector + {{2U|2UL|2ULL}}) = h_d2arg0_2(arr, weights, multiplier);
+// CHECK-NEXT:     *(diagonalHessianVector + {{3U|3UL|3ULL}}) = h_d2arg1_0(arr, weights, multiplier);
+// CHECK-NEXT:     *(diagonalHessianVector + {{4U|4UL|4ULL}}) = h_d2arg1_1(arr, weights, multiplier);
+// CHECK-NEXT:     *(diagonalHessianVector + {{5U|5UL|5ULL}}) = h_d2arg1_2(arr, weights, multiplier);
+// CHECK-NEXT:     *(diagonalHessianVector + {{6U|6UL|6ULL}}) = h_d2arg2(arr, weights, multiplier);
 // CHECK-NEXT: }
 
 #define TEST(var, i, j)                                                        \

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -12,33 +12,41 @@ float f1(float x) {
 }
 
 
-// CHECK: float f1_darg0(float x) {
-// CHECK-NEXT:     float _d_x = 1;
+// CHECK: inline clad::ValueAndPushforward<float, float> f1_pushforward(float x, float _d_x) {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::std::sin_pushforward(x, _d_x);
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t1 = clad::custom_derivatives::std::cos_pushforward(x, _d_x);
-// CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
+// CHECK-NEXT:     return {_t0.value + _t1.value, _t0.pushforward + _t1.pushforward};
 // CHECK-NEXT: }
 
-// CHECK: void f1_darg0_grad(float x, float *_d_x);
+// CHECK: inline void f1_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0);
 
-// CHECK: void f1_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f1_darg0_grad(x, hessianMatrix + {{0U|0UL|0ULL}});
+// CHECK: inline void f1_hessian(float x, float *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _d_y{0.F, 0.F};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     float _d_x(0.F);
+// CHECK-NEXT:     _d_x = 1.;
+// CHECK-NEXT:     f1_pushforward_pullback(x, _d_x, _d_y, hessianMatrix + {{0U|0UL|0ULL}});
+// CHECK-NEXT:     _d_x = 0.;
 // CHECK-NEXT: }
 
 float f2(float x) {
   return exp(x);
 }
 
-// CHECK: float f2_darg0(float x) {
-// CHECK-NEXT:     float _d_x = 1;
+// CHECK: inline clad::ValueAndPushforward<float, float> f2_pushforward(float x, float _d_x) {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::std::exp_pushforward(x, _d_x);
-// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT:     return {_t0.value, _t0.pushforward};
 // CHECK-NEXT: }
 
-// CHECK: void f2_darg0_grad(float x, float *_d_x);
+// CHECK: inline void f2_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0);
 
-// CHECK: void f2_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f2_darg0_grad(x, hessianMatrix + {{0U|0UL|0ULL}});
+// CHECK: inline void f2_hessian(float x, float *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _d_y{0.F, 0.F};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     float _d_x(0.F);
+// CHECK-NEXT:     _d_x = 1.;
+// CHECK-NEXT:     f2_pushforward_pullback(x, _d_x, _d_y, hessianMatrix + {{0U|0UL|0ULL}});
+// CHECK-NEXT:     _d_x = 0.;
 // CHECK-NEXT: }
 
 
@@ -46,16 +54,20 @@ float f3(float x) {
   return log(x);
 }
 
-// CHECK: float f3_darg0(float x) {
-// CHECK-NEXT:     float _d_x = 1;
+// CHECK: inline clad::ValueAndPushforward<float, float> f3_pushforward(float x, float _d_x) {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::std::log_pushforward(x, _d_x);
-// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT:     return {_t0.value, _t0.pushforward};
 // CHECK-NEXT: }
 
-// CHECK: void f3_darg0_grad(float x, float *_d_x);
+// CHECK: inline void f3_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0);
 
-// CHECK: void f3_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f3_darg0_grad(x, hessianMatrix + {{0U|0UL|0ULL}});
+// CHECK: inline void f3_hessian(float x, float *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _d_y{0.F, 0.F};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     float _d_x(0.F);
+// CHECK-NEXT:     _d_x = 1.;
+// CHECK-NEXT:     f3_pushforward_pullback(x, _d_x, _d_y, hessianMatrix + {{0U|0UL|0ULL}});
+// CHECK-NEXT:     _d_x = 0.;
 // CHECK-NEXT: }
 
 
@@ -63,16 +75,20 @@ float f4(float x) {
   return pow(x, 4.0F);
 }
 
-// CHECK: float f4_darg0(float x) {
-// CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::std::pow_pushforward(x, 4.F, _d_x, 0.F);
-// CHECK-NEXT:     return _t0.pushforward;
+// CHECK: inline clad::ValueAndPushforward<float, float> f4_pushforward(float x, float _d_x) {
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::std::pow_pushforward(x, 4.F, _d_x, 0.F);
+// CHECK-NEXT:     return {_t0.value, _t0.pushforward};
 // CHECK-NEXT: }
 
-// CHECK: void f4_darg0_grad(float x, float *_d_x);
+// CHECK: inline void f4_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0);
 
-// CHECK: void f4_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f4_darg0_grad(x, hessianMatrix + {{0U|0UL|0ULL}});
+// CHECK: inline void f4_hessian(float x, float *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _d_y{0.F, 0.F};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     float _d_x(0.F);
+// CHECK-NEXT:     _d_x = 1.;
+// CHECK-NEXT:     f4_pushforward_pullback(x, _d_x, _d_y, hessianMatrix + {{0U|0UL|0ULL}});
+// CHECK-NEXT:     _d_x = 0.;
 // CHECK-NEXT: }
 
 
@@ -80,16 +96,20 @@ float f5(float x) {
   return pow(2.0F, x);
 }
 
-// CHECK: float f5_darg0(float x) {
-// CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::std::pow_pushforward(2.F, x, 0.F, _d_x);
-// CHECK-NEXT:     return _t0.pushforward;
+// CHECK: inline clad::ValueAndPushforward<float, float> f5_pushforward(float x, float _d_x) {
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::std::pow_pushforward(2.F, x, 0.F, _d_x);
+// CHECK-NEXT:     return {_t0.value, _t0.pushforward};
 // CHECK-NEXT: }
 
-// CHECK: void f5_darg0_grad(float x, float *_d_x);
+// CHECK: inline void f5_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0);
 
-// CHECK: void f5_hessian(float x, float *hessianMatrix) {
-// CHECK-NEXT:     f5_darg0_grad(x, hessianMatrix + {{0U|0UL|0ULL}});
+// CHECK: inline void f5_hessian(float x, float *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _d_y{0.F, 0.F};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     float _d_x(0.F);
+// CHECK-NEXT:     _d_x = 1.;
+// CHECK-NEXT:     f5_pushforward_pullback(x, _d_x, _d_y, hessianMatrix + {{0U|0UL|0ULL}});
+// CHECK-NEXT:     _d_x = 0.;
 // CHECK-NEXT: }
 
 
@@ -97,26 +117,25 @@ float f6(float x, float y) {
   return pow(x, y);
 }
 
-// CHECK: float f6_darg0(float x, float y) {
-// CHECK-NEXT:     float _d_x = 1;
-// CHECK-NEXT:     float _d_y = 0;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::std::pow_pushforward(x, y, _d_x, _d_y);
-// CHECK-NEXT:     return _t0.pushforward;
+// CHECK: inline clad::ValueAndPushforward<float, float> f6_pushforward(float x, float y, float _d_x, float _d_y) {
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::std::pow_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     return {_t0.value, _t0.pushforward};
 // CHECK-NEXT: }
 
-// CHECK: float f6_darg1(float x, float y) {
-// CHECK-NEXT:     float _d_x = 0;
-// CHECK-NEXT:     float _d_y = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::std::pow_pushforward(x, y, _d_x, _d_y);
-// CHECK-NEXT:     return _t0.pushforward;
-// CHECK-NEXT: }
 
-// CHECK: void f6_darg0_grad(float x, float y, float *_d_x, float *_d_y);
-// CHECK: void f6_darg1_grad(float x, float y, float *_d_x, float *_d_y);
+// CHECK: inline void f6_pushforward_pullback(float x, float y, float _d_x, float _d_y, clad::ValueAndPushforward<float, float> _d_y0, float *_d_x0, float *_d_y1);
 
-// CHECK: void f6_hessian(float x, float y, float *hessianMatrix) {
-// CHECK-NEXT:     f6_darg0_grad(x, y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-// CHECK-NEXT:     f6_darg1_grad(x, y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+// CHECK: inline void f6_hessian(float x, float y, float *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<float, float> _d_y{0.F, 0.F};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     float _d_x(0.F);
+// CHECK-NEXT:     float _d_y0(0.F);
+// CHECK-NEXT:     _d_x = 1.;
+// CHECK-NEXT:     f6_pushforward_pullback(x, y, _d_x, _d_y0, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     _d_x = 0.;
+// CHECK-NEXT:     _d_y0 = 1.;
+// CHECK-NEXT:     f6_pushforward_pullback(x, y, _d_x, _d_y0, _d_y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+// CHECK-NEXT:     _d_y0 = 0.;
 // CHECK-NEXT: }
 
 namespace clad {
@@ -146,12 +165,12 @@ float f7(float x, float y) {
   return sin(x) + exp(y);
 }
 
-// CHECK: void f7_darg0_grad(float x, float y, float *_d_x, float *_d_y);
+// CHECK:  void f7_darg0_grad(float x, float y, float *_d_x, float *_d_y);
 
-// CHECK: void f7_hessian(float x, float y, float *hessianMatrix) {
+// CHECK:  void f7_hessian(float x, float y, float *hessianMatrix) {
 // CHECK-NEXT:     clad::custom_derivatives::f7_darg0_grad(x, y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
 // CHECK-NEXT:     clad::custom_derivatives::f7_darg1_grad(x, y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
-// CHECK-NEXT: }
+// CHECK-NEXT:  }
 
 float f8(float x, float y) {
   return (x*x + y*y)/2 + x*y;
@@ -195,150 +214,125 @@ int main() {
   TEST2(f7, 3, 4); // CHECK-EXEC: Result is = {-0.14, 0.00, 0.00, 54.60}
   TEST2(f8, 3, 4); // CHECK-EXEC: Result is = {1.00, 1.00, 1.00, 1.00}
 
-// CHECK: void sin_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
+// CHECK: inline void sin_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
-// CHECK: void cos_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
+// CHECK: inline void cos_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
-// CHECK: void f1_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d_d_x = 0.F;
-// CHECK-NEXT:     float _d_x0 = 1;
+// CHECK: inline void f1_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0) {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::sin_pushforward(x, _d_x0);
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::sin_pushforward(x, _d_x);
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d_t1 = {0.F, 0.F};
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t10 = clad::custom_derivatives::std::cos_pushforward(x, _d_x0);
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t10 = clad::custom_derivatives::std::cos_pushforward(x, _d_x);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_t0.pushforward += 1;
-// CHECK-NEXT:         _d_t1.pushforward += 1;
+// CHECK-NEXT:         _d_t0.value += _d_y.value;
+// CHECK-NEXT:         _d_t1.value += _d_y.value;
+// CHECK-NEXT:         _d_t0.pushforward += _d_y.pushforward;
+// CHECK-NEXT:         _d_t1.pushforward += _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::cos_pushforward_pullback(x, _d_x0, _d_t1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r2;
-// CHECK-NEXT:         _d_d_x += _r3;
+// CHECK-NEXT:         clad::custom_derivatives::std::cos_pushforward_pullback(x, _d_x, _d_t1, &_r2, &_r3);
+// CHECK-NEXT:         *_d_x0 += _r2;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::sin_pushforward_pullback(x, _d_x0, _d_t0, &_r0, &_r1);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         _d_d_x += _r1;
+// CHECK-NEXT:         clad::custom_derivatives::std::sin_pushforward_pullback(x, _d_x, _d_t0, &_r0, &_r1);
+// CHECK-NEXT:         *_d_x0 += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void exp_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
+// CHECK: inline void exp_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
-// CHECK: void f2_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d_d_x = 0.F;
-// CHECK-NEXT:     float _d_x0 = 1;
+// CHECK: inline void f2_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0) {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::exp_pushforward(x, _d_x0);
-// CHECK-NEXT:     _d_t0.pushforward += 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::exp_pushforward(x, _d_x);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_t0.value += _d_y.value;
+// CHECK-NEXT:         _d_t0.pushforward += _d_y.pushforward;
+// CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::exp_pushforward_pullback(x, _d_x0, _d_t0, &_r0, &_r1);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         _d_d_x += _r1;
+// CHECK-NEXT:         clad::custom_derivatives::std::exp_pushforward_pullback(x, _d_x, _d_t0, &_r0, &_r1);
+// CHECK-NEXT:         *_d_x0 += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void log_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
+// CHECK: inline void log_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x);
 
-// CHECK: void f3_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d_d_x = 0.F;
-// CHECK-NEXT:     float _d_x0 = 1;
+// CHECK: inline void f3_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0) {
 // CHECK-NEXT:     ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
-// CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::log_pushforward(x, _d_x0);
-// CHECK-NEXT:     _d_t0.pushforward += 1;
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::log_pushforward(x, _d_x);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_t0.value += _d_y.value;
+// CHECK-NEXT:         _d_t0.pushforward += _d_y.pushforward;
+// CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::log_pushforward_pullback(x, _d_x0, _d_t0, &_r0, &_r1);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         _d_d_x += _r1;
+// CHECK-NEXT:         clad::custom_derivatives::std::log_pushforward_pullback(x, _d_x, _d_t0, &_r0, &_r1);
+// CHECK-NEXT:         *_d_x0 += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void pow_pushforward_pullback(float x, float exponent, float d_x, float d_exponent, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_exponent, float *_d_d_x, float *_d_d_exponent);
+// CHECK: inline void pow_pushforward_pullback(float x, float exponent, float d_x, float d_exponent, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_exponent, float *_d_d_x, float *_d_d_exponent);
 
-// CHECK: void f4_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d_d_x = 0.F;
-// CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(x, 4.F, _d_x0, 0.F);
-// CHECK-NEXT:     _d_t0.pushforward += 1;
+// CHECK: inline void f4_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0) {
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(x, 4.F, _d_x, 0.F);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         float _r0 = 0.F;
-// CHECK-NEXT:         float _r1 = 0.F;
-// CHECK-NEXT:         float _r2 = 0.F;
-// CHECK-NEXT:         float _r3 = 0.F;
-// CHECK-NEXT:         clad::custom_derivatives::std::pow_pushforward_pullback(x, 4.F, _d_x0, 0.F, _d_t0, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         _d_d_x += _r2;
+// CHECK-NEXT:         _d_t0.value += _d_y.value;
+// CHECK-NEXT:         _d_t0.pushforward += _d_y.pushforward;
 // CHECK-NEXT:     }
-// CHECK-NEXT: }
-
-// CHECK: void f5_darg0_grad(float x, float *_d_x) {
-// CHECK-NEXT:     float _d_d_x = 0.F;
-// CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(2.F, x, 0.F, _d_x0);
-// CHECK-NEXT:     _d_t0.pushforward += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
-// CHECK-NEXT:         {{.*}}pow_pushforward_pullback(2.F, x, 0.F, _d_x0, _d_t0, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r1;
-// CHECK-NEXT:         _d_d_x += _r3;
+// CHECK-NEXT:         clad::custom_derivatives::std::pow_pushforward_pullback(x, 4.F, _d_x, 0.F, _d_t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         *_d_x0 += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void f6_darg0_grad(float x, float y, float *_d_x, float *_d_y) {
-// CHECK-NEXT:     float _d_d_x = 0.F;
-// CHECK-NEXT:     float _d_x0 = 1;
-// CHECK-NEXT:     float _d_d_y = 0.F;
-// CHECK-NEXT:     float _d_y0 = 0;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(x, y, _d_x0, _d_y0);
-// CHECK-NEXT:     _d_t0.pushforward += 1;
+// CHECK: inline void f5_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0) {
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(2.F, x, 0.F, _d_x);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_t0.value += _d_y.value;
+// CHECK-NEXT:         _d_t0.pushforward += _d_y.pushforward;
+// CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
-// CHECK-NEXT:         {{.*}}pow_pushforward_pullback(x, y, _d_x0, _d_y0, _d_t0, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         *_d_y += _r1;
-// CHECK-NEXT:         _d_d_x += _r2;
-// CHECK-NEXT:         _d_d_y += _r3;
+// CHECK-NEXT:         clad::custom_derivatives::std::pow_pushforward_pullback(2.F, x, 0.F, _d_x, _d_t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         *_d_x0 += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void f6_darg1_grad(float x, float y, float *_d_x, float *_d_y) {
-// CHECK-NEXT:     float _d_d_x = 0.F;
-// CHECK-NEXT:     float _d_x0 = 0;
-// CHECK-NEXT:     float _d_d_y = 0.F;
-// CHECK-NEXT:     float _d_y0 = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(x, y, _d_x0, _d_y0);
-// CHECK-NEXT:     _d_t0.pushforward += 1;
+// CHECK: inline void f6_pushforward_pullback(float x, float y, float _d_x, float _d_y, clad::ValueAndPushforward<float, float> _d_y0, float *_d_x0, float *_d_y1) {
+// CHECK-NEXT:     ValueAndPushforward<float, float> _d_t0 = {0.F, 0.F};
+// CHECK-NEXT:     ValueAndPushforward<float, float> _t00 = clad::custom_derivatives::std::pow_pushforward(x, y, _d_x, _d_y);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_t0.value += _d_y0.value;
+// CHECK-NEXT:         _d_t0.pushforward += _d_y0.pushforward;
+// CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         float _r1 = 0.F;
 // CHECK-NEXT:         float _r2 = 0.F;
 // CHECK-NEXT:         float _r3 = 0.F;
-// CHECK-NEXT:         {{.*}}pow_pushforward_pullback(x, y, _d_x0, _d_y0, _d_t0, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         *_d_y += _r1;
-// CHECK-NEXT:         _d_d_x += _r2;
-// CHECK-NEXT:         _d_d_y += _r3;
+// CHECK-NEXT:         clad::custom_derivatives::std::pow_pushforward_pullback(x, y, _d_x, _d_y, _d_t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         *_d_x0 += _r0;
+// CHECK-NEXT:         *_d_y1 += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void f7_darg0_grad(float x, float y, float *_d_x, float *_d_y) {
+
+// CHECK:  void f7_darg0_grad(float x, float y, float *_d_x, float *_d_y) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
 // CHECK-NEXT:         _r0 += 1 * clad::custom_derivatives::std::cos_pushforward(x, 1.F).pushforward;
@@ -346,7 +340,7 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void sin_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
+// CHECK: inline void sin_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
 // CHECK-NEXT:     float _t0 = ::std::cos(x);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
@@ -359,7 +353,7 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void cos_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
+// CHECK: inline void cos_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
 // CHECK-NEXT:     float _t0 = ::std::sin(x);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
@@ -372,7 +366,7 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void exp_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
+// CHECK: inline void exp_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
 // CHECK-NEXT:     float _t0 = ::std::exp(x);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         float _r0 = 0.F;
@@ -385,23 +379,23 @@ int main() {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void log_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
-// CHECK-NEXT:    float _d_dlog = 0.F;
-// CHECK-NEXT:    float dlog = 1. / x;
-// CHECK-NEXT:    {
-// CHECK-NEXT:        float _r1 = 0.F;
-// CHECK-NEXT:        _r1 += _d_y.value * clad::custom_derivatives::std::log_pushforward(x, 1.F).pushforward;
-// CHECK-NEXT:        *_d_x += _r1;
-// CHECK-NEXT:        _d_dlog += _d_y.pushforward * d_x;
-// CHECK-NEXT:        *_d_d_x += dlog * _d_y.pushforward;
-// CHECK-NEXT:    }
-// CHECK-NEXT:    {
-// CHECK-NEXT:        double _r0 = _d_dlog * -(1. / (x * x));
-// CHECK-NEXT:        *_d_x += _r0;
-// CHECK-NEXT:    }
-// CHECK-NEXT:}
+// CHECK: inline void log_pushforward_pullback(float x, float d_x, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_d_x) {
+// CHECK-NEXT:     float _d_dlog = 0.F;
+// CHECK-NEXT:     float dlog = 1. / x;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         float _r1 = 0.F;
+// CHECK-NEXT:         _r1 += _d_y.value * clad::custom_derivatives::std::log_pushforward(x, 1.F).pushforward;
+// CHECK-NEXT:         *_d_x += _r1;
+// CHECK-NEXT:         _d_dlog += _d_y.pushforward * d_x;
+// CHECK-NEXT:         *_d_d_x += dlog * _d_y.pushforward;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = _d_dlog * -(1. / (x * x));
+// CHECK-NEXT:         *_d_x += _r0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
 
-// CHECK: void pow_pushforward_pullback(float x, float exponent, float d_x, float d_exponent, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_exponent, float *_d_d_x, float *_d_d_exponent) {
+// CHECK: inline void pow_pushforward_pullback(float x, float exponent, float d_x, float d_exponent, ValueAndPushforward<float, float> _d_y, float *_d_x, float *_d_exponent, float *_d_d_x, float *_d_d_exponent) {
 // CHECK-NEXT:     bool _cond0 = false;
 // CHECK-NEXT:     double _d_cond0;
 // CHECK-NEXT:     _d_cond0 = 0.;

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -8,37 +8,44 @@
 __attribute__((always_inline)) double f_cubed_add1(double a, double b) {
   return a * a * a + b * b * b;
 }
-//CHECK:{{[__attribute__((always_inline)) ]*}}double f_cubed_add1_darg0(double a, double b){{[ __attribute__((always_inline))]*}} {
-//CHECK-NEXT:    double _d_a = 1;
-//CHECK-NEXT:    double _d_b = 0;
+//CHECK:{{[__attribute__((always_inline)) ]*}}inline clad::ValueAndPushforward<double, double> f_cubed_add1_pushforward(double a, double b, double _d_a, double _d_b){{[ __attribute__((always_inline))]*}} {
 //CHECK-NEXT:    double _t0 = a * a;
 //CHECK-NEXT:    double _t1 = b * b;
-//CHECK-NEXT:    return (_d_a * a + a * _d_a) * a + _t0 * _d_a + (_d_b * b + b * _d_b) * b + _t1 * _d_b;
+//CHECK-NEXT:    return {_t0 * a + _t1 * b, (_d_a * a + a * _d_a) * a + _t0 * _d_a + (_d_b * b + b * _d_b) * b + _t1 * _d_b};
 //CHECK-NEXT:}
 
-void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b);
-//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}};
-
-void f_cubed_add1_darg1_grad(double a, double b, double *_d_a, double *_d_b);
-//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg1_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}};
+//CHECK:{{[__attribute__((always_inline)) ]*}}inline void f_cubed_add1_pushforward_pullback(double a, double b, double _d_a, double _d_b, clad::ValueAndPushforward<double, double> _d_y, double *_d_a0, double *_d_b0){{[ __attribute__((always_inline))]*}};
 
 void f_cubed_add1_hessian(double a, double b, double *hessianMatrix);
-//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_hessian(double a, double b, double *hessianMatrix){{[ __attribute__((always_inline))]*}} {
-//CHECK-NEXT:    f_cubed_add1_darg0_grad(a, b, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-//CHECK-NEXT:    f_cubed_add1_darg1_grad(a, b, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
-//CHECK-NEXT: }
+//CHECK:{{[__attribute__((always_inline)) ]*}}inline void f_cubed_add1_hessian(double a, double b, double *hessianMatrix){{[ __attribute__((always_inline))]*}} {
+//CHECK-NEXT:    clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+//CHECK-NEXT:    _d_y.pushforward = 1.;
+//CHECK-NEXT:    double _d_a(0.);
+//CHECK-NEXT:    double _d_b(0.);
+//CHECK-NEXT:    _d_a = 1.;
+//CHECK-NEXT:    f_cubed_add1_pushforward_pullback(a, b, _d_a, _d_b, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+//CHECK-NEXT:    _d_a = 0.;
+//CHECK-NEXT:    _d_b = 1.;
+//CHECK-NEXT:    f_cubed_add1_pushforward_pullback(a, b, _d_a, _d_b, _d_y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+//CHECK-NEXT:    _d_b = 0.;
+//CHECK-NEXT:}
 
 double f_suvat1(double u, double t) {
   return ((u * t) + ((0.5) * (9.81) * (t * t)));
 }
 
-void f_suvat1_darg0_grad(double u, double t, double *_d_u, double *_d_t);
-void f_suvat1_darg1_grad(double u, double t, double *_d_u, double *_d_t);
-
 void f_suvat1_hessian(double u, double t, double *hessianMatrix);
-//CHECK:void f_suvat1_hessian(double u, double t, double *hessianMatrix) {
-//CHECK-NEXT:    f_suvat1_darg0_grad(u, t, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-//CHECK-NEXT:    f_suvat1_darg1_grad(u, t, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+//CHECK:inline void f_suvat1_hessian(double u, double t, double *hessianMatrix) {
+//CHECK-NEXT:    clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+//CHECK-NEXT:    _d_y.pushforward = 1.;
+//CHECK-NEXT:    double _d_u(0.);
+//CHECK-NEXT:    double _d_t(0.);
+//CHECK-NEXT:    _d_u = 1.;
+//CHECK-NEXT:    f_suvat1_pushforward_pullback(u, t, _d_u, _d_t, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+//CHECK-NEXT:    _d_u = 0.;
+//CHECK-NEXT:    _d_t = 1.;
+//CHECK-NEXT:    f_suvat1_pushforward_pullback(u, t, _d_u, _d_t, _d_y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+//CHECK-NEXT:    _d_t = 0.;
 //CHECK-NEXT:}
 
 double f_cond3(double x, double c) {
@@ -50,25 +57,33 @@ double f_cond3(double x, double c) {
   }
 }
 
-void f_cond3_darg0_grad(double x, double c, double *_d_x, double *_d_c);
-void f_cond3_darg1_grad(double x, double c, double *_d_x, double *_d_c);
-
 void f_cond3_hessian(double x, double c, double *hessianMatrix);
-//CHECK:void f_cond3_hessian(double x, double c, double *hessianMatrix) {
-//CHECK-NEXT:    f_cond3_darg0_grad(x, c, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-//CHECK-NEXT:    f_cond3_darg1_grad(x, c, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+//CHECK:inline void f_cond3_hessian(double x, double c, double *hessianMatrix) {
+//CHECK-NEXT:    clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+//CHECK-NEXT:    _d_y.pushforward = 1.;
+//CHECK-NEXT:    double _d_x(0.);
+//CHECK-NEXT:    double _d_c(0.);
+//CHECK-NEXT:    _d_x = 1.;
+//CHECK-NEXT:    f_cond3_pushforward_pullback(x, c, _d_x, _d_c, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+//CHECK-NEXT:    _d_x = 0.;
+//CHECK-NEXT:    _d_c = 1.;
+//CHECK-NEXT:    f_cond3_pushforward_pullback(x, c, _d_x, _d_c, _d_y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+//CHECK-NEXT:    _d_c = 0.;
 //CHECK-NEXT:}
 
 double f_power10(double x) {
   return x * x * x * x * x * x * x * x * x * x;
 }
 
-void f_power10_darg0_grad(double x, double *_d_x);
-
 void f_power10_hessian(double x, double *hessianMatrix);
-//CHECK: void f_power10_hessian(double x, double *hessianMatrix) {
-//CHECK-NEXT:     f_power10_darg0_grad(x, hessianMatrix + {{0U|0UL|0ULL}});
-//CHECK-NEXT: }
+//CHECK:inline void f_power10_hessian(double x, double *hessianMatrix) {
+//CHECK-NEXT:    clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+//CHECK-NEXT:    _d_y.pushforward = 1.;
+//CHECK-NEXT:    double _d_x(0.);
+//CHECK-NEXT:    _d_x = 1.;
+//CHECK-NEXT:    f_power10_pushforward_pullback(x, _d_x, _d_y, hessianMatrix + {{0U|0UL|0ULL}});
+//CHECK-NEXT:    _d_x = 0.;
+//CHECK-NEXT:}
 
 struct Experiment {
   double x, y;
@@ -87,12 +102,12 @@ struct Experiment {
                              double *_d_j);
 
   void someMethod_hessian(double x, double *hessianMatrix);
-  // CHECK: void someMethod_hessian(double i, double j, double *hessianMatrix) {
-  // CHECK-NEXT:     Experiment _d_this;
-  // CHECK-NEXT:     this->someMethod_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-  // CHECK-NEXT:     Experiment _d_this0;
-  // CHECK-NEXT:     this->someMethod_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
-  // CHECK-NEXT: }
+  //CHECK:inline void someMethod_hessian(double i, double j, double *hessianMatrix) {
+  //CHECK-NEXT:    Experiment _d_this;
+  //CHECK-NEXT:    this->someMethod_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+  //CHECK-NEXT:    Experiment _d_this0;
+  //CHECK-NEXT:    this->someMethod_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+  //CHECK-NEXT:}
 };
 
 struct Widget {
@@ -114,12 +129,12 @@ struct Widget {
   void memFn_1_hessian(double i,
                        double j,
                        double *hessianMatrix);
-  // CHECK: void memFn_1_hessian(double i, double j, double *hessianMatrix) {
-  // CHECK-NEXT:     Widget _d_this;
-  // CHECK-NEXT:     this->memFn_1_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-  // CHECK-NEXT:     Widget _d_this0;
-  // CHECK-NEXT:     this->memFn_1_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
-  // CHECK-NEXT: }
+  //CHECK:inline void memFn_1_hessian(double i, double j, double *hessianMatrix) {
+  //CHECK-NEXT:    Widget _d_this;
+  //CHECK-NEXT:    this->memFn_1_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+  //CHECK-NEXT:    Widget _d_this0;
+  //CHECK-NEXT:    this->memFn_1_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+  //CHECK-NEXT:}
 
   double memFn_2(double i, double j) {
     double a = x*i*j;
@@ -139,22 +154,18 @@ struct Widget {
   void memFn_2_hessian(double i,
                        double j,
                        double *hessianMatrix);
-  // CHECK: void memFn_2_hessian(double i, double j, double *hessianMatrix) {
-  // CHECK-NEXT:     Widget _d_this;
-  // CHECK-NEXT:     this->memFn_2_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-  // CHECK-NEXT:     Widget _d_this0;
-  // CHECK-NEXT:     this->memFn_2_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
-  // CHECK-NEXT: }
+  //CHECK:inline void memFn_2_hessian(double i, double j, double *hessianMatrix) {
+  //CHECK-NEXT:    Widget _d_this;
+  //CHECK-NEXT:    this->memFn_2_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+  //CHECK-NEXT:    Widget _d_this0;
+  //CHECK-NEXT:    this->memFn_2_darg1_grad(i, j, &_d_this0, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+  //CHECK-NEXT:}
 };
 
 double fn_def_arg(double i=0, double j=0) {
   return 2*i*j;
 }
 
-void fn_def_arg_darg0_grad(double, double, double*,
-                           double*);
-void fn_def_arg_darg1_grad(double, double, double*,
-                           double*);
 void fn_def_arg_hessian(double, double, double*);
 
 #define TEST1(F, x) { \
@@ -163,7 +174,6 @@ void fn_def_arg_hessian(double, double, double*);
   h.execute(x, result);\
   printf("Result is = {%.2f}\n", result[0]); \
   F##_hessian(x, result);\
-  F##_darg0_grad(x, result);\
 }
 
 #define TEST2(F, x, y)                                                         \
@@ -179,8 +189,6 @@ void fn_def_arg_hessian(double, double, double*);
            result[1],                                                          \
            result[2],                                                          \
            result[3]);                                                         \
-    F##_darg0_grad(x, y, &result[0], &result[1]);                              \
-    F##_darg1_grad(x, y, &result[2], &result[3]);                              \
     F##_hessian(x, y, result);                                                 \
 }
 
@@ -210,73 +218,33 @@ int main() {
   TEST3(&Widget::memFn_2, W, 7, 9); // CHECK-EXEC: Result is = {5400.00, 4200.00, 4200.00, 0.00}
   TEST2(fn_def_arg, 3, 5);  // CHECK-EXEC: Result is = {0.00, 2.00, 2.00, 0.00}
 
-//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg0_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
-//CHECK-NEXT:    double _d_d_a = 0.;
-//CHECK-NEXT:    double _d_a0 = 1;
-//CHECK-NEXT:    double _d_d_b = 0.;
-//CHECK-NEXT:    double _d_b0 = 0;
+//CHECK:{{[__attribute__((always_inline)) ]*}}inline void f_cubed_add1_pushforward_pullback(double a, double b, double _d_a, double _d_b, clad::ValueAndPushforward<double, double> _d_y, double *_d_a0, double *_d_b0){{[ __attribute__((always_inline))]*}} {
 //CHECK-NEXT:    double _d_t0 = 0.;
 //CHECK-NEXT:    double _t00 = a * a;
 //CHECK-NEXT:    double _d_t1 = 0.;
 //CHECK-NEXT:    double _t10 = b * b;
 //CHECK-NEXT:    {
-//CHECK-NEXT:        _d_d_a += 1 * a * a;
-//CHECK-NEXT:        *_d_a += _d_a0 * 1 * a;
-//CHECK-NEXT:        *_d_a += 1 * a * _d_a0;
-//CHECK-NEXT:        _d_d_a += a * 1 * a;
-//CHECK-NEXT:        *_d_a += (_d_a0 * a + a * _d_a0) * 1;
-//CHECK-NEXT:        _d_t0 += 1 * _d_a0;
-//CHECK-NEXT:        _d_d_a += _t00 * 1;
-//CHECK-NEXT:        _d_d_b += 1 * b * b;
-//CHECK-NEXT:        *_d_b += _d_b0 * 1 * b;
-//CHECK-NEXT:        *_d_b += 1 * b * _d_b0;
-//CHECK-NEXT:        _d_d_b += b * 1 * b;
-//CHECK-NEXT:        *_d_b += (_d_b0 * b + b * _d_b0) * 1;
-//CHECK-NEXT:        _d_t1 += 1 * _d_b0;
-//CHECK-NEXT:        _d_d_b += _t10 * 1;
+//CHECK-NEXT:        _d_t0 += _d_y.value * a;
+//CHECK-NEXT:        *_d_a0 += _t00 * _d_y.value;
+//CHECK-NEXT:        _d_t1 += _d_y.value * b;
+//CHECK-NEXT:        *_d_b0 += _t10 * _d_y.value;
+//CHECK-NEXT:        *_d_a0 += _d_a * _d_y.pushforward * a;
+//CHECK-NEXT:        *_d_a0 += _d_y.pushforward * a * _d_a;
+//CHECK-NEXT:        *_d_a0 += (_d_a * a + a * _d_a) * _d_y.pushforward;
+//CHECK-NEXT:        _d_t0 += _d_y.pushforward * _d_a;
+//CHECK-NEXT:        *_d_b0 += _d_b * _d_y.pushforward * b;
+//CHECK-NEXT:        *_d_b0 += _d_y.pushforward * b * _d_b;
+//CHECK-NEXT:        *_d_b0 += (_d_b * b + b * _d_b) * _d_y.pushforward;
+//CHECK-NEXT:        _d_t1 += _d_y.pushforward * _d_b;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        *_d_b += _d_t1 * b;
-//CHECK-NEXT:        *_d_b += b * _d_t1;
+//CHECK-NEXT:        *_d_b0 += _d_t1 * b;
+//CHECK-NEXT:        *_d_b0 += b * _d_t1;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        *_d_a += _d_t0 * a;
-//CHECK-NEXT:        *_d_a += a * _d_t0;
+//CHECK-NEXT:        *_d_a0 += _d_t0 * a;
+//CHECK-NEXT:        *_d_a0 += a * _d_t0;
 //CHECK-NEXT:    }
 //CHECK-NEXT:}
 
-//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_darg1_grad(double a, double b, double *_d_a, double *_d_b){{[ __attribute__((always_inline))]*}} {
-//CHECK-NEXT:    double _d_d_a = 0.;
-//CHECK-NEXT:    double _d_a0 = 0;
-//CHECK-NEXT:    double _d_d_b = 0.;
-//CHECK-NEXT:    double _d_b0 = 1;
-//CHECK-NEXT:    double _d_t0 = 0.;
-//CHECK-NEXT:    double _t00 = a * a;
-//CHECK-NEXT:    double _d_t1 = 0.;
-//CHECK-NEXT:    double _t10 = b * b;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        _d_d_a += 1 * a * a;
-//CHECK-NEXT:        *_d_a += _d_a0 * 1 * a;
-//CHECK-NEXT:        *_d_a += 1 * a * _d_a0;
-//CHECK-NEXT:        _d_d_a += a * 1 * a;
-//CHECK-NEXT:        *_d_a += (_d_a0 * a + a * _d_a0) * 1;
-//CHECK-NEXT:        _d_t0 += 1 * _d_a0;
-//CHECK-NEXT:        _d_d_a += _t00 * 1;
-//CHECK-NEXT:        _d_d_b += 1 * b * b;
-//CHECK-NEXT:        *_d_b += _d_b0 * 1 * b;
-//CHECK-NEXT:        *_d_b += 1 * b * _d_b0;
-//CHECK-NEXT:        _d_d_b += b * 1 * b;
-//CHECK-NEXT:        *_d_b += (_d_b0 * b + b * _d_b0) * 1;
-//CHECK-NEXT:        _d_t1 += 1 * _d_b0;
-//CHECK-NEXT:        _d_d_b += _t10 * 1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        *_d_b += _d_t1 * b;
-//CHECK-NEXT:        *_d_b += b * _d_t1;
-//CHECK-NEXT:    }
-//CHECK-NEXT:    {
-//CHECK-NEXT:        *_d_a += _d_t0 * a;
-//CHECK-NEXT:        *_d_a += a * _d_t0;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
 }

--- a/test/Hessian/NestedArrays.C
+++ b/test/Hessian/NestedArrays.C
@@ -33,53 +33,46 @@ double f2_outer(double x) {
     return f2_inner(arr, x);
 }
 
-// CHECK: clad::ValueAndPushforward<double, double> f0_inner_pushforward(double *params, double *_d_params) {
-// CHECK-NEXT:     double {{_t[0-9]+}} = params[0] * params[1];
-// CHECK-NEXT:     return {{{_t[0-9]+}} * params[2] + params[3] * params[3] + params[4] * params[0], (_d_params[0] * params[1] + params[0] * _d_params[1]) * params[2] + {{_t[0-9]+}} * _d_params[2] + _d_params[3] * params[3] + params[3] * _d_params[3] + _d_params[4] * params[0] + params[4] * _d_params[0]};
+// CHECK: inline clad::ValueAndPushforward<double, double> f0_inner_pushforward(double *params, double *_d_params) {
+// CHECK-NEXT:     double _t0 = params[0] * params[1];
+// CHECK-NEXT:     return {_t0 * params[2] + params[3] * params[3] + params[4] * params[0], (_d_params[0] * params[1] + params[0] * _d_params[1]) * params[2] + _t0 * _d_params[2] + _d_params[3] * params[3] + params[3] * _d_params[3] + _d_params[4] * params[0] + params[4] * _d_params[0]};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<double, double> f1_inner_pushforward(double *p, double *_d_p) {
+// CHECK: inline clad::ValueAndPushforward<double, double> f1_inner_pushforward(double *p, double *_d_p) {
 // CHECK-NEXT:     return {p[0] * p[1], _d_p[0] * p[1] + p[0] * _d_p[1]};
 // CHECK-NEXT: }
 
-// CHECK: clad::ValueAndPushforward<double, double> f2_inner_pushforward(double *p, double x, double *_d_p, double _d_x) {
-// CHECK-NEXT:     double {{_t[0-9]+}} = p[0] * x;
-// CHECK-NEXT:     return {{{_t[0-9]+}} * x, (_d_p[0] * x + p[0] * _d_x) * x + {{_t[0-9]+}} * _d_x};
+// CHECK: inline clad::ValueAndPushforward<double, double> f2_inner_pushforward(double *p, double x, double *_d_p, double _d_x) {
+// CHECK-NEXT:     double _t0 = p[0] * x;
+// CHECK-NEXT:     return {_t0 * x, (_d_p[0] * x + p[0] * _d_x) * x + _t0 * _d_x};
 // CHECK-NEXT: }
 
-// CHECK: void f0_inner_pushforward_pullback(double *params, double *_d_params, clad::ValueAndPushforward<double, double> _d_y, double *_d_params0, double *_d_d_params) {
-// CHECK-NEXT:     double {{_d_t[0-9]+}} = {{0\.|0\.0|0}};
-// CHECK-NEXT:     double {{_t[0-9]+}} = params[0] * params[1];
+// CHECK: inline void f0_inner_pushforward_pullback(double *params, double *_d_params, clad::ValueAndPushforward<double, double> _d_y, double *_d_params0) {
+// CHECK-NEXT:     double _d_t0 = 0.;
+// CHECK-NEXT:     double _t00 = params[0] * params[1];
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{_d_t[0-9]+}} += _d_y.value * params[2];
-// CHECK-NEXT:         _d_params0[2] += {{_t[0-9]+}} * _d_y.value;
+// CHECK-NEXT:         _d_t0 += _d_y.value * params[2];
+// CHECK-NEXT:         _d_params0[2] += _t00 * _d_y.value;
 // CHECK-NEXT:         _d_params0[3] += _d_y.value * params[3];
 // CHECK-NEXT:         _d_params0[3] += params[3] * _d_y.value;
 // CHECK-NEXT:         _d_params0[4] += _d_y.value * params[0];
 // CHECK-NEXT:         _d_params0[0] += params[4] * _d_y.value;
-// CHECK-NEXT:         _d_d_params[0] += _d_y.pushforward * params[2] * params[1];
 // CHECK-NEXT:         _d_params0[1] += _d_params[0] * _d_y.pushforward * params[2];
 // CHECK-NEXT:         _d_params0[0] += _d_y.pushforward * params[2] * _d_params[1];
-// CHECK-NEXT:         _d_d_params[1] += params[0] * _d_y.pushforward * params[2];
 // CHECK-NEXT:         _d_params0[2] += (_d_params[0] * params[1] + params[0] * _d_params[1]) * _d_y.pushforward;
-// CHECK-NEXT:         {{_d_t[0-9]+}} += _d_y.pushforward * _d_params[2];
-// CHECK-NEXT:         _d_d_params[2] += {{_t[0-9]+}} * _d_y.pushforward;
-// CHECK-NEXT:         _d_d_params[3] += _d_y.pushforward * params[3];
+// CHECK-NEXT:         _d_t0 += _d_y.pushforward * _d_params[2];
 // CHECK-NEXT:         _d_params0[3] += _d_params[3] * _d_y.pushforward;
 // CHECK-NEXT:         _d_params0[3] += _d_y.pushforward * _d_params[3];
-// CHECK-NEXT:         _d_d_params[3] += params[3] * _d_y.pushforward;
-// CHECK-NEXT:         _d_d_params[4] += _d_y.pushforward * params[0];
 // CHECK-NEXT:         _d_params0[0] += _d_params[4] * _d_y.pushforward;
 // CHECK-NEXT:         _d_params0[4] += _d_y.pushforward * _d_params[0];
-// CHECK-NEXT:         _d_d_params[0] += params[4] * _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_params0[0] += {{_d_t[0-9]+}} * params[1];
-// CHECK-NEXT:         _d_params0[1] += params[0] * {{_d_t[0-9]+}};
+// CHECK-NEXT:         _d_params0[0] += _d_t0 * params[1];
+// CHECK-NEXT:         _d_params0[1] += params[0] * _d_t0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void f1_inner_pushforward_pullback(double *p, double *_d_p, clad::ValueAndPushforward<double, double> _d_y, double *_d_p0, double *_d_d_p) {
+// CHECK: inline void f1_inner_pushforward_pullback(double *p, double *_d_p, clad::ValueAndPushforward<double, double> _d_y, double *_d_p0, double *_d_d_p) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_p0[0] += _d_y.value * p[1];
 // CHECK-NEXT:         _d_p0[1] += p[0] * _d_y.value;
@@ -90,23 +83,23 @@ double f2_outer(double x) {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void f2_inner_pushforward_pullback(double *p, double x, double *_d_p, double _d_x, clad::ValueAndPushforward<double, double> _d_y, double *_d_p0, double *_d_x0, double *_d_d_p, double *_d_d_x) {
-// CHECK-NEXT:     double {{_d_t[0-9]+}} = {{0\.|0\.0|0}};
-// CHECK-NEXT:     double {{_t[0-9]+}} = p[0] * x;
+// CHECK: inline void f2_inner_pushforward_pullback(double *p, double x, double *_d_p, double _d_x, clad::ValueAndPushforward<double, double> _d_y, double *_d_p0, double *_d_x0, double *_d_d_p, double *_d_d_x) {
+// CHECK-NEXT:     double _d_t0 = 0.;
+// CHECK-NEXT:     double _t00 = p[0] * x;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         {{_d_t[0-9]+}} += _d_y.value * x;
-// CHECK-NEXT:         *_d_x0 += {{_t[0-9]+}} * _d_y.value;
+// CHECK-NEXT:         _d_t0 += _d_y.value * x;
+// CHECK-NEXT:         *_d_x0 += _t00 * _d_y.value;
 // CHECK-NEXT:         _d_d_p[0] += _d_y.pushforward * x * x;
 // CHECK-NEXT:         *_d_x0 += _d_p[0] * _d_y.pushforward * x;
 // CHECK-NEXT:         _d_p0[0] += _d_y.pushforward * x * _d_x;
 // CHECK-NEXT:         *_d_d_x += p[0] * _d_y.pushforward * x;
 // CHECK-NEXT:         *_d_x0 += (_d_p[0] * x + p[0] * _d_x) * _d_y.pushforward;
-// CHECK-NEXT:         {{_d_t[0-9]+}} += _d_y.pushforward * _d_x;
-// CHECK-NEXT:         *_d_d_x += {{_t[0-9]+}} * _d_y.pushforward;
+// CHECK-NEXT:         _d_t0 += _d_y.pushforward * _d_x;
+// CHECK-NEXT:         *_d_d_x += _t00 * _d_y.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_p0[0] += {{_d_t[0-9]+}} * x;
-// CHECK-NEXT:         *_d_x0 += p[0] * {{_d_t[0-9]+}};
+// CHECK-NEXT:         _d_p0[0] += _d_t0 * x;
+// CHECK-NEXT:         *_d_x0 += p[0] * _d_t0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -15,50 +15,46 @@ double f2(double x, double y){
     return ans;
 }
 
-// CHECK: clad::ValueAndPushforward<double, double> f_pushforward(double x, double y, double _d_x, double _d_y) {
+// CHECK: inline clad::ValueAndPushforward<double, double> f_pushforward(double x, double y, double _d_x, double _d_y) {
 // CHECK-NEXT:     return {x * x + y * y, _d_x * x + x * _d_x + _d_y * y + y * _d_y};
 // CHECK-NEXT: }
 
-// CHECK: double f2_darg0(double x, double y) {
-// CHECK-NEXT:     double _d_x = 1;
-// CHECK-NEXT:     double _d_y = 0;
+// CHECK: inline clad::ValueAndPushforward<double, double> f2_pushforward(double x, double y, double _d_x, double _d_y) {
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = f_pushforward(x, y, _d_x, _d_y);
 // CHECK-NEXT:     double _d_ans = _t0.pushforward;
 // CHECK-NEXT:     double ans = _t0.value;
-// CHECK-NEXT:     return _d_ans;
+// CHECK-NEXT:     return {ans, _d_ans};
 // CHECK-NEXT: }
 
-// CHECK: double f2_darg1(double x, double y) {
-// CHECK-NEXT:     double _d_x = 0;
-// CHECK-NEXT:     double _d_y = 1;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = f_pushforward(x, y, _d_x, _d_y);
-// CHECK-NEXT:     double _d_ans = _t0.pushforward;
-// CHECK-NEXT:     double ans = _t0.value;
-// CHECK-NEXT:     return _d_ans;
+
+// CHECK: inline void f2_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1);
+
+// CHECK: inline void f2_hessian(double x, double y, double *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     double _d_x(0.);
+// CHECK-NEXT:     double _d_y0(0.);
+// CHECK-NEXT:     _d_x = 1.;
+// CHECK-NEXT:     f2_pushforward_pullback(x, y, _d_x, _d_y0, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     _d_x = 0.;
+// CHECK-NEXT:     _d_y0 = 1.;
+// CHECK-NEXT:     f2_pushforward_pullback(x, y, _d_x, _d_y0, _d_y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+// CHECK-NEXT:     _d_y0 = 0.;
 // CHECK-NEXT: }
 
-// CHECK: void f2_darg0_grad(double x, double y, double *_d_x, double *_d_y);
-// CHECK: void f2_darg1_grad(double x, double y, double *_d_x, double *_d_y);
+// CHECK: inline void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1, double *_d_d_x, double *_d_d_y);
 
-// CHECK: void f2_hessian(double x, double y, double *hessianMatrix) {
-// CHECK-NEXT:     f2_darg0_grad(x, y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-// CHECK-NEXT:     f2_darg1_grad(x, y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
-// CHECK-NEXT: }
-
-// CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1, double *_d_d_x, double *_d_d_y);
-
-// CHECK: void f2_darg0_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     double _d_d_x = 0.;
-// CHECK-NEXT:     double _d_x0 = 1;
-// CHECK-NEXT:     double _d_d_y = 0.;
-// CHECK-NEXT:     double _d_y0 = 0;
+// CHECK: inline void f2_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1) {
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_t0 = {0., 0.};
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x, _d_y);
 // CHECK-NEXT:     double _d_d_ans = 0.;
 // CHECK-NEXT:     double _d_ans = _t00.pushforward;
 // CHECK-NEXT:     double _d_ans0 = 0.;
 // CHECK-NEXT:     double ans = _t00.value;
-// CHECK-NEXT:     _d_d_ans += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_ans0 += _d_y0.value;
+// CHECK-NEXT:         _d_d_ans += _d_y0.pushforward;
+// CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t0.value += _d_ans0;
 // CHECK-NEXT:     _d_t0.pushforward += _d_d_ans;
 // CHECK-NEXT:     {
@@ -66,42 +62,14 @@ double f2(double x, double y){
 // CHECK-NEXT:         double _r1 = 0.;
 // CHECK-NEXT:         double _r2 = 0.;
 // CHECK-NEXT:         double _r3 = 0.;
-// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y0, _d_t0, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         *_d_y += _r1;
-// CHECK-NEXT:         _d_d_x += _r2;
-// CHECK-NEXT:         _d_d_y += _r3;
+// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x, _d_y, _d_t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         *_d_x0 += _r0;
+// CHECK-NEXT:         *_d_y1 += _r1;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void f2_darg1_grad(double x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     double _d_d_x = 0.;
-// CHECK-NEXT:     double _d_x0 = 0;
-// CHECK-NEXT:     double _d_d_y = 0.;
-// CHECK-NEXT:     double _d_y0 = 1;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_t0 = {0., 0.};
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = f_pushforward(x, y, _d_x0, _d_y0);
-// CHECK-NEXT:     double _d_d_ans = 0.;
-// CHECK-NEXT:     double _d_ans = _t00.pushforward;
-// CHECK-NEXT:     double _d_ans0 = 0.;
-// CHECK-NEXT:     double ans = _t00.value;
-// CHECK-NEXT:     _d_d_ans += 1;
-// CHECK-NEXT:     _d_t0.value += _d_ans0;
-// CHECK-NEXT:     _d_t0.pushforward += _d_d_ans;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         double _r0 = 0.;
-// CHECK-NEXT:         double _r1 = 0.;
-// CHECK-NEXT:         double _r2 = 0.;
-// CHECK-NEXT:         double _r3 = 0.;
-// CHECK-NEXT:         f_pushforward_pullback(x, y, _d_x0, _d_y0, _d_t0, &_r0, &_r1, &_r2, &_r3);
-// CHECK-NEXT:         *_d_x += _r0;
-// CHECK-NEXT:         *_d_y += _r1;
-// CHECK-NEXT:         _d_d_x += _r2;
-// CHECK-NEXT:         _d_d_y += _r3;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
 
-// CHECK: void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1, double *_d_d_x, double *_d_d_y) {
+// CHECK: inline void f_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1, double *_d_d_x, double *_d_d_y) {
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_x0 += _d_y0.value * x;
 // CHECK-NEXT:         *_d_x0 += x * _d_y0.value;

--- a/test/Hessian/PerDirectionFallback.C
+++ b/test/Hessian/PerDirectionFallback.C
@@ -1,0 +1,92 @@
+// RUN: %cladclang %s -I%S/../../include -oPerDirectionFallback.out 2>&1 | %filecheck %s
+// RUN: ./PerDirectionFallback.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+// The hessian-vector-product scheme needs one tangent per parameter, passed
+// by position and reseeded between directions. A parameter the pushforward's
+// signature filter skips (an enum) breaks the positions; a reference tangent
+// cannot be reseeded or zero-initialized; a custom pushforward's author never
+// promised the positional call the wrapper would make. The planner recognizes
+// each and schedules per-direction derivatives instead -- for that function
+// only, as `plain` below shows.
+
+enum Kind { Linear, Quadratic };
+
+double withEnum(double x, double y, Kind k) {
+  if (k == Quadratic)
+    return x * x * y;
+  return x * y;
+}
+
+// CHECK: void withEnum_hessian_0_1(double x, double y, Kind k, double *hessianMatrix) {
+// CHECK-NEXT: withEnum_darg0_grad_0_1(x, y, k, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT: withEnum_darg1_grad_0_1(x, y, k, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+// CHECK-NEXT: }
+
+double withRef(double x, double y, double& scale) {
+  return x * x * y * scale;
+}
+
+// CHECK: void withRef_hessian_0_1(double x, double y, double &scale, double *hessianMatrix) {
+// CHECK-NEXT: withRef_darg0_grad_0_1(x, y, scale, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT: withRef_darg1_grad_0_1(x, y, scale, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+// CHECK-NEXT: }
+
+double withCustomPushforward(double x, double y) { return x * y * y; }
+
+namespace clad {
+namespace custom_derivatives {
+clad::ValueAndPushforward<double, double>
+withCustomPushforward_pushforward(double x, double y, double _d_x,
+                                  double _d_y) {
+  return {x * y * y, y * y * _d_x + 2 * x * y * _d_y};
+}
+} // namespace custom_derivatives
+} // namespace clad
+
+// CHECK: void withCustomPushforward_hessian(double x, double y, double *hessianMatrix) {
+// CHECK-NEXT: withCustomPushforward_darg0_grad(x, y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT: withCustomPushforward_darg1_grad(x, y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+// CHECK-NEXT: }
+
+// The control: nothing above disqualifies this one, and in the same TU it
+// takes the hessian-vector-product scheme.
+double plain(double a, double b) { return a * a * b; }
+
+// CHECK: void plain_hessian(double a, double b, double *hessianMatrix) {
+// CHECK-NEXT: clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+// CHECK-NEXT: _d_y.pushforward = 1.;
+// CHECK-NEXT: double _d_a(0.);
+// CHECK-NEXT: double _d_b(0.);
+// CHECK-NEXT: _d_a = 1.;
+// CHECK-NEXT: plain_pushforward_pullback(a, b, _d_a, _d_b, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT: _d_a = 0.;
+// CHECK-NEXT: _d_b = 1.;
+// CHECK-NEXT: plain_pushforward_pullback(a, b, _d_a, _d_b, _d_y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+// CHECK-NEXT: _d_b = 0.;
+// CHECK-NEXT: }
+
+int main() {
+  double m[4] = {0};
+  clad::hessian(withEnum, "x, y").execute(1., 2., Quadratic, m);
+  printf("withEnum [%.2f, %.2f, %.2f, %.2f]\n", m[0], m[1], m[2], m[3]);
+  // CHECK-EXEC: withEnum [4.00, 2.00, 2.00, 0.00]
+
+  double scale = 3.;
+  double m2[4] = {0};
+  clad::hessian(withRef, "x, y").execute(1., 2., scale, m2);
+  printf("withRef [%.2f, %.2f, %.2f, %.2f]\n", m2[0], m2[1], m2[2], m2[3]);
+  // CHECK-EXEC: withRef [12.00, 6.00, 6.00, 0.00]
+
+  double m3[4] = {0};
+  clad::hessian(withCustomPushforward).execute(3., 4., m3);
+  printf("withCustomPushforward [%.2f, %.2f, %.2f, %.2f]\n", m3[0], m3[1],
+         m3[2], m3[3]);
+  // CHECK-EXEC: withCustomPushforward [0.00, 8.00, 8.00, 6.00]
+
+  double m4[4] = {0};
+  clad::hessian(plain).execute(1., 2., m4);
+  printf("plain [%.2f, %.2f, %.2f, %.2f]\n", m4[0], m4[1], m4[2], m4[3]);
+  // CHECK-EXEC: plain [4.00, 2.00, 2.00, 0.00]
+}

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -9,51 +9,35 @@ double nonMemFn(double i, double j) {
   return i*j;
 }
 
-// CHECK: double nonMemFn_darg0(double i, double j) {
-// CHECK-NEXT:     double _d_i = 1;
-// CHECK-NEXT:     double _d_j = 0;
-// CHECK-NEXT:     return _d_i * j + i * _d_j;
+// CHECK: inline clad::ValueAndPushforward<double, double> nonMemFn_pushforward(double i, double j, double _d_i, double _d_j) {
+// CHECK-NEXT:     return {i * j, _d_i * j + i * _d_j};
 // CHECK-NEXT: }
 
-// CHECK: double nonMemFn_darg1(double i, double j) {
-// CHECK-NEXT:     double _d_i = 0;
-// CHECK-NEXT:     double _d_j = 1;
-// CHECK-NEXT:     return _d_i * j + i * _d_j;
+
+// CHECK: inline void nonMemFn_pushforward_pullback(double i, double j, double _d_i, double _d_j, clad::ValueAndPushforward<double, double> _d_y, double *_d_i0, double *_d_j0);
+
+// CHECK: inline void nonMemFn_hessian(double i, double j, double *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     double _d_i(0.);
+// CHECK-NEXT:     double _d_j(0.);
+// CHECK-NEXT:     _d_i = 1.;
+// CHECK-NEXT:     nonMemFn_pushforward_pullback(i, j, _d_i, _d_j, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     _d_i = 0.;
+// CHECK-NEXT:     _d_j = 1.;
+// CHECK-NEXT:     nonMemFn_pushforward_pullback(i, j, _d_i, _d_j, _d_y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+// CHECK-NEXT:     _d_j = 0.;
 // CHECK-NEXT: }
 
-// CHECK: void nonMemFn_darg0_grad(double i, double j, double *_d_i, double *_d_j);
-// CHECK: void nonMemFn_darg1_grad(double i, double j, double *_d_i, double *_d_j);
-
-// CHECK: void nonMemFn_hessian(double i, double j, double *hessianMatrix) {
-// CHECK-NEXT:     nonMemFn_darg0_grad(i, j, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-// CHECK-NEXT:     nonMemFn_darg1_grad(i, j, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
-// CHECK-NEXT: }
-
-// CHECK: void nonMemFn_darg0_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_d_i = 0.;
-// CHECK-NEXT:     double _d_i0 = 1;
-// CHECK-NEXT:     double _d_d_j = 0.;
-// CHECK-NEXT:     double _d_j0 = 0;
+// CHECK: inline void nonMemFn_pushforward_pullback(double i, double j, double _d_i, double _d_j, clad::ValueAndPushforward<double, double> _d_y, double *_d_i0, double *_d_j0) {
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _d_d_i += 1 * j;
-// CHECK-NEXT:         *_d_j += _d_i0 * 1;
-// CHECK-NEXT:         *_d_i += 1 * _d_j0;
-// CHECK-NEXT:         _d_d_j += i * 1;
+// CHECK-NEXT:         *_d_i0 += _d_y.value * j;
+// CHECK-NEXT:         *_d_j0 += i * _d_y.value;
+// CHECK-NEXT:         *_d_j0 += _d_i * _d_y.pushforward;
+// CHECK-NEXT:         *_d_i0 += _d_y.pushforward * _d_j;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK: void nonMemFn_darg1_grad(double i, double j, double *_d_i, double *_d_j) {
-// CHECK-NEXT:     double _d_d_i = 0.;
-// CHECK-NEXT:     double _d_i0 = 0;
-// CHECK-NEXT:     double _d_d_j = 0.;
-// CHECK-NEXT:     double _d_j0 = 1;
-// CHECK-NEXT:     {
-// CHECK-NEXT:         _d_d_i += 1 * j;
-// CHECK-NEXT:         *_d_j += _d_i0 * 1;
-// CHECK-NEXT:         *_d_i += 1 * _d_j0;
-// CHECK-NEXT:         _d_d_j += i * 1;
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
 
 #define NON_MEM_FN_TEST(var)\
 res[0]=res[1]=res[2]=res[3]=0;\

--- a/test/Hessian/TBR.C
+++ b/test/Hessian/TBR.C
@@ -25,20 +25,87 @@ double linearAndNonlinear(double x, double y) {
   return s * a;
 }
 
-// CHECK: void linearAndNonlinear_darg0_grad(double x, double y, double *_d_x, double *_d_y) {
-// Two tapes, for the nonlinear assignment only.
-// CHECK: clad::tape<double> _t1 = {};
-// CHECK-NEXT: clad::tape<double> _t2 = {};
-// CHECK-NOT: clad::tape<double> _t3 = {};
-// CHECK: for (i = 0; i < 3; ++i) {
-// CHECK-NEXT: _t0++;
-// CHECK-NEXT: _d_s = _d_s + _d_a;
-// CHECK-NEXT: s = s + a;
-// CHECK-NEXT: clad::push(_t1, _d_a);
-// CHECK-NEXT: _d_a = _d_a * x + a * _d_x0;
-// CHECK-NEXT: clad::push(_t2, a);
-// CHECK-NEXT: a = a * x;
+// CHECK: inline void linearAndNonlinear_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1) {
+// CHECK-NEXT:     int _d_d_i = 0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     {{__size_t|size_t|unsigned long long|unsigned long|unsigned int}} _t0;
+// CHECK-NEXT:     int _d_i0 = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     clad::tape<double> _t2 = {};
+// CHECK-NEXT:     double _d_d_a = 0.;
+// CHECK-NEXT:     double _d_a = _d_x * y + x * _d_y;
+// CHECK-NEXT:     double _d_a0 = 0.;
+// CHECK-NEXT:     double a = x * y;
+// CHECK-NEXT:     double _d_d_s = 0.;
+// CHECK-NEXT:     double _d_s = _d_a;
+// CHECK-NEXT:     double _d_s0 = 0.;
+// CHECK-NEXT:     double s = a;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_i = 0;
+// CHECK-NEXT:         _t0 = 0;
+// CHECK-NEXT:         for (i = 0; i < 3; ++i) {
+// CHECK-NEXT:             _t0++;
+// CHECK-NEXT:             _d_s = _d_s + _d_a;
+// CHECK-NEXT:             s = s + a;
+// CHECK-NEXT:             clad::push(_t1, _d_a);
+// CHECK-NEXT:             _d_a = _d_a * x + a * _d_x;
+// CHECK-NEXT:             clad::push(_t2, a);
+// CHECK-NEXT:             a = a * x;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_s0 += _d_y0.value * a;
+// CHECK-NEXT:         _d_a0 += s * _d_y0.value;
+// CHECK-NEXT:         _d_d_s += _d_y0.pushforward * a;
+// CHECK-NEXT:         _d_a0 += _d_s * _d_y0.pushforward;
+// CHECK-NEXT:         _d_s0 += _d_y0.pushforward * _d_a;
+// CHECK-NEXT:         _d_d_a += s * _d_y0.pushforward;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 a = clad::pop(_t2);
+// CHECK-NEXT:                 double _r_d3 = _d_a0;
+// CHECK-NEXT:                 _d_a0 = 0.;
+// CHECK-NEXT:                 _d_a0 += _r_d3 * x;
+// CHECK-NEXT:                 *_d_x0 += a * _r_d3;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 _d_a = clad::pop(_t1);
+// CHECK-NEXT:                 double _r_d2 = _d_d_a;
+// CHECK-NEXT:                 _d_d_a = 0.;
+// CHECK-NEXT:                 _d_d_a += _r_d2 * x;
+// CHECK-NEXT:                 *_d_x0 += _d_a * _r_d2;
+// CHECK-NEXT:                 _d_a0 += _r_d2 * _d_x;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 double _r_d1 = _d_s0;
+// CHECK-NEXT:                 _d_s0 = 0.;
+// CHECK-NEXT:                 _d_s0 += _r_d1;
+// CHECK-NEXT:                 _d_a0 += _r_d1;
+// CHECK-NEXT:             }
+// CHECK-NEXT:             {
+// CHECK-NEXT:                 double _r_d0 = _d_d_s;
+// CHECK-NEXT:                 _d_d_s = 0.;
+// CHECK-NEXT:                 _d_d_s += _r_d0;
+// CHECK-NEXT:                 _d_d_a += _r_d0;
+// CHECK-NEXT:             }
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_a0 += _d_s0;
+// CHECK-NEXT:     _d_d_a += _d_d_s;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x0 += _d_a0 * y;
+// CHECK-NEXT:         *_d_y1 += x * _d_a0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_y1 += _d_x * _d_d_a;
+// CHECK-NEXT:         *_d_x0 += _d_d_a * _d_y;
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
+// The transcript above pins the taping exactly: two tapes for the nonlinear
+// assignment, none for the linear one.
 
 int main() {
   INIT_HESSIAN(linearAndNonlinear);

--- a/test/Hessian/VectorProducts.C
+++ b/test/Hessian/VectorProducts.C
@@ -1,0 +1,97 @@
+// RUN: %cladclang %s -I%S/../../include -oVectorProducts.out 2>&1 | %filecheck %s
+// RUN: ./VectorProducts.out | %filecheck_exec %s
+
+// A hessian is assembled from hessian-vector products: one pushforward of the
+// function, whose direction is a run-time argument, and one pullback of that
+// pushforward. Seeding the pullback with {.value = 0, .pushforward = 1} and a
+// direction of e_i yields row i, so the pair serves every direction and the
+// generated code stops growing with the number of parameters.
+
+#include "clad/Differentiator/Differentiator.h"
+#include <cstdio>
+
+double manyDirections(double* p, double q) {
+  return p[0] * p[1] * p[2] + p[3] * q * q;
+}
+
+// Four array directions and a scalar one, yet a single pullback covers them
+// all -- and the wrapper reuses one tangent buffer per parameter.
+// CHECK:  void manyDirections_hessian(double *p, double q, double *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     double _d_p[4]{0};
+// CHECK-NEXT:     double _d_q(0.);
+// CHECK-NEXT:     _d_p[{{0U|0UL|0ULL}}] = 1.;
+// CHECK-NEXT:     manyDirections_pushforward_pullback(p, q, _d_p, _d_q, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{4U|4UL|4ULL}});
+// CHECK-NEXT:     _d_p[{{0U|0UL|0ULL}}] = 0.;
+// CHECK-NEXT:     _d_p[{{1U|1UL|1ULL}}] = 1.;
+// CHECK-NEXT:     manyDirections_pushforward_pullback(p, q, _d_p, _d_q, _d_y, hessianMatrix + {{5U|5UL|5ULL}}, hessianMatrix + {{9U|9UL|9ULL}});
+// CHECK-NEXT:     _d_p[{{1U|1UL|1ULL}}] = 0.;
+// CHECK-NEXT:     _d_p[{{2U|2UL|2ULL}}] = 1.;
+// CHECK-NEXT:     manyDirections_pushforward_pullback(p, q, _d_p, _d_q, _d_y, hessianMatrix + {{10U|10UL|10ULL}}, hessianMatrix + {{14U|14UL|14ULL}});
+// CHECK-NEXT:     _d_p[{{2U|2UL|2ULL}}] = 0.;
+// CHECK-NEXT:     _d_p[{{3U|3UL|3ULL}}] = 1.;
+// CHECK-NEXT:     manyDirections_pushforward_pullback(p, q, _d_p, _d_q, _d_y, hessianMatrix + {{15U|15UL|15ULL}}, hessianMatrix + {{19U|19UL|19ULL}});
+// CHECK-NEXT:     _d_p[{{3U|3UL|3ULL}}] = 0.;
+// CHECK-NEXT:     _d_q = 1.;
+// CHECK-NEXT:     manyDirections_pushforward_pullback(p, q, _d_p, _d_q, _d_y, hessianMatrix + {{20U|20UL|20ULL}}, hessianMatrix + {{24U|24UL|24ULL}});
+// CHECK-NEXT:     _d_q = 0.;
+// CHECK-NEXT: }
+
+// A parameter no direction runs through keeps a zero tangent; for a pointer
+// that is a null tangent, which forward mode reads as a zero derivative.
+double someDirections(double* p, const double* x) {
+  return p[0] * p[0] * x[0] + p[1] * p[1] * p[1] * x[1];
+}
+
+// CHECK:  void someDirections_hessian_0(double *p, const double *x, double *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     double _d_p[2]{0};
+// CHECK-NEXT:     _d_p[{{0U|0UL|0ULL}}] = 1.;
+// CHECK-NEXT:     someDirections_pushforward_0_pullback(p, x, _d_p, nullptr, _d_y, hessianMatrix + {{0U|0UL|0ULL}});
+// CHECK-NEXT:     _d_p[{{0U|0UL|0ULL}}] = 0.;
+// CHECK-NEXT:     _d_p[{{1U|1UL|1ULL}}] = 1.;
+// CHECK-NEXT:     someDirections_pushforward_0_pullback(p, x, _d_p, nullptr, _d_y, hessianMatrix + {{2U|2UL|2ULL}});
+// CHECK-NEXT:     _d_p[{{1U|1UL|1ULL}}] = 0.;
+// CHECK-NEXT: }
+
+// Two hessians of one function w.r.t. different single parameters take two
+// different pullbacks of the same pushforward. The subset is part of the
+// pullback's name: with one name, the two same-signature inline definitions
+// would collapse onto one symbol and one body would serve both hessians.
+double twoSubsets(double x, double y) { return x * x * y + y * y; }
+
+// CHECK:  void twoSubsets_hessian_0(double x, double y, double *hessianMatrix) {
+// CHECK:  twoSubsets_pushforward_0_pullback(x, y, _d_x, 0., _d_y, hessianMatrix + {{0U|0UL|0ULL}});
+
+// CHECK:  void twoSubsets_hessian_1(double x, double y, double *hessianMatrix) {
+// CHECK:  twoSubsets_pushforward_1_pullback(x, y, 0., _d_y0, _d_y, hessianMatrix + {{0U|0UL|0ULL}});
+
+int main() {
+  double p[4] = {2., 3., 5., 7.};
+  double m[25] = {};
+  clad::hessian(manyDirections, "p[0:3], q").execute(p, 11., m);
+  for (int i = 0; i < 5; ++i)
+    printf("%.0f %.0f %.0f %.0f %.0f\n", m[5*i], m[5*i+1], m[5*i+2], m[5*i+3],
+           m[5*i+4]);
+  // CHECK-EXEC: 0 5 3 0 0
+  // CHECK-EXEC: 5 0 2 0 0
+  // CHECK-EXEC: 3 2 0 0 0
+  // CHECK-EXEC: 0 0 0 0 22
+  // CHECK-EXEC: 0 0 0 22 14
+
+  double q[2] = {2., 3.};
+  double x[2] = {1.5, 0.5};
+  double m2[4] = {};
+  clad::hessian(someDirections, "p[0:1]").execute(q, x, m2);
+  printf("%.2f %.2f %.2f %.2f\n", m2[0], m2[1], m2[2], m2[3]);
+  // CHECK-EXEC: 3.00 0.00 0.00 9.00
+
+  double mx[1] = {};
+  double my[1] = {};
+  clad::hessian(twoSubsets, "x").execute(2., 3., mx);
+  clad::hessian(twoSubsets, "y").execute(2., 3., my);
+  printf("%.2f %.2f\n", mx[0], my[0]);
+  // CHECK-EXEC: 6.00 2.00
+}

--- a/test/Hessian/ZeroTangentCalls.C
+++ b/test/Hessian/ZeroTangentCalls.C
@@ -7,11 +7,11 @@
 
 double cube(double u) { return u * u * u; }
 
-// A hessian seeds one direction at a time, so in every row all tangents but
-// the seeded one are zero-initialized constants. A call handed such a tangent
-// contributes nothing, so no pushforward is requested for it: each direction
-// calls cube_pushforward once instead of twice. The parameters have to be
-// const for this -- a tangent that can still be assigned to is not folded.
+// Deriving in one direction makes all tangents but the seeded one
+// zero-initialized constants. A call handed such a tangent contributes
+// nothing, so no pushforward is requested for it: each direction calls
+// cube_pushforward once instead of twice. The parameters have to be const
+// for this -- a tangent that can still be assigned to is not folded.
 double sumOfCubes(const double x, const double y) {
   return cube(x) + cube(y);
 }
@@ -30,26 +30,68 @@ double sumOfCubes(const double x, const double y) {
 // CHECK-NEXT:     return 0. + _t0.pushforward;
 // CHECK-NEXT: }
 
-// The same holds one order up, where the hessian rows are differentiated.
-// CHECK: void sumOfCubes_darg0_grad(const double x, const double y, double *_d_x, double *_d_y) {
+// A free function's hessian is assembled from hessian-vector products, whose
+// direction is a run-time argument, so there is nothing to fold there. The
+// wrapper reseeds its tangents between directions, so they drop the const of
+// the parameters they mirror.
+// CHECK: void sumOfCubes_hessian(const double x, const double y, double *hessianMatrix) {
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+// CHECK-NEXT:     _d_y.pushforward = 1.;
+// CHECK-NEXT:     double _d_x(0.);
+// CHECK-NEXT:     double _d_y0(0.);
+// CHECK-NEXT:     _d_x = 1.;
+// CHECK-NEXT:     sumOfCubes_pushforward_pullback(x, y, _d_x, _d_y0, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     _d_x = 0.;
+// CHECK-NEXT:     _d_y0 = 1.;
+// CHECK-NEXT:     sumOfCubes_pushforward_pullback(x, y, _d_x, _d_y0, _d_y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+// CHECK-NEXT:     _d_y0 = 0.;
+// CHECK-NEXT: }
+
+// An instance method's hessian still derives per direction, so the same
+// folding holds one order up, where the hessian rows are differentiated.
+struct SumOfCubes {
+  double operator()(const double x, const double y) const {
+    return cube(x) + cube(y);
+  }
+};
+
+// CHECK: void operator_call_darg0_grad(const double x, const double y, SumOfCubes *_d_this, double *_d_x, double *_d_y) const {
 // CHECK-NEXT:     double _d_d_x = 0.;
 // CHECK-NEXT:     const double _d_x0 = 1;
 // CHECK-NEXT:     double _d_d_y = 0.;
 // CHECK-NEXT:     const double _d_y0 = 0;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_t0 = {0., 0.};
+// CHECK:          clad::ValueAndPushforward<double, double> _d_t0 = {0., 0.};
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = cube_pushforward(x, _d_x0);
 // CHECK-NOT:      cube_pushforward(y
 
-// CHECK: void sumOfCubes_darg1_grad(const double x, const double y, double *_d_x, double *_d_y) {
+// CHECK: void operator_call_darg1_grad(const double x, const double y, SumOfCubes *_d_this, double *_d_x, double *_d_y) const {
 // CHECK-NEXT:     double _d_d_x = 0.;
 // CHECK-NEXT:     const double _d_x0 = 0;
 // CHECK-NEXT:     double _d_d_y = 0.;
 // CHECK-NEXT:     const double _d_y0 = 1;
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_t0 = {0., 0.};
+// CHECK:          clad::ValueAndPushforward<double, double> _d_t0 = {0., 0.};
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = cube_pushforward(y, _d_y0);
 // CHECK-NOT:      cube_pushforward(x
 
+// The pullback of the free function's pushforward bounds the CHECK-NOT
+// above; it calls cube_pushforward on both parameters, as it serves every
+// direction.
+// CHECK: void sumOfCubes_pushforward_pullback(const double x, const double y, const double _d_x, const double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1) {
+
 int main() {
+  auto dx = clad::differentiate(sumOfCubes, "x");
+  auto dy = clad::differentiate(sumOfCubes, "y");
+  printf("[%.2f, %.2f]\n", dx.execute(2, 3), dy.execute(2, 3));
+  // CHECK-EXEC: [12.00, 27.00]
+
+  auto methodHess = clad::hessian(&SumOfCubes::operator());
+  double methodMatrix[4] = {0};
+  SumOfCubes f;
+  methodHess.execute(f, 2, 3, methodMatrix);
+  printf("[%.2f, %.2f, %.2f, %.2f]\n", methodMatrix[0], methodMatrix[1],
+         methodMatrix[2], methodMatrix[3]);
+  // CHECK-EXEC: [12.00, 0.00, 0.00, 18.00]
+
   auto hess = clad::hessian(sumOfCubes);
   double matrix[4] = {0};
   hess.execute(2, 3, matrix);

--- a/test/Hessian/constexprTest.C
+++ b/test/Hessian/constexprTest.C
@@ -16,17 +16,35 @@ clad::array_ref<double>mat_ref_f1(mat_ref1, 9);
 
 constexpr double fn(double x, double y) { return x * y; }
 
-//CHECK: constexpr void fn_hessian(double x, double y, double *hessianMatrix) {
-//CHECK-NEXT:    fn_darg0_grad(x, y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-//CHECK-NEXT:    fn_darg1_grad(x, y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+//CHECK:inline constexpr void fn_hessian(double x, double y, double *hessianMatrix) {
+//CHECK-NEXT:    clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+//CHECK-NEXT:    _d_y.pushforward = 1.;
+//CHECK-NEXT:    double _d_x(0.);
+//CHECK-NEXT:    double _d_y0(0.);
+//CHECK-NEXT:    _d_x = 1.;
+//CHECK-NEXT:    fn_pushforward_pullback(x, y, _d_x, _d_y0, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+//CHECK-NEXT:    _d_x = 0.;
+//CHECK-NEXT:    _d_y0 = 1.;
+//CHECK-NEXT:    fn_pushforward_pullback(x, y, _d_x, _d_y0, _d_y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+//CHECK-NEXT:    _d_y0 = 0.;
 //CHECK-NEXT:}
 
 constexpr double g(double i, double j[2]) { return i * (j[0] + j[1]); }
 
-//CHECK: constexpr void g_hessian(double i, double j[2], double *hessianMatrix) {
-//CHECK-NEXT:    g_darg0_grad(i, j, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
-//CHECK-NEXT:    g_darg1_0_grad(i, j, hessianMatrix + {{3U|3UL|3ULL}}, hessianMatrix + {{4U|4UL|4ULL}});
-//CHECK-NEXT:    g_darg1_1_grad(i, j, hessianMatrix + {{6U|6UL|6ULL}}, hessianMatrix + {{7U|7UL|7ULL}});
+//CHECK:inline constexpr void g_hessian(double i, double j[2], double *hessianMatrix) {
+//CHECK-NEXT:    clad::ValueAndPushforward<double, double> _d_y{0., 0.};
+//CHECK-NEXT:    _d_y.pushforward = 1.;
+//CHECK-NEXT:    double _d_i(0.);
+//CHECK-NEXT:    double _d_j[2]{0};
+//CHECK-NEXT:    _d_i = 1.;
+//CHECK-NEXT:    g_pushforward_pullback(i, j, _d_i, _d_j, _d_y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+//CHECK-NEXT:    _d_i = 0.;
+//CHECK-NEXT:    _d_j[{{0U|0UL|0ULL}}] = 1.;
+//CHECK-NEXT:    g_pushforward_pullback(i, j, _d_i, _d_j, _d_y, hessianMatrix + {{3U|3UL|3ULL}}, hessianMatrix + {{4U|4UL|4ULL}});
+//CHECK-NEXT:    _d_j[{{0U|0UL|0ULL}}] = 0.;
+//CHECK-NEXT:    _d_j[{{1U|1UL|1ULL}}] = 1.;
+//CHECK-NEXT:    g_pushforward_pullback(i, j, _d_i, _d_j, _d_y, hessianMatrix + {{6U|6UL|6ULL}}, hessianMatrix + {{7U|7UL|7ULL}});
+//CHECK-NEXT:    _d_j[{{1U|1UL|1ULL}}] = 0.;
 //CHECK-NEXT:}
 
 int main() {

--- a/test/Regressions/hessian-intermediate-codegen.cpp
+++ b/test/Regressions/hessian-intermediate-codegen.cpp
@@ -3,27 +3,29 @@
 
 // Derivatives are generated into every translation unit that needs them, so
 // clad declares them inline. That also makes them discardable: CodeGen defers
-// each until a DeclRefExpr asks for it. Hessian mode derives fn once in forward
-// mode per direction and only reverse-differentiates the result, so nothing
-// references fn_darg0 and it never reaches the backend.
+// each until a DeclRefExpr asks for it. A hessian is assembled from one
+// pushforward of the function and one pullback of that pushforward, and only
+// the pullback is called, so the pushforward itself never reaches the backend.
 //
-// Derivatives are cached per request, so the clad::differentiate below reuses
-// that same declaration rather than building its own. Its call is the
-// DeclRefExpr that makes CodeGen emit fn_darg0 after all; were the intermediate
-// undiscardable instead (internal linkage, or held back from CodeGen), the
-// symbol would stay undefined and this would not link.
+// Derivatives are cached per request, so the forward-mode derivative below
+// reuses that same declaration rather than building its own. Its call to
+// fn_pushforward is the DeclRefExpr that makes CodeGen emit it after all; were
+// the intermediate undiscardable instead (internal linkage, or held back from
+// CodeGen), the symbol would stay undefined and this would not link.
 
 #include "clad/Differentiator/Differentiator.h"
 #include <cstdio>
 
 double fn(double x, double y) { return x * x * y; }
+double caller(double x, double y) { return fn(x, y) + y; }
 
-// CHECK: {{^}}inline double fn_darg0(double x, double y) {
+// CHECK: {{^}}inline clad::ValueAndPushforward<double, double> fn_pushforward(double x, double y, double _d_x, double _d_y) {
 // CHECK: {{^}}inline void fn_hessian(double x, double y, double *hessianMatrix) {
+// CHECK: {{^}}inline double caller_darg0(double x, double y) {
 
 int main() {
   auto h = clad::hessian(fn);
-  auto d = clad::differentiate(fn, "x");
+  auto d = clad::differentiate(caller, "x");
 
   double matrix[4] = {0, 0, 0, 0};
   h.execute(3, 5, matrix);

--- a/test/Regressions/issue-1804.cpp
+++ b/test/Regressions/issue-1804.cpp
@@ -24,6 +24,11 @@ double f_outer(double *params, double const *obs) {
 // CHECK-NEXT:     double _t0 = (obs[0] - params[1]);
 // CHECK-NEXT:     double _d_arg = (((_d_obs ? _d_obs[0] : 0.) - _d_params[1]) * params[2] - _t0 * _d_params[2]) / (params[2] * params[2]);
 
+// The hessian wrapper hands the pullback the same null tangent in every
+// direction.
+// CHECK: void f_outer_hessian_0(double *params, const double *obs, double *hessianMatrix) {
+// CHECK: f_outer_pushforward_0_pullback(params, obs, _d_params, nullptr, _d_y, hessianMatrix + {{0U|0UL|0ULL}});
+
 // The same holds for a dereference spelled without a subscript.
 double g_inner(double *params, double const *obs) { return *obs * params[0]; }
 
@@ -31,6 +36,11 @@ double g_outer(double *params, double const *obs) { return g_inner(params, obs);
 
 // CHECK: clad::ValueAndPushforward<double, double> g_inner_pushforward(double *params, const double *obs, double *_d_params, const double *_d_obs) {
 // CHECK-NEXT:     return {*obs * params[0], (_d_obs ? *_d_obs : 0.) * params[0] + *obs * _d_params[0]};
+
+// Clang prints the type of a compound literal as `double [1]` up to clang 13
+// and as `double[1]` from clang 14 on, so accept either spelling.
+// CHECK: double g_outer_darg0_0(double *params, const double *obs) {
+// CHECK-NEXT: clad::ValueAndPushforward<double, double> _t0 = g_inner_pushforward(params, obs, (double{{ ?}}[1]){1.}, nullptr);
 
 // A local pointer inherits the null tangent of the one it is derived from. The
 // classification runs over the whole function at once, so that a read that
@@ -55,16 +65,16 @@ double h_outer(double *params, double const *obs) { return h_inner(params, obs);
 // CHECK: double _d_s = (_d_q ? _d_q[0] : 0.) * params[0] + q[0] * _d_params[0];
 // CHECK: _d_s += (_d_p ? _d_p[0] : 0.) * params[0] + p[0] * _d_params[0];
 
-// Clang prints the type of a compound literal as `double [3]` up to clang 13
-// and as `double[3]` from clang 14 on, so accept either spelling.
-// CHECK: f_inner_pushforward_pullback(params, obs, (double{{ ?}}[3]){1., 0., 0.}, nullptr, _d_t0, _d_params, (double{{ ?}}[3]){0., 0., 0.}, nullptr);
+// The null tangent flows through the pullback chain unchanged.
+// CHECK: void f_outer_pushforward_0_pullback(double *params, const double *obs, double *_d_params, const double *_d_obs, clad::ValueAndPushforward<double, double> _d_y, double *_d_params0) {
+// CHECK: f_inner_pushforward_pullback(params, obs, _d_params, _d_obs, _d_t0, _d_params0);
 
-// The pullback of the guarded read is guarded by the same condition, so the
-// null adjoint of the null tangent is never written to either.
-// CHECK: void f_inner_pushforward_pullback(double *params, const double *obs, double *_d_params, const double *_d_obs, clad::ValueAndPushforward<double, double> _d_y, double *_d_params0, double *_d_d_params, double *_d_d_obs) {
+// The pullback takes no adjoint for the tangents -- only for the requested
+// parameters -- so the null tangent has no adjoint that could be written to,
+// and its reads are guarded by the same hoisted condition.
+// CHECK: void f_inner_pushforward_pullback(double *params, const double *obs, double *_d_params, const double *_d_obs, clad::ValueAndPushforward<double, double> _d_y, double *_d_params0) {
 // CHECK: bool _cond0 = _d_obs;
-// CHECK: if (_cond0)
-// CHECK-NEXT: _d_d_obs[0] += _d_d_arg / _t0 * params[2];
+// CHECK: double _d_arg = (((_cond0 ? _d_obs[0] : 0.) - _d_params[1]) * params[2] - _t00 * _d_params[2]) / _t0;
 
 int main() {
    double params[3] = {0.5, -1, 2};

--- a/test/Regressions/issue-1955.cpp
+++ b/test/Regressions/issue-1955.cpp
@@ -17,8 +17,10 @@ double ptr_alias(double* params, double const* xlArr) {
   return params[0] * params[0] * t[0] + params[0] * params[1] * t[1];
 }
 
-// The alias gets no tangent of its own; uses of it derive to a plain 0.
-// CHECK: double ptr_alias_darg0_0(double *params, const double *xlArr) {
+// In the hessian's pushforward the const pointer parameter has a run-time
+// tangent, so the alias inherits it -- nullable, with every read guarded.
+// CHECK: clad::ValueAndPushforward<double, double> ptr_alias_pushforward(double *params, const double *xlArr, double *_d_params, const double *_d_xlArr) {
+// CHECK-NEXT: const double *_d_t = _d_xlArr;
 // CHECK-NEXT: const double *t = xlArr;
 
 double ref_alias(double* params, double const* xlArr) {
@@ -27,7 +29,9 @@ double ref_alias(double* params, double const* xlArr) {
   return params[0] * params[0] * a * b;
 }
 
-// CHECK: double ref_alias_darg0_0(double *params, const double *xlArr) {
+// A reference alias cannot be reseated to a run-time tangent, so it gets
+// none; uses of it derive to a plain 0.
+// CHECK: clad::ValueAndPushforward<double, double> ref_alias_pushforward(double *params, const double *xlArr, double *_d_params, const double *_d_xlArr) {
 // CHECK-NEXT: const double &a = xlArr[0];
 // CHECK-NEXT: const double &b = 3.;
 
@@ -44,8 +48,9 @@ double loop_alias(double* params, double const* xlArr) {
   return sum;
 }
 
-// CHECK: double loop_alias_darg0_0(double *params, const double *xlArr) {
+// CHECK: clad::ValueAndPushforward<double, double> loop_alias_pushforward(double *params, const double *xlArr, double *_d_params, const double *_d_xlArr) {
 // CHECK: unsigned int idx = i;
+// CHECK-NEXT: const double *_d_t = (_d_xlArr ? _d_xlArr + idx : nullptr);
 // CHECK-NEXT: const double *t = xlArr + 1 * idx;
 
 // A `const double&` bound to a literal broke plain reverse mode as well.
@@ -58,7 +63,15 @@ double ref_to_literal(double* params) {
 // CHECK-NEXT: const double &r = 5.;
 // CHECK-NEXT: _d_params[0] += 1 * r;
 
-// CHECK: void ptr_alias_darg0_0_grad_0_0(double *params, const double *xlArr, double *_d_params) {
+// Outside the hessian there is no tangent to inherit: the alias gets none,
+// and uses of it derive to a plain 0.
+// CHECK: double ptr_alias_darg0_0(double *params, const double *xlArr) {
+// CHECK-NEXT: const double *t = xlArr;
+
+// The reverse pass keeps the alias and its tangent `const double*` and never
+// builds an adjoint out of them.
+// CHECK: void ptr_alias_pushforward_0_pullback(double *params, const double *xlArr, double *_d_params, const double *_d_xlArr, clad::ValueAndPushforward<double, double> _d_y, double *_d_params0) {
+// CHECK-NEXT: const double *_d_t = _d_xlArr;
 // CHECK-NEXT: const double *t = xlArr;
 
 int main() {


### PR DESCRIPTION
This is a huge change, but brings complexity for Hessian generation from O(n * f) to O(f), where f is the footprint of the primal function. For RooFit, that footprint is roughly proportional to the number of parameters n itself, so this means Hessian generation goes from O(n^2) to O(n), which makes it usable for big Higgs combination models. 

Running the added benchmark from #2002, so we can see the benefit if this change.

Before this PR:
```txt
      Start  6: clad-HistFactory
6: Test command: /usr/bin/python3.12 "/home/runner/work/clad/clad/benchmark/histfactory.py" "--clad-build" "/home/runner/work/clad/clad/obj" "--compiler" "/usr/lib/llvm-20/bin/clang++"
6: Working Directory: /home/runner/work/clad/clad/obj/benchmark
6: Test timeout computed to be: 1200
6: clad build    : /home/runner/work/clad/clad/obj
6: compilation   :     28.536 s
6: n params      : 91
6: function value: 4413.41174684329
6: primal        :      0.035 ms/call
6: gradient      :      0.287 ms/call  (8.3x primal)
6: hessian       :     66.165 ms/call  (230.6x gradient)
6: gradient vs numerical: worst rel. deviation 1.15e-06 (at index 10), 0 outside tolerance
6: hessian vs numerical (8 sampled rows): worst rel. deviation 5.62e-10 (at [18,39]), 0 outside tolerance
6: hessian asymmetry: worst rel. deviation 9.37e-16
6: validation passed
 6/11 Test  #6: clad-HistFactory .................   Passed   30.13 sec
```
With this PR:
```txt
      Start  6: clad-HistFactory
6: Test command: /usr/bin/python3.12 "/home/runner/work/clad/clad/benchmark/histfactory.py" "--clad-build" "/home/runner/work/clad/clad/obj" "--compiler" "/usr/lib/llvm-20/bin/clang++"
6: Working Directory: /home/runner/work/clad/clad/obj/benchmark
6: Test timeout computed to be: 1200
6: clad build    : /home/runner/work/clad/clad/obj
6: compilation   :      6.921 s
6: n params      : 91
6: function value: 4413.41174684329
6: primal        :      0.037 ms/call
6: gradient      :      0.311 ms/call  (8.4x primal)
6: hessian       :     67.910 ms/call  (218.1x gradient)
6: gradient vs numerical: worst rel. deviation 1.15e-06 (at index 10), 0 outside tolerance
6: hessian vs numerical (8 sampled rows): worst rel. deviation 5.62e-10 (at [18,39]), 0 outside tolerance
6: hessian asymmetry: worst rel. deviation 9.37e-16
6: validation passed
 6/11 Test  #6: clad-HistFactory .................   Passed    8.57 sec
```
Compilation time is drastically reduced, evaluation time remains the same within noise.