### PR TITLE
Let one switch turn off every analysis clad has.

### DIFF
--- a/test/Analyses/TBRLoopTapes.C
+++ b/test/Analyses/TBRLoopTapes.C
@@ -1,0 +1,67 @@
+// What to-be-recorded analysis changes about a loop: the tape a loop body
+// would otherwise fill with one value per iteration.
+//
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fdisable-analysis=all %s \
+// RUN:   -I%S/../../include -oTBRLoopTapes.out 2>&1 \
+// RUN:   | %filecheck --check-prefix=CHECK-OFF %s
+// RUN: ./TBRLoopTapes.out | %filecheck_exec %s
+//
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fenable-analysis=tbr %s \
+// RUN:   -I%S/../../include -oTBRLoopTapes.out 2>&1 \
+// RUN:   | %filecheck --check-prefix=CHECK-TBR %s
+// RUN: ./TBRLoopTapes.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+// The pullback of `+` reads neither operand, so no iteration's y is wanted in
+// reverse and the tape holding them goes away. The loop counter that drives
+// the reverse sweep is not the tape's business and stays either way.
+double sum(double x) {
+  double y = 0;
+  for (int i = 0; i < 3; ++i)
+    y = y + x * i;
+  return y;
+}
+
+// CHECK-OFF-LABEL: void sum_grad(double x, double *_d_x) {
+// CHECK-OFF: clad::tape<double> _t1 = {};
+// CHECK-OFF: _t0++;
+// CHECK-OFF: clad::push(_t1, y);
+// CHECK-OFF: y = clad::pop(_t1);
+
+// CHECK-TBR-LABEL: void sum_grad(double x, double *_d_x) {
+// CHECK-TBR: _t0++;
+// CHECK-TBR-NOT: clad::tape<double>
+// CHECK-TBR-NOT: clad::push
+// CHECK-TBR-NOT: clad::pop
+
+// The pullback of `*` reads both operands, so every iteration's y is wanted
+// and the tape stays. Without this, an analysis that dropped every tape would
+// still pass the case above.
+double product(double x) {
+  double y = 1;
+  for (int i = 0; i < 3; ++i)
+    y = y * x;
+  return y;
+}
+
+// CHECK-OFF-LABEL: void product_grad(double x, double *_d_x) {
+// CHECK-OFF: clad::tape<double> _t1 = {};
+// CHECK-OFF: clad::push(_t1, y);
+
+// CHECK-TBR-LABEL: void product_grad(double x, double *_d_x) {
+// CHECK-TBR: clad::tape<double> _t1 = {};
+// CHECK-TBR: clad::push(_t1, y);
+
+int main() {
+  auto s = clad::gradient(sum);
+  auto p = clad::gradient(product);
+  double d = 0;
+  s.execute(3, &d);
+  printf("%.2f\n", d); // CHECK-EXEC: 3.00
+  d = 0;
+  p.execute(3, &d);
+  printf("%.2f\n", d); // CHECK-EXEC: 27.00
+}

--- a/test/Analyses/TBRScalarStores.C
+++ b/test/Analyses/TBRScalarStores.C
@@ -1,0 +1,50 @@
+// What to-be-recorded analysis changes about a plain assignment: the copy
+// clad would otherwise take of the value the assignment is about to destroy.
+//
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fdisable-analysis=all %s \
+// RUN:   -I%S/../../include -oTBRScalarStores.out 2>&1 \
+// RUN:   | %filecheck --check-prefix=CHECK-OFF %s
+// RUN: ./TBRScalarStores.out | %filecheck_exec %s
+//
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fenable-analysis=tbr %s \
+// RUN:   -I%S/../../include -oTBRScalarStores.out 2>&1 \
+// RUN:   | %filecheck --check-prefix=CHECK-TBR %s
+// RUN: ./TBRScalarStores.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+// Two assignments overwrite t. The first is squaring, whose pullback reads the
+// value being overwritten, so that copy has to be taken either way. The second
+// discards t outright, and nothing in the reverse sweep asks what it held, so
+// only that copy and its restore go away. Keeping both cases in one function
+// is the point: it shows the analysis deciding, not deleting.
+double f(double x) {
+  double t = x * x;
+  t = t * t;
+  t = x + 1;
+  return t * x;
+}
+
+// CHECK-OFF-LABEL: void f_grad(double x, double *_d_x) {
+// CHECK-OFF: double _t0 = t;
+// CHECK-OFF: t = t * t;
+// CHECK-OFF: double _t1 = t;
+// CHECK-OFF: t = x + 1;
+// CHECK-OFF: t = _t1;
+// CHECK-OFF: t = _t0;
+
+// CHECK-TBR-LABEL: void f_grad(double x, double *_d_x) {
+// CHECK-TBR: double _t0 = t;
+// CHECK-TBR: t = t * t;
+// CHECK-TBR-NOT: double _t1 = t;
+// CHECK-TBR-NOT: t = _t1;
+// CHECK-TBR: t = _t0;
+
+int main() {
+  auto g = clad::gradient(f);
+  double d = 0;
+  g.execute(3, &d);
+  printf("%.2f\n", d); // CHECK-EXEC: 7.00
+}


### PR DESCRIPTION
Asking clad for the conservative derivative means naming each analysis that exists, and every analysis added later silently escapes a command line written before it. That is backwards for the one configuration every analysis is meant to be safe to fall back to, and it is the configuration a wrong-gradient report wants first: does it survive with nothing proven?

Add -fenable-analysis=<name> and -fdisable-analysis=<name>, taking any name in Analyses.def, plus 'all' to disable every one including those added afterwards. The last such switch decides rather than a conflict being an error, so a build that disables everything by default can hand one analysis back for a single translation unit. Only disabling takes 'all': falling back is safe for every analysis by construction, while whether one is sound to run is what its default encodes, so there is no configuration 'enable all' would name.

The original -enable-tbr/-disable-tbr pairs keep working and keep diagnosing the two given together, which is why the seen-flags bools stay alongside the new tri-state.