### PR TITLE
Give each generated node a location of its own.

### DIFF
--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -54,6 +54,8 @@ namespace clad {
 namespace clad {
 class ErrorEstimationHandler;
 
+class GeneratedCode;
+
 class VisitorBase;
 
 /// RAII handle for a cloned derivative function. cloneFunction opens one
@@ -110,6 +112,8 @@ struct DerivativeAndOverload {
     friend class JacobianModeVisitor;
     friend class ReverseModeForwPassVisitor;
     clang::Sema& m_Sema;
+    /// Distinct locations for the nodes clad builds; see GeneratedCode.
+    std::unique_ptr<GeneratedCode> m_GeneratedCode;
     plugin::CladPlugin& m_CladPlugin;
     clang::ASTContext& m_Context;
     DiffScheduler& m_Scheduler;
@@ -179,6 +183,9 @@ struct DerivativeAndOverload {
     DerivativeBuilder(clang::Sema& S, plugin::CladPlugin& P,
                       DiffScheduler& Scheduler);
     ~DerivativeBuilder();
+    /// A location for a node about to be built. Distinct per node, so that a
+    /// line note can later say where that node really ended up.
+    clang::SourceLocation GenLoc();
     /// Fuction to set the error diagnostic printing value for numerical
     /// differentiation.
     ///

--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -885,17 +885,31 @@ namespace clad {
                             clang::Expr* CUDAExecConfig = nullptr,
                             bool useRefQualifiedThisObj = false);
 
+    /// A location for a node about to be built, distinct from every other one
+    /// handed out.
+    clang::SourceLocation GenLoc();
+
+    /// Build a return statement. The `return` keyword is not one the user
+    /// wrote, so the location comes from here rather than from the caller.
+    clang::Stmt* BuildReturnStmt(clang::Expr* E);
+
+    /// Build `T(E)`. The parentheses are not ones the user wrote, so their
+    /// locations come from here rather than from the caller.
+    clang::Expr* BuildFunctionalCast(clang::TypeSourceInfo* TSI,
+                                     clang::QualType T, clang::Expr* E);
+
+    /// Build `(T)E`, likewise.
+    clang::Expr* BuildCStyleCast(clang::TypeSourceInfo* TSI, clang::Expr* E);
+
     /// Build a call to templated free function inside the clad namespace.
     ///
     /// \param[in] name name of the function
     /// \param[in] argExprs function arguments expressions
     /// \param[in] templateArgs template arguments
-    /// \param[in] loc location of the call
     /// \returns Built call expression
     clang::Expr* BuildCallExprToCladFunction(
         llvm::StringRef name, llvm::MutableArrayRef<clang::Expr*> argExprs,
-        llvm::ArrayRef<clang::TemplateArgument> templateArgs,
-        clang::SourceLocation loc);
+        llvm::ArrayRef<clang::TemplateArgument> templateArgs);
 
     /// Checks if the type is of clad::array<T> or clad::array_ref<T> type
     bool isCladArrayType(clang::QualType QT);
@@ -904,8 +918,7 @@ namespace clad {
     /// type and args.
     clang::Expr*
     BuildIdentityMatrixExpr(clang::QualType T,
-                            llvm::MutableArrayRef<clang::Expr*> Args,
-                            clang::SourceLocation Loc);
+                            llvm::MutableArrayRef<clang::Expr*> Args);
     /// Creates the expression Base.size() for the given Base expr. The Base
     /// expr must be of clad::array_ref<T> type
     clang::Expr* BuildArrayRefSizeExpr(clang::Expr* Base);

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -31,6 +31,7 @@
 #include "clang/Basic/Version.h"
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Overload.h"
+#include "clang/Sema/Ownership.h"
 #include "clang/Sema/Scope.h"
 #include "clang/Sema/ScopeInfo.h"
 #include "clang/Sema/Sema.h"

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1918,17 +1918,10 @@ BaseForwardModeVisitor::VisitImplicitCastExpr(const ImplicitCastExpr* ICE) {
 StmtDiff BaseForwardModeVisitor::VisitCXXFunctionalCastExpr(
     const clang::CXXFunctionalCastExpr* FCE) {
   StmtDiff castExprDiff = Visit(FCE->getSubExpr());
-  SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
-  Expr* clonedFCE = m_Sema
-                        .BuildCXXFunctionalCastExpr(
-                            FCE->getTypeInfoAsWritten(), FCE->getType(),
-                            fakeLoc, castExprDiff.getExpr(), fakeLoc)
-                        .get();
-  Expr* derivedFCE = m_Sema
-                         .BuildCXXFunctionalCastExpr(
-                             FCE->getTypeInfoAsWritten(), FCE->getType(),
-                             fakeLoc, castExprDiff.getExpr_dx(), fakeLoc)
-                         .get();
+  Expr* clonedFCE = BuildFunctionalCast(FCE->getTypeInfoAsWritten(),
+                                        FCE->getType(), castExprDiff.getExpr());
+  Expr* derivedFCE = BuildFunctionalCast(
+      FCE->getTypeInfoAsWritten(), FCE->getType(), castExprDiff.getExpr_dx());
   return {clonedFCE, derivedFCE};
 }
 
@@ -2040,9 +2033,9 @@ BaseForwardModeVisitor::VisitCharacterLiteral(const CharacterLiteral* CL) {
 }
 
 StmtDiff BaseForwardModeVisitor::VisitStringLiteral(const StringLiteral* SL) {
-  return StmtDiff(Clone(SL), StringLiteral::Create(
-                                 m_Context, "", SL->getKind(), SL->isPascal(),
-                                 SL->getType(), utils::GetValidSLoc(m_Sema)));
+  return StmtDiff(Clone(SL), StringLiteral::Create(m_Context, "", SL->getKind(),
+                                                   SL->isPascal(),
+                                                   SL->getType(), GenLoc()));
 }
 
 StmtDiff
@@ -2452,18 +2445,15 @@ StmtDiff BaseForwardModeVisitor::VisitCXXTemporaryObjectExpr(
     derivedArgs.push_back(argDiff.getExpr_dx());
   }
 
-  Expr* clonedTOE =
-      m_Sema
-          .ActOnCXXTypeConstructExpr(OpaquePtr<QualType>::make(TOE->getType()),
-                                     utils::GetValidSLoc(m_Sema), clonedArgs,
-                                     utils::GetValidSLoc(m_Sema),
-                                     TOE->isListInitialization())
-          .get();
+  Expr* clonedTOE = m_Sema
+                        .ActOnCXXTypeConstructExpr(
+                            OpaquePtr<QualType>::make(TOE->getType()), GenLoc(),
+                            clonedArgs, GenLoc(), TOE->isListInitialization())
+                        .get();
   Expr* derivedTOE =
       m_Sema
           .ActOnCXXTypeConstructExpr(OpaquePtr<QualType>::make(TOE->getType()),
-                                     utils::GetValidSLoc(m_Sema), derivedArgs,
-                                     utils::GetValidSLoc(m_Sema),
+                                     GenLoc(), derivedArgs, GenLoc(),
                                      TOE->isListInitialization())
           .get();
   return {clonedTOE, derivedTOE};

--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -53,6 +53,7 @@ llvm_add_library(cladDifferentiator
   DiffPlanner.cpp
   ErrorEstimator.cpp
   DerivativePrinter.cpp
+  GeneratedCode.cpp
   JacobianModeVisitor.cpp
   HessianModeVisitor.cpp
   MultiplexExternalRMVSource.cpp

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -7,6 +7,7 @@
 #include "clad/Differentiator/DerivativeBuilder.h"
 
 #include "ASTIntegrity.h"
+#include "GeneratedCode.h"
 #include "JacobianModeVisitor.h"
 
 #include "clad/Differentiator/BaseForwardModeVisitor.h"
@@ -60,12 +61,16 @@ namespace clad {
 
 DerivativeBuilder::DerivativeBuilder(clang::Sema& S, plugin::CladPlugin& P,
                                      DiffScheduler& Scheduler)
-    : m_Sema(S), m_CladPlugin(P), m_Context(S.getASTContext()),
-      m_Scheduler(Scheduler),
+    : m_Sema(S), m_GeneratedCode(std::make_unique<GeneratedCode>(S)),
+      m_CladPlugin(P), m_Context(S.getASTContext()), m_Scheduler(Scheduler),
       m_NodeCloner(new utils::StmtClone(m_Sema, m_Context)),
       m_BuiltinDerivativesNSD(nullptr), m_NumericalDiffNSD(nullptr) {}
 
 DerivativeBuilder::~DerivativeBuilder() {}
+
+SourceLocation DerivativeBuilder::GenLoc() {
+  return m_GeneratedCode->nextLoc();
+}
 
 static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
   DeclContext* DC = D->getLexicalDeclContext();
@@ -249,7 +254,7 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
 
     IdentifierInfo* II = &m_Context.Idents.get(Name);
     DeclarationName name(II);
-    DeclarationNameInfo DNInfo(name, utils::GetValidSLoc(m_Sema));
+    DeclarationNameInfo DNInfo(name, GenLoc());
     LookupResult R(m_Sema, DNInfo, Sema::LookupOrdinaryName);
 
     NamespaceDecl* NSD = nullptr;
@@ -586,14 +591,13 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
           Expr* dummy = utils::getZeroInit(ptrType, m_Sema);
           // Build ``*nullptr``
           dummy = m_Sema.BuildUnaryOp(nullptr, {}, UO_Deref, dummy).get();
-          SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
           // Build ``static_cast<parTy>(*nullptr)``
           dummy =
               m_Sema
                   .BuildCStyleCastExpr(
-                      fakeLoc,
+                      GenLoc(),
                       m_Sema.getASTContext().getTrivialTypeSourceInfo(parTy),
-                      fakeLoc, dummy)
+                      GenLoc(), dummy)
                   .get();
           Inits.push_back(dummy);
         }

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -10,6 +10,8 @@
 #include "GeneratedCode.h"
 #include "JacobianModeVisitor.h"
 
+#include "clang/Basic/SourceLocation.h"
+
 #include "clad/Differentiator/BaseForwardModeVisitor.h"
 #include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/Compatibility.h"

--- a/lib/Differentiator/GeneratedCode.cpp
+++ b/lib/Differentiator/GeneratedCode.cpp
@@ -1,0 +1,43 @@
+#include "GeneratedCode.h"
+
+#include "clang/Basic/SourceManager.h"
+#include "clang/Sema/Sema.h"
+
+#include "llvm/Support/MemoryBuffer.h"
+
+#include <string>
+
+using namespace clang;
+
+namespace clad {
+
+SourceLocation GeneratedCode::nextLoc() {
+  SourceManager& SM = m_Sema.getSourceManager();
+  if (m_Used == kSlotsPerChunk) {
+    // One newline per slot: a slot is a line, so its presumed line is already
+    // its index and a note only has to say where that line really is.
+    std::string Slots(kSlotsPerChunk, '\n');
+    // Named apart from the chunks before it. A chunk restarts line numbering
+    // at 1 and the line table keys a file by its name, so same-named chunks
+    // fold into one entry and two generated statements report the same
+    // position.
+    std::string Name = "<clad generated code>";
+    if (m_Chunks)
+      Name = "<clad generated code #" + std::to_string(m_Chunks + 1) + ">";
+    ++m_Chunks;
+    // Entered from the main file. A chunk outside the translation unit's
+    // include tree cannot be ordered against anything inside it:
+    // isBeforeInTranslationUnit walks up to a file the two share, runs out of
+    // parents, and reports "Unsortable locations found" -- which clad reaches
+    // whenever it sorts a derivative against a pragma. clang-repl enters its
+    // input buffers the same way.
+    m_Chunk = SM.createFileID(llvm::MemoryBuffer::getMemBufferCopy(Slots, Name),
+                              SrcMgr::C_User,
+                              /*LoadedID=*/0, /*LoadedOffset=*/0,
+                              SM.getLocForStartOfFile(SM.getMainFileID()));
+    m_Used = 0;
+  }
+  return SM.getLocForStartOfFile(m_Chunk).getLocWithOffset(m_Used++);
+}
+
+} // namespace clad

--- a/lib/Differentiator/GeneratedCode.cpp
+++ b/lib/Differentiator/GeneratedCode.cpp
@@ -1,5 +1,6 @@
 #include "GeneratedCode.h"
 
+#include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Sema/Sema.h"
 
@@ -37,7 +38,10 @@ SourceLocation GeneratedCode::nextLoc() {
                               SM.getLocForStartOfFile(SM.getMainFileID()));
     m_Used = 0;
   }
-  return SM.getLocForStartOfFile(m_Chunk).getLocWithOffset(m_Used++);
+  // Signed, because that is what getLocWithOffset takes; a slot index is
+  // bounded by kSlotsPerChunk, so it always fits.
+  return SM.getLocForStartOfFile(m_Chunk).getLocWithOffset(
+      static_cast<int>(m_Used++));
 }
 
 } // namespace clad

--- a/lib/Differentiator/GeneratedCode.h
+++ b/lib/Differentiator/GeneratedCode.h
@@ -1,0 +1,46 @@
+#ifndef CLAD_DIFFERENTIATOR_GENERATEDCODE_H
+#define CLAD_DIFFERENTIATOR_GENERATEDCODE_H
+
+#include "clang/Basic/SourceLocation.h"
+
+namespace clang {
+class Sema;
+} // namespace clang
+
+namespace clad {
+
+/// The code clad generates, and the source locations that point into it.
+///
+/// A location has to be supplied when a node is built, long before the text
+/// that node will be printed as exists, so it cannot be the node's real
+/// position. What it can be is *distinct*, which is enough to tell two
+/// generated nodes apart in a diagnostic or in DWARF, and enough for a line
+/// note to say later where each one really ended up.
+///
+/// Slots come from buffers of newlines, one per line, so a slot's presumed
+/// line is its index. They are allocated in chunks as slots run out. One large
+/// buffer instead would not do: a buffer handed to the SourceManager is fixed,
+/// and reserving generously is not free either, because every slot is written
+/// and the SourceManager scans a buffer end to end to build its line table the
+/// first time anyone asks for a line number in it.
+class GeneratedCode {
+  /// Slots per buffer. A chunk is paid for in full once allocated, so this
+  /// trades memory against how many files a derivative is split across -- the
+  /// first is not allocated until the first slot is asked for.
+  static constexpr unsigned kSlotsPerChunk = 8192;
+
+  clang::Sema& m_Sema;
+  clang::FileID m_Chunk;
+  unsigned m_Used = kSlotsPerChunk; // forces the first nextLoc() to allocate
+  unsigned m_Chunks = 0; // names the next chunk apart from the ones before it
+
+public:
+  explicit GeneratedCode(clang::Sema& S) : m_Sema(S) {}
+
+  /// A location no other generated node has been given.
+  clang::SourceLocation nextLoc();
+};
+
+} // namespace clad
+
+#endif // CLAD_DIFFERENTIATOR_GENERATEDCODE_H

--- a/lib/Differentiator/JacobianModeVisitor.cpp
+++ b/lib/Differentiator/JacobianModeVisitor.cpp
@@ -197,14 +197,14 @@ DerivativeAndOverload JacobianModeVisitor::Derive() {
         // and number of columns equal to the number of independent variables
         llvm::SmallVector<Expr*, 3> args = {getSize, buildIndVarCountRef(),
                                             offsetExpr};
-        dVectorParam = BuildIdentityMatrixExpr(dParamType, args, loc);
+        dVectorParam = BuildIdentityMatrixExpr(dParamType, args);
 
         offsetTracker.advanceByArray(getSize);
       } else {
         // Create a one hot vector for the parameter.
         llvm::SmallVector<Expr*, 2> args = {buildIndVarCountRef(), offsetExpr};
-        dVectorParam = BuildCallExprToCladFunction("one_hot_vector", args,
-                                                   {dParamType}, loc);
+        dVectorParam =
+            BuildCallExprToCladFunction("one_hot_vector", args, {dParamType});
         offsetTracker.advanceByScalar();
       }
       ++independentVarIndex;
@@ -216,8 +216,8 @@ DerivativeAndOverload JacobianModeVisitor::Derive() {
       // This parameter is not an independent variable.
       // Initialize by all zeros.
       Expr* dCount = buildIndVarCountRef();
-      dVectorParam = BuildCallExprToCladFunction("zero_vector", {dCount},
-                                                 {dParamType}, loc);
+      dVectorParam =
+          BuildCallExprToCladFunction("zero_vector", {dCount}, {dParamType});
     }
 
     // For each function arg to be differentiated, create a variable
@@ -262,13 +262,7 @@ StmtDiff JacobianModeVisitor::VisitReturnStmt(const clang::ReturnStmt* RS) {
     return nullptr;
 
   StmtDiff retValDiff = Visit(RS->getRetValue());
-  // This can instantiate as part of the move or copy initialization and
-  // needs a fake source location.
-  SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
-  Stmt* returnStmt =
-      m_Sema
-          .ActOnReturnStmt(fakeLoc, retValDiff.getExpr_dx(), getCurrentScope())
-          .get();
+  Stmt* returnStmt = BuildReturnStmt(retValDiff.getExpr_dx());
   return StmtDiff(returnStmt);
 }
 } // end namespace clad

