### PR TITLE
Make CUDA builtin variables passive

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -540,6 +540,10 @@ namespace clad {
     /// includes.
     clang::Expr* BuildEnzymeActivityMarkerRef(clang::Sema& semaRef,
                                               llvm::StringRef name);
+    /// Returns true if the expression represents a CUDA built-in variable
+    /// like threadIdx, blockIdx, blockDim, or gridDim.
+    bool isCUDABuiltinVariable(const clang::Expr* E,
+                               const clang::ASTContext& Context);
     } // namespace utils
     } // namespace clad
 

--- a/lib/Differentiator/ActivityAnalyzer.cpp
+++ b/lib/Differentiator/ActivityAnalyzer.cpp
@@ -1,6 +1,8 @@
 #include "ActivityAnalyzer.h"
 #include "AnalysisBase.h"
 
+#include "clad/Differentiator/CladUtils.h"
+
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/Expr.h"
@@ -344,6 +346,13 @@ bool VariedAnalyzer::TraverseCXXThisExpr(clang::CXXThisExpr* TE) {
 }
 
 bool VariedAnalyzer::TraverseCXXMemberCallExpr(clang::CXXMemberCallExpr* CE) {
+  if (utils::isCUDABuiltinVariable(
+          CE->getImplicitObjectArgument()->IgnoreParenImpCasts(),
+          m_AnalysisDC->getASTContext())) {
+    m_Varied = false;
+    return false;
+  }
+
   const CXXMethodDecl* Method = CE->getMethodDecl();
   auto params = Method->parameters();
 
@@ -419,6 +428,8 @@ bool VariedAnalyzer::TraverseUnaryOperator(UnaryOperator* UnOp) {
 }
 
 bool VariedAnalyzer::TraverseDeclRefExpr(DeclRefExpr* DRE) {
+  if (utils::isCUDABuiltinVariable(DRE, m_AnalysisDC->getASTContext()))
+    return false;
   // A reference to something that is not a variable -- a function passed as an
   // argument, an enumerator -- carries no varied state of its own.
   auto* VD = dyn_cast<VarDecl>(DRE->getDecl());

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1930,6 +1930,23 @@ namespace clad {
       } while (E->IgnoreImplicit() != E);
       return false;
     }
+    bool isCUDABuiltinVariable(const clang::Expr* E,
+                               const clang::ASTContext& Context) {
+      if (const auto* DRE = clang::dyn_cast<clang::DeclRefExpr>(E)) {
+        const clang::ValueDecl* VD = DRE->getDecl();
+        const clang::IdentifierInfo* II = VD->getIdentifier();
+        if (!II)
+          return false;
+        llvm::StringRef Name = II->getName();
+
+        if (Name == "threadIdx" || Name == "blockIdx" || Name == "blockDim" ||
+            Name == "gridDim") {
+          const clang::SourceManager& SM = Context.getSourceManager();
+          return SM.isInSystemHeader(VD->getLocation());
+        }
+      }
+      return false;
+    }
 
     /// Called in ShouldRecompute. In CUDA, to access a current thread/block id
     /// we use functions that do not change the state of any variable, since no

--- a/lib/Differentiator/TBRAnalyzer.cpp
+++ b/lib/Differentiator/TBRAnalyzer.cpp
@@ -194,6 +194,8 @@ void TBRAnalyzer::VisitCFGBlock(const CFGBlock& block) {
 }
 
 bool TBRAnalyzer::TraverseDeclRefExpr(DeclRefExpr* DRE) {
+  if (utils::isCUDABuiltinVariable(DRE, m_AnalysisDC->getASTContext()))
+    return false;
   setIsRequired(DRE);
   return false;
 }

--- a/test/CUDA/ActivityAnalysis.cu
+++ b/test/CUDA/ActivityAnalysis.cu
@@ -1,0 +1,61 @@
+// RUN: %cladclang_cuda -I%S/../../include --cuda-path=%cudapath \
+// RUN: --cuda-gpu-arch=%cudaarch %cudaldflags -oActivityTest.out \
+// RUN: -Xclang -plugin-arg-clad -Xclang -enable-va -Xclang -verify %s 2>&1 | %filecheck %s
+//
+// RUN: %if cuda-runtime %{ %cudarun ./ActivityTest.out | %filecheck_exec %s %}
+//
+// REQUIRES: cuda-compile
+//
+// expected-no-diagnostics
+
+#include <iostream>
+#include "clad/Differentiator/Differentiator.h"
+#include <cuda.h>
+
+__global__ void func(double* out, double x) {
+    double val = x;
+    dim3 t = threadIdx;
+    val = val + t.x + threadIdx.x;
+    val = val + blockIdx.x + blockDim.x + gridDim.x;
+    if (threadIdx.x == 0) {
+        val = val * 2.0;
+    }
+    out[threadIdx.x] = val;
+}
+
+// CHECK-LABEL: void func_grad(double *out, double x, double *_d_out, double *_d_x) {
+// CHECK-NOT: _d_threadIdx
+// CHECK: double val = x;
+// CHECK: dim3 t = threadIdx;
+// CHECK-NEXT: val = val + t.x + threadIdx.x;
+// CHECK: val = val + blockIdx.x + blockDim.x + gridDim.x;
+// CHECK: if
+// CHECK: val = val * 2.;
+// CHECK: }
+
+int main() {
+    double *d_out, *d_out_d, *d_x;
+    cudaMalloc(&d_out, sizeof(double) * 2);
+    cudaMalloc(&d_out_d, sizeof(double) * 2);
+    cudaMalloc(&d_x, sizeof(double));
+
+    double seed_out[2] = {0.0, 1.0};
+    double seed_x = 0;
+    
+    cudaMemcpy(d_out_d, seed_out, sizeof(double) * 2, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_x, &seed_x, sizeof(double), cudaMemcpyHostToDevice);
+
+    auto df = clad::gradient(func);
+    df.execute_kernel(dim3(1), dim3(2), d_out, 5.0, d_out_d, d_x);
+    cudaDeviceSynchronize();
+
+    double grad_x;
+    cudaMemcpy(&grad_x, d_x, sizeof(double), cudaMemcpyDeviceToHost);
+    std::cout << "Grad x: " << grad_x << std::endl;
+    // CHECK-EXEC: Grad x: 1
+    
+    cudaFree(d_out);
+    cudaFree(d_out_d);
+    cudaFree(d_x);
+    return 0;
+}


### PR DESCRIPTION
CUDA built-in variables such as threadIdx, blockIdx, blockDim, and gridDim are hardware execution context variables and should not be treated as active. This PR marks them as passive in Activity and TBR analysis, avoiding unnecessary adjoint allocations and tape entries. 