### PR TITLE
Print a derivative where its nodes already point.

### DIFF
--- a/docs/userDocs/source/user/DevelopersDocumentation.rst
+++ b/docs/userDocs/source/user/DevelopersDocumentation.rst
@@ -162,10 +162,13 @@ Inspecting the generated code
 =============================
 
 Clad builds the derivative as an AST, so its statements belong to no file and
-have nothing a diagnostic can point at. Clad renders a derivative into a
+have nothing a diagnostic can point at. Clad renders its derivatives into a
 buffer it registers with the ``SourceManager``, which gives every generated
-statement a line and a column, and two switches report through it. Both are
-plugin arguments, so each needs ``-Xclang -plugin-arg-clad -Xclang`` in front.
+statement a line and a column, and two switches report through it. One buffer
+holds every derivative in the translation unit, so a diagnostic names the
+buffer rather than the derivative -- which derivative it is comes from a note.
+Both are plugin arguments, so each needs ``-Xclang -plugin-arg-clad -Xclang``
+in front.
 
 ``-Rclad-analysis=<name>``
 --------------------------------
@@ -177,11 +180,10 @@ plugin working on the AST.
 
 .. code-block:: none
 
-   In file included from doc.cpp:8:
-   <clad derivative of f_grad>:4:5: remark: clad keeps this value for the reverse sweep
+   <clad generated code>:4:5: remark: clad keeps this value for the reverse sweep
        4 |     double _t0 = t;
          |     ^~~~~~~~~~~~~~
-   <clad derivative of f_grad>:4:5: note: to-be-recorded analysis could not show it unused
+   <clad generated code>:4:5: note: to-be-recorded analysis could not show it unused
    doc.cpp:8:12: note: in the derivative of 'f' requested here
        8 |   auto g = clad::gradient(f);
          |            ^

