### PR TITLE
Free the objects a constructor's reverse_forw allocates.

### DIFF
--- a/lib/Differentiator/ReverseModeForwPassVisitor.cpp
+++ b/lib/Differentiator/ReverseModeForwPassVisitor.cpp
@@ -73,7 +73,7 @@ DerivativeAndOverload ReverseModeForwPassVisitor::Derive() {
 
     // If we the differentiated function is a constructor, generate `this`
     // object and differentiate its inits.
-    Stmt* ctorReturnStmt = nullptr;
+    llvm::SmallVector<Stmt*, 4> ctorEpilogue;
     if (const auto* CD = dyn_cast<CXXConstructorDecl>(m_DiffReq.Function)) {
       QualType thisTy = CD->getThisType();
       StmtDiff thisObj = BuildThisExpr(thisTy);
@@ -88,14 +88,27 @@ DerivativeAndOverload ReverseModeForwPassVisitor::Derive() {
         addToCurrentBlock(CI_diff.getStmt(), direction::forward);
         addToCurrentBlock(CI_diff.getStmt_dx(), direction::forward);
       }
-      // Build `return {*_this, *_d_this};`
+      // Build `_ret = {*_this, *_d_this}; free(_this); free(_d_this);
+      // return _ret;`. Both objects are malloc'd above, so the result has to
+      // be copied out of them before they are released; returning the list
+      // directly leaves nowhere for the free()s to go, and both blocks leak
+      // for the lifetime of the program.
       SourceLocation validLoc{CD->getBeginLoc()};
       llvm::SmallVector<Expr*, 2> returnArgs = {
           BuildOp(UO_Deref, CloneNode(thisObj.getExpr())),
           BuildOp(UO_Deref, CloneNode(dthisObj.getExpr()))};
       Expr* returnInitList =
           m_Sema.ActOnInitList(validLoc, returnArgs, validLoc).get();
-      ctorReturnStmt = m_Sema.BuildReturnStmt(validLoc, returnInitList).get();
+      VarDecl* resultDecl =
+          BuildVarDecl(m_Derivative->getReturnType(), "_ret", returnInitList);
+      ctorEpilogue.push_back(BuildDeclStmt(resultDecl));
+      // BuildThisExpr pairs the object's malloc with a free and hands it back;
+      // the derived object is allocated the same way and needs its own.
+      ctorEpilogue.push_back(thisObj.getStmt_dx());
+      llvm::SmallVector<Expr*, 1> dThisArg{CloneNode(dthisObj.getExpr())};
+      ctorEpilogue.push_back(GetFunctionCall("free", "", dThisArg));
+      ctorEpilogue.push_back(
+          m_Sema.BuildReturnStmt(validLoc, BuildDeclRef(resultDecl)).get());
     }
 
     StmtDiff bodyDiff = Visit(m_DiffReq->getBody());
@@ -110,7 +123,8 @@ DerivativeAndOverload ReverseModeForwPassVisitor::Derive() {
     else
       addToCurrentBlock(forward);
 
-    addToCurrentBlock(ctorReturnStmt);
+    for (Stmt* S : ctorEpilogue)
+      addToCurrentBlock(S);
 
     Stmt* fnBody = endBlock();
     m_Derivative->setBody(fnBody);

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -35,7 +35,10 @@ double fn1(double x, double y) {
 // CHECK-NEXT:     _this->x = val;
 // CHECK-NEXT:     val *= val;
 // CHECK-NEXT:     _this->y = val;
-// CHECK-NEXT:     return {*_this, *_d_this};
+// CHECK-NEXT:     clad::ValueAndAdjoint<argByVal, argByVal> _ret0 = {*_this, *_d_this};
+// CHECK-NEXT:     free(_this);
+// CHECK-NEXT:     free(_d_this);
+// CHECK-NEXT:     return _ret0;
 // CHECK-NEXT: }
 
 // CHECK:  static inline void constructor_pullback(double val, argByVal *_d_this, double *_d_val) {
@@ -134,7 +137,10 @@ double fn2(double u, double v) {
 // CHECK-NEXT:      memset(_d_this, 0, sizeof(S1));
 // CHECK-NEXT:      _this->p = x;
 // CHECK-NEXT:      _this->d = 0.;
-// CHECK-NEXT:      return {*_this, *_d_this};
+// CHECK-NEXT:      clad::ValueAndAdjoint<S1, S1> _ret0 = {*_this, *_d_this};
+// CHECK-NEXT:      free(_this);
+// CHECK-NEXT:      free(_d_this);
+// CHECK-NEXT:      return _ret0;
 // CHECK-NEXT:  }
 
 // CHECK:  static inline void constructor_pullback(double x, S1 *_d_this, double *_d_x) {
@@ -152,7 +158,10 @@ double fn2(double u, double v) {
 // CHECK-NEXT:     _this->p = x;
 // CHECK-NEXT:     _this->i = 1.;
 // CHECK-NEXT:     _this->d = 0.;
-// CHECK-NEXT:     return {*_this, *_d_this};
+// CHECK-NEXT:     clad::ValueAndAdjoint<S2, S2> _ret0 = {*_this, *_d_this};
+// CHECK-NEXT:     free(_this);
+// CHECK-NEXT:     free(_d_this);
+// CHECK-NEXT:     return _ret0;
 // CHECK-NEXT: }
 
 // CHECK:  static inline void constructor_pullback(double x, S2 *_d_this, double *_d_x) {
@@ -174,7 +183,10 @@ double fn2(double u, double v) {
 // CHECK-NEXT:     S3 *_d_this = (S3 *)malloc(sizeof(S3));
 // CHECK-NEXT:     memset(_d_this, 0, sizeof(S3));
 // CHECK-NEXT:     _this->p = x * x;
-// CHECK-NEXT:     return {*_this, *_d_this};
+// CHECK-NEXT:     clad::ValueAndAdjoint<S3, S3> _ret0 = {*_this, *_d_this};
+// CHECK-NEXT:     free(_this);
+// CHECK-NEXT:     free(_d_this);
+// CHECK-NEXT:     return _ret0;
 // CHECK-NEXT: }
 
 // CHECK:  static inline void constructor_pullback(double x, S3 *_d_this, double *_d_x) {
@@ -193,7 +205,10 @@ double fn2(double u, double v) {
 // CHECK-NEXT:     S5 *_this = (S5 *)malloc(sizeof(S5));
 // CHECK-NEXT:     S5 *_d_this = (S5 *)malloc(sizeof(S5));
 // CHECK-NEXT:     memset(_d_this, 0, sizeof(S5));
-// CHECK-NEXT:     return {*_this, *_d_this};
+// CHECK-NEXT:     clad::ValueAndAdjoint<S5, S5> _ret0 = {*_this, *_d_this};
+// CHECK-NEXT:     free(_this);
+// CHECK-NEXT:     free(_d_this);
+// CHECK-NEXT:     return _ret0;
 // CHECK-NEXT: }
 
 // CHECK:  static inline void constructor_pullback(double x, S5 *_d_this, double *_d_x) {
@@ -247,7 +262,10 @@ double fn3(double u, double v) {
 // CHECK-NEXT:    memset(_d_this, 0, sizeof(S4));
 // CHECK-NEXT:    _this->i = 9;
 // CHECK-NEXT:    _this->p = x;
-// CHECK-NEXT:    return {*_this, *_d_this};
+// CHECK-NEXT:    clad::ValueAndAdjoint<S4, S4> _ret0 = {*_this, *_d_this};
+// CHECK-NEXT:    free(_this);
+// CHECK-NEXT:    free(_d_this);
+// CHECK-NEXT:    return _ret0;
 // CHECK-NEXT:}
 
 // CHECK: static inline void constructor_pullback(double x, S4 *_d_this, double *_d_x) {
@@ -371,7 +389,10 @@ double fn6(double x, double y) {
 // CHECK-NEXT:     memset(_d_this, 0, sizeof(argByValWrapper));
 // CHECK-NEXT:     new (_this) argByValWrapper(v);
 // CHECK-NEXT:     _this->z = _this->y * u;
-// CHECK-NEXT:     return {*_this, *_d_this};
+// CHECK-NEXT:     clad::ValueAndAdjoint<argByValWrapper, argByValWrapper> _ret0 = {*_this, *_d_this};
+// CHECK-NEXT:     free(_this);
+// CHECK-NEXT:     free(_d_this);
+// CHECK-NEXT:     return _ret0;
 // CHECK-NEXT: }
 
 // CHECK:  static inline void constructor_pullback(double v, double u, argByValWrapper *_d_this, double *_d_v, double *_d_u) {
@@ -418,7 +439,10 @@ double fn7(double x, double y) {
 // CHECK-NEXT:     clad::ValueAndAdjoint<argByVal, argByVal> _t0 = argByVal::constructor_reverse_forw(clad::Tag<argByVal>(), v, 0.);
 // CHECK-NEXT:     new (static_cast<argByVal *>(_this)) argByVal(_t0.value);
 // CHECK-NEXT:     _this->z = _this->x * _this->y;
-// CHECK-NEXT:     return {*_this, *_d_this};
+// CHECK-NEXT:     clad::ValueAndAdjoint<argByValWrapper, argByValWrapper> _ret0 = {*_this, *_d_this};
+// CHECK-NEXT:     free(_this);
+// CHECK-NEXT:     free(_d_this);
+// CHECK-NEXT:     return _ret0;
 // CHECK-NEXT: }
 
 // CHECK:  static inline void constructor_pullback(double v, bool arg, argByValWrapper *_d_this, double *_d_v, bool *_d_arg) {
@@ -653,7 +677,10 @@ class ptrConstr {
 // CHECK-NEXT:      _this->ptr = &x;
 // CHECK-NEXT:      _d_this->ptr = &_d_x;
 // CHECK-NEXT:      _this->val = y * y;
-// CHECK-NEXT:      return {*_this, *_d_this};
+// CHECK-NEXT:      clad::ValueAndAdjoint<ptrConstr, ptrConstr> _ret0 = {*_this, *_d_this};
+// CHECK-NEXT:      free(_this);
+// CHECK-NEXT:      free(_d_this);
+// CHECK-NEXT:      return _ret0;
 // CHECK-NEXT:  }
 
 // CHECK:  static inline void constructor_pullback(double &x, const double &y, ptrConstr *_d_this, double *_d_x, double *_d_y) {


### PR DESCRIPTION
The wrapper mallocs the object and its adjoint, fills them in, and returns `{*_this, *_d_this}` -- copies, with the two blocks left behind. Every call leaks them, twice sizeof(T), for the lifetime of the program. BuildThisExpr already builds the matching free() and hands it back; the pullback path collects it, this one dropped it, and the adjoint object never had one at all.

Copy the result into a local before releasing them, since returning the list directly leaves nowhere for the free()s to go. Valgrind over the test suite reported 38 leak records before this and 18 after, all of the remainder from allocations the tests themselves never free.