### PR TITLE
Let one switch turn off every analysis clad has.

### DIFF
--- a/test/Analyses/AnalysisSwitches.C
+++ b/test/Analyses/AnalysisSwitches.C
@@ -1,0 +1,66 @@
+// The switches that select an analysis, and the value they must not change.
+//
+// With the analyses off, clad stores t before each assignment that overwrites
+// it: nothing has proven the overwritten value is never read again.
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fdisable-analysis=all %s \
+// RUN:   -I%S/../../include -oAnalysisSwitches.out 2>&1 \
+// RUN:   | %filecheck --check-prefix=CHECK-OFF %s
+// RUN: ./AnalysisSwitches.out | %filecheck_exec %s
+//
+// Naming the one analysis that changes this function does the same.
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fdisable-analysis=tbr %s \
+// RUN:   -I%S/../../include -oAnalysisSwitches.out 2>&1 \
+// RUN:   | %filecheck --check-prefix=CHECK-OFF %s
+// RUN: ./AnalysisSwitches.out | %filecheck_exec %s
+//
+// With to-be-recorded on, one store and its restore are gone.
+// RUN: %cladclang %s -I%S/../../include -oAnalysisSwitches.out 2>&1 \
+// RUN:   | %filecheck --check-prefix=CHECK-TBR %s
+// RUN: ./AnalysisSwitches.out | %filecheck_exec %s
+//
+// The last switch decides, in either order.
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fdisable-analysis=all \
+// RUN:   -Xclang -plugin-arg-clad -Xclang -fenable-analysis=tbr %s \
+// RUN:   -I%S/../../include -oAnalysisSwitches.out 2>&1 \
+// RUN:   | %filecheck --check-prefix=CHECK-TBR %s
+// RUN: ./AnalysisSwitches.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fenable-analysis=tbr \
+// RUN:   -Xclang -plugin-arg-clad -Xclang -fdisable-analysis=all %s \
+// RUN:   -I%S/../../include -oAnalysisSwitches.out 2>&1 \
+// RUN:   | %filecheck --check-prefix=CHECK-OFF %s
+// RUN: ./AnalysisSwitches.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+double f(double x) {
+  double t = x * x;
+  t = t * t;
+  t = x + 1;
+  return t * x;
+}
+
+// The first assignment's store survives either way -- `t = t * t` reads the
+// value it overwrites. The second's does not: `t = x + 1` discards t, and the
+// reverse sweep needs no value from before it.
+
+// CHECK-OFF: void f_grad(double x, double *_d_x) {
+// CHECK-OFF: double _t0 = t;
+// CHECK-OFF: t = t * t;
+// CHECK-OFF: double _t1 = t;
+// CHECK-OFF: t = x + 1;
+// CHECK-OFF: t = _t1;
+
+// CHECK-TBR: void f_grad(double x, double *_d_x) {
+// CHECK-TBR: double _t0 = t;
+// CHECK-TBR: t = t * t;
+// CHECK-TBR-NOT: double _t1 = t;
+// CHECK-TBR-NOT: t = _t1;
+
+int main() {
+  auto g = clad::gradient(f);
+  double d = 0;
+  g.execute(3, &d);
+  printf("%.2f\n", d); // CHECK-EXEC: 7.00
+}

--- a/test/Misc/Args.C
+++ b/test/Misc/Args.C
@@ -10,7 +10,8 @@
 // CHECK_HELP-NEXT: -fprint-num-diff-errors
 // CHECK_HELP-NEXT: -fclad-porting-hints
 // Every analysis clad knows about is listed, with the default it runs at.
-// CHECK_HELP: -enable-tbr / -disable-tbr {{.*}} Default: on.
+// CHECK_HELP: -fenable-analysis=<name> / -fdisable-analysis=<name>
+// CHECK_HELP-NEXT: -enable-tbr / -disable-tbr {{.*}} Default: on.
 // CHECK_HELP-NEXT: -enable-va / -disable-va {{.*}} Default: off.
 // CHECK_HELP-NEXT: -enable-ua / -disable-ua {{.*}} Default: off.
 // CHECK_HELP-NEXT: -help
@@ -45,3 +46,14 @@
 // RUN: clang -fsyntax-only -fplugin=%cladlib -Xclang -plugin-arg-clad -Xclang -enable-ua \
 // RUN:  -Xclang -plugin-arg-clad -Xclang -disable-ua %s 2>&1 | FileCheck --check-prefix=CHECK_UA %s
 // CHECK_UA: -enable-ua and -disable-ua cannot be used together
