### PR TITLE
[docs] update supported llvm versions and fix spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ double x, y, d_x, d_y, final_error = 0;
 df.execute(x, y, &d_x, &d_y, final_error);
 // After this, 'final_error' contains the floating point error in function 'f'.
 ```
-The above example generates the the error code using an in-built taylor approximation model. However, clad is capable of using any user defined custom model, for information on how to use you own custom model, please visit [this demo](https://github.com/vgvassilev/clad/tree/master/demos/ErrorEstimation/CustomModel).
+The above example generates the error code using an in-built taylor approximation model. However, clad is capable of using any user defined custom model, for information on how to use your own custom model, please visit [this demo](https://github.com/vgvassilev/clad/tree/master/demos/ErrorEstimation/CustomModel).
 
 More detail on the APIs can be found under clad's [user documentation](https://clad.readthedocs.io/en/latest/index.html).
 ### Compiling and executing your code with clad
@@ -272,7 +272,7 @@ Clad also provides certain flags to save and print the generated derivative code
   - `-Xclang -plugin-arg-clad -Xclang -fdump-derived-fn` (Clang <14)
 
 ## How to install
-At the moment, LLVM/Clang 11.0.x - 21.1.x are supported.
+At the moment, LLVM/Clang 12.0.x - 22.2.x are supported.
 
 ### Conda Installation
 
@@ -351,7 +351,7 @@ make check-clad
 ```
 pip3 install lit
 ```
-Clone the LLVM project and checkout the required LLVM version (Currently supported versions 8.x - 18.x)
+Clone the LLVM project and checkout the required LLVM version (Currently supported versions 12.0.x - 22.2.x)
 
 ```
 git clone https://github.com/llvm/llvm-project.git

--- a/docs/userDocs/source/user/CustomDerivatives.rst
+++ b/docs/userDocs/source/user/CustomDerivatives.rst
@@ -261,7 +261,7 @@ Some important things to note here:
 Reverse-forward custom derivatives
 ====================================
 
-This is an advance section. Please feel free to skip it if it is your first read of this document.
+This is an advanced section. Please feel free to skip it if it is your first read of this document.
 
 The reverse-forward custom derivative is used by the Clad reverse mode AD to determine
 the adjoint of a function's return value for functions which returns a reference or a
@@ -373,7 +373,7 @@ An example will make things clear::
 
 .. note::
 
-   If :code:`fn` is a :code:`const` member function, then the the primal
+   If :code:`fn` is a :code:`const` member function, then the primal
    object is taken as a :code:`const` parameter. For example, the signature
    of pushforward and pullback will be as follows for :code:`fn(...) const`::
 

--- a/docs/userDocs/source/user/InstallationAndUsage.rst
+++ b/docs/userDocs/source/user/InstallationAndUsage.rst
@@ -3,7 +3,7 @@ Clad Installation
 
 This page covers both installation and usage details for Clad.
 
-At the moment, LLVM/Clang 11.0.x - 21.0.x are supported.
+At the moment, LLVM/Clang 12.0.x - 22.2.x are supported.
 
 Conda Installation
 ====================

--- a/docs/userDocs/source/user/UsingClad.rst
+++ b/docs/userDocs/source/user/UsingClad.rst
@@ -777,7 +777,7 @@ function `double f(double, double)` example usage is described below::
   }
 
 The above example generates the floating point error estimation code using an in-built taylor approximation model. 
-However, Clad is capable of using any user defined custom model, for information on how to use you own custom model, 
+However, Clad is capable of using any user defined custom model, for information on how to use your own custom model, 
 please visit this `demo <https://github.com/vgvassilev/clad/tree/master/demos/ErrorEstimation/CustomModel>`__.
 This `tutorial <https://compiler-research.org/tutorials/fp_error_estimation_clad_tutorial/>`_
 provides a comprehensive guide on building your own custom models and understanding the working behind the error 


### PR DESCRIPTION
Updated the llvm version for clad as per the CMakeLists.txt. There are also some spelling errors like duplicated words or incomplete ones which are fixed in this patch.

NFC change only modifying the docs.