### PR TITLE
Report what an analysis left in the derivative, where it left it.

### DIFF
--- a/docs/userDocs/source/user/DevelopersDocumentation.rst
+++ b/docs/userDocs/source/user/DevelopersDocumentation.rst
@@ -158,6 +158,71 @@ temporarily the differences in the produced outputs with:
    cmake --build . --target check-clad-execonly
 
 
+Inspecting the generated code
+=============================
+
+Clad builds the derivative as an AST, so its statements belong to no file and
+have nothing a diagnostic can point at. Clad renders a derivative into a
+buffer it registers with the ``SourceManager``, which gives every generated
+statement a line and a column, and two switches report through it. Both are
+plugin arguments, so each needs ``-Xclang -plugin-arg-clad -Xclang`` in front.
+
+``-Rclad-analysis=<name>``
+--------------------------------
+
+Reports what the named analysis could not remove from the derivative, and
+where. This is the analogue of ``-Rpass-missed``, which cannot serve clad:
+clang's remark machinery runs in the backend over LLVM IR and never sees a
+plugin working on the AST.
+
+.. code-block:: none
+
+   In file included from doc.cpp:8:
+   <clad derivative of f_grad>:4:5: remark: clad keeps this value for the reverse sweep
+       4 |     double _t0 = t;
+         |     ^~~~~~~~~~~~~~
+   <clad derivative of f_grad>:4:5: note: to-be-recorded analysis could not show it unused
+   doc.cpp:4:3: note: the value kept is the one this expression had
+       4 |   t = t * t;
+         |   ^
+
+Expect three positions: the differentiation that asked for the derivative
+(the ``In file included from`` line), the generated statement that costs, and
+the expression in your own code whose value is being kept -- the half you can
+act on. The note giving the reason distinguishes an analysis that ran and
+could not prove the value dead from one that was switched off, so a remark
+never claims to have proved something it never ran.
+
+Run ``-plugin-arg-clad -help`` for the analysis names this accepts.
+
+``-fdump-generated-source``
+--------------------------------
+
+Prints a derivative as text together with the position every statement
+occupies in it, which is how the mapping is checked without a diagnostic to
+hang it on.
+
+.. code-block:: none
+
+   generated-source: f_grad
+     1:44-44: {
+     2:5-20: double _d_t = 0.;
+     3:5-20: double t = x * x;
+     4:5-18: double _t0 = t;
+     5:5-13: t = t * t;
+     5:9-13: t * t;
+
+Each line is ``line:begin-end`` followed by the text that starts there. A node
+that renders on one line reports the columns it spans, so a subexpression such
+as ``t * t`` is reported inside the statement containing it; one that cannot
+be measured that way, such as a compound statement, reports only where it
+begins.
+
+This is not ``-fgenerate-source-file``, which appends each derivative to
+``Derivatives.cpp`` for reading. This one reports where each statement *sits*,
+which is what a diagnostic needs in order to point at it.
+
+
 Debugging Clang
 ==================
 

--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -52,6 +52,7 @@ llvm_add_library(cladDifferentiator
   DerivedFnInfo.cpp
   DiffPlanner.cpp
   ErrorEstimator.cpp
+  DerivativePrinter.cpp
   JacobianModeVisitor.cpp
   HessianModeVisitor.cpp
   MultiplexExternalRMVSource.cpp

--- a/lib/Differentiator/DerivativePrinter.cpp
+++ b/lib/Differentiator/DerivativePrinter.cpp
@@ -1,0 +1,142 @@
+#include "DerivativePrinter.h"
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/PrettyPrinter.h"
+#include "clang/AST/Stmt.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Sema/Sema.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+#include <utility>
+
+using namespace clang;
+
+namespace clad {
+
+namespace {
+
+/// Notes where each statement's text begins as the printer reaches it.
+///
+/// PrinterHelper is a substitution hook: returning true means "I printed this,
+/// skip it". Returning false leaves the output byte for byte what it would
+/// have been, which is what makes the offsets describe the text a reader sees.
+class OffsetRecorder : public PrinterHelper {
+  llvm::DenseMap<const Stmt*, unsigned>& m_Offsets;
+
+public:
+  explicit OffsetRecorder(llvm::DenseMap<const Stmt*, unsigned>& Offsets)
+      : m_Offsets(Offsets) {}
+
+  bool handledStmt(Stmt* S, llvm::raw_ostream& OS) override {
+    // A node reached twice keeps the first offset, where its text starts.
+    m_Offsets.try_emplace(S, static_cast<unsigned>(OS.tell()));
+    return false;
+  }
+};
+
+} // namespace
+
+const DerivativePrinter::Rendering&
+DerivativePrinter::render(const FunctionDecl* FD) {
+  auto Found = m_Rendered.find(FD);
+  if (Found != m_Rendered.end())
+    return Found->second;
+
+  Rendering R;
+  // Not retained: the SourceManager keeps a copy for the life of the
+  // compilation, and in a long-running session nothing is reclaimed until it
+  // ends, so a second copy would double what this costs.
+  std::string Text;
+  llvm::raw_string_ostream OS(Text);
+  PrintingPolicy Policy = m_Sema.getASTContext().getPrintingPolicy();
+
+  // The signature comes from Decl::print, which takes no PrinterHelper, so it
+  // is printed without one and the body follows separately. TerseOutput is
+  // what stops Decl::print from printing the body itself.
+  PrintingPolicy Signature = Policy;
+  Signature.TerseOutput = true;
+  FD->print(OS, Signature);
+  OS << " ";
+
+  if (const Stmt* Body = FD->getBody()) {
+    OffsetRecorder Recorder(R.Offsets);
+    Body->printPretty(OS, &Recorder, Policy);
+  }
+  OS.flush();
+
+  SourceManager& SM = m_Sema.getSourceManager();
+  std::string Name = "<clad derivative of " + FD->getNameAsString() + ">";
+  // Entered from the differentiation that asked for it, falling back to the
+  // main file. Somewhere inside the translation unit is required either way:
+  // isBeforeInTranslationUnit orders two locations by walking up to a file
+  // they share, and reports "Unsortable locations found" when there is none.
+  SourceLocation IncludeLoc = m_RequestedAt.lookup(FD);
+  if (IncludeLoc.isInvalid())
+    IncludeLoc = SM.getLocForStartOfFile(SM.getMainFileID());
+  R.File = SM.createFileID(llvm::MemoryBuffer::getMemBufferCopy(Text, Name),
+                           SrcMgr::C_User, /*LoadedID=*/0, /*LoadedOffset=*/0,
+                           IncludeLoc);
+  return m_Rendered.insert({FD, std::move(R)}).first->second;
+}
+
+void DerivativePrinter::noteRequestedAt(const FunctionDecl* FD,
+                                        SourceLocation Loc) {
+  // The first request wins, and a later one is ignored rather than asserted
+  // on: which request a shared derivative is attributed to is presentational,
+  // and not worth ending a compilation over.
+  if (Loc.isValid() && Loc.isFileID())
+    m_RequestedAt.try_emplace(FD, Loc);
+}
+
+SourceLocation DerivativePrinter::locationOf(const FunctionDecl* FD,
+                                             const Stmt* S) {
+  const Rendering& R = render(FD);
+  auto Found = R.Offsets.find(S);
+  if (Found == R.Offsets.end())
+    return {};
+  // The printer announces a statement before emitting the indentation in
+  // front of it, so the recorded offset can sit at the start of the line.
+  // Point at the first character of the statement itself, which is where a
+  // caret belongs.
+  llvm::StringRef Text = m_Sema.getSourceManager().getBufferData(R.File);
+  unsigned Offset = Found->second;
+  while (Offset < Text.size() && (Text[Offset] == ' ' || Text[Offset] == '\t'))
+    ++Offset;
+  return m_Sema.getSourceManager()
+      .getLocForStartOfFile(R.File)
+      .getLocWithOffset(Offset);
+}
+
+SourceRange DerivativePrinter::rangeOf(const FunctionDecl* FD, const Stmt* S) {
+  SourceLocation Begin = locationOf(FD, S);
+  if (Begin.isInvalid())
+    return {};
+  // How wide the node is, measured by rendering it alone under the same
+  // policy. A statement is printed with a trailing separator it does not own,
+  // so that comes back off.
+  std::string Own;
+  llvm::raw_string_ostream OS(Own);
+  S->printPretty(OS, /*Helper=*/nullptr,
+                 m_Sema.getASTContext().getPrintingPolicy());
+  OS.flush();
+  llvm::StringRef Text = llvm::StringRef(Own).rtrim(" \t\n;");
+  // Only a node that renders on one line can be measured this way: a compound
+  // statement printed alone carries its own line breaks, and a range built
+  // from that would end before it began. Those report a bare location, which
+  // is right for them anyway -- underlining a whole loop body says nothing.
+  if (Text.empty() || Text.contains(/*C=*/'\n'))
+    return Begin;
+  // A range's end names the last character, not one past it.
+  return {Begin, Begin.getLocWithOffset(Text.size() - 1)};
+}
+
+llvm::StringRef DerivativePrinter::textOf(const FunctionDecl* FD) {
+  return m_Sema.getSourceManager().getBufferData(render(FD).File);
+}
+
+} // namespace clad

--- a/lib/Differentiator/DerivativePrinter.h
+++ b/lib/Differentiator/DerivativePrinter.h
@@ -1,0 +1,78 @@
+#ifndef CLAD_DIFFERENTIATOR_DERIVATIVEPRINTER_H
+#define CLAD_DIFFERENTIATOR_DERIVATIVEPRINTER_H
+
+#include "clang/Basic/SourceLocation.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace clang {
+class FunctionDecl;
+class Sema;
+class Stmt;
+} // namespace clang
+
+namespace clad {
+
+/// Gives clad-generated code somewhere to be pointed at.
+///
+/// A generated node has no source location of its own -- clad builds it, so
+/// there is no file it came from -- and the placeholder every visitor reaches
+/// for is the start of the main file, which puts a caret on the user's first
+/// line. That is not a diagnostic anyone can act on.
+///
+/// Rendering the derivative into a buffer and registering it with the
+/// SourceManager gives the node a real location: one inside text that reads
+/// like the code clad produced. Diagnostics then render with a caret and
+/// context, exactly as they do for code the user wrote. The same mechanism
+/// backs interactive input in cling and clang-repl, and macro expansions in
+/// Swift.
+///
+/// The rendering is built on first use and cached per function: a compilation
+/// that reports nothing never pays for one.
+class DerivativePrinter {
+public:
+  explicit DerivativePrinter(clang::Sema& S) : m_Sema(S) {}
+
+  /// Where \p S appears within the rendering of \p FD, or an invalid location
+  /// if \p FD has no body or the printer never announced \p S.
+  clang::SourceLocation locationOf(const clang::FunctionDecl* FD,
+                                   const clang::Stmt* S);
+
+  /// The span \p S occupies in the rendering, so a diagnostic can underline
+  /// the whole expression rather than mark its first character. A loop's
+  /// condition or increment is several nodes wide and reads as one thing.
+  clang::SourceRange rangeOf(const clang::FunctionDecl* FD,
+                             const clang::Stmt* S);
+
+  /// The rendered text of \p FD, for a caller that wants to show it rather
+  /// than point into it.
+  llvm::StringRef textOf(const clang::FunctionDecl* FD);
+
+  /// Records that \p FD exists because of the differentiation at \p Loc.
+  ///
+  /// A rendering has to be entered from somewhere in the translation unit, and
+  /// a diagnostic prints that place above itself. The request is the useful
+  /// answer -- it is the line a reader would edit -- so a caller that knows it
+  /// should say so before the first diagnostic about \p FD. Without this the
+  /// rendering is entered from the start of the main file, which is sortable
+  /// but tells a reader nothing.
+  void noteRequestedAt(const clang::FunctionDecl* FD,
+                       clang::SourceLocation Loc);
+
+private:
+  struct Rendering {
+    clang::FileID File;
+    llvm::DenseMap<const clang::Stmt*, unsigned> Offsets;
+  };
+  const Rendering& render(const clang::FunctionDecl* FD);
+
+  clang::Sema& m_Sema;
+  llvm::DenseMap<const clang::FunctionDecl*, Rendering> m_Rendered;
+  llvm::DenseMap<const clang::FunctionDecl*, clang::SourceLocation>
+      m_RequestedAt;
+};
+
+} // namespace clad
+
+#endif // CLAD_DIFFERENTIATOR_DERIVATIVEPRINTER_H

--- a/test/Misc/AnalysisRemarks.C
+++ b/test/Misc/AnalysisRemarks.C
@@ -1,0 +1,109 @@
+// A remark about generated code, pointed at the generated code.
+//
+// Clad's analyses decide what the derivative has to keep, and when one cannot
+// prove a value dead the user pays for it with no way to find out where. This
+// is the -Rpass-missed analogue: clang's own remark machinery runs in the
+// backend over LLVM IR and never sees an AST-level plugin, so clad carries its
+// own switch and its own locations.
+//
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -Rclad-analysis=tbr \
+// RUN:   -fsyntax-only %s -I%S/../../include 2>&1 \
+// RUN:   | %filecheck --check-prefixes=CHECK,CHECK-NOKEEP %s
+//
+// A rendering has to be entered from somewhere in the translation unit, and
+// clang prints that place above the diagnostic. It is the differentiation
+// that asked for this derivative, which is the line a reader would edit --
+// not the top of their file, which would say nothing.
+// CHECK: In file included from {{.*}}AnalysisRemarks.C:[[@LINE+84]]:
+//
+// The caret lands inside the rendered derivative, on the statement itself --
+// the whole point, since none of this text exists in any file.
+// CHECK: <clad derivative of f_grad>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK: double _t0 = t;
+// The whole statement is underlined, not just its first character: a range
+// reads as one thing where a caret reads as a position.
+// CHECK-NEXT: ^~~~~~~~~~~~~~
+// CHECK: note: to-be-recorded analysis could not show it unused
+//
+// And the half the user can act on -- their own code, with the expression
+// whose value is being kept.
+// CHECK: {{.*}}AnalysisRemarks.C:[[@LINE+52]]:3: note: the value kept is the one this expression had
+// CHECK-NEXT: t = t * t;
+//
+// A value the reverse sweep needs once per iteration cannot go into a
+// variable of its own, so clad pushes it onto a tape. The push is what
+// costs, and it is what the remark has to point at -- not the tape, which
+// is only the container.
+// CHECK: <clad derivative of loopy_grad_0>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK: clad::push(
+// CHECK: note: to-be-recorded analysis could not show it unused
+// CHECK: {{.*}}AnalysisRemarks.C:[[@LINE+52]]:5: note: the value kept is the one this expression had
+// CHECK-NEXT: t = t * t;
+//
+// With the analysis switched off the value is kept for a different reason, and
+// the note says which. Claiming it "could not prove" something it never ran
+// would be false.
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -Rclad-analysis=tbr \
+// RUN:   -Xclang -plugin-arg-clad -Xclang -fdisable-analysis=tbr \
+// RUN:   -fsyntax-only %s -I%S/../../include 2>&1 \
+// RUN:   | %filecheck --check-prefix=CHECK-OFF %s
+// CHECK-OFF: <clad derivative of f_grad>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK-OFF: note: to-be-recorded analysis is disabled
+// The pointer back into the user's code does not depend on the analysis.
+// CHECK-OFF: note: the value kept is the one this expression had
+// Nor does the tape: what changes with the switch is the reason, not which
+// values are reported or where they came from.
+// CHECK-OFF: <clad derivative of loopy_grad_0>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK-OFF: note: to-be-recorded analysis is disabled
+// CHECK-OFF: note: the value kept is the one this expression had
+//
+// A derivative with nothing to keep is not something to report: asking about
+// it says nothing rather than saying there is nothing.
+// CHECK-NOKEEP-NOT: <clad derivative of lin_grad>
+//
+// A name no analysis answers to is refused, and the refusal says which names
+// there are. Plain FileCheck here: the run fails, so its output carries an
+// error the shared %filecheck is set to reject.
+// RUN: not %cladclang -Xclang -plugin-arg-clad -Xclang -Rclad-analysis=bogus \
+// RUN:   -fsyntax-only %s -I%S/../../include 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-BADNAME %s
+// CHECK-BADNAME: clad: Error: unknown analysis 'bogus'; known:{{.*}}tbr
+//
+// Nothing is rendered unless asked: no flag, no remark, and no buffer built.
+// RUN: %cladclang -fsyntax-only %s -I%S/../../include 2>&1 \
+// RUN:   | %filecheck --check-prefix=CHECK-QUIET --allow-empty %s
+// CHECK-QUIET-NOT: remark:
+// CHECK-QUIET-NOT: clad derivative of
+
+#include "clad/Differentiator/Differentiator.h"
+
+double f(double x) {
+  double t = x * x;
+  t = t * t;
+  return t;
+}
+
+// A value the reverse sweep needs once per iteration cannot go into a variable
+// of its own -- there is one of it per iteration -- so clad pushes it onto a
+// tape instead.
+double loopy(double x, int n) {
+  double t = x;
+  for (int i = 0; i < n; ++i)
+    t = t * t;
+  return t;
+}
+
+// Nothing here has to be kept: the reverse sweep reads no value this wrote.
+double lin(double x) { return 2 * x; }
+
+int main() {
+  double d0 = 0;
+  auto g = clad::gradient(f);
+  auto gn = clad::gradient(lin);
+  gn.execute(2, &d0);
+  double d = 0;
+  g.execute(2, &d);
+  auto gl = clad::gradient(loopy, "x");
+  gl.execute(2, 3, &d);
+  return 0;
+}

--- a/test/Misc/Args.C
+++ b/test/Misc/Args.C
@@ -4,6 +4,8 @@
 // CHECK_HELP-NEXT: -fdump-source-fn-ast
 // CHECK_HELP-NEXT: -fdump-derived-fn
 // CHECK_HELP-NEXT: -fdump-derived-fn-ast
+// CHECK_HELP-NEXT: -fdump-generated-source
+// CHECK_HELP-NEXT: -Rclad-analysis=<name>
 // CHECK_HELP-NEXT: -fgenerate-source-file
 // CHECK_HELP-NEXT: -fno-validate-clang-version
 // CHECK_HELP-NEXT: -fcustom-estimation-model

--- a/test/Misc/GeneratedSourceLocations.C
+++ b/test/Misc/GeneratedSourceLocations.C
@@ -1,0 +1,45 @@
+// Clad-generated code has no source location of its own, and the placeholder
+// every visitor reaches for is the start of the main file -- so a diagnostic
+// about generated code puts its caret on the user's first line.
+//
+// Rendering the derivative into a buffer registered with the SourceManager
+// gives each generated statement a real location instead. This checks the
+// round-trip: the line and column reported for a statement is the one that
+// statement's text actually occupies in the rendering.
+//
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fdump-generated-source \
+// RUN:   -fsyntax-only %s -I%S/../../include 2>&1 | %filecheck %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+double f(double x) {
+  double t = x * x;
+  t = t * t;
+  return t;
+}
+
+// The forward sweep, in the order the rendering lays it out. Each node reports
+// the span it occupies, not just where it starts: a diagnostic underlines the
+// whole expression, which is what makes a multi-node one -- a loop condition,
+// an increment -- read as one thing.
+// CHECK: generated-source: f_grad
+// CHECK: {{[0-9]+}}:5-{{[0-9]+}}: double _d_t = 0.;
+// CHECK-NEXT: {{[0-9]+}}:5-{{[0-9]+}}: double t = x * x;
+// CHECK-NEXT: {{[0-9]+}}:5-18: double _t0 = t;
+
+// The nested expressions of `t = t * t` sit further in on the same line, and
+// each spans exactly its own text: the assignment reaches column 13, its
+// right-hand side starts at 9, and the operand at 13 is one character wide.
+// CHECK-NEXT: [[LINE:[0-9]+]]:5-13: t = t * t;
+// CHECK-NEXT: [[LINE]]:9-13: t * t;
+// CHECK-NEXT: [[LINE]]:13-13: t;
+
+// The reverse sweep restores what the forward one saved.
+// CHECK: {{[0-9]+}}:9-{{[0-9]+}}: t = _t0;
+
+int main() {
+  auto g = clad::gradient(f);
+  double d = 0;
+  g.execute(2, &d);
+  return 0;
+}

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -11,11 +11,13 @@
 #include "clad/Differentiator/Sins.h"
 #include "clad/Differentiator/Timers.h"
 #include "clad/Differentiator/Version.h"
