### PR TITLE
Support discrete compound assignments in reverse mode

### DIFF
--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -202,6 +202,12 @@ namespace clad {
       return llvm::cast_or_null<clang::Expr>(getRevSweepStmt());
     }
 
+    bool hasRevSweep() const {
+      return m_ValueForRevSweep || m_RevSweepBuild || m_RevSweepSrc;
+    }
+
+    bool hasRevSweepBuild() const { return static_cast<bool>(m_RevSweepBuild); }
+
     clang::Stmt* getRevSweepStmt() {
       if (!m_ValueForRevSweep && m_RevSweepBuild) {
         m_ValueForRevSweep = m_RevSweepBuild();
@@ -216,7 +222,8 @@ namespace clad {
 
     /// Materialize a pending reverse-sweep LazyBuild (e.g. discrete snapshot)
     /// before CloneNode(getExpr()). In-place FwdWrapper upgrades must run on
-    /// the canonical node first; cloning an un-upgraded wrapper loses the store.
+    /// the canonical node first; cloning an un-upgraded wrapper loses the
+    /// store.
     void prepareForFwdClone() {
       if (m_RevSweepBuild)
         getRevSweepStmt();

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -82,9 +82,13 @@ namespace clad {
     // produces the node on first read, so a representation no consumer reads
     // constructs nothing (unlike a Lazy clone, it holds no template node). The
     // adjoint slot uses it for a reverse-mode leaf's rebuilt m_Variables ref,
-    // which a terminal product-rule leaf never reads.
+    // which a terminal product-rule leaf never reads. The rev-sweep slot keeps
+    // the same LazyBuild infrastructure; discrete compound assignments use it
+    // for a consumed-only snapshot (lazy Pop/store) so discarded standalones
+    // never push.
     std::function<clang::Stmt*()> m_StmtBuild;
     std::function<clang::Stmt*()> m_StmtDxBuild;
+    std::function<clang::Stmt*()> m_RevSweepBuild;
 
     // Clone Src into Slot on first read; a no-op when Src is null (eager slot).
     clang::Stmt* materialize(clang::Stmt*& Slot, const clang::Stmt*& Src);
@@ -141,7 +145,8 @@ namespace clad {
             return valueForRevSweep.Deferred.Cloner;
           }()),
           m_StmtBuild(std::move(orig.Build)),
-          m_StmtDxBuild(std::move(diff.Build)) {
+          m_StmtDxBuild(std::move(diff.Build)),
+          m_RevSweepBuild(std::move(valueForRevSweep.Build)) {
       m_Data[1] = orig.Node;
       m_Data[0] = diff.Node;
     }
@@ -182,6 +187,7 @@ namespace clad {
     void updateRevSweep(clang::Stmt* S) {
       m_ValueForRevSweep = S;
       m_RevSweepSrc = nullptr;
+      m_RevSweepBuild = nullptr;
     }
     // Stmt_dx goes first!
     std::array<clang::Stmt*, 2>& getBothStmts() {
@@ -197,11 +203,23 @@ namespace clad {
     }
 
     clang::Stmt* getRevSweepStmt() {
+      if (!m_ValueForRevSweep && m_RevSweepBuild) {
+        m_ValueForRevSweep = m_RevSweepBuild();
+        m_RevSweepBuild = nullptr;
+      }
       if (clang::Stmt* R = materialize(m_ValueForRevSweep, m_RevSweepSrc))
         return R;
       // If there is no specific value for the reverse sweep, use the forward
       // statement.
       return getStmt();
+    }
+
+    /// Materialize a pending reverse-sweep LazyBuild (e.g. discrete snapshot)
+    /// before CloneNode(getExpr()). In-place FwdWrapper upgrades must run on
+    /// the canonical node first; cloning an un-upgraded wrapper loses the store.
+    void prepareForFwdClone() {
+      if (m_RevSweepBuild)
+        getRevSweepStmt();
     }
   };
 
@@ -1021,9 +1039,10 @@ namespace clad {
     StmtDiff::Lazy LazyClone(const clang::Stmt* N) {
       return {m_Builder.m_NodeCloner.get(), N};
     }
-    /// A StmtDiff forward-value input that runs \p B on first read and nothing
+    /// A StmtDiff representation input that runs \p B on first read and nothing
     /// if the value is never read -- for a representation that is freshly
-    /// constructed (e.g. BuildDeclRef of a remapped decl) rather than cloned,
+    /// constructed (e.g. BuildDeclRef of a remapped decl, or a reverse-sweep
+    /// snapshot that would otherwise emit an unused store) rather than cloned,
     /// so LazyClone's template node is not orphaned.
     StmtDiff::In LazyBuild(std::function<clang::Stmt*()> B) {
       return StmtDiff::In(std::move(B));

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1034,9 +1034,23 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             direction::reverse);
       // Materialize rev before closing the arm reverse block (Pop placement)
       // only when the conditional reverse value is consumed.
-      Expr* Rev =
-          requestArmRev ? ExprDiff.getRevSweepAsExpr() : nullptr;
+      Expr* Rev = requestArmRev ? ExprDiff.getRevSweepAsExpr() : nullptr;
       Expr* Fwd = ExprDiff.getExpr();
+      // Compositionally stabilize any side-effectful forward value under its
+      // branch only when the branch's reverse value is consumed (requestArmRev)
+      // so the side effects execute exactly once under this branch's condition,
+      // and the expression used downstream (in condExpr and any reverse
+      // calls/pullbacks) is pure. Discarded ternaries do not force tape/store.
+      if (requestArmRev && Fwd && Fwd->HasSideEffects(m_Context)) {
+        if (Fwd->isLValue() && Fwd->getObjectKind() != OK_BitField) {
+          Expr* addr = BuildOp(UO_AddrOf, Fwd);
+          Expr* storeAddr =
+              GlobalStoreAndRef(addr, /*prefix=*/"_t", /*force=*/true);
+          Fwd = BuildOp(UO_Deref, storeAddr);
+        } else {
+          Fwd = GlobalStoreAndRef(Fwd, /*prefix=*/"_t", /*force=*/true);
+        }
+      }
       Expr* Dx = ExprDiff.getExpr_dx();
       CompoundStmt* RCS = endBlock(direction::reverse);
       Stmt* ForwardResult = endBlock(direction::forward);
@@ -1074,7 +1088,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       addToCurrentBlock(Reverse, direction::reverse);
 
     // Arms already materialized above when requestArmRev; reuse those exprs
-    // (do not re-request rev after BuildIf -- that would mis-place discrete Pop).
+    // (do not re-request rev after BuildIf -- that would mis-place discrete
+    // Pop).
     Expr* condExpr =
         m_Sema
             .ActOnConditionalOp(noLoc, noLoc, CloneNode(condStored),
@@ -1967,26 +1982,15 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       result.updateRevSweep(moveCall);
     }
 
-    // Save cloned arg in a "global" variable, so that it is accessible from
-    // the reverse pass.
-    // For example:
-    // ```
-    // // forward pass
-    // _t0 = a;
-    // modify(a); // a is modified so we store it
-    //
-    // // reverse pass
-    // a = _t0;
-    // modify_pullback(a, ...); // the pullback should always keep `a` intact
-    // ```
-    // FIXME: Handle storing data passed through pointers and structures.
-    // FIXME: Improve TBR to handle these stores.
+    bool isDiscrete = argDiff.hasRevSweepBuild();
     bool passByRef = paramTy->isLValueReferenceType() &&
                      !paramTy.getNonReferenceType().isConstQualified();
-    if (passByRef && m_DiffReq.shouldBeRecorded(arg)) {
-      // Finalize discrete FwdWrapper before CloneNode(getExpr()). Without
-      // this, in-place upgrade never runs (argDiff dies) or runs after the
-      // clone and StoreAndRestore keeps a stale Paren(Assign).
+    bool shouldRecordRef = passByRef && m_DiffReq.shouldBeRecorded(arg);
+
+    if (isDiscrete || shouldRecordRef) {
+      // Finalize discrete FwdWrapper before CloneNode(getExpr()) or call
+      // assembly. Without this, in-place upgrade never runs (argDiff dies) or
+      // runs after the clone and CallArgs keeps a stale Paren(Assign).
       argDiff.prepareForFwdClone();
       Expr* E = argDiff.getExpr();
       // Side-effectful args (e.g. discrete assign) must run once before
@@ -2017,6 +2021,23 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           argDiff.updateStmt(CloneNode(returnExprs[0]));
         }
       }
+    }
+
+    // Save cloned arg in a "global" variable, so that it is accessible from
+    // the reverse pass.
+    // For example:
+    // ```
+    // // forward pass
+    // _t0 = a;
+    // modify(a); // a is modified so we store it
+    //
+    // // reverse pass
+    // a = _t0;
+    // modify_pullback(a, ...); // the pullback should always keep `a` intact
+    // ```
+    // FIXME: Handle storing data passed through pointers and structures.
+    // FIXME: Improve TBR to handle these stores.
+    if (shouldRecordRef) {
       // argDiff.getExpr() is also returned below as the call argument; clone
       // it for the store/restore so the node is not shared with the call.
       StmtDiff pushPop = StoreAndRestore(CloneNode(argDiff.getExpr()));
@@ -3055,17 +3076,35 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // derivative pointer also.
     bool isPointerOp = E->getType()->isPointerType();
 
-    if (opCode == UO_Plus)
+    if (opCode == UO_Plus) {
       // xi = +xj
       // dxi/dxj = +1.0
       // df/dxj += df/dxi * dxi/dxj = df/dxi
       diff = Visit(E, dfdx());
-    else if (opCode == UO_Minus) {
+      if (diff.hasRevSweep()) {
+        auto sub = std::make_shared<StmtDiff>(std::move(diff));
+        return StmtDiff(LazyBuild([this, sub]() -> Stmt* {
+                          return BuildOp(UO_Plus, sub->getExpr());
+                        }),
+                        sub->getExpr_dx(), LazyBuild([sub]() -> Stmt* {
+                          return sub->getRevSweepAsExpr();
+                        }));
+      }
+    } else if (opCode == UO_Minus) {
       // xi = -xj
       // dxi/dxj = -1.0
       // df/dxj += df/dxi * dxi/dxj = -df/dxi
       auto* d = BuildOp(UO_Minus, dfdx());
       diff = Visit(E, d);
+      if (diff.hasRevSweep()) {
+        auto sub = std::make_shared<StmtDiff>(std::move(diff));
+        return StmtDiff(LazyBuild([this, sub]() -> Stmt* {
+                          return BuildOp(UO_Minus, sub->getExpr());
+                        }),
+                        sub->getExpr_dx(), LazyBuild([this, sub]() -> Stmt* {
+                          return BuildOp(UO_Minus, sub->getRevSweepAsExpr());
+                        }));
+      }
     } else if (opCode == UO_PostInc || opCode == UO_PostDec) {
       diff = Visit(E, dfdx());
       Expr* diff_dx = diff.getExpr_dx();
@@ -3323,14 +3362,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             Expr* aseIdx = ASE->getIdx();
             const bool baseSE = aseBase->HasSideEffects(m_Context);
             const bool idxSE = aseIdx->HasSideEffects(m_Context);
-            Expr* stabBase =
-                baseSE ? GlobalStoreAndRef(aseBase, /*prefix=*/"_t",
-                                           /*force=*/true)
-                       : CloneNode(aseBase);
-            Expr* stabIdx =
-                idxSE ? GlobalStoreAndRef(aseIdx, /*prefix=*/"_t",
-                                          /*force=*/true)
-                      : CloneNode(aseIdx);
+            Expr* stabBase = baseSE
+                                 ? GlobalStoreAndRef(aseBase, /*prefix=*/"_t",
+                                                     /*force=*/true)
+                                 : CloneNode(aseBase);
+            Expr* stabIdx = idxSE ? GlobalStoreAndRef(aseIdx, /*prefix=*/"_t",
+                                                      /*force=*/true)
+                                  : CloneNode(aseIdx);
             llvm::SmallVector<Expr*, 1> idxs = {stabIdx};
             Expr* newBase = BuildArraySubscript(stabBase, idxs);
             llvm::StringRef fieldName = ME->getMemberDecl()->getName();
@@ -3344,8 +3382,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                 if (auto* ASEdx = dyn_cast<ArraySubscriptExpr>(
                         MEdx->getBase()->IgnoreParenImpCasts())) {
                   llvm::SmallVector<Expr*, 1> idxsDx = {
-                      idxSE ? CloneNode(stabIdx)
-                            : CloneNode(ASEdx->getIdx())};
+                      idxSE ? CloneNode(stabIdx) : CloneNode(ASEdx->getIdx())};
                   Expr* newBaseDx =
                       BuildArraySubscript(CloneNode(ASEdx->getBase()), idxsDx);
                   Expr* newEdx = utils::BuildMemberExpr(
@@ -4419,18 +4456,63 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
   StmtDiff ReverseModeVisitor::VisitCXXFunctionalCastExpr(
       const clang::CXXFunctionalCastExpr* FCE) {
-    StmtDiff castExprDiff = Visit(FCE->getSubExpr(), dfdx());
-    castExprDiff.updateStmt(m_Sema
-                                .BuildCXXFunctionalCastExpr(
-                                    FCE->getTypeInfoAsWritten(), FCE->getType(),
-                                    FCE->getBeginLoc(), castExprDiff.getExpr(),
-                                    FCE->getEndLoc())
-                                .get());
-    return castExprDiff;
+    StmtDiff subDiff = Visit(FCE->getSubExpr(), dfdx());
+    if (subDiff.hasRevSweep()) {
+      auto sub = std::make_shared<StmtDiff>(std::move(subDiff));
+      TypeSourceInfo* TSI = FCE->getTypeInfoAsWritten();
+      QualType Ty = FCE->getType();
+      auto beginLoc = FCE->getBeginLoc();
+      auto endLoc = FCE->getEndLoc();
+      return StmtDiff(
+          LazyBuild([this, sub, TSI, Ty, beginLoc, endLoc]() -> Stmt* {
+            return m_Sema
+                .BuildCXXFunctionalCastExpr(TSI, Ty, beginLoc, sub->getExpr(),
+                                            endLoc)
+                .get();
+          }),
+          sub->getExpr_dx(),
+          LazyBuild([this, sub, TSI, Ty, beginLoc, endLoc]() -> Stmt* {
+            return m_Sema
+                .BuildCXXFunctionalCastExpr(TSI, Ty, beginLoc,
+                                            sub->getRevSweepAsExpr(), endLoc)
+                .get();
+          }));
+    }
+    subDiff.updateStmt(
+        m_Sema
+            .BuildCXXFunctionalCastExpr(FCE->getTypeInfoAsWritten(),
+                                        FCE->getType(), FCE->getBeginLoc(),
+                                        subDiff.getExpr(), FCE->getEndLoc())
+            .get());
+    return subDiff;
   }
 
   StmtDiff ReverseModeVisitor::VisitCStyleCastExpr(const CStyleCastExpr* CSCE) {
     StmtDiff subExprDiff = Visit(CSCE->getSubExpr(), dfdx());
+    if (subExprDiff.hasRevSweep()) {
+      auto sub = std::make_shared<StmtDiff>(std::move(subExprDiff));
+      auto lParen = CSCE->getLParenLoc();
+      auto rParen = CSCE->getRParenLoc();
+      TypeSourceInfo* TSI = CSCE->getTypeInfoAsWritten();
+      return StmtDiff(
+          LazyBuild([this, sub, lParen, rParen, TSI]() -> Stmt* {
+            return m_Sema
+                .BuildCStyleCastExpr(lParen, TSI, rParen, sub->getExpr())
+                .get();
+          }),
+          LazyBuild([this, sub, lParen, rParen, TSI]() -> Stmt* {
+            Expr* dx = sub->getExpr_dx();
+            if (!dx)
+              return nullptr;
+            return m_Sema.BuildCStyleCastExpr(lParen, TSI, rParen, dx).get();
+          }),
+          LazyBuild([this, sub, lParen, rParen, TSI]() -> Stmt* {
+            return m_Sema
+                .BuildCStyleCastExpr(lParen, TSI, rParen,
+                                     sub->getRevSweepAsExpr())
+                .get();
+          }));
+    }
     Expr* castExpr = m_Sema
                          .BuildCStyleCastExpr(
                              CSCE->getLParenLoc(), CSCE->getTypeInfoAsWritten(),
@@ -4448,7 +4530,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
   StmtDiff ReverseModeVisitor::VisitCXXNamedCastExpr(
       const clang::CXXNamedCastExpr* NCE) {
-    StmtDiff subExprDiff = Visit(NCE->getSubExpr(), dfdx());
+    StmtDiff subDiff = Visit(NCE->getSubExpr(), dfdx());
 
     // Reconstruct the cast
     TypeSourceInfo* TSI = NCE->getTypeInfoAsWritten();
@@ -4476,14 +4558,31 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       assert(0 && "Unsupported cast kind!");
       break;
     }
-    Expr* castExpr =
-        m_Sema
-            .BuildCXXNamedCast(KWLoc, CastKind, TSI, subExprDiff.getExpr(),
-                               Brackets, Range)
-            .get();
-    subExprDiff.updateStmt(castExpr);
-
-    return subExprDiff;
+    if (subDiff.hasRevSweep()) {
+      auto sub = std::make_shared<StmtDiff>(std::move(subDiff));
+      return StmtDiff(LazyBuild([this, sub, KWLoc, CastKind, TSI, Brackets,
+                                 Range]() -> Stmt* {
+                        return m_Sema
+                            .BuildCXXNamedCast(KWLoc, CastKind, TSI,
+                                               sub->getExpr(), Brackets, Range)
+                            .get();
+                      }),
+                      sub->getExpr_dx(),
+                      LazyBuild([this, sub, KWLoc, CastKind, TSI, Brackets,
+                                 Range]() -> Stmt* {
+                        return m_Sema
+                            .BuildCXXNamedCast(KWLoc, CastKind, TSI,
+                                               sub->getRevSweepAsExpr(),
+                                               Brackets, Range)
+                            .get();
+                      }));
+    }
+    Expr* castExpr = m_Sema
+                         .BuildCXXNamedCast(KWLoc, CastKind, TSI,
+                                            subDiff.getExpr(), Brackets, Range)
+                         .get();
+    subDiff.updateStmt(castExpr);
+    return subDiff;
   }
 
   StmtDiff ReverseModeVisitor::VisitImplicitValueInitExpr(
@@ -4826,14 +4925,25 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             used = true;
             // Since we are manually replacing the statement, implicit casts are
             // not generated automatically.
+            if (repl->isGLValue()) {
+              ExprResult rvalueRes = m_Sema.DefaultLvalueConversion(repl);
+              if (rvalueRes.isUsable())
+                repl = rvalueRes.get();
+            }
             ExprResult newExprRes{repl};
             QualType targetTy = cast<Expr>(S)->getType();
             CastKind kind = m_Sema.PrepareScalarCast(newExprRes, targetTy);
             // CK_NoOp casts trigger an assertion on debug Clang
             if (kind == CK_NoOp)
-              S = repl;
-            else
-              S = m_Sema.ImpCastExprToType(repl, targetTy, kind).get();
+              S = newExprRes.get();
+            else {
+              ExprResult castRes =
+                  m_Sema.ImpCastExprToType(newExprRes.get(), targetTy, kind);
+              if (castRes.isUsable())
+                S = castRes.get();
+              else
+                S = newExprRes.get();
+            }
           }
         return true;
       }

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -61,6 +61,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -1000,32 +1001,53 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     auto* ifTrue = CO->getTrueExpr();
     auto* ifFalse = CO->getFalseExpr();
 
-    auto VisitBranch =
-        [&](const Expr* Branch,
-            std::function<Expr*()> dfdx) -> std::pair<StmtDiff, StmtDiff> {
-      ScopeRAII branchScope(*this, Scope::DeclScope);
-      auto Result = DifferentiateSingleExpr(Branch, std::move(dfdx));
-      StmtDiff BranchDiff = Result.first;
-      StmtDiff ExprDiff = Result.second;
-      Stmt* Forward = utils::unwrapIfSingleStmt(BranchDiff.getStmt());
-      Stmt* Reverse = utils::unwrapIfSingleStmt(BranchDiff.getStmt_dx());
-      return {StmtDiff(Forward, Reverse), ExprDiff};
-    };
-
-    StmtDiff ifTrueDiff;
-    StmtDiff ifTrueExprDiff;
-    StmtDiff ifFalseDiff;
-    StmtDiff ifFalseExprDiff;
-
     // Both arms claim a shared seed lazily: only an arm whose reverse code
     // consumes it pulls, so a constant arm builds nothing and the seed is
     // parented once across the two arms.
     SeedClaim seed(*this, dfdx());
+    // Request arm rev (and discrete Pop into the arm reverse If) only when the
+    // conditional value is differentiated. Discarded ternaries must not force
+    // unused tape -- mirror VisitParenExpr laziness.
+    const bool requestArmRev = static_cast<bool>(seed);
     auto seedThunk = [&seed]() -> Expr* {
       return seed ? seed.claim() : nullptr;
     };
-    std::tie(ifTrueDiff, ifTrueExprDiff) = VisitBranch(ifTrue, seedThunk);
-    std::tie(ifFalseDiff, ifFalseExprDiff) = VisitBranch(ifFalse, seedThunk);
+
+    // Per-arm scaffolding: when requestArmRev, materialize each arm's
+    // reverse-sweep value WHILE that arm's reverse statements are still being
+    // collected, so discrete LazyBuild Pop lands in the arm reverse block that
+    // becomes the reverse If -- not in the outer reverse block after BuildIf.
+    struct CondArm {
+      StmtDiff Stmts; // forward / reverse statement blocks
+      Expr* Fwd = nullptr;
+      Expr* Dx = nullptr;
+      Expr* Rev = nullptr;
+    };
+    auto VisitBranch = [&](const Expr* Branch,
+                           std::function<Expr*()> dfdx) -> CondArm {
+      ScopeRAII branchScope(*this, Scope::DeclScope);
+      beginBlock(direction::forward);
+      beginBlock(direction::reverse);
+      StmtDiff ExprDiff = Visit(Branch, std::move(dfdx));
+      if (m_ExternalSource)
+        m_ExternalSource->ActBeforeFinalizingDifferentiateSingleExpr(
+            direction::reverse);
+      // Materialize rev before closing the arm reverse block (Pop placement)
+      // only when the conditional reverse value is consumed.
+      Expr* Rev =
+          requestArmRev ? ExprDiff.getRevSweepAsExpr() : nullptr;
+      Expr* Fwd = ExprDiff.getExpr();
+      Expr* Dx = ExprDiff.getExpr_dx();
+      CompoundStmt* RCS = endBlock(direction::reverse);
+      Stmt* ForwardResult = endBlock(direction::forward);
+      std::reverse(RCS->body_begin(), RCS->body_end());
+      Stmt* ReverseResult = utils::unwrapIfSingleStmt(RCS);
+      Stmt* Forward = utils::unwrapIfSingleStmt(ForwardResult);
+      return {StmtDiff(Forward, ReverseResult), Fwd, Dx, Rev};
+    };
+
+    CondArm ifTrueArm = VisitBranch(ifTrue, seedThunk);
+    CondArm ifFalseArm = VisitBranch(ifFalse, seedThunk);
 
     // Clone the stored condition inside, after the empty-branch check, so an
     // if that is never built (e.g. a conditional operator whose branches have
@@ -1042,37 +1064,50 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
     // A fresh clone of the stored condition per consumer (forward if, reverse
     // if, and each conditional operator) so it is never parented twice.
-    Stmt* Forward =
-        BuildIf(condStored, ifTrueDiff.getStmt(), ifFalseDiff.getStmt());
-    Stmt* Reverse =
-        BuildIf(condStored, ifTrueDiff.getStmt_dx(), ifFalseDiff.getStmt_dx());
+    Stmt* Forward = BuildIf(condStored, ifTrueArm.Stmts.getStmt(),
+                            ifFalseArm.Stmts.getStmt());
+    Stmt* Reverse = BuildIf(condStored, ifTrueArm.Stmts.getStmt_dx(),
+                            ifFalseArm.Stmts.getStmt_dx());
     if (Forward)
       addToCurrentBlock(Forward, direction::forward);
     if (Reverse)
       addToCurrentBlock(Reverse, direction::reverse);
 
+    // Arms already materialized above when requestArmRev; reuse those exprs
+    // (do not re-request rev after BuildIf -- that would mis-place discrete Pop).
     Expr* condExpr =
         m_Sema
             .ActOnConditionalOp(noLoc, noLoc, CloneNode(condStored),
-                                ifTrueExprDiff.getExpr(),
-                                ifFalseExprDiff.getExpr())
+                                ifTrueArm.Fwd, ifFalseArm.Fwd)
             .get();
     // If result is a glvalue, we should keep it as it can potentially be
     // assigned as in (c ? a : b) = x;
     Expr* ResultRef = nullptr;
     if ((CO->isModifiableLvalue(m_Context) == Expr::MLV_Valid) &&
-        ifTrueExprDiff.getExpr_dx() && ifFalseExprDiff.getExpr_dx()) {
+        ifTrueArm.Dx && ifFalseArm.Dx) {
       ResultRef = m_Sema
                       .ActOnConditionalOp(noLoc, noLoc, CloneNode(condStored),
-                                          ifTrueExprDiff.getExpr_dx(),
-                                          ifFalseExprDiff.getExpr_dx())
+                                          ifTrueArm.Dx, ifFalseArm.Dx)
                       .get();
       if (ResultRef->isModifiableLvalue(m_Context) != Expr::MLV_Valid)
         ResultRef = nullptr;
     }
+    // Reverse-sweep value must use each arm's valueForRevPass (e.g. discrete
+    // compound assign snapshots) rather than re-evaluating the forward arms.
+    // When arms were not requested (discarded conditional), leave null so
+    // getRevSweep falls back to the forward conditional without forcing tape.
+    Expr* valueForRevPass = nullptr;
+    if (requestArmRev) {
+      valueForRevPass =
+          m_Sema
+              .ActOnConditionalOp(noLoc, noLoc, CloneNode(condStored),
+                                  CloneNode(ifTrueArm.Rev),
+                                  CloneNode(ifFalseArm.Rev))
+              .get();
+    }
     Stmt* revBlock = utils::unwrapIfSingleStmt(endBlock(direction::reverse));
     addToCurrentBlock(revBlock, direction::reverse);
-    return StmtDiff(condExpr, ResultRef);
+    return StmtDiff(condExpr, ResultRef, valueForRevPass);
   }
 
   StmtDiff
@@ -1531,10 +1566,19 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
   }
 
   StmtDiff ReverseModeVisitor::VisitParenExpr(const ParenExpr* PE) {
-    StmtDiff subStmtDiff = Visit(PE->getSubExpr(), dfdx());
-    return StmtDiff(BuildParens(subStmtDiff.getExpr()),
-                    BuildParens(subStmtDiff.getExpr_dx()),
-                    BuildParens(subStmtDiff.getRevSweepAsExpr()));
+    // Keep reverse-sweep lazy: do not force getRevSweepAsExpr here. Captured
+    // StmtDiff state is shared so discrete in-place FwdWrapper upgrades remain
+    // visible no matter which representation a parent reads first.
+    auto sub = std::make_shared<StmtDiff>(Visit(PE->getSubExpr(), dfdx()));
+    return StmtDiff(LazyBuild([this, sub]() -> Stmt* {
+                      return BuildParens(sub->getExpr());
+                    }),
+                    LazyBuild([this, sub]() -> Stmt* {
+                      return BuildParens(sub->getExpr_dx());
+                    }),
+                    LazyBuild([this, sub]() -> Stmt* {
+                      return BuildParens(sub->getRevSweepAsExpr());
+                    }));
   }
 
   StmtDiff ReverseModeVisitor::VisitInitListExpr(const InitListExpr* ILE) {
@@ -1940,6 +1984,39 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     bool passByRef = paramTy->isLValueReferenceType() &&
                      !paramTy.getNonReferenceType().isConstQualified();
     if (passByRef && m_DiffReq.shouldBeRecorded(arg)) {
+      // Finalize discrete FwdWrapper before CloneNode(getExpr()). Without
+      // this, in-place upgrade never runs (argDiff dies) or runs after the
+      // clone and StoreAndRestore keeps a stale Paren(Assign).
+      argDiff.prepareForFwdClone();
+      Expr* E = argDiff.getExpr();
+      // Side-effectful args (e.g. discrete assign) must run once before
+      // StoreAndRestore and the call both read the stable innermost lvalue;
+      // otherwise store + call re-execute n ^= 5 (12 -> 9 -> 12).
+      if (E && E->HasSideEffects(m_Context)) {
+        llvm::SmallVector<Expr*, 4> returnExprs;
+        utils::GetInnermostReturnExpr(E, returnExprs);
+        // Discrete upgrade is `(store, Lhs)`: GetInnermostReturnExpr skips
+        // non-assignment commas, so peel to the RHS lvalue.
+        if (returnExprs.empty()) {
+          Expr* cur = E->IgnoreParenImpCasts();
+          while (auto* BO = dyn_cast<BinaryOperator>(cur)) {
+            if (BO->getOpcode() != BO_Comma)
+              break;
+            cur = BO->getRHS()->IgnoreParenImpCasts();
+          }
+          utils::GetInnermostReturnExpr(cur, returnExprs);
+        }
+        if (returnExprs.size() == 1) {
+          // `(store, Lhs)` as a stmt is an unused-result and addToBlock drops
+          // it; emit the store/assign (comma LHS) which is a valid stmt.
+          Expr* toEmit = E;
+          if (auto* BO = dyn_cast<BinaryOperator>(E->IgnoreParenImpCasts()))
+            if (BO->getOpcode() == BO_Comma)
+              toEmit = BO->getLHS();
+          addToCurrentBlock(toEmit, direction::forward);
+          argDiff.updateStmt(CloneNode(returnExprs[0]));
+        }
+      }
       // argDiff.getExpr() is also returned below as the call argument; clone
       // it for the store/restore so the node is not shared with the call.
       StmtDiff pushPop = StoreAndRestore(CloneNode(argDiff.getExpr()));
@@ -3090,6 +3167,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     StmtDiff Rdiff{};
     StmtDiff Lstored{};
     Expr* valueForRevPass = nullptr;
+    Expr* primalResult = nullptr;
     auto* L = BinOp->getLHS();
     auto* R = BinOp->getRHS();
     // If it is an assignment operator, its result is a reference to LHS and
@@ -3230,18 +3308,94 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
       if (L->HasSideEffects(m_Context)) {
         Expr* E = Ldiff.getExpr();
-        llvm::SmallVector<Expr*, 4> returnExprs;
-        utils::GetInnermostReturnExpr(E, returnExprs);
-        if (returnExprs.size() == 1) {
-          addToCurrentBlock(E, direction::forward);
-          // returnExprs[0] is the innermost lvalue still parented inside E,
-          // which was just emitted; clone it so the enclosing assignment
-          // rebuilt below (e.g. the outer `= y` in `(t = x) = y`) does not
-          // share the node with E.
-          Ldiff.updateStmt(CloneNode(returnExprs[0]));
-        } else {
-          auto* storeE = GlobalStoreAndRef(BuildOp(UO_AddrOf, E));
-          Ldiff.updateStmt(BuildOp(UO_Deref, storeE));
+        // Member of an array element with a side-effectful designator (e.g.
+        // b[i++].flags or (p++)[0].flags): stabilize every side-effectful part
+        // of the designator (base and/or indices) once, then rebuild both the
+        // primal and adjoint as arr[stored].field. Do not take AddrOf of a
+        // bit-field (ill-formed). Adjoint base is not GlobalStoreAndRef'd:
+        // mirrored pointer ++/-- is undone in reverse, so DeclRef _d_p is
+        // correct when reverse runs.
+        bool stabilizedMemberSubscript = false;
+        if (auto* ME = dyn_cast<MemberExpr>(E->IgnoreParenImpCasts())) {
+          if (auto* ASE = dyn_cast<ArraySubscriptExpr>(
+                  ME->getBase()->IgnoreParenImpCasts())) {
+            Expr* aseBase = ASE->getBase();
+            Expr* aseIdx = ASE->getIdx();
+            const bool baseSE = aseBase->HasSideEffects(m_Context);
+            const bool idxSE = aseIdx->HasSideEffects(m_Context);
+            Expr* stabBase =
+                baseSE ? GlobalStoreAndRef(aseBase, /*prefix=*/"_t",
+                                           /*force=*/true)
+                       : CloneNode(aseBase);
+            Expr* stabIdx =
+                idxSE ? GlobalStoreAndRef(aseIdx, /*prefix=*/"_t",
+                                          /*force=*/true)
+                      : CloneNode(aseIdx);
+            llvm::SmallVector<Expr*, 1> idxs = {stabIdx};
+            Expr* newBase = BuildArraySubscript(stabBase, idxs);
+            llvm::StringRef fieldName = ME->getMemberDecl()->getName();
+            Expr* newE = utils::BuildMemberExpr(m_Sema, getCurrentScope(),
+                                                newBase, fieldName);
+            Ldiff.updateStmt(newE);
+
+            if (Expr* Edx = Ldiff.getExpr_dx()) {
+              if (auto* MEdx =
+                      dyn_cast<MemberExpr>(Edx->IgnoreParenImpCasts())) {
+                if (auto* ASEdx = dyn_cast<ArraySubscriptExpr>(
+                        MEdx->getBase()->IgnoreParenImpCasts())) {
+                  llvm::SmallVector<Expr*, 1> idxsDx = {
+                      idxSE ? CloneNode(stabIdx)
+                            : CloneNode(ASEdx->getIdx())};
+                  Expr* newBaseDx =
+                      BuildArraySubscript(CloneNode(ASEdx->getBase()), idxsDx);
+                  Expr* newEdx = utils::BuildMemberExpr(
+                      m_Sema, getCurrentScope(), newBaseDx, fieldName);
+                  // Visit(L) may already have emitted an AddAssign whose LHS is
+                  // the old adjoint; rewrite those reverse stmts onto the
+                  // stabilized adjoint so reverse does not re-run i++ / p++.
+                  Expr* oldEdx = Edx;
+                  for (Stmt*& S : getCurrentBlock(direction::reverse)) {
+                    if (auto* BO = dyn_cast<BinaryOperator>(S)) {
+                      if (BO->getLHS() == oldEdx)
+                        S = BuildOp(BO->getOpcode(), newEdx, BO->getRHS());
+                    }
+                  }
+                  Ldiff.updateStmtDx(newEdx);
+                }
+              }
+            }
+            stabilizedMemberSubscript = true;
+          }
+        }
+        if (!stabilizedMemberSubscript) {
+          llvm::SmallVector<Expr*, 4> returnExprs;
+          utils::GetInnermostReturnExpr(E, returnExprs);
+          if (returnExprs.size() == 1) {
+            addToCurrentBlock(E, direction::forward);
+            // returnExprs[0] is the innermost lvalue still parented inside E,
+            // which was just emitted; clone it so the enclosing assignment
+            // rebuilt below (e.g. the outer `= y` in `(t = x) = y`) does not
+            // share the node with E.
+            Ldiff.updateStmt(CloneNode(returnExprs[0]));
+            if (Expr* Edx = Ldiff.getExpr_dx()) {
+              llvm::SmallVector<Expr*, 4> dxExprs;
+              utils::GetInnermostReturnExpr(Edx, dxExprs);
+              if (dxExprs.size() == 1)
+                Ldiff.updateStmtDx(CloneNode(dxExprs[0]));
+            }
+          } else if (E->getObjectKind() != OK_BitField) {
+            auto* storeE = GlobalStoreAndRef(BuildOp(UO_AddrOf, E));
+            Ldiff.updateStmt(BuildOp(UO_Deref, storeE));
+            if (Expr* Edx = Ldiff.getExpr_dx()) {
+              if (Edx->getObjectKind() != OK_BitField) {
+                auto* storeDx = GlobalStoreAndRef(BuildOp(UO_AddrOf, Edx));
+                Ldiff.updateStmtDx(BuildOp(UO_Deref, storeDx));
+              }
+            }
+          } else {
+            addToCurrentBlock(E, direction::forward);
+            Ldiff.updateStmt(CloneNode(E));
+          }
         }
       }
 
@@ -3370,19 +3524,25 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       if (m_ExternalSource)
         m_ExternalSource->ActAfterCloningLHSOfAssignOp(LCloned, R, opCode);
 
-      // Save old value for the derivative of LHS, to avoid problems with cases
-      // like x = x.
       clang::Expr* oldValue = nullptr;
 
-      // For pointer types, no need to store old derivatives.
+      bool isDiscreteAssign =
+          (opCode == BO_RemAssign || opCode == BO_AndAssign ||
+           opCode == BO_OrAssign || opCode == BO_XorAssign ||
+           opCode == BO_ShlAssign || opCode == BO_ShrAssign);
+
+      // For pointer types or discrete ops, no need to store old derivatives.
       // ResultRef is returned as the adjoint and, for nested compound
       // assignments, reused as the next level's ResultRef; clone it for the
       // old-value store so the stores do not share the node.
-      if (indepSides)
-        oldValue = CloneNode(ResultRef);
-      else if (!isPointerOp)
-        oldValue = StoreAndRef(CloneNode(ResultRef), direction::reverse, "_r_d",
-                               /*forceDeclCreation=*/true);
+      if (!isDiscreteAssign) {
+        if (indepSides)
+          oldValue = CloneNode(ResultRef);
+        else if (!isPointerOp)
+          oldValue =
+              StoreAndRef(CloneNode(ResultRef), direction::reverse, "_r_d",
+                          /*forceDeclCreation=*/true);
+      }
       if (opCode == BO_Assign) {
         // Add the statement `dl = 0;`
         Expr* zero = getZeroInit(ResultRef->getType());
@@ -3434,21 +3594,23 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         // share the node with it.
         Expr* dr = BuildOp(BO_Mul, CloneNode(LCloned), oldValue);
         Rdiff = Visit(R, dr);
+        // Materialize reverse value while RBlock is still current so a nested
+        // discrete LazyBuild can add Pop into this block before it closes.
+        Expr* RRev = Rdiff.getRevSweepAsExpr();
         Stmts RBlock = EndBlockWithoutCreatingCS(direction::reverse);
-        // Rdiff.getRevSweepAsExpr() aliases the forward expr returned below;
-        // clone at each reverse-sweep use so they own distinct nodes. It can
-        // also be an un-stored compound expr (`l *= a + b`), so parenthesize
-        // it wherever it is embedded under a higher-precedence operator or
-        // the printed derivative mis-associates.
-        addToCurrentBlock(
-            BuildOp(BO_AddAssign, CloneNode(ResultRef),
-                    BuildOp(BO_Mul, CloneNode(oldValue),
-                            BuildParens(CloneNode(Rdiff.getRevSweepAsExpr())))),
-            direction::reverse);
+        // RRev aliases the forward expr returned below; clone at each
+        // reverse-sweep use so they own distinct nodes. It can also be an
+        // un-stored compound expr (`l *= a + b`), so parenthesize it wherever
+        // it is embedded under a higher-precedence operator or the printed
+        // derivative mis-associates.
+        addToCurrentBlock(BuildOp(BO_AddAssign, CloneNode(ResultRef),
+                                  BuildOp(BO_Mul, CloneNode(oldValue),
+                                          BuildParens(CloneNode(RRev)))),
+                          direction::reverse);
         for (auto& S : RBlock)
           addToCurrentBlock(S, direction::reverse);
         valueForRevPass =
-            BuildOp(BO_Mul, BuildParens(CloneNode(Rdiff.getRevSweepAsExpr())),
+            BuildOp(BO_Mul, BuildParens(CloneNode(RRev)),
                     BuildParens(CloneNode(Ldiff.getRevSweepAsExpr())));
         std::tie(Ldiff, Rdiff) = std::make_pair(LCloned, Rdiff.getExpr());
       } else if (opCode == BO_DivAssign) {
@@ -3479,13 +3641,115 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             BuildOp(UO_Minus, BuildOp(BO_Div, CloneNode(LCloned), RxR)));
         dr = StoreAndRef(dr, direction::reverse);
         Rdiff = Visit(R, dr);
+        // Request reverse value before any further block reshuffling so a
+        // nested discrete LazyBuild can emit Pop into the current reverse
+        // block.
+        Expr* RRev = Rdiff.getRevSweepAsExpr();
         RDelayed.Finalize(Rdiff.getExpr());
         // Parenthesize: either side can be a compound expr, which would
         // mis-associate under the division when the derivative is printed.
-        valueForRevPass =
-            BuildOp(BO_Div, BuildParens(Rdiff.getRevSweepAsExpr()),
-                    BuildParens(Ldiff.getRevSweepAsExpr()));
+        valueForRevPass = BuildOp(BO_Div, BuildParens(CloneNode(RRev)),
+                                  BuildParens(Ldiff.getRevSweepAsExpr()));
         std::tie(Ldiff, Rdiff) = std::make_pair(LCloned, RResult);
+      } else if (isDiscreteAssign) {
+        // Built-in discrete compound assignments (%=,&=,|=,^=,<<=,>>=) require
+        // integral operands, so ResultRef is never a pointer adjoint here.
+        // Snapshot of the post-assign value is LazyBuild-deferred: discarded
+        // standalone uses never push/store; a reverse consumer materializes
+        // the snapshot (and Pop) on first getRevSweepAsExpr.
+        //
+        // Order-independent protocol: a stable ParenExpr wrapper is returned
+        // from getExpr. When rev is requested (before or after getExpr), the
+        // wrapper is upgraded in place to (store_or_push(Assign), Lhs) so
+        // parents that already held the forward pointer still see the store,
+        // and lvalue identity is preserved -- (n ^= 5) &= 3 modifies n.
+        if (ResultRef) {
+          Expr* zero = getZeroInit(ResultRef->getType());
+          Expr* assign_zero = BuildOp(BO_Assign, CloneNode(ResultRef), zero);
+          addToCurrentBlock(assign_zero, direction::reverse);
+        }
+        Rdiff = Visit(R);
+        // Single evaluation of LHS+op+RHS as the store source; also covers
+        // bit-fields and side-effectful bases (no CloneNode re-read of LHS).
+        Expr* assignExpr = BuildOp(opCode, Ldiff.getExpr(), Rdiff.getExpr());
+        QualType valueType =
+            utils::getNonConstType(Ldiff.getExpr()->getType(), m_Sema);
+
+        struct DiscreteSnap {
+          Expr* Assign = nullptr;
+          Expr* Lhs = nullptr; // original / stabilized LHS lvalue
+          QualType ValueTy;
+          bool InsideLoop = false;
+          bool Requested = false;
+          bool Inited = false;
+          Expr* PushOrStore = nullptr;
+          Expr* RevVal = nullptr;
+          ParenExpr* FwdWrapper = nullptr; // stable node; upgraded in place
+        };
+        auto snap = std::make_shared<DiscreteSnap>();
+        snap->Assign = assignExpr;
+        snap->Lhs = Ldiff.getExpr();
+        snap->ValueTy = valueType;
+        snap->InsideLoop = isInsideLoop;
+        // Stable paren around Assign; unused-tape keeps this as Paren(Assign).
+        snap->FwdWrapper = cast<ParenExpr>(
+            m_Sema
+                .ActOnParenExpr(assignExpr->getBeginLoc(),
+                                assignExpr->getEndLoc(), assignExpr)
+                .get());
+
+        auto upgradeFwdWrapper = [](const std::shared_ptr<DiscreteSnap>& S,
+                                    Expr* Upgraded) {
+          // ParenExpr::setSubExpr mutates the node parents already hold.
+          S->FwdWrapper->setSubExpr(Upgraded);
+          S->FwdWrapper->setType(Upgraded->getType());
+          S->FwdWrapper->setValueKind(Upgraded->getValueKind());
+          S->FwdWrapper->setObjectKind(Upgraded->getObjectKind());
+        };
+
+        StmtDiff::In discreteRev =
+            LazyBuild([this, snap, upgradeFwdWrapper]() -> Stmt* {
+              snap->Requested = true;
+              if (!snap->Inited) {
+                if (snap->InsideLoop) {
+                  auto tape =
+                      MakeCladTapeFor(snap->Assign, "_t", snap->ValueTy);
+                  addToCurrentBlock(tape.Pop, direction::reverse);
+                  snap->PushOrStore = tape.Push;
+                  snap->RevVal = tape.Last();
+                } else {
+                  VarDecl* VD = BuildGlobalVarDecl(snap->ValueTy, "_t");
+                  addToBlock(BuildDeclStmt(VD), m_Globals);
+                  Expr* Ref = BuildDeclRef(VD);
+                  snap->PushOrStore =
+                      BuildOp(BO_Assign, BuildDeclRef(VD), snap->Assign);
+                  snap->RevVal = Ref;
+                }
+                snap->Inited = true;
+              }
+              // Upgrade even if getExpr already returned FwdWrapper.
+              Expr* upgraded =
+                  BuildOp(BO_Comma, snap->PushOrStore, CloneNode(snap->Lhs));
+              upgradeFwdWrapper(snap, upgraded);
+              return snap->RevVal;
+            });
+
+        StmtDiff::In discreteFwd = LazyBuild([snap]() -> Stmt* {
+          // Always the same pointer; may already be upgraded by discreteRev.
+          return snap->FwdWrapper;
+        });
+
+        if (m_ExternalSource)
+          m_ExternalSource->ActBeforeFinalizingAssignOp(LCloned, ResultRef, R,
+                                                        opCode);
+
+        // Output statements from Visit(L).
+        for (Stmt* S : Lblock)
+          addToCurrentBlock(S, direction::reverse);
+
+        // ResultRef stays the LHS adjoint (zeroed above in reverse). Wire
+        // LazyBuild Ins directly -- an Expr* primalResult would lose them.
+        return StmtDiff(discreteFwd, ResultRef, discreteRev);
       } else
         llvm_unreachable("unknown assignment opCode");
       if (m_ExternalSource)
@@ -3496,12 +3760,19 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       for (Stmt* S : Lblock)
         addToCurrentBlock(S, direction::reverse);
     } else if (opCode == BO_Comma) {
+      // Keep RHS reverse-sweep lazy: for-inc / discarded commas must not force
+      // discrete tape just because valueForRevPass was built eagerly.
       auto* zero =
           ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, 0);
-      Rdiff = Visit(R, dfdx());
-      Ldiff = Visit(L, zero);
-      valueForRevPass = Rdiff.getRevSweepAsExpr();
-      ResultRef = Rdiff.getExpr_dx();
+      auto Rshared = std::make_shared<StmtDiff>(Visit(R, dfdx()));
+      auto Lshared = std::make_shared<StmtDiff>(Visit(L, zero));
+      return StmtDiff(
+          LazyBuild([this, Lshared, Rshared]() -> Stmt* {
+            return BuildOp(BO_Comma, Lshared->getExpr(), Rshared->getExpr());
+          }),
+          LazyBuild([Rshared]() -> Stmt* { return Rshared->getExpr_dx(); }),
+          LazyBuild(
+              [Rshared]() -> Stmt* { return Rshared->getRevSweepAsExpr(); }));
     } else if (opCode == BO_LAnd) {
       VarDecl* condVar = GlobalStoreImpl(m_Context.BoolTy, "_cond",
                                          m_DiffReq.hasEarlyReturns()
@@ -3541,7 +3812,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
 
       return BuildOp(opCode, Visit(L).getExpr(), Visit(R).getExpr());
     }
-    Expr* op = BuildOp(opCode, Ldiff.getExpr(), Rdiff.getExpr());
+    Expr* op = primalResult ? primalResult
+                            : BuildOp(opCode, Ldiff.getExpr(), Rdiff.getExpr());
 
     // For pointer types.
     if (isPointerOp) {

--- a/test/Gradient/Assignments.C
+++ b/test/Gradient/Assignments.C
@@ -435,14 +435,15 @@ double f12(double x, double y) {
 //CHECK-NEXT:       else
 //CHECK-NEXT:           _t1 = t;
 //CHECK-NEXT:       double *_t2 = &(_cond0 ? (t = x) : (t = y));
-//CHECK-NEXT:       double _t3 = *_t2;
+//CHECK-NEXT:       double *_t3 = &(_cond0 ? _d_t : _d_t);
+//CHECK-NEXT:       double _t4 = *_t2;
 //CHECK-NEXT:       *_t2 *= y;
 //CHECK-NEXT:       _d_t += 1;
 //CHECK-NEXT:       {
-//CHECK-NEXT:           *_t2 = _t3;
-//CHECK-NEXT:           double _r_d0 = (_cond0 ? _d_t : _d_t);
-//CHECK-NEXT:           (_cond0 ? _d_t : _d_t) = 0.;
-//CHECK-NEXT:           (_cond0 ? _d_t : _d_t) += _r_d0 * y;
+//CHECK-NEXT:           *_t2 = _t4;
+//CHECK-NEXT:           double _r_d0 = *_t3;
+//CHECK-NEXT:           *_t3 = 0.;
+//CHECK-NEXT:           *_t3 += _r_d0 * y;
 //CHECK-NEXT:           *_d_y += *_t2 * _r_d0;
 //CHECK-NEXT:           if (_cond0) {
 //CHECK-NEXT:               t = _t0;

--- a/test/Gradient/CompoundBitwiseOps.C
+++ b/test/Gradient/CompoundBitwiseOps.C
@@ -698,6 +698,7 @@ double f_ternary_xor(double x, int cond) {
 // CHECK-LABEL: f_ternary_xor_grad
 // CHECK-NEXT:     int _d_cond = 0;
 // CHECK-NEXT:     int _t1;
+// CHECK-NEXT:     int *_{{[a-zA-Z0-9]+}};
 // CHECK-NEXT:     double _d_r = 0.;
 // CHECK-NEXT:     double r = x;
 // CHECK-NEXT:     int _d_n = 0;
@@ -706,7 +707,9 @@ double f_ternary_xor(double x, int cond) {
 // CHECK-NEXT:     int m = 3;
 // CHECK-NEXT:     double _t0 = r;
 // CHECK-NEXT:     bool _cond0 = cond > 0;
-// CHECK-NEXT:     r *= (_cond0 ? (_t1 = n ^= 5 , n) : m);
+// CHECK-NEXT:     if (_cond0)
+// CHECK-NEXT:         _t{{[0-9]+}} = &(_t{{[0-9]+}} = n ^= 5 , n);
+// CHECK-NEXT:     r *= (_cond0 ? *_t{{[0-9]+}} : m);
 // CHECK-NEXT:     _d_r += 1;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         r = _t0;
@@ -865,9 +868,10 @@ double f_ternary_xor_loop(double x, int count, int cond) {
 // CHECK-LABEL: f_ternary_xor_loop_grad
 // Pop for discrete arm must be inside the reverse If arm (not outer mis-pop).
 // CHECK:         clad::push(_cond0, cond > 0);
-// CHECK:         if (clad::back(_cond0))
+// CHECK:         if (clad::back(_cond0)) {
 // CHECK-NEXT:         clad::push(_t{{[0-9]+}}, n);
-// CHECK:         r *= (clad::back(_cond0) ? (clad::push(_t{{[0-9]+}}, n ^= 5) , n) : m);
+// CHECK-NEXT:         clad::push(_t{{[0-9]+}}, &(clad::push(_t{{[0-9]+}}, n ^= 5) , n));
+// CHECK:         r *= (clad::back(_cond0) ? *clad::back(_t{{[0-9]+}}) : m);
 // CHECK:         for (; _t{{[0-9]+}}; _t{{[0-9]+}}--)
 // CHECK:         if (clad::back(_cond0)) {
 // CHECK:             clad::pop(_t{{[0-9]+}});
@@ -943,6 +947,224 @@ double f_ref_call_discrete(double x) {
 // CHECK-NOT: id_ref((n ^= 5)
 // CHECK: id_ref(n);
 
+
+// Finding 2: unary-plus parent wrapping a discrete compound assign under *=.
+// Must snapshot n's post-assign value, not re-execute the assignment.
+double f_unary_plus_discrete(double x) {
+  double r = x;
+  int n = 12;
+  r *= +(n ^= 5);
+  return r;
+}
+
+// CHECK-LABEL: f_unary_plus_discrete_grad
+// CHECK: _t{{[0-9]+}} = n ^= 5
+// CHECK-NOT: +(n ^= 5)
+// CHECK: _d_r += _r_d{{[0-9]+}} * _t
+
+// Finding 2b: unary-minus parent wrapping a discrete compound assign under *=.
+double f_unary_minus_discrete(double x) {
+  double r = x;
+  int n = 12;
+  r *= -(n ^= 5);
+  return r;
+}
+
+// CHECK-LABEL: f_unary_minus_discrete_grad
+// CHECK: _t{{[0-9]+}} = n ^= 5
+// CHECK-NOT: -(n ^= 5)
+// CHECK: _d_r += _r_d{{[0-9]+}} * -_t
+
+// Finding 2c: C-style cast parent wrapping a discrete compound assign under *=.
+double f_cast_discrete(double x) {
+  double r = x;
+  int n = 12;
+  r *= (double)(n ^= 5);
+  return r;
+}
+
+// CHECK-LABEL: f_cast_discrete_grad
+// CHECK: _t{{[0-9]+}} = n ^= 5
+// CHECK-NOT: (double)(n ^= 5)
+// CHECK: _d_r += _r_d{{[0-9]+}} * (double)_t
+
+// Finding 2d: unary-plus under *= in a loop with non-self-inverse op.
+// Exposes the re-execution bug when <<= is not its own inverse.
+double f_unary_plus_shl_loop(double x, int count) {
+  double r = x;
+  int n = 3;
+  for (int i = 0; i < count; ++i)
+    r *= +(n <<= 1);
+  return r;
+}
+
+// CHECK-LABEL: f_unary_plus_shl_loop_grad
+// Pop for snapshot must be inside the reverse loop body.
+// CHECK: clad::push(_t{{[0-9]+}}, n <<= 1)
+// CHECK: clad::back(_t{{[0-9]+}})
+// CHECK-NOT: +(n <<= 1)
+
+
+// Call-parent discrete: idd(n <<= 1) in a loop.
+// The assignment must not re-execute in the pullback or reverse-forward call.
+double idd(double v) { return v; }
+
+double f_call_discrete_shl(double x) {
+  int n = 3; double r = x;
+  for (int i = 0; i < 2; ++i) r *= idd(n <<= 1);
+  return r;
+}
+
+// CHECK-LABEL: f_call_discrete_shl_grad
+// The forward loop separates the push from the call argument.
+// CHECK: clad::push({{.*}}, n <<= 1)
+// CHECK: idd(n)
+// The reverse must not re-execute n <<= 1 inside a call.
+// CHECK-NOT: idd((n <<= 1))
+// CHECK-NOT: idd_pushforward((n <<= 1)
+
+// int-returning identity variant.
+int idi(int v) { return v; }
+
+double f_call_discrete_shl_int(double x) {
+  int n = 3; double r = x;
+  for (int i = 0; i < 2; ++i) r *= idi(n <<= 1);
+  return r;
+}
+
+// Functional-cast discrete: double(n ^= 5).
+double f_funccast_discrete(double x) {
+  int n = 12;
+  double r = x * double(n ^= 5);
+  return r;
+}
+
+// CHECK-LABEL: f_funccast_discrete_grad
+// Snapshot must use the cast-wrapped assignment, not re-execute it.
+// CHECK: _t{{[0-9]+}} = {{.*}}(n ^= 5)
+// Reverse must not re-execute the assignment inside the cast.
+// CHECK-NOT: double(n ^= 5)
+
+// Named-cast discrete: static_cast<double>(n ^= 5).
+double f_namedcast_discrete(double x) {
+  int n = 12;
+  double r = x * static_cast<double>(n ^= 5);
+  return r;
+}
+
+// CHECK-LABEL: f_namedcast_discrete_grad
+// Snapshot must use the cast-wrapped assignment, not re-execute it.
+// CHECK: _t{{[0-9]+}} = {{.*}}(n ^= 5)
+// Reverse must not re-execute the assignment inside the cast.
+// CHECK-NOT: static_cast<double>(n ^= 5)
+
+// Conditional-discrete regressions:
+// 1. Unary-plus wrapping conditional with discrete arm in loop:
+double f_cond_uplus_discrete(double x) {
+  int n = 3, m = 3; double r = x;
+  for (int i = 0; i < 2; ++i) r *= +(i == 0 ? n <<= 1 : m);
+  return r;
+}
+
+// CHECK-LABEL: f_cond_uplus_discrete_grad
+// CHECK: if (clad::back(_cond0))
+// CHECK: clad::push(_t{{[0-9]+}}, &(clad::push(_t{{[0-9]+}}, n <<= 1) , n))
+// CHECK: +(clad::back(_cond0) ? *clad::back(_t{{[0-9]+}}) : m)
+// CHECK: _d_r += _r_d0 * (clad::back(_cond0) ? clad::back(_t{{[0-9]+}}) : m);
+
+// 2. C-style cast wrapping conditional with discrete arm in loop:
+double f_cond_cstyle_discrete(double x) {
+  int n = 3, m = 3; double r = x;
+  for (int i = 0; i < 2; ++i) r *= (double)(i == 0 ? n <<= 1 : m);
+  return r;
+}
+
+// CHECK-LABEL: f_cond_cstyle_discrete_grad
+// CHECK: if (clad::back(_cond0))
+// CHECK: clad::push(_t{{[0-9]+}}, &(clad::push(_t{{[0-9]+}}, n <<= 1) , n))
+// CHECK: (double)(clad::back(_cond0) ? *clad::back(_t{{[0-9]+}}) : m)
+// CHECK: _d_r += _r_d0 * (double)(clad::back(_cond0) ? clad::back(_t{{[0-9]+}}) : m);
+
+// 3. Call-parent wrapping conditional with discrete arm in loop:
+double f_cond_call_discrete(double x) {
+  int n = 3, m = 3; double r = x;
+  for (int i = 0; i < 2; ++i) r *= idd(i == 0 ? n <<= 1 : m);
+  return r;
+}
+
+// CHECK-LABEL: f_cond_call_discrete_grad
+// CHECK: if (clad::back(_cond0))
+// CHECK: clad::push(_t{{[0-9]+}}, &(clad::push(_t{{[0-9]+}}, n <<= 1) , n))
+// CHECK: idd(clad::back(_cond0) ? *clad::back(_t{{[0-9]+}}) : m)
+// The reverse pass must NOT re-execute n <<= 1 or push again.
+// CHECK-NOT: idd(clad::back(_cond0) ? (clad::push
+// CHECK-NOT: idd_pushforward(clad::back(_cond0) ? (clad::push
+
+// 4. Branch containing unary-plus inside call: idd(i == 0 ? +(n <<= 1) : m)
+double f_branch_plus(double x) {
+  int n = 3, m = 3; double r = x;
+  for (int i = 0; i < 2; ++i) r *= idd(i == 0 ? +(n <<= 1) : m);
+  return r;
+}
+
+// CHECK-LABEL: f_branch_plus_grad
+// CHECK: if (clad::back(_cond0))
+// CHECK: clad::push(_t{{[0-9]+}}, +(clad::push(_t{{[0-9]+}}, n <<= 1) , n))
+// CHECK: idd(clad::back(_cond0) ? clad::back(_t{{[0-9]+}}) : m)
+// CHECK-NOT: idd(clad::back(_cond0) ? +(clad::push
+// CHECK-NOT: idd_pushforward(clad::back(_cond0) ? +(clad::push
+
+// 5. Branch containing C-style cast inside call: idd(i == 0 ? (double)(n <<= 1) : m)
+double f_branch_cast(double x) {
+  int n = 3, m = 3; double r = x;
+  for (int i = 0; i < 2; ++i) r *= idd(i == 0 ? (double)(n <<= 1) : m);
+  return r;
+}
+
+// CHECK-LABEL: f_branch_cast_grad
+// CHECK: if (clad::back(_cond0))
+// CHECK: clad::push(_t{{[0-9]+}}, (double)(clad::push(_t{{[0-9]+}}, n <<= 1) , n))
+// CHECK: idd(clad::back(_cond0) ? clad::back(_t{{[0-9]+}}) : m)
+// CHECK-NOT: idd(clad::back(_cond0) ? (double)(clad::push
+// CHECK-NOT: idd_pushforward(clad::back(_cond0) ? (double)(clad::push
+
+// 6. Branch containing comma operator inside call: idd(i == 0 ? ((n = 4), (n <<= 1)) : m)
+double f_branch_comma(double x) {
+  int n = 3, m = 3; double r = x;
+  for (int i = 0; i < 2; ++i) r *= idd(i == 0 ? ((n = 4), (n <<= 1)) : m);
+  return r;
+}
+
+// CHECK-LABEL: f_branch_comma_grad
+// CHECK: if (clad::back(_cond0))
+// CHECK: clad::push(_t{{[0-9]+}}, &((n = 4) , (clad::push(_t{{[0-9]+}}, n <<= 1) , n)))
+// CHECK: idd(clad::back(_cond0) ? *clad::back(_t{{[0-9]+}}) : m)
+// CHECK-NOT: idd(clad::back(_cond0) ? ((n = 4)
+// CHECK-NOT: idd_pushforward(clad::back(_cond0) ? ((n = 4)
+
+// 7. xvalue in conditional arm: stored by value (cannot take address of xvalue).
+double f_xvalue_conditional(double x) {
+  double n = x;
+  double fallback = 3;
+  return x > 0 ? static_cast<double&&>(n += 1) : fallback;
+}
+
+// CHECK-LABEL: f_xvalue_conditional_grad
+// CHECK: if (_cond0)
+// CHECK: _t{{[0-9]+}} = static_cast<double &&>(n += 1);
+
+// 8. xvalue identity probe: mutation through rvalue reference.
+double set_seven(double&& value) { value = 7; return value; }
+
+double f_xvalue_identity(double x) {
+  double a = 3, b = 5;
+  set_seven(x > 0 ? static_cast<double&&>(a += 1)
+                  : static_cast<double&&>(b += 1));
+  return x * a;
+}
+
+// CHECK-LABEL: f_xvalue_identity_grad
+// CHECK: set_seven(_cond0 ? static_cast<double &&>(a += 1) : static_cast<double &&>(b += 1));
 
 
 int main() {
@@ -1173,6 +1395,111 @@ int main() {
   df_ref_call.execute(2.0, &dx_ref_call);
   std::cout << "f_ref_call_discrete df/dx = " << dx_ref_call << std::endl;
   // CHECK-EXEC: f_ref_call_discrete df/dx = 9
+
+  // Finding 2: unary-plus parent (12 ^ 5 = 9, r = x * 9, df/dx = 9)
+  auto df_uplus = clad::gradient(f_unary_plus_discrete, "x");
+  double dx_uplus = 0;
+  df_uplus.execute(2.0, &dx_uplus);
+  std::cout << "f_unary_plus_discrete df/dx = " << dx_uplus << std::endl;
+  // CHECK-EXEC: f_unary_plus_discrete df/dx = 9
+
+  // Finding 2b: unary-minus parent (-(12 ^ 5) = -9, r = x * (-9), df/dx = -9)
+  auto df_uminus = clad::gradient(f_unary_minus_discrete, "x");
+  double dx_uminus = 0;
+  df_uminus.execute(2.0, &dx_uminus);
+  std::cout << "f_unary_minus_discrete df/dx = " << dx_uminus << std::endl;
+  // CHECK-EXEC: f_unary_minus_discrete df/dx = -9
+
+  // Finding 2c: C-style cast parent ((double)(12 ^ 5) = 9, df/dx = 9)
+  auto df_cast = clad::gradient(f_cast_discrete, "x");
+  double dx_cast = 0;
+  df_cast.execute(2.0, &dx_cast);
+  std::cout << "f_cast_discrete df/dx = " << dx_cast << std::endl;
+  // CHECK-EXEC: f_cast_discrete df/dx = 9
+
+  // Finding 2d: unary-plus <<= in loop (3<<1=6, 6<<1=12, r=x*6*12=72x, df/dx=72)
+  auto df_shl_loop = clad::gradient(f_unary_plus_shl_loop, "x");
+  double dx_shl_loop = 0;
+  df_shl_loop.execute(1.0, 2, &dx_shl_loop);
+  std::cout << "f_unary_plus_shl_loop df/dx = " << dx_shl_loop << std::endl;
+  // CHECK-EXEC: f_unary_plus_shl_loop df/dx = 72
+
+  // Call-parent discrete: idd(n <<= 1) in loop, f(x) = x * 6 * 12 = 72x
+  auto df_call_shl = clad::gradient(f_call_discrete_shl, "x");
+  double dx_call_shl = 0;
+  df_call_shl.execute(1.0, &dx_call_shl);
+  std::cout << "f_call_discrete_shl df/dx = " << dx_call_shl << std::endl;
+  // CHECK-EXEC: f_call_discrete_shl df/dx = 72
+
+  // int-returning identity variant
+  auto df_call_shl_int = clad::gradient(f_call_discrete_shl_int, "x");
+  double dx_call_shl_int = 0;
+  df_call_shl_int.execute(1.0, &dx_call_shl_int);
+  std::cout << "f_call_discrete_shl_int df/dx = " << dx_call_shl_int << std::endl;
+  // CHECK-EXEC: f_call_discrete_shl_int df/dx = 72
+
+  // Functional-cast discrete: int(12 ^ 5) = 9, f = x * 9
+  auto df_funccast = clad::gradient(f_funccast_discrete, "x");
+  double dx_funccast = 0;
+  df_funccast.execute(3.0, &dx_funccast);
+  std::cout << "f_funccast_discrete df/dx = " << dx_funccast << std::endl;
+  // CHECK-EXEC: f_funccast_discrete df/dx = 9
+
+  // Named-cast discrete: static_cast<double>(12 ^ 5) = 9, f = x * 9
+  auto df_namedcast = clad::gradient(f_namedcast_discrete, "x");
+  double dx_namedcast = 0;
+  df_namedcast.execute(3.0, &dx_namedcast);
+  std::cout << "f_namedcast_discrete df/dx = " << dx_namedcast << std::endl;
+  // CHECK-EXEC: f_namedcast_discrete df/dx = 9
+
+  // Conditional-discrete regressions:
+  auto df_cond_uplus = clad::gradient(f_cond_uplus_discrete, "x");
+  double dx_cond_uplus = 0;
+  df_cond_uplus.execute(1.0, &dx_cond_uplus);
+  std::cout << "f_cond_uplus_discrete df/dx = " << dx_cond_uplus << std::endl;
+  // CHECK-EXEC: f_cond_uplus_discrete df/dx = 18
+
+  auto df_cond_cstyle = clad::gradient(f_cond_cstyle_discrete, "x");
+  double dx_cond_cstyle = 0;
+  df_cond_cstyle.execute(1.0, &dx_cond_cstyle);
+  std::cout << "f_cond_cstyle_discrete df/dx = " << dx_cond_cstyle << std::endl;
+  // CHECK-EXEC: f_cond_cstyle_discrete df/dx = 18
+
+  auto df_cond_call = clad::gradient(f_cond_call_discrete, "x");
+  double dx_cond_call = 0;
+  df_cond_call.execute(1.0, &dx_cond_call);
+  std::cout << "f_cond_call_discrete df/dx = " << dx_cond_call << std::endl;
+  // CHECK-EXEC: f_cond_call_discrete df/dx = 18
+
+  auto df_bplus = clad::gradient(f_branch_plus, "x");
+  double dx_bplus = 0;
+  df_bplus.execute(1.0, &dx_bplus);
+  std::cout << "f_branch_plus df/dx = " << dx_bplus << std::endl;
+  // CHECK-EXEC: f_branch_plus df/dx = 18
+
+  auto df_bcast = clad::gradient(f_branch_cast, "x");
+  double dx_bcast = 0;
+  df_bcast.execute(1.0, &dx_bcast);
+  std::cout << "f_branch_cast df/dx = " << dx_bcast << std::endl;
+  // CHECK-EXEC: f_branch_cast df/dx = 18
+
+  auto df_bcomma = clad::gradient(f_branch_comma, "x");
+  double dx_bcomma = 0;
+  df_bcomma.execute(1.0, &dx_bcomma);
+  std::cout << "f_branch_comma df/dx = " << dx_bcomma << std::endl;
+  // CHECK-EXEC: f_branch_comma df/dx = 24
+
+  auto df_xval = clad::gradient(f_xvalue_conditional);
+  double dx_xval = 0;
+  df_xval.execute(2.0, &dx_xval);
+  std::cout << "f_xvalue_conditional df/dx = " << dx_xval << std::endl;
+  // CHECK-EXEC: f_xvalue_conditional df/dx = 1
+
+  auto df_xval_id = clad::gradient(f_xvalue_identity);
+  double dx_xval_id = 0;
+  df_xval_id.execute(2.0, &dx_xval_id);
+  std::cout << "f_xvalue_identity df/dx = " << dx_xval_id << std::endl;
+  // CHECK-EXEC: f_xvalue_identity df/dx = 7
 
   return 0;
 }

--- a/test/Gradient/CompoundBitwiseOps.C
+++ b/test/Gradient/CompoundBitwiseOps.C
@@ -1,0 +1,1178 @@
+// RUN: %cladclang %s -I%S/../../include -oCompoundBitwiseOps.out 2>&1 | %filecheck %s
+// RUN: ./CompoundBitwiseOps.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+#include <iostream>
+
+// 1. %= operator
+double f_rem(double x, int y) {
+  int n = 10;
+  n %= y;
+  return x * n;
+}
+
+// CHECK-LABEL: f_rem_grad
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 10;
+// CHECK-NEXT:     (n %= y);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * n;
+// CHECK-NEXT:         _d_n += x * 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_n = 0;
+// CHECK-NEXT: }
+
+
+// 2. &= operator
+double f_and(double x, int y) {
+  int n = y;
+  n &= 7;
+  return x * n;
+}
+
+// CHECK-LABEL: f_and_grad
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = y;
+// CHECK-NEXT:     (n &= 7);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * n;
+// CHECK-NEXT:         _d_n += x * 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_n = 0;
+// CHECK-NEXT:     _d_y += _d_n;
+// CHECK-NEXT: }
+
+
+// 3. |= operator
+double f_or(double x, int y) {
+  int n = y;
+  n |= 3;
+  return x * n;
+}
+
+// CHECK-LABEL: f_or_grad
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = y;
+// CHECK-NEXT:     (n |= 3);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * n;
+// CHECK-NEXT:         _d_n += x * 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_n = 0;
+// CHECK-NEXT:     _d_y += _d_n;
+// CHECK-NEXT: }
+
+
+// 4. ^= operator
+double f_xor(double x, int y) {
+  int n = y;
+  n ^= 5;
+  return x * n;
+}
+
+// CHECK-LABEL: f_xor_grad
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = y;
+// CHECK-NEXT:     (n ^= 5);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * n;
+// CHECK-NEXT:         _d_n += x * 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_n = 0;
+// CHECK-NEXT:     _d_y += _d_n;
+// CHECK-NEXT: }
+
+
+// 5. <<= operator
+double f_shl(double x, int y) {
+  int n = y;
+  n <<= 2;
+  return x * n;
+}
+
+// CHECK-LABEL: f_shl_grad
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = y;
+// CHECK-NEXT:     (n <<= 2);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * n;
+// CHECK-NEXT:         _d_n += x * 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_n = 0;
+// CHECK-NEXT:     _d_y += _d_n;
+// CHECK-NEXT: }
+
+
+// 6. >>= operator
+double f_shr(double x, int y) {
+  int n = y;
+  n >>= 1;
+  return x * n;
+}
+
+// CHECK-LABEL: f_shr_grad
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = y;
+// CHECK-NEXT:     (n >>= 1);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * n;
+// CHECK-NEXT:         _d_n += x * 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_n = 0;
+// CHECK-NEXT:     _d_y += _d_n;
+// CHECK-NEXT: }
+
+
+// 7. Compound assignment inside a loop
+double f_loop(double x, int n) {
+  double res = x;
+  int mask = 15;
+  for (int i = 0; i < n; ++i) {
+    mask %= 4;
+    res += x * mask;
+    mask += 5;
+  }
+  return res;
+}
+
+// CHECK-LABEL: f_loop_grad
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     clad::tape<int> _t1 = {};
+// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double res = x;
+// CHECK-NEXT:     int _d_mask = 0;
+// CHECK-NEXT:     int mask = 15;
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         (mask %= 4);
+// CHECK-NEXT:         res += x * mask;
+// CHECK-NEXT:         clad::push(_t1, mask);
+// CHECK-NEXT:         mask += 5;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         mask = clad::pop(_t1);
+// CHECK-NEXT:         {
+// CHECK-NEXT:             *_d_x += _d_res * mask;
+// CHECK-NEXT:             _d_mask += x * _d_res;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         _d_mask = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_x += _d_res;
+// CHECK-NEXT: }
+
+
+// 8. Nested %= expression
+double f_nested_rem(double x, int y) {
+  int n = 10;
+  return x * (n %= y);
+}
+
+// CHECK-LABEL: f_nested_rem_grad
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 10;
+// CHECK-NEXT:     double _t0 = (n %= y);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * _t0;
+// CHECK-NEXT:         _d_n += x * 1;
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+
+// 9. Nested &= expression
+double f_nested_and(double x, int y) {
+  int n = 11;
+  return x * (n &= y);
+}
+
+// CHECK-LABEL: f_nested_and_grad
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 11;
+// CHECK-NEXT:     double _t0 = (n &= y);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * _t0;
+// CHECK-NEXT:         _d_n += x * 1;
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+
+int next(int& y) {
+  return ++y;
+}
+
+// 10. Nested compound assignment with RHS side effect
+double f_nested_side_effect(double x, int y) {
+  int n = 10;
+  return x * (n %= next(y));
+}
+
+// CHECK-LABEL: f_nested_side_effect_grad
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 10;
+// CHECK-NEXT:     int _t1 = y;
+// CHECK-NEXT:     double _t0 = (n %= next(y));
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * _t0;
+// CHECK-NEXT:         _d_n += x * 1;
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:         y = _t1;
+// CHECK-NEXT:         next_pullback(y, 0, &_d_y);
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+
+// 11. Compound assignment inside a loop with RHS side effect
+double f_loop_side_effect(double x, int n, int y) {
+  double res = x;
+  int mask = 15;
+  for (int i = 0; i < n; ++i) {
+    mask %= next(y);
+    res += x * mask;
+  }
+  return res;
+}
+
+// CHECK-LABEL: f_loop_side_effect_grad
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     clad::tape<int> _t1 = {};
+// CHECK-NEXT:     clad::tape<int> _t2 = {};
+// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double res = x;
+// CHECK-NEXT:     int _d_mask = 0;
+// CHECK-NEXT:     int mask = 15;
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         clad::push(_t1, mask);
+// CHECK-NEXT:         clad::push(_t2, y);
+// CHECK-NEXT:         (mask %= next(y));
+// CHECK-NEXT:         res += x * mask;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             *_d_x += _d_res * mask;
+// CHECK-NEXT:             _d_mask += x * _d_res;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             mask = clad::pop(_t1);
+// CHECK-NEXT:             _d_mask = 0;
+// CHECK-NEXT:             y = clad::pop(_t2);
+// CHECK-NEXT:             next_pullback(y, 0, &_d_y);
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_x += _d_res;
+// CHECK-NEXT: }
+
+
+// 12. Nested XOR under parent compound assignment (*=)
+double nested_xor_mul_assign(double x, int y) {
+  double result = x;
+  int n = 12;
+  result *= (n ^= y);
+  return result;
+}
+
+// CHECK-LABEL: nested_xor_mul_assign_grad
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _t1;
+// CHECK-NEXT:     double _d_result = 0.;
+// CHECK-NEXT:     double result = x;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 12;
+// CHECK-NEXT:     double _t0 = result;
+// CHECK-NEXT:     result *= (_t1 = n ^= y , n);
+// CHECK-NEXT:     _d_result += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         result = _t0;
+// CHECK-NEXT:         double _r_d0 = _d_result;
+// CHECK-NEXT:         _d_result = 0.;
+// CHECK-NEXT:         _d_result += _r_d0 * _t1;
+// CHECK-NEXT:         _d_n += result * _r_d0;
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_x += _d_result;
+// CHECK-NEXT: }
+
+
+// 13. Nested left shift under parent compound assignment (*=)
+double nested_shl_mul_assign(double x, int shift) {
+  double result = x;
+  int n = 3;
+  result *= (n <<= shift);
+  return result;
+}
+
+// CHECK-LABEL: nested_shl_mul_assign_grad
+// CHECK-NEXT:     int _d_shift = 0;
+// CHECK-NEXT:     int _t1;
+// CHECK-NEXT:     double _d_result = 0.;
+// CHECK-NEXT:     double result = x;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 3;
+// CHECK-NEXT:     double _t0 = result;
+// CHECK-NEXT:     result *= (_t1 = n <<= shift , n);
+// CHECK-NEXT:     _d_result += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         result = _t0;
+// CHECK-NEXT:         double _r_d0 = _d_result;
+// CHECK-NEXT:         _d_result = 0.;
+// CHECK-NEXT:         _d_result += _r_d0 * _t1;
+// CHECK-NEXT:         _d_n += result * _r_d0;
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_x += _d_result;
+// CHECK-NEXT: }
+
+
+
+// 14. Nested right shift under parent compound assignment (*=)
+double nested_shr_mul_assign(double x, int shift) {
+  double result = x;
+  int n = 20;
+  result *= (n >>= shift);
+  return result;
+}
+
+// CHECK-LABEL: nested_shr_mul_assign_grad
+// CHECK-NEXT:     int _d_shift = 0;
+// CHECK-NEXT:     int _t1;
+// CHECK-NEXT:     double _d_result = 0.;
+// CHECK-NEXT:     double result = x;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 20;
+// CHECK-NEXT:     double _t0 = result;
+// CHECK-NEXT:     result *= (_t1 = n >>= shift , n);
+// CHECK-NEXT:     _d_result += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         result = _t0;
+// CHECK-NEXT:         double _r_d0 = _d_result;
+// CHECK-NEXT:         _d_result = 0.;
+// CHECK-NEXT:         _d_result += _r_d0 * _t1;
+// CHECK-NEXT:         _d_n += result * _r_d0;
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_x += _d_result;
+// CHECK-NEXT: }
+
+
+
+// 15. Narrowing conversion (unsigned char)
+double nested_narrow_shift(double x) {
+  double result = x;
+  unsigned char n = 200;
+  result *= (n <<= 1);
+  return result;
+}
+
+// CHECK-LABEL: nested_narrow_shift_grad
+// CHECK-NEXT:     unsigned char _t1;
+// CHECK-NEXT:     double _d_result = 0.;
+// CHECK-NEXT:     double result = x;
+// CHECK-NEXT:     unsigned char _d_n = 0;
+// CHECK-NEXT:     unsigned char n = 200;
+// CHECK-NEXT:     double _t0 = result;
+// CHECK-NEXT:     result *= (_t1 = n <<= 1 , n);
+// CHECK-NEXT:     _d_result += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         result = _t0;
+// CHECK-NEXT:         double _r_d0 = _d_result;
+// CHECK-NEXT:         _d_result = 0.;
+// CHECK-NEXT:         _d_result += _r_d0 * _t1;
+// CHECK-NEXT:         _d_n += result * _r_d0;
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_x += _d_result;
+// CHECK-NEXT: }
+
+
+
+// 16. Loop-aware preservation for discrete compound assignment
+double nested_xor_loop(double x, int count, int y) {
+  double result = x;
+  int n = 12;
+  for (int i = 0; i < count; ++i)
+    result *= (n ^= y);
+  return result;
+}
+
+// CHECK-LABEL: nested_xor_loop_grad
+// CHECK-NEXT:     int _d_count = 0;
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     clad::tape<int> _t2 = {};
+// CHECK-NEXT:     clad::tape<int> _t3 = {};
+// CHECK-NEXT:     double _d_result = 0.;
+// CHECK-NEXT:     double result = x;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 12;
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
+// CHECK-NEXT:     for (i = 0; i < count; ++i) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         clad::push(_t1, result);
+// CHECK-NEXT:         clad::push(_t2, n);
+// CHECK-NEXT:         result *= (clad::push(_t3, n ^= y) , n);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_result += 1;
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         result = clad::pop(_t1);
+// CHECK-NEXT:         double _r_d0 = _d_result;
+// CHECK-NEXT:         _d_result = 0.;
+// CHECK-NEXT:         _d_result += _r_d0 * clad::back(_t3);
+// CHECK-NEXT:         _d_n += result * _r_d0;
+// CHECK-NEXT:         n = clad::pop(_t2);
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:         clad::pop(_t3);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_x += _d_result;
+// CHECK-NEXT: }
+
+
+// 17. Bit-field LHS: reference binding is ill-formed ([class.bit]/5),
+// so the generated code must not bind T& to the result.
+struct Bits { int flags : 8; };
+double f_bitfield(double x, int mask) {
+  Bits b;
+  b.flags = 12;
+  b.flags &= mask;
+  return x * b.flags;
+}
+
+// CHECK-LABEL: f_bitfield_grad
+// CHECK-NOT: int &{{.*}} = b.flags
+// CHECK-NEXT:     int _d_mask = 0;
+// CHECK-NEXT:     Bits _d_b = {0};
+// CHECK-NEXT:     Bits b;
+// CHECK-NEXT:     b.flags = 12;
+// CHECK-NEXT:     (b.flags &= mask);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * b.flags;
+// CHECK-NEXT:         _d_b.flags += x * 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_b.flags = 0;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r_d0 = _d_b.flags;
+// CHECK-NEXT:         _d_b.flags = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+
+// 18. Array subscript LHS
+double f_arr_rem(double x, int y) {
+  int arr[2] = {10, 20};
+  arr[0] %= y;
+  return x * arr[0];
+}
+
+// CHECK-LABEL: f_arr_rem_grad
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_arr[2] = {0};
+// CHECK-NEXT:     int arr[2] = {10, 20};
+// CHECK-NEXT:     (arr[0] %= y);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * arr[0];
+// CHECK-NEXT:         _d_arr[0] += x * 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_arr[0] = 0;
+// CHECK-NEXT: }
+
+
+
+// 19. Nested bit-field value consumption under parent *=.
+// Must not bind T& to the bit-field; parent consumes the post-assign value.
+double nested_bitfield_mul_assign(double x, int mask) {
+  double result = x;
+  Bits b;
+  b.flags = 12;
+  result *= (b.flags &= mask);
+  return result;
+}
+
+// CHECK-LABEL: nested_bitfield_mul_assign_grad
+// CHECK-NOT: int &{{.*}} = b.flags
+// CHECK-NEXT:     int _d_mask = 0;
+// CHECK-NEXT:     int _t1;
+// CHECK-NEXT:     double _d_result = 0.;
+// CHECK-NEXT:     double result = x;
+// CHECK-NEXT:     Bits _d_b = {0};
+// CHECK-NEXT:     Bits b;
+// CHECK-NEXT:     b.flags = 12;
+// CHECK-NEXT:     double _t0 = result;
+// CHECK-NEXT:     result *= (_t1 = b.flags &= mask , b.flags);
+// CHECK-NEXT:     _d_result += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         result = _t0;
+// CHECK-NEXT:         double _r_d1 = _d_result;
+// CHECK-NEXT:         _d_result = 0.;
+// CHECK-NEXT:         _d_result += _r_d1 * _t1;
+// CHECK-NEXT:         _d_b.flags += result * _r_d1;
+// CHECK-NEXT:         _d_b.flags = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         int _r_d0 = _d_b.flags;
+// CHECK-NEXT:         _d_b.flags = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_x += _d_result;
+// CHECK-NEXT: }
+
+
+
+
+// --- Astra review findings coverage (diff w.r.t. x) ---
+
+// Finding 1 BLOCKER: unparenthesized discrete under *= in a loop.
+// Must not pop-before-back; expected gradient 108 (same as nested_xor_loop).
+double f_unparen_xor_mul_loop(double x, int count, int y) {
+  double r = x;
+  int n = 12;
+  for (int i = 0; i < count; ++i)
+    r *= n ^= y;
+  return r;
+}
+
+// CHECK-LABEL: f_unparen_xor_mul_loop_grad
+// CHECK-NEXT:     int _d_count = 0;
+// CHECK-NEXT:     int _d_y = 0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     clad::tape<double> _t1 = {};
+// CHECK-NEXT:     clad::tape<int> _t2 = {};
+// CHECK-NEXT:     clad::tape<int> _t3 = {};
+// CHECK-NEXT:     double _d_r = 0.;
+// CHECK-NEXT:     double r = x;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 12;
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
+// CHECK-NEXT:     for (i = 0; i < count; ++i) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         clad::push(_t1, r);
+// CHECK-NEXT:         clad::push(_t2, n);
+// CHECK-NEXT:         r *= (clad::push(_t3, n ^= y) , n);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_r += 1;
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         r = clad::pop(_t1);
+// CHECK-NEXT:         double _r_d0 = _d_r;
+// CHECK-NEXT:         _d_r = 0.;
+// CHECK-NEXT:         _d_r += _r_d0 * clad::back(_t3);
+// CHECK-NEXT:         _d_n += r * _r_d0;
+// CHECK-NEXT:         n = clad::pop(_t2);
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:         clad::pop(_t3);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_x += _d_r;
+// CHECK-NEXT: }
+
+
+// Finding 2: discrete inside comma expression.
+double f_comma_xor(double x) {
+  int n = 0;
+  return x * ((n = 12), (n ^= 5));
+}
+
+// CHECK-LABEL: f_comma_xor_grad
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 0;
+// CHECK-NEXT:     double _t0 = ((n = 12) , (n ^= 5));
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * _t0;
+// CHECK-NEXT:         _d_n += x * 1;
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:         _d_n += 0;
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+
+// Finding 3: side-effectful bit-field base under *=.
+// Harden: b[2] so a second reverse i++ would be OOB; assert index stays 1.
+double f_bitfield_side_effect(double x) {
+  Bits b[2];
+  b[0].flags = 7;
+  b[1].flags = 7;
+  int i = 0;
+  double r = x;
+  r *= (b[i++].flags &= 5);
+  // Forward must evaluate i++ once; reverse must reuse the stored index.
+  if (i != 1)
+    return -1; // signal failure without aborting lit
+  return r;
+}
+
+// CHECK-LABEL: f_bitfield_side_effect_grad
+// CHECK-NOT: int &{{.*}} = b[
+// CHECK-NOT: _d_b[i++]
+// CHECK-NEXT:     int _t2;
+// CHECK-NEXT:     bool _cond0 = false;
+// CHECK-NEXT:     Bits _d_b[2]{0};
+// CHECK-NEXT:     Bits b[2];
+// CHECK-NEXT:     double _d_r = 0.;
+// CHECK-NEXT:     double r = x;
+// CHECK-NEXT:     double _t0 = r;
+// CHECK-NEXT:     int _t1 = 0;
+// CHECK-NEXT:     auto _rev0 = [&] {
+// CHECK-NEXT:         if (_cond0)
+// CHECK-NEXT:             ;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             r = _t0;
+// CHECK-NEXT:             double _r_d2 = _d_r;
+// CHECK-NEXT:             _d_r = 0.;
+// CHECK-NEXT:             _d_r += _r_d2 * _t2;
+// CHECK-NEXT:             _d_b[_t1].flags += r * _r_d2;
+// CHECK-NEXT:             _d_b[_t1].flags = 0;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         *_d_x += _d_r;
+// CHECK-NEXT:         {
+// CHECK-NEXT:             int _r_d1 = _d_b[1].flags;
+// CHECK-NEXT:             _d_b[1].flags = 0;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         {
+// CHECK-NEXT:             int _r_d0 = _d_b[0].flags;
+// CHECK-NEXT:             _d_b[0].flags = 0;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     };
+// CHECK-NEXT:     b[0].flags = 7;
+// CHECK-NEXT:     b[1].flags = 7;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     _t1 = i++;
+// CHECK-NEXT:     r *= (_t2 = b[_t1].flags &= 5 , b[_t1].flags);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _cond0 = i != 1;
+// CHECK-NEXT:         if (_cond0) {
+// CHECK-NEXT:             _rev0();
+// CHECK-NEXT:             return;
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_r += 1;
+// CHECK-NEXT:     _rev0();
+// CHECK-NEXT: }
+
+
+// Finding 3b: side-effectful pointer base under bit-field discrete assign.
+// Without stabilizing the complete designator, the snap comma re-runs p++ and
+// the reverse value reads b[1].flags (==3) instead of the post-assign 5.
+double f_bitfield_base_side_effect(double x) {
+  Bits b[2] = {{7}, {3}};
+  Bits* p = b;
+  double r = x;
+  r *= ((p++)[0].flags &= 5);
+  return r;
+}
+
+// CHECK-LABEL: f_bitfield_base_side_effect_grad
+// Stabilized base: one p++ into a stored pointer; no second p++ on value/adjoint.
+// CHECK-NOT: ({{.*}}p++{{.*}}flags &= 5{{.*}},{{.*}}p++
+// CHECK:     {{.*}} = p++;
+// CHECK:     r *= ({{.*}} = {{.*}}[0].flags &= 5 , {{.*}}[0].flags);
+
+
+// Finding 4: discrete in ternary arm under *=.
+double f_ternary_xor(double x, int cond) {
+  double r = x;
+  int n = 12;
+  int m = 3;
+  r *= (cond > 0 ? n ^= 5 : m);
+  return r;
+}
+
+// CHECK-LABEL: f_ternary_xor_grad
+// CHECK-NEXT:     int _d_cond = 0;
+// CHECK-NEXT:     int _t1;
+// CHECK-NEXT:     double _d_r = 0.;
+// CHECK-NEXT:     double r = x;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 12;
+// CHECK-NEXT:     int _d_m = 0;
+// CHECK-NEXT:     int m = 3;
+// CHECK-NEXT:     double _t0 = r;
+// CHECK-NEXT:     bool _cond0 = cond > 0;
+// CHECK-NEXT:     r *= (_cond0 ? (_t1 = n ^= 5 , n) : m);
+// CHECK-NEXT:     _d_r += 1;
+// CHECK-NEXT:     {
+// CHECK-NEXT:         r = _t0;
+// CHECK-NEXT:         double _r_d0 = _d_r;
+// CHECK-NEXT:         _d_r = 0.;
+// CHECK-NEXT:         _d_r += _r_d0 * (_cond0 ? _t1 : m);
+// CHECK-NEXT:         if (_cond0) {
+// CHECK-NEXT:             _d_n += r * _r_d0;
+// CHECK-NEXT:             _d_n = 0;
+// CHECK-NEXT:         } else
+// CHECK-NEXT:             _d_m += r * _r_d0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_x += _d_r;
+// CHECK-NEXT: }
+
+
+// Finding 5: discrete in for-loop increment (must not crash cast<Expr>).
+double f_for_inc_xor(double x) {
+  double r = 0;
+  int n = 12;
+  for (int i = 0; i < 2; ++i, n ^= 5)
+    r += x * n;
+  return r;
+}
+
+// CHECK-LABEL: f_for_inc_xor_grad
+// CHECK-NOT: clad::push({{.*}}n ^= 5
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     clad::tape<int> _t1 = {};
+// CHECK-NEXT:     double _d_r = 0.;
+// CHECK-NEXT:     double r = 0;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 12;
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
+// CHECK-NEXT:     for (i = 0; i < 2; clad::push(_t1, n) , (++i , (n ^= 5))) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         r += x * n;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_r += 1;
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         {
+// CHECK-NEXT:             n = clad::pop(_t1);
+// CHECK-NEXT:             _d_n = 0;
+// CHECK-NEXT:             _d_i += 0;
+// CHECK-NEXT:         }
+// CHECK-NEXT:         *_d_x += _d_r * n;
+// CHECK-NEXT:         _d_n += x * _d_r;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+
+
+// Finding 6 BLOCKER: chained discrete must keep LHS lvalue identity.
+// (n ^= 5) &= 3 must modify n, not a snapshot temporary _t.
+double f_discrete_lvalue_chain(double x) {
+  int n = 0;
+  (n ^= 5) &= 3;
+  return x * n;
+}
+
+// CHECK-LABEL: f_discrete_lvalue_chain_grad
+// CHECK-NOT: (_t{{[0-9]*}} &=
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 0;
+// CHECK-NEXT:     (n ^= 5);
+// CHECK-NEXT:     (n &= 3);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * n;
+// CHECK-NEXT:         _d_n += x * 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+
+double f_discrete_lvalue_chain_loop(double x, int count) {
+  int n = 0;
+  for (int i = 0; i < count; ++i)
+    (n ^= 5) &= 3;
+  return x * n;
+}
+
+// CHECK-LABEL: f_discrete_lvalue_chain_loop_grad
+// CHECK-NEXT:     int _d_count = 0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int n = 0;
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
+// CHECK-NEXT:     for (i = 0; i < count; ++i) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         (n ^= 5);
+// CHECK-NEXT:         (n &= 3);
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         *_d_x += 1 * n;
+// CHECK-NEXT:         _d_n += x * 1;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:         _d_n = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+
+// Finding 7: discarded standalone discrete in a loop must not always push.
+double f_loop_discarded_discrete(double x, int n) {
+  double res = x;
+  int mask = 15;
+  for (int i = 0; i < n; ++i) {
+    mask %= 4; // discarded; reverse never consumes the post-assign value
+    res += x;
+  }
+  return res;
+}
+
+// CHECK-LABEL: f_loop_discarded_discrete_grad
+// CHECK-NOT: clad::push({{.*}}mask %=
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double res = x;
+// CHECK-NEXT:     int _d_mask = 0;
+// CHECK-NEXT:     int mask = 15;
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         (mask %= 4);
+// CHECK-NEXT:         res += x;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         *_d_x += _d_res;
+// CHECK-NEXT:         _d_mask = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_x += _d_res;
+// CHECK-NEXT: }
+
+
+
+// Finding 4b: ternary discrete arm inside a loop -- Pop must live in the
+// arm's reverse If, not the outer reverse block (mis-pop when cond==0).
+double f_ternary_xor_loop(double x, int count, int cond) {
+  double r = x;
+  int n = 12;
+  int m = 3;
+  for (int i = 0; i < count; ++i)
+    r *= (cond > 0 ? (n ^= 5) : m);
+  return r;
+}
+
+// CHECK-LABEL: f_ternary_xor_loop_grad
+// Pop for discrete arm must be inside the reverse If arm (not outer mis-pop).
+// CHECK:         clad::push(_cond0, cond > 0);
+// CHECK:         if (clad::back(_cond0))
+// CHECK-NEXT:         clad::push(_t{{[0-9]+}}, n);
+// CHECK:         r *= (clad::back(_cond0) ? (clad::push(_t{{[0-9]+}}, n ^= 5) , n) : m);
+// CHECK:         for (; _t{{[0-9]+}}; _t{{[0-9]+}}--)
+// CHECK:         if (clad::back(_cond0)) {
+// CHECK:             clad::pop(_t{{[0-9]+}});
+// CHECK:         } else
+// CHECK:         clad::pop(_cond0);
+
+// count=2, cond=0 => df/dx = 3*3 = 9
+// count=2, cond=1 => df/dx = 9*12 = 108
+
+// Finding 4c: parenthesized discarded discrete in a loop -- VisitParenExpr
+// must not eagerly request rev (no discrete tape/push).
+double f_loop_paren_discarded_discrete(double x, int n) {
+  double res = x;
+  int mask = 15;
+  for (int i = 0; i < n; ++i) {
+    (mask %= 4);
+    res += x;
+  }
+  return res;
+}
+
+// CHECK-LABEL: f_loop_paren_discarded_discrete_grad
+// CHECK-NOT: clad::push({{.*}}mask %=
+// CHECK-NEXT:     int _d_n = 0;
+// CHECK-NEXT:     int _d_i = 0;
+// CHECK-NEXT:     int i = 0;
+// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double res = x;
+// CHECK-NEXT:     int _d_mask = 0;
+// CHECK-NEXT:     int mask = 15;
+// CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
+// CHECK-NEXT:     for (i = 0; i < n; ++i) {
+// CHECK-NEXT:         _t0++;
+// CHECK-NEXT:         (mask %= 4);
+// CHECK-NEXT:         res += x;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:         *_d_x += _d_res;
+// CHECK-NEXT:         _d_mask = 0;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     *_d_x += _d_res;
+// CHECK-NEXT: }
+// Finding 4d: discarded ternary discrete arm in a loop -- must not push.
+double f_loop_discarded_ternary_discrete(double x, int n, int cond) {
+  double res = x;
+  int mask = 15;
+  for (int i = 0; i < n; ++i) {
+    (cond ? (mask ^= 5) : mask);
+    res += x;
+  }
+  return res;
+}
+
+// CHECK-LABEL: f_loop_discarded_ternary_discrete_grad
+// CHECK-NOT: clad::push({{.*}}mask ^=
+
+
+// Finding 8: non-const-ref call arg with discrete assign -- DifferentiateCallArg
+// must prepareForFwdClone before CloneNode(getExpr()) so StoreAndRestore sees
+// the upgraded snapshot wrapper (order-independent / clone-safe).
+// disable_tbr forces shouldBeRecorded so the CloneNode path is exercised.
+int id_ref(int& n) { return n; }
+
+double f_ref_call_discrete(double x) {
+  int n = 12;
+  return x * id_ref(n ^= 5);
+}
+
+// CHECK-LABEL: f_ref_call_discrete_grad
+// Snap/assign runs once as a stmt; call/store use stable n.
+// CHECK: {{_t[0-9]+ = n \^= 5;|clad::push\(.*n \^= 5}}
+// CHECK-NOT: id_ref((n ^= 5)
+// CHECK: id_ref(n);
+
+
+
+int main() {
+  // Test 1: rem (10 % 3 = 1 -> df/dx = 1)
+  auto df_rem = clad::gradient(f_rem, "x");
+  double dx_rem = 0;
+  df_rem.execute(5.0, 3, &dx_rem);
+  std::cout << "df_rem/dx = " << dx_rem << std::endl;
+  // CHECK-EXEC: df_rem/dx = 1
+
+  // Test 2: and (11 & 7 = 3 -> df/dx = 3)
+  auto df_and = clad::gradient(f_and, "x");
+  double dx_and = 0;
+  df_and.execute(4.0, 11, &dx_and);
+  std::cout << "df_and/dx = " << dx_and << std::endl;
+  // CHECK-EXEC: df_and/dx = 3
+
+  // Test 3: or (4 | 3 = 7 -> df/dx = 7)
+  auto df_or = clad::gradient(f_or, "x");
+  double dx_or = 0;
+  df_or.execute(2.0, 4, &dx_or);
+  std::cout << "df_or/dx = " << dx_or << std::endl;
+  // CHECK-EXEC: df_or/dx = 7
+
+  // Test 4: xor (12 ^ 5 = 9 -> df/dx = 9)
+  auto df_xor = clad::gradient(f_xor, "x");
+  double dx_xor = 0;
+  df_xor.execute(3.0, 12, &dx_xor);
+  std::cout << "df_xor/dx = " << dx_xor << std::endl;
+  // CHECK-EXEC: df_xor/dx = 9
+
+  // Test 5: shl (3 << 2 = 12 -> df/dx = 12)
+  auto df_shl = clad::gradient(f_shl, "x");
+  double dx_shl = 0;
+  df_shl.execute(2.0, 3, &dx_shl);
+  std::cout << "df_shl/dx = " << dx_shl << std::endl;
+  // CHECK-EXEC: df_shl/dx = 12
+
+  // Test 6: shr (10 >> 1 = 5 -> df/dx = 5)
+  auto df_shr = clad::gradient(f_shr, "x");
+  double dx_shr = 0;
+  df_shr.execute(2.0, 10, &dx_shr);
+  std::cout << "df_shr/dx = " << dx_shr << std::endl;
+  // CHECK-EXEC: df_shr/dx = 5
+
+  // Test 7: loop
+  auto df_loop = clad::gradient(f_loop, "x");
+  double dx_loop = 0;
+  df_loop.execute(2.0, 3, &dx_loop);
+  std::cout << "df_loop/dx = " << dx_loop << std::endl;
+  // CHECK-EXEC: df_loop/dx = 5
+
+  // Test 8: nested_rem (x * (n %= y) with x=5, n=10, y=3 -> n becomes 1 -> df/dx = 1)
+  auto df_nested_rem = clad::gradient(f_nested_rem, "x");
+  double dx_nested_rem = 0;
+  df_nested_rem.execute(5.0, 3, &dx_nested_rem);
+  std::cout << "df_nested_rem/dx = " << dx_nested_rem << std::endl;
+  // CHECK-EXEC: df_nested_rem/dx = 1
+
+  // Test 9: nested_and (x * (n &= y) with x=4, n=11, y=7 -> n becomes 3 -> df/dx = 3)
+  auto df_nested_and = clad::gradient(f_nested_and, "x");
+  double dx_nested_and = 0;
+  df_nested_and.execute(4.0, 7, &dx_nested_and);
+  std::cout << "df_nested_and/dx = " << dx_nested_and << std::endl;
+  // CHECK-EXEC: df_nested_and/dx = 3
+
+  // Test 10: nested_side_effect
+  auto df_nested_side_effect = clad::gradient(f_nested_side_effect, "x");
+  double dx_nested_side_effect = 0;
+  df_nested_side_effect.execute(5.0, 2, &dx_nested_side_effect);
+  std::cout << "df_nested_side_effect/dx = " << dx_nested_side_effect << std::endl;
+  // CHECK-EXEC: df_nested_side_effect/dx = 1
+
+  // Test 11: loop_side_effect
+  auto df_loop_side_effect = clad::gradient(f_loop_side_effect, "x");
+  double dx_loop_side_effect = 0;
+  df_loop_side_effect.execute(2.0, 2, 2, &dx_loop_side_effect);
+  std::cout << "df_loop_side_effect/dx = " << dx_loop_side_effect << std::endl;
+  // CHECK-EXEC: df_loop_side_effect/dx = 1
+
+  // Test 12: nested_xor_mul_assign (12 ^ 5 = 9 -> expected df/dx = 9)
+  auto df_nested_xor = clad::gradient(nested_xor_mul_assign, "x");
+  double dx_nested_xor = 0;
+  df_nested_xor.execute(2.0, 5, &dx_nested_xor);
+  std::cout << "nested_xor_mul_assign df/dx = " << dx_nested_xor << std::endl;
+  // CHECK-EXEC: nested_xor_mul_assign df/dx = 9
+
+  // Test 13: nested_shl_mul_assign (3 << 2 = 12 -> expected df/dx = 12)
+  auto df_nested_shl = clad::gradient(nested_shl_mul_assign, "x");
+  double dx_nested_shl = 0;
+  df_nested_shl.execute(2.0, 2, &dx_nested_shl);
+  std::cout << "nested_shl_mul_assign df/dx = " << dx_nested_shl << std::endl;
+  // CHECK-EXEC: nested_shl_mul_assign df/dx = 12
+
+  // Test 14: nested_shr_mul_assign (20 >> 1 = 10 -> expected df/dx = 10)
+  auto df_nested_shr = clad::gradient(nested_shr_mul_assign, "x");
+  double dx_nested_shr = 0;
+  df_nested_shr.execute(2.0, 1, &dx_nested_shr);
+  std::cout << "nested_shr_mul_assign df/dx = " << dx_nested_shr << std::endl;
+  // CHECK-EXEC: nested_shr_mul_assign df/dx = 10
+
+  // Test 15: nested_narrow_shift (200 <<= 1 -> unsigned char 144 -> expected df/dx = 144)
+  auto df_nested_narrow = clad::gradient(nested_narrow_shift, "x");
+  double dx_nested_narrow = 0;
+  df_nested_narrow.execute(2.0, &dx_nested_narrow);
+  std::cout << "nested_narrow_shift df/dx = " << dx_nested_narrow << std::endl;
+  // CHECK-EXEC: nested_narrow_shift df/dx = 144
+
+  // Test 16: nested_xor_loop (iter 1: 12^5=9, iter 2: 9^5=12 -> 9 * 12 = 108 -> expected df/dx = 108)
+  auto df_nested_xor_loop = clad::gradient(nested_xor_loop, "x");
+  double dx_nested_xor_loop = 0;
+  df_nested_xor_loop.execute(2.0, 2, 5, &dx_nested_xor_loop);
+  std::cout << "nested_xor_loop df/dx = " << dx_nested_xor_loop << std::endl;
+  // CHECK-EXEC: nested_xor_loop df/dx = 108
+
+  // Test 17: bit-field LHS (12 & 5 = 4 -> df/dx = 4)
+  auto df_bitfield = clad::gradient(f_bitfield, "x");
+  double dx_bitfield = 0;
+  df_bitfield.execute(3.0, 5, &dx_bitfield);
+  std::cout << "f_bitfield df/dx = " << dx_bitfield << std::endl;
+  // CHECK-EXEC: f_bitfield df/dx = 4
+
+  // Test 18: array subscript LHS (10 % 3 = 1 -> df/dx = 1)
+  auto df_arr_rem = clad::gradient(f_arr_rem, "x");
+  double dx_arr_rem = 0;
+  df_arr_rem.execute(5.0, 3, &dx_arr_rem);
+  std::cout << "f_arr_rem df/dx = " << dx_arr_rem << std::endl;
+  // CHECK-EXEC: f_arr_rem df/dx = 1
+
+
+  // Test 19: nested bit-field under *= (12 & 5 = 4 -> df/dx = 4)
+  auto df_nested_bitfield = clad::gradient(nested_bitfield_mul_assign, "x");
+  double dx_nested_bitfield = 0;
+  df_nested_bitfield.execute(3.0, 5, &dx_nested_bitfield);
+  std::cout << "nested_bitfield_mul_assign df/dx = " << dx_nested_bitfield << std::endl;
+  // CHECK-EXEC: nested_bitfield_mul_assign df/dx = 4
+
+
+  // Finding 1: unparenthesized r *= n ^= y in loop -> 108
+  auto df_unparen = clad::gradient(f_unparen_xor_mul_loop, "x");
+  double dx_unparen = 0;
+  df_unparen.execute(2.0, 2, 5, &dx_unparen);
+  std::cout << "f_unparen_xor_mul_loop df/dx = " << dx_unparen << std::endl;
+  // CHECK-EXEC: f_unparen_xor_mul_loop df/dx = 108
+
+  // Finding 2: comma (n=12, n^=5) -> 9
+  auto df_comma = clad::gradient(f_comma_xor, "x");
+  double dx_comma = 0;
+  df_comma.execute(2.0, &dx_comma);
+  std::cout << "f_comma_xor df/dx = " << dx_comma << std::endl;
+  // CHECK-EXEC: f_comma_xor df/dx = 9
+
+  // Finding 3: side-effectful bit-field -> 5
+  auto df_bf_se = clad::gradient(f_bitfield_side_effect, "x");
+  double dx_bf_se = 0;
+  df_bf_se.execute(2.0, &dx_bf_se);
+  std::cout << "f_bitfield_side_effect df/dx = " << dx_bf_se << std::endl;
+  // CHECK-EXEC: f_bitfield_side_effect df/dx = 5
+
+  // Finding 3b: side-effectful pointer base -> 5
+  auto df_bf_base_se = clad::gradient(f_bitfield_base_side_effect, "x");
+  double dx_bf_base_se = 0;
+  df_bf_base_se.execute(2.0, &dx_bf_base_se);
+  std::cout << "f_bitfield_base_side_effect df/dx = " << dx_bf_base_se << std::endl;
+  // CHECK-EXEC: f_bitfield_base_side_effect df/dx = 5
+
+  // Finding 4: ternary discrete arm (cond>0: 12^5=9)
+  auto df_tern = clad::gradient(f_ternary_xor, "x");
+  double dx_tern = 0;
+  df_tern.execute(2.0, 1, &dx_tern);
+  std::cout << "f_ternary_xor df/dx = " << dx_tern << std::endl;
+  // CHECK-EXEC: f_ternary_xor df/dx = 9
+
+  // Finding 5: for-increment discrete
+  // i=0: n=12, r+=x*12; then n^=5 -> 9; i=1: r+=x*9; then n^=5
+  // gradient = 12+9 = 21
+  auto df_for_inc = clad::gradient(f_for_inc_xor, "x");
+  double dx_for_inc = 0;
+  df_for_inc.execute(2.0, &dx_for_inc);
+  std::cout << "f_for_inc_xor df/dx = " << dx_for_inc << std::endl;
+  // CHECK-EXEC: f_for_inc_xor df/dx = 21
+
+  // Finding 6: lvalue chain (n^=5)&=3 -> n becomes 1 -> dx=1
+  auto df_lvalue = clad::gradient(f_discrete_lvalue_chain, "x");
+  double dx_lvalue = 0;
+  df_lvalue.execute(2.0, &dx_lvalue);
+  std::cout << "f_discrete_lvalue_chain df/dx = " << dx_lvalue << std::endl;
+  // CHECK-EXEC: f_discrete_lvalue_chain df/dx = 1
+
+  auto df_lvalue_loop = clad::gradient(f_discrete_lvalue_chain_loop, "x");
+  double dx_lvalue_loop = 0;
+  df_lvalue_loop.execute(2.0, 1, &dx_lvalue_loop);
+  std::cout << "f_discrete_lvalue_chain_loop df/dx = " << dx_lvalue_loop << std::endl;
+  // CHECK-EXEC: f_discrete_lvalue_chain_loop df/dx = 1
+
+  // Finding 7: discarded loop discrete (gradient is n+1 for res+=x each iter + init)
+  auto df_disc = clad::gradient(f_loop_discarded_discrete, "x");
+  double dx_disc = 0;
+  df_disc.execute(2.0, 3, &dx_disc);
+  std::cout << "f_loop_discarded_discrete df/dx = " << dx_disc << std::endl;
+  // CHECK-EXEC: f_loop_discarded_discrete df/dx = 4
+
+  // Ternary+loop: cond=0 => 9; cond=1 => 108
+  auto df_tern_loop = clad::gradient(f_ternary_xor_loop, "x");
+  double dx_tern_loop0 = 0;
+  df_tern_loop.execute(2.0, 2, 0, &dx_tern_loop0);
+  std::cout << "f_ternary_xor_loop cond0 df/dx = " << dx_tern_loop0 << std::endl;
+  // CHECK-EXEC: f_ternary_xor_loop cond0 df/dx = 9
+  double dx_tern_loop1 = 0;
+  df_tern_loop.execute(2.0, 2, 1, &dx_tern_loop1);
+  std::cout << "f_ternary_xor_loop cond1 df/dx = " << dx_tern_loop1 << std::endl;
+  // CHECK-EXEC: f_ternary_xor_loop cond1 df/dx = 108
+
+  auto df_paren_disc = clad::gradient(f_loop_paren_discarded_discrete, "x");
+  double dx_paren_disc = 0;
+  df_paren_disc.execute(2.0, 3, &dx_paren_disc);
+  std::cout << "f_loop_paren_discarded_discrete df/dx = " << dx_paren_disc << std::endl;
+  // CHECK-EXEC: f_loop_paren_discarded_discrete df/dx = 4
+
+  auto df_tern_disc = clad::gradient(f_loop_discarded_ternary_discrete, "x");
+  double dx_tern_disc = 0;
+  df_tern_disc.execute(2.0, 3, 1, &dx_tern_disc);
+  std::cout << "f_loop_discarded_ternary_discrete df/dx = " << dx_tern_disc << std::endl;
+  // CHECK-EXEC: f_loop_discarded_ternary_discrete df/dx = 4
+
+  auto df_ref_call = clad::gradient<clad::opts::disable_tbr>(f_ref_call_discrete, "x");
+  double dx_ref_call = 0;
+  df_ref_call.execute(2.0, &dx_ref_call);
+  std::cout << "f_ref_call_discrete df/dx = " << dx_ref_call << std::endl;
+  // CHECK-EXEC: f_ref_call_discrete df/dx = 9
+
+  return 0;
+}

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -576,13 +576,14 @@ int main() {
 // CHECK-NEXT:          std::vector<double> _t1 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, x, &_d_a, *_d_x);
 // CHECK-NEXT:          {{.*}}value_type *_t2 = &a[1];
-// CHECK-NEXT:          {{.*}}value_type _t3 = *_t2;
+// CHECK-NEXT:          {{.*}}value_type *_t3 = &_d_a[1];
+// CHECK-NEXT:          {{.*}}value_type _t4 = *_t2;
 // CHECK-NEXT:          *_t2 = x * x;
 // CHECK-NEXT:          _d_a[1] += 1;
 // CHECK-NEXT:          {
-// CHECK-NEXT:              *_t2 = _t3;
-// CHECK-NEXT:              {{.*}}value_type _r_d0 = _d_a[1];
-// CHECK-NEXT:              _d_a[1] = 0.;
+// CHECK-NEXT:              *_t2 = _t4;
+// CHECK-NEXT:              {{.*}}value_type _r_d0 = *_t3;
+// CHECK-NEXT:              *_t3 = 0.;
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
 // CHECK-NEXT:          }
@@ -628,22 +629,27 @@ int main() {
 // CHECK-NEXT:         std::array<double, 2> _d_a = {{.*}};
 // CHECK-NEXT:         std::array<double, 2> a;
 // CHECK-NEXT:         {{.*}}value_type *_t0 = &a[0];
-// CHECK-NEXT:         {{.*}}value_type _t1 = *_t0;
+// CHECK-NEXT:         {{.*}}value_type *_t1 = &_d_a[0];
+// CHECK-NEXT:         {{.*}}value_type _t2 = *_t0;
 // CHECK-NEXT:         *_t0 = 5;
-// CHECK-NEXT:         {{.*}}value_type *_t2 = &a[1];
-// CHECK-NEXT:         {{.*}}value_type _t3 = *_t2;
-// CHECK-NEXT:         *_t2 = y;
+// CHECK-NEXT:         {{.*}}value_type *_t3 = &a[1];
+// CHECK-NEXT:         {{.*}}value_type *_t4 = &_d_a[1];
+// CHECK-NEXT:         {{.*}}value_type _t5 = *_t3;
+// CHECK-NEXT:         *_t3 = y;
 // CHECK-NEXT:         std::array<double, 3> _d_b = {{.*}};
 // CHECK-NEXT:         std::array<double, 3> _b0;
-// CHECK-NEXT:         {{.*}}value_type *_t4 = &_b0[0];
-// CHECK-NEXT:         {{.*}}value_type _t5 = *_t4;
-// CHECK-NEXT:         *_t4 = x;
-// CHECK-NEXT:         {{.*}}value_type *_t6 = &_b0[1];
-// CHECK-NEXT:         {{.*}}value_type _t7 = *_t6;
-// CHECK-NEXT:         *_t6 = 0;
-// CHECK-NEXT:         {{.*}}value_type *_t8 = &_b0[2];
-// CHECK-NEXT:         {{.*}}value_type _t9 = *_t8;
-// CHECK-NEXT:         *_t8 = x * x;
+// CHECK-NEXT:         {{.*}}value_type *_t6 = &_b0[0];
+// CHECK-NEXT:         {{.*}}value_type *_t7 = &_d_b[0];
+// CHECK-NEXT:         {{.*}}value_type _t8 = *_t6;
+// CHECK-NEXT:         *_t6 = x;
+// CHECK-NEXT:         {{.*}}value_type *_t9 = &_b0[1];
+// CHECK-NEXT:         {{.*}}value_type *_t10 = &_d_b[1];
+// CHECK-NEXT:         {{.*}}value_type _t11 = *_t9;
+// CHECK-NEXT:         *_t9 = 0;
+// CHECK-NEXT:         {{.*}}value_type *_t12 = &_b0[2];
+// CHECK-NEXT:         {{.*}}value_type *_t13 = &_d_b[2];
+// CHECK-NEXT:         {{.*}}value_type _t14 = *_t12;
+// CHECK-NEXT:         *_t12 = x * x;
 // CHECK-NEXT:         std::array<double, 3> _d_b0 = {{.*}};
 // CHECK-NEXT:         const std::array<double, 3> b = _b0;
 // CHECK:              {{.*}}value_type [[T_BACK:_t[0-9]+]] = a.back();
@@ -659,33 +665,33 @@ int main() {
 // CHECK-NEXT:         }
 // CHECK:              {{.*}}constructor_pullback(_b0, &_d_b0, &_d_b);
 // CHECK:                  {
-// CHECK-NEXT:             *_t8 = _t9;
-// CHECK-NEXT:             {{.*}}value_type _r_d4 = _d_b[2];
-// CHECK-NEXT:             _d_b[2] = 0.;
+// CHECK-NEXT:             *_t12 = _t14;
+// CHECK-NEXT:             {{.*}}value_type _r_d4 = *_t13;
+// CHECK-NEXT:             *_t13 = 0.;
 // CHECK-NEXT:             *_d_x += _r_d4 * x;
 // CHECK-NEXT:             *_d_x += x * _r_d4;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             *_t6 = _t7;
-// CHECK-NEXT:             {{.*}}value_type _r_d3 = _d_b[1];
-// CHECK-NEXT:             _d_b[1] = 0.;
+// CHECK-NEXT:             *_t9 = _t11;
+// CHECK-NEXT:             {{.*}}value_type _r_d3 = *_t10;
+// CHECK-NEXT:             *_t10 = 0.;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             *_t4 = _t5;
-// CHECK-NEXT:             {{.*}}value_type _r_d2 = _d_b[0];
-// CHECK-NEXT:             _d_b[0] = 0.;
+// CHECK-NEXT:             *_t6 = _t8;
+// CHECK-NEXT:             {{.*}}value_type _r_d2 = *_t7;
+// CHECK-NEXT:             *_t7 = 0.;
 // CHECK-NEXT:             *_d_x += _r_d2;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             *_t2 = _t3;
-// CHECK-NEXT:             {{.*}}value_type _r_d1 = _d_a[1];
-// CHECK-NEXT:             _d_a[1] = 0.;
+// CHECK-NEXT:             *_t3 = _t5;
+// CHECK-NEXT:             {{.*}}value_type _r_d1 = *_t4;
+// CHECK-NEXT:             *_t4 = 0.;
 // CHECK-NEXT:             *_d_y += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             *_t0 = _t1;
-// CHECK-NEXT:             {{.*}}value_type _r_d0 = _d_a[0];
-// CHECK-NEXT:             _d_a[0] = 0.;
+// CHECK-NEXT:             *_t0 = _t2;
+// CHECK-NEXT:             {{.*}}value_type _r_d0 = *_t1;
+// CHECK-NEXT:             *_t1 = 0.;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 
@@ -712,13 +718,14 @@ int main() {
 // CHECK-NEXT:         std::array<double, 2> _d_a = {{.*}};
 // CHECK-NEXT:         std::array<double, 2> a;
 // CHECK-NEXT:         {{.*}}value_type *_t0 = &a[1];
-// CHECK-NEXT:         {{.*}}value_type _t1 = *_t0;
+// CHECK-NEXT:         {{.*}}value_type *_t1 = &_d_a[1];
+// CHECK-NEXT:         {{.*}}value_type _t2 = *_t0;
 // CHECK-NEXT:         *_t0 = 2 * x;
 // CHECK-NEXT:         _d_a[1] += 1;
 // CHECK-NEXT:         {
-// CHECK-NEXT:             *_t0 = _t1;
-// CHECK-NEXT:             {{.*}} _r_d0 = _d_a[1];
-// CHECK-NEXT:             _d_a[1] = 0.;
+// CHECK-NEXT:             *_t0 = _t2;
+// CHECK-NEXT:             {{.*}} _r_d0 = *_t1;
+// CHECK-NEXT:             *_t1 = 0.;
 // CHECK-NEXT:             *_d_x += 2 * _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
@@ -817,13 +824,14 @@ int main() {
 // CHECK-NEXT:          std::vector<double> _t0 = a;
 // CHECK-NEXT:          {{.*}}push_back_reverse_forw(&a, 0, &_d_a, 0);
 // CHECK-NEXT:          {{.*}}value_type *_t1 = &a[0];
-// CHECK-NEXT:          {{.*}}value_type _t2 = *_t1;
+// CHECK-NEXT:          {{.*}}value_type *_t2 = &_d_a[0];
+// CHECK-NEXT:          {{.*}}value_type _t3 = *_t1;
 // CHECK-NEXT:          *_t1 = x * x;
 // CHECK-NEXT:          _d_a[0] += 1;
 // CHECK-NEXT:          {
-// CHECK-NEXT:              *_t1 = _t2;
-// CHECK-NEXT:              {{.*}}value_type _r_d0 = _d_a[0];
-// CHECK-NEXT:              _d_a[0] = 0{{.*}};
+// CHECK-NEXT:              *_t1 = _t3;
+// CHECK-NEXT:              {{.*}}value_type _r_d0 = *_t2;
+// CHECK-NEXT:              *_t2 = 0{{.*}};
 // CHECK-NEXT:              *_d_x += _r_d0 * x;
 // CHECK-NEXT:              *_d_x += x * _r_d0;
 // CHECK-NEXT:          }
@@ -860,7 +868,8 @@ int main() {
 // CHECK-NEXT:      std::vector<double> ls = {};
 // CHECK-NEXT:      std::vector<double> _d_ls{};
 // CHECK-NEXT:      clad::tape<{{.*}}value_type *> _t3 = {};
-// CHECK-NEXT:      clad::tape<{{.*}}value_type> _t4 = {};
+// CHECK-NEXT:      clad::tape<{{.*}}value_type *> _t4 = {};
+// CHECK-NEXT:      clad::tape<{{.*}}value_type> _t5 = {};
 // CHECK-NEXT:      {{.*}}allocator_type alloc;
 // CHECK-NEXT:      {{.*}}allocator_type _d_alloc;
 // CHECK-NEXT:      unsigned {{int|long|long long}} _t0 = 0;
@@ -870,7 +879,8 @@ int main() {
 // CHECK-NEXT:          clad::push(_t2, std::move(ls)) , ls = {u, v}, alloc;
 // CHECK-NEXT:          _d_ls = {0., 0.}, _d_alloc;
 // CHECK-NEXT:          clad::push(_t3, &ls[1]);
-// CHECK-NEXT:          clad::push(_t4, ls[1]);
+// CHECK-NEXT:          clad::push(_t4, &_d_ls[1]);
+// CHECK-NEXT:          clad::push(_t5, ls[1]);
 // CHECK-NEXT:          *clad::back(_t3) += ls[0];
 // CHECK-NEXT:          u = ls[1];
 // CHECK-NEXT:      }
@@ -882,10 +892,11 @@ int main() {
 // CHECK-NEXT:              _d_ls[1] += _r_d1;
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
-// CHECK-NEXT:              ls[1] = clad::pop(_t4);
-// CHECK-NEXT:              {{.*}}value_type _r_d0 = _d_ls[1];
+// CHECK-NEXT:              ls[1] = clad::pop(_t5);
+// CHECK-NEXT:              {{.*}} _r_d0 = *clad::back(_t4);
 // CHECK-NEXT:              _d_ls[0] += _r_d0;
 // CHECK-NEXT:              clad::pop(_t3);
+// CHECK-NEXT:              clad::pop(_t4);
 // CHECK-NEXT:          }
 // CHECK-NEXT:          {
 // CHECK-NEXT:              clad::array<{{double|std::vector<double, std::allocator<double> >::value_type}}> _r0 = {{2U|2UL|2ULL}};
@@ -904,10 +915,11 @@ int main() {
 // CHECK-NEXT:     std::unique_ptr{{.*}} up(p);
 // CHECK-NEXT:     std::unique_ptr{{.*}} _d_up(_d_p);
 // CHECK-NEXT:     double *_t0 = &* up;
+// CHECK-NEXT:     double *_t1 = &* _d_up;
 // CHECK-NEXT:     *_t0 += 5 * e;
 // CHECK-NEXT:     * _d_up += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         double _r_d0 = * _d_up;
+// CHECK-NEXT:         double _r_d0 = *_t1;
 // CHECK-NEXT:         *_d_e += 5 * _r_d0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_d += *_d_p;
@@ -967,7 +979,8 @@ int main() {
 // CHECK-NEXT:     std::vector<double> ls = {};
 // CHECK-NEXT:     std::vector<double> _d_ls{};
 // CHECK-NEXT:     clad::tape<value_type *> _t3 = {};
-// CHECK-NEXT:     clad::tape<value_type> _t4 = {};
+// CHECK-NEXT:     clad::tape<value_type *> _t4 = {};
+// CHECK-NEXT:     clad::tape<value_type> _t5 = {};
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
 // CHECK-NEXT:     for (i = 0; i < 3; ++i) {
 // CHECK-NEXT:         _t0++;
@@ -975,7 +988,8 @@ int main() {
 // CHECK-NEXT:         clad::push(_t2, std::move(ls)) , ls = {{.*{u, v}.*}};
 // CHECK-NEXT:         _d_ls = {{.*}}{0., 0.}{{.*}};
 // CHECK-NEXT:         clad::push(_t3, &ls[1]);
-// CHECK-NEXT:         clad::push(_t4, ls[1]);
+// CHECK-NEXT:         clad::push(_t4, &_d_ls[1]);
+// CHECK-NEXT:         clad::push(_t5, ls[1]);
 // CHECK-NEXT:         *clad::back(_t3) += ls[0];
 // CHECK-NEXT:         u = ls[1];
 // CHECK-NEXT:     }
@@ -987,10 +1001,11 @@ int main() {
 // CHECK-NEXT:             _d_ls[1] += _r_d1;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
-// CHECK-NEXT:             ls[1] = clad::pop(_t4);
-// CHECK-NEXT:             {{.*}}value_type _r_d0 = _d_ls[1];
+// CHECK-NEXT:             ls[1] = clad::pop(_t5);
+// CHECK-NEXT:             {{.*}} _r_d0 = *clad::back(_t4);
 // CHECK-NEXT:             _d_ls[0] += _r_d0;
 // CHECK-NEXT:             clad::pop(_t3);
+// CHECK-NEXT:             clad::pop(_t4);
 // CHECK-NEXT:         }
 // CHECK-NEXT:         {
 // CHECK-NEXT:             clad::array<{{double|std::vector<double, std::allocator<double> >::value_type}}> _r0 = {{2U|2UL|2ULL}};


### PR DESCRIPTION
### Description

ReverseModeVisitor entered its assignment path for all Clang assignment operators but explicitly handled only `=`, `+=`, `-=`, `*=`, and `/=`. Remainder, bitwise, and shift compound assignments (`%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`) fell through to an `llvm_unreachable`.

This PR adds discrete compound assignment support in reverse mode:

1. **Primal Result Materialization & Lvalue Reference Preservation**: `(L op= R)` is evaluated exactly once in the forward pass inside an lvalue-reference declaration `T& _ref = (L op= R);`. A primal result override returns this reference directly as the forward expression result, preserving C++ lvalue semantics for nested operations.
2. **Reverse Value Snapshot**: Snapshot the converted post-assignment value `T _t = _ref;` (or `clad::tape<T>` inside loops) using `GlobalStoreAndRef` for use in the reverse sweep.
3. **No Operator Reconstruction**: Eliminates binary operator reconstruction during the reverse sweep, preventing double execution and avoiding Clad shared AST node integrity violations.
4. **Clean Adjoint Storage**: Restructures `oldValue` adjoint storage to avoid emitting unused `_r_d` declarations for discrete operations.
5. **Coverage**: Adds tests in `test/Gradient/CompoundBitwiseOps.C` covering all six operators, nested assignments under parent `*=`, narrowing conversions, loops, and side-effectful RHS expressions.
