### PR TITLE
Stop asking clad's macros to be constexpr functions. NFC

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,6 +19,7 @@ Checks: >
   -misc-non-private-member-variables-in-classes,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -misc-no-recursion,
+  -cppcoreguidelines-macro-usage,
   -misc-use-anonymous-namespace,
   -modernize-return-braced-init-list,
   -modernize-use-trailing-return-type,

--- a/include/clad/Differentiator/Array.h
+++ b/include/clad/Differentiator/Array.h
@@ -22,14 +22,12 @@ template <typename T> class array_ref;
 // only in the operator token, passed to these generators as `op`: one of `+=`,
 // `-=`, `*=`, `/=`, or `=` where plain assignment has the same shape.
 //
-// Three checks fire on the generators below and cannot be followed here:
-// cppcoreguidelines-macro-usage, because `op` is an operator token and each
-// expansion declares a different operator overload; bugprone-macro-parentheses,
-// because neither an operator token nor a function definition can be wrapped in
-// parentheses; and modernize-type-traits, because `std::is_arithmetic_v` is
-// C++17 while these headers are also included from C++14 code.
-// NOLINTBEGIN(cppcoreguidelines-macro-usage, bugprone-macro-parentheses,
-// modernize-type-traits)
+// Two checks fire on the generators below and cannot be followed here:
+// bugprone-macro-parentheses, because neither an operator token nor a function
+// definition can be wrapped in parentheses; and modernize-type-traits, because
+// `std::is_arithmetic_v` is C++17 while these headers are also included from
+// C++14 code.
+// NOLINTBEGIN(bugprone-macro-parentheses, modernize-type-traits)
 
 /// Applies `op` between every element and a scalar.
 #define CLAD_ARRAY_OP_SCALAR(op)                                               \
@@ -79,8 +77,7 @@ template <typename T> class array_ref;
       m_arr[i] op arr_exp[i];                                                  \
     return *this;                                                              \
   }
-// NOLINTEND(cppcoreguidelines-macro-usage, bugprone-macro-parentheses,
-// modernize-type-traits)
+// NOLINTEND(bugprone-macro-parentheses, modernize-type-traits)
 
 /// This class is not meant to be used by user. It is used by clad internally
 /// only

--- a/include/clad/Differentiator/ArrayRef.h
+++ b/include/clad/Differentiator/ArrayRef.h
@@ -14,10 +14,9 @@ namespace clad {
 // as `op`: one of `+=`, `-=`, `*=`, `/=`, or `=` where plain assignment has the
 // same shape.
 //
-// The generators below suppress the same three checks as the ones in Array.h;
-// see the comment there for why none of them can be followed.
-// NOLINTBEGIN(cppcoreguidelines-macro-usage, bugprone-macro-parentheses,
-// modernize-type-traits)
+// The generators below suppress the same two checks as the ones in Array.h;
+// see the comment there for why neither can be followed.
+// NOLINTBEGIN(bugprone-macro-parentheses, modernize-type-traits)
 
 /// Applies `op` between every element and a scalar.
 #define CLAD_ARRAY_REF_OP_SCALAR(op)                                           \
@@ -60,8 +59,7 @@ namespace clad {
       m_arr[i] op arr_exp[i];                                                  \
     return *this;                                                              \
   }
-// NOLINTEND(cppcoreguidelines-macro-usage, bugprone-macro-parentheses,
-// modernize-type-traits)
+// NOLINTEND(bugprone-macro-parentheses, modernize-type-traits)
 
 /// Stores the pointer to and the size of an array and provides some helper
 /// functions for it. The array is supplied should have a life greater than

--- a/include/clad/Differentiator/Sins.h
+++ b/include/clad/Differentiator/Sins.h
@@ -5,7 +5,6 @@
 
 /// Standard-protected facility allowing access into private members in C++.
 /// Use with caution!
-// NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define CONCATE_(X, Y) X##Y
 #define CONCATE(X, Y) CONCATE_(X, Y)
 #define ALLOW_ACCESS(CLASS, MEMBER, ...)                                       \
@@ -23,7 +22,5 @@
 #define ACCESS(OBJECT, MEMBER)                                                 \
   (OBJECT).*Access((Only_##MEMBER<                                             \
                     std::remove_reference<decltype(OBJECT)>::type>*)nullptr)
-
-// NOLINTEND(cppcoreguidelines-macro-usage)
 
 #endif // CLAD_DIFFERENTIATOR_SINS_H


### PR DESCRIPTION
cppcoreguidelines-macro-usage wants a function-like macro replaced by a constexpr template. Three headers already carry a NOLINT for it, because the macros it fires on cannot be functions: Array.h and ArrayRef.h generate one operator overload per operator token, and Sins.h names a member pointer to reach a private member. The registry that lists clad's analyses is a fourth, and the next .def table will be a fifth -- there is no version of an X-macro that satisfies this check.

Turn it off where the rest of the checks clad does not follow are turned off, and drop the suppressions it forced. The two checks Array.h and ArrayRef.h suppress for their own reasons stay, along with the comment explaining them.