### PR TITLE
List the analyses clad can run in one place. NFC

### DIFF
--- a/include/clad/Differentiator/Analyses.def
+++ b/include/clad/Differentiator/Analyses.def
@@ -1,0 +1,29 @@
+//--------------------------------------------------------*- C++ -*----------//
+// The analyses clad can run, and the switches that select each one.
+//
+// Every analysis here is optional: it may change the code clad generates,
+// never the values that code computes. With all of them off clad must still
+// produce a correct derivative, only a more conservative one.
+//
+// CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)
+//
+//   Id       Spells the generated members, as in Enable<Id>Analysis.
+//   Name     How the analysis is named to users.
+//   Legacy   Suffix of the original -enable-<legacy>/-disable-<legacy> pair.
+//   Default  Whether the analysis runs when no switch selects it.
+//   Desc     One line for -help.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CLAD_ANALYSIS
+#error "define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc) before including"
+#endif
+
+CLAD_ANALYSIS(TBR, "tbr", "tbr", true,
+              "skips storing a value whose reverse sweep can recover it")
+CLAD_ANALYSIS(Varied, "activity", "va", false,
+              "skips the adjoint of a value no input can vary")
+CLAD_ANALYSIS(Useful, "useful", "ua", false,
+              "skips the adjoint of a value no output depends on")
+
+#undef CLAD_ANALYSIS

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -230,12 +230,21 @@ public:
   bool CallUpdateRequired = false;
   /// A flag to enable/disable diag warnings/errors during differentiation.
   bool VerboseDiags = false;
-  /// A flag to enable TBR analysis during reverse-mode differentiation.
-  bool EnableTBRAnalysis = false;
-  /// A flag to enable varied analysis during reverse-mode differentiation.
-  bool EnableVariedAnalysis = false;
-  /// A flag to enable useful analysis during reverse-mode differentiation.
-  bool EnableUsefulAnalysis = false;
+  /// Whether each analysis runs for this request. One member per entry in
+  /// Analyses.def, spelled Enable<Id>Analysis.
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
+  bool Enable##Id##Analysis = false;
+#include "clad/Differentiator/Analyses.def"
+
+  /// Run the same analyses \p Other runs. A derived request -- the pullback of
+  /// a callee, the pushforward of a nested call -- covers a different
+  /// function, but the user asked for the analyses once, for the whole
+  /// differentiation.
+  void inheritAnalysesFrom(const DiffRequest& Other) {
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
+  Enable##Id##Analysis = Other.Enable##Id##Analysis;
+#include "clad/Differentiator/Analyses.def"
+  }
   /// A flag to emit porting-hint remarks (-fclad-porting-hints) when a function
   /// defined outside the main source file is differentiated by cloning its
   /// definition. Diagnostic-only; it does not affect the generated derivative
