### PR TITLE
Declare only clad-internal derivatives inline

### DIFF
--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -97,6 +97,17 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
     if (std::any_of(Previous.begin(), Previous.end(), definedNotInline))
       dFD->setInlineSpecified(false);
 
+    // Inline fits a derivative clad calls but never names outside: a unit that
+    // does not call one should not emit it. The root of the request graph is
+    // the one name that leaves clad, and an interpreter reaches it from a
+    // later translation unit, where a discardable definition is emitted again
+    // along with every derivative it calls. Let the root follow the primal,
+    // which is what decides whether naming it twice is a redefinition at all.
+    if (R.CallUpdateRequired && R.Function) {
+      dFD->setInlineSpecified(R.Function->isInlineSpecified());
+      dFD->setImplicitlyInline(R.Function->isInlined());
+    }
+
     // Check if we created a top-level decl with the same name for another
     // class.
     // FIXME: This case should be addressed by providing proper names and

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -28,7 +28,7 @@ __device__ __host__ double gauss(const double* x, double* p, double sigma, int d
 }
 
 
-// CHECK: __attribute__((device)) __attribute__((host)) inline void gauss_grad_1(const double *x, double *p, double sigma, int dim, double *_d_p) {
+// CHECK: __attribute__((device)) __attribute__((host)) void gauss_grad_1(const double *x, double *p, double sigma, int dim, double *_d_p) {
 //CHECK-NEXT:     double _d_sigma = 0.;
 //CHECK-NEXT:     int _d_dim = 0;
 //CHECK-NEXT:     int _d_i = 0;

--- a/test/Enzyme/GradientsComparisonWithClad.C
+++ b/test/Enzyme/GradientsComparisonWithClad.C
@@ -15,7 +15,7 @@ __attribute__((always_inline)) double f_add1(double x, double y) {
   return x + y;
 }
 
-// CHECK: __attribute__((always_inline)) inline void f_add1_grad_enzyme(double x, double y, double *_d_x, double *_d_y) {
+// CHECK: __attribute__((always_inline)) void f_add1_grad_enzyme(double x, double y, double *_d_x, double *_d_y) {
 // CHECK-NEXT:     clad::EnzymeGradient<2> grad = __enzyme_autodiff_f_add1(f_add1, x, y);
 // CHECK-NEXT:     *_d_x = grad.d_arr[0U];
 // CHECK-NEXT:     *_d_y = grad.d_arr[1U];

--- a/test/Gradient/MemberFunctions.C
+++ b/test/Gradient/MemberFunctions.C
@@ -367,7 +367,7 @@ public:
 
   static double static_mem_fn(double u, double v) { return u + v; }
   
-  // CHECK: static inline void static_mem_fn_grad(double u, double v, double *_d_u, double *_d_v) {
+  // CHECK: static void static_mem_fn_grad(double u, double v, double *_d_u, double *_d_v) {
   // CHECK-NEXT:     {
   // CHECK-NEXT:         *_d_u += 1;
   // CHECK-NEXT:         *_d_v += 1;

--- a/test/Hessian/Arrays.C
+++ b/test/Hessian/Arrays.C
@@ -6,7 +6,7 @@
 #include "clad/Differentiator/Differentiator.h"
 
 double f(double i, double j[2]) { return i * j[0] * j[1]; }
-// CHECK: inline void f_hessian(double i, double j[2], double *hessianMatrix) {
+// CHECK: void f_hessian(double i, double j[2], double *hessianMatrix) {
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_y{0., 0.};
 // CHECK-NEXT:     _d_y.pushforward = 1.;
 // CHECK-NEXT:     double _d_i(0.);
@@ -23,7 +23,7 @@ double f(double i, double j[2]) { return i * j[0] * j[1]; }
 // CHECK-NEXT: }
 
 double g(double i, double j[2]) { return i * (j[0] + j[1]); }
