### PR TITLE
Let the visitors build calls and braces without inventing locations.

### DIFF
--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -811,6 +811,20 @@ namespace clad {
                                  const std::string& nmspace,
                                  llvm::SmallVectorImpl<clang::Expr*>& callArgs);
 
+    /// Builds a call to \p Callee, giving its parentheses locations of their
+    /// own.
+    ///
+    /// A generated call has no parentheses anyone wrote, so the caller of
+    /// Sema::ActOnCallExpr has to say where they are. Deciding that here
+    /// rather than at each site is what makes one generated call tell apart
+    /// from another. Returns null if Sema rejects the call.
+    clang::Expr* BuildCallExpr(clang::Expr* Callee,
+                               llvm::MutableArrayRef<clang::Expr*> Args);
+
+    /// Builds a braced initializer over \p Elements, giving its braces
+    /// locations of their own. Same reason as BuildCallExpr.
+    clang::Expr* BuildInitList(llvm::MutableArrayRef<clang::Expr*> Elements);
+
     clang::DeclRefExpr* GetCladTapePushDRE();
 
     clang::Stmt* GetCladZeroInit(llvm::MutableArrayRef<clang::Expr*> args);

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -439,7 +439,7 @@ void BaseForwardModeVisitor::GenerateSeeds(const clang::FunctionDecl* dFD) {
               m_Context.IntTy, m_Context, dValue);
           dArrVal.push_back(dValueLiteral);
         }
-        dInitializer = m_Sema.ActOnInitList(validLoc, dArrVal, validLoc).get();
+        dInitializer = BuildInitList(dArrVal);
       } else if (const auto* ptrType =
                      dyn_cast<PointerType>(fieldType.getTypePtr())) {
         if (!ptrType->getPointeeType()->isRealType())
@@ -850,8 +850,8 @@ StmtDiff BaseForwardModeVisitor::VisitInitListExpr(const InitListExpr* ILE) {
     derivedExprs[i] = ResultI.getExpr_dx();
   }
 
-  Expr* clonedILE = m_Sema.ActOnInitList(noLoc, clonedExprs, noLoc).get();
-  Expr* derivedILE = m_Sema.ActOnInitList(noLoc, derivedExprs, noLoc).get();
+  Expr* clonedILE = BuildInitList(clonedExprs);
+  Expr* derivedILE = BuildInitList(derivedExprs);
   return StmtDiff(clonedILE, derivedILE);
 }
 
@@ -2405,8 +2405,8 @@ BaseForwardModeVisitor::VisitCXXConstructExpr(const CXXConstructExpr* CE) {
       // Rely on the initializer list expressions as they seem to be more
       // flexible in terms of conversions and other similar scenarios where a
       // constructor is called implicitly.
-      clonedArgsE = m_Sema.ActOnInitList(noLoc, clonedArgs, noLoc).get();
-      derivedArgsE = m_Sema.ActOnInitList(noLoc, derivedArgs, noLoc).get();
+      clonedArgsE = BuildInitList(clonedArgs);
+      derivedArgsE = BuildInitList(derivedArgs);
     }
   } else {
     clonedArgsE = clonedArgs[0];

--- a/lib/Differentiator/PushForwardModeVisitor.cpp
+++ b/lib/Differentiator/PushForwardModeVisitor.cpp
@@ -48,7 +48,7 @@ StmtDiff PushForwardModeVisitor::VisitReturnStmt(const ReturnStmt* RS) {
             .get();
   }
   llvm::SmallVector<Expr*, 2> returnValues = {retVal, retVal_dx};
-  Expr* initList = m_Sema.ActOnInitList(GenLoc(), returnValues, noLoc).get();
+  Expr* initList = BuildInitList(returnValues);
   Stmt* returnStmt = BuildReturnStmt(initList);
   return StmtDiff(returnStmt);
 }

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -107,11 +107,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // call owns its tape reference. A local lvalue is required: the single
     // element is passed as a MultiExprArg, which stores a pointer to it.
     Expr* RefClone = V.CloneNode(Ref);
-    Expr* Call =
-        V.m_Sema
-            .ActOnCallExpr(V.getCurrentScope(), BackDRE, noLoc, RefClone, noLoc)
-            .get();
-    return Call;
+    return V.BuildCallExpr(BackDRE, RefClone);
   }
 
   ReverseModeVisitor::CladTapeResult
@@ -144,15 +140,11 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                         .BuildDeclarationNameExpr(CSS, Push,
                                                   /*AcceptInvalidDecl=*/false)
                         .get();
-    Expr* PopExpr =
-        m_Sema.ActOnCallExpr(getCurrentScope(), PopDRE, noLoc, TapeRef, noLoc)
-            .get();
+    Expr* PopExpr = BuildCallExpr(PopDRE, TapeRef);
     // pop, push and the returned last-ref each get their own tape DeclRef so
     // the same node is not parented by both the push and pop CallExprs.
     Expr* CallArgs[] = {CloneNode(TapeRef), E};
