### PR TITLE
Cover the dependent non-const pointer diagnostic in hessian mode

### DIFF
--- a/test/Hessian/ArrayErrors.C
+++ b/test/Hessian/ArrayErrors.C
@@ -6,9 +6,16 @@ double f(double a, const double *b) {
   return b[0] * a + b[1] * a + b[2] * a;
 }
 
+// A non-const pointer parameter outside the requested set has no tangent to
+// pass and no const pointee to read a null one as zero through.
+double g(double a, double *b) { // expected-error 2 {{dependent non-const pointer and array parameters are not supported; differentiate w.r.t. 'b' or mark it const}}
+  return b[0] * a;
+}
+
 int main() {
     clad::hessian(f, 1); // expected-error {{hessian mode differentiation w.r.t. array or pointer parameters needs explicit declaration of the indices of the array using the args parameter; did you mean 'clad::hessian}}
     clad::hessian(f, "a");
     clad::hessian(f, "a, b"); // expected-error {{hessian mode differentiation w.r.t. array or pointer parameters needs explicit declaration of the indices of the array using the args parameter; did you mean 'clad::hessian}}
     clad::hessian(f, "a, b[0:2]");
+    clad::hessian(g, "a");
 };


### PR DESCRIPTION
A hessian w.r.t. a subset of the parameters leaves the parameters outside that subset without a tangent. Forward mode reads a missing tangent as an identically zero derivative only through a const pointee, so it rejects a dependent non-const pointer parameter instead: "dependent non-const pointer and array parameters are not supported".

Hessian mode reaches that diagnostic through the per-direction forward requests it schedules, but no test pinned it there -- test/Hessian/ ArrayErrors.C covers only the missing-index-interval error, and its pointer parameter is const. Add the case, so that the behavior is guarded before anything changes how hessian mode derives.