+
+// An analysis has to be one clad has; the message names the ones it does.
+// RUN: clang -fsyntax-only -fplugin=%cladlib -Xclang -plugin-arg-clad \
+// RUN:  -Xclang -fdisable-analysis=nosuch %s 2>&1 | FileCheck --check-prefix=CHECK_NO_SUCH %s
+// CHECK_NO_SUCH: unknown analysis 'nosuch'; known: tbr activity useful
+
+// 'all' asks for the conservative derivative, so it only makes sense as
+// something to turn off.
+// RUN: clang -fsyntax-only -fplugin=%cladlib -Xclang -plugin-arg-clad \
+// RUN:  -Xclang -fenable-analysis=all %s 2>&1 | FileCheck --check-prefix=CHECK_ENABLE_ALL %s
+// CHECK_ENABLE_ALL: unknown analysis 'all'

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -566,13 +566,13 @@ void InitTimers();
     }
 
     void CladPlugin::SetRequestOptions(RequestOptions& opts) const {
-      // A switch on the command line decides; otherwise the analysis runs at
+      // The last switch that named the analysis decides; otherwise it runs at
       // the default Analyses.def gives it.
 #define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                     \
       opts.Enable##Id##Analysis =                                              \
-          (m_DO.Enable##Id##Analysis || m_DO.Disable##Id##Analysis)            \
-              ? (m_DO.Enable##Id##Analysis && !m_DO.Disable##Id##Analysis)     \
-              : (Default);
+          (m_DO.Id##Switch == AnalysisSwitch::Unset)                           \
+              ? (Default)                                                      \
+              : (m_DO.Id##Switch == AnalysisSwitch::On);
 #include "clad/Differentiator/Analyses.def"
       opts.EmitPortingHints = m_DO.EmitPortingHints;
     }

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -29,6 +29,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <cassert>
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <set>
@@ -48,6 +49,12 @@ namespace clad {
 
 bool checkClangVersion();
 namespace plugin {
+/// What the command line last said about one analysis. Unset means no switch
+/// named it, so it runs at the default Analyses.def gives it. Not spelled
+/// 'Default', which is a CLAD_ANALYSIS parameter and would be substituted
+/// inside the macro bodies naming this enum.
+enum class AnalysisSwitch : std::uint8_t { Unset, On, Off };
+
 struct DifferentiationOptions {
   // Plain bool, not `: 1` bit-fields: packing single-bit bools into shared
   // bytes makes the compiler emit each ctor-init-list write as a
@@ -60,9 +67,11 @@ struct DifferentiationOptions {
   bool DumpDerivedAST = false;
   bool GenerateSourceFile = false;
   bool ValidateClangVersion = true;
-  /// What the command line asked of each analysis. Neither bit set means the
-  /// analysis is left at its default; see Analyses.def.
+  /// What the command line asked of each analysis. The two bools record which
+  /// of the original -enable-<x>/-disable-<x> pair were seen, so that giving
+  /// both is still diagnosed rather than resolved by order. See Analyses.def.
 #define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
+  AnalysisSwitch Id##Switch = AnalysisSwitch::Unset;                           \
   bool Enable##Id##Analysis = false;                                           \
   bool Disable##Id##Analysis = false;
 #include "clad/Differentiator/Analyses.def"
@@ -70,21 +79,63 @@ struct DifferentiationOptions {
   bool EmitPortingHints = false;
 };
 
-/// Match one of the per-analysis switches, -enable-<x> or -disable-<x>, and
-/// record what it asked for. Returns false if \p Arg is not such a switch.
+/// Match one of the original per-analysis switches, -enable-<x> or
+/// -disable-<x>. Returns false if \p Arg is not such a switch.
 inline bool setAnalysisFromFlag(DifferentiationOptions& DO,
                                 llvm::StringRef Arg) {
 #define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
   if (Arg == "-enable-" Legacy) {                                              \
     DO.Enable##Id##Analysis = true;                                            \
+    DO.Id##Switch = AnalysisSwitch::On;                                        \
     return true;                                                               \
   }                                                                            \
   if (Arg == "-disable-" Legacy) {                                             \
     DO.Disable##Id##Analysis = true;                                           \
+    DO.Id##Switch = AnalysisSwitch::Off;                                       \
     return true;                                                               \
   }
 #include "clad/Differentiator/Analyses.def"
   return false;
+}
+
+enum class AnalysisFlagResult : std::uint8_t { NotMine, Ok, Error };
+
+/// Match -fenable-analysis=<name> or -fdisable-analysis=<name>. The last such
+/// switch on the command line decides, so a build that turns everything off by
+/// default can be overridden one analysis at a time.
+inline AnalysisFlagResult setAnalysisByName(DifferentiationOptions& DO,
+                                            llvm::StringRef Arg) {
+  AnalysisSwitch To = AnalysisSwitch::On;
+  if (!Arg.consume_front("-fenable-analysis=")) {
+    if (!Arg.consume_front("-fdisable-analysis="))
+      return AnalysisFlagResult::NotMine;
+    To = AnalysisSwitch::Off;
+  }
+
+  // 'all' asks for the conservative derivative rather than for a particular
+  // list, so it covers analyses added after the command line was written.
+  // Only disabling has that meaning: falling back is safe for every analysis
+  // by construction, while whether one is sound to run is what its default
+  // encodes, so there is no configuration 'enable all' would name.
+  if (Arg == "all" && To == AnalysisSwitch::Off) {
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
+  DO.Id##Switch = AnalysisSwitch::Off;
+#include "clad/Differentiator/Analyses.def"
+    return AnalysisFlagResult::Ok;
+  }
+
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
+  if (Arg == Name) {                                                           \
+    DO.Id##Switch = To;                                                        \
+    return AnalysisFlagResult::Ok;                                             \
+  }
+#include "clad/Differentiator/Analyses.def"
+
+  llvm::errs() << "clad: Error: unknown analysis '" << Arg << "'; known:";
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc) llvm::errs() << " " Name;
+#include "clad/Differentiator/Analyses.def"
+  llvm::errs() << "; -fdisable-analysis also takes 'all'.\n";
+  return AnalysisFlagResult::Error;
 }
 
     class CladExternalSource : public clang::ExternalSemaSource {
@@ -343,6 +394,10 @@ inline bool setAnalysisFromFlag(DifferentiationOptions& DO,
             m_DO.ValidateClangVersion = false;
           } else if (setAnalysisFromFlag(m_DO, args[i])) {
             // -enable-tbr, -disable-va, and the rest of Analyses.def.
+          } else if (AnalysisFlagResult R = setAnalysisByName(m_DO, args[i]);
+                     R != AnalysisFlagResult::NotMine) {
+            if (R == AnalysisFlagResult::Error)
+              return false;
           } else if (args[i] == "-fcustom-estimation-model") {
             llvm::errs() << "`-fcustom-estimation-model` is deprecated.";
             ++i;
@@ -380,11 +435,16 @@ inline bool setAnalysisFromFlag(DifferentiationOptions& DO,
                    "the non-differentiable marker. Useful when teaching clad "
                    "about a new library.\n";
 
-            llvm::errs() << "Each analysis below is optional: it changes the "
-                            "code clad generates, never the values that code "
-                            "computes. Enabling one asks clad to prove more "
-                            "and store less; disabling one falls back to the "
-                            "conservative derivative.\n";
+            llvm::errs()
+                << "Each analysis below is optional: it changes the code clad "
+                   "generates, never the values that code computes. Enabling "
+                   "one asks clad to prove more and store less; disabling one "
+                   "falls back to the conservative derivative.\n"
+                << "-fenable-analysis=<name> / -fdisable-analysis=<name> - "
+                   "Turns one analysis on or off; the last such option on the "
+                   "command line decides. -fdisable-analysis=all turns off "
+                   "every analysis clad has, asking for the most conservative "
+                   "derivative it can produce.\n";
 #define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                     \
       llvm::errs()                                                             \
           << "-enable-" Legacy " / -disable-" Legacy " - Turns the " Name      \


### PR DESCRIPTION
Asking clad for the conservative derivative means naming each analysis that exists, and every analysis added later silently escapes a command line written before it. That is backwards for the one configuration every analysis is meant to be safe to fall back to, and it is the configuration a wrong-gradient report wants first: does it survive with nothing proven?

Add -fenable-analysis=<name> and -fdisable-analysis=<name>, taking any name in Analyses.def, plus 'all' to disable every one including those added afterwards. The last such switch decides rather than a conflict being an error, so a build that disables everything by default can hand one analysis back for a single translation unit. Only disabling takes 'all': falling back is safe for every analysis by construction, while whether one is sound to run is what its default encodes, so there is no configuration 'enable all' would name.

The original -enable-tbr/-disable-tbr pairs keep working and keep diagnosing the two given together, which is why the seen-flags bools stay alongside the new tri-state.