### PR TITLE
[test] Free what the tests allocate.

### DIFF
--- a/test/ForwardMode/Casts.C
+++ b/test/ForwardMode/Casts.C
@@ -13,6 +13,7 @@ long double fn1(double i, double j) {
   const S * s_const = new S();
   S * s = const_cast<S*>(s_const);
   long double x = reinterpret_cast<S*>(s)->get() + dynamic_cast<S*>(s)->get();
+  delete s;
   return res + x;
 }
 

--- a/test/ForwardMode/Pointer.C
+++ b/test/ForwardMode/Pointer.C
@@ -10,7 +10,10 @@ double fn1(double i, double j) {
   double **q = new double *;
   *q = new double;
   **q = j;
-  return *p * **q;
+  double res = *p * **q;
+  delete *q;
+  delete q;
+  return res;
 }
 
 // CHECK: double fn1_darg0(double i, double j) {
@@ -24,7 +27,13 @@ double fn1(double i, double j) {
 // CHECK-NEXT:     *q = new double;
 // CHECK-NEXT:     **_d_q = _d_j;
 // CHECK-NEXT:     **q = j;
-// CHECK-NEXT:     return *_d_p * **q + *p * **_d_q;
+// CHECK-NEXT:     double _d_res = *_d_p * **q + *p * **_d_q;
+// CHECK-NEXT:     double res = *p * **q;
+// CHECK-NEXT:     delete *_d_q;
+// CHECK-NEXT:     delete *q;
+// CHECK-NEXT:     delete _d_q;
+// CHECK-NEXT:     delete q;
+// CHECK-NEXT:     return _d_res;
 // CHECK-NEXT: }
 
 double fn2(double i, double j) {
@@ -41,7 +50,9 @@ double fn3(double i, double j) {
   double *p = new double[2];
   p[0] = i + j;
   p[1] = i*j;
-  return p[0] + p[1];
+  double res = p[0] + p[1];
+  delete[] p;
+  return res;
 }
 
 // CHECK: double fn3_darg0(double i, double j) {
@@ -53,7 +64,11 @@ double fn3(double i, double j) {
 // CHECK-NEXT:     p[0] = i + j;
 // CHECK-NEXT:     _d_p[1] = _d_i * j + i * _d_j;
 // CHECK-NEXT:     p[1] = i * j;
-// CHECK-NEXT:     return _d_p[0] + _d_p[1];
+// CHECK-NEXT:     double _d_res = _d_p[0] + _d_p[1];
+// CHECK-NEXT:     double res = p[0] + p[1];
+// CHECK-NEXT:     delete [] _d_p;
+// CHECK-NEXT:     delete [] p;
+// CHECK-NEXT:     return _d_res;
 // CHECK-NEXT: }
 
 double fn4(double i, double j) {

--- a/test/Gradient/Constructors.C
+++ b/test/Gradient/Constructors.C
@@ -721,7 +721,9 @@ int main() {
     S s{new double[3]{5, 6, 7}}, _d_s{new double[3]{0}};
     auto dfn9 = clad::gradient(fn9);
     dfn9.execute(s, &_d_s);
-    printf("{%.2f, %.2f, %.2f}\n", _d_s.a[0], _d_s.a[1], _d_s.a[2]);   // CHECK-EXEC: {0.00, 0.00, 1.00}
+    printf("{%.2f, %.2f, %.2f}\n", _d_s.a[0], _d_s.a[1], _d_s.a[2]);
+    delete[] s.a;
+    delete[] _d_s.a;   // CHECK-EXEC: {0.00, 0.00, 1.00}
 
     INIT_GRADIENT(fn10);
     TEST_GRADIENT(fn10, /*numOfDerivativeArgs=*/2, 7, 2, &d_i, &d_j);    // CHECK-EXEC: {1.00, 1.00}

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -1260,18 +1260,27 @@ void destroy(T* p) {
 double fn34(double x, double y) {
   int* a = new int(x + y);
   destroy(a);
-  return *a;
+  double res = *a;
+  // int has a trivial destructor, so destroy() above only ran a no-op and the
+  // storage is still ours to release.
+  delete a;
+  return res;
 }
 
 // CHECK: void fn34_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     int *_d_a = new int(0.);
 // CHECK-NEXT:     int *a = new int(x + y);
 // CHECK-NEXT:     destroy(a);
-// CHECK-NEXT:     *_d_a += 1;
+// CHECK-NEXT:     double _d_res = 0.;
+// CHECK-NEXT:     double res = *a;
+// CHECK-NEXT:     _d_res += 1;
+// CHECK-NEXT:     *_d_a += _d_res;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         *_d_x += *_d_a;
 // CHECK-NEXT:         *_d_y += *_d_a;
 // CHECK-NEXT:     }
+// CHECK-NEXT:     delete a;
+// CHECK-NEXT:     delete _d_a;
 // CHECK-NEXT: }
 
 double fn35(double x, double y) {

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -652,14 +652,21 @@ double fn8(double x, double y) {
 
 double fn9(double x, double y) {
   S* s = new S{x, false};
-  return s->getVal();
+  double res = s->getVal();
+  delete s;
+  return res;
 }
 
 // CHECK:  void fn9_grad(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:      S *_d_s = new S({0., false});
 // CHECK-NEXT:      S *s = new S({x, false});
-// CHECK-NEXT:      s->getVal_pullback(1, _d_s);
+// CHECK-NEXT:      double _d_res = 0.;
+// CHECK-NEXT:      double res = s->getVal();
+// CHECK-NEXT:      _d_res += 1;
+// CHECK-NEXT:      s->getVal_pullback(_d_res, _d_s);
 // CHECK-NEXT:      *_d_x += *_d_s.val;
+// CHECK-NEXT:      delete s;
+// CHECK-NEXT:      delete _d_s;
 // CHECK-NEXT:  }
 
 // CHECK:  void operator_minus_pullback(const double &x, S _d_y, S *_d_this, double *_d_x) const {


### PR DESCRIPTION
Five tests allocate and never release: Constructors.C builds two arrays in main, MemberFunctions.C and Casts.C `new` an object they read once, Pointer.C `new`s two pointers and an array, and FunctionCalls.C hands its `int*` to a destroy() that only runs the destructor. The derivative inherits each one, since clad reproduces the allocation and adds an adjoint beside it, so a leak check over the generated programs reports every one of them twice.

Release them where the primal is done with the storage, holding the value in a local first where the result is read through the pointer being freed. clad differentiates delete -- VisitCXXDeleteExpr releases the adjoint alongside the primal -- so the derivatives free both, which the expectations here now record.