--- a/include/clad/Differentiator/DerivativeBuilder.h
+++ b/include/clad/Differentiator/DerivativeBuilder.h
@@ -186,6 +186,9 @@ struct DerivativeAndOverload {
     /// A location for a node about to be built. Distinct per node, so that a
     /// line note can later say where that node really ended up.
     clang::SourceLocation GenLoc();
+    /// Where those locations point, for a caller with generated code to print
+    /// into it.
+    GeneratedCode& getGeneratedCode();
     /// Fuction to set the error diagnostic printing value for numerical
     /// differentiation.
     ///

--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -74,6 +74,10 @@ SourceLocation DerivativeBuilder::GenLoc() {
   return m_GeneratedCode->nextLoc();
 }
 
+GeneratedCode& DerivativeBuilder::getGeneratedCode() {
+  return *m_GeneratedCode;
+}
+
 static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
   DeclContext* DC = D->getLexicalDeclContext();
   if (auto* dFD = dyn_cast<FunctionDecl>(D)) {

--- a/lib/Differentiator/DerivativePrinter.cpp
+++ b/lib/Differentiator/DerivativePrinter.cpp
@@ -4,7 +4,6 @@
 #include "clang/AST/PrettyPrinter.h"
 #include "clang/AST/Stmt.h"
 #include "clang/Basic/SourceLocation.h"
-#include "clang/Basic/SourceManager.h"
 #include "clang/Sema/Sema.h"
 
 #include "llvm/ADT/DenseMap.h"
@@ -105,7 +104,7 @@ SourceLocation DerivativePrinter::locationOf(const FunctionDecl* FD,
   unsigned Offset = Found->second;
   while (Offset < Text.size() && (Text[Offset] == ' ' || Text[Offset] == '\t'))
     ++Offset;
-  return R.At.Loc.getLocWithOffset(Offset);
+  return R.At.Loc.getLocWithOffset(static_cast<int>(Offset));
 }
 
 unsigned DerivativePrinter::lineOf(const FunctionDecl* FD, const Stmt* S) {
@@ -147,7 +146,7 @@ SourceRange DerivativePrinter::rangeOf(const FunctionDecl* FD, const Stmt* S) {
   if (Text.empty() || Text.contains(/*C=*/'\n'))
     return Begin;
   // A range's end names the last character, not one past it.
-  return {Begin, Begin.getLocWithOffset(Text.size() - 1)};
+  return {Begin, Begin.getLocWithOffset(static_cast<int>(Text.size()) - 1)};
 }
 
 SourceLocation DerivativePrinter::startOf(const FunctionDecl* FD) {

--- a/lib/Differentiator/DerivativePrinter.cpp
+++ b/lib/Differentiator/DerivativePrinter.cpp
@@ -8,9 +8,9 @@
 #include "clang/Sema/Sema.h"
 
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <algorithm>
 #include <string>
 #include <utility>
 
@@ -22,9 +22,9 @@ namespace {
 
 /// Notes where each statement's text begins as the printer reaches it.
 ///
-/// PrinterHelper is a substitution hook: returning true means "I printed this,
-/// skip it". Returning false leaves the output byte for byte what it would
-/// have been, which is what makes the offsets describe the text a reader sees.
+/// PrinterHelper is a substitution hook: returning true means "I printed
+/// this, skip it". Returning false leaves the output exactly as it would have
+/// been, so the offsets describe the text a reader sees.
 class OffsetRecorder : public PrinterHelper {
   llvm::DenseMap<const Stmt*, unsigned>& m_Offsets;
 
@@ -41,16 +41,13 @@ public:
 
 } // namespace
 
-const DerivativePrinter::Rendering&
-DerivativePrinter::render(const FunctionDecl* FD) {
-  auto Found = m_Rendered.find(FD);
-  if (Found != m_Rendered.end())
+const DerivativePrinter::Printout&
+DerivativePrinter::print(const FunctionDecl* FD) {
+  auto Found = m_Printed.find(FD);
+  if (Found != m_Printed.end())
     return Found->second;
 
-  Rendering R;
-  // Not retained: the SourceManager keeps a copy for the life of the
-  // compilation, and in a long-running session nothing is reclaimed until it
-  // ends, so a second copy would double what this costs.
+  Printout R;
   std::string Text;
   llvm::raw_string_ostream OS(Text);
   PrintingPolicy Policy = m_Sema.getASTContext().getPrintingPolicy();
@@ -69,74 +66,97 @@ DerivativePrinter::render(const FunctionDecl* FD) {
   }
   OS.flush();
 
-  SourceManager& SM = m_Sema.getSourceManager();
-  std::string Name = "<clad derivative of " + FD->getNameAsString() + ">";
-  // Entered from the differentiation that asked for it, falling back to the
-  // main file. Somewhere inside the translation unit is required either way:
-  // isBeforeInTranslationUnit orders two locations by walking up to a file
-  // they share, and reports "Unsortable locations found" when there is none.
-  SourceLocation IncludeLoc = m_RequestedAt.lookup(FD);
-  if (IncludeLoc.isInvalid())
-    IncludeLoc = SM.getLocForStartOfFile(SM.getMainFileID());
-  R.File = SM.createFileID(llvm::MemoryBuffer::getMemBufferCopy(Text, Name),
-                           SrcMgr::C_User, /*LoadedID=*/0, /*LoadedOffset=*/0,
-                           IncludeLoc);
-  return m_Rendered.insert({FD, std::move(R)}).first->second;
-}
+  // Into the chunk this function's own slots came from: a note on a slot can
+  // only name a line of its own file. The body's opening brace is among the
+  // first slots the function was given, so it names the chunk the function
+  // started in. A derivative with no slot of its own takes a fresh one, which
+  // at least guarantees there is a chunk to print into.
+  SourceLocation Anchor;
+  if (const Stmt* Body = FD->getBody())
+    Anchor = Body->getBeginLoc();
+  if (!m_Locs.owns(Anchor))
+    Anchor = FD->getEndLoc();
+  if (!m_Locs.owns(Anchor))
+    Anchor = m_Locs.nextLoc();
 
-void DerivativePrinter::noteRequestedAt(const FunctionDecl* FD,
-                                        SourceLocation Loc) {
-  // The first request wins, and a later one is ignored rather than asserted
-  // on: which request a shared derivative is attributed to is presentational,
-  // and not worth ending a compilation over.
-  if (Loc.isValid() && Loc.isFileID())
-    m_RequestedAt.try_emplace(FD, Loc);
+  R.Size = static_cast<unsigned>(Text.size());
+  R.At = m_Locs.addText(Anchor, Text);
+  if (R.At) {
+    R.LineStarts.push_back(0);
+    for (unsigned I = 0; I != R.Size; ++I)
+      if (Text[I] == '\n')
+        R.LineStarts.push_back(I + 1);
+  }
+  return m_Printed.insert({FD, std::move(R)}).first->second;
 }
 
 SourceLocation DerivativePrinter::locationOf(const FunctionDecl* FD,
                                              const Stmt* S) {
-  const Rendering& R = render(FD);
+  const Printout& R = print(FD);
+  if (!R.At)
+    return {};
   auto Found = R.Offsets.find(S);
   if (Found == R.Offsets.end())
     return {};
-  // The printer announces a statement before emitting the indentation in
-  // front of it, so the recorded offset can sit at the start of the line.
-  // Point at the first character of the statement itself, which is where a
-  // caret belongs.
-  llvm::StringRef Text = m_Sema.getSourceManager().getBufferData(R.File);
+  // The printer announces a statement before the indentation in front of it,
+  // so the recorded offset can sit at the start of the line. A caret belongs
+  // on the first character of the statement itself.
+  llvm::StringRef Text = m_Locs.textAt(R.At, R.Size);
   unsigned Offset = Found->second;
   while (Offset < Text.size() && (Text[Offset] == ' ' || Text[Offset] == '\t'))
     ++Offset;
-  return m_Sema.getSourceManager()
-      .getLocForStartOfFile(R.File)
-      .getLocWithOffset(Offset);
+  return R.At.Loc.getLocWithOffset(Offset);
+}
+
+unsigned DerivativePrinter::lineOf(const FunctionDecl* FD, const Stmt* S) {
+  const Printout& R = print(FD);
+  if (!R.At)
+    return 0;
+  auto Found = R.Offsets.find(S);
+  if (Found == R.Offsets.end())
+    return 0;
+  // Counted from the line the printout starts at. Asking the SourceManager
+  // instead is not an option: it settles a chunk's lines on the first
+  // question, and more code may still be printed into the chunk after that.
+  const auto It =
+      std::upper_bound(R.LineStarts.begin(), R.LineStarts.end(), Found->second);
+  return R.At.Line + static_cast<unsigned>(It - R.LineStarts.begin()) - 1;
+}
+
+unsigned DerivativePrinter::lineOf(const FunctionDecl* FD) {
+  return print(FD).At.Line;
 }
 
 SourceRange DerivativePrinter::rangeOf(const FunctionDecl* FD, const Stmt* S) {
   SourceLocation Begin = locationOf(FD, S);
   if (Begin.isInvalid())
     return {};
-  // How wide the node is, measured by rendering it alone under the same
-  // policy. A statement is printed with a trailing separator it does not own,
-  // so that comes back off.
+  // How wide the node is, measured by printing it alone under the same
+  // policy. A statement carries a trailing separator it does not own, so that
+  // comes back off.
   std::string Own;
   llvm::raw_string_ostream OS(Own);
   S->printPretty(OS, /*Helper=*/nullptr,
                  m_Sema.getASTContext().getPrintingPolicy());
   OS.flush();
   llvm::StringRef Text = llvm::StringRef(Own).rtrim(" \t\n;");
-  // Only a node that renders on one line can be measured this way: a compound
-  // statement printed alone carries its own line breaks, and a range built
-  // from that would end before it began. Those report a bare location, which
-  // is right for them anyway -- underlining a whole loop body says nothing.
+  // Only a node that prints on one line can be measured this way: one with
+  // line breaks would give a range that ends before it begins. Those report a
+  // bare location, which is right anyway -- underlining a loop body says
+  // nothing.
   if (Text.empty() || Text.contains(/*C=*/'\n'))
     return Begin;
   // A range's end names the last character, not one past it.
   return {Begin, Begin.getLocWithOffset(Text.size() - 1)};
 }
 
+SourceLocation DerivativePrinter::startOf(const FunctionDecl* FD) {
+  return print(FD).At.Loc;
+}
+
 llvm::StringRef DerivativePrinter::textOf(const FunctionDecl* FD) {
-  return m_Sema.getSourceManager().getBufferData(render(FD).File);
+  const Printout& R = print(FD);
+  return m_Locs.textAt(R.At, R.Size);
 }
 
 } // namespace clad

--- a/lib/Differentiator/DerivativePrinter.h
+++ b/lib/Differentiator/DerivativePrinter.h
@@ -1,10 +1,14 @@
 #ifndef CLAD_DIFFERENTIATOR_DERIVATIVEPRINTER_H
 #define CLAD_DIFFERENTIATOR_DERIVATIVEPRINTER_H
 
+#include "GeneratedCode.h"
+
 #include "clang/Basic/SourceLocation.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
+
+#include <vector>
 
 namespace clang {
 class FunctionDecl;
@@ -14,63 +18,60 @@ class Stmt;
 
 namespace clad {
 
-/// Gives clad-generated code somewhere to be pointed at.
+/// Prints clad's generated code where its nodes already point.
 ///
-/// A generated node has no source location of its own -- clad builds it, so
-/// there is no file it came from -- and the placeholder every visitor reaches
-/// for is the start of the main file, which puts a caret on the user's first
-/// line. That is not a diagnostic anyone can act on.
+/// A generated node has no text of its own, but it does have a slot in one of
+/// GeneratedCode's buffers. Printing the derivative into that same buffer
+/// gives the node text at the position it already claims: a diagnostic gets a
+/// caret and a source line, and a line note can send a debugger to the same
+/// bytes.
 ///
-/// Rendering the derivative into a buffer and registering it with the
-/// SourceManager gives the node a real location: one inside text that reads
-/// like the code clad produced. Diagnostics then render with a caret and
-/// context, exactly as they do for code the user wrote. The same mechanism
-/// backs interactive input in cling and clang-repl, and macro expansions in
-/// Swift.
-///
-/// The rendering is built on first use and cached per function: a compilation
-/// that reports nothing never pays for one.
+/// A function is printed once, the first time anything is asked about it, and
+/// the answer kept. A compilation that asks nothing prints nothing.
 class DerivativePrinter {
 public:
-  explicit DerivativePrinter(clang::Sema& S) : m_Sema(S) {}
+  DerivativePrinter(clang::Sema& S, GeneratedCode& Locs)
+      : m_Sema(S), m_Locs(Locs) {}
 
-  /// Where \p S appears within the rendering of \p FD, or an invalid location
-  /// if \p FD has no body or the printer never announced \p S.
+  /// Where \p S appears in the printout of \p FD, or an invalid location if
+  /// there is no printout or \p S is not in it.
   clang::SourceLocation locationOf(const clang::FunctionDecl* FD,
                                    const clang::Stmt* S);
 
-  /// The span \p S occupies in the rendering, so a diagnostic can underline
-  /// the whole expression rather than mark its first character. A loop's
-  /// condition or increment is several nodes wide and reads as one thing.
+  /// The span \p S occupies in the printout, so a diagnostic can underline
+  /// the whole expression rather than mark its first character.
   clang::SourceRange rangeOf(const clang::FunctionDecl* FD,
                              const clang::Stmt* S);
 
-  /// The rendered text of \p FD, for a caller that wants to show it rather
-  /// than point into it.
+  /// The line of the chunk \p S was printed on, or zero if it was not. This is
+  /// what a slot standing for \p S has to be presented as.
+  unsigned lineOf(const clang::FunctionDecl* FD, const clang::Stmt* S);
+
+  /// The line the printout of \p FD begins on, which is its signature.
+  unsigned lineOf(const clang::FunctionDecl* FD);
+
+  /// Where the printout of \p FD begins, so a caller can tell which chunk it
+  /// went into.
+  clang::SourceLocation startOf(const clang::FunctionDecl* FD);
+
+  /// The printed text of \p FD, for a caller that wants to show it rather than
+  /// point into it.
   llvm::StringRef textOf(const clang::FunctionDecl* FD);
 
-  /// Records that \p FD exists because of the differentiation at \p Loc.
-  ///
-  /// A rendering has to be entered from somewhere in the translation unit, and
-  /// a diagnostic prints that place above itself. The request is the useful
-  /// answer -- it is the line a reader would edit -- so a caller that knows it
-  /// should say so before the first diagnostic about \p FD. Without this the
-  /// rendering is entered from the start of the main file, which is sortable
-  /// but tells a reader nothing.
-  void noteRequestedAt(const clang::FunctionDecl* FD,
-                       clang::SourceLocation Loc);
-
 private:
-  struct Rendering {
-    clang::FileID File;
+  struct Printout {
+    GeneratedCode::Placement At;
+    unsigned Size = 0;
     llvm::DenseMap<const clang::Stmt*, unsigned> Offsets;
+    /// Offset of each line's first character, so an offset can be turned into
+    /// a line without rescanning the text for every statement.
+    std::vector<unsigned> LineStarts;
   };
-  const Rendering& render(const clang::FunctionDecl* FD);
+  const Printout& print(const clang::FunctionDecl* FD);
 
   clang::Sema& m_Sema;
-  llvm::DenseMap<const clang::FunctionDecl*, Rendering> m_Rendered;
-  llvm::DenseMap<const clang::FunctionDecl*, clang::SourceLocation>
-      m_RequestedAt;
+  GeneratedCode& m_Locs;
+  llvm::DenseMap<const clang::FunctionDecl*, Printout> m_Printed;
 };
 
 } // namespace clad

--- a/lib/Differentiator/GeneratedCode.cpp
+++ b/lib/Differentiator/GeneratedCode.cpp
@@ -6,42 +6,170 @@
 
 #include "llvm/Support/MemoryBuffer.h"
 
+#include <algorithm>
+#include <cstring>
 #include <string>
+#include <utility>
 
 using namespace clang;
 
 namespace clad {
 
+namespace {
+
+/// Whether the SourceManager has already worked out where \p File's lines
+/// are. It does that once and keeps the answer, so anything printed after
+/// that would sit on lines it does not know about.
+bool lineBoundariesTaken(SourceManager& SM, FileID File) {
+  return bool(
+      SM.getSLocEntry(File).getFile().getContentCache().SourceLineCache);
+}
+
+} // namespace
+
 SourceLocation GeneratedCode::nextLoc() {
   SourceManager& SM = m_Sema.getSourceManager();
   if (m_Used == kSlotsPerChunk) {
-    // One newline per slot: a slot is a line, so its presumed line is already
-    // its index and a note only has to say where that line really is.
-    std::string Slots(kSlotsPerChunk, '\n');
-    // Named apart from the chunks before it. A chunk restarts line numbering
-    // at 1 and the line table keys a file by its name, so same-named chunks
-    // fold into one entry and two generated statements report the same
-    // position.
-    std::string Name = "<clad generated code>";
-    if (m_Chunks)
-      Name = "<clad generated code #" + std::to_string(m_Chunks + 1) + ">";
-    ++m_Chunks;
-    // Entered from the main file. A chunk outside the translation unit's
-    // include tree cannot be ordered against anything inside it:
-    // isBeforeInTranslationUnit walks up to a file the two share, runs out of
-    // parents, and reports "Unsortable locations found" -- which clad reaches
-    // whenever it sorts a derivative against a pragma. clang-repl enters its
-    // input buffers the same way.
-    m_Chunk = SM.createFileID(llvm::MemoryBuffer::getMemBufferCopy(Slots, Name),
-                              SrcMgr::C_User,
-                              /*LoadedID=*/0, /*LoadedOffset=*/0,
-                              SM.getLocForStartOfFile(SM.getMainFileID()));
+    const std::string Name = nextName();
+    constexpr unsigned TextBytes = kSlotsPerChunk * kTextBytesPerSlot;
+    auto Owned = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
+        TextBytes + kSlotsPerChunk, Name);
+    char* Start = Owned->getBufferStart();
+    // A blank line everywhere until code is printed over it: every slot has
+    // to be a line of its own, and uninitialised bytes would otherwise reach
+    // whoever reads this.
+    std::memset(Start, '\n', TextBytes + kSlotsPerChunk);
+
+    // Entered from the main file, the way clang-repl enters its input. A
+    // chunk outside the include tree cannot be ordered against anything
+    // inside it: isBeforeInTranslationUnit runs out of shared parents and
+    // reports "Unsortable locations found", which clad hits whenever it sorts
+    // a derivative against a pragma.
+    FileID File = SM.createFileID(std::move(Owned), SrcMgr::C_User,
+                                  /*LoadedID=*/0, /*LoadedOffset=*/0,
+                                  SM.getLocForStartOfFile(SM.getMainFileID()));
+    Chunk C;
+    C.File = File;
+    C.Name = Name;
+    C.Text = Start;
+    C.Capacity = TextBytes;
+    m_ChunkList.push_back(std::move(C));
     m_Used = 0;
   }
-  // Signed, because that is what getLocWithOffset takes; a slot index is
-  // bounded by kSlotsPerChunk, so it always fits.
-  return SM.getLocForStartOfFile(m_Chunk).getLocWithOffset(
-      static_cast<int>(m_Used++));
+  ++m_ChunkList.back().Slots;
+  // Slots sit behind the code. Signed because that is what getLocWithOffset
+  // takes; a chunk is small enough that the offset always fits.
+  return SM.getLocForStartOfFile(m_ChunkList.back().File)
+      .getLocWithOffset(
+          static_cast<int>(m_ChunkList.back().Capacity + m_Used++));
+}
+
+std::string GeneratedCode::nextName() const {
+  // Named apart from the chunks before it. Every chunk numbers its lines
+  // from 1 and the line table keys a file by name, so two chunks sharing a
+  // name would put two statements at the same position.
+  if (m_ChunkList.empty())
+    return "<clad generated code>";
+  return "<clad generated code #" + std::to_string(m_ChunkList.size() + 1) +
+         ">";
+}
+
+GeneratedCode::Chunk* GeneratedCode::chunkFor(SourceLocation Loc) {
+  return const_cast<Chunk*>(
+      static_cast<const GeneratedCode*>(this)->chunkFor(Loc));
+}
+
+const GeneratedCode::Chunk* GeneratedCode::chunkFor(SourceLocation Loc) const {
+  if (Loc.isInvalid())
+    return nullptr;
+  FileID File = m_Sema.getSourceManager().getFileID(Loc);
+  for (const Chunk& C : m_ChunkList)
+    if (C.File == File)
+      return &C;
+  return nullptr;
+}
+
+GeneratedCode::Placement GeneratedCode::addText(SourceLocation Anchor,
+                                                llvm::StringRef Text) {
+  Chunk* C = chunkFor(Anchor);
+  if (!C || Text.empty())
+    return {};
+  SourceManager& SM = m_Sema.getSourceManager();
+  // Printing now would move lines the SourceManager has already committed to,
+  // and every position it reports here afterwards would be off. Say nothing
+  // rather than something untrue.
+  if (lineBoundariesTaken(SM, C->File))
+    return {};
+  // A trailing newline so the next derivative starts on a line of its own
+  // rather than continuing this one.
+  const size_t Need = Text.size() + 1;
+  if (Need > C->Capacity - C->Used)
+    return {}; // Code that does not fit stays a blank line.
+  const unsigned At = C->Used;
+  const unsigned First = C->NextLine;
+  std::memcpy(C->Text + At, Text.data(), Text.size());
+  C->Text[At + Text.size()] = '\n';
+  C->Used += static_cast<unsigned>(Need);
+  // Printing over blank lines removes newlines, so the lines after this one
+  // move up. Only lines nothing has been printed on yet, so nothing already
+  // placed moves.
+  C->NextLine += static_cast<unsigned>(Text.count('\n')) + 1;
+  return {SM.getLocForStartOfFile(C->File).getLocWithOffset(At), First};
+}
+
+llvm::StringRef GeneratedCode::textAt(Placement P, unsigned Size) const {
+  const Chunk* C = chunkFor(P.Loc);
+  if (!C)
+    return {};
+  const unsigned At = m_Sema.getSourceManager().getFileOffset(P.Loc);
+  return llvm::StringRef(C->Text + At, std::min(Size, C->Capacity - At));
+}
+
+void GeneratedCode::assign(SourceLocation Begin, SourceLocation End,
+                           unsigned Line) {
+  Chunk* C = chunkFor(Begin);
+  if (!C || !Line)
+    return;
+  SourceManager& SM = m_Sema.getSourceManager();
+  const unsigned First = SM.getFileOffset(Begin);
+  // An end in another chunk says nothing about this one; keep to the slot
+  // the range started at.
+  unsigned Last = First;
+  if (End.isValid() && chunkFor(End) == C)
+    Last = std::max(First, SM.getFileOffset(End));
+
+  C->SlotLine.resize(C->Slots, 0);
+  for (unsigned O = First; O <= Last; ++O) {
+    if (O < C->Capacity)
+      continue; // Before the slots: part of the code, not a slot.
+    const unsigned I = O - C->Capacity;
+    if (I < C->SlotLine.size())
+      C->SlotLine[I] = Line;
+  }
+}
+
+void GeneratedCode::present() {
+  SourceManager& SM = m_Sema.getSourceManager();
+  for (Chunk& C : m_ChunkList) {
+    if (C.Presented)
+      continue; // Its notes are in, and a second pass would go backwards.
+    C.Presented = true;
+    C.SlotLine.resize(C.Slots, 0);
+    const SourceLocation Base = SM.getLocForStartOfFile(C.File);
+    // Line 1 until told otherwise, so a slot nobody described points at the
+    // start of the code rather than past its end.
+    unsigned Line = 1;
+    for (unsigned I = 0; I != C.Slots; ++I) {
+      if (C.SlotLine[I])
+        Line = C.SlotLine[I];
+      // Line + 1 because a note reads as #line does: it gives the number of
+      // the line after it, and each slot is a line.
+      SM.AddLineNote(Base.getLocWithOffset(static_cast<int>(C.Capacity + I)),
+                     Line + 1,
+                     /*FilenameID=*/-1, /*IsFileEntry=*/false,
+                     /*IsFileExit=*/false, SrcMgr::C_User);
+    }
+  }
 }
 
 } // namespace clad

--- a/lib/Differentiator/GeneratedCode.cpp
+++ b/lib/Differentiator/GeneratedCode.cpp
@@ -4,6 +4,7 @@
 #include "clang/Basic/SourceManager.h"
 #include "clang/Sema/Sema.h"
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MemoryBuffer.h"
 
 #include <algorithm>
@@ -15,17 +16,13 @@ using namespace clang;
 
 namespace clad {
 
-namespace {
-
 /// Whether the SourceManager has already worked out where \p File's lines
 /// are. It does that once and keeps the answer, so anything printed after
 /// that would sit on lines it does not know about.
-bool lineBoundariesTaken(SourceManager& SM, FileID File) {
+static bool hasLineTable(SourceManager& SM, FileID File) {
   return bool(
       SM.getSLocEntry(File).getFile().getContentCache().SourceLineCache);
 }
-
-} // namespace
 
 SourceLocation GeneratedCode::nextLoc() {
   SourceManager& SM = m_Sema.getSourceManager();
@@ -75,6 +72,7 @@ std::string GeneratedCode::nextName() const {
 }
 
 GeneratedCode::Chunk* GeneratedCode::chunkFor(SourceLocation Loc) {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   return const_cast<Chunk*>(
       static_cast<const GeneratedCode*>(this)->chunkFor(Loc));
 }
@@ -98,7 +96,7 @@ GeneratedCode::Placement GeneratedCode::addText(SourceLocation Anchor,
   // Printing now would move lines the SourceManager has already committed to,
   // and every position it reports here afterwards would be off. Say nothing
   // rather than something untrue.
-  if (lineBoundariesTaken(SM, C->File))
+  if (hasLineTable(SM, C->File))
     return {};
   // A trailing newline so the next derivative starts on a line of its own
   // rather than continuing this one.
@@ -107,14 +105,18 @@ GeneratedCode::Placement GeneratedCode::addText(SourceLocation Anchor,
     return {}; // Code that does not fit stays a blank line.
   const unsigned At = C->Used;
   const unsigned First = C->NextLine;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   std::memcpy(C->Text + At, Text.data(), Text.size());
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   C->Text[At + Text.size()] = '\n';
   C->Used += static_cast<unsigned>(Need);
   // Printing over blank lines removes newlines, so the lines after this one
   // move up. Only lines nothing has been printed on yet, so nothing already
   // placed moves.
   C->NextLine += static_cast<unsigned>(Text.count('\n')) + 1;
-  return {SM.getLocForStartOfFile(C->File).getLocWithOffset(At), First};
+  return {
+      SM.getLocForStartOfFile(C->File).getLocWithOffset(static_cast<int>(At)),
+      First};
 }
 
 llvm::StringRef GeneratedCode::textAt(Placement P, unsigned Size) const {
@@ -122,6 +124,7 @@ llvm::StringRef GeneratedCode::textAt(Placement P, unsigned Size) const {
   if (!C)
     return {};
   const unsigned At = m_Sema.getSourceManager().getFileOffset(P.Loc);
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   return llvm::StringRef(C->Text + At, std::min(Size, C->Capacity - At));
 }
 
@@ -138,10 +141,9 @@ void GeneratedCode::assign(SourceLocation Begin, SourceLocation End,
   if (End.isValid() && chunkFor(End) == C)
     Last = std::max(First, SM.getFileOffset(End));
 
+  // Slots only: the range comes from nodes, which never sit in the code.
   C->SlotLine.resize(C->Slots, 0);
   for (unsigned O = First; O <= Last; ++O) {
-    if (O < C->Capacity)
-      continue; // Before the slots: part of the code, not a slot.
     const unsigned I = O - C->Capacity;
     if (I < C->SlotLine.size())
       C->SlotLine[I] = Line;

--- a/lib/Differentiator/GeneratedCode.h
+++ b/lib/Differentiator/GeneratedCode.h
@@ -79,11 +79,11 @@ class GeneratedCode {
   };
 
   /// The chunk \p Loc is in, or null if it is not one of ours.
-  Chunk* chunkFor(clang::SourceLocation Loc);
-  const Chunk* chunkFor(clang::SourceLocation Loc) const;
+  [[nodiscard]] Chunk* chunkFor(clang::SourceLocation Loc);
+  [[nodiscard]] const Chunk* chunkFor(clang::SourceLocation Loc) const;
 
   /// What to call the chunk about to be made.
-  std::string nextName() const;
+  [[nodiscard]] std::string nextName() const;
 
   clang::Sema& m_Sema;
   llvm::SmallVector<Chunk, 2> m_ChunkList;
@@ -110,7 +110,7 @@ public:
   Placement addText(clang::SourceLocation Anchor, llvm::StringRef Text);
 
   /// The bytes printed at \p P, \p Size of them.
-  llvm::StringRef textAt(Placement P, unsigned Size) const;
+  [[nodiscard]] llvm::StringRef textAt(Placement P, unsigned Size) const;
 
   /// Says that the slots from \p Begin through \p End belong to code on line
   /// \p Line of the chunk they are in.
@@ -137,13 +137,14 @@ public:
 
   /// Whether \p A and \p B are in the same chunk, which is what it takes for
   /// a note on one to name a line of the other.
-  bool sameChunk(clang::SourceLocation A, clang::SourceLocation B) const {
+  [[nodiscard]] bool isSameChunk(clang::SourceLocation A,
+                                 clang::SourceLocation B) const {
     const Chunk* C = chunkFor(A);
     return C && C == chunkFor(B);
   }
 
   /// Whether \p Loc is one of the slots handed out here.
-  bool owns(clang::SourceLocation Loc) const {
+  [[nodiscard]] bool owns(clang::SourceLocation Loc) const {
     return chunkFor(Loc) != nullptr;
   }
 };

--- a/lib/Differentiator/GeneratedCode.h
+++ b/lib/Differentiator/GeneratedCode.h
@@ -3,42 +3,149 @@
 
 #include "clang/Basic/SourceLocation.h"
 
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <string>
+#include <vector>
+
 namespace clang {
 class Sema;
 } // namespace clang
 
 namespace clad {
 
-/// The code clad generates, and the source locations that point into it.
+/// Somewhere for clad's generated code to be, and for its nodes to point at.
 ///
-/// A location has to be supplied when a node is built, long before the text
-/// that node will be printed as exists, so it cannot be the node's real
-/// position. What it can be is *distinct*, which is enough to tell two
-/// generated nodes apart in a diagnostic or in DWARF, and enough for a line
-/// note to say later where each one really ended up.
+/// Nothing clad builds comes from a file, so a diagnostic about it has
+/// nothing to underline and a debugger nothing to show. So clad prints each
+/// derivative into a buffer the SourceManager knows about, and the nodes it
+/// built point into that same buffer.
 ///
-/// Slots come from buffers of newlines, one per line, so a slot's presumed
-/// line is its index. They are allocated in chunks as slots run out. One large
-/// buffer instead would not do: a buffer handed to the SourceManager is fixed,
-/// and reserving generously is not free either, because every slot is written
-/// and the SourceManager scans a buffer end to end to build its line table the
-/// first time anyone asks for a line number in it.
+/// A node needs its location the moment it is built, long before the
+/// derivative is printed, so it cannot be told where it will end up. It gets
+/// a *slot* instead: one byte of the buffer, reserved for it alone. Once the
+/// code is printed, a line note in front of each slot says which line that
+/// node landed on, the way `#line` does.
+///
+/// The buffer -- a *chunk* -- is the printed code followed by the slots:
+///
+/// \code
+///   inline void f_grad(double x, double *_d_x) {   line 1
+///       double _t0 = t;                            line 2
+///       t = t * t;                                 line 3
+///   }                                              line 4
+///                                                  a slot, presented as the
+///                                                  line its node was printed
+///                                                  on
+/// \endcode
+///
+/// Code and slots share a file because a diagnostic and a debugger have to
+/// agree on where a statement is. Slots come after the code, so one that
+/// nobody described lands past the end of it rather than in the middle, and
+/// take a byte each, since a slot needs a distinct offset and not a line.
+///
+/// Chunks are a fixed size, and a new one is made when the slots run out: the
+/// SourceManager owns a buffer once it is handed over, so none of them can
+/// grow. That brings the one rule here -- a chunk has to be finished before
+/// it is read. The SourceManager works out where a buffer's lines are on the
+/// first question about it and keeps the answer, so code printed later would
+/// sit on lines it has never heard of. Printing into a chunk that has been
+/// read is refused.
 class GeneratedCode {
-  /// Slots per buffer. A chunk is paid for in full once allocated, so this
-  /// trades memory against how many files a derivative is split across -- the
-  /// first is not allocated until the first slot is asked for.
+  /// Slots in a chunk. A chunk is paid for in full as soon as it is made, so
+  /// this trades memory against how many buffers a derivative is spread over.
   static constexpr unsigned kSlotsPerChunk = 8192;
 
+  /// Room for printed code, per slot. Reserved up front because a buffer
+  /// cannot grow, and paid for whether it is used or not. Clad's own test
+  /// suite averages ten bytes of code per slot; a derivative that runs over
+  /// what is left of a chunk does not get printed at all.
+  static constexpr unsigned kTextBytesPerSlot = 12;
+
+  /// One buffer: the printed code at the front, then one byte per slot.
+  struct Chunk {
+    clang::FileID File;
+    std::string Name;       ///< what the line table calls it
+    char* Text = nullptr;   ///< the writable region, at the front
+    unsigned Capacity = 0;  ///< how many bytes of it there are
+    unsigned Used = 0;      ///< how many of them are written
+    unsigned Slots = 0;     ///< how many slots have been handed out
+    unsigned NextLine = 1;  ///< the line the next code written here starts on
+    bool Presented = false; ///< whether its line notes are already in
+    /// The line of printed code each slot stands for, by slot; zero for a slot
+    /// nobody described.
+    std::vector<unsigned> SlotLine;
+  };
+
+  /// The chunk \p Loc is in, or null if it is not one of ours.
+  Chunk* chunkFor(clang::SourceLocation Loc);
+  const Chunk* chunkFor(clang::SourceLocation Loc) const;
+
+  /// What to call the chunk about to be made.
+  std::string nextName() const;
+
   clang::Sema& m_Sema;
-  clang::FileID m_Chunk;
+  llvm::SmallVector<Chunk, 2> m_ChunkList;
   unsigned m_Used = kSlotsPerChunk; // forces the first nextLoc() to allocate
-  unsigned m_Chunks = 0; // names the next chunk apart from the ones before it
 
 public:
   explicit GeneratedCode(clang::Sema& S) : m_Sema(S) {}
 
   /// A location no other generated node has been given.
   clang::SourceLocation nextLoc();
+
+  /// Where a piece of code was printed, and the line it starts on.
+  struct Placement {
+    clang::SourceLocation Loc; ///< the first character of the code
+    unsigned Line = 0;         ///< the line it begins on; 0 if it went nowhere
+    explicit operator bool() const { return Line != 0; }
+  };
+
+  /// Prints \p Text into the chunk \p Anchor is in, after whatever is there.
+  ///
+  /// \p Anchor is a slot of the code being printed: a note on a slot can only
+  /// name a line of its own file, so the two have to share a chunk. Comes
+  /// back empty if the code does not fit or the chunk has been read.
+  Placement addText(clang::SourceLocation Anchor, llvm::StringRef Text);
+
+  /// The bytes printed at \p P, \p Size of them.
+  llvm::StringRef textAt(Placement P, unsigned Size) const;
+
+  /// Says that the slots from \p Begin through \p End belong to code on line
+  /// \p Line of the chunk they are in.
+  ///
+  /// By range, because a statement is built out of many nodes and the one an
+  /// instruction is attributed to is rarely the first. Assign the outer
+  /// statements before the inner ones, so the innermost -- the most specific
+  /// answer -- is the one that stays.
+  void assign(clang::SourceLocation Begin, clang::SourceLocation End,
+              unsigned Line);
+
+  /// Puts a line note in front of every slot, so each presents as the line of
+  /// code it stands for.
+  ///
+  /// Every slot, not only the described ones: without a note of its own a
+  /// slot reports one line further on than the slot before it, which walks
+  /// off the end of the code.
+  void present();
+
+  /// Stops anything more being printed into the chunks made so far, because
+  /// they have been read. Incremental compilation comes back for another
+  /// round of derivatives; those get chunks of their own.
+  void seal() { m_Used = kSlotsPerChunk; }
+
+  /// Whether \p A and \p B are in the same chunk, which is what it takes for
+  /// a note on one to name a line of the other.
+  bool sameChunk(clang::SourceLocation A, clang::SourceLocation B) const {
+    const Chunk* C = chunkFor(A);
+    return C && C == chunkFor(B);
+  }
+
+  /// Whether \p Loc is one of the slots handed out here.
+  bool owns(clang::SourceLocation Loc) const {
+    return chunkFor(Loc) != nullptr;
+  }
 };
 
 } // namespace clad

--- a/test/Misc/AnalysisRemarks.C
+++ b/test/Misc/AnalysisRemarks.C
@@ -10,15 +10,11 @@
 // RUN:   -fsyntax-only %s -I%S/../../include 2>&1 \
 // RUN:   | %filecheck --check-prefixes=CHECK,CHECK-NOKEEP %s
 //
-// A rendering has to be entered from somewhere in the translation unit, and
-// clang prints that place above the diagnostic. It is the differentiation
-// that asked for this derivative, which is the line a reader would edit --
-// not the top of their file, which would say nothing.
-// CHECK: In file included from {{.*}}AnalysisRemarks.C:[[@LINE+113]]:
-//
-// The caret lands inside the rendered derivative, on the statement itself --
-// the whole point, since none of this text exists in any file.
-// CHECK: <clad derivative of f_grad>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// The caret lands inside the generated code, on the statement itself -- the
+// whole point, since none of this text exists in a file the user wrote. One
+// buffer holds every derivative in the unit, so which one this is comes from
+// the note below rather than from the buffer's name.
+// CHECK: <clad generated code>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
 // CHECK: double _t0 = t;
 // The whole statement is underlined, not just its first character: a range
 // reads as one thing where a caret reads as a position.
@@ -28,23 +24,28 @@
 // Which derivative this is, said in the diagnostic rather than left to the
 // include stack: a caret on the differentiation, and the name of what is
 // being differentiated.
-// CHECK: {{.*}}AnalysisRemarks.C:[[@LINE+99]]:12: note: in the derivative of 'f' requested here
+// CHECK: {{.*}}AnalysisRemarks.C:[[@LINE+105]]:12: note: in the derivative of 'f' requested here
 // CHECK-NEXT: clad::gradient(f)
 //
 // And the half the user can act on -- their own code, with the expression
 // whose value is being kept.
-// CHECK: {{.*}}AnalysisRemarks.C:[[@LINE+75]]:3: note: the value kept is the one this expression had
+// CHECK: {{.*}}AnalysisRemarks.C:[[@LINE+81]]:3: note: the value kept is the one this expression had
 // CHECK-NEXT: t = t * t;
 //
 // A value the reverse sweep needs once per iteration cannot go into a
 // variable of its own, so clad pushes it onto a tape. The push is what
 // costs, and it is what the remark has to point at -- not the tape, which
 // is only the container.
-// CHECK: <clad derivative of loopy_grad_0>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK: <clad generated code>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
 // CHECK: clad::push(
+// Directly under it the underline, and nothing else. Clang reads the line to
+// show out of the buffer, at the number the remark gives, so a derivative
+// printed somewhere other than where it says it is shows up right here: the
+// next line of the buffer instead of the underline.
+// CHECK-NEXT: {{\^~+$}}
 // CHECK: note: to-be-recorded analysis could not show it unused
 // CHECK: note: in the derivative of 'loopy' requested here
-// CHECK: {{.*}}AnalysisRemarks.C:[[@LINE+74]]:5: note: the value kept is the one this expression had
+// CHECK: {{.*}}AnalysisRemarks.C:[[@LINE+75]]:5: note: the value kept is the one this expression had
 // CHECK-NEXT: t = t * t;
 //
 // Not every derivative has a differentiation to name. The second derivative a
@@ -52,10 +53,10 @@
 // note is left out rather than aimed at something arbitrary -- and the run's
 // exhaustive note matching is what holds it to that. The rest of the remark is
 // unchanged.
-// CHECK: <clad derivative of f_pushforward_pullback>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK: <clad generated code>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
 // CHECK: note: to-be-recorded analysis could not show it unused
 // CHECK: note: the value kept is the one this expression had
-// CHECK: <clad derivative of f_pushforward_pullback>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK: <clad generated code>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
 // CHECK: note: to-be-recorded analysis could not show it unused
 // CHECK: note: the value kept is the one this expression had
 //
@@ -66,7 +67,7 @@
 // RUN:   -Xclang -plugin-arg-clad -Xclang -fdisable-analysis=tbr \
 // RUN:   -fsyntax-only %s -I%S/../../include 2>&1 \
 // RUN:   | %filecheck --check-prefix=CHECK-OFF %s
-// CHECK-OFF: <clad derivative of f_grad>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK-OFF: <clad generated code>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
 // CHECK-OFF: note: to-be-recorded analysis is disabled
 // Neither pointer back into the user's code depends on the analysis: which
 // derivative this is, and the expression whose value is kept.
@@ -74,21 +75,22 @@
 // CHECK-OFF: note: the value kept is the one this expression had
 // Nor does the tape: what changes with the switch is the reason, not which
 // values are reported or where they came from.
-// CHECK-OFF: <clad derivative of loopy_grad_0>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK-OFF: <clad generated code>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
 // CHECK-OFF: note: to-be-recorded analysis is disabled
 // CHECK-OFF: note: in the derivative of 'loopy' requested here
 // CHECK-OFF: note: the value kept is the one this expression had
 // Nor does the switch put an attribution back where there never was one.
-// CHECK-OFF: <clad derivative of f_pushforward_pullback>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK-OFF: <clad generated code>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
 // CHECK-OFF: note: to-be-recorded analysis is disabled
 // CHECK-OFF: note: the value kept is the one this expression had
-// CHECK-OFF: <clad derivative of f_pushforward_pullback>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK-OFF: <clad generated code>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
 // CHECK-OFF: note: to-be-recorded analysis is disabled
 // CHECK-OFF: note: the value kept is the one this expression had
 //
 // A derivative with nothing to keep is not something to report: asking about
-// it says nothing rather than saying there is nothing.
-// CHECK-NOKEEP-NOT: <clad derivative of lin_grad>
+// it says nothing rather than saying there is nothing. By the note, since one
+// buffer holds every derivative and its name says nothing about which.
+// CHECK-NOKEEP-NOT: in the derivative of 'lin' requested here
 //
 // A name no analysis answers to is refused, and the refusal says which names
 // there are. Plain FileCheck here: the run fails, so its output carries an
@@ -102,7 +104,7 @@
 // RUN: %cladclang -fsyntax-only %s -I%S/../../include 2>&1 \
 // RUN:   | %filecheck --check-prefix=CHECK-QUIET --allow-empty %s
 // CHECK-QUIET-NOT: remark:
-// CHECK-QUIET-NOT: clad derivative of
+// CHECK-QUIET-NOT: clad generated code
 
 #include "clad/Differentiator/Differentiator.h"
 

--- a/test/Misc/GeneratedCodeChunks.C
+++ b/test/Misc/GeneratedCodeChunks.C
@@ -1,0 +1,63 @@
+// A derivative is printed into the buffer its own nodes point into.
+//
+// Clad hands out locations from a buffer as it builds a derivative and starts
+// a new buffer when that one runs out. The printed code has to go into the
+// buffer that derivative's nodes came from, not into whichever buffer happens
+// to be current when the printing is done: a note on a node can only name a
+// line of the file that node is in.
+//
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -Rclad-analysis=tbr \
+// RUN:   -fsyntax-only %s -I%S/../../include 2>&1 | %filecheck %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+// Differentiated first, so its nodes are in the first buffer.
+double first(double x) {
+  double t = x * x;
+  t = t * t;
+  return t;
+}
+
+// Enough nodes to run past the first buffer and into later ones. Linear, so
+// the reverse sweep keeps nothing here and this reports nothing of its own.
+#define B1 t = t + x;
+#define B8 B1 B1 B1 B1 B1 B1 B1 B1
+#define B64 B8 B8 B8 B8 B8 B8 B8 B8
+#define B512 B64 B64 B64 B64 B64 B64 B64 B64
+#define B2048 B512 B512 B512 B512
+double bulk(double x) {
+  double t = x;
+  B2048
+  return t;
+}
+
+// Differentiated last, so its nodes are in a later buffer.
+double last(double x) {
+  double t = x * x;
+  t = t * t;
+  return t;
+}
+
+int main() {
+  double d = 0;
+  auto gf = clad::gradient(first);
+  auto gb = clad::gradient(bulk);
+  auto gl = clad::gradient(last);
+  gf.execute(2, &d);
+  gb.execute(2, &d);
+  gl.execute(2, &d);
+  return 0;
+}
+
+// The first derivative reports the first buffer, which has no number.
+// CHECK: <clad generated code>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK: note: to-be-recorded analysis could not show it unused
+// CHECK: {{.*}}GeneratedCodeChunks.C:[[@LINE-12]]:13: note: in the derivative of 'first' requested here
+// CHECK: {{.*}}GeneratedCodeChunks.C:[[@LINE-39]]:3: note: the value kept is the one this expression had
+
+// And the last one a later buffer. That is also what says there was more than
+// one buffer to get wrong: with a single buffer this would read as the first.
+// CHECK: <clad generated code #{{[0-9]+}}>:{{[0-9]+}}:{{[0-9]+}}: remark: clad keeps this value for the reverse sweep
+// CHECK: note: to-be-recorded analysis could not show it unused
+// CHECK: {{.*}}GeneratedCodeChunks.C:[[@LINE-17]]:13: note: in the derivative of 'last' requested here
+// CHECK: {{.*}}GeneratedCodeChunks.C:[[@LINE-26]]:3: note: the value kept is the one this expression had

--- a/test/Misc/GeneratedCodeDebugInfo.C
+++ b/test/Misc/GeneratedCodeDebugInfo.C
@@ -12,10 +12,14 @@
 //
 // Two generated statements do not report one position. Counted rather than
 // pinned to particular lines: which line a statement lands on depends on how
-// many nodes clad built before it, and asserting that would test the
+// much code clad wrote before it, and asserting that would test the
 // generator's output instead of the property. Every row the buffer owns,
 // deduplicated by line -- one would mean every statement shares a position,
 // which is the state this replaces.
+//
+// A handful rather than thousands: a slot is presented as the line of
+// generated code it stands for, so this counts lines of a derivative, not
+// slots handed out.
 // RUN: %llvm-dwarfdump --debug-line %t.o | awk '\
 // RUN:   BEGIN { want = -1 } \
 // RUN:   /file_names\[/ { idx++ } \
@@ -23,7 +27,7 @@
 // RUN:   /^0x[0-9a-f]+ / && $4 == want { line[$2] = 1 } \
 // RUN:   END { n = 0; for (l in line) n++; print "distinct-lines", n }' \
 // RUN:   | %filecheck --check-prefix=DISTINCT %s
-// DISTINCT: distinct-lines {{[0-9][0-9]+}}
+// DISTINCT: distinct-lines {{([2-9]|[1-9][0-9]+)}}
 
 #include "clad/Differentiator/Differentiator.h"
 

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -24,6 +24,13 @@
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/Basic/LLVM.h" // isa, dyn_cast
 #include "clang/Basic/SourceLocation.h"
+// Clang 17 moved the debug info kinds out of clang::codegenoptions and into
+// llvm::codegenoptions.
+#if CLANG_VERSION_MAJOR < 17
+#include "clang/Basic/DebugInfoOptions.h"
+#else
+#include "llvm/Frontend/Debug/Options.h"
+#endif
 
 #ifdef _WIN32
 // <windows.h> defines function-like min/max macros that mangle
@@ -262,6 +269,12 @@ void InitTimers();
         collectStmts(Child, Printer, FD, Out);
     }
 
+#if CLANG_VERSION_MAJOR < 17
+    namespace codegenoptions = clang::codegenoptions;
+#else
+    namespace codegenoptions = llvm::codegenoptions;
+#endif
+
     /// Every statement under \p S standing at a slot, outermost first.
     static void collectSlotted(const clang::Stmt* S, GeneratedCode& Locs,
                                llvm::SmallVectorImpl<const clang::Stmt*>& Out) {
@@ -279,8 +292,8 @@ void InitTimers();
       // The line notes are for debug information alone: they decide what
       // CodeGen writes into the line table. A diagnostic reads the printed
       // code directly.
-      const bool WantLineNotes = m_CI.getCodeGenOpts().getDebugInfo() !=
-                                 llvm::codegenoptions::NoDebugInfo;
+      const bool WantLineNotes =
+          m_CI.getCodeGenOpts().getDebugInfo() != codegenoptions::NoDebugInfo;
       if (!WantLineNotes && !m_DO.RemarkTBRAnalysis &&
           !m_DO.DumpGeneratedSource)
         return; // Nobody will read the code, so nobody has to print it.
@@ -321,11 +334,11 @@ void InitTimers();
         // The brace clad built the body with stands for the signature, so
         // stopping at the function by name lands on its first line.
         const clang::SourceLocation Brace = FD->getBody()->getBeginLoc();
-        if (Code.sameChunk(Brace, Printed))
+        if (Code.isSameChunk(Brace, Printed))
           Code.assign(Brace, FD->getEndLoc(), Signature);
 
         for (const clang::Stmt* S : Nodes)
-          if (Code.sameChunk(S->getBeginLoc(), Printed))
+          if (Code.isSameChunk(S->getBeginLoc(), Printed))
             Code.assign(S->getBeginLoc(), S->getEndLoc(),
                         Printer.lineOf(FD, S));
       }

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -12,6 +12,7 @@
 #include "clad/Differentiator/Timers.h"
 #include "clad/Differentiator/Version.h"
 #include "../lib/Differentiator/DerivativePrinter.h"
+#include "../lib/Differentiator/GeneratedCode.h"
 #include "../lib/Differentiator/TBRAnalyzer.h"
 
 #include "clang/AST/ASTConsumer.h"
@@ -261,10 +262,89 @@ void InitTimers();
         collectStmts(Child, Printer, FD, Out);
     }
 
-    /// Shows what a generated function looks like as text, and where inside
-    /// that text each of its statements sits. A statement's reported line and
-    /// column is the one a diagnostic pointing at it would carry, so this is
-    /// how the mapping is checked without a diagnostic to hang it on.
+    /// Every statement under \p S standing at a slot, outermost first.
+    static void collectSlotted(const clang::Stmt* S, GeneratedCode& Locs,
+                               llvm::SmallVectorImpl<const clang::Stmt*>& Out) {
+      if (!S)
+        return;
+      if (Locs.owns(S->getBeginLoc()))
+        Out.push_back(S);
+      for (const clang::Stmt* Child : S->children())
+        collectSlotted(Child, Locs, Out);
+    }
+
+    void CladPlugin::materializeGeneratedCode() {
+      if (m_Generated.empty() || !m_DerivativeBuilder)
+        return;
+      // The line notes are for debug information alone: they decide what
+      // CodeGen writes into the line table. A diagnostic reads the printed
+      // code directly.
+      const bool WantLineNotes = m_CI.getCodeGenOpts().getDebugInfo() !=
+                                 llvm::codegenoptions::NoDebugInfo;
+      if (!WantLineNotes && !m_DO.RemarkTBRAnalysis &&
+          !m_DO.DumpGeneratedSource)
+        return; // Nobody will read the code, so nobody has to print it.
+
+      // A derivative that gets a forward declaration ahead of its definition
+      // is recorded twice. Only the declaration carrying the body has
+      // anything of its own to say.
+      llvm::erase_if(m_Generated, [](const Generated& G) {
+        return !G.Derivative->doesThisDeclarationHaveABody();
+      });
+
+      GeneratedCode& Code = m_DerivativeBuilder->getGeneratedCode();
+      DerivativePrinter& Printer = getDerivativePrinter();
+
+      // Print first, ask afterwards: a buffer's lines are settled by the
+      // first question about it, and a derivative printed after that would
+      // sit on lines nobody knows are there.
+      for (const Generated& G : m_Generated) {
+        clang::FunctionDecl* FD = G.Derivative;
+        // Printing it is what lineOf does on the way to answering.
+        const unsigned Signature = Printer.lineOf(FD);
+        if (!WantLineNotes)
+          continue;
+
+        // Outermost first, so that an inner statement assigns over the outer
+        // one it sits in and the most specific answer is the one that stays.
+        llvm::SmallVector<const clang::Stmt*, 64> Nodes;
+        collectSlotted(FD->getBody(), Code, Nodes);
+        if (Nodes.empty())
+          continue;
+
+        // A note can only name a line of its own file, so a statement whose
+        // slots landed in another chunk than the printout is left alone. That
+        // is a derivative with more nodes than one chunk holds: it runs on
+        // into the next chunk, the printout stays where it started.
+        const clang::SourceLocation Printed = Printer.startOf(FD);
+
+        // The brace clad built the body with stands for the signature, so
+        // stopping at the function by name lands on its first line.
+        const clang::SourceLocation Brace = FD->getBody()->getBeginLoc();
+        if (Code.sameChunk(Brace, Printed))
+          Code.assign(Brace, FD->getEndLoc(), Signature);
+
+        for (const clang::Stmt* S : Nodes)
+          if (Code.sameChunk(S->getBeginLoc(), Printed))
+            Code.assign(S->getBeginLoc(), S->getEndLoc(),
+                        Printer.lineOf(FD, S));
+      }
+
+      if (WantLineNotes)
+        Code.present();
+
+      for (const Generated& G : m_Generated) {
+        if (m_DO.DumpGeneratedSource)
+          dumpGeneratedSource(G.Derivative);
+        emitAnalysisRemarks(G);
+      }
+
+      // All of this has been read now, and incremental compilation comes
+      // back with more derivatives to print somewhere else.
+      Code.seal();
+      m_Generated.clear();
+    }
+
     void CladPlugin::dumpGeneratedSource(clang::Decl* D) {
       const auto* FD = llvm::dyn_cast<clang::FunctionDecl>(D);
       if (!FD || !FD->getBody())
@@ -384,12 +464,11 @@ void InitTimers();
       return Loc;
     }
 
-    void CladPlugin::emitAnalysisRemarks(clang::Decl* D,
-                                         const DiffRequest& request) {
+    void CladPlugin::emitAnalysisRemarks(const Generated& G) {
       if (!m_DO.RemarkTBRAnalysis)
         return;
-      const auto* FD = llvm::dyn_cast<clang::FunctionDecl>(D);
-      if (!FD || !FD->getBody())
+      const clang::FunctionDecl* FD = G.Derivative;
+      if (!FD->getBody())
         return;
 
       llvm::SmallVector<std::pair<const clang::Stmt*, const clang::VarDecl*>,
@@ -399,25 +478,14 @@ void InitTimers();
       if (Kept.empty())
         return; // Nothing to say, so nothing gets rendered.
 
-      // The differentiation this derivative came from, so a reader is pointed
-      // at the line they would edit rather than at the top of their file.
-      if (request.CallContext)
-        getDerivativePrinter().noteRequestedAt(
-            FD, request.CallContext->getBeginLoc());
       clang::Sema& S = m_CI.getSema();
       // Why the value is still here is a different sentence depending on
       // whether the analysis ran at all; saying "could not prove" when it was
       // switched off would be false.
       const char* Because =
-          request.EnableTBRAnalysis
-              ? "to-be-recorded analysis could not show it unused"
-              : "to-be-recorded analysis is disabled";
+          G.AnalysisRan ? "to-be-recorded analysis could not show it unused"
+                        : "to-be-recorded analysis is disabled";
       const clang::SourceManager& SM = m_CI.getSourceManager();
-      const clang::SourceLocation Requested =
-          request.CallContext ? request.CallContext->getBeginLoc()
-                              : clang::SourceLocation();
-      const std::string Original =
-          request.Function ? request.Function->getNameAsString() : "";
       for (const auto& [K, VD] : Kept) {
         clang::SourceLocation Loc = getDerivativePrinter().locationOf(FD, K);
         if (Loc.isInvalid())
@@ -426,14 +494,12 @@ void InitTimers();
                     "clad keeps this value for the reverse sweep")
             << getDerivativePrinter().rangeOf(FD, K);
         utils::diag(S, clang::DiagnosticsEngine::Note, Loc, "%0") << Because;
-        // Which derivative this is, said outright. The include stack carries
-        // it today, but only as a bare "In file included from" line with no
-        // caret and no wording, and only for as long as a derivative has a
-        // file to itself.
-        if (Requested.isValid())
-          utils::diag(S, clang::DiagnosticsEngine::Note, Requested,
+        // Which derivative this is, said outright rather than left to the
+        // include stack, which has no caret and no wording.
+        if (G.RequestedAt.isValid())
+          utils::diag(S, clang::DiagnosticsEngine::Note, G.RequestedAt,
                       "in the derivative of '%0' requested here")
-              << Original;
+              << G.Original->getNameAsString();
         // The half the user can act on: the expression in their own code
         // whose value this is.
         if (clang::SourceLocation Primal = primalLocationOf(K, VD, SM);
@@ -634,10 +700,21 @@ void InitTimers();
       if (DerivativeDecl) {
         if (!alreadyDerived &&
             (!request.CustomDerivative || request.CallUpdateRequired)) {
+          // Reported on at the end of the unit rather than here: reading a
+          // buffer settles where its lines are, so everything has to be
+          // printed into it first.
+          Generated G;
+          G.Derivative = DerivativeDecl;
+          G.AnalysisRan = request.EnableTBRAnalysis;
+          // Where a user asked for this derivative, when one did. Clad asks
+          // for some itself -- the second derivative a hessian needs -- and
+          // those were written on no line at all.
+          if (request.CallContext && request.Function) {
+            G.Original = request.Function;
+            G.RequestedAt = request.CallContext->getBeginLoc();
+          }
+          m_Generated.push_back(G);
           printDerivative(DerivativeDecl, request.DeclarationOnly, m_DO);
-          if (m_DO.DumpGeneratedSource)
-            dumpGeneratedSource(DerivativeDecl);
-          emitAnalysisRemarks(DerivativeDecl, request);
 
           S.MarkFunctionReferenced(SourceLocation(), DerivativeDecl);
           // We ideally should not call `HandleTopLevelDecl` for declarations
@@ -780,9 +857,11 @@ void InitTimers();
     }
 
     DerivativePrinter& CladPlugin::getDerivativePrinter() {
+      assert(m_DerivativeBuilder &&
+             "asked to print before anything was derived");
       if (!m_DerivativePrinter)
-        m_DerivativePrinter =
-            std::make_unique<DerivativePrinter>(m_CI.getSema());
+        m_DerivativePrinter = std::make_unique<DerivativePrinter>(
+            m_CI.getSema(), m_DerivativeBuilder->getGeneratedCode());
       return *m_DerivativePrinter;
     }
 
@@ -857,6 +936,9 @@ void InitTimers();
         }
 
         FinalizeTranslationUnit();
+        // Before the multiplexer: this is the last point at which every
+        // derivative exists and none has reached code generation.
+        materializeGeneratedCode();
         SendToMultiplexer();
       }
       if (m_Multiplexer)

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -253,6 +253,22 @@ inline AnalysisFlagResult remarkAnalysisByName(DifferentiationOptions& DO,
     /// The Sema::TUScope to restore in CladPlugin::HandleTranslationUnit.
     clang::Scope* m_StoredTUScope = nullptr;
 
+    /// A derivative, and what a report about it would say.
+    struct Generated {
+      clang::FunctionDecl* Derivative = nullptr;
+      /// What was differentiated to get it, and where that was written.
+      /// Both or neither: clad asks for some derivatives itself, and those
+      /// were written on no line at all.
+      const clang::FunctionDecl* Original = nullptr;
+      clang::SourceLocation RequestedAt;
+      /// Whether the to-be-recorded analysis ran, which decides the reason a
+      /// remark gives for a value being kept.
+      bool AnalysisRan = false;
+    };
+
+    /// The derivatives produced here, in the order they were produced.
+    llvm::SmallVector<Generated, 8> m_Generated;
+
   public:
     CladPlugin(clang::CompilerInstance& CI, DifferentiationOptions& DO);
     ~CladPlugin() override;
@@ -355,6 +371,10 @@ inline AnalysisFlagResult remarkAnalysisByName(DifferentiationOptions& DO,
   private:
     DiffScheduler& getScheduler();
     DerivativePrinter& getDerivativePrinter();
+    /// Prints every derivative into the buffer its nodes point into, then
+    /// reports on it: the line notes, the remarks, the source dump. Runs once
+    /// the whole unit is derived and before code generation.
+    void materializeGeneratedCode();
     void AppendDelayed(DelayedCallInfo DCI) {
       // Incremental processing handles the translation unit in chunks and it is
       // expected to have multiple calls to this functionality.
@@ -381,8 +401,8 @@ inline AnalysisFlagResult remarkAnalysisByName(DifferentiationOptions& DO,
     /// that text each of its statements sits.
     void dumpGeneratedSource(clang::Decl* D);
     /// Reports what an analysis left behind, at the generated code it left it
-    /// in. Renders that code only if there is something to report.
-    void emitAnalysisRemarks(clang::Decl* D, const DiffRequest& request);
+    /// in.
+    void emitAnalysisRemarks(const Generated& G);
 
     void ProcessTopLevelDecl(clang::Decl* D) {
       DelayedCallInfo DCI{CallKind::HandleTopLevelDecl, D};


### PR DESCRIPTION
Clad prints a derivative into a buffer of its own so that a diagnostic has something to point at, and hands its nodes locations from a different buffer so that DWARF can tell them apart. Two buffers holding the same code, and no way to say that a statement in one is the statement in the other -- which is also why a debugger stopping in a derivative finds blank lines: the buffer it is sent to has no text in it.

Print into the buffer the nodes already point into. One buffer holds the printed code at the front and one blank line per node behind it, and a note in front of each of those lines says which line of the code that node stands for. What clang ends up reading is what a user would have written as:

    inline void f_grad(double x, double *_d_x) {
        double _t0 = t;
        t = t * t;
        ...
    }
    #line 1
                  <- the node handed this line reports line 1
    #line 2
                  <- this one reports line 2
    #line 3
                  <- and this one line 3

The blank lines at the bottom are the slots. Each is one byte, given to one generated node while the derivative is being built, long before anyone knows what line that node will be printed on; the #lines go in at the end, once it is known. A remark and a breakpoint name the same bytes because there is only one copy of them.

The arrangement comes with one rule: a buffer has to be finished before it is read. The SourceManager works out where a buffer's lines are the first time it is asked about one and keeps the answer, so code printed after that sits on lines it has never heard of. That showed as a remark quoting the right line number and the wrong text, sliding one character further along on every line after the first. So every derivative is printed in one pass at the end of the translation unit, and everything that reads them -- the remarks, the source dump, the line notes -- runs after that pass.

What it costs: a buffer grows from 8 KB to 104 KB, since it now reserves twelve bytes of room for code beside each of its 8192 slots, and it is written once when it is made. Sixty non-trivial functions, whose derivatives come to 4300 lines, need two of them -- 200 KB against the 135 MB clang wants for that file. Nothing is printed unless something is going to read it, so an ordinary compile pays for the room and not for the printing. Where printing does happen it goes into this buffer instead of the second one this deletes, not on top of it. With -g on that file the difference against the previous commit stayed inside the noise between runs, 1.47s against 1.49s over five runs each.

Two things this does not reach. A derivative printing more than a buffer's 96 KB of room gets nothing printed, and a debugger stopping in it still finds blank lines. And a derivative with more nodes than one buffer holds runs on into the next one; the statements that land there get no note, because a note can only name a line of the file its own slot is in.