### PR TITLE
Parenthesise the analysis name in the switch matcher. NFC

### DIFF
--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -125,7 +125,7 @@ inline AnalysisFlagResult setAnalysisByName(DifferentiationOptions& DO,
   }
 
 #define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
-  if (Arg == Name) {                                                           \
+  if (Arg == (Name)) {                                                         \
     DO.Id##Switch = To;                                                        \
     return AnalysisFlagResult::Ok;                                             \
   }


### PR DESCRIPTION
bugprone-macro-parentheses flags the comparison: CLAD_ANALYSIS's Name is a macro argument used as an operand, so a caller passing an expression rather than a literal would have it parsed against the wrong precedence. Every caller today is a string literal in Analyses.def, which is why nothing has gone wrong.

The other uses of the argument in that file are string-literal concatenation -- "-enable-" Legacy -- where parentheses do not compile, which is why only this one is flagged.