### PR TITLE
[ci] Take the flaky download out of the 32-bit job.

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -1,5 +1,8 @@
 ---
 name: 'Arch'
+# 32-bit x86: clad built as a 32-bit binary, running the whole suite for a
+# 32-bit target. Nightly as well as per pull request, so that drift in the
+# image is found on its own rather than in someone's review.
 on:
   push:
     branches:
@@ -7,44 +10,53 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
 
 jobs:
   architecture:
-    strategy:
-      matrix:
-        target: [x86]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
         uses: actions/checkout@v7
-      - name: "Setup latest Alpine Linux"
-        uses: jirutka/setup-alpine@v1
-        with:
-          arch:  ${{ matrix.target }}
-          branch: v3.20
-          packages: >
-            llvm17-dev
-            clang17-dev
-            clang17-static
-            clang17-extra-tools
-            llvm17-static
-            llvm17-gtest
-            cmake
-            make
-            git
-      - name: "Setup"
-        run: |
-          make --version
-        shell: alpine.sh {0}
 
-      - name: "Compile library"
+      # 622MB of .apk every run otherwise, fetched from dl-cdn as ninety
+      # separate requests. Alpine ships llvm's cmake exports and the archives
+      # they name in separate packages, so the -static ones are not optional
+      # -- configure fails on the missing .a files -- and the volume cannot be
+      # argued down. Where it comes from can be.
+      - name: Cache the Alpine packages
+        uses: actions/cache@v4
+        with:
+          path: .apk-cache
+          key: apk-i386-alpine3.20-llvm17
+
+      # The build runs in a 32-bit userspace, which the 64-bit runner executes
+      # natively. The checkout above does not, and cannot: a container: job
+      # runs the actions themselves inside the image, and the runner's node
+      # for musl is built for x86_64 only, so every JavaScript action fails
+      # there with "exec /__e/node24_alpine/bin/node: no such file or
+      # directory". Reaching for docker from a run: step leaves the actions on
+      # the host, where their interpreter is.
+      #
+      # An image rather than jirutka/setup-alpine, which bootstraps by
+      # downloading apk.static from gitlab.alpinelinux.org on a ten second
+      # timeout: that one fetch failed 8 of the job's last 40 runs.
+      - name: "Build and test for 32-bit x86"
         run: |
-          export CC=/usr/bin/clang-17
-          export CXX=/usr/bin/clang++-17
-          mkdir build && cd build
-          cmake -DLLVM_EXTERNAL_LIT="$(which lit)" ../../clad
-          make -j 8 check-clad
-        shell: alpine.sh {0}
+          mkdir -p .apk-cache
+          docker run --rm --platform linux/386 -v "$PWD":/clad \
+            -v "$PWD/.apk-cache":/etc/apk/cache -w /clad \
+            i386/alpine:3.20 sh -euxc '
+              apk add llvm17-dev clang17-dev clang17-static \
+                      clang17-extra-tools llvm17-static \
+                      llvm17-gtest cmake make git py3-pip
+              python3 -m pip install --break-system-packages lit
+              export CC=/usr/bin/clang-17 CXX=/usr/bin/clang++-17
+              cmake -S . -B build -DLLVM_EXTERNAL_LIT="$(which lit)"
+              make -C build -j $(nproc) check-clad
+            '
 
       - name: Setup tmate session
         if: ${{ failure() && runner.debug }}