+#include "../lib/Differentiator/DerivativePrinter.h"
 #include "../lib/Differentiator/TBRAnalyzer.h"
 
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/Expr.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
 #include "clang/Basic/CodeGenOptions.h"
@@ -47,6 +49,7 @@
 #include "clang/Sema/Sema.h"
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -60,6 +63,7 @@
 #include <iostream> // for std::cerr
 #include <memory>
 #include <set>
+#include <utility>
 
 using namespace clang;
 
@@ -243,6 +247,194 @@ void InitTimers();
       if (!m_CI.getDiagnostics().hasErrorOccurred() &&
           !getScheduler().isTraversalInFlight() && !m_Multiplexer)
         FinalizeTranslationUnit();
+    }
+
+    /// The statements of \p S that the printer gave an offset, paired with it.
+    static void collectStmts(const clang::Stmt* S, DerivativePrinter& Printer,
+                             const clang::FunctionDecl* FD,
+                             llvm::SmallVectorImpl<const clang::Stmt*>& Out) {
+      if (!S)
+        return;
+      if (Printer.locationOf(FD, S).isValid())
+        Out.push_back(S);
+      for (const clang::Stmt* Child : S->children())
+        collectStmts(Child, Printer, FD, Out);
+    }
+
+    /// Shows what a generated function looks like as text, and where inside
+    /// that text each of its statements sits. A statement's reported line and
+    /// column is the one a diagnostic pointing at it would carry, so this is
+    /// how the mapping is checked without a diagnostic to hang it on.
+    void CladPlugin::dumpGeneratedSource(clang::Decl* D) {
+      const auto* FD = llvm::dyn_cast<clang::FunctionDecl>(D);
+      if (!FD || !FD->getBody())
+        return;
+      if (!m_DerivativePrinter)
+        m_DerivativePrinter =
+            std::make_unique<DerivativePrinter>(m_CI.getSema());
+
+      llvm::outs() << "generated-source: " << FD->getNameAsString() << "\n";
+      // Every statement the printer announced, in the order its text appears.
+      llvm::SmallVector<const clang::Stmt*, 32> Ordered;
+      collectStmts(FD->getBody(), *m_DerivativePrinter, FD, Ordered);
+      clang::SourceManager& SM = m_CI.getSourceManager();
+      auto offsetOf = [&](const clang::Stmt* S) {
+        return SM.getFileOffset(m_DerivativePrinter->locationOf(FD, S));
+      };
+      llvm::stable_sort(Ordered,
+                        [&](const clang::Stmt* A, const clang::Stmt* B) {
+                          return offsetOf(A) < offsetOf(B);
+                        });
+      llvm::StringRef Text = m_DerivativePrinter->textOf(FD);
+      unsigned Last = ~0U;
+      for (const clang::Stmt* S : Ordered) {
+        // One line per position: the innermost and outermost node starting at
+        // the same character would otherwise repeat it.
+        unsigned Offset = offsetOf(S);
+        if (Offset == Last)
+          continue;
+        Last = Offset;
+        clang::SourceRange R = m_DerivativePrinter->rangeOf(FD, S);
+        clang::PresumedLoc B = SM.getPresumedLoc(R.getBegin());
+        clang::PresumedLoc E = SM.getPresumedLoc(R.getEnd());
+        // Begin and end columns, so a test can pin how wide a node is and not
+        // just where it starts.
+        // A node measured to one line reports its span; one that could not be
+        // measured reports just where it starts.
+        llvm::outs() << "  " << B.getLine() << ":" << B.getColumn();
+        if (R.getEnd().isValid() && E.getLine() == B.getLine() &&
+            E.getColumn() >= B.getColumn())
+          llvm::outs() << "-" << E.getColumn();
+        llvm::outs() << ": " << Text.drop_front(Offset).take_until([](char C) {
+          return C == '\n';
+        }) << "\n";
+      }
+    }
+
+    /// Whether \p VD holds a value clad kept for the reverse sweep.
+    ///
+    /// Clad names its temporaries `_t<N>`, but not all of them are kept
+    /// values: a tape is the container for values kept in a loop, and a loop
+    /// counter is bookkeeping. Reporting either as a cost the analysis failed
+    /// to remove would be wrong, not merely noisy.
+    // FIXME: This reads clad's naming convention from the outside. The
+    // durable answer is for the visitor to mark a store as it emits one.
+    static bool isKeptValue(const clang::VarDecl* VD) {
+      if (!VD->hasInit() || !VD->getName().starts_with("_t"))
+        return false;
+      if (VD->getType().getAsString().find("tape") != std::string::npos)
+        return false;
+      return !llvm::isa<clang::IntegerLiteral>(
+          VD->getInit()->IgnoreParenImpCasts());
+    }
+
+    /// The values a derivative keeps for its reverse sweep, in the order they
+    /// appear. Clad names them `_t<N>`; a value kept in a loop goes onto a
+    /// tape instead, so both shapes count.
+    static void collectKeptValues(
+        const clang::Stmt* S,
+        llvm::SmallVectorImpl<
+            std::pair<const clang::Stmt*, const clang::VarDecl*>>& Out) {
+      if (!S)
+        return;
+      if (const auto* DS = llvm::dyn_cast<clang::DeclStmt>(S))
+        for (const clang::Decl* D : DS->decls())
+          if (const auto* VD = llvm::dyn_cast<clang::VarDecl>(D))
+            if (isKeptValue(VD))
+              Out.emplace_back(S, VD);
+      // A value kept once per iteration goes onto a tape rather than into its
+      // own variable. The push is the thing that costs, not the tape.
+      if (const auto* CE = llvm::dyn_cast<clang::CallExpr>(S))
+        if (const clang::FunctionDecl* Callee = CE->getDirectCallee())
+          if (Callee->getName() == "push" && CE->getNumArgs() == 2)
+            Out.emplace_back(S, nullptr);
+      for (const clang::Stmt* Child : S->children())
+        collectKeptValues(Child, Out);
+    }
+
+    /// The primal expression itself, so the note underlines all of it. The
+    /// clone kept its original range, so this is the user's own code.
+    static clang::SourceRange primalRangeOf(const clang::Stmt* K,
+                                            const clang::VarDecl* VD) {
+      const clang::Expr* Init =
+          VD ? VD->getInit() : llvm::cast<clang::CallExpr>(K)->getArg(1);
+      return Init ? Init->getSourceRange() : clang::SourceRange();
+    }
+
+    /// Where in the user's code the kept value came from.
+    ///
+    /// The stored initializer is a clone of a primal expression and carries
+    /// that expression's location, so a note can point at code the user can
+    /// actually change -- which the remark itself cannot, since it points at
+    /// code clad wrote. Nodes clad invented outright carry GetValidSLoc, the
+    /// start of the main file; a caret on line one would be worse than saying
+    /// nothing, so those report no location at all.
+    static clang::SourceLocation
+    primalLocationOf(const clang::Stmt* K, const clang::VarDecl* VD,
+                     const clang::SourceManager& SM) {
+      const clang::Expr* Init = nullptr;
+      if (VD)
+        Init = VD->getInit();
+      else if (const auto* CE = llvm::dyn_cast<clang::CallExpr>(K))
+        Init = CE->getArg(1); // what the push saves
+      if (!Init)
+        return {};
+      clang::SourceLocation Loc = Init->getBeginLoc();
+      if (Loc.isInvalid() || !Loc.isFileID())
+        return {};
+      if (Loc == SM.getLocForStartOfFile(SM.getMainFileID()))
+        return {};
+      return Loc;
+    }
+
+    void CladPlugin::emitAnalysisRemarks(clang::Decl* D,
+                                         const DiffRequest& request) {
+      if (!m_DO.RemarkTBRAnalysis)
+        return;
+      const auto* FD = llvm::dyn_cast<clang::FunctionDecl>(D);
+      if (!FD || !FD->getBody())
+        return;
+
+      llvm::SmallVector<std::pair<const clang::Stmt*, const clang::VarDecl*>,
+                        16>
+          Kept;
+      collectKeptValues(FD->getBody(), Kept);
+      if (Kept.empty())
+        return; // Nothing to say, so nothing gets rendered.
+
+      if (!m_DerivativePrinter)
+        m_DerivativePrinter =
+            std::make_unique<DerivativePrinter>(m_CI.getSema());
+      // The differentiation this derivative came from, so a reader is pointed
+      // at the line they would edit rather than at the top of their file.
+      if (request.CallContext)
+        m_DerivativePrinter->noteRequestedAt(
+            FD, request.CallContext->getBeginLoc());
+      clang::Sema& S = m_CI.getSema();
+      // Why the value is still here is a different sentence depending on
+      // whether the analysis ran at all; saying "could not prove" when it was
+      // switched off would be false.
+      const char* Because =
+          request.EnableTBRAnalysis
+              ? "to-be-recorded analysis could not show it unused"
+              : "to-be-recorded analysis is disabled";
+      const clang::SourceManager& SM = m_CI.getSourceManager();
+      for (const auto& [K, VD] : Kept) {
+        clang::SourceLocation Loc = m_DerivativePrinter->locationOf(FD, K);
+        if (Loc.isInvalid())
+          continue;
+        utils::diag(S, clang::DiagnosticsEngine::Remark, Loc,
+                    "clad keeps this value for the reverse sweep")
+            << m_DerivativePrinter->rangeOf(FD, K);
+        utils::diag(S, clang::DiagnosticsEngine::Note, Loc, "%0") << Because;
+        // The half the user can act on: the expression in their own code
+        // whose value this is.
+        if (clang::SourceLocation Primal = primalLocationOf(K, VD, SM);
+            Primal.isValid())
+          utils::diag(S, clang::DiagnosticsEngine::Note, Primal,
+                      "the value kept is the one this expression had")
+              << primalRangeOf(K, VD);
+      }
     }
 
     static void printDerivative(clang::Decl* D, bool DeclarationOnly,
@@ -436,6 +628,9 @@ void InitTimers();
         if (!alreadyDerived &&
             (!request.CustomDerivative || request.CallUpdateRequired)) {
           printDerivative(DerivativeDecl, request.DeclarationOnly, m_DO);
+          if (m_DO.DumpGeneratedSource)
+            dumpGeneratedSource(DerivativeDecl);
+          emitAnalysisRemarks(DerivativeDecl, request);
 
           S.MarkFunctionReferenced(SourceLocation(), DerivativeDecl);
           // We ideally should not call `HandleTopLevelDecl` for declarations

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -13,6 +13,7 @@
 #include "clad/Differentiator/DiffPlanner.h"
 #include "clad/Differentiator/DiffScheduler.h"
 #include "clad/Differentiator/Version.h"
+#include "../lib/Differentiator/DerivativePrinter.h"
 
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
@@ -65,7 +66,11 @@ struct DifferentiationOptions {
   bool DumpSourceFnAST = false;
   bool DumpDerivedFn = false;
   bool DumpDerivedAST = false;
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
+  bool Remark##Id##Analysis = false;
+#include "clad/Differentiator/Analyses.def"
   bool GenerateSourceFile = false;
+  bool DumpGeneratedSource = false;
   bool ValidateClangVersion = true;
   /// What the command line asked of each analysis. The two bools record which
   /// of the original -enable-<x>/-disable-<x> pair were seen, so that giving
@@ -138,6 +143,27 @@ inline AnalysisFlagResult setAnalysisByName(DifferentiationOptions& DO,
   return AnalysisFlagResult::Error;
 }
 
+/// Match -Rclad-analysis=<name>, asking for remarks about what that analysis
+/// left in the generated code. Named after -Rpass-missed, which it is the
+/// analogue of: clang's own remark machinery runs in the backend over LLVM IR
+/// and cannot see an AST-level plugin, so clad carries its own switch.
+inline AnalysisFlagResult remarkAnalysisByName(DifferentiationOptions& DO,
+                                               llvm::StringRef Arg) {
+  if (!Arg.consume_front("-Rclad-analysis="))
+    return AnalysisFlagResult::NotMine;
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
+  if (Arg == (Name)) {                                                         \
+    DO.Remark##Id##Analysis = true;                                            \
+    return AnalysisFlagResult::Ok;                                             \
+  }
+#include "clad/Differentiator/Analyses.def"
+  llvm::errs() << "clad: Error: unknown analysis '" << Arg << "'; known:";
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc) llvm::errs() << " " Name;
+#include "clad/Differentiator/Analyses.def"
+  llvm::errs() << ".\n";
+  return AnalysisFlagResult::Error;
+}
+
     class CladExternalSource : public clang::ExternalSemaSource {
     // ExternalSemaSource
     void ReadUndefinedButUsed(
@@ -171,6 +197,8 @@ inline AnalysisFlagResult setAnalysisByName(DifferentiationOptions& DO,
     /// Lazily constructed because it needs Sema, which is not available
     /// until InitializeSema; reach it through getScheduler().
     std::unique_ptr<DiffScheduler> m_Scheduler;
+    /// Built on first use; a run that reports nothing never renders anything.
+    std::unique_ptr<DerivativePrinter> m_DerivativePrinter;
     enum class CallKind {
       HandleCXXStaticMemberVarInstantiation,
       HandleTopLevelDecl,
@@ -347,6 +375,12 @@ inline AnalysisFlagResult setAnalysisByName(DifferentiationOptions& DO,
     void SendToMultiplexer();
     bool CheckBuiltins();
     void SetRequestOptions(RequestOptions& opts) const;
+    /// Shows what a generated function looks like as text, and where inside
+    /// that text each of its statements sits.
+    void dumpGeneratedSource(clang::Decl* D);
+    /// Reports what an analysis left behind, at the generated code it left it
+    /// in. Renders that code only if there is something to report.
+    void emitAnalysisRemarks(clang::Decl* D, const DiffRequest& request);
 
     void ProcessTopLevelDecl(clang::Decl* D) {
       DelayedCallInfo DCI{CallKind::HandleTopLevelDecl, D};
@@ -388,6 +422,12 @@ inline AnalysisFlagResult setAnalysisByName(DifferentiationOptions& DO,
             m_DO.DumpDerivedFn = true;
           } else if (args[i] == "-fdump-derived-fn-ast") {
             m_DO.DumpDerivedAST = true;
+          } else if (args[i] == "-fdump-generated-source") {
+            m_DO.DumpGeneratedSource = true;
+          } else if (AnalysisFlagResult R = remarkAnalysisByName(m_DO, args[i]);
+                     R != AnalysisFlagResult::NotMine) {
+            if (R == AnalysisFlagResult::Error)
+              return false;
           } else if (args[i] == "-fgenerate-source-file") {
             m_DO.GenerateSourceFile = true;
           } else if (args[i] == "-fno-validate-clang-version") {
@@ -419,6 +459,14 @@ inline AnalysisFlagResult setAnalysisByName(DifferentiationOptions& DO,
                    "derivative.\n"
                 << "-fdump-derived-fn-ast - Prints out the AST of the "
                    "derivative.\n"
+                << "-fdump-generated-source - For each derivative, prints "
+                   "the text clad renders it as and, for every statement in "
+                   "it, the line and column that text occupies. Diagnostics "
+                   "about generated code point into that rendering.\n"
+                << "-Rclad-analysis=<name> - Reports what the named analysis "
+                   "left in the derivative, as remarks pointed at the "
+                   "generated code itself. The analogue of -Rpass-missed, "
+                   "which cannot reach an AST-level plugin.\n"
                 << "-fgenerate-source-file - Produces a file containing the "
                    "derivatives.\n"
                 << "-fno-validate-clang-version - Disables the validation of "


### PR DESCRIPTION
Clad's analyses decide what a derivative has to keep, and a value one of them cannot prove dead is paid for on every call. Nothing said which values those were. The cost appears in generated code, and generated code had no position a diagnostic could name: every node reaches for the same placeholder, the start of the main file, so a caret about it lands on the user's first line.

Give the code somewhere to be pointed at. A derivative is rendered into a buffer registered with the SourceManager, and each of its statements can then be named by the line and column its text occupies there -- the same mechanism that backs interactive input in cling and clang-repl, and macro expansions in Swift. The rendering is built on first use and cached per function, so a compilation that reports nothing never pays for one, and it is entered from the differentiation that asked for the derivative, so the place clang prints above a diagnostic is the line a reader would edit.

On top of that, -Rclad-analysis=<name>. It is the -Rpass-missed analogue for an AST-level plugin, which clang's own remark machinery cannot serve because that runs in the backend over LLVM IR and never sees one. Each remark points at the statement still in the derivative and carries a note back to the expression in the user's code whose value is being kept -- the half they can act on. Why the value survived is a separate sentence for an analysis that ran and could not prove it dead and for one that was switched off; saying the former when the latter is true would be false.

-fdump-generated-source prints the rendering and the position of every statement in it, which is how the mapping is checked without a diagnostic to hang it on.