### PR TITLE
Let lit tell compiling CUDA apart from running it, and compile it in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
           - { name: ubu24-clang16-runtime17, os: ubuntu-24.04, compiler: clang-16, clang-runtime: '17' }
           - { name: ubu24-gcc14-runtime18, os: ubuntu-24.04, compiler: gcc-14, clang-runtime: '18' }
           - { name: ubu24-clang17-runtime19, os: ubuntu-24.04, compiler: clang-17, clang-runtime: '19' }
-          - { name: ubu24-clang19-runtime20, os: ubuntu-24.04, compiler: clang-19, clang-runtime: '20' }
-          - { name: ubu24-clang20-runtime21, os: ubuntu-24.04, compiler: clang-20, clang-runtime: '21' }
-          - { name: ubu24-clang20-runtime22, os: ubuntu-24.04, compiler: clang-20, clang-runtime: '22' }
+          - { name: ubu24-clang19-runtime20, os: ubuntu-24.04, compiler: clang-19, clang-runtime: '20', cuda: '12.6.3' }
+          - { name: ubu24-clang20-runtime21, os: ubuntu-24.04, compiler: clang-20, clang-runtime: '21', cuda: '12.8.1' }
+          - { name: ubu24-clang20-runtime22, os: ubuntu-24.04, compiler: clang-20, clang-runtime: '22', cuda: '13.0.3' }
           - { name: ubu24-clang22-runtime22-asan, os: ubuntu-24.04, compiler: clang-22, clang-runtime: '22', flavor: asan, extra_cmake_options: '-DLLVM_USE_SANITIZER=Address' }
           # --- MACOS: Last 5 Runtimes (17-21) ---
           # Using macOS ARM (standard) for all; Runtime 17 on Intel for x86 sanity
@@ -80,7 +80,6 @@ jobs:
             os: ubuntu-22.04
             compiler: clang-13
             clang-runtime: '13'
-            cuda: true
 
           - name: ubuntu-clang15-runtime16-doc
             os: ubuntu-latest
@@ -313,20 +312,16 @@ jobs:
         echo "Runtime LLVM/Clang: $env:PATH_TO_LLVM_BUILD"
         echo "PATH_TO_LLVM_BUILD=$env:PATH_TO_LLVM_BUILD"
         echo "PATH_TO_LLVM_BUILD=$env:PATH_TO_LLVM_BUILD" >> $env:GITHUB_ENV
-    - name: Setup CUDA 8 on Linux
-      if: ${{ matrix.cuda == true && !matrix.os == 'self-hosted'}}
-      run: |
-        wget --no-verbose https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda_8.0.61_375.26_linux-run
-        wget --no-verbose https://developer.nvidia.com/compute/cuda/8.0/Prod2/patches/2/cuda_8.0.61.2_linux-run
-        sh ./cuda_8.0.61_375.26_linux-run --tar mxvf
-        sudo cp InstallUtils.pm /usr/lib/x86_64-linux-gnu/perl-base
-        export $PERL5LIB
-        sudo sh cuda_8.0.61_375.26_linux-run --override --no-opengl-lib --silent --toolkit --kernel-source-path=/lib/modules/4.15.0-1113-azure/build
-        sudo sh cuda_8.0.61.2_linux-run --silent --accept-eula
-        export PATH=/usr/local/cuda-8.0/bin:${PATH}
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda-8.0/lib64
-        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PATH=$PATH" >> $GITHUB_ENV
+    # Headers only: enough to compile a .cu, which is all a runner with no
+    # GPU can do. The self-hosted rows bring their own toolkit and run the
+    # tests for real, so they are left alone.
+    - name: Setup CUDA headers
+      if: ${{ matrix.cuda && !contains(matrix.os, 'self-hosted') }}
+      uses: compiler-research/ci-workflows/actions/setup-cuda@main
+      with:
+        version: ${{ matrix.cuda }}
+        os: ${{ matrix.os }}
+        arch: x86_64
     - name: Setup code coverage
       if: ${{ (matrix.coverage == true) }}
       run: |

--- a/include/clad/Differentiator/Tape.h
+++ b/include/clad/Differentiator/Tape.h
@@ -898,7 +898,7 @@ private:
     getDiskInfo().m_ActiveVramSlabs = 0;
   }
 
