### PR TITLE
Give a generated variable and each reference to it a location.

### DIFF
--- a/lib/Differentiator/GeneratedCode.cpp
+++ b/lib/Differentiator/GeneratedCode.cpp
@@ -16,14 +16,6 @@ using namespace clang;
 
 namespace clad {
 
-/// Whether the SourceManager has already worked out where \p File's lines
-/// are. It does that once and keeps the answer, so anything printed after
-/// that would sit on lines it does not know about.
-static bool hasLineTable(SourceManager& SM, FileID File) {
-  return bool(
-      SM.getSLocEntry(File).getFile().getContentCache().SourceLineCache);
-}
-
 SourceLocation GeneratedCode::nextLoc() {
   SourceManager& SM = m_Sema.getSourceManager();
   if (m_Used == kSlotsPerChunk) {
@@ -93,11 +85,6 @@ GeneratedCode::Placement GeneratedCode::addText(SourceLocation Anchor,
   if (!C || Text.empty())
     return {};
   SourceManager& SM = m_Sema.getSourceManager();
-  // Printing now would move lines the SourceManager has already committed to,
-  // and every position it reports here afterwards would be off. Say nothing
-  // rather than something untrue.
-  if (hasLineTable(SM, C->File))
-    return {};
   // A trailing newline so the next derivative starts on a line of its own
   // rather than continuing this one.
   const size_t Need = Text.size() + 1;
@@ -148,6 +135,19 @@ void GeneratedCode::assign(SourceLocation Begin, SourceLocation End,
     if (I < C->SlotLine.size())
       C->SlotLine[I] = Line;
   }
+}
+
+void GeneratedCode::forgetLineTables() {
+  SourceManager& SM = m_Sema.getSourceManager();
+  // The line table is a cache the SourceManager fills on demand, so dropping
+  // it only means the next question is answered by reading the buffer again.
+  for (const Chunk& C : m_ChunkList)
+    SM.getSLocEntry(C.File).getFile().getContentCache().SourceLineCache =
+        SrcMgr::LineOffsetMapping();
+  // It also remembers the answer it last gave, to start the next search near
+  // it. That answer came from a table just dropped, so ask about another file
+  // to make the next question about these start over.
+  SM.getLineNumber(SM.getMainFileID(), 0);
 }
 
 void GeneratedCode::present() {

--- a/lib/Differentiator/GeneratedCode.h
+++ b/lib/Differentiator/GeneratedCode.h
@@ -47,11 +47,14 @@ namespace clad {
 ///
 /// Chunks are a fixed size, and a new one is made when the slots run out: the
 /// SourceManager owns a buffer once it is handed over, so none of them can
-/// grow. That brings the one rule here -- a chunk has to be finished before
-/// it is read. The SourceManager works out where a buffer's lines are on the
-/// first question about it and keeps the answer, so code printed later would
-/// sit on lines it has never heard of. Printing into a chunk that has been
-/// read is refused.
+/// grow.
+///
+/// The SourceManager also works out where a buffer's lines are on the first
+/// question about it and keeps the answer, so code printed after that would
+/// sit on lines it has never heard of. Clad cannot stop the question being
+/// asked -- building a derivative puts generated locations in front of Sema,
+/// and on some builds that is enough for something to ask. So the answer is
+/// dropped instead: print everything, call forgetLineTables, then read.
 class GeneratedCode {
   /// Slots in a chunk. A chunk is paid for in full as soon as it is made, so
   /// this trades memory against how many buffers a derivative is spread over.
@@ -106,7 +109,7 @@ public:
   ///
   /// \p Anchor is a slot of the code being printed: a note on a slot can only
   /// name a line of its own file, so the two have to share a chunk. Comes
-  /// back empty if the code does not fit or the chunk has been read.
+  /// back empty if the code does not fit.
   Placement addText(clang::SourceLocation Anchor, llvm::StringRef Text);
 
   /// The bytes printed at \p P, \p Size of them.
@@ -129,6 +132,11 @@ public:
   /// slot reports one line further on than the slot before it, which walks
   /// off the end of the code.
   void present();
+
+  /// Throws away what the SourceManager worked out about these buffers, so
+  /// that the next question about a line is answered from what they hold now.
+  /// Call it once everything is printed and before anything reads.
+  void forgetLineTables();
 
   /// Stops anything more being printed into the chunks made so far, because
   /// they have been read. Incremental compilation comes back for another

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -165,9 +165,9 @@ namespace clad {
                                      TypeSourceInfo* TSI, StorageClass SC) {
     // add namespace specifier in variable declaration if needed.
     Type = utils::AddNamespaceSpecifier(m_Sema, m_Context, Type);
-    auto* VD =
-        VarDecl::Create(m_Context, m_Sema.CurContext, m_DiffReq->getLocation(),
-                        m_DiffReq->getLocation(), Identifier, Type, TSI, SC);
+    SourceLocation Loc = GenLoc();
+    auto* VD = VarDecl::Create(m_Context, m_Sema.CurContext, Loc, Loc,
+                               Identifier, Type, TSI, SC);
 
     SetDeclInit(VD, Init, DirectInit);
     m_Sema.FinalizeDeclaration(VD);
@@ -342,7 +342,7 @@ namespace clad {
     QualType T = D->getType();
     T = T.getNonReferenceType();
     return cast<DeclRefExpr>(clad_compat::GetResult<Expr*>(
-        m_Sema.BuildDeclRefExpr(D, T, VK, D->getBeginLoc(), &CSS)));
+        m_Sema.BuildDeclRefExpr(D, T, VK, GenLoc(), &CSS)));
   }
 
   void VisitorBase::LambdaCaptures::collect(llvm::ArrayRef<Stmt*> Body) {

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -343,6 +343,11 @@ void InitTimers();
                         Printer.lineOf(FD, S));
       }
 
+      // Everything is printed. What the SourceManager worked out about these
+      // buffers while the derivatives were being built describes an emptier
+      // version of them, so drop it before anything asks.
+      Code.forgetLineTables();
+
       if (WantLineNotes)
         Code.present();
 


### PR DESCRIPTION
Every variable clad builds was created at m_DiffReq->getLocation(), the location of the function being differentiated, and every reference to one was built at the declaration's location. So the temporaries, the adjoints and the stores a reverse sweep inserts all reported the user's function as where they were written, and a variable and its every mention shared one position.

Give each a slot of its own. A declaration then names the line of generated code it is printed on, and a mention names the line it is mentioned on rather than the line the variable came from.

Both halves are needed: with only the first, every mention of a variable still lands on the variable's slot, and the line that slot ends up presenting is whichever mention was described last. Measured on test/Gradient/Loops.C, no generated variable is declared in the generated buffer at all today; with this, 528 of them are, over 236 distinct lines. The ones still sharing a line are those clad clones from the user's code, which keep the primal's location and so are never described.