### PR TITLE
[docs] fix spelling errors in docs and code comments

### DIFF
--- a/docs/userDocs/source/user/UsingClad.rst
+++ b/docs/userDocs/source/user/UsingClad.rst
@@ -173,7 +173,7 @@ An example that demonstrates the usage of ``clad::hessian``::
 
   int main() {
     // Tells clad to generate a function that computes hessian matrix of the function 
-    // 'kinetic_energy' with respect to all the input paramters.
+    // 'kinetic_energy' with respect to all the input parameters.
     auto hessian_one = clad::hessian(kinetic_energy);
 
     // Can manually specify independent arguments
@@ -209,7 +209,7 @@ Few important things to note about ``clad::hessian``:
     // 'product' function with respect to the input parameters 'i' and 'j'.
     auto d_fn = clad::hessian(product, "i, j");
 
-- ``clad::hessian`` also supports differentiating w.r.t multiple paramters.
+- ``clad::hessian`` also supports differentiating w.r.t multiple parameters.
 
 ::
   
@@ -290,7 +290,7 @@ Clad can compute the
 
  Few important things to note through this example:
 
- - ``clad::jacobian`` supports differentiating w.r.t multiple paramters.
+ - ``clad::jacobian`` supports differentiating w.r.t multiple parameters.
 
  - The clad::matrix args are generated for all array/pointer parameters. They need to be passed
    after the original parameters to ``CladFunction::execute`` call. The size of every matrix

--- a/docs/userDocs/source/user/reference.rst
+++ b/docs/userDocs/source/user/reference.rst
@@ -31,7 +31,7 @@ API reference
    For now it is enough to know that forward mode automatic differentiation (AD)
    is more efficient than the reverse mode automatic differentiation when the
    number of output parameters of the function are greater than the number of
-   input paramters of the function.
+   input parameters of the function.
 
    ::
 
@@ -64,7 +64,7 @@ API reference
 
    Please refer this to know more about the reverse mode automatic differentiation.
    For now it is enough to know that generally reverse mode AD is more efficient
-   than the forward mode AD when there are multiple input paramters.
+   than the forward mode AD when there are multiple input parameters.
 
    ::
 

--- a/lib/Differentiator/HessianModeVisitor.cpp
+++ b/lib/Differentiator/HessianModeVisitor.cpp
@@ -613,7 +613,8 @@ DerivativeAndOverload HessianModeVisitor::Derive() {
       auto size_type = clad_compat::getSizeType(m_Context);
       auto size_type_bits = m_Context.getIntWidth(size_type);
 
-      // Transforms ParmVarDecls into Expr paramters for insertion into function
+      // Transforms ParmVarDecls into Expr parameters for insertion into
+      // function
       std::vector<Expr*> DeclRefToParams;
       DeclRefToParams.resize(params.size());
       std::transform(params.begin(),


### PR DESCRIPTION
The patch changes instances of "paramters" to "parameters" at multiple instances in two documentation files as well as a comment in code.

NFC change only fixing spellings errors.