-  void clear_impl(std::false_type) {
+  CUDA_HOST_DEVICE void clear_impl(std::false_type) {
     std::size_t count = m_size;
     for (std::size_t i = 0; i < SBO_SIZE && count > 0; ++i, --count)
       destroy_element(&sbo_elements()[i]);
@@ -915,7 +915,7 @@ private:
     }
   }
 
-  void clear() {
+  CUDA_HOST_DEVICE void clear() {
     clear_impl(std::integral_constant < bool, DiskOffload || GpuOffload > {});
     m_head = nullptr;
     m_tail = nullptr;

--- a/include/clad/Differentiator/ThrustDerivatives.h
+++ b/include/clad/Differentiator/ThrustDerivatives.h
@@ -20,6 +20,7 @@
 #include <thrust/sort.h>
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
+#include <thrust/version.h>
 #include <type_traits>
 
 namespace clad::custom_derivatives::thrust {
@@ -53,6 +54,16 @@ struct has_binary_operator_call_pullback<
         (::std::add_pointer_t<T>)(nullptr),    // d_x1
         (::std::add_pointer_t<T>)(nullptr)))>> // d_x2
     : ::std::true_type {};
+
+// CCCL 3.0, which ships with CUDA 13, removed the public thrust::identity
+// functor. No caller on such a release can name it, so the pullback branch
+// that recognises it is unreachable there and must not be compiled.
+template <typename Op, typename T> struct is_identity : ::std::false_type {};
+
+#if THRUST_VERSION < 300000
+template <typename T>
+struct is_identity<::thrust::identity<T>, T> : ::std::true_type {};
+#endif
 } // namespace detail
 
 template <typename Iterator, typename OutputIterator>
