### PR TITLE
Add the missing include guard to BuiltinDerivativesCUDA.cuh. NFC

### DIFF
--- a/include/clad/Differentiator/BuiltinDerivativesCUDA.cuh
+++ b/include/clad/Differentiator/BuiltinDerivativesCUDA.cuh
@@ -1,3 +1,6 @@
+#ifndef CLAD_DIFFERENTIATOR_BUILTINDERIVATIVESCUDA_CUH
+#define CLAD_DIFFERENTIATOR_BUILTINDERIVATIVESCUDA_CUH
+
 #include "clad/Differentiator/CladConfig.h"
 
 namespace clad {
@@ -30,3 +33,5 @@ __device__ inline void make_float2_pullback(float a, float b, float2 d_y,
 }
 } // namespace custom_derivatives
 } // namespace clad
+
+#endif // CLAD_DIFFERENTIATOR_BUILTINDERIVATIVESCUDA_CUH


### PR DESCRIPTION
It is the only header under include/clad/Differentiator without one, so including it twice redefines everything it declares. Nothing does that today -- Differentiator.h is its only includer, and it is guarded itself -- which is why this has gone unnoticed.

Static analysis is what turned it up: analysing the header on its own means compiling it after the header that already pulls it in, and that second inclusion is exactly the case a guard exists for.