-    Expr* PushExpr =
-        m_Sema.ActOnCallExpr(getCurrentScope(), PushDRE, noLoc, CallArgs, noLoc)
-            .get();
+    Expr* PushExpr = BuildCallExpr(PushDRE, CallArgs);
 
     if (isInsideOMPBlock)
       MarkDeclThreadPrivate(VD);
@@ -231,7 +223,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             .ActOnCallExpr(
                 getCurrentScope(),
                 /*Fn=*/UnresolvedLookup,
-                /*LParenLoc=*/noLoc,
+                /*LParenLoc=*/GenLoc(),
                 /*ArgExprs=*/llvm::MutableArrayRef<Expr*>(atomicArgs),
                 /*RParenLoc=*/m_DiffReq->getLocation())
             .get();
@@ -638,11 +630,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // shared replacement would land under several parents and violate the
       // single-parent AST invariant, so build one per marker site.
       patchEarlyReturnMarkers([&]() -> Stmt* {
-        Expr* RevCallEarly =
-            m_Sema
-                .ActOnCallExpr(getCurrentScope(), BuildDeclRef(RevVD), noLoc,
-                               {}, noLoc)
-                .get();
+        Expr* RevCallEarly = BuildCallExpr(BuildDeclRef(RevVD), {});
         Stmt* RetStmt = m_Sema
                             .ActOnReturnStmt(noLoc, /*RetValExpr=*/nullptr,
                                              getCurrentScope())
@@ -655,11 +643,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       // (VisitReturnStmt), so it runs only on fall-through. Follow it with the
       // lambda call; the function's implicit fall-off-end serves as the natural
       // return.
-      Expr* RevCallTail =
-          m_Sema
-              .ActOnCallExpr(getCurrentScope(), BuildDeclRef(RevVD), noLoc, {},
-                             noLoc)
-              .get();
+      Expr* RevCallTail = BuildCallExpr(BuildDeclRef(RevVD), {});
       addToCurrentBlock(RevCallTail, direction::forward);
     }
     for (auto S = initsDiff.rbegin(), S_end = initsDiff.rend(); S != S_end; ++S)
@@ -1583,8 +1567,8 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         exprsDiff[i] = getZeroInit(ILE->getInit(i)->getType());
     }
 
-    Expr* clonedILE = m_Sema.ActOnInitList(noLoc, clonedExprs, noLoc).get();
-    Expr* ILEDiff = m_Sema.ActOnInitList(noLoc, exprsDiff, noLoc).get();
+    Expr* clonedILE = BuildInitList(clonedExprs);
+    Expr* ILEDiff = BuildInitList(exprsDiff);
     return StmtDiff(clonedILE, ILEDiff);
   }
 
@@ -2467,7 +2451,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                 .ActOnCallExpr(
                     getCurrentScope(),
                     /*Fn=*/LambdaCallOpExpr,
-                    /*LParenLoc=*/noLoc,
+                    /*LParenLoc=*/GenLoc(),
                     /*ArgExprs=*/llvm::MutableArrayRef<Expr*>(pullbackCallArgs),
                     /*RParenLoc=*/m_DiffReq->getLocation(), CUDAExecConfig)
                 .get();
@@ -2837,7 +2821,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
         /*IndexTypeQuals*/ 0);
     Expr* zero =
         ConstantFolder::synthesizeLiteral(m_Context.IntTy, m_Context, 0);
-    Expr* init = m_Sema.ActOnInitList(noLoc, {zero}, noLoc).get();
+    Expr* init = BuildInitList({zero});
     auto* VD = BuildVarDecl(GradType, "_grad", init);
 
     NumDiffArgs.push_back(BuildDeclRef(VD));
@@ -3573,7 +3557,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
       if (CAT) {
         llvm::SmallVector<Expr*, 2> args(CAT->getSize().getZExtValue(),
                                          dummyInit);
-        dummyInit = m_Sema.ActOnInitList(noLoc, args, noLoc).get();
+        dummyInit = BuildInitList(args);
       }
     }
 
@@ -5144,11 +5128,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     Expr* pushDRE = m_RMV.GetCladTapePushDRE();
     Expr* callArgs[] = {m_RMV.CloneNode(m_ControlFlowTape->Ref),
                         CreateSizeTLiteralExpr(value)};
-    Expr* pushExpr = m_RMV.m_Sema
-                         .ActOnCallExpr(m_RMV.getCurrentScope(), pushDRE, noLoc,
-                                        callArgs, noLoc)
-                         .get();
-    return pushExpr;
+    return m_RMV.BuildCallExpr(pushDRE, callArgs);
   }
 
   void

