### PR TITLE
Resolve each hessian direction's custom forward derivative independently

### DIFF
--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1764,6 +1764,10 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
               forwRequest.UpdateDiffParamsInfo(m_Sema);
               if (!forwRequest.DVI.empty())
                 forwRequest.DVI.back().TotalCapacity = indexInterval.Finish;
+              // The request is reused across directions and the lookup only
+              // writes on success; without this reset a direction with a
+              // custom derivative leaks it into every direction after it.
+              forwRequest.CustomDerivative = nullptr;
               LookupCustomDerivativeDecl(forwRequest);
               m_DiffRequestGraph.addNode(forwRequest, /*isSource=*/true);
             }
@@ -1771,6 +1775,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
             forwRequest.Args = utils::CreateStringLiteral(
                 m_Sema.getASTContext(), PVD->getNameAsString());
             forwRequest.UpdateDiffParamsInfo(m_Sema);
+            forwRequest.CustomDerivative = nullptr;
             LookupCustomDerivativeDecl(forwRequest);
             m_DiffRequestGraph.addNode(forwRequest, /*isSource=*/true);
           }

--- a/test/Hessian/CustomDerivatives.C
+++ b/test/Hessian/CustomDerivatives.C
@@ -1,0 +1,31 @@
+// RUN: %cladclang %s -I%S/../../include -oCustomDerivatives.out 2>&1 | %filecheck %s
+// RUN: ./CustomDerivatives.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+// Each direction of a hessian resolves its own custom forward derivative. The
+// planner reuses one forward request across directions, so a custom derivative
+// registered for the first direction must not be carried into the second.
+
+double f(double x, double y) { return x * x * y; }
+
+namespace clad {
+namespace custom_derivatives {
+// Only the first direction has a custom derivative, and it is deliberately
+// scaled by 1000 so that using it for the second direction too is visible.
+double f_darg0(double x, double y) { return 1000 * 2 * x * y; }
+} // namespace custom_derivatives
+} // namespace clad
+
+// CHECK: void f_hessian(double x, double y, double *hessianMatrix) {
+// CHECK-NEXT:     clad::custom_derivatives::f_darg0_grad(x, y, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
+// CHECK-NEXT:     f_darg1_grad(x, y, hessianMatrix + {{2U|2UL|2ULL}}, hessianMatrix + {{3U|3UL|3ULL}});
+// CHECK-NEXT: }
+
+int main() {
+  double m[4] = {};
+  clad::hessian(f).execute(3., 1., m);
+  // Row 0 differentiates the custom 2000*x*y; row 1 the real df/dy = x*x.
+  printf("f [%.0f, %.0f, %.0f, %.0f]\n", m[0], m[1], m[2], m[3]);
+  // CHECK-EXEC: f [2000, 6000, 6, 0]
+}


### PR DESCRIPTION
Hessian mode derives the function once in forward mode per requested direction, and the planner builds those forward requests by mutating one DiffRequest in a loop. LookupCustomDerivativeDecl writes CustomDerivative only when it finds one, so the field survives into the next iteration: a direction whose custom derivative exists leaks it into every direction after it.

A hessian of f(x, y) with a user-registered f_darg0 but no f_darg1 then takes both of its rows from f_darg0 -- the second row is the gradient of df/dx where it should be the gradient of df/dy -- and clad emits no diagnostic. Reset the field before each lookup so every direction resolves its own.

Existing coverage misses this because test/Hessian/BuiltinDerivatives.C registers custom derivatives for both directions of f7, where a leak is indistinguishable from a correct lookup. The new test registers one for the first direction only and scales it by 1000, so the leak shows in both the generated f_hessian body and the hessian values: without the fix the second row comes out {2000, 6000} instead of {6, 0}.