@@ -670,7 +681,7 @@ void transform_pullback(InputIt first, InputIt last, OutputIt result,
     auto iter = ::thrust::make_zip_iterator(
         ::thrust::make_tuple(d_src_dev_ptr, d_dst_dev_ptr));
     ::thrust::for_each(iter, iter + n, grad_functor());
-  } else if constexpr (::std::is_same_v<UnaryOp, ::thrust::identity<Value>>) {
+  } else if constexpr (detail::is_identity<UnaryOp, Value>::value) {
     struct grad_functor {
       CUDA_HOST_DEVICE void
       operator()(::thrust::tuple<Value&, Value&> t) const {

--- a/test/CUDA/ForwardMode.cu
+++ b/test/CUDA/ForwardMode.cu
@@ -2,9 +2,9 @@
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oForwardMode.out \
 // RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
 //
-// RUN: %cudarun ./ForwardMode.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./ForwardMode.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 //
 // expected-no-diagnostics
 

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -8,9 +8,9 @@
 // RUN: %cladclang_cuda -I%S/../../include --cuda-gpu-arch=%cudaarch \
 // RUN:      --cuda-path=%cudapath %cudaldflags -oGradientCuda.out %s
 //
-// RUN: %cudarun ./GradientCuda.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./GradientCuda.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 //
 // expected-no-diagnostics
 

--- a/test/CUDA/GradientKernels.cu
+++ b/test/CUDA/GradientKernels.cu
@@ -1,13 +1,20 @@
+// A CUDA compile runs the frontend once per side, and each run dumps every
+// derivative, so without --cuda-device-only the input below is two copies
+// of the same list and a check can match one copy while the check before it
+// matched the other. The order the two agree on is the order the gradients
+// are requested in main(), which is what the blocks below follow -- not the
+// order the kernels are declared in.
+//
 // RUN: %cladclang_cuda -Xclang -plugin-arg-clad -Xclang -disable-tbr -I%S/../../include -fsyntax-only \
-// RUN:     --cuda-gpu-arch=%cudaarch --cuda-path=%cudapath  -Xclang -verify \
-// RUN:     %s 2>&1 | %filecheck %s
+// RUN:     --cuda-gpu-arch=%cudaarch --cuda-path=%cudapath --cuda-device-only \
+// RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
 //
 // RUN: %cladclang_cuda -Xclang -plugin-arg-clad -Xclang -disable-tbr -I%S/../../include --cuda-path=%cudapath \
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oGradientKernels.out %s
 //
-// RUN: %cudarun ./GradientKernels.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./GradientKernels.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 
 #include "clad/Differentiator/Differentiator.h"
 
@@ -392,39 +399,6 @@ __global__ void kernel_with_nested_device_call(double *out, double *in, double v
   out[index] = device_with_device_call(in, val);
 }
 
-// CHECK: __attribute__((device)) inline void device_fn_4_pullback_0_1(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    int _d_index = 0;
-//CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
-//CHECK-NEXT:    {
-//CHECK-NEXT:        _d_in[index0] += _d_y;
-//CHECK-NEXT:        *_d_val += _d_y;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
-
-// CHECK: __attribute__((device)) inline void device_with_device_call_pullback_0(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
-//CHECK-NEXT:    {
-//CHECK-NEXT:        double _r0 = 0.;
-//CHECK-NEXT:        device_fn_4_pullback_0_1(in, val, _d_y, _d_in, &_r0);
-//CHECK-NEXT:        *_d_val += _r0;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
-
-// CHECK: void kernel_with_nested_device_call_grad_0_1(double *out, double *in, double val, double *_d_out, double *_d_in) {
-//CHECK-NEXT:    double _d_val = 0.;
-//CHECK-NEXT:    int _d_index = 0;
-//CHECK-NEXT:    int index0 = threadIdx.x;
-//CHECK-NEXT:    double _t0 = out[index0];
-//CHECK-NEXT:    out[index0] = device_with_device_call(in, val);
-//CHECK-NEXT:    {
-//CHECK-NEXT:       out[index0] = _t0;
-//CHECK-NEXT:       double _r_d0 = _d_out[index0];
-//CHECK-NEXT:        _d_out[index0] = 0.;
-//CHECK-NEXT:        double _r0 = 0.;
-//CHECK-NEXT:        device_with_device_call_pullback_0(in, val, _r_d0, _d_in, &_r0);
-//CHECK-NEXT:        _d_val += _r0;
-//CHECK-NEXT:    }
-//CHECK-NEXT:}
-
 __global__ void fn1(double *out, const double *in, double val) {
   int index = threadIdx.x + blockIdx.x * blockDim.x;
   double temp = val;
@@ -464,6 +438,39 @@ void fn(double *out, double *in) {
 //CHECK-NEXT:     kernel_call_pullback<<<1, 10>>>(out, in, _d_out, _d_in);
 //CHECK-NEXT: }
 
+// CHECK: __attribute__((device)) inline void device_fn_4_pullback_0_1(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int index0 = threadIdx.x + blockIdx.x * blockDim.x;
+//CHECK-NEXT:    {
+//CHECK-NEXT:        _d_in[index0] += _d_y;
+//CHECK-NEXT:        *_d_val += _d_y;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
+// CHECK: __attribute__((device)) inline void device_with_device_call_pullback_0(double *in, double val, double _d_y, double *_d_in, double *_d_val) {
+//CHECK-NEXT:    {
+//CHECK-NEXT:        double _r0 = 0.;
+//CHECK-NEXT:        device_fn_4_pullback_0_1(in, val, _d_y, _d_in, &_r0);
+//CHECK-NEXT:        *_d_val += _r0;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
+// CHECK: void kernel_with_nested_device_call_grad_0_1(double *out, double *in, double val, double *_d_out, double *_d_in) {
+//CHECK-NEXT:    double _d_val = 0.;
+//CHECK-NEXT:    int _d_index = 0;
+//CHECK-NEXT:    int index0 = threadIdx.x;
+//CHECK-NEXT:    double _t0 = out[index0];
+//CHECK-NEXT:    out[index0] = device_with_device_call(in, val);
+//CHECK-NEXT:    {
+//CHECK-NEXT:       out[index0] = _t0;
+//CHECK-NEXT:       double _r_d0 = _d_out[index0];
+//CHECK-NEXT:        _d_out[index0] = 0.;
+//CHECK-NEXT:        double _r0 = 0.;
+//CHECK-NEXT:        device_with_device_call_pullback_0(in, val, _r_d0, _d_in, &_r0);
+//CHECK-NEXT:        _d_val += _r0;
+//CHECK-NEXT:    }
+//CHECK-NEXT:}
+
 double fn_memory(double *out, double *in) {
   double *in_dev = nullptr;
   cudaMalloc(&in_dev, 10 * sizeof(double));
@@ -475,7 +482,7 @@ double fn_memory(double *out, double *in) {
   double res = 0;
   for (int i=0; i < 10; ++i) {
     printf("Writing result of out[%d]\n", i); // expected-warning {{attempted differentiation of function 'printf' without definition and no suitable overload was found in namespace 'custom_derivatives'}}
-                                    // expected-note@477 {{numerical differentiation is not viable for 'printf'; considering 'printf' as 0}}
+                                    // expected-note@-1 {{numerical differentiation is not viable for 'printf'; considering 'printf' as 0}}
     res += out_host[i];
   }
   free(out_host);
@@ -519,13 +526,13 @@ double fn_memory(double *out, double *in) {
 //CHECK-NEXT:        }
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        unsigned long _r2 = 0UL;
+//CHECK-NEXT:        {{(unsigned long|[_a-zA-Z]*size_t)}} _r2 = 0UL;
 //CHECK-NEXT:        cudaMemcpyKind _r3 = static_cast<cudaMemcpyKind>(0U);
 //CHECK-NEXT:        clad::custom_derivatives::cudaMemcpy_pullback(out_host, out, 10 * sizeof(double), cudaMemcpyDeviceToHost, static_cast<cudaError>(0U), _d_out_host, _d_out, &_r2, &_r3);
 //CHECK-NEXT:    }
 //CHECK-NEXT:    kernel_call_pullback<<<1, 10>>>(out, in_dev, _d_out, _d_in_dev);
 //CHECK-NEXT:    {
-//CHECK-NEXT:        unsigned long _r0 = 0UL;
+//CHECK-NEXT:        {{(unsigned long|[_a-zA-Z]*size_t)}} _r0 = 0UL;
 //CHECK-NEXT:        cudaMemcpyKind _r1 = static_cast<cudaMemcpyKind>(0U);
 //CHECK-NEXT:        clad::custom_derivatives::cudaMemcpy_pullback(in_dev, in, 10 * sizeof(double), cudaMemcpyHostToDevice, static_cast<cudaError>(0U), _d_in_dev, _d_in, &_r0, &_r1);
 //CHECK-NEXT:    }
@@ -616,7 +623,7 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
 //CHECK-NEXT:    add_kernel_4<<<1, 5>>>(out_dev, in_dev, N);
 //CHECK-NEXT:    cudaMemcpy(out, out_dev, N * sizeof(int), cudaMemcpyDeviceToHost);
 //CHECK-NEXT:    {
-//CHECK-NEXT:        unsigned long _r6 = 0UL;
+//CHECK-NEXT:        {{(unsigned long|[_a-zA-Z]*size_t)}} _r6 = 0UL;
 //CHECK-NEXT:        cudaMemcpyKind _r7 = static_cast<cudaMemcpyKind>(0U);
 //CHECK-NEXT:        clad::custom_derivatives::cudaMemcpy_pullback(out, out_dev, N * sizeof(int), cudaMemcpyDeviceToHost, static_cast<cudaError>(0U), _d_out, _d_out_dev, &_r6, &_r7);
 //CHECK-NEXT:        _d_N += _r6 * sizeof(int);
@@ -632,13 +639,13 @@ void launch_add_kernel_4(int *out, int *in, const int N) {
 //CHECK-NEXT:        _d_N += _r4;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        unsigned long _r2 = 0UL;
+//CHECK-NEXT:        {{(unsigned long|[_a-zA-Z]*size_t)}} _r2 = 0UL;
 //CHECK-NEXT:        cudaMemcpyKind _r3 = static_cast<cudaMemcpyKind>(0U);
 //CHECK-NEXT:        clad::custom_derivatives::cudaMemcpy_pullback(out_dev, out, N * sizeof(int), cudaMemcpyHostToDevice, static_cast<cudaError>(0U), _d_out_dev, _d_out, &_r2, &_r3);
 //CHECK-NEXT:        _d_N += _r2 * sizeof(int);
 //CHECK-NEXT:    }
 //CHECK-NEXT:    {
-//CHECK-NEXT:        unsigned long _r0 = 0UL;
+//CHECK-NEXT:        {{(unsigned long|[_a-zA-Z]*size_t)}} _r0 = 0UL;
 //CHECK-NEXT:        cudaMemcpyKind _r1 = static_cast<cudaMemcpyKind>(0U);
 //CHECK-NEXT:        clad::custom_derivatives::cudaMemcpy_pullback(in_dev, in, N * sizeof(int), cudaMemcpyHostToDevice, static_cast<cudaError>(0U), _d_in_dev, _d_in, &_r0, &_r1);
 //CHECK-NEXT:        _d_N += _r0 * sizeof(int);

--- a/test/CUDA/RestoreTrackerDevice.cu
+++ b/test/CUDA/RestoreTrackerDevice.cu
@@ -1,9 +1,9 @@
 // RUN: %cladclang_cuda -I%S/../../include --cuda-path=%cudapath \
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -o RestoreTrackerDevice.out %s
 //
-// RUN: %cudarun ./RestoreTrackerDevice.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./RestoreTrackerDevice.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 #include "clad/Differentiator/Differentiator.h"
 #include <iostream>
 

--- a/test/CUDA/ThrustAdjacentDifference.cu
+++ b/test/CUDA/ThrustAdjacentDifference.cu
@@ -2,9 +2,9 @@
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oThrustAdjacentDifference.out \
 // RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
 //
-// RUN: %cudarun ./ThrustAdjacentDifference.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./ThrustAdjacentDifference.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 //
 // expected-no-diagnostics
 

--- a/test/CUDA/ThrustCopy.cu
+++ b/test/CUDA/ThrustCopy.cu
@@ -2,9 +2,9 @@
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oThrustCopy.out \
 // RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
 //
-// RUN: %cudarun ./ThrustCopy.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./ThrustCopy.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 //
 // expected-no-diagnostics
 
@@ -41,8 +41,8 @@ void copy_with_return_value_stored(const thrust::device_vector<double>& src,
 }
 // CHECK: void copy_with_return_value_stored_grad(const thrust::device_vector<double> &src, thrust::device_vector<double> &dst, thrust::device_vector<double> *_d_src, thrust::device_vector<double> *_d_dst) {
 // CHECK-NEXT:     clad::ValueAndAdjoint<{{.*}}> _t0 = {{.*}}thrust::copy_reverse_forw(std::begin(src), std::end(src), std::begin(dst), std::begin((*_d_src)), std::end((*_d_src)), std::begin((*_d_dst)));
-// CHECK-NEXT:     thrust::detail::normal_iterator<device_ptr<double> > it = _t0.value;
-// CHECK-NEXT:     thrust::detail::normal_iterator<device_ptr<double> > _d_it = _t0.adjoint;
+// CHECK-NEXT:     thrust::detail::normal_iterator<{{(thrust::)?}}device_ptr<double> > it = _t0.value;
+// CHECK-NEXT:     thrust::detail::normal_iterator<{{(thrust::)?}}device_ptr<double> > _d_it = _t0.adjoint;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         const_iterator _r0 = std::begin((*_d_src));
 // CHECK-NEXT:         const_iterator _r1 = std::end((*_d_src));

--- a/test/CUDA/ThrustReduce.cu
+++ b/test/CUDA/ThrustReduce.cu
@@ -2,9 +2,9 @@
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oThrustReduce.out \
 // RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
 //
-// RUN: %cudarun ./ThrustReduce.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./ThrustReduce.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 //
 // expected-no-diagnostics
 

--- a/test/CUDA/ThrustReduceByKey.cu
+++ b/test/CUDA/ThrustReduceByKey.cu
@@ -2,9 +2,9 @@
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oThrustReduceByKey.out \
 // RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
 //
-// RUN: %cudarun ./ThrustReduceByKey.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./ThrustReduceByKey.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 //
 // expected-no-diagnostics
 

--- a/test/CUDA/ThrustScan.cu
+++ b/test/CUDA/ThrustScan.cu
@@ -2,9 +2,9 @@
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oThrustScan.out \
 // RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
 //
-// RUN: %cudarun ./ThrustScan.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./ThrustScan.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 //
 // expected-no-diagnostics
 

--- a/test/CUDA/ThrustScanByKey.cu
+++ b/test/CUDA/ThrustScanByKey.cu
@@ -2,9 +2,9 @@
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oThrustScanByKey.out \
 // RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
 //
-// RUN: %cudarun ./ThrustScanByKey.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./ThrustScanByKey.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 //
 // expected-no-diagnostics
 

--- a/test/CUDA/ThrustSortByKey.cu
+++ b/test/CUDA/ThrustSortByKey.cu
@@ -2,9 +2,9 @@
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oThrustSortByKey.out \
 // RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
 //
-// RUN: %cudarun ./ThrustSortByKey.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./ThrustSortByKey.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 //
 // expected-no-diagnostics
 

--- a/test/CUDA/ThrustTransform.cu
+++ b/test/CUDA/ThrustTransform.cu
@@ -2,9 +2,13 @@
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oThrustTransform.out \
 // RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
 //
-// RUN: %cudarun ./ThrustTransform.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./ThrustTransform.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
+//
+// This test transforms with thrust::identity, which CCCL 3.0 removed, so
+// there is nothing to name on a CUDA 13 toolkit.
+// UNSUPPORTED: cccl-3
 //
 // expected-no-diagnostics
 

--- a/test/CUDA/ThrustTransformReduce.cu
+++ b/test/CUDA/ThrustTransformReduce.cu
@@ -2,9 +2,13 @@
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oThrustTransformReduce.out \
 // RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
 //
-// RUN: %cudarun ./ThrustTransformReduce.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./ThrustTransformReduce.out | %filecheck_exec %s %}
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
+//
+// Two of the reductions here transform with thrust::identity, which CCCL
+// 3.0 removed, so there is nothing to name on a CUDA 13 toolkit.
+// UNSUPPORTED: cccl-3
 //
 // expected-no-diagnostics
 

--- a/test/CUDA/ZeroInitDevice.cu
+++ b/test/CUDA/ZeroInitDevice.cu
@@ -2,13 +2,13 @@
 // RUN:     --cuda-gpu-arch=%cudaarch %cudaldflags -oZeroInitDevice.out \
 // RUN:     -Xclang -verify %s 2>&1 | %filecheck %s
 //
-// RUN: %cudarun ./ZeroInitDevice.out | %filecheck_exec %s
+// RUN: %if cuda-runtime %{ %cudarun ./ZeroInitDevice.out | %filecheck_exec %s %}
 //
 // RUN: %cladclang_cuda -I%S/../../include --cuda-path=%cudapath \
 // RUN:     --cuda-gpu-arch=%cudaarch -fsyntax-only %s -DEXPECT_DIAG \
 // RUN:     -Xclang -verify=device -Xclang -verify-ignore-unexpected=note
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 //
 // expected-no-diagnostics
 

--- a/test/Regressions/issue-1624.cu
+++ b/test/Regressions/issue-1624.cu
@@ -1,7 +1,7 @@
 // RUN: %cladclang_cuda -fsyntax-only -I%S/../../include --cuda-path=%cudapath \
 // RUN:     --cuda-gpu-arch=%cudaarch -Xclang -verify %s
 //
-// REQUIRES: cuda-runtime
+// REQUIRES: cuda-compile
 // expected-no-diagnostics
 
 #include "clad/Differentiator/Tape.h"

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -262,7 +262,40 @@ flags = ' -std=c++17 -Xclang -add-plugin -Xclang clad -Xclang \
         -plugin-arg-clad -Xclang -fdump-derived-fn -Xclang \
         -load -Xclang ' + config.cladlib
 
-config.substitutions.append( ('%cladclang_cuda', config.clang + flags) )
+# Compiling against headers alone means the CUDA release is one CI picked,
+# so a compiler that does not recognise it says nothing about the code --
+# and %filecheck fails on any warning. Where a real toolkit is installed
+# the mismatch is worth hearing about, so the warning stays.
+# Asked here as well as below: the answer decides both which flags the CUDA
+# compiler gets and which tests can run at all.
+have_cuda_runtime = lit.util.which('libcudart.so', config.cuda_libdir) is not None
+cuda_flags = flags if have_cuda_runtime else ' -Wno-unknown-cuda-version' + flags
+
+# find_package(CUDAToolkit) wants nvcc and the runtime library, so it does
+# not see a headers-only prefix and leaves cuda_path empty. CUDA_PATH is
+# where such a prefix announces itself.
+cuda_path = config.cuda_path or os.environ.get('CUDA_PATH', '')
+
+# CUDA 13 moved Thrust, CUB and libcu++ out of include/ and into
+# include/cccl/, and clang's CUDA detector only ever adds include/. Without
+# this a test that includes <thrust/...> does not compile at all.
+cccl_include = os.path.join(cuda_path, 'include', 'cccl') if cuda_path else ''
+if cccl_include and os.path.isdir(cccl_include):
+    cuda_flags = ' -I' + cccl_include + cuda_flags
+
+# CCCL 3.0 also retired public API, thrust::identity among it, so a test
+# that names such a thing can only run where the toolkit still has it.
+thrust_root = cccl_include or (os.path.join(cuda_path, 'include') if cuda_path else '')
+if thrust_root:
+    try:
+        with open(os.path.join(thrust_root, 'thrust', 'version.h')) as f:
+            match = re.search(r'#define\s+THRUST_VERSION\s+(\d+)', f.read())
+        if match and int(match.group(1)) >= 300000:
+            config.available_features.add('cccl-3')
+    except OSError:
+        pass
+
+config.substitutions.append( ('%cladclang_cuda', config.clang + cuda_flags) )
 
 config.substitutions.append( ('%cladclang', config.clang + '++ -DCLAD_NO_NUM_DIFF ' + flags) )
 
@@ -333,19 +366,34 @@ if lit_config.params.get('cuda_sanitizer'):
     cuda_run_prefix = san_path + ' --tool memcheck --error-exitcode=1 --print-limit=0'
 config.substitutions.append(('%cudarun', cuda_run_prefix))
 
-libcudart_path = lit.util.which('libcudart.so', config.cuda_libdir)
-if libcudart_path is not None:
-    config.available_features.add('cuda-runtime')
+# Compiling a .cu needs only the headers; running what comes out needs the
+# runtime library and a device. A runner with neither can still catch the
+# regressions that show up at compile time, so the two are separate
+# features and a test can ask for whichever it needs.
+cuda_arch = config.cuda_test_arch or 'sm_60'
+
+if cuda_path and os.path.exists(
+        os.path.join(cuda_path, 'include', 'cuda_runtime.h')):
+    config.available_features.add('cuda-compile')
     # set the CUDA SDK root path
     # necessary if CUDA is not installed under /usr/local/
-    config.substitutions.append(('%cudapath', config.cuda_path))
+    config.substitutions.append(('%cudapath', cuda_path))
+    config.substitutions.append(('%cudaarch', cuda_arch))
+
+if have_cuda_runtime:
+    config.available_features.add('cuda-runtime')
     config.substitutions.append(('%cudaldflags', '-L' + config.cuda_libdir +
                                  ' -lcudart -ldl -lrt -pthread -lm -lstdc++'))
+else:
+    # Nothing to link against, so compile and stop there. This is what lets
+    # a test's compile half run on a machine with no runtime, without the
+    # test having to spell the condition out; -o alongside -fsyntax-only is
+    # ignored without complaint.
+    config.substitutions.append(('%cudaldflags', '-fsyntax-only'))
     # limit the number of usable GPUs in a system
     # https://developer.nvidia.com/blog/cuda-pro-tip-control-gpu-visibility-cuda_visible_devices/
     if 'CUDA_VISIBLE_DEVICES' in os.environ:
         config.environment['CUDA_VISIBLE_DEVICES'] = os.environ['CUDA_VISIBLE_DEVICES']
-    config.substitutions.append(('%cudaarch', config.cuda_test_arch))
 
 def _openmp_usable():
     """Can the compiler the tests use actually compile an OpenMP source?


### PR DESCRIPTION
cuda-runtime looks for libcudart.so, and every CUDA test asks for it, so a machine with the CUDA headers but no runtime library and no device is treated as having no CUDA at all and skips the lot -- including the compile half, which such a machine runs perfectly well. That is every hosted runner, so nothing outside the two self-hosted rows has ever compiled a .cu, and the step that was supposed to give a hosted row CUDA could not run at all: its condition read `!matrix.os == 'self-hosted'`, which `!` binding tighter than `==` makes always false.

Split the question. cuda-compile is available wherever the headers are and carries what a compile needs; cuda-runtime keeps libcudart.so and what linking needs. A test asks for cuda-compile, %cudaldflags degrades to -fsyntax-only when there is nothing to link against, and only the line that runs the built binary is spelled out as conditional -- lit wraps each RUN in a brace group, so a substitution cannot swallow the trailing FileCheck.

Provision the headers on three hosted rows, at 12.6, 12.8 and 13.0, since version skew is where CUDA breaks and headers cost 19 MB. Compiling against headers alone means the release is one CI picked, so a compiler that does not recognise it says nothing about the code and the warning is silenced -- only there; where a real toolkit is installed the mismatch is worth hearing. ubu22-clang13-runtime13-cuda loses its flag rather than gaining a version, clang 13 predating all three, and the self-hosted rows keep theirs, still linking and running for real.