### PR TITLE
[ci] Tell an adaptation apart from an unrelated test edit.

### DIFF
--- a/.github/actions/observes-change/action.yml
+++ b/.github/actions/observes-change/action.yml
@@ -121,6 +121,21 @@ runs:
       }
       ${{ inputs.rebuild-command }}
 
+  # The mirror of the baseline pass, here rather than with it because it
+  # needs the build that has the change: only a test's pre-change form tells
+  # an edit the change forced from one that wandered in.
+  - name: Ask whether the unexplained tests are adaptations
+    if: ${{ inputs.mode == 'check' && env.observes_check == '1' }}
+    shell: bash
+    run: |
+      cd "$GITHUB_WORKSPACE"
+      "${{ github.action_path }}/test-observes-change.py" \
+        --adapt \
+        --build "${{ inputs.build-dir }}" \
+        --base-rev "$observes_base_sha" \
+        --platform "${{ inputs.platform }}" \
+        --verdict "${{ inputs.verdict-dir }}/${{ inputs.platform }}.json"
+
   - name: Decide across platforms
     if: ${{ inputs.mode == 'verdict' }}
     shell: bash

--- a/.github/actions/observes-change/observes-change-verdict.py
+++ b/.github/actions/observes-change/observes-change-verdict.py
@@ -3,9 +3,11 @@
 
 A test counts as observing the change if it failed at baseline on any row,
 since a defect can be invisible everywhere but under valgrind. The check
-fails only for a touched test that ran somewhere and failed nowhere: a row
-that skipped it (an unmet REQUIRES:) reports no evidence, and a test no row
-ran leaves the question open rather than answered in the negative.
+fails only for a touched test that ran somewhere, failed nowhere, and whose
+pre-change form passes with the change too. A row that skipped it (an unmet
+REQUIRES:) reports no evidence; a test no row ran leaves the question open
+rather than answered in the negative; and one whose pre-change form fails is
+an edit this change forced, which belongs with it.
 
 How many rows saw it is reported rather than collapsed: failing everywhere
 is an ordinary regression test, while failing on exactly one is either the
@@ -46,7 +48,7 @@ def main(vdir, out=None):
     total = len(applicable)
     # test -> [(platform, kind)] where it failed at baseline, and
     # test -> [platform] for the rows that ran it at all.
-    seen, ran, every = {}, {}, set()
+    seen, ran, adapts, every = {}, {}, {}, set()
     for v in applicable:
         for name, r in v.get("tests", {}).items():
             every.add(name)
@@ -57,16 +59,21 @@ def main(vdir, out=None):
             ran.setdefault(name, []).append(v["platform"])
             if not r.get("passed"):
                 seen.setdefault(name, []).append((v["platform"], r.get("kind")))
+            elif r.get("adapts"):
+                adapts.setdefault(name, []).append(v["platform"])
 
-    rows, narrow, blind, unrun = [], [], [], []
+    rows, narrow, blind, unrun, forced = [], [], [], [], []
     for name in sorted(every):
         where = seen.get(name, [])
         # Judge each test against the rows that ran it, not the rows that
         # reported: 5/5 among those that ran it is not 5/20 of the matrix.
-        n, m = len(where), len(ran.get(name, []))
+        n, m, k = len(where), len(ran.get(name, [])), len(adapts.get(name, []))
         if m == 0:
             rows.append((name, f"not run on any of the {total}"))
             unrun.append(name)
+        elif n == 0 and k:
+            rows.append((name, f"adapts to the change on {k}/{m}"))
+            forced.append(name)
         elif n == 0:
             rows.append((name, f"passes at baseline on all {m}"))
             blind.append(name)
@@ -89,6 +96,15 @@ def main(vdir, out=None):
                   "manifests under one", "row's checking, such as valgrind or "
                   "a sanitizer. If this test is not", "about such a defect, "
                   "the result is more likely flaky than meaningful."]
+
+    if forced:
+        lines += ["", "These cannot fail without the change, but their "
+                  "pre-change form fails with", "it -- edits the change "
+                  "forced, which belong with it:", ""]
+        lines += [f"  {f}" for f in forced]
+        lines += ["", "Whether each adaptation is the right one is a "
+                  "reviewer's call; that it is not", "an unrelated edit is "
+                  "not."]
 
     if unrun:
         lines += ["", "No platform running this check executes these tests, "
@@ -119,6 +135,9 @@ def main(vdir, out=None):
         if narrow:
             md += ["", "**Evidence from a single platform**", ""]
             md += [f"- `{n}` -- only `{p}` ({k})" for n, (p, k) in narrow]
+        if forced:
+            md += ["", "**Adaptations the change forced**", ""]
+            md += [f"- `{f}`" for f in forced]
         if unrun:
             md += ["", "**Not run by any platform reporting here**", ""]
             md += [f"- `{u}`" for u in unrun]
@@ -143,12 +162,14 @@ def main(vdir, out=None):
                     "kinds": sorted({k for _, k in seen.get(name, []) if k}),
                     "observed": len(seen.get(name, [])),
                     "ran_on": sorted(ran.get(name, [])),
+                    "adapts_on": sorted(adapts.get(name, [])),
                     "of": len(ran.get(name, [])),
                 }
                 for name in sorted(every)
             },
             "blind": blind,
             "unrun": unrun,