-// CHECK: inline void g_hessian(double i, double j[2], double *hessianMatrix) {
+// CHECK: void g_hessian(double i, double j[2], double *hessianMatrix) {
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_y{0., 0.};
 // CHECK-NEXT:     _d_y.pushforward = 1.;
 // CHECK-NEXT:     double _d_i(0.);
@@ -47,7 +47,7 @@ double h(double arr[3], double weights[3], double multiplier) {
   weightedSum *= multiplier;
   return weightedSum * weightedSum;
 }
-// CHECK: inline void h_hessian_diagonal(double arr[3], double weights[3], double multiplier, double *diagonalHessianVector) {
+// CHECK: void h_hessian_diagonal(double arr[3], double weights[3], double multiplier, double *diagonalHessianVector) {
 // CHECK-NEXT:     *(diagonalHessianVector + {{0U|0UL|0ULL}}) = h_d2arg0_0(arr, weights, multiplier);
 // CHECK-NEXT:     *(diagonalHessianVector + {{1U|1UL|1ULL}}) = h_d2arg0_1(arr, weights, multiplier);
 // CHECK-NEXT:     *(diagonalHessianVector + {{2U|2UL|2ULL}}) = h_d2arg0_2(arr, weights, multiplier);

--- a/test/Hessian/BuiltinDerivatives.C
+++ b/test/Hessian/BuiltinDerivatives.C
@@ -20,7 +20,7 @@ float f1(float x) {
 
 // CHECK: inline void f1_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0);
 
-// CHECK: inline void f1_hessian(float x, float *hessianMatrix) {
+// CHECK: void f1_hessian(float x, float *hessianMatrix) {
 // CHECK-NEXT:     clad::ValueAndPushforward<float, float> _d_y{0.F, 0.F};
 // CHECK-NEXT:     _d_y.pushforward = 1.;
 // CHECK-NEXT:     float _d_x(0.F);
@@ -40,7 +40,7 @@ float f2(float x) {
 
 // CHECK: inline void f2_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0);
 
-// CHECK: inline void f2_hessian(float x, float *hessianMatrix) {
+// CHECK: void f2_hessian(float x, float *hessianMatrix) {
 // CHECK-NEXT:     clad::ValueAndPushforward<float, float> _d_y{0.F, 0.F};
 // CHECK-NEXT:     _d_y.pushforward = 1.;
 // CHECK-NEXT:     float _d_x(0.F);
@@ -61,7 +61,7 @@ float f3(float x) {
 
 // CHECK: inline void f3_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0);
 
-// CHECK: inline void f3_hessian(float x, float *hessianMatrix) {
+// CHECK: void f3_hessian(float x, float *hessianMatrix) {
 // CHECK-NEXT:     clad::ValueAndPushforward<float, float> _d_y{0.F, 0.F};
 // CHECK-NEXT:     _d_y.pushforward = 1.;
 // CHECK-NEXT:     float _d_x(0.F);
@@ -82,7 +82,7 @@ float f4(float x) {
 
 // CHECK: inline void f4_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0);
 
-// CHECK: inline void f4_hessian(float x, float *hessianMatrix) {
+// CHECK: void f4_hessian(float x, float *hessianMatrix) {
 // CHECK-NEXT:     clad::ValueAndPushforward<float, float> _d_y{0.F, 0.F};
 // CHECK-NEXT:     _d_y.pushforward = 1.;
 // CHECK-NEXT:     float _d_x(0.F);
@@ -103,7 +103,7 @@ float f5(float x) {
 
 // CHECK: inline void f5_pushforward_pullback(float x, float _d_x, clad::ValueAndPushforward<float, float> _d_y, float *_d_x0);
 
-// CHECK: inline void f5_hessian(float x, float *hessianMatrix) {
+// CHECK: void f5_hessian(float x, float *hessianMatrix) {
 // CHECK-NEXT:     clad::ValueAndPushforward<float, float> _d_y{0.F, 0.F};
 // CHECK-NEXT:     _d_y.pushforward = 1.;
 // CHECK-NEXT:     float _d_x(0.F);
@@ -125,7 +125,7 @@ float f6(float x, float y) {
 
 // CHECK: inline void f6_pushforward_pullback(float x, float y, float _d_x, float _d_y, clad::ValueAndPushforward<float, float> _d_y0, float *_d_x0, float *_d_y1);
 
-// CHECK: inline void f6_hessian(float x, float y, float *hessianMatrix) {
+// CHECK: void f6_hessian(float x, float y, float *hessianMatrix) {
 // CHECK-NEXT:     clad::ValueAndPushforward<float, float> _d_y{0.F, 0.F};
 // CHECK-NEXT:     _d_y.pushforward = 1.;
 // CHECK-NEXT:     float _d_x(0.F);

--- a/test/Hessian/Hessians.C
+++ b/test/Hessian/Hessians.C
@@ -17,7 +17,7 @@ __attribute__((always_inline)) double f_cubed_add1(double a, double b) {
 //CHECK:{{[__attribute__((always_inline)) ]*}}inline void f_cubed_add1_pushforward_pullback(double a, double b, double _d_a, double _d_b, clad::ValueAndPushforward<double, double> _d_y, double *_d_a0, double *_d_b0){{[ __attribute__((always_inline))]*}};
 
 void f_cubed_add1_hessian(double a, double b, double *hessianMatrix);
-//CHECK:{{[__attribute__((always_inline)) ]*}}inline void f_cubed_add1_hessian(double a, double b, double *hessianMatrix){{[ __attribute__((always_inline))]*}} {
+//CHECK:{{[__attribute__((always_inline)) ]*}}void f_cubed_add1_hessian(double a, double b, double *hessianMatrix){{[ __attribute__((always_inline))]*}} {
 //CHECK-NEXT:    clad::ValueAndPushforward<double, double> _d_y{0., 0.};
 //CHECK-NEXT:    _d_y.pushforward = 1.;
 //CHECK-NEXT:    double _d_a(0.);
@@ -35,7 +35,7 @@ double f_suvat1(double u, double t) {
 }
 
 void f_suvat1_hessian(double u, double t, double *hessianMatrix);
-//CHECK:inline void f_suvat1_hessian(double u, double t, double *hessianMatrix) {
+//CHECK:void f_suvat1_hessian(double u, double t, double *hessianMatrix) {
 //CHECK-NEXT:    clad::ValueAndPushforward<double, double> _d_y{0., 0.};
 //CHECK-NEXT:    _d_y.pushforward = 1.;
 //CHECK-NEXT:    double _d_u(0.);
@@ -58,7 +58,7 @@ double f_cond3(double x, double c) {
 }
 
 void f_cond3_hessian(double x, double c, double *hessianMatrix);
-//CHECK:inline void f_cond3_hessian(double x, double c, double *hessianMatrix) {
+//CHECK:void f_cond3_hessian(double x, double c, double *hessianMatrix) {
 //CHECK-NEXT:    clad::ValueAndPushforward<double, double> _d_y{0., 0.};
 //CHECK-NEXT:    _d_y.pushforward = 1.;
 //CHECK-NEXT:    double _d_x(0.);
@@ -76,7 +76,7 @@ double f_power10(double x) {
 }
 
 void f_power10_hessian(double x, double *hessianMatrix);
-//CHECK:inline void f_power10_hessian(double x, double *hessianMatrix) {
+//CHECK:void f_power10_hessian(double x, double *hessianMatrix) {
 //CHECK-NEXT:    clad::ValueAndPushforward<double, double> _d_y{0., 0.};
 //CHECK-NEXT:    _d_y.pushforward = 1.;
 //CHECK-NEXT:    double _d_x(0.);
@@ -102,7 +102,7 @@ struct Experiment {
                              double *_d_j);
 
   void someMethod_hessian(double x, double *hessianMatrix);
-  //CHECK:inline void someMethod_hessian(double i, double j, double *hessianMatrix) {
+  //CHECK:void someMethod_hessian(double i, double j, double *hessianMatrix) {
   //CHECK-NEXT:    Experiment _d_this;
   //CHECK-NEXT:    this->someMethod_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
   //CHECK-NEXT:    Experiment _d_this0;
@@ -129,7 +129,7 @@ struct Widget {
   void memFn_1_hessian(double i,
                        double j,
                        double *hessianMatrix);
-  //CHECK:inline void memFn_1_hessian(double i, double j, double *hessianMatrix) {
+  //CHECK:void memFn_1_hessian(double i, double j, double *hessianMatrix) {
   //CHECK-NEXT:    Widget _d_this;
   //CHECK-NEXT:    this->memFn_1_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
   //CHECK-NEXT:    Widget _d_this0;
@@ -154,7 +154,7 @@ struct Widget {
   void memFn_2_hessian(double i,
                        double j,
                        double *hessianMatrix);
-  //CHECK:inline void memFn_2_hessian(double i, double j, double *hessianMatrix) {
+  //CHECK:void memFn_2_hessian(double i, double j, double *hessianMatrix) {
   //CHECK-NEXT:    Widget _d_this;
   //CHECK-NEXT:    this->memFn_2_darg0_grad(i, j, &_d_this, hessianMatrix + {{0U|0UL|0ULL}}, hessianMatrix + {{1U|1UL|1ULL}});
   //CHECK-NEXT:    Widget _d_this0;

--- a/test/Hessian/NestedFunctionCalls.C
+++ b/test/Hessian/NestedFunctionCalls.C
@@ -29,7 +29,7 @@ double f2(double x, double y){
 
 // CHECK: inline void f2_pushforward_pullback(double x, double y, double _d_x, double _d_y, clad::ValueAndPushforward<double, double> _d_y0, double *_d_x0, double *_d_y1);
 
-// CHECK: inline void f2_hessian(double x, double y, double *hessianMatrix) {
+// CHECK: void f2_hessian(double x, double y, double *hessianMatrix) {
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_y{0., 0.};
 // CHECK-NEXT:     _d_y.pushforward = 1.;
 // CHECK-NEXT:     double _d_x(0.);

--- a/test/Hessian/Pointers.C
+++ b/test/Hessian/Pointers.C
@@ -16,7 +16,7 @@ double nonMemFn(double i, double j) {
 
 // CHECK: inline void nonMemFn_pushforward_pullback(double i, double j, double _d_i, double _d_j, clad::ValueAndPushforward<double, double> _d_y, double *_d_i0, double *_d_j0);
 
-// CHECK: inline void nonMemFn_hessian(double i, double j, double *hessianMatrix) {
+// CHECK: void nonMemFn_hessian(double i, double j, double *hessianMatrix) {
 // CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_y{0., 0.};
 // CHECK-NEXT:     _d_y.pushforward = 1.;
 // CHECK-NEXT:     double _d_i(0.);

--- a/test/Hessian/constexprTest.C
+++ b/test/Hessian/constexprTest.C
@@ -16,7 +16,7 @@ clad::array_ref<double>mat_ref_f1(mat_ref1, 9);
 
 constexpr double fn(double x, double y) { return x * y; }
 
-//CHECK:inline constexpr void fn_hessian(double x, double y, double *hessianMatrix) {
+//CHECK:constexpr void fn_hessian(double x, double y, double *hessianMatrix) {
 //CHECK-NEXT:    clad::ValueAndPushforward<double, double> _d_y{0., 0.};
 //CHECK-NEXT:    _d_y.pushforward = 1.;
 //CHECK-NEXT:    double _d_x(0.);
@@ -31,7 +31,7 @@ constexpr double fn(double x, double y) { return x * y; }
 
 constexpr double g(double i, double j[2]) { return i * (j[0] + j[1]); }
 
-//CHECK:inline constexpr void g_hessian(double i, double j[2], double *hessianMatrix) {
+//CHECK:constexpr void g_hessian(double i, double j[2], double *hessianMatrix) {
 //CHECK-NEXT:    clad::ValueAndPushforward<double, double> _d_y{0., 0.};
 //CHECK-NEXT:    _d_y.pushforward = 1.;
 //CHECK-NEXT:    double _d_i(0.);

--- a/test/Regressions/hessian-intermediate-codegen.cpp
+++ b/test/Regressions/hessian-intermediate-codegen.cpp
@@ -1,11 +1,13 @@
 // RUN: %cladclang -std=c++17 -I%S/../../include %s -o %t 2>&1 | %filecheck %s
 // RUN: %t | %filecheck_exec %s
 
-// Derivatives are generated into every translation unit that needs them, so
-// clad declares them inline. That also makes them discardable: CodeGen defers
-// each until a DeclRefExpr asks for it. A hessian is assembled from one
-// pushforward of the function and one pullback of that pushforward, and only
-// the pullback is called, so the pushforward itself never reaches the backend.
+// Derivatives clad calls but never names outside are declared inline, which
+// makes them discardable: CodeGen defers each until a DeclRefExpr asks for it.
+// A hessian is assembled from one pushforward of the function and one pullback
+// of that pushforward, and only the pullback is called, so the pushforward
+// itself never reaches the backend. The root of each request follows its
+// primal instead — fn and caller are not inline, so neither are fn_hessian and
+// caller_darg0.
 //
 // Derivatives are cached per request, so the forward-mode derivative below
 // reuses that same declaration rather than building its own. Its call to
@@ -20,8 +22,8 @@ double fn(double x, double y) { return x * x * y; }
 double caller(double x, double y) { return fn(x, y) + y; }
 
 // CHECK: {{^}}inline clad::ValueAndPushforward<double, double> fn_pushforward(double x, double y, double _d_x, double _d_y) {
-// CHECK: {{^}}inline void fn_hessian(double x, double y, double *hessianMatrix) {
-// CHECK: {{^}}inline double caller_darg0(double x, double y) {
+// CHECK: {{^}}void fn_hessian(double x, double y, double *hessianMatrix) {
+// CHECK: {{^}}double caller_darg0(double x, double y) {
 
 int main() {
   auto h = clad::hessian(fn);

--- a/unittests/Misc/CallDeclOnly.cpp
+++ b/unittests/Misc/CallDeclOnly.cpp
@@ -23,7 +23,7 @@ TEST(CallDeclOnly, CheckNumDiff) {
 
   // Check the generated code from grad.dump()
   std::string expected = R"(The code is: 
-inline void wrapper1_grad(double *params, double *_d_params) {
+void wrapper1_grad(double *params, double *_d_params) {
     double _d_ix = 0.;
     const double ix = 1 + params[0];
     {


### PR DESCRIPTION
863e29dd ("Declare clad's derivatives inline") declared every derivative inline so that CodeGen drops the ones nothing calls, like a hessian's intermediate pushforward. But an inline definition must also be emitted by every translation unit that references it. In an interpreter the unit that requests a derivative and a later unit naming it are separate, so each such unit runs CodeGen over the whole pullback tree again.

Only the root of the request graph is exposed to this, being the one derivative whose name clad hands back to the caller. Give it its primal's inline-ness again -- the property that decides whether a second unit naming it is a redefinition in the first place -- and leave every derivative clad calls but never names discardable, as 863e29dd made them. The intermediate pushforward is still dropped, so hessian generation keeps what that commit bought it.

The CHECK lines for root derivatives lose the inline specifier again; Regressions/hessian-intermediate-codegen.cpp still checks that the intermediate pushforward carries it and that nothing referencing it fails to link.