### PR TITLE
Ci observes change cuda

### DIFF
--- a/.github/actions/observes-change/observes-change-verdict.py
+++ b/.github/actions/observes-change/observes-change-verdict.py
@@ -3,7 +3,9 @@
 
 A test counts as observing the change if it failed at baseline on any row,
 since a defect can be invisible everywhere but under valgrind. The check
-fails only for a touched test that failed nowhere.
+fails only for a touched test that ran somewhere and failed nowhere: a row
+that skipped it (an unmet REQUIRES:) reports no evidence, and a test no row
+ran leaves the question open rather than answered in the negative.
 
 How many rows saw it is reported rather than collapsed: failing everywhere
 is an ordinary regression test, while failing on exactly one is either the
@@ -42,25 +44,36 @@ def main(vdir, out=None):
         return 0
 
     total = len(applicable)
-    # test -> [(platform, kind)] for the rows where it failed at baseline
-    seen, every = {}, set()
+    # test -> [(platform, kind)] where it failed at baseline, and
+    # test -> [platform] for the rows that ran it at all.
+    seen, ran, every = {}, {}, set()
     for v in applicable:
         for name, r in v.get("tests", {}).items():
             every.add(name)
+            # A row that skipped the test learned nothing about it. Older
+            # verdicts predate the field and always ran what they report.
+            if not r.get("ran", True):
+                continue
+            ran.setdefault(name, []).append(v["platform"])
             if not r.get("passed"):
                 seen.setdefault(name, []).append((v["platform"], r.get("kind")))
 
-    rows, narrow, blind = [], [], []
+    rows, narrow, blind, unrun = [], [], [], []
     for name in sorted(every):
         where = seen.get(name, [])
-        n = len(where)
-        if n == 0:
-            rows.append((name, f"passes at baseline on all {total}"))
+        # Judge each test against the rows that ran it, not the rows that
+        # reported: 5/5 among those that ran it is not 5/20 of the matrix.
+        n, m = len(where), len(ran.get(name, []))
+        if m == 0:
+            rows.append((name, f"not run on any of the {total}"))
+            unrun.append(name)
+        elif n == 0:
+            rows.append((name, f"passes at baseline on all {m}"))
             blind.append(name)
         else:
-            rows.append((name, f"observes the change on {n}/{total}"))
+            rows.append((name, f"observes the change on {n}/{m}"))
             # One row out of many is the interesting end of the range.
-            if n == 1 and total > 1:
+            if n == 1 and m > 1:
                 narrow.append((name, where[0]))
 
     width = max(len(r[0]) for r in rows)
@@ -76,6 +89,15 @@ def main(vdir, out=None):
                   "manifests under one", "row's checking, such as valgrind or "
                   "a sanitizer. If this test is not", "about such a defect, "
                   "the result is more likely flaky than meaningful."]
+
+    if unrun:
+        lines += ["", "No platform running this check executes these tests, "
+                  "so it has no evidence", "about them either way:", ""]
+        lines += [f"  {u}" for u in unrun]
+        lines += ["", "The features their REQUIRES: names are absent from "
+                  "every row that reports", "here. Either a row that has "
+                  "them should run this check, or the change", "needs a test "
+                  "the matrix can execute."]
 
     if blind:
         lines += ["", "No platform saw these fail with the change reverted, "
@@ -97,6 +119,9 @@ def main(vdir, out=None):
         if narrow:
             md += ["", "**Evidence from a single platform**", ""]
             md += [f"- `{n}` -- only `{p}` ({k})" for n, (p, k) in narrow]
+        if unrun:
+            md += ["", "**Not run by any platform reporting here**", ""]
+            md += [f"- `{u}`" for u in unrun]
         if blind:
             md += ["", "**No platform saw these fail with the change "
                    "reverted**", ""]
@@ -117,11 +142,13 @@ def main(vdir, out=None):
                     "observed_on": sorted(p for p, _ in seen.get(name, [])),
                     "kinds": sorted({k for _, k in seen.get(name, []) if k}),
                     "observed": len(seen.get(name, [])),
-                    "of": total,
+                    "ran_on": sorted(ran.get(name, [])),
+                    "of": len(ran.get(name, [])),
                 }
                 for name in sorted(every)
             },
             "blind": blind,
+            "unrun": unrun,
             "single_platform": [n for n, _ in narrow],
             "verdict": "blind" if blind else "observed",
         }

--- a/.github/actions/observes-change/test-observes-change.py
+++ b/.github/actions/observes-change/test-observes-change.py
@@ -7,9 +7,12 @@ test drags the whole pipeline through: on a sample batch seven of eight
 tests executed a one-line patch only two of them could observe.
 
 The caller reverts and rebuilds; this runs the touched test files against