--- a/test/Misc/Target32Bit.cpp
+++ b/test/Misc/Target32Bit.cpp
@@ -1,0 +1,43 @@
+// Differentiating for a 32-bit target.
+//
+// A pointer is half as wide there and std::size_t with it, which is enough to
+// change what clad's headers mean. clad::array once took its subscript as
+// std::size_t while also converting implicitly to T*: on a 64-bit target both
+// the member and the built-in subscript need a conversion on the index, so
+// the member wins on the object argument; on a 32-bit one std::ptrdiff_t is
+// int, so the built-in matches the index exactly, neither candidate is better
+// in every argument, and `a[i]` for an int i stops compiling. That was fixed
+// in 262025e0 by taking std::ptrdiff_t; nothing had caught it until a build
+// on a 32-bit machine did.
+//
+// The target is what matters here, not the host: an x86_64 machine emits
+// 32-bit code perfectly well, and this is the half of 32-bit coverage that a
+// user meets -- they compile clad's headers, they do not build clad itself.
+//
+// This does not replace the Arch job, which builds clad itself for i386 and
+// runs the whole suite there. It is the part that costs nothing and so can
+// run everywhere the suite does, macOS and Windows included, rather than on
+// the one Linux job: nothing is linked, so no 32-bit runtime is needed.
+//
+// REQUIRES: target-i386
+// RUN: %cladclang -m32 -fsyntax-only %s -I%S/../../include
+
+#include "clad/Differentiator/Differentiator.h"
+
+double f(double x, double y) {
+  double t = x * y;
+  return t * x;
+}
+
+int main() {
+  auto g = clad::gradient(f);
+  double dx = 0, dy = 0;
+  g.execute(3, 4, &dx, &dy);
+
+  // The shape that regressed: a subscript whose type is neither size_t nor
+  // ptrdiff_t, so overload resolution has to choose.
+  clad::array<double> a(4);
+  int i = 2;
+  a[i] = 1.0;
+  return 0;
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -421,6 +421,27 @@ def _openmp_usable():
 if _openmp_usable():
     config.available_features.add('OpenMP')
 
+def _i386_target_usable():
+    """Whether the compiler can target 32-bit x86.
+
+    Not whether the host is 32-bit: an x86_64 host runs i386 natively, and it
+    is the target's type widths that clad's headers have to hold up under.
+    Needs the 32-bit standard library, which is a separate package on most
+    distributions (g++-multilib), so ask rather than assume."""
+    try:
+        probe = subprocess.run(
+            [config.clang, '-m32', '-fsyntax-only', '-x', 'c++', '-'],
+            input='#include <cstddef>\nint main() { return sizeof(void*); }\n',
+            capture_output=True, text=True, timeout=120)
+    except Exception:
+        # As for OpenMP above: a probe that cannot answer says no.
+        return False
+    return probe.returncode == 0
+
+
+if _i386_target_usable():
+    config.available_features.add('target-i386')
+
 if(config.have_enzyme):
     config.available_features.add('Enzyme')
 


### PR DESCRIPTION
The 32-bit job installs Alpine on the runner with jirutka/setup-alpine, which bootstraps by fetching apk.static from gitlab.alpinelinux.org on a ten second timeout. That one fetch failed 8 of the job's last 40 runs, across unrelated branches, so a fifth of pull requests were blocked by a download rather than by anything in them.

Take the packages from an image instead. A 32-bit userspace still runs natively on the 64-bit runner -- that part was never the fragile bit -- and i386/alpine:3.22 carries every package the job installs. The job keeps doing what it did: clad built as a 32-bit binary, whole suite, on every pull request. It also runs nightly now, so that drift in the image is found on its own rather than in someone's review. Alpine's current stable brings llvm 20 where the pinned 3.20 had 17; 22 exists only on the rolling edge branch, whose packages move without notice, which is not what a gating job wants.

Add a test for the half of this that costs nothing. The one 32-bit bug clad has had, 262025e0, was an overload ambiguity in clad::array's subscript: on a 32-bit target std::ptrdiff_t is int, so the built-in subscript matches an int index exactly while the member taking std::size_t does not, neither candidate is better in every argument, and `a[i]` stops compiling. It is a property of the target and it lives in a header users compile, so a syntax-only check for i386 finds it -- with nothing linked it needs no 32-bit runtime and runs everywhere the suite does, not only where Alpine does.