+            "forced": forced,
             "single_platform": [n for n, _ in narrow],
             "verdict": "blind" if blind else "observed",
         }

--- a/.github/actions/observes-change/test-observes-change.py
+++ b/.github/actions/observes-change/test-observes-change.py
@@ -14,6 +14,11 @@ failure to build is reported apart from a FileCheck mismatch, since it
 usually means the test needs a new API rather than that it pins a
 behavior.
 
+A test the baseline pass does not explain gets the mirror question, once the
+change is restored and rebuilt: does its pre-change form fail against the
+change? If it does, the edit is one the change forced, which the baseline
+side cannot tell from one that wandered in.
+
 Exits 0 either way. One platform cannot decide the question -- a defect can
 be invisible everywhere but under valgrind -- so it writes a verdict and
 observes-change-verdict.py combines them.
@@ -74,6 +79,58 @@ def clad_obj_root(build: Path):
     return Path(m.group(1))
 
 
+def run_lit(lit, obj_root, test):
+    """Run one test file and reduce lit's answer to PASS, FAIL or SKIP.
+
+    lit discovers tests through the build tree, so the test is addressed
+    there. SKIP needs --show-unsupported: lit exits 0 for a test it never ran
+    just as it does for one that passed.
+    """
+    p = subprocess.run([lit, "-v", "--no-progress-bar", "--show-unsupported",
+                        str(obj_root / test)], capture_output=True, text=True)
+    if p.returncode != 0:
+        return "FAIL", p.stdout + p.stderr
+    return ("SKIP" if UNSUPPORTED.search(p.stdout) else "PASS"), p.stdout
+
+
+def probe_adaptation(a, obj_root, verdict, width):
+    """Ask the mirror question of the tests the baseline pass left unexplained.
+
+    A test that passes at baseline can still be an edit the change forced.
+    From the baseline side that is indistinguishable from an edit with
+    nothing to do with the change, though the two call for opposite things:
+    keep it here, or move it to its own commit.
+    """
+    for t, r in verdict["tests"].items():
+        if not (r.get("ran") and r.get("passed")):
+            continue
+        # A file the change adds has no pre-change form to put in front of it.
+        if subprocess.run(["git", "cat-file", "-e", f"{a.base_rev}:{t}"],
+                          capture_output=True).returncode:
+            print(f"{t:<{width + 2}}{'NEW':<13}added by this change -- "
+                  f"nothing to compare")
+            continue
+        subprocess.run(["git", "checkout", a.base_rev, "--", t], check=True)
+        try:
+            state, _ = run_lit(a.lit, obj_root, t)
+        finally:
+            # HEAD is the change, restored above. Leaving the pre-change
+            # file behind would hand it to the rest of the job.
+            subprocess.run(["git", "checkout", "HEAD", "--", t], check=True)
+        if state == "SKIP":
+            continue
+        r["adapts"] = state == "FAIL"
+        if state == "FAIL":
+            print(f"{t:<{width + 2}}{'ADAPTS':<13}its pre-change form fails "
+                  f"with the change")
+            annotate("notice", t, f"The pre-change form of this test fails on "
+                     f"{a.platform} with the change, so the edit is one the "
+                     "change forced rather than an unrelated one.")
+        else:
+            print(f"{t:<{width + 2}}{'UNRELATED':<13}its pre-change form "
+                  f"passes too")
+
+
 def annotate(level, test, message):
     """Report this row's own result while the rest of the suite still runs.
 
@@ -105,6 +162,10 @@ def main():
     ap.add_argument("--lit", default=shutil.which("lit"))
     ap.add_argument("--list", action="store_true",
                     help="print the touched test files and exit")
+    ap.add_argument("--adapt", action="store_true",
+                    help="probe the tests the baseline pass did not explain, "
+                         "against a build that has the change (run after the "
+                         "hunks are restored and rebuilt)")
     ap.add_argument("--test-dirs", nargs="+", default=list(TEST_DIRS))
     ap.add_argument("--test-suffixes", nargs="+", default=list(TEST_SUFFIXES))
     ap.add_argument("--functional-dirs", nargs="+",
@@ -114,6 +175,26 @@ def main():
     ap.add_argument("tests", nargs="*",
                     help="test files to check (default: those the change touches)")
     a = ap.parse_args()
+
+    if a.adapt:
+        if not a.verdict or not Path(a.verdict).exists():
+            sys.exit("--adapt needs the verdict the baseline pass wrote")
+        if not a.build or not a.lit:
+            sys.exit("--adapt needs --build and lit")
+        verdict = json.loads(Path(a.verdict).read_text())
+        left = [t for t, r in verdict.get("tests", {}).items()
+                if r.get("ran") and r.get("passed")]
+        if not left:
+            print("The baseline pass explained every touched test.")
+            return 0
+        print(f"Putting the pre-change form of {len(left)} test file(s) in "
+              f"front of the change:\n")
+        width = max(len(t) for t in left)
+        print(f"{'test':<{width + 2}}{'verdict':<13}evidence")
+        print("-" * (width + 55))
+        probe_adaptation(a, clad_obj_root(Path(a.build)), verdict, width)
+        Path(a.verdict).write_text(json.dumps(verdict, indent=2))
+        return 0
 
     tests, functional = ((a.tests, ["(explicit)"]) if a.tests
                          else changed(a.base_rev, a.test_dirs, a.test_suffixes,
@@ -144,19 +225,15 @@ def main():
         print(f"{'test':<{width + 2}}{'at baseline':<13}evidence")
         print("-" * (width + 55))
         for t in tests:
-            # lit discovers tests through the build tree, so address them there.
-            p = subprocess.run([a.lit, "-v", "--no-progress-bar",
-                                "--show-unsupported", str(obj_root / t)],
-                               capture_output=True, text=True)
-            if p.returncode == 0:
-                if UNSUPPORTED.search(p.stdout):
-                    verdict["tests"][t] = {"ran": False, "passed": None,
-                                           "kind": None}
-                    print(f"{t:<{width + 2}}{'SKIP':<13}not run here -- "
-                          f"REQUIRES not met")
-                    annotate("notice", t, f"Not run on {a.platform}, so this "
-                             "row has no evidence about it either way.")
-                    continue
+            state, out = run_lit(a.lit, obj_root, t)
+            if state == "SKIP":
+                verdict["tests"][t] = {"ran": False, "passed": None,
+                                       "kind": None}
+                print(f"{t:<{width + 2}}{'SKIP':<13}not run here -- "
+                      f"REQUIRES not met")
+                annotate("notice", t, f"Not run on {a.platform}, so this "
+                         "row has no evidence about it either way.")
+            elif state == "PASS":
                 verdict["tests"][t] = {"ran": True, "passed": True,
                                        "kind": None}
                 print(f"{t:<{width + 2}}{'PASS':<13}none -- cannot fail for "
@@ -164,12 +241,13 @@ def main():
                 annotate("warning", t, f"Passes on {a.platform} with this "
                          "change reverted, so it cannot be its regression "
                          "test. Another platform may still observe it.")
-                continue
-            kind, note = classify(p.stdout + p.stderr)
-            verdict["tests"][t] = {"ran": True, "passed": False, "kind": kind}
-            print(f"{t:<{width + 2}}{'FAIL':<13}{kind} -- {note}")
-            annotate("notice", t, f"Observes this change on {a.platform} "
-                     f"({kind}).")
+            else:
+                kind, note = classify(out)
+                verdict["tests"][t] = {"ran": True, "passed": False,
+                                       "kind": kind}
+                print(f"{t:<{width + 2}}{'FAIL':<13}{kind} -- {note}")
+                annotate("notice", t, f"Observes this change on {a.platform} "
+                         f"({kind}).")
 
     if a.verdict:
         Path(a.verdict).write_text(json.dumps(verdict, indent=2))


### PR DESCRIPTION
The baseline pass asks whether the edited test fails without the change and reads "no" as "this test has nothing to do with the change". That conflates two opposite cases: a test whose RUN line or expectations the change forced also passes at baseline, since the edit is what keeps it passing, and it is told to move to its own commit -- the one place it does not belong. #1992 hit this with an Enzyme comparison test that had to move to -O1.

Ask the mirror question of whatever is left unexplained, once the hunks are restored and rebuilt: put the test's pre-change form in front of the change. If that fails, the edit is one the change forced and the verdict says so instead of failing; if it passes there too, nothing about the change explains the edit and the old advice stands. A file the change adds has no pre-change form and is left alone.

The probe reverts one test file at a time, so an edit that another test-side change in the same pull request forced reads as forced by this one. It costs a lit run per unexplained test on a build that already exists.