--- a/lib/Differentiator/PushForwardModeVisitor.cpp
+++ b/lib/Differentiator/PushForwardModeVisitor.cpp
@@ -8,6 +8,9 @@
 #include "clad/Differentiator/BaseForwardModeVisitor.h"
 
 #include "clad/Differentiator/CladUtils.h"
+#include "clad/Differentiator/DerivativeBuilder.h"
+
+#include "clang/AST/Stmt.h"
 
 #include "llvm/Support/SaveAndRestore.h"
 

--- a/lib/Differentiator/PushForwardModeVisitor.cpp
+++ b/lib/Differentiator/PushForwardModeVisitor.cpp
@@ -45,12 +45,8 @@ StmtDiff PushForwardModeVisitor::VisitReturnStmt(const ReturnStmt* RS) {
             .get();
   }
   llvm::SmallVector<Expr*, 2> returnValues = {retVal, retVal_dx};
-  // This can instantiate as part of the move or copy initialization and
-  // needs a fake source location.
-  SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
-  Expr* initList = m_Sema.ActOnInitList(fakeLoc, returnValues, noLoc).get();
-  Stmt* returnStmt =
-      m_Sema.ActOnReturnStmt(fakeLoc, initList, getCurrentScope()).get();
+  Expr* initList = m_Sema.ActOnInitList(GenLoc(), returnValues, noLoc).get();
+  Stmt* returnStmt = BuildReturnStmt(initList);
   return StmtDiff(returnStmt);
 }
 } // end namespace clad

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -1413,7 +1413,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         Clone(SL),
         StringLiteral::Create(m_Context, "", SL->getKind(), SL->isPascal(),
                               utils::getNonConstType(SL->getType(), m_Sema),
-                              utils::GetValidSLoc(m_Sema)));
+                              GenLoc()));
   }
 
   StmtDiff ReverseModeVisitor::VisitCXXNullPtrLiteralExpr(

--- a/lib/Differentiator/VectorForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorForwardModeVisitor.cpp
@@ -139,14 +139,14 @@ DerivativeAndOverload VectorForwardModeVisitor::Derive() {
         // and number of columns equal to the number of independent variables
         llvm::SmallVector<Expr*, 3> args = {getSize, buildIndVarCountRef(),
                                             offsetExpr};
-        dVectorParam = BuildIdentityMatrixExpr(dParamType, args, loc);
+        dVectorParam = BuildIdentityMatrixExpr(dParamType, args);
 
         offsetTracker.advanceByArray(getSize);
       } else {
         // Create a one hot vector for the parameter.
         llvm::SmallVector<Expr*, 2> args = {buildIndVarCountRef(), offsetExpr};
-        dVectorParam = BuildCallExprToCladFunction("one_hot_vector", args,
-                                                   {dParamType}, loc);
+        dVectorParam =
+            BuildCallExprToCladFunction("one_hot_vector", args, {dParamType});
         offsetTracker.advanceByScalar();
       }
       ++independentVarIndex;
@@ -158,8 +158,8 @@ DerivativeAndOverload VectorForwardModeVisitor::Derive() {
       // This parameter is not an independent variable.
       // Initialize by all zeros.
       Expr* dCount = buildIndVarCountRef();
-      dVectorParam = BuildCallExprToCladFunction("zero_vector", {dCount},
-                                                 {dParamType}, loc);
+      dVectorParam =
+          BuildCallExprToCladFunction("zero_vector", {dCount}, {dParamType});
     }
 
     // For each function arg to be differentiated, create a variable
@@ -391,19 +391,17 @@ VectorForwardModeVisitor::DifferentiateVarDecl(const VarDecl* VD) {
 
 StmtDiff VectorForwardModeVisitor::VisitFloatingLiteral(
     const clang::FloatingLiteral* FL) {
-  SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
   Expr* dCount = buildIndVarCountRef();
-  auto* zero_vec = BuildCallExprToCladFunction("zero_vector", {dCount},
-                                               {FL->getType()}, fakeLoc);
+  auto* zero_vec =
+      BuildCallExprToCladFunction("zero_vector", {dCount}, {FL->getType()});
   return StmtDiff(Clone(FL), zero_vec);
 }
 
 StmtDiff
 VectorForwardModeVisitor::VisitIntegerLiteral(const clang::IntegerLiteral* IL) {
-  SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
   Expr* dCount = buildIndVarCountRef();
-  auto* zero_vec = BuildCallExprToCladFunction("zero_vector", {dCount},
-                                               {IL->getType()}, fakeLoc);
+  auto* zero_vec =
+      BuildCallExprToCladFunction("zero_vector", {dCount}, {IL->getType()});
   return StmtDiff(Clone(IL), zero_vec);
 }
 

--- a/lib/Differentiator/VectorPushForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorPushForwardModeVisitor.cpp
@@ -61,12 +61,8 @@ VectorPushForwardModeVisitor::VisitReturnStmt(const clang::ReturnStmt* RS) {
   StmtDiff retValDiff = Visit(RS->getRetValue());
   llvm::SmallVector<Expr*, 2> returnValues = {retValDiff.getExpr(),
                                               retValDiff.getExpr_dx()};
-  // This can instantiate as part of the move or copy initialization and
-  // needs a fake source location.
-  SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
-  Expr* initList = m_Sema.ActOnInitList(fakeLoc, returnValues, noLoc).get();
-  Stmt* returnStmt =
-      m_Sema.ActOnReturnStmt(fakeLoc, initList, getCurrentScope()).get();
+  Expr* initList = m_Sema.ActOnInitList(GenLoc(), returnValues, noLoc).get();
+  Stmt* returnStmt = BuildReturnStmt(initList);
   return StmtDiff(returnStmt);
 }
 

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -68,7 +68,7 @@ namespace clad {
         m_Context,
         Stmts_ref /**/ CLAD_COMPAT_CLANG15_CompoundStmt_Create_ExtraParam2(
             FPOptionsOverride()),
-        utils::GetValidSLoc(m_Sema), utils::GetValidSLoc(m_Sema));
+        GenLoc(), GenLoc());
   }
 
   bool VisitorBase::isUnusedResult(const Expr* E) {
@@ -298,7 +298,6 @@ namespace clad {
                                          clad_compat::NestedNameSpecifierTy NNS,
                                          ExprValueKind VK /*=VK_LValue*/) {
     CXXScopeSpec CSS;
-    SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
 
     // A local variable or parameter is never name-qualified: `NS::local` does
     // not exist. Building a qualifier for one is not only meaningless printing
@@ -339,7 +338,7 @@ namespace clad {
     // (the trivial-scope wraps it as Global); skip when there's no
     // qualifier so local-variable refs print bare.
     if (clad_compat::hasQualifier(NNS))
-      CSS.MakeTrivial(m_Context, NNS, fakeLoc);
+      CSS.MakeTrivial(m_Context, NNS, GenLoc());
     QualType T = D->getType();
     T = T.getNonReferenceType();
     return cast<DeclRefExpr>(clad_compat::GetResult<Expr*>(
@@ -718,7 +717,7 @@ namespace clad {
     }
     // Debug clang requires the location to be valid
     if (!OpLoc.isValid())
-      OpLoc = utils::GetValidSLoc(m_Sema);
+      OpLoc = GenLoc();
     // Call function for UnaryMinus
     if (OpCode == UO_Minus)
       return ResolveUnaryMinus(E->IgnoreCasts(), OpLoc);
@@ -745,7 +744,7 @@ namespace clad {
       return nullptr;
     // Debug clang requires the location to be valid
     if (!OpLoc.isValid())
-      OpLoc = utils::GetValidSLoc(m_Sema);
+      OpLoc = GenLoc();
     return m_Sema.BuildBinOp(nullptr, OpLoc, OpCode, L, R).get();
   }
 
@@ -788,10 +787,9 @@ namespace clad {
   Expr* VisitorBase::BuildArraySubscript(
       Expr* Base, const llvm::SmallVectorImpl<clang::Expr*>& Indices) {
     Expr* result = Base;
-    SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
     for (Expr* I : Indices)
       result =
-          m_Sema.CreateBuiltinArraySubscriptExpr(result, fakeLoc, I, fakeLoc)
+          m_Sema.CreateBuiltinArraySubscriptExpr(result, GenLoc(), I, GenLoc())
               .get();
     return result;
   }
@@ -1022,10 +1020,27 @@ namespace clad {
     return call;
   }
 
+  SourceLocation VisitorBase::GenLoc() { return m_Builder.GenLoc(); }
+
+  Stmt* VisitorBase::BuildReturnStmt(Expr* E) {
+    return m_Sema.ActOnReturnStmt(GenLoc(), E, getCurrentScope()).get();
+  }
+
+  Expr* VisitorBase::BuildFunctionalCast(TypeSourceInfo* TSI, QualType T,
+                                         Expr* E) {
+    // One location per parenthesis: they are separate tokens.
+    return m_Sema.BuildCXXFunctionalCastExpr(TSI, T, GenLoc(), E, GenLoc())
+        .get();
+  }
+
+  Expr* VisitorBase::BuildCStyleCast(TypeSourceInfo* TSI, Expr* E) {
+    return m_Sema.BuildCStyleCastExpr(GenLoc(), TSI, GenLoc(), E).get();
+  }
+
   Expr* VisitorBase::BuildCallExprToCladFunction(
       llvm::StringRef name, llvm::MutableArrayRef<clang::Expr*> argExprs,
-      llvm::ArrayRef<clang::TemplateArgument> templateArgs,
-      SourceLocation loc) {
+      llvm::ArrayRef<clang::TemplateArgument> templateArgs) {
+    const SourceLocation loc = GenLoc();
     DeclarationName declName = &m_Context.Idents.get(name);
     clang::LookupResult R(m_Sema, declName, noLoc, Sema::LookupOrdinaryName);
 
@@ -1051,10 +1066,8 @@ namespace clad {
   }
 
   Expr* VisitorBase::BuildIdentityMatrixExpr(clang::QualType T,
-                                             MutableArrayRef<Expr*> Args,
-                                             clang::SourceLocation Loc) {
-    return BuildCallExprToCladFunction(/*name=*/"identity_matrix", Args, {T},
-                                       Loc);
+                                             MutableArrayRef<Expr*> Args) {
+    return BuildCallExprToCladFunction(/*name=*/"identity_matrix", Args, {T});
   }
 
   Expr* VisitorBase::BuildArrayRefSizeExpr(Expr* Base) {
@@ -1561,9 +1574,7 @@ namespace clad {
                                       typeInfo, init, noLoc, noLoc)
                    .get();
       } else {
-        SourceLocation fakeLoc = utils::GetValidSLoc(m_Sema);
-        init =
-            m_Sema.BuildCStyleCastExpr(fakeLoc, typeInfo, fakeLoc, init).get();
+        init = BuildCStyleCast(typeInfo, init);
       }
 
       auto* diffVD =
@@ -1632,7 +1643,7 @@ namespace clad {
                                        SourceLocation OpLoc) {
     // Sema requires a valid location for rebuilt operator calls.
     if (!OpLoc.isValid())
-      OpLoc = utils::GetValidSLoc(m_Sema);
+      OpLoc = GenLoc();
 
     // First check operator kinds that are not considered binary/unary.
 

--- a/test/Misc/GeneratedCodeDebugInfo.C
+++ b/test/Misc/GeneratedCodeDebugInfo.C
@@ -1,0 +1,79 @@
+// Debug info for code clad wrote.
+//
+// A generated node has no location of its own, so clad gives it one from a
+// buffer of its own -- and that has to survive all the way into DWARF, or a
+// debugger stopping inside a derivative has nothing to show. Before this,
+// generated instructions were attributed to whatever the user happened to
+// have on line one of their file.
+//
+// REQUIRES: llvm-dwarfdump
+// RUN: %cladclang -g -gdwarf-5 -O0 -c %s -I%S/../../include -o %t.o
+// RUN: %llvm-dwarfdump --debug-line %t.o | %filecheck %s
+//
+// Two generated statements do not report one position. Counted rather than
+// pinned to particular lines: which line a statement lands on depends on how
+// many nodes clad built before it, and asserting that would test the
+// generator's output instead of the property. Every row the buffer owns,
+// deduplicated by line -- one would mean every statement shares a position,
+// which is the state this replaces.
+// RUN: %llvm-dwarfdump --debug-line %t.o | awk '\
+// RUN:   BEGIN { want = -1 } \
+// RUN:   /file_names\[/ { idx++ } \
+// RUN:   /name: "<clad generated code>"/ { want = idx - 1 } \
+// RUN:   /^0x[0-9a-f]+ / && $4 == want { line[$2] = 1 } \
+// RUN:   END { n = 0; for (l in line) n++; print "distinct-lines", n }' \
+// RUN:   | %filecheck --check-prefix=DISTINCT %s
+// DISTINCT: distinct-lines {{[0-9][0-9]+}}
+
+#include "clad/Differentiator/Differentiator.h"
+
+// The generated buffer is a file as far as the line table is concerned, and it
+// is not the user's.
+// CHECK-DAG: name: "<clad generated code>"
+
+// A call in the body: the pullback of a call is where clad generates the most
+// code that is not a rewrite of something the user wrote.
+double helper(double x) { return x * x; }
+
+double f(double x) {
+  double t = helper(x);
+  t = t * x;
+  return t;
+}
+
+// A derivative with more generated nodes than one buffer holds continues in
+// another, since a buffer cannot grow once the SourceManager holds it. Each
+// restarts line numbering at 1, and the line table keys a file by its name --
+// so buffers sharing a name fold into one entry and their lines collide,
+// putting two different statements at the same file and line. Naming them
+// apart is what keeps a position unambiguous.
+// CHECK-DAG: name: "<clad generated code #2>"
+
+// Enough statements to spill past one buffer, without a file of that length.
+// Each one generates nodes in both sweeps, so this needs far fewer statements
+// than a buffer holds slots -- these fill seven of them. The margin is
+// deliberate: at only two, a target that generated somewhat fewer nodes per
+// statement would fit in one buffer and fail this for the wrong reason.
+#define CLAD_S1 t = t * 1.0000000001 + x * 0.5;
+#define CLAD_S8 CLAD_S1 CLAD_S1 CLAD_S1 CLAD_S1 CLAD_S1 CLAD_S1 CLAD_S1 CLAD_S1
+#define CLAD_S64 CLAD_S8 CLAD_S8 CLAD_S8 CLAD_S8 CLAD_S8 CLAD_S8 CLAD_S8 CLAD_S8
+#define CLAD_S512                                                              \
+  CLAD_S64 CLAD_S64 CLAD_S64 CLAD_S64 CLAD_S64 CLAD_S64 CLAD_S64 CLAD_S64
+#define CLAD_S2048 CLAD_S512 CLAD_S512 CLAD_S512 CLAD_S512
+
+double big(double x, double y) {
+  double t = x * y;
+  CLAD_S2048
+  return t;
+}
+
+int main() {
+  auto g = clad::gradient(f);
+  double d = 0;
+  g.execute(2, &d);
+
+  auto gbig = clad::gradient(big);
+  double dx = 0, dy = 0;
+  gbig.execute(1.0, 1.0, &dx, &dy);
+  return 0;
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -346,6 +346,23 @@ if clang_repl_path:
   config.available_features.add("clang-repl")
   config.substitutions.append(("%clang-repl", clang_repl_path))
 
+# A DWARF reader, for the tests that check what clad's locations become in the
+# line table. Not part of every LLVM install -- the toolchain clad's debug_build
+# row uses does not ship it -- so gate on the feature instead of assuming a name
+# on PATH resolves to anything.
+dwarfdump_path = ""
+for _cand in (os.path.join(config.llvm_tools_dir, "llvm-dwarfdump"),
+              os.path.join(inferred_binary_dir, "llvm-dwarfdump-{0}".format(config.clang_version_major)),
+              os.path.join(inferred_binary_dir, "llvm-dwarfdump")):
+  if os.path.exists(_cand):
+    dwarfdump_path = _cand
+    break
+if not dwarfdump_path:
+  dwarfdump_path = lit.util.which("llvm-dwarfdump", config.environment["PATH"]) or ""
+if dwarfdump_path:
+  config.available_features.add("llvm-dwarfdump")
+  config.substitutions.append(("%llvm-dwarfdump", dwarfdump_path))
+
 # Loadable module
 # FIXME: This should be supplied by Makefile or autoconf.
 #if sys.platform in ['win32', 'cygwin']:


### PR DESCRIPTION
A location has to be supplied when a node is built, long before the text that node will be printed as exists, so it cannot be the node's real position. Clad has therefore given every generated node the same placeholder, which is why generated code cannot be told apart in a diagnostic or in DWARF -- it all reports one position.

It does not have to be the real position to be useful. It has to be distinct. Hand out a location per node from buffers of newlines, one slot per line, and the difference between two generated nodes survives into whatever reads them. Where those nodes really ended up is then a question of remapping, which #line already does and which SourceManager exposes as AddLineNote -- and remapping needs no second copy of the AST.

Sites ask for one where they need it, and those building something clad's runtime provides do not ask at all: BuildCallExprToCladFunction and BuildIdentityMatrixExpr stop taking a location, which also drops four callers that were handing them the primal's. Only part of a derivative is distinguishable so far -- the many sites passing an invalid location still are not. The test reads the line table, and fails against the commit before this one.