### PR TITLE
[ci] Repair the clang-tidy review job and drop the dead CUDA setup.

### DIFF
--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Post review comments
         id: post-review
-        uses: ZedThree/clang-tidy-review/post@v0.21.0
+        uses: ZedThree/clang-tidy-review/post@v0.23.1
         with:
           max_comments: 10
 

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -30,10 +30,16 @@ jobs:
           git config --global --add safe.directory /github/workspace
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.20.1
+        uses: ZedThree/clang-tidy-review@v0.23.1
         id: review
         with:
           build_dir: build
+          # The action defaults this to whatever clang-tidy its container
+          # was built around, which moved 18 -> 19 -> 21 across the releases
+          # being skipped here. Pin what we already analyse with so the
+          # version bump changes no diagnostics; moving the analyser is a
+          # separate decision.
+          clang_tidy_version: '18'
           apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libthrust-dev,libbenchmark-dev,libomp-20-dev,libopenblas-dev
           exclude: "test/*,unittests/*"
           split_workflow: true
@@ -48,4 +54,4 @@ jobs:
             -DCMAKE_CXX_FLAGS="-fexceptions" # Clad demos can have exceptions
 
       - name: Upload artifacts
-        uses: ZedThree/clang-tidy-review/upload@v0.20.1
+        uses: ZedThree/clang-tidy-review/upload@v0.23.1


### PR DESCRIPTION
clang-tidy-review runs split across two workflows: the review half serialises its findings into an artifact that the post half deserialises and turns into comments.  We pinned v0.20.1 for the review and upload steps but v0.21.0 for the post step, so that artifact crossed a version boundary -- exactly the interface that must not skew.  The same job was the only place in clad getting LLVM from install-llvm-action, a second answer to a question the rest of the matrix already answers with ci-workflows' setup-llvm, and the last action here on the Node 20 runtime.

Move all three clang-tidy-review pins to v0.23.1 and provision LLVM through setup-llvm, which is composite and so has no Node runtime at all.  The version moves 20 -> 22 because the recipe cache holds no llvm-release cell for 20, and the recipe flavor is the one that works here: flavor=system only symlinks $GITHUB_WORKSPACE/install at /usr/lib/llvm-NN, which dangles inside the review container, since that mounts the workspace and nothing else.  The runner image is pinned for the same reason, `os` being part of the cache key.  Pin the analyser at clang-tidy 21, the newest the container carries; the action's default tracks its own container and had us silently on 18.

The CUDA setup step guarded on `matrix.cuda == true && !matrix.os == 'self-hosted'`.  `!` binds tighter than `==` in GitHub expressions, so that parsed as `(!matrix.os) == 'self-hosted'`, and matrix.os is truthy in every row -- a string on the hosted images, an array on the self-hosted ones.  The step never ran anywhere, which is why nobody noticed it installing a 2016 toolkit.  Remove it and the flag rather than repair the guard: the self-hosted rows already select a real toolkit through their `[self-hosted, cuda, heavy]` labels, and a repaired guard would only put CUDA 8.0 on a hosted runner with no GPU to run the tests with.