### PR TITLE
Stop two clang-tidy checks that clad cannot satisfy.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,16 @@
+# Two checks are off for reasons that outlive any one patch:
+#
+# llvm-header-guard derives the expected guard from the absolute path, so for
+# the 28 headers outside include/ it asks for the checkout directory and no
+# committed value can satisfy it. Upstream declined to make it configurable
+# (llvm/llvm-project#71732), and the rest of what it encodes -- include/,
+# tools/clang/, the LLVM_CLANG_ and FORTRAN_ prefixes -- is LLVM's own layout.
+#
+# cppcoreguidelines-avoid-const-or-ref-data-members exists to stop a value type
+# losing copy-assignment by accident. Clad's visitors and analyzers are not
+# value types: they are short-lived objects holding references to compiler
+# state that outlives them, 38 such members across VisitorBase,
+# DerivativeBuilder, DiffPlanner and the rest.
 Checks: >
   -*,
   bugprone-*,
@@ -32,6 +45,8 @@ Checks: >
   -readability-implicit-bool-conversion,
   -cppcoreguidelines-avoid-magic-numbers,
   -clang-analyzer-cplusplus.NewDeleteLeaks,
+  -llvm-header-guard,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
 
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase


### PR DESCRIPTION
llvm-header-guard derives the guard it wants from the header's absolute path, so for a header not under a directory named include/ it asks for the checkout directory: USERS_..._LIB_DIFFERENTIATOR_TBRANALYZER_H here, and GITHUB_WORKSPACE_LIB_... on a runner. No committed value is right in both places, and clad keeps 28 headers outside include/ -- in demos, lib, test, tools, unittests and benchmark. Upstream considers the report real and has declined to make the derivation configurable (llvm/llvm-project#71732), which is reasonable on their side: the rest of what the check encodes, include/ and tools/clang/ and the LLVM_CLANG_ and FORTRAN_ prefixes, is LLVM's own layout.

cppcoreguidelines-avoid-const-or-ref-data-members exists to stop a value type losing copy-assignment by accident. Clad's visitors and analyzers are not value types: they are short-lived objects holding references to the compiler state that outlives them -- Sema, ASTContext, the DiffRequest -- and there are 38 such members across VisitorBase, DerivativeBuilder, DiffPlanner and the rest. The check disagrees with the design rather than with any one use of it.

Nothing is lost in coverage by the first: llvm-header-guard only judges a guard's spelling and does not notice a missing one.