### PR TITLE
[ci] Run the OpenMP tests on the Valgrind row.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,13 +108,19 @@ jobs:
           # compiler did -- so it is what this row runs. Nothing here needs
           # the from-source LLVM recipe, since clang is not the process being
           # watched; the full run is build-valgrind, on push.
-          - name: ubu24-clang20-runtime22-vg-exec
+          #
+          # The runtime matches the compiler so that libomp-20-dev, which the
+          # Linux setup installs for the runtime major, serves both: the
+          # OpenMP tests are the ones this row is most worth running, since
+          # what a parallel region does to memory is what nothing else here
+          # checks. Which LLVM builds the plugin does not matter to that.
+          - name: ubu24-clang20-runtime20-vg-exec
             os: ubuntu-24.04
             compiler: clang-20
             extra_packages: 'valgrind'
             extra_cmake_options: '-DCLAD_TEST_VG_EXEC_ONLY=On'
             test_target: check-clad-execonly
-            clang-runtime: '22'
+            clang-runtime: '20'
 
           - name: ubu24-arm-clang16-runtime17-shared-libs
             os: ubuntu-24.04-arm

--- a/test/ExecOnly/lit.local.cfg
+++ b/test/ExecOnly/lit.local.cfg
@@ -28,7 +28,12 @@ if lit_config.params.get('vg_exec_only'):
     _valgrind = lit.util.which('valgrind')
     if not _valgrind:
         lit_config.fatal('vg_exec_only was asked for but valgrind was not found')
-    WRAPPER = _valgrind + ' -q --error-exitcode=1 --leak-check=full '
+    # The OpenMP runtime holds its thread pool until the process exits; see
+    # the file for why nothing of clad's can match that entry.
+    _supp = os.path.join(os.path.dirname(__file__), os.pardir,
+                         'clad-valgrind-exec.supp')
+    WRAPPER = (_valgrind + ' -q --error-exitcode=1 --leak-check=full'
+               ' --suppressions=' + _supp + ' ')
 
 class ExecOnlyFormat(lit.formats.ShTest):
     def getTestsInDirectory(self, testSuite, path_in_suite, litConfig, localConfig):

--- a/test/clad-valgrind-exec.supp
+++ b/test/clad-valgrind-exec.supp
@@ -1,0 +1,14 @@
+# Memcheck suppressions for the programs the tests produce, used by the
+# exec-only Valgrind mode (CLAD_TEST_VG_EXEC_ONLY).
+#
+# The OpenMP runtime allocates its thread pool on first use and holds it
+# until the process exits, so Memcheck reports the blocks as possibly lost.
+# The frame directly below malloc is libomp's own, so nothing allocated by
+# clad or by a test can match this.
+{
+   libomp keeps its thread pool until the process exits
+   Memcheck:Leak
+   match-leak-kinds: possible,definite
+   fun:malloc
+   obj:*libomp.so*
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -5,6 +5,7 @@
 import os
 import platform
 import re
+import subprocess
 
 import lit.formats
 import lit.util
@@ -346,7 +347,31 @@ if libcudart_path is not None:
         config.environment['CUDA_VISIBLE_DEVICES'] = os.environ['CUDA_VISIBLE_DEVICES']
     config.substitutions.append(('%cudaarch', config.cuda_test_arch))
 
-if(config.have_openmp == "TRUE"):
+def _openmp_usable():
+    """Can the compiler the tests use actually compile an OpenMP source?
+
+    have_openmp comes from find_package(OpenMP), which probes the compiler
+    CMake was configured with. That is not the one the tests run: a row builds
+    clad with one clang and runs lit against another, and only the second one
+    has to find omp.h. Asking the wrong compiler turns a skip into a failure
+    on every row where the two disagree.
+    """
+    if config.have_openmp != "TRUE":
+        return False
+    try:
+        probe = subprocess.run(
+            [config.clang, '-fopenmp', '-fsyntax-only', '-x', 'c++', '-'],
+            input='#include <omp.h>\nint main() { return omp_get_max_threads(); }\n',
+            capture_output=True, text=True, timeout=120)
+    except Exception:
+        # A probe that cannot answer must not take the suite down with it:
+        # anything from a missing compiler to a hung one means the feature is
+        # not offered, which is the same answer as a compiler that says no.
+        return False
+    return probe.returncode == 0
+
+
+if _openmp_usable():
     config.available_features.add('OpenMP')
 
 if(config.have_enzyme):


### PR DESCRIPTION
The row asked for LLVM 22 while building with clang-20, and the Linux setup installs libomp for the runtime major -- so it looked for libomp-22-dev, which apt-llvm.org does not carry for the newest major, and the OpenMP tests skipped. They are the tests this row is most worth running: what a parallel region does to memory is what nothing else here checks, and the adjoint of a private variable was uninitialised until recently with nothing to catch it. Match the runtime to the compiler, so the libomp the setup installs serves both; which LLVM builds the plugin does not matter to a row that runs Valgrind over the produced programs rather than over clang.

Whether the tests run at all was decided by find_package(OpenMP), which probes the compiler CMake was configured with rather than the one lit uses. Where the two disagree, lit promises a feature the tests then fail on with "'omp.h' file not found". Ask the compiler the tests use instead, so a row without libomp skips them, which is what REQUIRES: OpenMP was meant to do.

Once they run, the OpenMP runtime's own thread pool shows up: libomp allocates it on first use and holds it until the process exits. Suppress it by the frame directly below malloc, which is libomp's own, so no allocation made by clad or by a test can match the entry.