### PR TITLE
[ci] Stop running actions on the deprecated Node 20 runtime.

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: "Setup latest Alpine Linux"
         uses: jirutka/setup-alpine@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,11 +141,11 @@ jobs:
             clang-runtime: '18'
 
     steps: &build_steps
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.11
     - name: Save PR Info
@@ -154,13 +154,12 @@ jobs:
         mkdir -p ./pr
         echo ${{ github.event.number }} > ./pr/NR
         echo ${{ github.repository }} > ./pr/REPO
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: ${{ matrix.coverage == true }}
       with:
         name: pr
         path: pr/
         overwrite: true
-    - uses: nelonoel/branch-name@v1.0.1
     - name: Setup default Build Type on *nux
       if: ${{ (matrix.debug_build != true) && (runner.os != 'windows') }}
       run: |
@@ -414,7 +413,7 @@ jobs:
         rebuild-command: cmake --build obj -- -j${{ env.ncpus }}
     - name: Upload the baseline verdict
       if: ${{ runner.os != 'windows' && env.observes_check == '1' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: observes-change-${{ matrix.name }}
         path: observes/
@@ -619,7 +618,7 @@ jobs:
       issues: write
     steps:
     - name: File the failure against the commit that caused it
-      uses: actions/github-script@v7.0.1
+      uses: actions/github-script@v9
       with:
         script: |
           const repo = { owner: context.repo.owner, repo: context.repo.repo };
@@ -671,8 +670,8 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/download-artifact@v4
+    - uses: actions/checkout@v7
+    - uses: actions/download-artifact@v8
       with:
         pattern: observes-change-*
         path: verdicts
@@ -688,7 +687,7 @@ jobs:
     # merging, which is a claim about defects caught rather than lines run.
     - name: Upload the summary record
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: observes-change-summary
         path: observes-change-summary.json

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: 3.11
       - name: Install clang-format

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2

--- a/.github/workflows/godbolt.yml
+++ b/.github/workflows/godbolt.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@v5
 
       - name: Clone Builder Repo
         run: |

--- a/.github/workflows/postci.yml
+++ b/.github/workflows/postci.yml
@@ -11,7 +11,7 @@ jobs:
       ${{ github.event.workflow_run.event == 'pull_request'}}
     steps:
     - name: 'Download artifact'
-      uses: actions/github-script@v7.0.1
+      uses: actions/github-script@v9
       with:
         script: |
           var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -37,7 +37,7 @@ jobs:
         echo "PR_NUMBER=`cat ./NR`" >> $GITHUB_ENV
         echo "PR_REPO=`cat ./REPO`" >> $GITHUB_ENV
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
GitHub is retiring the Node 20 action runtime and already forces every Node 20 action onto Node 24, so each job on a pull request carries a deprecation warning.  Today that is only noise, but once the forced fallback is removed the affected actions stop working outright.

Bump the pinned actions to their current majors.  The artifact actions are the surprise: upload-artifact stayed on Node 20 through v5 and download-artifact through v6, so taking only the next major would have left the warning in place.  Drop nelonoel/branch-name outright -- it is the oldest offender at Node 12 and nothing reads the BRANCH_NAME it exports.

install-llvm-action and setup-alpine, which pulls in webiny/action-post-run, have no Node 24 release yet, so the clang-tidy and Alpine rows keep warning until upstream tags one.