### PR TITLE
Accept a pullback_state carrier taken by reference.

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivatives.h
+++ b/include/clad/Differentiator/BuiltinDerivatives.h
@@ -48,7 +48,9 @@ struct no_state {};
 /// Per-call state a custom `X_reverse_forw` hands to its matching `X_pullback`.
 /// The reverse_forw takes a trailing `pullback_state<Payload>&` out-parameter
 /// and fills it in the forward sweep; the pullback takes a trailing
-/// `pullback_state<Payload>` by value and reads it in the reverse sweep. clad
+/// `pullback_state<Payload>`, by value or by reference, and reads it in the
+/// reverse sweep. Take it by reference when the payload owns storage that
+/// cannot be copied, such as a `clad::tape<T>` the pullback pops from. clad
 /// declares one carrier and threads it into both calls -- the same out-param
 /// mechanism as `clad::restore_tracker`, and it composes with the
 /// `ValueAndAdjoint` a value-returning reverse_forw already returns. Use it to

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1339,6 +1339,20 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
           }
       return {};
     };
+    // A payload that owns storage -- a clad::tape, say -- has no copy
+    // constructor, so a pullback carrying one must take the carrier by
+    // reference. Whichever form the candidate declares is the one to expect.
+    auto pullbackTakesStateByRef = [](const LookupResult& LR) {
+      for (const NamedDecl* ND : LR)
+        if (const FunctionDecl* FD = ND->getUnderlyingDecl()->getAsFunction())
+          for (const ParmVarDecl* PVD : FD->parameters()) {
+            QualType PT = PVD->getType();
+            if (!utils::GetPullbackStatePayload(PT.getNonReferenceType())
+                     .isNull())
+              return PT->isLValueReferenceType();
+          }
+      return false;
+    };
     QualType stateParam;
     if (R.Mode == DiffMode::reverse_mode_forward_pass)
       stateParam = findStateParam(Found);
@@ -1347,9 +1361,10 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
           LookupPropagator(R.BaseFunctionName + "_reverse_forw"));
     if (!stateParam.isNull())
       if (const auto* FPT = dTy->getAs<FunctionProtoType>()) {
-        // The reverse_forw takes the state by reference (out-param); the
-        // pullback takes it by value.
-        QualType stateArg = R.Mode == DiffMode::reverse_mode_forward_pass
+        // The reverse_forw always takes the state by reference: it is an
+        // out-param it fills during the forward sweep.
+        QualType stateArg = (R.Mode == DiffMode::reverse_mode_forward_pass ||
+                             pullbackTakesStateByRef(Found))
                                 ? C.getLValueReferenceType(stateParam)
                                 : stateParam;
         llvm::SmallVector<QualType, 8> params(FPT->param_types().begin(),

--- a/test/Gradient/PullbackStateByRef.C
+++ b/test/Gradient/PullbackStateByRef.C
@@ -1,0 +1,86 @@
+// RUN: %cladclang %s -I%S/../../include -oPullbackStateByRef.out 2>&1 | %filecheck %s
+// RUN: ./PullbackStateByRef.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oPullbackStateByRef.out
+// RUN: ./PullbackStateByRef.out | %filecheck_exec %s
+
+// A pullback may take its clad::pullback_state carrier by reference as well as
+// by value. By value cannot express a payload that owns storage: a payload
+// holding a clad::tape<T> has no copy constructor, so a by-value pullback does
+// not compile at all. Recording values in the reverse_forw and popping them in
+// the pullback -- the shape a replay-free pullback needs -- therefore requires
+// the by-reference form.
+
+#include "clad/Differentiator/Differentiator.h"
+#include "../TestUtils.h"
+
+struct Recorded {
+  clad::tape<double> values; // non-copyable: forces the by-reference form
+};
+
+double* rec(double* p) { return p; }
+
+namespace clad::custom_derivatives {
+clad::ValueAndAdjoint<double*, double*>
+rec_reverse_forw(double* p, double* d_p, clad::pullback_state<Recorded>& state) {
+  // Forward sweep records; the pullback consumes without re-running anything.
+  clad::push(state.data.values, 3.0);
+  clad::push(state.data.values, 4.0);
+  return {p, d_p};
+}
+void rec_pullback(double* p, double* d_p, clad::pullback_state<Recorded>& state) {
+  *d_p += clad::pop(state.data.values); // 4
+  *d_p += clad::pop(state.data.values); // 3
+}
+} // namespace clad::custom_derivatives
+
+double f(double x) { return *rec(&x); }
+
+// The carrier is declared once and passed to both calls as an lvalue, so the
+// same object serves the reverse_forw's out-param and the pullback's reference.
+//CHECK: void f_grad(double x, double *_d_x) {
+//CHECK-NEXT:     clad::pullback_state<Recorded> _state0 = {{.*}};
+//CHECK-NEXT:     clad::ValueAndAdjoint<double *, double *> _t0 = clad::custom_derivatives::rec_reverse_forw(&x, _d_x, _state0);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         *_t0.adjoint += 1;
+//CHECK-NEXT:         clad::custom_derivatives::rec_pullback(&x, _d_x, _state0);
+//CHECK-NEXT:     }
+//CHECK-NEXT: }
+
+// The by-value convention still matches, so existing custom derivatives keep
+// working unchanged.
+double* val(double* p) { return p; }
+
+namespace clad::custom_derivatives {
+clad::ValueAndAdjoint<double*, double*>
+val_reverse_forw(double* p, double* d_p, clad::pullback_state<double>& state) {
+  state.data = 5;
+  return {p, d_p};
+}
+void val_pullback(double* p, double* d_p, clad::pullback_state<double> state) {
+  *d_p += state.data;
+}
+} // namespace clad::custom_derivatives
+
+double fv(double x) { return *val(&x); }
+
+//CHECK: void fv_grad(double x, double *_d_x) {
+//CHECK-NEXT:     clad::pullback_state<double> _state0 = {0.};
+//CHECK-NEXT:     clad::ValueAndAdjoint<double *, double *> _t0 = clad::custom_derivatives::val_reverse_forw(&x, _d_x, _state0);
+//CHECK-NEXT:     {
+//CHECK-NEXT:         *_t0.adjoint += 1;
+//CHECK-NEXT:         clad::custom_derivatives::val_pullback(&x, _d_x, _state0);
+//CHECK-NEXT:     }
+//CHECK-NEXT: }
+
+int main() {
+  auto df = clad::gradient(f);
+  double dx = 0;
+  df.execute(2.0, &dx);
+  // seed 1, plus the two recorded values popped in reverse: 1 + 4 + 3
+  printf("%.2f\n", dx); // CHECK-EXEC: 8.00
+
+  auto dfv = clad::gradient(fv);
+  double dxv = 0;
+  dfv.execute(2.0, &dxv);
+  printf("%.2f\n", dxv); // CHECK-EXEC: 6.00
+}


### PR DESCRIPTION
A custom pullback had to take its trailing `clad::pullback_state<S>` by value. That rules out any payload owning storage: a payload holding a `clad::tape<T>` has no copy constructor, so recording values in the `reverse_forw` and popping them in the pullback -- the shape a pullback that consumes state instead of replaying the primal needs -- could not be written at all.

Let the candidate decide. Whichever form its trailing parameter declares is the one clad expects, so a by-reference pullback matches and a by-value one keeps matching unchanged. The `reverse_forw` still always takes the carrier by reference; it is an out-parameter it fills during the forward sweep.

Both forms are pinned, with the by-value case kept as a regression.