### PR TITLE
Decide in the planner which calls a forward direction differentiates

### DIFF
--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -147,6 +147,9 @@ private:
   mutable struct ActivityRunInfo {
     std::set<const clang::VarDecl*> VariedDecls;
     std::set<const clang::Stmt*> VariedS;
+    /// Whether a call of the primal has a varied argument. Only filled for
+    /// requests varied analysis has run on; see shouldHavePushforward().
+    llvm::DenseMap<const clang::CallExpr*, bool> VariedCalls;
     bool HasAnalysisRun = false;
   } m_ActivityRunInfo;
 
@@ -376,6 +379,11 @@ public:
   bool shouldHaveAdjoint(const clang::VarDecl* VD) const;
   bool shouldHaveAdjointForw(const clang::VarDecl* VD) const;
   bool isVaried(const clang::Expr* E) const;
+  /// Whether forward mode has to differentiate through the call \p CE. False
+  /// only when varied analysis proved that no argument of the call depends on
+  /// the direction this request differentiates along. A call the analysis
+  /// never saw answers true.
+  [[nodiscard]] bool shouldHavePushforward(const clang::CallExpr* CE) const;
   std::string ComputeDerivativeName() const;
   bool HasIndependentParameter(const clang::ParmVarDecl* PVD) const;
 
@@ -396,6 +404,22 @@ public:
   void addVariedDecl(const clang::VarDecl* init) {
     m_ActivityRunInfo.VariedDecls.insert(init);
   }
+
+  /// Records whether varied analysis found a varied argument of the call
+  /// \p CE. Only a forward-mode request is analyzed along exactly the
+  /// direction it differentiates; other -enable-va runs are unseeded or
+  /// seeded for a caller, and their verdicts must not drop pushforwards.
+  /// Monotone, because a loop body is passed over more than once and a later
+  /// pass may find an argument varied.
+  void recordCallActivity(const clang::CallExpr* CE, bool isVaried) const {
+    if (Mode == DiffMode::forward)
+      m_ActivityRunInfo.VariedCalls[CE] |= isVaried;
+  }
+
+  /// Drops the result of a previous varied-analysis run. A request reused for
+  /// another direction -- as the hessian reuses one forward request per row --
+  /// has to be analyzed from scratch.
+  void resetActivityInfo() const { m_ActivityRunInfo = ActivityRunInfo(); }
   std::set<const clang::VarDecl*>& getVariedDecls() const {
     return m_ActivityRunInfo.VariedDecls;
   }