@@ -405,11 +414,11 @@ using DiffInterval = std::vector<clang::SourceRange>;
 // FIXME: These are translation-unit-wide defaults taken from the compiler
 // invocation, not the options of a request; rename to InvocationOptions.
 struct RequestOptions {
-  /// This is a flag to indicate the default behaviour to enable/disable
-  /// TBR analysis during reverse-mode differentiation.
-  bool EnableTBRAnalysis = false;
-  bool EnableVariedAnalysis = false;
-  bool EnableUsefulAnalysis = false;
+  /// Whether each analysis runs, once the switches on the command line have
+  /// been resolved against the defaults in Analyses.def.
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
+  bool Enable##Id##Analysis = Default;
+#include "clad/Differentiator/Analyses.def"
   bool EmitPortingHints = false;
 };
 

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1389,8 +1389,7 @@ StmtDiff BaseForwardModeVisitor::VisitCallExpr(const CallExpr* CE) {
     pushforwardFnRequest.BaseFunctionName = utils::ComputeEffectiveFnName(FD);
     // Silence diag outputs in nested derivation process.
     pushforwardFnRequest.VerboseDiags = false;
-    pushforwardFnRequest.EnableTBRAnalysis = m_DiffReq.EnableTBRAnalysis;
-    pushforwardFnRequest.EnableVariedAnalysis = m_DiffReq.EnableVariedAnalysis;
+    pushforwardFnRequest.inheritAnalysesFrom(m_DiffReq);
 
     FunctionDecl* pushforwardFD = nullptr;
     if (m_DiffReq.CurrentDerivativeOrder != 1 || !m_DiffReq.CallContext) {

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -1490,9 +1490,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
         return true;
 
       request.VerboseDiags = false;
-      request.EnableTBRAnalysis = m_TopMostReq->EnableTBRAnalysis;
-      request.EnableVariedAnalysis = m_TopMostReq->EnableVariedAnalysis;
-      request.EnableUsefulAnalysis = m_TopMostReq->EnableUsefulAnalysis;
+      request.inheritAnalysesFrom(*m_TopMostReq);
       request.EmitPortingHints = m_TopMostReq->EmitPortingHints;
       request.EnableErrorEstimation = m_TopMostReq->EnableErrorEstimation;
       request.CallContext = E;
@@ -1903,8 +1901,7 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     request.Function = CD;
     request.Mode = DiffMode::pullback;
     request.VerboseDiags = false;
-    request.EnableTBRAnalysis = m_TopMostReq->EnableTBRAnalysis;
-    request.EnableVariedAnalysis = m_TopMostReq->EnableVariedAnalysis;
+    request.inheritAnalysesFrom(*m_TopMostReq);
     request.EmitPortingHints = m_TopMostReq->EmitPortingHints;
 
     for (const auto* paramDecl : CD->parameters())

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -2220,8 +2220,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       pullbackRequest.Mode =
           asGrad ? DiffMode::pullback : DiffMode::pushforward;
       // Silence diag outputs in nested derivation process.
-      pullbackRequest.EnableTBRAnalysis = m_DiffReq.EnableTBRAnalysis;
-      pullbackRequest.EnableVariedAnalysis = m_DiffReq.EnableVariedAnalysis;
+      pullbackRequest.inheritAnalysesFrom(m_DiffReq);
       pullbackRequest.EnableErrorEstimation = m_DiffReq.EnableErrorEstimation;
       // Error estimation only uses forward mode derivatives if they are
       // user-prodived to handle builtin derivatives. We cannot determine which

--- a/test/Misc/Args.C
+++ b/test/Misc/Args.C
@@ -6,11 +6,13 @@
 // CHECK_HELP-NEXT: -fdump-derived-fn-ast
 // CHECK_HELP-NEXT: -fgenerate-source-file
 // CHECK_HELP-NEXT: -fno-validate-clang-version
-// CHECK_HELP-NEXT: -enable-tbr
-// CHECK_HELP-NEXT: -disable-tbr
 // CHECK_HELP-NEXT: -fcustom-estimation-model
 // CHECK_HELP-NEXT: -fprint-num-diff-errors
 // CHECK_HELP-NEXT: -fclad-porting-hints
+// Every analysis clad knows about is listed, with the default it runs at.
+// CHECK_HELP: -enable-tbr / -disable-tbr {{.*}} Default: on.
+// CHECK_HELP-NEXT: -enable-va / -disable-va {{.*}} Default: off.
+// CHECK_HELP-NEXT: -enable-ua / -disable-ua {{.*}} Default: off.
 // CHECK_HELP-NEXT: -help
 
 // RUN: clang -fsyntax-only -fplugin=%cladlib -Xclang -plugin-arg-clad\

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -565,38 +565,15 @@ void InitTimers();
       return m_HasRuntime;
     }
 
-    static void SetTBRAnalysisOptions(const DifferentiationOptions& DO,
-                                      RequestOptions& opts) {
-      // If user has explicitly specified the mode for TBR analysis, use it.
-      if (DO.EnableTBRAnalysis || DO.DisableTBRAnalysis)
-        opts.EnableTBRAnalysis = DO.EnableTBRAnalysis && !DO.DisableTBRAnalysis;
-      else
-        opts.EnableTBRAnalysis = true; // Default mode.
-    }
-
-    static void SetActivityAnalysisOptions(const DifferentiationOptions& DO,
-                                           RequestOptions& opts) {
-      // If user has explicitly specified the mode for AA, use it.
-      if (DO.EnableVariedAnalysis || DO.DisableVariedAnalysis)
-        opts.EnableVariedAnalysis =
-            DO.EnableVariedAnalysis && !DO.DisableVariedAnalysis;
-      else
-        opts.EnableVariedAnalysis = false; // Default mode.
-    }
-
-    static void SetUsefulAnalysisOptions(const DifferentiationOptions& DO,
-                                         RequestOptions& opts) {
-      // If user has explicitly specified the mode for TBR analysis, use it.
-      if (DO.EnableUsefulAnalysis || DO.DisableUsefulAnalysis)
-        opts.EnableUsefulAnalysis =
-            DO.EnableUsefulAnalysis && !DO.DisableUsefulAnalysis;
-      else
-        opts.EnableUsefulAnalysis = false; // Default mode.
-    }
     void CladPlugin::SetRequestOptions(RequestOptions& opts) const {
-      SetTBRAnalysisOptions(m_DO, opts);
-      SetActivityAnalysisOptions(m_DO, opts);
-      SetUsefulAnalysisOptions(m_DO, opts);
+      // A switch on the command line decides; otherwise the analysis runs at
+      // the default Analyses.def gives it.
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                     \
+      opts.Enable##Id##Analysis =                                              \
+          (m_DO.Enable##Id##Analysis || m_DO.Disable##Id##Analysis)            \
+              ? (m_DO.Enable##Id##Analysis && !m_DO.Disable##Id##Analysis)     \
+              : (Default);
+#include "clad/Differentiator/Analyses.def"
       opts.EmitPortingHints = m_DO.EmitPortingHints;
     }
 

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -49,26 +49,43 @@ namespace clad {
 bool checkClangVersion();
 namespace plugin {
 struct DifferentiationOptions {
-  // Plain bool, not `: 1` bit-fields: with 13 single-bit bools packed
-  // into shared bytes, the compiler emits each ctor-init-list write as
-  // a read-modify-write of the storage byte. The first RMW reads the
-  // byte while it is still uninitialised, which MSan reports as a SEGV
-  // on uninitialised memory under -fsanitize=memory.
+  // Plain bool, not `: 1` bit-fields: packing single-bit bools into shared
+  // bytes makes the compiler emit each ctor-init-list write as a
+  // read-modify-write of the storage byte. The first RMW reads the byte while
+  // it is still uninitialised, which MSan reports as a SEGV on uninitialised
+  // memory under -fsanitize=memory.
   bool DumpSourceFn = false;
   bool DumpSourceFnAST = false;
   bool DumpDerivedFn = false;
   bool DumpDerivedAST = false;
   bool GenerateSourceFile = false;
   bool ValidateClangVersion = true;
-  bool EnableTBRAnalysis = false;
-  bool DisableTBRAnalysis = false;
-  bool EnableVariedAnalysis = false;
-  bool DisableVariedAnalysis = false;
-  bool EnableUsefulAnalysis = false;
-  bool DisableUsefulAnalysis = false;
+  /// What the command line asked of each analysis. Neither bit set means the
+  /// analysis is left at its default; see Analyses.def.
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
+  bool Enable##Id##Analysis = false;                                           \
+  bool Disable##Id##Analysis = false;
+#include "clad/Differentiator/Analyses.def"
   bool PrintNumDiffErrorInfo = false;
   bool EmitPortingHints = false;
 };
+
+/// Match one of the per-analysis switches, -enable-<x> or -disable-<x>, and
+/// record what it asked for. Returns false if \p Arg is not such a switch.
+inline bool setAnalysisFromFlag(DifferentiationOptions& DO,
+                                llvm::StringRef Arg) {
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
+  if (Arg == "-enable-" Legacy) {                                              \
+    DO.Enable##Id##Analysis = true;                                            \
+    return true;                                                               \
+  }                                                                            \
+  if (Arg == "-disable-" Legacy) {                                             \
+    DO.Disable##Id##Analysis = true;                                           \
+    return true;                                                               \
+  }
+#include "clad/Differentiator/Analyses.def"
+  return false;
+}
 
     class CladExternalSource : public clang::ExternalSemaSource {
     // ExternalSemaSource
@@ -324,18 +341,8 @@ struct DifferentiationOptions {
             m_DO.GenerateSourceFile = true;
           } else if (args[i] == "-fno-validate-clang-version") {
             m_DO.ValidateClangVersion = false;
-          } else if (args[i] == "-enable-tbr") {
-            m_DO.EnableTBRAnalysis = true;
-          } else if (args[i] == "-disable-tbr") {
-            m_DO.DisableTBRAnalysis = true;
-          } else if (args[i] == "-enable-va") {
-            m_DO.EnableVariedAnalysis = true;
-          } else if (args[i] == "-disable-va") {
-            m_DO.DisableVariedAnalysis = true;
-          } else if (args[i] == "-enable-ua") {
-            m_DO.EnableUsefulAnalysis = true;
-          } else if (args[i] == "-disable-ua") {
-            m_DO.DisableUsefulAnalysis = true;
+          } else if (setAnalysisFromFlag(m_DO, args[i])) {
+            // -enable-tbr, -disable-va, and the rest of Analyses.def.
           } else if (args[i] == "-fcustom-estimation-model") {
             llvm::errs() << "`-fcustom-estimation-model` is deprecated.";
             ++i;
@@ -361,12 +368,6 @@ struct DifferentiationOptions {
                    "derivatives.\n"
                 << "-fno-validate-clang-version - Disables the validation of "
                    "the clang version.\n"
-                << "-enable-tbr - Ensures that TBR analysis is enabled during "
-                   "reverse-mode differentiation unless explicitly specified "
-                   "in an individual request.\n"
-                << "-disable-tbr - Ensures that TBR analysis is disabled "
-                   "during reverse-mode differentiation unless explicitly "
-                   "specified in an individual request.\n"
                 << "-fcustom-estimation-model - allows user to send in a "
                    "shared object to use as the custom estimation model.\n"
                 << "-fprint-num-diff-errors - allows users to print the "
@@ -378,6 +379,19 @@ struct DifferentiationOptions {
                    "remark naming the expected custom-derivative signature and "
                    "the non-differentiable marker. Useful when teaching clad "
                    "about a new library.\n";
+
+            llvm::errs() << "Each analysis below is optional: it changes the "
+                            "code clad generates, never the values that code "
+                            "computes. Enabling one asks clad to prove more "
+                            "and store less; disabling one falls back to the "
+                            "conservative derivative.\n";
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                     \
+      llvm::errs()                                                             \
+          << "-enable-" Legacy " / -disable-" Legacy " - Turns the " Name      \
+             " analysis on or off for the whole translation unit, unless an "  \
+             "individual request specifies otherwise. It " Desc ". Default: "  \
+          << ((Default) ? "on" : "off") << ".\n";
+#include "clad/Differentiator/Analyses.def"
 
             llvm::errs() << "-help - Prints out this screen.\n\n";
           } else if (args[i] == "-version" || args[i] == "-v") {
@@ -392,21 +406,13 @@ struct DifferentiationOptions {
           if (!checkClangVersion())
             return false;
         }
-        if (m_DO.EnableTBRAnalysis && m_DO.DisableTBRAnalysis) {
-          llvm::errs() << "clad: Error: -enable-tbr and -disable-tbr cannot "
-                          "be used together.\n";
-          return false;
-        }
-        if (m_DO.EnableVariedAnalysis && m_DO.DisableVariedAnalysis) {
-          llvm::errs() << "clad: Error: -enable-va and -disable-va cannot "
-                          "be used together.\n";
-          return false;
-        }
-        if (m_DO.EnableUsefulAnalysis && m_DO.DisableUsefulAnalysis) {
-          llvm::errs() << "clad: Error: -enable-ua and -disable-ua cannot "
-                          "be used together.\n";
-          return false;
-        }
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                     \
+      if (m_DO.Enable##Id##Analysis && m_DO.Disable##Id##Analysis) {           \
+        llvm::errs() << "clad: Error: -enable-" Legacy " and -disable-" Legacy \
+                        " cannot be used together.\n";                         \
+        return false;                                                          \
+      }
+#include "clad/Differentiator/Analyses.def"
         return true;
       }
 


### PR DESCRIPTION
Every analysis clad grew brought a copy of the same plumbing: a pair of bools on DifferentiationOptions, a pair of branches in ParseArgs, a mutual-exclusion check, a Set<X>AnalysisOptions that differs from its neighbours only in which member it writes, a field on RequestOptions, and a line at each site that hands a derived request its decisions. Adding an analysis means finding all of them, and the copies have already drifted: only TBR is mentioned in -help, and three of the six derived-request sites forget the useful analysis.

Describe the analyses once, in Analyses.def, and generate the plumbing from it. The table carries what actually differs between them -- how a user names one, its legacy switch pair, its default, a line of help text -- while what an analysis *is* stays in its own Analyzer. A derived request now inherits its decisions through one helper rather than through whichever fields each site remembered.

Forgetting the useful analysis is not observable today: a callee the planner reached already has the flag on its own request, and HandleNestedDiffRequest turns the varied and useful analyses off for dynamically scheduled requests regardless. The dumped derivatives of a forward-mode and a reverse-mode nested call are identical across this change with and without -enable-ua. The only user-visible difference is -help, which now lists every analysis with its default rather than TBR alone.