### PR TITLE
Add a HistFactory-style likelihood benchmark generator

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -9,6 +9,25 @@ if (CLAD_ENABLE_ENZYME_BACKEND)
   CB_ADD_GBENCHMARK(EnzymeCladComparison EnzymeCladComparison.cpp)
 endif(CLAD_ENABLE_ENZYME_BACKEND)
 
+# The HistFactory-style likelihood benchmark is driven by histfactory.py: it
+# generates the model source, compiles it with the clad plugin, runs it, and
+# fails on numerical validation errors. One of its metrics is the compilation
+# time of the generated code, so it compiles at test time rather than going
+# through CB_ADD_GBENCHMARK.
+find_package(Python3 COMPONENTS Interpreter QUIET)
+if (Python3_FOUND)
+  add_test(NAME clad-HistFactory
+    COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/histfactory.py
+            --clad-build ${CMAKE_BINARY_DIR}
+            --compiler ${LLVM_TOOLS_BINARY_DIR}/clang++)
+  set_tests_properties(clad-HistFactory PROPERTIES
+                       TIMEOUT 1200
+                       LABELS "benchmark;short"
+                       RUN_SERIAL TRUE)
+else()
+  message(STATUS "Python3 not found; skipping the clad-HistFactory benchmark")
+endif()
+
 include(FetchContent)
 FetchContent_Declare(
   tapenade_kit

--- a/benchmark/HistFactoryMathFuncs.h
+++ b/benchmark/HistFactoryMathFuncs.h
@@ -1,0 +1,980 @@
+// The RooFit math functions and clad custom derivatives used by the
+// HistFactory-style likelihood benchmark that histfactory.py generates.
+//
+// Extracted from a standalone version of a real ATLAS RooFit likelihood:
+// the subset of RooFit::Detail::MathFuncs the generated model code calls,
+// with TMath and ROOT::Math calls replaced by their std:: equivalents; the
+// incomplete gamma function (needed by poissonIntegral) is the Cephes
+// implementation that ROOT's ROOT::Math::inc_gamma wraps, and its custom
+// clad derivatives are copied verbatim from ROOT's Math/CladDerivator.h.
+//
+// `constraintSum` is NOT here but in the generated file: like in ROOT it
+// enables clad's `#pragma clad checkpoint loop` on its loop (its pullback
+// needs nothing from previous iterations, so checkpointing replaces the
+// tape at zero cost), and as of 2026-08 clad mis-attributes a checkpoint
+// pragma that lives in an included header -- the planner selects pragmas by
+// raw SourceLocation order, which does not match translation-unit order
+// across files -- so the pragma'd function must sit in the main file.
+// `flexibleInterp` does NOT take the pragma: its loop carries `total` into
+// the next iteration's call, so taping it beats recomputing.
+
+// The llvm-header-guard check derives the guard name from the checkout path,
+// which no fixed name can satisfy.
+#ifndef CLAD_BENCHMARK_HISTFACTORY_MATHFUNCS_H // NOLINT(llvm-header-guard)
+#define CLAD_BENCHMARK_HISTFACTORY_MATHFUNCS_H
+
+// This file keeps the formatting and the code style of the ROOT sources it
+// was extracted from, so it stays diffable against RooFit/Detail/MathFuncs.h,
+// Math/CladDerivator.h and the Cephes code in mathcore. The markers below
+// shield the copied code from clang-format and from the clang-tidy checks it
+// predates; the dead stores are the hand-derived pullbacks' unused restores.
+// clang-format off
+
+#include "clad/Differentiator/BuiltinDerivatives.h"
+#include "clad/Differentiator/Differentiator.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+// The copied code below stays verbatim, so it neither follows this project's
+// clang-tidy configuration nor is warning-clean: the ROOT pullbacks snapshot
+// not-yet-initialized values on purpose (their restores are dead), which
+// trips the uninitialized-use compiler diagnostics that clang-tidy surfaces.
+// NOLINTBEGIN
+
+namespace ROOT {
+namespace Math {
+
+namespace Cephes {
+
+// Incomplete gamma function, from ROOT's Cephes copy
+// (math/mathcore/src/SpecFuncCephes.cxx), with lgam() replaced by
+// std::lgamma().
+
+constexpr double kMACHEP = 1.11022302462515654042363166809e-16;
+constexpr double kMAXLOG = 709.782712893383973096206318587;
+constexpr double kBig = 4.503599627370496e15;
+constexpr double kBiginv = 2.22044604925031308085e-16;
+
+inline double igamc(double a, double x);
+
+inline double igam(double a, double x)
+{
+   double ans, ax, c, r;
+
+   // LM: for negative values returns 1.0 instead of zero
+   // This is correct if a is a negative integer since Gamma(-n) = +/- inf
+   if (a <= 0)
+      return 1.0;
+
+   if (x <= 0)
+      return 0.0;
+
+   if ((x > 1.0) && (x > a))
+      return 1.0 - igamc(a, x);
+
+   /* Compute  x**a * exp(-x) / gamma(a)  */
+   ax = a * std::log(x) - x - std::lgamma(a);
+   if (ax < -kMAXLOG)
+      return 0.0;
+
+   ax = std::exp(ax);
+
+   /* power series */
+   r = a;
+   c = 1.0;
+   ans = 1.0;
+
+   do {
+      r += 1.0;
+      c *= x / r;
+      ans += c;
+   } while (c / ans > kMACHEP);
+
+   return ans * ax / a;
+}
+
+inline double igamc(double a, double x)
+{
+   double ans, ax, c, yc, r, t, y, z;
+   double pk, pkm1, pkm2, qk, qkm1, qkm2;
+
+   // LM: for negative values returns 0.0
+   // This is correct if a is a negative integer since Gamma(-n) = +/- inf
+   if (a <= 0)
+      return 0.0;
+
+   if (x <= 0)
+      return 1.0;
+
+   if ((x < 1.0) || (x < a))
+      return 1.0 - igam(a, x);
+
+   ax = a * std::log(x) - x - std::lgamma(a);
+   if (ax < -kMAXLOG)
+      return 0.0;
+
+   ax = std::exp(ax);
+
+   /* continued fraction */
+   y = 1.0 - a;
+   z = x + y + 1.0;
+   c = 0.0;
+   pkm2 = 1.0;
+   qkm2 = x;
+   pkm1 = x + 1.0;
+   qkm1 = z * x;
+   ans = pkm1 / qkm1;
+
+   do {
+      c += 1.0;
+      y += 1.0;
+      z += 2.0;
+      yc = y * c;
+      pk = pkm1 * z - pkm2 * yc;
+      qk = qkm1 * z - qkm2 * yc;
+      if (qk) {
+         r = pk / qk;
+         t = std::abs((ans - r) / r);
+         ans = r;
+      } else
+         t = 1.0;
+      pkm2 = pkm1;
+      pkm1 = pk;
+      qkm2 = qkm1;
+      qkm1 = qk;
+      if (std::abs(pk) > kBig) {
+         pkm2 *= kBiginv;
+         pkm1 *= kBiginv;
+         qkm2 *= kBiginv;
+         qkm1 *= kBiginv;
+      }
+   } while (t > kMACHEP);
+
+   return ans * ax;
+}
+
+} // namespace Cephes
+
+inline double inc_gamma(double a, double x)
+{
+   return Cephes::igam(a, x);
+}
+
+inline double inc_gamma_c(double a, double x)
+{
+   return Cephes::igamc(a, x);
+}
+
+} // namespace Math
+} // namespace ROOT
+
+// The subset of RooFit::Detail::MathFuncs (from
+// roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h) used by the generated
+// model code below. TMath calls are replaced by std:: equivalents:
+// TMath::LnGamma -> std::lgamma, TMath::QuietNaN ->
+// std::numeric_limits::quiet_NaN, TMath::Limits<double>::Min() ->
+// std::numeric_limits::min, TMath::TwoPi / TMath::Sqrt2 -> literals.
+
+namespace RooFit {
+namespace Detail {
+namespace MathFuncs {
+
+/// @brief Function to evaluate an un-normalized RooGaussian.
+inline double gaussian(double x, double mean, double sigma)
+{
+   const double arg = x - mean;
+   const double sig = sigma;
+   return std::exp(-0.5 * arg * arg / (sig * sig));
+}
+
+template <typename DoubleArray>
+double product(DoubleArray factors, std::size_t nFactors)
+{
+   double out = 1.0;
+   for (std::size_t i = 0; i < nFactors; ++i) {
+      out *= factors[i];
+   }
+   return out;
+}
+
+// constraintSum lives in the generated main file; see the header comment.
+
+inline unsigned int uniformBinNumber(double low, double high, double val, unsigned int numBins, double coef)
+{
+   double binWidth = (high - low) / numBins;
+   return coef * (val >= high ? numBins - 1 : std::abs((val - low) / binWidth));
+}
+
+inline double poisson(double x, double par)
+{
+   if (par < 0)
+      return std::numeric_limits<double>::quiet_NaN();
+
+   if (x < 0) {
+      return 0;
+   } else if (x == 0.0) {
+      return std::exp(-par);
+   } else {
+      double out = x * std::log(par) - std::lgamma(x + 1.) - par;
+      return std::exp(out);
+   }
+}
+
+inline double flexibleInterpSingle(unsigned int code, double low, double high, double boundary, double nominal,
+                                   double paramVal, double res)
+{
+   if (code == 0) {
+      // piece-wise linear
+      if (paramVal > 0) {
+         return paramVal * (high - nominal);
+      } else {
+         return paramVal * (nominal - low);
+      }
+   } else if (code == 1) {
+      // piece-wise log
+      if (paramVal >= 0) {
+         return res * (std::pow(high / nominal, +paramVal) - 1);
+      } else {
+         return res * (std::pow(low / nominal, -paramVal) - 1);
+      }
+   } else if (code == 2) {
+      // parabolic with linear
+      double a = 0.5 * (high + low) - nominal;
+      double b = 0.5 * (high - low);
+      double c = 0;
+      if (paramVal > 1) {
+         return (2 * a + b) * (paramVal - 1) + high - nominal;
+      } else if (paramVal < -1) {
+         return -1 * (2 * a - b) * (paramVal + 1) + low - nominal;
+      } else {
+         return a * paramVal * paramVal + b * paramVal + c;
+      }
+   } else if (code == 4 || code == 6) {
+      double x = paramVal;
+      double mod = 1.0;
+      if (code == 6) {
+         high /= nominal;
+         low /= nominal;
+         nominal = 1;
+      }
+      if (x >= boundary) {
+         mod = x * (high - nominal);
+      } else if (x <= -boundary) {
+         mod = x * (nominal - low);
+      } else {
+         // interpolate 6th degree
+         double t = x / boundary;
+         double eps_plus = high - nominal;
+         double eps_minus = nominal - low;
+         double S = 0.5 * (eps_plus + eps_minus);
+         double A = 0.0625 * (eps_plus - eps_minus);
+
+         mod = x * (S + t * A * (15 + t * t * (-10 + t * t * 3)));
+      }
+
+      // code 6 is multiplicative version of code 4
+      if (code == 6) {
+         mod *= res;
+      }
+      return mod;
+
+   } else if (code == 5) {
+      double x = paramVal;
+      double mod = 1.0;
+      if (x >= boundary) {
+         mod = std::pow(high / nominal, +paramVal);
+      } else if (x <= -boundary) {
+         mod = std::pow(low / nominal, -paramVal);
+      } else {
+         // interpolate 6th degree exp
+         double x0 = boundary;
+
+         high /= nominal;
+         low /= nominal;
+
+         // GHL: Swagato's suggestions
+         double logHi = std::log(high);
+         double logLo = std::log(low);
+         double powUp = std::exp(x0 * logHi);
+         double powDown = std::exp(x0 * logLo);
+         double powUpLog = high <= 0.0 ? 0.0 : powUp * logHi;
+         double powDownLog = low <= 0.0 ? 0.0 : -powDown * logLo;
+         double powUpLog2 = high <= 0.0 ? 0.0 : powUpLog * logHi;
+         double powDownLog2 = low <= 0.0 ? 0.0 : -powDownLog * logLo;
+
+         double S0 = 0.5 * (powUp + powDown);
+         double A0 = 0.5 * (powUp - powDown);
+         double S1 = 0.5 * (powUpLog + powDownLog);
+         double A1 = 0.5 * (powUpLog - powDownLog);
+         double S2 = 0.5 * (powUpLog2 + powDownLog2);
+         double A2 = 0.5 * (powUpLog2 - powDownLog2);
+
+         // fcns+der+2nd_der are eq at bd
+
+         double x0Sq = x0 * x0;
+
+         double a = 1. / (8 * x0) * (15 * A0 - 7 * x0 * S1 + x0 * x0 * A2);
+         double b = 1. / (8 * x0Sq) * (-24 + 24 * S0 - 9 * x0 * A1 + x0 * x0 * S2);
+         double c = 1. / (4 * x0Sq * x0) * (-5 * A0 + 5 * x0 * S1 - x0 * x0 * A2);
+         double d = 1. / (4 * x0Sq * x0Sq) * (12 - 12 * S0 + 7 * x0 * A1 - x0 * x0 * S2);
+         double e = 1. / (8 * x0Sq * x0Sq * x0) * (+3 * A0 - 3 * x0 * S1 + x0 * x0 * A2);
+         double f = 1. / (8 * x0Sq * x0Sq * x0Sq) * (-8 + 8 * S0 - 5 * x0 * A1 + x0 * x0 * S2);
+
+         // evaluate the 6-th degree polynomial using Horner's method
+         double value = 1. + x * (a + x * (b + x * (c + x * (d + x * (e + x * f)))));
+         mod = value;
+      }
+      return res * (mod - 1.0);
+   }
+
+   return 0.0;
+}
+
+template <typename ParamsArray, typename DoubleArray>
+double flexibleInterp(unsigned int code, ParamsArray params, unsigned int n, DoubleArray low, DoubleArray high,
+                      double boundary, double nominal, int doCutoff)
+{
+   double total = nominal;
+   // No checkpoint pragma here (see the header comment): the loop carries
+   // `total` into the next iteration's call, so taping it beats recomputing.
+   for (std::size_t i = 0; i < n; ++i) {
+      total += flexibleInterpSingle(code, low[i], high[i], boundary, nominal, params[i], total);
+   }
+
+   return doCutoff && total <= 0 ? std::numeric_limits<double>::min() : total;
+}
+
+inline double nll(double pdf, double weight, int binnedL, int doBinOffset)
+{
+   if (binnedL) {
+      // Special handling of this case since std::log(Poisson(0,0)=0 but can't be
+      // calculated with usual log-formula since std::log(mu)=0. No update of result
+      // is required since term=0.
+      if (std::abs(pdf) < 1e-10 && std::abs(weight) < 1e-10) {
+         return 0.0;
+      }
+      if (doBinOffset) {
+         return pdf - weight - weight * (std::log(pdf) - std::log(weight));
+      }
+      return pdf - weight * std::log(pdf) + std::lgamma(weight + 1);
+   } else {
+      return -weight * std::log(pdf);
+   }
+}
+
+/// @brief Function to calculate the integral of an un-normalized RooGaussian over x. To calculate the integral over
+/// mean, just interchange the respective values of x and mean.
+inline double gaussianIntegral(double xMin, double xMax, double mean, double sigma)
+{
+   // The normalisation constant 1./sqrt(2*pi*sigma^2) is left out in evaluate().
+   // Therefore, the integral is scaled up by that amount to make RooFit normalise
+   // correctly.
+   const double sqrtTwoPi = 2.50662827463100050241576528481; // sqrt(2*pi)
+   const double sqrtTwo = 1.41421356237309514547462185874;   // sqrt(2)
+   double resultScale = 0.5 * sqrtTwoPi * sigma;
+
+   // Here everything is scaled and shifted into a standard normal distribution:
+   double xscale = sqrtTwo * sigma;
+   double scaledMin = 0.;
+   double scaledMax = 0.;
+   scaledMin = (xMin - mean) / xscale;
+   scaledMax = (xMax - mean) / xscale;
+
+   // Here we go for maximum precision: We compute all integrals in the UPPER
+   // tail of the Gaussian, because erfc has the highest precision there.
+   // Therefore, the different cases for range limits in the negative hemisphere are mapped onto
+   // the equivalent points in the upper hemisphere using erfc(-x) = 2. - erfc(x)
+   double ecmin = std::erfc(std::abs(scaledMin));
+   double ecmax = std::erfc(std::abs(scaledMax));
+
+   double cond = 0.0;
+   // Don't put this "prd" inside the "if" because clad will not be able to differentiate the code correctly (as of
+   // v1.1)!
+   double prd = scaledMin * scaledMax;
+   if (prd < 0.0) {
+      cond = 2.0 - (ecmin + ecmax);
+   } else if (scaledMax <= 0.0) {
+      cond = ecmax - ecmin;
+   } else {
+      cond = ecmin - ecmax;
+   }
+   return resultScale * cond;
+}
+
+// The last param should be of type bool but it is not as that causes some issues with Cling for some reason...
+inline double
+poissonIntegral(int code, double mu, double x, double integrandMin, double integrandMax, unsigned int protectNegative)
+{
+   if (protectNegative && mu < 0.0) {
+      return std::exp(-2.0 * mu); // make it fall quickly
+   }
+
+   if (code == 1) {
+      // Implement integral over x as summation. Add special handling in case
+      // range boundaries are not on integer values of x
+      integrandMin = std::max(0., integrandMin);
+
+      if (integrandMax < 0. || integrandMax < integrandMin) {
+         return 0;
+      }
+      const double delta = 100.0 * std::sqrt(mu);
+      // If the limits are more than many standard deviations away from the mean,
+      // we might as well return the integral of the full Poisson distribution to
+      // save computing time.
+      if (integrandMin < std::max(mu - delta, 0.0) && integrandMax > mu + delta) {
+         return 1.;
+      }
+
+      // The range as integers. ixMin is included, ixMax outside.
+      const unsigned int ixMin = integrandMin;
+      const unsigned int ixMax = std::min(integrandMax + 1, (double)std::numeric_limits<unsigned int>::max());
+
+      // Sum from 0 to just before the bin outside of the range.
+      if (ixMin == 0) {
+         return ROOT::Math::inc_gamma_c(ixMax, mu);
+      } else {
+         // If necessary, subtract from 0 to the beginning of the range
+         if (ixMin <= mu) {
+            return ROOT::Math::inc_gamma_c(ixMax, mu) - ROOT::Math::inc_gamma_c(ixMin, mu);
+         } else {
+            // Avoid catastrophic cancellation in the high tails:
+            return ROOT::Math::inc_gamma(ixMin, mu) - ROOT::Math::inc_gamma(ixMax, mu);
+         }
+      }
+   }
+
+   // the integral with respect to the mean is the integral of a gamma distribution
+   // negative ix does not need protection (gamma returns 0.0)
+   const double ix = 1 + x;
+
+   return ROOT::Math::inc_gamma(ix, integrandMax) - ROOT::Math::inc_gamma(ix, integrandMin);
+}
+
+} // namespace MathFuncs
+} // namespace Detail
+} // namespace RooFit
+
+// Custom clad derivatives for the incomplete gamma function, copied verbatim
+// from ROOT's math/mathcore/inc/Math/CladDerivator.h. The pushforwards make
+// forward mode work; the pullbacks additionally enable second derivatives
+// (clad::hessian differentiates the pushforward in reverse mode).
+
+namespace clad {
+namespace custom_derivatives {
+namespace ROOT {
+namespace Math {
+
+inline void inc_gamma_c_pullback(double a, double x, double _d_y, double *_d_a, double *_d_x);
+
+inline void inc_gamma_pullback(double a, double x, double _d_y, double *_d_a, double *_d_x)
+{
+   // Synced with SpecFuncCephes.h
+   constexpr double kMACHEP = 1.11022302462515654042363166809e-16;
+   constexpr double kMAXLOG = 709.782712893383973096206318587;
+
+   double _d_ans = 0, _d_ax = 0, _d_c = 0, _d_r = 0;
+   double _t1;
+   double _t2;
+   double _t3;
+   double _t4;
+   double _t5;
+   clad::tape<double> _t7 = {};
+   clad::tape<double> _t8 = {};
+   clad::tape<double> _t9 = {};
+   double ans, ax, c, r;
+   if (a <= 0)
+      return;
+   if (x <= 0)
+      return;
+   if ((x > 1.) && (x > a)) {
+      double _r0 = 0;
+      double _r1 = 0;
+      inc_gamma_c_pullback(a, x, -_d_y, &_r0, &_r1);
+      *_d_a += _r0;
+      *_d_x += _r1;
+      return;
+   }
+   _t1 = ::std::log(x);
+   ax = a * _t1 - x - ::std::lgamma(a);
+   if (ax < -kMAXLOG) {
+      *_d_x += (a * _d_ax / x) - _d_ax;
+      *_d_a += _d_ax * (_t1 - ::clad::custom_derivatives::std::clad_digamma(
+                                 a)); // numerical_diff::forward_central_difference(::std::lgamma, a, 0, 0, a);
+      _d_ax = 0.;
+      return;
+   }
+   _t2 = ax;
+   ax = ::std::exp(ax);
+   _t3 = r;
+   r = a;
+   _t4 = c;
+   c = 1.;
+   _t5 = ans;
+   ans = 1.;
+   unsigned long _t6 = 0;
+   do {
+      _t6++;
+      clad::push(_t7, r);
+      r += 1.;
+      clad::push(_t8, c);
+      c *= x / r;
+      clad::push(_t9, ans);
+      ans += c;
+   } while (c / ans > kMACHEP);
+   {
+      _d_ans += _d_y / a * ax;
+      _d_ax += ans * _d_y / a;
+      double _r6 = _d_y * -(ans * ax / (a * a));
+      *_d_a += _r6;
+   }
+   do {
+      {
+         {
+            ans = clad::pop(_t9);
+            double _r_d7 = _d_ans;
+            _d_c += _r_d7;
+         }
+         {
+            c = clad::pop(_t8);
+            double _r_d6 = _d_c;
+            _d_c -= _r_d6;
+            _d_c += _r_d6 * x / r;
+            *_d_x += c * _r_d6 / r;
+            double _r5 = c * _r_d6 * -(x / (r * r));
+            _d_r += _r5;
+         }
+         {
+            r = clad::pop(_t7);
+            double _r_d5 = _d_r;
+         }
+      }
+      _t6--;
+   } while (_t6);
+   {
+      ans = _t5;
+      double _r_d4 = _d_ans;
+      _d_ans -= _r_d4;
+   }
+   {
+      c = _t4;
+      double _r_d3 = _d_c;
+      _d_c -= _r_d3;
+   }
+   {
+      r = _t3;
+      double _r_d2 = _d_r;
+      _d_r -= _r_d2;
+      *_d_a += _r_d2;
+   }
+   {
+      ax = _t2;
+      double _r_d1 = _d_ax;
+      _d_ax -= _r_d1;
+      double _r4 = 0;
+      _r4 += _r_d1 * ::std::exp(ax);
+      _d_ax += _r4;
+   }
+   {
+      *_d_x += (a * _d_ax / x) - _d_ax;
+      *_d_a += _d_ax * (_t1 - ::clad::custom_derivatives::std::clad_digamma(
+                                 a)); // numerical_diff::forward_central_difference(::std::lgamma, a, 0, 0, a);
+      _d_ax = 0.;
+   }
+}
+
+inline void inc_gamma_c_pullback(double a, double x, double _d_y, double *_d_a, double *_d_x)
+{
+   // Synced with SpecFuncCephes.h
+   constexpr double kMACHEP = 1.11022302462515654042363166809e-16;
+   constexpr double kMAXLOG = 709.782712893383973096206318587;
+   constexpr double kBig = 4.503599627370496e15;
+   constexpr double kBiginv = 2.22044604925031308085e-16;
+
+   double _d_ans = 0, _d_ax = 0, _d_c = 0, _d_yc = 0, _d_r = 0, _d_y0 = 0, _d_z = 0;
+   double _d_pk = 0, _d_pkm1 = 0, _d_pkm2 = 0, _d_qk = 0, _d_qkm1 = 0, _d_qkm2 = 0;
+   double _t1;
+   double _t2;
+   double _t3;
+   double _t4;
+   double _t5;
+   double _t6;
+   double _t7;
+   double _t8;
+   double _t9;
+   double _t10;
+   unsigned long _t11;
+   clad::tape<double> _t12 = {};
+   clad::tape<double> _t13 = {};
+   clad::tape<double> _t14 = {};
+   clad::tape<double> _t15 = {};
+   clad::tape<double> _t16 = {};
+   clad::tape<double> _t17 = {};
+   clad::tape<double> _t19 = {};
+   clad::tape<double> _t20 = {};
+   clad::tape<double> _t22 = {};
+   clad::tape<double> _t24 = {};
+   clad::tape<double> _t25 = {};
+   clad::tape<double> _t26 = {};
+   clad::tape<double> _t27 = {};
+   clad::tape<bool> _t29 = {};
+   clad::tape<double> _t30 = {};
+   clad::tape<double> _t31 = {};
+   clad::tape<double> _t32 = {};
+   clad::tape<double> _t33 = {};
+   double ans, ax, c, yc, r, t, y, z;
+   double pk, pkm1, pkm2, qk, qkm1, qkm2;
+   if (a <= 0)
+      return;
+   if (x <= 0)
+      return;
+   if ((x < 1.) || (x < a)) {
+      double _r0 = 0;
+      double _r1 = 0;
+      inc_gamma_pullback(a, x, -_d_y, &_r0, &_r1);
+      *_d_a += _r0;
+      *_d_x += _r1;
+      return;
+   }
+   _t1 = ::std::log(x);
+   ax = a * _t1 - x - ::std::lgamma(a);
+   if (ax < -kMAXLOG) {
+      *_d_x += a * _d_ax / x - _d_ax;
+      *_d_a += _d_ax * (_t1 - ::clad::custom_derivatives::std::clad_digamma(
+                                 a)); // numerical_diff::forward_central_difference(::std::lgamma, a, 0, 0, a);
+      _d_ax = 0.;
+      return;
+   }
+   _t2 = ax;
+   ax = ::std::exp(ax);
+   _t3 = y;
+   y = 1. - a;
+   _t4 = z;
+   z = x + y + 1.;
+   _t5 = c;
+   c = 0.;
+   _t6 = pkm2;
+   pkm2 = 1.;
+   _t7 = qkm2;
+   qkm2 = x;
+   _t8 = pkm1;
+   pkm1 = x + 1.;
+   _t9 = qkm1;
+   qkm1 = z * x;
+   _t10 = ans;
+   ans = pkm1 / qkm1;
+   _t11 = 0;
+   do {
+      _t11++;
+      clad::push(_t12, c);
+      c += 1.;
+      clad::push(_t13, y);
+      y += 1.;
+      clad::push(_t14, z);
+      z += 2.;
+      clad::push(_t15, yc);
+      yc = y * c;
+      clad::push(_t16, pk);
+      pk = pkm1 * z - pkm2 * yc;
+      clad::push(_t17, qk);
+      qk = qkm1 * z - qkm2 * yc;
+      double _t18 = qk;
+      {
+         if (_t18) {
+            clad::push(_t20, r);
+            r = pk / qk;
+            t = ::std::abs((ans - r) / r);
+            clad::push(_t22, ans);
+            ans = r;
+         } else {
+            t = 1.;
+         }
+         clad::push(_t19, _t18);
+      }
+      clad::push(_t24, pkm2);
+      pkm2 = pkm1;
+      clad::push(_t25, pkm1);
+      pkm1 = pk;
+      clad::push(_t26, qkm2);
+      qkm2 = qkm1;
+      clad::push(_t27, qkm1);
+      qkm1 = qk;
+      bool _t28 = ::std::abs(pk) > kBig;
+      {
+         if (_t28) {
+            clad::push(_t30, pkm2);
+            pkm2 *= kBiginv;
+            clad::push(_t31, pkm1);
+            pkm1 *= kBiginv;
+            clad::push(_t32, qkm2);
+            qkm2 *= kBiginv;
+            clad::push(_t33, qkm1);
+            qkm1 *= kBiginv;
+         }
+         clad::push(_t29, _t28);
+      }
+   } while (t > kMACHEP);
+   {
+      _d_ans += _d_y * ax;
+      _d_ax += ans * _d_y;
+   }
+   do {
+      {
+         if (clad::pop(_t29)) {
+            {
+               qkm1 = clad::pop(_t33);
+               double _r_d27 = _d_qkm1;
+               _d_qkm1 -= _r_d27;
+               _d_qkm1 += _r_d27 * kBiginv;
+            }
+            {
+               qkm2 = clad::pop(_t32);
+               double _r_d26 = _d_qkm2;
+               _d_qkm2 -= _r_d26;
+               _d_qkm2 += _r_d26 * kBiginv;
+            }
+            {
+               pkm1 = clad::pop(_t31);
+               double _r_d25 = _d_pkm1;
+               _d_pkm1 -= _r_d25;
+               _d_pkm1 += _r_d25 * kBiginv;
+            }
+            {
+               pkm2 = clad::pop(_t30);
+               double _r_d24 = _d_pkm2;
+               _d_pkm2 -= _r_d24;
+               _d_pkm2 += _r_d24 * kBiginv;
+            }
+         }
+         {
+            qkm1 = clad::pop(_t27);
+            double _r_d23 = _d_qkm1;
+            _d_qkm1 -= _r_d23;
+            _d_qk += _r_d23;
+         }
+         {
+            qkm2 = clad::pop(_t26);
+            double _r_d22 = _d_qkm2;
+            _d_qkm2 -= _r_d22;
+            _d_qkm1 += _r_d22;
+         }
+         {
+            pkm1 = clad::pop(_t25);
+            double _r_d21 = _d_pkm1;
+            _d_pkm1 -= _r_d21;
+            _d_pk += _r_d21;
+         }
+         {
+            pkm2 = clad::pop(_t24);
+            double _r_d20 = _d_pkm2;
+            _d_pkm2 -= _r_d20;
+            _d_pkm1 += _r_d20;
+         }
+         // t only controls the loop exit, so its adjoint is identically zero
+         // and it needs neither a tape nor a restore.
+         if (clad::pop(_t19)) {
+            {
+               ans = clad::pop(_t22);
+               double _r_d18 = _d_ans;
+               _d_ans -= _r_d18;
+               _d_r += _r_d18;
+            }
+            {
+               r = clad::pop(_t20);
+               double _r_d16 = _d_r;
+               _d_r -= _r_d16;
+               _d_pk += _r_d16 / qk;
+               double _r6 = _r_d16 * -(pk / (qk * qk));
+               _d_qk += _r6;
+            }
+         }
+         {
+            qk = clad::pop(_t17);
+            double _r_d15 = _d_qk;
+            _d_qk -= _r_d15;
+            _d_qkm1 += _r_d15 * z;
+            _d_z += qkm1 * _r_d15;
+            _d_qkm2 += -_r_d15 * yc;
+            _d_yc += qkm2 * -_r_d15;
+         }
+         {
+            pk = clad::pop(_t16);
+            double _r_d14 = _d_pk;
+            _d_pk -= _r_d14;
+            _d_pkm1 += _r_d14 * z;
+            _d_z += pkm1 * _r_d14;
+            _d_pkm2 += -_r_d14 * yc;
+            _d_yc += pkm2 * -_r_d14;
+         }
+         {
+            yc = clad::pop(_t15);
+            double _r_d13 = _d_yc;
+            _d_yc -= _r_d13;
+            _d_y0 += _r_d13 * c;
+            _d_c += y * _r_d13;
+         }
+         {
+            z = clad::pop(_t14);
+            double _r_d12 = _d_z;
+         }
+         {
+            y = clad::pop(_t13);
+            double _r_d11 = _d_y0;
+         }
+         {
+            c = clad::pop(_t12);
+            double _r_d10 = _d_c;
+         }
+      }
+      _t11--;
+   } while (_t11);
+   {
+      ans = _t10;
+      double _r_d9 = _d_ans;
+      _d_ans -= _r_d9;
+      _d_pkm1 += _r_d9 / qkm1;
+      double _r5 = _r_d9 * -(pkm1 / (qkm1 * qkm1));
+      _d_qkm1 += _r5;
+   }
+   {
+      qkm1 = _t9;
+      double _r_d8 = _d_qkm1;
+      _d_qkm1 -= _r_d8;
+      _d_z += _r_d8 * x;
+      *_d_x += z * _r_d8;
+   }
+   {
+      pkm1 = _t8;
+      double _r_d7 = _d_pkm1;
+      _d_pkm1 -= _r_d7;
+      *_d_x += _r_d7;
+   }
+   {
+      qkm2 = _t7;
+      double _r_d6 = _d_qkm2;
+      _d_qkm2 -= _r_d6;
+      *_d_x += _r_d6;
+   }
+   {
+      pkm2 = _t6;
+      double _r_d5 = _d_pkm2;
+      _d_pkm2 -= _r_d5;
+   }
+   {
+      c = _t5;
+      double _r_d4 = _d_c;
+      _d_c -= _r_d4;
+   }
+   {
+      z = _t4;
+      double _r_d3 = _d_z;
+      _d_z -= _r_d3;
+      *_d_x += _r_d3;
+      _d_y0 += _r_d3;
+   }
+   {
+      y = _t3;
+      double _r_d2 = _d_y0;
+      _d_y0 -= _r_d2;
+      *_d_a += -_r_d2;
+   }
+   {
+      ax = _t2;
+      double _r_d1 = _d_ax;
+      _d_ax -= _r_d1;
+      double _r4 = _r_d1 * ::std::exp(ax);
+      _d_ax += _r4;
+   }
+   {
+      *_d_x += a * _d_ax / x - _d_ax;
+      *_d_a += _d_ax * (_t1 - ::clad::custom_derivatives::std::clad_digamma(
+                                 a)); // numerical_diff::forward_central_difference(::std::lgamma, a, 0, 0, a);
+      _d_ax = 0.;
+   }
+}
+
+/// Derivative of the normalized lower incomplete gamma function P(a, x) with
+/// respect to x. This is the integrand of P(a, x), i.e. the gamma
+/// distribution density: x^(a-1) * exp(-x) / Gamma(a).
+inline double inc_gamma_dx(double a, double x)
+{
+   if (a <= 0 || x <= 0)
+      return 0.;
+   return ::std::exp((a - 1.) * ::std::log(x) - x - ::std::lgamma(a));
+}
+
+/// Pullback of inc_gamma_dx(), using the closed forms of the second
+/// derivatives of P(a, x):
+///
+///    d2P/dx2  = inc_gamma_dx(a, x) * ((a - 1) / x - 1)
+///    d2P/dxda = inc_gamma_dx(a, x) * (log(x) - digamma(a))
+inline void inc_gamma_dx_pullback(double a, double x, double _d_y, double *_d_a, double *_d_x)
+{
+   if (a <= 0 || x <= 0)
+      return;
+   const double g = inc_gamma_dx(a, x);
+   *_d_a += _d_y * g * (::std::log(x) - ::clad::custom_derivatives::std::clad_digamma(a));
+   *_d_x += _d_y * g * ((a - 1.) / x - 1.);
+}
+
+/// Derivative of the normalized lower incomplete gamma function P(a, x) with
+/// respect to a. It has no closed form, but inc_gamma_pullback() computes it
+/// exactly by differentiating through the algorithm that evaluates P(a, x).
+inline double inc_gamma_da(double a, double x)
+{
+   double da = 0.;
+   double dx = 0.;
+   inc_gamma_pullback(a, x, 1., &da, &dx);
+   return da;
+}
+
+/// Pullback of inc_gamma_da(). The mixed second derivative is known in
+/// closed form (it is the same as the a-derivative of inc_gamma_dx(), see
+/// inc_gamma_dx_pullback()). For d2P/da2 there is no closed form, so it is
+/// approximated by a central difference of the exact first derivative.
+///
+/// For a <= h, the lower stencil point leaves the domain (inc_gamma_da()
+/// returns zero for non-positive a), so d2P/da2 is unreliable there. This is
+/// acceptable because RooFit never differentiates with respect to a, which is
+/// data there.
+inline void inc_gamma_da_pullback(double a, double x, double _d_y, double *_d_a, double *_d_x)
+{
+   if (a <= 0 || x <= 0)
+      return;
+   *_d_x += _d_y * inc_gamma_dx(a, x) * (::std::log(x) - ::clad::custom_derivatives::std::clad_digamma(a));
+   // A first-order central difference of the exact derivative is much more
+   // accurate than a second-order finite difference of P(a, x) itself. The
+   // step size balances truncation and roundoff error (~ cbrt of the machine
+   // epsilon).
+   const double h = 6e-6 * ::std::max(1., ::std::abs(a));
+   *_d_a += _d_y * (inc_gamma_da(a + h, x) - inc_gamma_da(a - h, x)) / (2. * h);
+}
+
+/// Pushforward of ROOT::Math::inc_gamma. Besides forward-mode differentiation,
+/// this enables second derivatives (e.g. clad::hessian): clad differentiates
+/// this function in reverse mode, and all derivatives it needs for that are
+/// provided by custom pullbacks.
+inline clad::ValueAndPushforward<double, double> inc_gamma_pushforward(double a, double x, double d_a, double d_x)
+{
+   return {::ROOT::Math::inc_gamma(a, x), inc_gamma_da(a, x) * d_a + inc_gamma_dx(a, x) * d_x};
+}
+
+/// Pushforward of ROOT::Math::inc_gamma_c, which is 1 - inc_gamma. See
+/// inc_gamma_pushforward().
+inline clad::ValueAndPushforward<double, double> inc_gamma_c_pushforward(double a, double x, double d_a, double d_x)
+{
+   return {::ROOT::Math::inc_gamma_c(a, x), -inc_gamma_da(a, x) * d_a - inc_gamma_dx(a, x) * d_x};
+}
+
+} // namespace Math
+} // namespace ROOT
+} // namespace custom_derivatives
+} // namespace clad
+
+// NOLINTEND
+
+// clang-format on
+
+#endif // CLAD_BENCHMARK_HISTFACTORY_MATHFUNCS_H

--- a/benchmark/histfactory.py
+++ b/benchmark/histfactory.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""HistFactory-style likelihood benchmark for clad hessians.
+
+Generates a scaled-down proxy of a real 1470-parameter ATLAS likelihood
+with the same computational structure as the code RooFit generates for it,
+compiles it with the clad plugin, and runs it. The generated .cpp is a
+transient artifact; the compilation time is reported in the same format as
+the timing output of the benchmark executable, so a full run reads as one
+timing table.
+
+Structure mirrored from the full benchmark:
+- N channel functions, each: weight-sum loop; straight-line per-sample
+  yields (flexibleInterp over a nuisance subset x product-of-4 free norms x
+  lumi); a bin loop with per-sample uniformBinNumber shape lookups, a
+  yield.shape dot product and a binned nll term.
+- A top-level function summing the channels plus a constraint block:
+  gaussian/gaussianIntegral ratios per nuisance, poisson/poissonIntegral
+  ratios per gamma parameter, one tight (1e-4) lumi constraint, all fed
+  into constraintSum (which carries clad's loop-checkpointing pragma, like
+  in ROOT).
+
+Scale: 91 parameters (36 gaussian nuisances, 6 gammas, lumi, 5 free norms,
+36+6+1 global observables), 4 channels with {8,10,12,6} samples and
+{1,2,4,1} bins.
+
+Usage:
+  histfactory.py                       # generate + compile + run against ../build
+  histfactory.py --clad-build <dir>    # use another clad build tree
+  histfactory.py --cpp out.cpp         # also keep the generated source
+  histfactory.py --gen-only --cpp out.cpp
+"""
+
+import argparse
+import math
+import random
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+BENCHMARK_DIR = Path(__file__).resolve().parent
+REPO = BENCHMARK_DIR.parent
+
+# ---- parameter layout -------------------------------------------------------
+N_NUIS = 36          # gaussian-constrained interpolation nuisances
+N_GAMMA = 6          # poisson-constrained (gamma) parameters
+NUIS = list(range(0, N_NUIS))                    # 0..35
+GAMMA = list(range(N_NUIS, N_NUIS + N_GAMMA))    # 36..41
+LUMI = 42                                        # in every yield, 1e-4 constr.
+FREE = [43, 44, 45, 46, 47]                      # unconstrained norm factors
+GOBS0 = 48                                       # 48..83 gaussian glob. obs
+POBS0 = 84                                       # 84..89 poisson glob. obs
+LUMIOBS = 90
+N_PARAMS = 91
+
+# ---- channels ---------------------------------------------------------------
+CH_SAMPLES = [8, 10, 12, 6]
+CH_BINS = [1, 2, 4, 1]
+INTERP_SIZES = [24, 3, 28, 16, 8, 20, 32, 12,
+                26, 22, 2, 30, 18, 25, 6, 23, 27, 10,
+                21, 29, 4, 24, 19, 31, 14, 26, 22, 5, 33, 17,
+                28, 7, 25, 15, 34, 11]
+assert len(INTERP_SIZES) == sum(CH_SAMPLES)
+
+TAU = 50.0
+
+# The timing/validation driver appended to the generated model code.
+DRIVER = r'''
+namespace {
+
+double funcEval(std::vector<double> &params)
+{
+   return roo_mini_0(params.data(), observablesVec.data(), auxConstantsVec.data());
+}
+
+template <typename Fn>
+double timeIt(int reps, Fn &&fn)
+{
+   auto start = std::chrono::steady_clock::now();
+   for (int r = 0; r < reps; ++r) {
+      fn();
+   }
+   auto stop = std::chrono::steady_clock::now();
+   return std::chrono::duration<double, std::milli>(stop - start).count() / reps;
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+   const bool validate = !(argc > 1 && std::strcmp(argv[1], "--no-validation") == 0);
+
+   const std::size_t n = parametersVec.size();
+
+   auto grad = clad::gradient(roo_mini_0, "params");
+   auto hess = clad::hessian(roo_mini_0, "params[0:{maxparam}]");
+
+   std::vector<double> gradientVec(n);
+   std::vector<double> hessianVec(n * n);
+
+   auto evalGradient = [&](std::vector<double> &params, std::vector<double> &out) {
+      std::fill(out.begin(), out.end(), 0.0);
+      grad.execute(params.data(), observablesVec.data(), auxConstantsVec.data(), out.data());
+   };
+   auto evalHessian = [&](std::vector<double> &params, std::vector<double> &out) {
+      std::fill(out.begin(), out.end(), 0.0);
+      hess.execute(params.data(), observablesVec.data(), auxConstantsVec.data(), out.data());
+   };
+
+   const double nllVal = funcEval(parametersVec);
+   std::printf("n params      : %zu\n", n);
+   std::printf("function value: %.15g\n", nllVal);
+
+   // ---------- Timings ----------
+   const double tFunc = timeIt(2000, [&] { funcEval(parametersVec); });
+   std::printf("primal        : %10.3f ms/call\n", tFunc);
+
+   const double tGrad = timeIt(500, [&] { evalGradient(parametersVec, gradientVec); });
+   std::printf("gradient      : %10.3f ms/call  (%.1fx primal)\n", tGrad, tGrad / tFunc);
+
+   const double tHess = timeIt(20, [&] { evalHessian(parametersVec, hessianVec); });
+   std::printf("hessian       : %10.3f ms/call  (%.1fx gradient)\n", tHess, tHess / tGrad);
+
+   if (!validate) {
+      return 0;
+   }
+
+   int numBadGrad = 0;
+   int numBadHess = 0;
+
+   // ---------- Validate the gradient against central differences ----------
+   {
+      std::vector<double> p = parametersVec;
+      double worst = 0.0;
+      std::size_t worstIdx = 0;
+      for (std::size_t i = 0; i < n; ++i) {
+         const double eps = 1e-6;
+         p[i] = parametersVec[i] - eps;
+         const double funcValDown = funcEval(p);
+         p[i] = parametersVec[i] + eps;
+         const double funcValUp = funcEval(p);
+         p[i] = parametersVec[i];
+         const double num = (funcValUp - funcValDown) / (2 * eps);
+
+         // The primal is O(1e6), so central differences carry ~1e-4 of
+         // cancellation noise on top of the truncation error.
+         const double err = std::abs(gradientVec[i] - num) / std::max(1.0, std::abs(num));
+         if (err > worst) {
+            worst = err;
+            worstIdx = i;
+         }
+         if (err > 1e-3) {
+            if (++numBadGrad <= 10) {
+               std::printf("  grad[%zu]: clad=%.10g num=%.10g\n", i, gradientVec[i], num);
+            }
+         }
+      }
+      std::printf("gradient vs numerical: worst rel. deviation %.2e (at index %zu), %d outside tolerance\n", worst,
+                  worstIdx, numBadGrad);
+   }
+
+   // ---------- Validate sampled hessian rows against central differences of the gradient ----------
+   {
+      std::vector<double> p = parametersVec;
+      std::vector<double> gradUp(n);
+      std::vector<double> gradDown(n);
+      double worst = 0.0;
+      std::size_t worstRow = 0;
+      std::size_t worstCol = 0;
+      unsigned int lcg = 12345;
+      for (int sample = 0; sample < 8; ++sample) {
+         lcg = 1664525 * lcg + 1013904223;
+         const std::size_t i = lcg % n;
+         const double eps = 1e-5;
+         p[i] = parametersVec[i] - eps;
+         evalGradient(p, gradDown);
+         p[i] = parametersVec[i] + eps;
+         evalGradient(p, gradUp);
+         p[i] = parametersVec[i];
+         for (std::size_t j = 0; j < n; ++j) {
+            const double num = (gradUp[j] - gradDown[j]) / (2 * eps);
+            const double cladH = hessianVec[i * n + j];
+            const double err = std::abs(cladH - num) / std::max(1.0, std::abs(num));
+            if (err > worst) {
+               worst = err;
+               worstRow = i;
+               worstCol = j;
+            }
+            if (err > 1e-3) {
+               if (++numBadHess <= 10) {
+                  std::printf("  hess[%zu,%zu]: clad=%.10g num=%.10g\n", i, j, cladH, num);
+               }
+            }
+         }
+      }
+      std::printf("hessian vs numerical (8 sampled rows): worst rel. deviation %.2e (at [%zu,%zu]), %d outside "
+                  "tolerance\n",
+                  worst, worstRow, worstCol, numBadHess);
+   }
+
+   // ---------- Hessian symmetry ----------
+   {
+      double worst = 0.0;
+      for (std::size_t i = 0; i < n; ++i) {
+         for (std::size_t j = 0; j < i; ++j) {
+            const double a = hessianVec[i * n + j];
+            const double b = hessianVec[j * n + i];
+            worst = std::max(worst, std::abs(a - b) / std::max(1.0, std::abs(a)));
+         }
+      }
+      std::printf("hessian asymmetry: worst rel. deviation %.2e\n", worst);
+   }
+
+   if (numBadGrad + numBadHess > 0) {
+      std::printf("VALIDATION FAILED\n");
+      return 1;
+   }
+   std::printf("validation passed\n");
+   return 0;
+}
+'''
+
+
+def fmt(v):
+    return f"{v:.9g}"
+
+
+def generate():
+    """Return the full source text of the mini benchmark."""
+    rng = random.Random(20260821)
+    xl = []          # xlArr contents, allocated sequentially
+    lines = []       # generated code lines
+
+    def alloc_xl(values):
+        off = len(xl)
+        xl.extend(values)
+        return off
+
+    # parameter values --------------------------------------------------------
+    par = [0.0] * N_PARAMS
+    for i in NUIS:
+        par[i] = 0.35 * math.sin(3.1 * i + 0.4)          # interior |alpha| < 1
+    for j, g in enumerate(GAMMA):
+        par[g] = 1.0 + 0.06 * math.sin(2.3 * j)
+    par[LUMI] = 1.0
+    for k, f in enumerate(FREE):
+        par[f] = 1.0 + 0.08 * math.cos(1.7 * k)
+    for i in NUIS:                                        # global observables
+        par[GOBS0 + i] = par[i] + 0.12 * math.sin(5.7 * i)
+    for j in range(N_GAMMA):
+        par[POBS0 + j] = round(TAU * par[GAMMA[j]] + 3 * math.sin(7.1 * j))
+    par[LUMIOBS] = 1.0
+
+    def interp_expr(t, subset, size):
+        """Emit a flexibleInterp over `size` nuisances like the codegen does."""
+        los = [1.0 - (0.04 + 0.03 * abs(math.sin(2.9 * (len(xl) + i)))) for i in range(size)]
+        his = [1.0 + (0.04 + 0.03 * abs(math.cos(3.7 * (len(xl) + i)))) for i in range(size)]
+        lo_off = alloc_xl(los)
+        hi_off = alloc_xl(his)
+        plist = ", ".join(f"params[{p}]" for p in subset)
+        lines.append(f"    double t{t}[]{{{plist}}};")
+        lines.append(
+            f"    const double t{t + 1} = RooFit::Detail::MathFuncs::flexibleInterp"
+            f"(5, t{t}, {size}, xlArr + {lo_off}, xlArr + {hi_off}, 1, 1, 1);")
+        return t + 2
+
+    # channel functions -------------------------------------------------------
+    obs_data = []        # payload appended after the 12 header slots
+    channel_exp = []     # per channel: expected yields per bin (for weights)
+
+    for c, (n_samples, n_bins) in enumerate(zip(CH_SAMPLES, CH_BINS)):
+        t = 1
+        lines.append(f"double roo_mini_{c + 1}(double *params, const double *obs, const double *xlArr)")
+        lines.append("{")
+        lines.append("    const double t0 = 1;")
+        hdr = 3 * c
+        lines.append(f"    double wsum_{c} = 0.;")
+        lines.append(f"    double res_{c} = 0.;")
+        lines.append(f"    for (int loopIdx1 = 0; loopIdx1 < obs[{hdr + 2}]; loopIdx1++) {{")
+        lines.append(f"        wsum_{c} += obs[static_cast<int>(obs[{hdr + 1}]) + loopIdx1];")
+        lines.append("    }")
+        lines.append(f"    res_{c} += wsum_{c} * std::log({TAU:.1f});")
+        # gamma parameter as 1-element lookup table, like `double t4[]{params[404]}`
+        gpar = GAMMA[c % N_GAMMA]
+        lines.append(f"    double tg[]{{params[{gpar}]}};")
+        # two product-of-4 free-norm factors shared between samples
+        f4 = []
+        for _ in range(2):
+            quad = rng.sample(FREE, 4)
+            qlist = ", ".join(f"params[{q}]" for q in quad)
+            lines.append(f"    double t{t}[]{{{qlist}}};")
+            lines.append(f"    const double t{t + 1} = RooFit::Detail::MathFuncs::product(t{t}, 4);")
+            f4.append(t + 1)
+            t += 2
+        # straight-line sample yields
+        yields = []
+        sizes = INTERP_SIZES[sum(CH_SAMPLES[:c]):sum(CH_SAMPLES[:c]) + n_samples]
+        for s, size in enumerate(sizes):
+            subset = rng.sample(NUIS, min(size, N_NUIS))
+            t2 = interp_expr(t, subset, len(subset))
+            interp_res = t2 - 1
+            t = t2
+            if s % 4 == 3:  # some yields have no product-of-4 factor
+                lines.append(f"    double t{t}[]{{t{interp_res}, params[{LUMI}]}};")
+                lines.append(f"    const double t{t + 1} = RooFit::Detail::MathFuncs::product(t{t}, 2);")
+            else:
+                lines.append(f"    double t{t}[]{{t{interp_res}, t{f4[s % 2]}, params[{LUMI}]}};")
+                lines.append(f"    const double t{t + 1} = RooFit::Detail::MathFuncs::product(t{t}, 3);")
+            yields.append(t + 1)
+            t += 2
+        ylist = ", ".join(f"t{y}" for y in yields)
+        lines.append(f"    double ty[]{{{ylist}}};")
+        # per-sample shape tables and expected bin contents
+        shape_offs = []
+        exp_bins = [0.0] * n_bins
+        for s in range(n_samples):
+            shapes = [2.0 + 18.0 * abs(math.sin(1.3 * (len(xl) + b + 7 * s))) for b in range(n_bins)]
+            shape_offs.append(alloc_xl(shapes))
+            for b in range(n_bins):
+                exp_bins[b] += shapes[b]  # yields are ~1 at nominal
+        channel_exp.append(exp_bins)
+        # bin loop
+        lines.append(f"    for (int loopIdx1 = 0; loopIdx1 < obs[{hdr + 2}]; loopIdx1++) {{")
+        bl = []
+        tb = t
+        for s in range(n_samples):
+            off = shape_offs[s]
+            shape = (f"(xlArr + {off})[RooFit::Detail::MathFuncs::uniformBinNumber"
+                     f"(75, 150, obs[static_cast<int>(obs[{hdr}]) + loopIdx1], 1, 1)]")
+            lines.append(f"        const double t{tb} = {shape};")
+            if s % 3 == 0:  # some samples carry the gamma shape factor
+                gshape = (f"tg[RooFit::Detail::MathFuncs::uniformBinNumber"
+                          f"(75, 150, obs[static_cast<int>(obs[{hdr}]) + loopIdx1], 1, 1)]")
+                lines.append(f"        const double t{tb + 1} = {gshape};")
+                lines.append(f"        double t{tb + 2}[]{{t{tb}, t{tb + 1}, t0}};")
+                lines.append(f"        const double t{tb + 3} = RooFit::Detail::MathFuncs::product(t{tb + 2}, 3);")
+                bl.append(tb + 3)
+                tb += 4
+            else:
+                lines.append(f"        double t{tb + 1}[]{{t{tb}, t0}};")
+                lines.append(f"        const double t{tb + 2} = RooFit::Detail::MathFuncs::product(t{tb + 1}, 2);")
+                bl.append(tb + 2)
+                tb += 3
+        bllist = ", ".join(f"t{b}" for b in bl)
+        lines.append(f"        double tb[]{{{bllist}}};")
+        lines.append("        double tsum = 0;")
+        lines.append("        double tnorm = 0;")
+        lines.append(f"        for (int i = 0; i < {n_samples}; i++) {{")
+        lines.append("            tsum += tb[i] * ty[i];")
+        lines.append("            tnorm += ty[i];")
+        lines.append("        }")
+        lines.append(
+            f"        res_{c} += RooFit::Detail::MathFuncs::nll(tsum, "
+            f"obs[static_cast<int>(obs[{hdr + 1}]) + loopIdx1], 1, 0);")
+        lines.append("    }")
+        lines.append(f"    return res_{c};")
+        lines.append("}")
+        lines.append("")
+
+    # obs vector: 12 header slots, then per channel x-values and weights
+    obs = [0.0] * 12
+    for c, n_bins in enumerate(CH_BINS):
+        x_off = 12 + len(obs_data)
+        for b in range(n_bins):
+            obs_data.append(75.0 + (150.0 - 75.0) * (b + 0.5) / n_bins)
+        w_off = 12 + len(obs_data)
+        for b in range(n_bins):
+            # data close to the nominal expectation, with a small offset
+            obs_data.append(round(channel_exp[c][b] * (1.0 + 0.05 * math.sin(4.9 * (c + b))), 1))
+        obs[3 * c] = x_off
+        obs[3 * c + 1] = w_off
+        obs[3 * c + 2] = n_bins
+    obs += obs_data
+
+    # top-level function ------------------------------------------------------
+    lines.append("double roo_mini_0(double *params, const double *obs, const double *xlArr)")
+    lines.append("{")
+    calls = " + ".join(f"roo_mini_{c + 1}(params, obs, xlArr)" for c in range(len(CH_SAMPLES)))
+    lines.append(f"    const double t0 = ({calls});")
+    t = 1
+    cons = []
+    # tight lumi constraint
+    lines.append(f"    const double t{t} = 1.0E-4;")
+    lines.append(f"    const double t{t + 1} = RooFit::Detail::MathFuncs::gaussian(params[{LUMI}], params[{LUMIOBS}], t{t});")
+    cons.append(t + 1)
+    lines.append(f"    const double t{t + 2} = 1;")
+    tone = t + 2
+    t += 3
+    for i in NUIS:
+        lines.append(f"    const double t{t} = RooFit::Detail::MathFuncs::gaussian(params[{i}], params[{GOBS0 + i}], t{tone});")
+        lines.append(f"    const double t{t + 1} = RooFit::Detail::MathFuncs::gaussianIntegral(-10, 10, params[{i}], t{tone});")
+        lines.append(f"    const double t{t + 2} = t{t} / t{t + 1};")
+        cons.append(t + 2)
+        t += 3
+    for j in range(N_GAMMA):
+        lines.append(f"    const double t{t} = {fmt(TAU)};")
+        lines.append(f"    double t{t + 1}[]{{params[{GAMMA[j]}], t{t}}};")
+        lines.append(f"    const double t{t + 2} = RooFit::Detail::MathFuncs::product(t{t + 1}, 2);")
+        lines.append(f"    const double t{t + 3} = RooFit::Detail::MathFuncs::poisson(params[{POBS0 + j}], t{t + 2});")
+        lines.append(f"    const double t{t + 4} = RooFit::Detail::MathFuncs::poissonIntegral(1, t{t + 2}, 0, 0, 1.0E+30, 1);")
+        lines.append(f"    const double t{t + 5} = t{t + 3} / t{t + 4};")
+        cons.append(t + 5)
+        t += 6
+    clist = ", ".join(f"t{cn}" for cn in cons)
+    lines.append(f"    double tc[]{{{clist}}};")
+    lines.append(f"    const double t{t} = RooFit::Detail::MathFuncs::constraintSum(tc, {len(cons)});")
+    lines.append(f"    return t0 + t{t};")
+    lines.append("}")
+
+    # assemble the file -------------------------------------------------------
+    sep = "// " + "-" * 75 + "\n"
+    shared = (
+        "// Scaled-down clad benchmark: hessian of a HistFactory-style likelihood.\n"
+        "//\n"
+        "// Transient file, generated by histfactory.py (see there for the\n"
+        "// structure); a small proxy of the code RooFit generates for a real\n"
+        "// 1470-parameter ATLAS likelihood.\n\n"
+        '#include "HistFactoryMathFuncs.h"\n\n'
+        "#include <algorithm>\n"
+        "#include <chrono>\n"
+        "#include <cmath>\n"
+        "#include <cstddef>\n"
+        "#include <cstdio>\n"
+        "#include <cstring>\n"
+        "#include <vector>\n\n"
+        # constraintSum sits here rather than in the header: clad currently
+        # mis-attributes a checkpoint pragma that lives in an included header
+        # (the planner selects pragmas by raw SourceLocation order, which does
+        # not match translation-unit order across files).
+        "namespace RooFit {\n"
+        "namespace Detail {\n"
+        "namespace MathFuncs {\n"
+        "\n"
+        "template <typename DoubleArray>\n"
+        "double constraintSum(DoubleArray comp, unsigned int compSize)\n"
+        "{\n"
+        "   double sum = 0;\n"
+        "#ifndef CLAD_HISTFACTORY_NO_CHECKPOINT\n"
+        "#pragma clad checkpoint loop\n"
+        "#endif\n"
+        "   for (unsigned int i = 0; i < compSize; i++) {\n"
+        "      sum -= std::log(comp[i]);\n"
+        "   }\n"
+        "   return sum;\n"
+        "}\n"
+        "\n"
+        "} // namespace MathFuncs\n"
+        "} // namespace Detail\n"
+        "} // namespace RooFit\n\n"
+    )
+
+    def literal_block(name, values):
+        out = [f"std::vector<double> {name} = {{"]
+        for i in range(0, len(values), 10):
+            chunk = ", ".join(fmt(v) for v in values[i:i + 10])
+            tail = "," if i + 10 < len(values) else ""
+            out.append("    " + chunk + tail)
+        out.append("};")
+        return "\n".join(out)
+
+    data = "\n\n".join([
+        "// clang-format off",
+        literal_block("parametersVec", par),
+        literal_block("observablesVec", obs),
+        literal_block("auxConstantsVec", xl),
+        "// clang-format on",
+    ])
+
+    driver = DRIVER.replace("{maxparam}", str(N_PARAMS - 1))
+
+    return "".join([
+        shared, sep,
+        "// Generated model code: HistFactory-style channels, mini scale.\n",
+        sep, "\n",
+        "\n".join(lines), "\n\n",
+        data, "\n",
+        driver,
+    ])
+
+
+def cmake_cache_get(build_dir, key):
+    cache = build_dir / "CMakeCache.txt"
+    if cache.exists():
+        m = re.search(rf"^{re.escape(key)}:\w+=(.*)$", cache.read_text(), re.M)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--clad-build", type=Path, default=REPO / "build",
+                    help="clad build tree containing lib/clad.so (default: ./build)")
+    ap.add_argument("--compiler", default=None,
+                    help="C++ compiler to use; must be the clang the clad "
+                         "build targets (default: CMAKE_CXX_COMPILER from the "
+                         "build tree's CMakeCache.txt)")
+    ap.add_argument("--cpp", type=Path, default=None,
+                    help="write (and keep) the generated source here instead of a temp dir")
+    ap.add_argument("--gen-only", action="store_true",
+                    help="only generate the source, do not compile or run")
+    ap.add_argument("--run-args", nargs=argparse.REMAINDER, default=[],
+                    help="arguments passed to the benchmark executable (e.g. --no-validation)")
+    args = ap.parse_args()
+
+    if args.gen_only and args.cpp is None:
+        ap.error("--gen-only needs --cpp to name the output file")
+
+    source = generate()
+
+    tmp = None
+    if args.cpp is None:
+        tmp = tempfile.TemporaryDirectory(prefix="histfactory_")
+        cpp = Path(tmp.name) / "histfactory_model.cpp"
+    else:
+        cpp = args.cpp
+    cpp.write_text(source)
+
+    if args.gen_only:
+        print(f"generated     : {cpp} ({len(source.splitlines())} lines)")
+        return 0
+
+    build = args.clad_build.resolve()
+    clad_so = build / "lib" / "clad.so"
+    if not clad_so.exists():
+        sys.exit(f"error: {clad_so} not found (pass --clad-build)")
+    compiler = (args.compiler or
+                cmake_cache_get(build, "CMAKE_CXX_COMPILER") or "clang++")
+    include = cmake_cache_get(build, "CMAKE_HOME_DIRECTORY")
+    include = (Path(include) if include else REPO) / "include"
+    exe = cpp.with_suffix("")
+
+    cmd = [compiler, "-std=c++17", "-O2", "-I", str(include),
+           "-I", str(BENCHMARK_DIR),
+           "-Xclang", "-add-plugin", "-Xclang", "clad",
+           "-Xclang", "-load", "-Xclang", str(clad_so),
+           "-DCLAD_NO_NUM_DIFF", str(cpp), "-o", str(exe)]
+
+    print(f"clad build    : {build}")
+    start = time.monotonic()
+    res = subprocess.run(cmd)
+    seconds = time.monotonic() - start
+    if res.returncode != 0:
+        sys.exit(res.returncode)
+    print(f"compilation   : {seconds:10.3f} s")
+    sys.stdout.flush()
+
+    res = subprocess.run([str(exe)] + args.run_args)
+    if tmp is not None:
+        tmp.cleanup()
+    return res.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
benchmark/histfactory.py generates a scaled-down proxy of the code RooFit emits for a real 1470-parameter ATLAS likelihood, compiles it with the clad plugin, and runs it, printing the compilation time in the same table format as the benchmark executable's primal/gradient/hessian timings. The .cpp is a transient artifact in a temp directory (kept with --cpp); the compiler is read from the clad build tree's CMakeCache, so `histfactory.py --clad-build <dir>` is all that is needed to compare clad revisions.

The generated model reproduces the statement patterns of the full likelihood at 1/16 scale: 91 parameters, 4 channels with straight-line per-sample yields (flexibleInterp over nuisance subsets, product factors, a lumi parameter), bin loops with uniformBinNumber shape lookups feeding binned nll terms, and a constraint block (gaussian/gaussianIntegral and poisson/poissonIntegral ratios into constraintSum). The driver validates the gradient against central differences of the primal and sampled hessian rows against central differences of the gradient. Measured against the full benchmark, the mini preserves the relative cost profile (gradient ~7x primal vs 12x; hessian-vector product ~2.2x gradient vs 2.9x) while compiling in seconds instead of minutes.

benchmark/HistFactoryMathFuncs.h carries the RooFit::Detail::MathFuncs subset the model calls, with TMath/ROOT::Math replaced by std:: equivalents, the Cephes incomplete gamma behind poissonIntegral, and its custom clad derivatives copied verbatim from ROOT's Math/CladDerivator.h (kept verbatim on purpose, including the Cephes do-while loops and the ROOT formatting, which clang-format off/on markers protect so the file stays diffable against the originals).
constraintSum, the one function carrying `#pragma clad checkpoint loop`, is emitted into the generated main file instead: clad currently mis-attributes a checkpoint pragma living in an included header, because the planner selects pragmas by raw SourceLocation order, which does not match translation-unit order across files.

The benchmark registers as the CTest test clad-HistFactory (labels "benchmark;short", RUN_SERIAL) under CLAD_ENABLE_BENCHMARKS. Because one of its metrics is the compilation time of the generated code, it compiles at test time via the script instead of going through CB_ADD_GBENCHMARK; CMake passes the tested clang explicitly through the new --compiler option, since the CMakeCache fallback would pick the host compiler on builds configured with gcc.

Output in the CI looks as follows:
```txt
[7](https://github.com/vgvassilev/clad/actions/runs/32480829289/job/96766612084?pr=2002#step:30:628)
      Start  6: clad-HistFactory
6: Test command: /usr/bin/python3.12 "/home/runner/work/clad/clad/benchmark/histfactory.py" "--clad-build" "/home/runner/work/clad/clad/obj" "--compiler" "/usr/lib/llvm-20/bin/clang++"
6: Working Directory: /home/runner/work/clad/clad/obj/benchmark
6: Test timeout computed to be: 1200
6: clad build    : /home/runner/work/clad/clad/obj
6: compilation   :     22.867 s
6: n params      : 91
6: function value: 4413.41174684329
6: primal        :      0.023 ms/call
6: gradient      :      0.184 ms/call  (8.1x primal)
6: hessian       :     37.619 ms/call  (204.9x gradient)
6: gradient vs numerical: worst rel. deviation 1.15e-06 (at index 10), 0 outside tolerance
6: hessian vs numerical (8 sampled rows): worst rel. deviation 5.62e-10 (at [18,39]), 0 outside tolerance
6: hessian asymmetry: worst rel. deviation 9.37e-16
6: validation passed
 6/11 Test  #6: clad-HistFactory .................   Passed   23.84 sec
```