--- a/lib/Differentiator/VectorPushForwardModeVisitor.cpp
+++ b/lib/Differentiator/VectorPushForwardModeVisitor.cpp
@@ -61,7 +61,7 @@ VectorPushForwardModeVisitor::VisitReturnStmt(const clang::ReturnStmt* RS) {
   StmtDiff retValDiff = Visit(RS->getRetValue());
   llvm::SmallVector<Expr*, 2> returnValues = {retValDiff.getExpr(),
                                               retValDiff.getExpr_dx()};
-  Expr* initList = m_Sema.ActOnInitList(GenLoc(), returnValues, noLoc).get();
+  Expr* initList = BuildInitList(returnValues);
   Stmt* returnStmt = BuildReturnStmt(initList);
   return StmtDiff(returnStmt);
 }

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -833,6 +833,25 @@ namespace clad {
     return clad_compat::llvm_Optional_GetValue(Result);
   }
 
+  Expr* VisitorBase::BuildInitList(llvm::MutableArrayRef<Expr*> Elements) {
+    // A location each, not one for both: the two braces are distinct positions
+    // in the printed derivative, and one location for both would make a range
+    // whose ends coincide.
+    SourceLocation LBrace = GenLoc();
+    SourceLocation RBrace = GenLoc();
+    return m_Sema.ActOnInitList(LBrace, Elements, RBrace).get();
+  }
+
+  Expr* VisitorBase::BuildCallExpr(Expr* Callee,
+                                   llvm::MutableArrayRef<Expr*> Args) {
+    // A location each, for the same reason as the braces above.
+    SourceLocation LParen = GenLoc();
+    SourceLocation RParen = GenLoc();
+    ExprResult Call =
+        m_Sema.ActOnCallExpr(getCurrentScope(), Callee, LParen, Args, RParen);
+    return Call.isInvalid() ? nullptr : Call.get();
+  }
+
   Expr* VisitorBase::GetFunctionCall(const std::string& funcName,
                                      const std::string& nmspace,
                                      llvm::SmallVectorImpl<Expr*>& callArgs) {
@@ -1012,7 +1031,7 @@ namespace clad {
                  .ActOnCallExpr(
                      getCurrentScope(),
                      /*Fn=*/exprFunc,
-                     /*LParenLoc=*/noLoc,
+                     /*LParenLoc=*/GenLoc(),
                      /*ArgExprs=*/llvm::MutableArrayRef<Expr*>(argExprs),
                      /*RParenLoc=*/m_DiffReq->getLocation(), CUDAExecConfig)
                  .get();
@@ -1405,8 +1424,7 @@ namespace clad {
     CSS.Extend(m_Context, utils::GetCladNamespace(m_Sema), noLoc, noLoc);
     auto* pushDRE =
         m_Sema.BuildDeclarationNameExpr(CSS, init, false).getAs<DeclRefExpr>();
-    return m_Sema.ActOnCallExpr(getCurrentScope(), pushDRE, noLoc, args, noLoc)
-        .get();
+    return BuildCallExpr(pushDRE, args);
   }
 
   Expr* VisitorBase::GetCladZeroLike(Expr* value) {
@@ -1433,9 +1451,7 @@ namespace clad {
     if (m_Builder.noOverloadExists(UnresolvedLookup, ARargs))
       return nullptr;
 
-    ExprResult Call = m_Sema.ActOnCallExpr(getCurrentScope(), UnresolvedLookup,
-                                           noLoc, ARargs, noLoc);
-    return Call.isInvalid() ? nullptr : Call.get();
+    return BuildCallExpr(UnresolvedLookup, ARargs);
   }
 
   FunctionDecl* VisitorBase::CreateDerivativeOverload(FunctionDecl* derivative,


### PR DESCRIPTION
A generated call has no parentheses anyone wrote and a generated braced initializer has no braces, so every caller of Sema::ActOnCallExpr and Sema::ActOnInitList had to supply locations of its own. Nineteen sites did, nearly all of them passing the same placeholder, which leaves the node they build with no position at all to report.

VisitorBase already wraps most of what the visitors build -- BuildOp, BuildVarDecl, BuildDeclRef, BuildCallExprToMemFn -- and these two were the gap. BuildCallExpr and BuildInitList hand out the locations themselves, one per parenthesis and one per brace, so the decision is made in one place and a site has nowhere left to pass a placeholder.

Measured, the gain is modest, because a call already began at its callee and only its closing parenthesis moves; a braced initializer begins at its opening brace, so that one is a position where there was none. A reverse gradient over test/Gradient/Loops.C gains three distinguishable lines in the debug line table and loses none, as does Arrays/ArrayInputsReverseMode.C.

Five sites keep their placeholder. The free helpers in CladUtils and BuildConstructorCall take a Sema and no visitor, so the wrappers are out of reach without threading the builder through them, and clad's atomic add and the lambda pullback pass a CUDA execution configuration the wrappers do not take and deliberately close at the primal's location.