### PR TITLE
[cmake] Bump the Enzyme backend to v0.0.290.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -92,7 +92,7 @@ if (NOT CLAD_BUILD_STATIC_ONLY)
     clad_externalProject_add(
       Enzyme
       GIT_REPOSITORY https://github.com/EnzymeAD/Enzyme
-      GIT_TAG v0.0.224
+      GIT_TAG v0.0.290
       UPDATE_COMMAND ""
       # The tag is pinned, so there is nothing to update, and leaving the step
       # connected costs a great deal: an empty UPDATE_COMMAND never creates


### PR DESCRIPTION
The pin has not moved since the backend landed: v0.0.224 is from November 2025 and sixty-six releases back, so every fix Enzyme has made since -- and every one clad might report -- is against code nobody here is running.

v0.0.290 keeps everything clad depends on. It still exports registerEnzyme(PassBuilder&), which is the whole of clad's link-time surface besides the __enzyme_autodiff calls it emits by name; ENZYME_CLANG and ENZYME_STATIC_LIB are still the options that select the static library, and EnzymeStatic-<LLVM major> is still the target that builds it. Enzyme's own CI covers LLVM 15 through 21, which contains the 19 to 21 window clad requires for this backend.