### PR TITLE
[ci] Do not read a gating edit as a test that ignores the change.

### DIFF
--- a/.github/actions/observes-change/observes-change-verdict.py
+++ b/.github/actions/observes-change/observes-change-verdict.py
@@ -97,10 +97,13 @@ def main(vdir, out=None):
         lines += ["", f"Evidence from a single platform:", ""]
         for name, (plat, kind) in narrow:
             lines.append(f"  {name} -- only {plat} ({kind})")
-        lines += ["", "That is the expected shape for a defect that only "
-                  "manifests under one", "row's checking, such as valgrind or "
-                  "a sanitizer. If this test is not", "about such a defect, "
-                  "the result is more likely flaky than meaningful."]
+        lines += ["", "One row and no other is what a defect confined to "
+                  "that row's configuration", "looks like: a sanitizer or "
+                  "valgrind row, but equally the only row with a", "given "
+                  "toolkit, compiler or standard-library version. It is also "
+                  "what a", "flake looks like. Which one this is depends on "
+                  "whether that row is singular", "in a way the change is "
+                  "about."]
 
     if moved:
         lines += ["", "This change edits where these run rather than what "
@@ -108,6 +111,7 @@ def main(vdir, out=None):
                   "gating against the old sources and is", "not evidence "
                   "either way:", ""]
         lines += [f"  {t}" for t in moved]
+
     if forced:
         lines += ["", "These cannot fail without the change, but their "
                   "pre-change form fails with", "it -- edits the change "

--- a/.github/actions/observes-change/observes-change-verdict.py
+++ b/.github/actions/observes-change/observes-change-verdict.py
@@ -48,7 +48,7 @@ def main(vdir, out=None):
     total = len(applicable)
     # test -> [(platform, kind)] where it failed at baseline, and
     # test -> [platform] for the rows that ran it at all.
-    seen, ran, adapts, every = {}, {}, {}, set()
+    seen, ran, adapts, every, regated = {}, {}, {}, set(), set()
     for v in applicable:
         for name, r in v.get("tests", {}).items():
             every.add(name)
@@ -57,12 +57,14 @@ def main(vdir, out=None):
             if not r.get("ran", True):
                 continue
             ran.setdefault(name, []).append(v["platform"])
+            if r.get("regated"):
+                regated.add(name)
             if not r.get("passed"):
                 seen.setdefault(name, []).append((v["platform"], r.get("kind")))
             elif r.get("adapts"):
                 adapts.setdefault(name, []).append(v["platform"])
 
-    rows, narrow, blind, unrun, forced = [], [], [], [], []
+    rows, narrow, blind, unrun, forced, moved = [], [], [], [], [], []
     for name in sorted(every):
         where = seen.get(name, [])
         # Judge each test against the rows that ran it, not the rows that
@@ -74,6 +76,9 @@ def main(vdir, out=None):
         elif n == 0 and k:
             rows.append((name, f"adapts to the change on {k}/{m}"))
             forced.append(name)
+        elif n == 0 and name in regated:
+            rows.append((name, f"gating edited, passes at baseline on {m}"))
+            moved.append(name)
         elif n == 0:
             rows.append((name, f"passes at baseline on all {m}"))
             blind.append(name)
@@ -97,6 +102,12 @@ def main(vdir, out=None):
                   "a sanitizer. If this test is not", "about such a defect, "
                   "the result is more likely flaky than meaningful."]
 
+    if moved:
+        lines += ["", "This change edits where these run rather than what "
+                  "they assert, so the", "baseline pass measures the new "
+                  "gating against the old sources and is", "not evidence "
+                  "either way:", ""]
+        lines += [f"  {t}" for t in moved]
     if forced:
         lines += ["", "These cannot fail without the change, but their "
                   "pre-change form fails with", "it -- edits the change "
@@ -135,6 +146,10 @@ def main(vdir, out=None):
         if narrow:
             md += ["", "**Evidence from a single platform**", ""]
             md += [f"- `{n}` -- only `{p}` ({k})" for n, (p, k) in narrow]
+        if moved:
+            md += ["", "**Gating edited, so the baseline pass proves "
+                   "nothing**", ""]
+            md += [f"- `{t}`" for t in moved]
         if forced:
             md += ["", "**Adaptations the change forced**", ""]
             md += [f"- `{f}`" for f in forced]

--- a/.github/actions/observes-change/test-observes-change.py
+++ b/.github/actions/observes-change/test-observes-change.py
@@ -41,6 +41,19 @@ DIAG = re.compile(r"^[^\s].*?:\d+:\d+: error: (.*)$", re.M)
 # without it a test nothing executed is indistinguishable from one that
 # ran and passed.
 UNSUPPORTED = re.compile(r"^UNSUPPORTED: ", re.M)
+
+# What decides where a test runs, as opposed to what it asserts. A change
+# that edits these moves the test to new rows, and "passes at baseline"
+# then measures the new gating against the old sources -- which says
+# nothing about whether the test can observe the change.
+GATING = re.compile(r"^//\s*(?:REQUIRES|UNSUPPORTED|XFAIL):.*$", re.M)
+
+
+def gating(rev, path):
+    """The gating directives this test carries at rev, None if absent there."""
+    p = subprocess.run(["git", "show", f"{rev}:{path}"],
+                       capture_output=True, text=True, check=False)
+    return GATING.findall(p.stdout) if p.returncode == 0 else None
 # Project convention, not anything intrinsic; each is overridable so a
 # project laid out differently configures rather than forks.
 TEST_DIRS = ("test",)
@@ -234,13 +247,25 @@ def main():
                 annotate("notice", t, f"Not run on {a.platform}, so this "
                          "row has no evidence about it either way.")
             elif state == "PASS":
+                # A file the change adds has no pre-change gating to
+                # differ from, so it is not one the change re-gated.
+                was = gating(a.base_rev, t)
+                regated = was is not None and was != gating("HEAD", t)
                 verdict["tests"][t] = {"ran": True, "passed": True,
-                                       "kind": None}
-                print(f"{t:<{width + 2}}{'PASS':<13}none -- cannot fail for "
-                      f"this change")
-                annotate("warning", t, f"Passes on {a.platform} with this "
-                         "change reverted, so it cannot be its regression "
-                         "test. Another platform may still observe it.")
+                                       "kind": None, "regated": regated}
+                if regated:
+                    print(f"{t:<{width + 2}}{'PASS':<13}gating edited -- "
+                          f"runs where it did not")
+                    annotate("notice", t, f"This change edits where this test "
+                             "runs, not what it asserts, so passing with the "
+                             "change reverted is the expected result and not "
+                             "evidence either way.")
+                else:
+                    print(f"{t:<{width + 2}}{'PASS':<13}none -- cannot fail "
+                          f"for this change")
+                    annotate("warning", t, f"Passes on {a.platform} with this "
+                             "change reverted, so it cannot be its regression "
+                             "test. Another platform may still observe it.")
             else:
                 kind, note = classify(out)
                 verdict["tests"][t] = {"ran": True, "passed": False,


### PR DESCRIPTION
The baseline pass runs each touched test with the change's sources
reverted, and one that still passes is reported as a test the change
cannot have broken -- fair, unless what the change edited is that test's
REQUIRES. Then the run measures the new gating against the old sources,
which answers a question nobody asked: the change moved where the test
runs, not what it asserts. Enabling a suite on new rows is exactly that,
and every test it enables is told it belongs in another commit.

Read the gating directives on both sides and report those tests apart, so
the advice lands only on the ones that really do pin unrelated behavior.
A file the change adds has no pre-change gating to differ from, and is
not one the change re-gated.

That should fix the recent false positive in #2024.