--- a/lib/Differentiator/ActivityAnalyzer.cpp
+++ b/lib/Differentiator/ActivityAnalyzer.cpp
@@ -216,6 +216,19 @@ bool VariedAnalyzer::TraverseCallExpr(CallExpr* CE) {
   bool variedBefore = m_Varied;
   bool hasVariedArg = false;
   FunctionDecl* FD = CE->getDirectCallee();
+  // A call through a function pointer has no declaration to inspect: assume
+  // its arguments and result are varied, and record nothing.
+  if (!FD) {
+    for (Expr* arg : CE->arguments()) {
+      m_Varied = true;
+      m_Marking = true;
+      TraverseStmt(arg);
+      markExpr(arg);
+    }
+    m_Marking = false;
+    m_Varied = true;
+    return false;
+  }
   bool noHiddenParam = (CE->getNumArgs() == FD->getNumParams());
   if (noHiddenParam) {
     MutableArrayRef<ParmVarDecl*> FDparam = FD->parameters();
@@ -247,6 +260,8 @@ bool VariedAnalyzer::TraverseCallExpr(CallExpr* CE) {
       m_Marking = false;
       m_Varied = false;
     }
+    // Forward mode asks this to decide whether the call needs a pushforward.
+    m_DiffReq.recordCallActivity(CE, hasVariedArg);
     m_Varied = hasVariedArg || variedBefore;
   }
   return false;
@@ -319,6 +334,12 @@ bool VariedAnalyzer::TraverseCXXConstructExpr(clang::CXXConstructExpr* CE) {
 bool VariedAnalyzer::TraverseCXXThisExpr(clang::CXXThisExpr* TE) {
   markExpr(TE);
   setVaried(TE);
+  // Report the stored `this` data the way TraverseDeclRefExpr reports a
+  // variable: a member can carry the derivative (`c = x; return sq(c);`)
+  // and must not read as constant.
+  if (VarData* data = getVarDataFromDecl(/*VD=*/nullptr))
+    if (findReq(*data))
+      m_Varied = true;
   return false;
 }
 
@@ -398,7 +419,11 @@ bool VariedAnalyzer::TraverseUnaryOperator(UnaryOperator* UnOp) {
 }
 
 bool VariedAnalyzer::TraverseDeclRefExpr(DeclRefExpr* DRE) {
-  auto* VD = cast<VarDecl>(DRE->getDecl());
+  // A reference to something that is not a variable -- a function passed as an
+  // argument, an enumerator -- carries no varied state of its own.
+  auto* VD = dyn_cast<VarDecl>(DRE->getDecl());
+  if (!VD)
+    return false;
 
   if (m_Varied && m_Marking) {
     setVaried(DRE);

--- a/lib/Differentiator/AnalysisBase.cpp
+++ b/lib/Differentiator/AnalysisBase.cpp
@@ -65,7 +65,17 @@ VarData::VarData(QualType QT, bool forceInit) {
     utils::getRecordDeclFields(recordDecl, Fields);
     for (const auto* field : Fields) {
       const auto varType = field->getType();
-      (*newArrMap)[getProfileID(field)] = VarData(varType);
+      if (varType->isLValueReferenceType()) {
+        // A reference field is never rebound by the analysis -- constructor
+        // bodies are not modeled -- so a REF_TYPE's dependency set would stay
+        // empty and drop every bit setIsRequired stores. Keep one bit on the
+        // field itself: whether what it refers to is required.
+        VarData& fieldData = (*newArrMap)[getProfileID(field)];
+        fieldData.m_Type = VarData::FUND_TYPE;
+        fieldData.m_Val.m_FundData = false;
+      } else {
+        (*newArrMap)[getProfileID(field)] = VarData(varType);
+      }
     }
   }
 }

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1341,10 +1341,6 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
                            diffArgs.end());
 
   Expr* callDiff = nullptr;
-  // FIXME: Move non-differentiable function handling to the DiffPlanner.
-  // If all arguments are constant literals, then this does not contribute to
-  // the gradient.
-  // FIXME: revert this when this is integrated in the activity analysis pass.
 
   QualType returnType = FD->getReturnType();
   // FIXME: Decide this in the diff planner
@@ -1353,29 +1349,29 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
   if (!callDiff) {
     if (!isa<CXXOperatorCallExpr>(CE) && !isa<CXXMemberCallExpr>(CE) &&
         !needsForwPass) {
-      bool allArgsHaveZeroDerivatives = true;
-      for (unsigned i = 0, e = diffArgs.size(); i < e; ++i) {
-        Expr* dArg = diffArgs[i];
-        // If argDiff.expr_dx is nullptr or is a constant 0, then the derivative
-        // of the function call is 0. Constant-fold rather than pattern-match a
-        // literal: by the time a tangent reaches a call it has usually been
-        // bound to a `const` variable, and seeding one direction of a
-        // multi-directional request leaves every other tangent exactly that --
-        // a zero-initialized constant.
-        if (!clad::utils::IsZeroOrNullValue(dArg, m_Context)) {
-          allArgsHaveZeroDerivatives = false;
-          break;
-        }
+      // The planner's varied analysis already knows whether any argument of
+      // the call depends on the direction being differentiated.
+      bool contributes = m_DiffReq.shouldHavePushforward(CE);
+      // Activity is tracked per variable: seeding p[1] leaves the whole of p
+      // varied, but the tangents are built with the seeded index in hand and
+      // still recognize `f(p[0])` as inactive.
+      // FIXME: Drop this once varied analysis resolves array elements.
+      if (contributes) {
+        contributes = false;
+        for (const Expr* dArg : diffArgs)
+          if (!clad::utils::IsZeroOrNullValue(dArg, m_Context)) {
+            contributes = true;
+            break;
+          }
       }
-      if (allArgsHaveZeroDerivatives) {
+      if (!contributes) {
         Expr* call =
             m_Sema
                 .ActOnCallExpr(getCurrentScope(), Clone(CE->getCallee()),
                                validLoc, llvm::MutableArrayRef<Expr*>(CallArgs),
                                validLoc, CUDAExecConfig)
                 .get();
-        auto* zero = getZeroInit(CE->getType());
-        return StmtDiff(call, zero);
+        return StmtDiff(call, getZeroInit(CE->getType()));
       }
     }
   }

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -921,6 +921,11 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
       return true;
     return getVariedDecls().find(VD) != getVariedDecls().end();
   }
+  bool DiffRequest::shouldHavePushforward(const CallExpr* CE) const {
+    auto found = m_ActivityRunInfo.VariedCalls.find(CE);
+    return found == m_ActivityRunInfo.VariedCalls.end() || found->second;
+  }
+
   bool DiffRequest::isVaried(const Expr* E) const {
     // FIXME: We should consider removing pullback requests from the
     // diff graph.
@@ -930,8 +935,14 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     public:
       VariedChecker(const DiffRequest& DR) : m_Request(DR) {}
       bool isVariedE(const clang::Expr* E) {
-        auto j = m_Request.getVariedStmt().find(E);
-        if (j != m_Request.getVariedStmt().end())
+        // The call-activity pre-pass also fills the varied set, and its
+        // conservative markings (an argument handed to a non-const pointer
+        // parameter is varied no matter what it is) must only feed
+        // shouldHavePushforward. Without the opt-in analysis, keep answering
+        // from the expression alone, as before the pre-pass existed.
+        if (m_Request.EnableVariedAnalysis &&
+            m_Request.getVariedStmt().find(E) !=
+                m_Request.getVariedStmt().end())
           return true;
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
         return !TraverseStmt(const_cast<clang::Expr*>(E));
@@ -1184,6 +1195,65 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     }
 
     return false;
+  }
+
+  /// Whether \p S contains a call forward mode may skip differentiating: a
+  /// plain call that is not an operator or member call (see
+  /// BaseForwardModeVisitor::VisitCallExpr). Missing one is safe -- the
+  /// visitor then differentiates through everything.
+  static bool hasPushforwardCandidate(const Stmt* S) {
+    llvm::SmallVector<const Stmt*, 32> workList{S};
+    while (!workList.empty()) {
+      const Stmt* cur = workList.pop_back_val();
+      if (!cur)
+        continue;
+      if (isa<CallExpr>(cur) && !isa<CXXOperatorCallExpr>(cur) &&
+          !isa<CXXMemberCallExpr>(cur))
+        return true;
+      for (const Stmt* child : cur->children())
+        workList.push_back(child);
+    }
+    return false;
+  }
+
+  /// Whether the planner has to work out which calls of \p request contribute
+  /// to its derivative: only a forward-mode request differentiates along a
+  /// single known direction, and a body without a candidate call has nothing
+  /// to decide.
+  static bool needsCallActivity(const DiffRequest& request) {
+    return request.Mode == DiffMode::forward && request->isDefined() &&
+           hasPushforwardCandidate(request->getBody());
+  }
+
+  /// Seeds the varied set with the parameters \p request differentiates with
+  /// respect to. A FieldDecl (a functor differentiated w.r.t. a field) cannot
+  /// be seeded; the analyzer covers it by treating everything reached through
+  /// `this` as varied.
+  static void seedVariedDirection(DiffRequest& request) {
+    for (const DiffInputVarInfo& dParam : request.DVI)
+      if (const auto* VD = dyn_cast_or_null<VarDecl>(dParam.param))
+        request.addVariedDecl(VD);
+  }
+
+  /// Runs varied analysis for \p request over \p AnalysisDC, which has to
+  /// describe request.Function.
+  static void runVariedAnalysis(DiffRequest& request,
+                                AnalysisDeclContext* AnalysisDC) {
+    TimedAnalysisRegion R("VA " + request.BaseFunctionName);
+    VariedAnalyzer analyzer(AnalysisDC, request, request.getVariedStmt());
+    analyzer.Analyze();
+  }
+
+  /// Runs varied analysis for one direction of \p request over \p AnalysisDC.
+  /// A hessian reuses one forward request for row after row, so what the
+  /// previous direction concluded is dropped first.
+  static void analyzeDirection(DiffRequest& request,
+                               AnalysisDeclContext* AnalysisDC) {
+    request.resetActivityInfo();
+    if (!AnalysisDC || !needsCallActivity(request))
+      return;
+    seedVariedDirection(request);
+    runVariedAnalysis(request, AnalysisDC);
   }
 
   static bool allArgumentsAreLiterals(const CallExpr::arg_range& args,
@@ -1495,11 +1565,9 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
 
       request.Args = E->getArg(1);
       request.UpdateDiffParamsInfo(m_Sema);
-      if (request.Mode == DiffMode::reverse && request.EnableVariedAnalysis) {
-        if (request.Args)
-          for (const auto& dParam : request.DVI)
-            request.addVariedDecl(cast<VarDecl>(dParam.param));
-      }
+      if (request.Mode == DiffMode::reverse && request.EnableVariedAnalysis &&
+          request.Args)
+        seedVariedDirection(request);
 
       if (request.Function->hasAttr<CUDAGlobalAttr>())
         for (size_t i = 0, e = request.Function->getNumParams(); i < e; ++i)
@@ -1744,11 +1812,12 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
               /*AnalysisDeclContextManager=*/nullptr, request.Function,
               Options);
 
-      if (request.EnableVariedAnalysis && request->isDefined()) {
-        TimedAnalysisRegion R("VA " + request.BaseFunctionName);
-        VariedAnalyzer analyzer(AnalysisDC.get(), request,
-                                request.getVariedStmt());
-        analyzer.Analyze();
+      if (needsCallActivity(request)) {
+        seedVariedDirection(request);
+        runVariedAnalysis(request, AnalysisDC.get());
+      } else if (request.EnableVariedAnalysis && request->isDefined()) {
+        // The opt-in analysis; requests it seeds are seeded by the collector.
+        runVariedAnalysis(request, AnalysisDC.get());
       }
 
       if (m_TopMostReq->EnableUsefulAnalysis) {
@@ -1825,28 +1894,26 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
         for (const auto& dParam : request.DVI) {
           const auto* PVD = cast<ParmVarDecl>(dParam.param);
           auto indexInterval = dParam.paramIndexInterval;
-          if (utils::isArrayOrPointerType(PVD->getType())) {
+          bool perIndex = utils::isArrayOrPointerType(PVD->getType());
+          std::size_t start = perIndex ? indexInterval.Start : 0;
+          std::size_t finish = perIndex ? indexInterval.Finish : 1;
+          for (std::size_t i = start; i < finish; ++i) {
             // FIXME: We shouldn't synthesize Args strings.
-            for (auto i = indexInterval.Start; i < indexInterval.Finish; ++i) {
-              auto independentArgString =
-                  PVD->getNameAsString() + "[" + std::to_string(i) + "]";
-              forwRequest.Args = utils::CreateStringLiteral(
-                  m_Sema.getASTContext(), independentArgString);
-              forwRequest.UpdateDiffParamsInfo(m_Sema);
-              if (!forwRequest.DVI.empty())
-                forwRequest.DVI.back().TotalCapacity = indexInterval.Finish;
-              // The request is reused across directions and the lookup only
-              // writes on success; without this reset a direction with a
-              // custom derivative leaks it into every direction after it.
-              forwRequest.CustomDerivative = nullptr;
-              hasCustomForwardDerivative |=
-                  LookupCustomDerivativeDecl(forwRequest);
-              forwRequests.push_back(forwRequest);
-            }
-          } else {
+            std::string independentArgString = PVD->getNameAsString();
+            if (perIndex)
+              independentArgString += "[" + std::to_string(i) + "]";
             forwRequest.Args = utils::CreateStringLiteral(
-                m_Sema.getASTContext(), PVD->getNameAsString());
+                m_Sema.getASTContext(), independentArgString);
             forwRequest.UpdateDiffParamsInfo(m_Sema);
+            if (perIndex && !forwRequest.DVI.empty())
+              forwRequest.DVI.back().TotalCapacity = indexInterval.Finish;
+            // Every row of an array parameter seeds the same VarDecl, so the
+            // first row's analysis holds for all of them.
+            if (i == start)
+              analyzeDirection(forwRequest, request.m_AnalysisDC);
+            // The request is reused across directions and the lookup only
+            // writes on success; without this reset a direction with a
+            // custom derivative leaks it into every direction after it.
             forwRequest.CustomDerivative = nullptr;
             hasCustomForwardDerivative |=
                 LookupCustomDerivativeDecl(forwRequest);

--- a/test/Analyses/ActivityForward.cpp
+++ b/test/Analyses/ActivityForward.cpp
@@ -1,0 +1,177 @@
+// RUN: %cladclang %s -I%S/../../include -oActivityForward.out -Xclang -verify 2>&1 | %filecheck %s
+// RUN: ./ActivityForward.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oActivityForward.out -Xclang -verify
+// RUN: ./ActivityForward.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -enable-va %s -I%S/../../include -oActivityForward.out -Xclang -verify 2>&1 | %filecheck %s
+// RUN: ./ActivityForward.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+double h(double u) { return u * u; }
+
+// The planner runs varied analysis over the direction the request seeds, so a
+// call none of whose arguments can carry that direction gets no pushforward.
+// Neither parameter is const: what decides is activity, not whether the
+// tangent clad built happens to be a constant.
+double two_calls(double x, double y) { return h(x) + h(y); }
+
+// CHECK: double two_calls_darg0(double x, double y) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     double _d_y = 0;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = h_pushforward(x, _d_x);
+// CHECK-NEXT:     return _t0.pushforward + 0.;
+// CHECK-NEXT: }
+
+// A local that the direction reaches only through an assignment is varied all
+// the same, so the call it feeds keeps its pushforward.
+double through_local(double x, double y) {
+  double t = y;
+  t = t + x;
+  return h(t);
+}
+
+// CHECK: double through_local_darg1(double x, double y) {
+// CHECK-NEXT:     double _d_x = 0;
+// CHECK-NEXT:     double _d_y = 1;
+// CHECK-NEXT:     double _d_t = _d_y;
+// CHECK-NEXT:     double t = y;
+// CHECK-NEXT:     _d_t = _d_t + _d_x;
+// CHECK-NEXT:     t = t + x;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = h_pushforward(t, _d_t);
+// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT: }
+
+// The analysis passes over a loop body more than once, and the first pass
+// reaches the call before `t = x` makes t varied. The verdict has to be the
+// one of the last pass, or the derivative loses the term.
+double varied_late_in_loop(double x, double y) {
+  double s = 0;
+  double t = y;
+  for (int i = 0; i < 2; ++i) {
+    s += h(t);
+    t = x;
+  }
+  return s;
+}
+
+// Object state is not tracked per field, so a member carrying the direction
+// counts as varied and the call reading it keeps its pushforward.
+struct MemberState {
+  double c;
+  double m(double x) {
+    c = x;
+    return h(c);
+  }
+};
+
+// CHECK: double m_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     MemberState _d_this_obj;
+// CHECK-NEXT:     MemberState *_d_this = &_d_this_obj;
+// CHECK-NEXT:     _d_this->c = _d_x;
+// CHECK-NEXT:     this->c = x;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = h_pushforward(this->c, _d_this->c);
+// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT: }
+
+// A functor differentiated with respect to one of its fields seeds no
+// parameter at all; what it reads through `this` is varied all the same.
+struct Functor {
+  double x;
+  double operator()() { return h(x); }
+};
+
+// CHECK: double operator_call_darg0() {
+// CHECK-NEXT:     Functor _d_this_obj;
+// CHECK-NEXT:     Functor *_d_this = &_d_this_obj;
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = h_pushforward(this->x, _d_x);
+// CHECK-NEXT:     return _t0.pushforward;
+// CHECK-NEXT: }
+
+// A call through a function pointer has no callee declaration for the
+// analysis to inspect; it must survive the analysis and stay in the primal.
+int cb(int v) { return v; }
+double with_indirect_call(double x, int (*f)(int)) {
+  f(1); // expected-warning {{differentiation of indirect calls is not supported}}
+  return x * x;
+}
+
+// CHECK: double with_indirect_call_darg0(double x, int (*f)(int)) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     f(1);
+// CHECK-NEXT:     return _d_x * x + x * _d_x;
+// CHECK-NEXT: }
+
+// Activity is tracked per variable: seeding p[1] leaves the whole of p
+// varied, and only folding the tangents built with the seeded index in hand
+// recognizes h(p[0]) as inactive. See BaseForwardModeVisitor::VisitCallExpr.
+double element_calls(double p[2]) { return h(p[0]) + h(p[1]); }
+
+// CHECK: double element_calls_darg0_1(double p[2]) {
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = h_pushforward(p[1], 1.);
+// CHECK-NEXT:     return 0. + _t0.pushforward;
+// CHECK-NEXT: }
+
+// An object built from the direction carries it through reference members.
+// The analysis does not model constructor bodies, so a reference field's
+// referent is unknown; the field is tracked as the object's own state,
+// marked when a constructor argument is varied. The call handed the object
+// keeps its pushforward. (The shape of a Kokkos functor capturing the
+// independent variable by reference.)
+struct RefCapture {
+  double& out;
+  double& x;
+  RefCapture(double& _out, double& _x) : out(_out), x(_x) {}
+  void operator()(int i) const { out = x * i; }
+};
+
+template <typename F> void run(int n, const F& f) { f(n); }
+
+double through_ref_capture(double x) {
+  double out = 0;
+  RefCapture f(out, x);
+  f(0); // puts RefCapture::operator() into the differentiation plan
+  run(3, f);
+  return out;
+}
+
+// CHECK: double through_ref_capture_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     double _d_out = 0;
+// CHECK-NEXT:     double out = 0;
+// CHECK-NEXT:     RefCapture _d_f{_d_out, _d_x};
+// CHECK-NEXT:     RefCapture f{out, x};
+// CHECK-NEXT:     f.operator_call_pushforward(0, &_d_f, 0);
+// CHECK-NEXT:     run_pushforward(3, f, 0, _d_f);
+// CHECK-NEXT:     return _d_out;
+// CHECK-NEXT: }
+
+int main() {
+  auto d0 = clad::differentiate(two_calls, "x");
+  printf("%.2f\n", d0.execute(3, 4)); // CHECK-EXEC: 6.00
+
+  auto d1 = clad::differentiate(through_local, "y");
+  printf("%.2f\n", d1.execute(3, 4)); // CHECK-EXEC: 14.00
+
+  auto d2 = clad::differentiate(varied_late_in_loop, "x");
+  printf("%.2f\n", d2.execute(3, 4)); // CHECK-EXEC: 6.00
+
+  MemberState obj = {};
+  auto d3 = clad::differentiate(&MemberState::m, "x");
+  printf("%.2f\n", d3.execute(obj, 3)); // CHECK-EXEC: 6.00
+
+  Functor fn = {3};
+  auto d4 = clad::differentiate(fn, "x");
+  printf("%.2f\n", d4.execute(fn)); // CHECK-EXEC: 6.00
+
+  auto d5 = clad::differentiate(with_indirect_call, "x");
+  printf("%.2f\n", d5.execute(3, cb)); // CHECK-EXEC: 6.00
+
+  double p[2] = {3, 4};
+  auto d6 = clad::differentiate(element_calls, "p[1]");
+  printf("%.2f\n", d6.execute(p)); // CHECK-EXEC: 8.00
+
+  auto d7 = clad::differentiate(through_ref_capture, "x");
+  printf("%.2f\n", d7.execute(3)); // CHECK-EXEC: 3.00
+}

--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -586,6 +586,26 @@ double f14(double x){
   printf("{%.2f, %.2f}\n", result[0], result[1]); \
 }
 
+// A function passed as an argument is a reference to something that is not a
+// variable, so it has no varied state of its own.
+int pick(double k) { return 7; }
+
+double f15_1(double x, int (*f)(double)) { return x * x; }
+
+double f15(double x) { return f15_1(x, pick); }
+
+// CHECK: void f15_grad(double x, double *_d_x) {
+// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     _tracker0.clear();
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _tracker0.restore();
+// CHECK-NEXT:         double _r0 = 0.;
+// CHECK-NEXT:         f15_1_pullback(x, pick, 1, &_r0);
+// CHECK-NEXT:         _tracker0.restore();
+// CHECK-NEXT:         *_d_x += _r0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
 int main(){
     double arr[] = {1,2,3,4,5};
     double darr[] = {0,0,0,0,0};
@@ -611,4 +631,5 @@ int main(){
     grad13.execute(3, arr, &dx, darr);
     printf("{%.2f}\n", dx); // CHECK-EXEC: {0.00}
     TEST1(f14, 3);// CHECK-EXEC: {1.00}
+    TEST1(f15, 3);// CHECK-EXEC: {6.00}
 }

--- a/test/FirstDerivative/BuiltinDerivatives.C
+++ b/test/FirstDerivative/BuiltinDerivatives.C
@@ -90,16 +90,14 @@ float f3(float x, float y) {
 // CHECK-NEXT:     float _d_x = 1;
 // CHECK-NEXT:     float _d_y = 0;
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t0 = clad::custom_derivatives::std::sin_pushforward(x, _d_x);
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t1 = clad::custom_derivatives::std::sin_pushforward(y, _d_y);
-// CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
+// CHECK-NEXT:     return _t0.pushforward + 0.{{F?}};
 // CHECK-NEXT: }
 
 // CHECK: float f3_darg1(float x, float y) {
 // CHECK-NEXT:     float _d_x = 0;
 // CHECK-NEXT:     float _d_y = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t0 = clad::custom_derivatives::std::sin_pushforward(x, _d_x);
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t1 = clad::custom_derivatives::std::sin_pushforward(y, _d_y);
-// CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
+// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t0 = clad::custom_derivatives::std::sin_pushforward(y, _d_y);
+// CHECK-NEXT:     return 0.{{F?}} + _t0.pushforward;
 // CHECK-NEXT: }
 
 float f4(float x, float y) {
@@ -110,16 +108,14 @@ float f4(float x, float y) {
 // CHECK-NEXT:     float _d_x = 1;
 // CHECK-NEXT:     float _d_y = 0;
 // CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t0 = clad::custom_derivatives::std::sin_pushforward(x * x, _d_x * x + x * _d_x);
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t1 = clad::custom_derivatives::std::sin_pushforward(y * y, _d_y * y + y * _d_y);
-// CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
+// CHECK-NEXT:     return _t0.pushforward + 0.{{F?}};
 // CHECK-NEXT: }
 
 // CHECK: float f4_darg1(float x, float y) {
 // CHECK-NEXT:     float _d_x = 0;
 // CHECK-NEXT:     float _d_y = 1;
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t0 = clad::custom_derivatives::std::sin_pushforward(x * x, _d_x * x + x * _d_x);
-// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t1 = clad::custom_derivatives::std::sin_pushforward(y * y, _d_y * y + y * _d_y);
-// CHECK-NEXT:     return _t0.pushforward + _t1.pushforward;
+// CHECK-NEXT:     {{(clad::)?}}ValueAndPushforward<{{float|double}}, {{float|double}}> _t0 = clad::custom_derivatives::std::sin_pushforward(y * y, _d_y * y + y * _d_y);
+// CHECK-NEXT:     return 0.{{F?}} + _t0.pushforward;
 // CHECK-NEXT: }
 
 float f5(float x) {

--- a/test/FirstDerivative/CallArguments.C
+++ b/test/FirstDerivative/CallArguments.C
@@ -112,10 +112,10 @@ float f_const_args_func_7(const float x, const float y) {
   return f_const_helper(x) + f_const_helper(y) - y;
 }
 
-// The tangent of y is a zero-initialized constant, so the call contributes
-// nothing and no pushforward is requested for it. f_const_args_func_8 below is
-// the same function with a non-const y, whose tangent can still be assigned to,
-// so there the pushforward stays.
+// y is not varied along this direction, so the call cannot contribute and no
+// pushforward is requested for it. f_const_args_func_8 below is the same
+// function with a non-const y: what decides is whether y can carry the
+// direction, not whether its tangent is const.
 // CHECK: float f_const_args_func_7_darg0(const float x, const float y) {
 // CHECK-NEXT: const float _d_x = 1;
 // CHECK-NEXT: const float _d_y = 0;
@@ -131,8 +131,7 @@ float f_const_args_func_8(const float x, float y) {
 // CHECK-NEXT: const float _d_x = 1;
 // CHECK-NEXT: float _d_y = 0;
 // CHECK-NEXT: clad::ValueAndPushforward<float, float> _t0 = f_const_helper_pushforward(x, _d_x);
-// CHECK-NEXT: clad::ValueAndPushforward<float, float> _t1 = f_const_helper_pushforward(y, _d_y);
-// CHECK-NEXT: return _t0.pushforward + _t1.pushforward - _d_y;
+// CHECK-NEXT: return _t0.pushforward - _d_y;
 // CHECK-NEXT: }
 
 float f_literal_helper(float x, char ch, const float* p, float* q) {

--- a/test/FirstDerivative/FunctionCalls.C
+++ b/test/FirstDerivative/FunctionCalls.C
@@ -107,8 +107,7 @@ float test_6(float x, float y) {
 // CHECK-NEXT: float _d_x = 1;
 // CHECK-NEXT: float _d_y = 0;
 // CHECK-NEXT: {{(clad::)?}}ValueAndPushforward<float, float> _t0 = clad::custom_derivatives::std::sin_pushforward(x, _d_x);
-// CHECK-NEXT: {{(clad::)?}}ValueAndPushforward<float, float> _t1 = clad::custom_derivatives::std::cos_pushforward(y, _d_y);
-// CHECK-NEXT: return _t0.pushforward + _t1.pushforward;
+// CHECK-NEXT: return _t0.pushforward + 0.F;
 // CHECK-NEXT: }
 
 void increment(int &i) {
@@ -202,6 +201,27 @@ double test_10(double x) {
 // CHECK-NEXT:     return _d_x;
 // CHECK-NEXT: }
 
+// The analysis marks an argument handed to a non-const pointer parameter as
+// varied no matter what it is -- the callee may write through it. That
+// verdict feeds shouldHavePushforward only; it must not make the planner
+// schedule a derivative for a call whose arguments are all literals. (The
+// shape of a CUDA kernel launch's config call, whose stream argument is a
+// null pointer.)
+void opaque_config(int a, void* p) {}
+
+double test_11(double x) {
+  opaque_config(1, nullptr);
+  return x * x;
+}
+
+// CHECK-NOT: opaque_config_pushforward
+// CHECK:      double test_11_darg0(double x) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     opaque_config(1, nullptr);
+// CHECK-NEXT:     return _d_x * x + x * _d_x;
+// CHECK-NEXT: }
+// CHECK-NOT: opaque_config_pushforward
+
 int main () {
   clad::differentiate(test_1, 0);
   clad::differentiate(test_2, 0);
@@ -219,5 +239,6 @@ int main () {
   clad::differentiate<clad::opts::diagonal_only>(test_8); // expected-error {{diagonal only option is only valid for hessian mode}}
   clad::differentiate(test_9);
   clad::differentiate(test_10);
+  clad::differentiate(test_11);
   return 0;
 }

--- a/test/FirstDerivative/FunctionCallsWithResults.C
+++ b/test/FirstDerivative/FunctionCallsWithResults.C
@@ -340,10 +340,8 @@ double fn9 (double i, double j) {
 // CHECK-NEXT:     const int _d_k = 0;
 // CHECK-NEXT:     const int k = 1;
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = g_pushforward(i, _d_i);
-// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t1 = g_pushforward(j, _d_j);
-// CHECK-NEXT:     double &_t2 = _t0.value;
-// CHECK-NEXT:     double &_t3 = _t1.value;
-// CHECK-NEXT:     return _t0.pushforward * _t3 + _t2 * _t1.pushforward;
+// CHECK-NEXT:     double _t1 = g(j);
+// CHECK-NEXT:     return _t0.pushforward * _t1;
 // CHECK-NEXT: }
 
 double fn10(double x) {

--- a/test/FirstDerivative/Variables.C
+++ b/test/FirstDerivative/Variables.C
@@ -77,9 +77,8 @@ double f_sin(double x, double y) {
 // CHECK-NEXT:     ValueAndPushforward<double, double> _t0 = clad::custom_derivatives::std::sin_pushforward(x, _d_x);
 // CHECK-NEXT:     double _d_xsin = _t0.pushforward;
 // CHECK-NEXT:     double xsin = _t0.value;
-// CHECK-NEXT:     ValueAndPushforward<double, double> _t1 = clad::custom_derivatives::std::sin_pushforward(y, _d_y);
-// CHECK-NEXT:     double _d_ysin = _t1.pushforward;
-// CHECK-NEXT:     double ysin = _t1.value;
+// CHECK-NEXT:     double _d_ysin = 0.;
+// CHECK-NEXT:     double ysin = std::sin(y);
 // CHECK-NEXT:     double _d_xt = _d_xsin * xsin + xsin * _d_xsin;
 // CHECK-NEXT:     double xt = xsin * xsin;
 // CHECK-NEXT:     double _d_yt = _d_ysin * ysin + ysin * _d_ysin;

--- a/test/Hessian/ZeroTangentCalls.C
+++ b/test/Hessian/ZeroTangentCalls.C
@@ -7,11 +7,9 @@
 
 double cube(double u) { return u * u * u; }
 
-// Deriving in one direction makes all tangents but the seeded one
-// zero-initialized constants. A call handed such a tangent contributes
-// nothing, so no pushforward is requested for it: each direction calls
-// cube_pushforward once instead of twice. The parameters have to be const
-// for this -- a tangent that can still be assigned to is not folded.
+// Deriving in one direction, the planner sees only the seeded parameter as
+// varied: the call handed the other one cannot contribute and gets no
+// pushforward. Each direction calls cube_pushforward once instead of twice.
 double sumOfCubes(const double x, const double y) {
   return cube(x) + cube(y);
 }
@@ -26,6 +24,27 @@ double sumOfCubes(const double x, const double y) {
 // CHECK: double sumOfCubes_darg1(const double x, const double y) {
 // CHECK-NEXT:     const double _d_x = 0;
 // CHECK-NEXT:     const double _d_y = 1;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = cube_pushforward(y, _d_y);
+// CHECK-NEXT:     return 0. + _t0.pushforward;
+// CHECK-NEXT: }
+
+// The same function without const parameters. What decides is the direction
+// the request seeds, not the shape of the tangent clad built for it, so the
+// derivatives come out the same.
+double sumOfCubesNonConst(double x, double y) {
+  return cube(x) + cube(y);
+}
+
+// CHECK: double sumOfCubesNonConst_darg0(double x, double y) {
+// CHECK-NEXT:     double _d_x = 1;
+// CHECK-NEXT:     double _d_y = 0;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = cube_pushforward(x, _d_x);
+// CHECK-NEXT:     return _t0.pushforward + 0.;
+// CHECK-NEXT: }
+
+// CHECK: double sumOfCubesNonConst_darg1(double x, double y) {
+// CHECK-NEXT:     double _d_x = 0;
+// CHECK-NEXT:     double _d_y = 1;
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = cube_pushforward(y, _d_y);
 // CHECK-NEXT:     return 0. + _t0.pushforward;
 // CHECK-NEXT: }
@@ -54,6 +73,28 @@ struct SumOfCubes {
     return cube(x) + cube(y);
   }
 };
+
+// One varied analysis serves every row of an array parameter -- each row
+// seeds the same VarDecl. A row still keeps only the pushforward of the
+// element it seeds: the tangents are folded with the seeded index in hand.
+// An instance method, so the hessian derives per direction.
+struct SumOfCubesArr {
+  double operator()(const double* p) const { return cube(p[0]) + cube(p[1]); }
+};
+
+// CHECK: double operator_call_darg0_0(const double *p) const {
+// CHECK-NEXT:     const SumOfCubesArr _d_this_obj;
+// CHECK-NEXT:     const SumOfCubesArr *_d_this = &_d_this_obj;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = cube_pushforward(p[0], 1.);
+// CHECK-NEXT:     return _t0.pushforward + 0.;
+// CHECK-NEXT: }
+
+// CHECK: double operator_call_darg0_1(const double *p) const {
+// CHECK-NEXT:     const SumOfCubesArr _d_this_obj;
+// CHECK-NEXT:     const SumOfCubesArr *_d_this = &_d_this_obj;
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t0 = cube_pushforward(p[1], 1.);
+// CHECK-NEXT:     return 0. + _t0.pushforward;
+// CHECK-NEXT: }
 
 // CHECK: void operator_call_darg0_grad(const double x, const double y, SumOfCubes *_d_this, double *_d_x, double *_d_y) const {
 // CHECK-NEXT:     double _d_d_x = 0.;
@@ -84,6 +125,11 @@ int main() {
   printf("[%.2f, %.2f]\n", dx.execute(2, 3), dy.execute(2, 3));
   // CHECK-EXEC: [12.00, 27.00]
 
+  auto dxNonConst = clad::differentiate(sumOfCubesNonConst, "x");
+  auto dyNonConst = clad::differentiate(sumOfCubesNonConst, "y");
+  printf("[%.2f, %.2f]\n", dxNonConst.execute(2, 3), dyNonConst.execute(2, 3));
+  // CHECK-EXEC: [12.00, 27.00]
+
   auto methodHess = clad::hessian(&SumOfCubes::operator());
   double methodMatrix[4] = {0};
   SumOfCubes f;
@@ -97,4 +143,12 @@ int main() {
   hess.execute(2, 3, matrix);
   printf("[%.2f, %.2f, %.2f, %.2f]\n", matrix[0], matrix[1], matrix[2],
          matrix[3]); // CHECK-EXEC: [12.00, 0.00, 0.00, 18.00]
+
+  auto hessArr = clad::hessian(&SumOfCubesArr::operator(), "p[0:1]");
+  SumOfCubesArr g;
+  double p[2] = {2, 3};
+  double matrixArr[4] = {0};
+  hessArr.execute(g, p, matrixArr);
+  printf("[%.2f, %.2f, %.2f, %.2f]\n", matrixArr[0], matrixArr[1], matrixArr[2],
+         matrixArr[3]); // CHECK-EXEC: [12.00, 0.00, 0.00, 18.00]
 }


### PR DESCRIPTION
**Follows up on https://github.com/vgvassilev/clad/pull/1984#issuecomment-5330149662**

Forward mode worked out for itself whether a call could contribute to the derivative: VisitCallExpr folded the tangents it had just built and, when they were all zero, emitted the plain call with a zero derivative. Two FIXMEs at that site asked for the decision to move to the planner.

The planner now runs varied analysis for forward-mode requests, seeded from the direction the request differentiates along, and VariedAnalyzer records for each call whether any argument is varied. DiffRequest::shouldHavePushforward answers the question the visitor used to answer itself; a call the analysis never saw answers "differentiate it". Only forward-mode requests record and consume this: the requests -enable-va analyzes are unseeded or seeded for a caller, and their verdicts would zero out direction-agnostic pushforwards. A body without a plain call skips the analysis, and a hessian analyzes each parameter once, not once per array index. The record is monotone within a run, so later passes over a loop body can only add varied calls, never lose them.

Activity does not care whether a tangent is a const-qualified zero, so the elision now fires for plain parameters too; four tests lose the pushforward of the direction they do not seed. The tangent fold stays as an index-level refinement: a direction seeding p[1] leaves the whole of p varied, and only the tangents know f(p[0]) is inactive.

A "not varied" verdict now deletes derivatives by default, so the analyzer is made conservative where it does not track state: a DeclRefExpr naming a function (an assert, reachable on master with -enable-va), a call through a function pointer (a crash on a null getDirectCallee()), and member state reached through `this`, which is not tracked per field and can carry the derivative -- this also covers functors differentiated with respect to a field, whose FieldDecl the seed set cannot hold. ActivityForward.cpp pins these with and without -enable-va, which used to run the forward analysis unseeded; ZeroTangentCalls.C pins the once-per-parameter array hessian.