-the result and records, per test, whether each still passes. A failure to
-build is reported apart from a FileCheck mismatch, since it usually means
-the test needs a new API rather than that it pins a behavior.
+the result and records, per test, whether it ran at all and whether it
+still passes. A test this platform does not support is recorded as not
+run, since a row that never executed one learned nothing about it. A
+failure to build is reported apart from a FileCheck mismatch, since it
+usually means the test needs a new API rather than that it pins a
+behavior.
 
 Exits 0 either way. One platform cannot decide the question -- a defect can
 be invisible everywhere but under valgrind -- so it writes a verdict and
@@ -28,6 +31,11 @@ from pathlib import Path
 # A clang diagnostic and a FileCheck diagnostic share this shape; only the
 # message tells them apart.
 DIAG = re.compile(r"^[^\s].*?:\d+:\d+: error: (.*)$", re.M)
+# lit exits 0 for a test it never ran: an unmet REQUIRES: is UNSUPPORTED,
+# not a failure. Only --show-unsupported puts that in the output, and
+# without it a test nothing executed is indistinguishable from one that
+# ran and passed.
+UNSUPPORTED = re.compile(r"^UNSUPPORTED: ", re.M)
 # Project convention, not anything intrinsic; each is overridable so a
 # project laid out differently configures rather than forks.
 TEST_DIRS = ("test",)
@@ -138,10 +146,19 @@ def main():
         for t in tests:
             # lit discovers tests through the build tree, so address them there.
             p = subprocess.run([a.lit, "-v", "--no-progress-bar",
-                                str(obj_root / t)],
+                                "--show-unsupported", str(obj_root / t)],
                                capture_output=True, text=True)
             if p.returncode == 0:
-                verdict["tests"][t] = {"passed": True, "kind": None}
+                if UNSUPPORTED.search(p.stdout):
+                    verdict["tests"][t] = {"ran": False, "passed": None,
+                                           "kind": None}
+                    print(f"{t:<{width + 2}}{'SKIP':<13}not run here -- "
+                          f"REQUIRES not met")
+                    annotate("notice", t, f"Not run on {a.platform}, so this "
+                             "row has no evidence about it either way.")
+                    continue
+                verdict["tests"][t] = {"ran": True, "passed": True,
+                                       "kind": None}
                 print(f"{t:<{width + 2}}{'PASS':<13}none -- cannot fail for "
                       f"this change")
                 annotate("warning", t, f"Passes on {a.platform} with this "
@@ -149,7 +166,7 @@ def main():
                          "test. Another platform may still observe it.")
                 continue
             kind, note = classify(p.stdout + p.stderr)
-            verdict["tests"][t] = {"passed": False, "kind": kind}
+            verdict["tests"][t] = {"ran": True, "passed": False, "kind": kind}
             print(f"{t:<{width + 2}}{'FAIL':<13}{kind} -- {note}")
             annotate("notice", t, f"Observes this change on {a.platform} "
                      f"({kind}).")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
     # rebuilds only what they touch, so this costs one incremental build
     # rather than a second full one.
     - name: Revert functional hunks for the baseline
-      if: ${{ runner.os != 'windows' && matrix.cuda != true && github.event_name == 'pull_request' }}
+      if: ${{ runner.os != 'windows' && github.event_name == 'pull_request' }}
       uses: ./.github/actions/observes-change
       with:
         mode: revert
@@ -397,7 +397,7 @@ jobs:
 
         cmake --build . -- -j${{ env.ncpus }}
     - name: Check the touched tests against the baseline
-      if: ${{ always() && runner.os != 'windows' && matrix.cuda != true && env.observes_check == '1' }}
+      if: ${{ always() && runner.os != 'windows' && env.observes_check == '1' }}
       uses: ./.github/actions/observes-change
       with:
         mode: check
@@ -576,7 +576,10 @@ jobs:
   observes-change:
     name: Tests observe the change
     if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-    needs: [build]
+    # The self-hosted rows are the only ones with a GPU, so a CUDA test is
+    # measured nowhere else. Waiting for them costs the dell's wake-up time;
+    # when it never comes they simply report nothing.
+    needs: [build, build-selfhost]
     runs-on: ubuntu-24.04
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
test/CUDA files can never be shown to fail without the change that updates them: the only rows able to run them are excluded from the observes-change check, and on every other row lit skips them and the checker reads that skip as a pass. #1988 was told its updated CUDA reference results were not evidence about the change they came with.

The first commit stops a row that never ran a test from voting on it, so an unmet REQUIRES: reports "unmeasured" instead of "cannot fail" — this affects all 26 REQUIRES:-gated tests (16 cuda-runtime, 6 Enzyme, 2 OpenMP, 1 clang-repl, 1 asserts). The second lets the CUDA rows run the check and makes the verdict wait for the self-hosted matrix.