### PR TITLE
Give a debugger somewhere to read the generated code from.

### DIFF
--- a/docs/userDocs/source/user/DevelopersDocumentation.rst
+++ b/docs/userDocs/source/user/DevelopersDocumentation.rst
@@ -200,6 +200,25 @@ never ran.
 
 Run ``-plugin-arg-clad -help`` for the analysis names this accepts.
 
+``-fgenerated-source-dir=<dir>``
+--------------------------------
+
+Writes the code clad generates into ``<dir>``, one file per translation unit
+named after it, and names that file in the debug line table. A debugger then
+has something to open when it stops inside a derivative.
+
+.. code-block:: bash
+
+   clang++ -g -fplugin=clad.so -Xclang -plugin-arg-clad \
+       -Xclang -fgenerated-source-dir=build/ doc.cpp
+
+Without it, the only way to reach the code is ``-gembed-source``, which puts
+it in the object; lldb reads that and gdb does not support it at all. When
+debug information is asked for and neither is in place, clad says so once and
+names the flag that fits the debugger being tuned for. Giving the flag with no
+directory writes nothing and turns that advice off, which is the only way to:
+a plugin's diagnostic belongs to no ``-W`` group.
+
 ``-fdump-generated-source``
 --------------------------------
 

--- a/lib/Differentiator/GeneratedCode.cpp
+++ b/lib/Differentiator/GeneratedCode.cpp
@@ -1,15 +1,21 @@
 #include "GeneratedCode.h"
 
+#include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Sema/Sema.h"
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
 #include <cstring>
 #include <string>
+#include <system_error>
 #include <utility>
 
 using namespace clang;
@@ -53,14 +59,47 @@ SourceLocation GeneratedCode::nextLoc() {
           static_cast<int>(m_ChunkList.back().Capacity + m_Used++));
 }
 
+void GeneratedCode::setFileBase(llvm::StringRef Dir, llvm::StringRef Unit) {
+  if (Unit.empty())
+    return; // Nothing to name them after; leave them anonymous.
+  // Left exactly as it was given. A relative name is written relative to the
+  // working directory and read back against the compilation directory the
+  // line table records, which is the same place; making it absolute here
+  // would only put this machine's paths in the debug information.
+  llvm::SmallString<128> Path(Dir);
+  llvm::sys::path::append(Path, llvm::sys::path::filename(Unit));
+  m_FileBase = std::string(Path);
+}
+
 std::string GeneratedCode::nextName() const {
   // Named apart from the chunks before it. Every chunk numbers its lines
   // from 1 and the line table keys a file by name, so two chunks sharing a
   // name would put two statements at the same position.
-  if (m_ChunkList.empty())
-    return "<clad generated code>";
-  return "<clad generated code #" + std::to_string(m_ChunkList.size() + 1) +
-         ">";
+  const size_t N = m_ChunkList.size() + 1;
+  if (m_FileBase.empty())
+    return N == 1 ? "<clad generated code>"
+                  : "<clad generated code #" + std::to_string(N) + ">";
+  return N == 1 ? m_FileBase + ".clad.cpp"
+                : m_FileBase + ".clad." + std::to_string(N) + ".cpp";
+}
+
+void GeneratedCode::writeChunksToFiles(DiagnosticsEngine& Diags) const {
+  if (m_FileBase.empty())
+    return;
+  for (const Chunk& C : m_ChunkList) {
+    if (!C.Used)
+      continue;
+    std::error_code EC;
+    llvm::raw_fd_ostream Out(C.Name, EC, llvm::sys::fs::OF_Text);
+    if (EC) {
+      unsigned ID = Diags.getCustomDiagID(
+          DiagnosticsEngine::Warning,
+          "could not write the generated source to '%0': %1");
+      Diags.Report(ID) << C.Name << EC.message();
+      continue;
+    }
+    Out << llvm::StringRef(C.Text, C.Used);
+  }
 }
 
 GeneratedCode::Chunk* GeneratedCode::chunkFor(SourceLocation Loc) {

--- a/lib/Differentiator/GeneratedCode.h
+++ b/lib/Differentiator/GeneratedCode.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 namespace clang {
+class DiagnosticsEngine;
 class Sema;
 } // namespace clang
 
@@ -89,11 +90,26 @@ class GeneratedCode {
   [[nodiscard]] std::string nextName() const;
 
   clang::Sema& m_Sema;
+  /// What the chunks are named after, without the number and the suffix.
+  /// Empty while they are anonymous, which is until someone asks for the code
+  /// on disk.
+  std::string m_FileBase;
   llvm::SmallVector<Chunk, 2> m_ChunkList;
   unsigned m_Used = kSlotsPerChunk; // forces the first nextLoc() to allocate
 
 public:
   explicit GeneratedCode(clang::Sema& S) : m_Sema(S) {}
+
+  /// Sets what the chunks, and so the files they are written to, are named
+  /// after: \p Unit's file name under \p Dir. A debugger handed one of those
+  /// names then has something to open. Call it before the first location is
+  /// handed out, since a chunk keeps the name it was made with.
+  void setFileBase(llvm::StringRef Dir, llvm::StringRef Unit);
+
+  /// Writes each chunk to the file it is named after. Says so and carries on
+  /// if one cannot be written: without the file a debugger still has the
+  /// right file and line, and only the text is missing.
+  void writeChunksToFiles(clang::DiagnosticsEngine& Diags) const;
 
   /// A location no other generated node has been given.
   clang::SourceLocation nextLoc();

--- a/test/Misc/Args.C
+++ b/test/Misc/Args.C
@@ -6,6 +6,7 @@
 // CHECK_HELP-NEXT: -fdump-derived-fn-ast
 // CHECK_HELP-NEXT: -fdump-generated-source
 // CHECK_HELP-NEXT: -Rclad-analysis=<name>
+// CHECK_HELP-NEXT: -fgenerated-source-dir=<dir>
 // CHECK_HELP-NEXT: -fgenerate-source-file
 // CHECK_HELP-NEXT: -fno-validate-clang-version
 // CHECK_HELP-NEXT: -fcustom-estimation-model

--- a/test/Misc/GeneratedCodeDebugInfo.C
+++ b/test/Misc/GeneratedCodeDebugInfo.C
@@ -28,6 +28,17 @@
 // RUN:   END { n = 0; for (l in line) n++; print "distinct-lines", n }' \
 // RUN:   | %filecheck --check-prefix=DISTINCT %s
 // DISTINCT: distinct-lines {{([2-9]|[1-9][0-9]+)}}
+//
+// Given somewhere to put it, the buffer is named after a file that is there,
+// which is what a debugger with no support for source embedded in the object
+// resolves and opens.
+// RUN: rm -rf %t.dir && mkdir -p %t.dir
+// RUN: %cladclang -g -gdwarf-5 -O0 -Xclang -plugin-arg-clad \
+// RUN:   -Xclang -fgenerated-source-dir=%t.dir -c %s -I%S/../../include \
+// RUN:   -o %t.named.o
+// RUN: %llvm-dwarfdump --debug-line %t.named.o \
+// RUN:   | %filecheck --check-prefix=CHECK-NAMED %s
+// CHECK-NAMED: name: "{{.*}}.clad.cpp"
 
 #include "clad/Differentiator/Differentiator.h"
 

--- a/test/Misc/GeneratedSourceFile.C
+++ b/test/Misc/GeneratedSourceFile.C
@@ -1,0 +1,79 @@
+// Getting at the code clad generated, from a debugger.
+//
+// The derivative's statements have locations in a buffer that holds their
+// code, which is enough for a diagnostic but not for a debugger: lldb can
+// read the text out of the object with -gembed-source, and gdb cannot read
+// that extension at all -- it resolves the name in the line table against the
+// compilation directory and opens a file. Write the code to a file and name
+// the buffer after it and both are served.
+//
+// RUN: rm -rf %t.dir && mkdir -p %t.dir
+// RUN: %cladclang -g -gdwarf-5 -Xclang -plugin-arg-clad \
+// RUN:   -Xclang -fgenerated-source-dir=%t.dir -c -o %t.o %s \
+// RUN:   -I%S/../../include 2>&1 | %filecheck --allow-empty %s
+// RUN: cat %t.dir/*.clad.cpp | FileCheck --check-prefix=CHECK-FILE %s
+//
+// One file per translation unit, named after it, holding what clad wrote.
+// CHECK-FILE: void f_grad(double x, double *_d_x)
+// CHECK-FILE: double _t0 = t;
+// CHECK-FILE: t = _t0;
+//
+// Asking for it says nothing: the advice below is for the case where nothing
+// can read the code, and this is not that case.
+// CHECK-NOT: warning:
+
+#include "clad/Differentiator/Differentiator.h"
+
+double f(double x) {
+  double t = x * x;
+  t = t * t;
+  return t;
+}
+
+int main() {
+  auto g = clad::gradient(f);
+  double d = 0;
+  g.execute(2, &d);
+  return 0;
+}
+
+// Debug information was asked for and nothing will be able to show the code,
+// so clad says which flag to add. What it suggests depends on the debugger
+// being tuned for, because -gembed-source only serves one of them. Plain
+// FileCheck: the run is about a warning, which the shared %filecheck rejects.
+//
+// RUN: %cladclang -glldb -gdwarf-5 -c -o %t.o %s -I%S/../../include 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-LLDB %s
+// CHECK-LLDB: warning: debug information for the code clad generated points at no source a debugger can open; add -gembed-source, or -plugin-arg-clad -fgenerated-source-dir=<dir>
+//
+// gdb has no support for the embedded-source extension, so it is not offered.
+// RUN: %cladclang -ggdb -gdwarf-5 -c -o %t.o %s -I%S/../../include 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-GDB %s
+// CHECK-GDB: warning: debug information for the code clad generated points at no source a debugger can open; add -plugin-arg-clad -fgenerated-source-dir=<dir>
+// CHECK-GDB-NOT: -gembed-source
+//
+// With the code in the object and a debugger that reads it from there, there
+// is nothing to say.
+// RUN: %cladclang -glldb -gdwarf-5 -gembed-source -c -o %t.o %s \
+// RUN:   -I%S/../../include 2>&1 | %filecheck --check-prefix=CHECK-QUIET \
+// RUN:   --allow-empty %s
+// CHECK-QUIET-NOT: warning:
+//
+// And nothing at all without debug information, which is the common build.
+// RUN: %cladclang -c -o %t.o %s -I%S/../../include 2>&1 \
+// RUN:   | %filecheck --check-prefix=CHECK-QUIET --allow-empty %s
+//
+// A directory that cannot be written to is worth a word and not worth
+// failing over: the line table still has the right file and line, and only
+// the text is missing. Plain FileCheck, since this is about a warning.
+// RUN: %cladclang -g -Xclang -plugin-arg-clad \
+// RUN:   -Xclang -fgenerated-source-dir=%t.dir/missing -c -o %t.o %s \
+// RUN:   -I%S/../../include 2>&1 | FileCheck --check-prefix=CHECK-UNWRITABLE %s
+// CHECK-UNWRITABLE: warning: could not write the generated source to '{{.*}}missing{{.*}}.clad.cpp':
+//
+// Naming the flag with no directory is an answer too: nothing is written and
+// nothing is said. A plugin's diagnostic belongs to no -W group, so this is
+// the only way to turn the advice off.
+// RUN: %cladclang -g -gdwarf-5 -Xclang -plugin-arg-clad \
+// RUN:   -Xclang -fgenerated-source-dir= -c -o %t.o %s -I%S/../../include \
+// RUN:   2>&1 | %filecheck --check-prefix=CHECK-QUIET --allow-empty %s

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -348,8 +348,11 @@ void InitTimers();
       // version of them, so drop it before anything asks.
       Code.forgetLineTables();
 
-      if (WantLineNotes)
+      if (WantLineNotes) {
         Code.present();
+        Code.writeChunksToFiles(m_CI.getDiagnostics());
+        adviseOnGeneratedSource();
+      }
 
       for (const Generated& G : m_Generated) {
         if (m_DO.DumpGeneratedSource)
@@ -361,6 +364,32 @@ void InitTimers();
       // back with more derivatives to print somewhere else.
       Code.seal();
       m_Generated.clear();
+    }
+
+    void CladPlugin::adviseOnGeneratedSource() const {
+      // Only when there is nothing to read. A debugger reaches the code clad
+      // generated either through the object, which needs -gembed-source and a
+      // debugger that understands it, or through a file on disk.
+      // Naming the flag at all is an answer, even with no directory after it:
+      // it says the generated code being unreadable is known and meant.
+      if (m_DO.GeneratedSourceDirGiven)
+        return;
+      const clang::CodeGenOptions& CGO = m_CI.getCodeGenOpts();
+      // Through the enum's own type rather than by name: which header spells
+      // it, and in which namespace, has moved between releases.
+      const auto Tuning = CGO.getDebuggerTuning();
+      const bool ReadsEmbedded = Tuning == decltype(Tuning)::LLDB;
+      if (CGO.EmbedSource && ReadsEmbedded)
+        return;
+      const char* Advice =
+          ReadsEmbedded ? "add -gembed-source, or -plugin-arg-clad "
+                          "-fgenerated-source-dir=<dir>"
+                        : "add -plugin-arg-clad -fgenerated-source-dir=<dir>";
+      unsigned ID = m_CI.getDiagnostics().getCustomDiagID(
+          clang::DiagnosticsEngine::Warning,
+          "debug information for the code clad generated points at no source a "
+          "debugger can open; %0");
+      m_CI.getDiagnostics().Report(ID) << Advice;
     }
 
     void CladPlugin::dumpGeneratedSource(clang::Decl* D) {
@@ -635,9 +664,15 @@ void InitTimers();
 
     FunctionDecl* CladPlugin::ProcessDiffRequest(DiffRequest& request) {
       Sema& S = m_CI.getSema();
-      if (!m_DerivativeBuilder)
+      if (!m_DerivativeBuilder) {
         m_DerivativeBuilder =
             std::make_unique<DerivativeBuilder>(S, *this, getScheduler());
+        // Before the first chunk is made: a chunk keeps the name it was made
+        // with, and that name is what the line table records.
+        if (!m_DO.GeneratedSourceDir.empty())
+          m_DerivativeBuilder->getGeneratedCode().setFileBase(
+              m_DO.GeneratedSourceDir, m_CI.getCodeGenOpts().MainFileName);
+      }
 
       if (request.Global) {
         auto deriveResult = m_DerivativeBuilder->Derive(request);

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -71,6 +71,12 @@ struct DifferentiationOptions {
 #include "clad/Differentiator/Analyses.def"
   bool GenerateSourceFile = false;
   bool DumpGeneratedSource = false;
+  /// Where to write the generated code so a debugger can open it, and
+  /// whether that was asked at all. Asking with no directory writes nothing
+  /// and says nothing, which is how a build that knows it does not want this
+  /// turns the advice off.
+  std::string GeneratedSourceDir;
+  bool GeneratedSourceDirGiven = false;
   bool ValidateClangVersion = true;
   /// What the command line asked of each analysis. The two bools record which
   /// of the original -enable-<x>/-disable-<x> pair were seen, so that giving
@@ -371,6 +377,11 @@ inline AnalysisFlagResult remarkAnalysisByName(DifferentiationOptions& DO,
   private:
     DiffScheduler& getScheduler();
     DerivativePrinter& getDerivativePrinter();
+    /// Says, once, that nothing will be able to show the generated code, and
+    /// what to add. Only when debug information was asked for and neither way
+    /// of reaching the code is in place.
+    void adviseOnGeneratedSource() const;
+
     /// Prints every derivative into the buffer its nodes point into, then
     /// reports on it: the line notes, the remarks, the source dump. Runs once
     /// the whole unit is derived and before code generation.
@@ -446,6 +457,13 @@ inline AnalysisFlagResult remarkAnalysisByName(DifferentiationOptions& DO,
             m_DO.DumpDerivedAST = true;
           } else if (args[i] == "-fdump-generated-source") {
             m_DO.DumpGeneratedSource = true;
+          } else if (llvm::StringRef(args[i]).starts_with(
+                         "-fgenerated-source-dir=")) {
+            m_DO.GeneratedSourceDirGiven = true;
+            m_DO.GeneratedSourceDir =
+                llvm::StringRef(args[i])
+                    .drop_front(sizeof("-fgenerated-source-dir=") - 1)
+                    .str();
           } else if (AnalysisFlagResult R = remarkAnalysisByName(m_DO, args[i]);
                      R != AnalysisFlagResult::NotMine) {
             if (R == AnalysisFlagResult::Error)
@@ -489,6 +507,13 @@ inline AnalysisFlagResult remarkAnalysisByName(DifferentiationOptions& DO,
                    "left in the derivative, as remarks pointed at the "
                    "generated code itself. The analogue of -Rpass-missed, "
                    "which cannot reach an AST-level plugin.\n"
+                << "-fgenerated-source-dir=<dir> - Writes the code clad "
+                   "generates into <dir>, one file per translation unit, and "
+                   "names it in the debug line table. A debugger that cannot "
+                   "read source embedded in the object -- gdb cannot -- opens "
+                   "that file instead. Given with no directory, nothing is "
+                   "written and clad stops advising that nothing can be "
+                   "read.\n"
                 << "-fgenerate-source-file - Produces a file containing the "
                    "derivatives.\n"
                 << "-fno-validate-clang-version - Disables the validation of "


### PR DESCRIPTION
A derivative's statements have locations in a buffer that holds their code, which is enough for a diagnostic and not enough for a debugger. There are two ways to reach that code from a debug session and clad offers neither: lldb can read it out of the object, but only with -gembed-source, which is off by default; gdb has no support for that extension at all and resolves the name in the line table against the compilation directory and opens a file, so a name no file answers to shows nothing. Plain -g therefore leaves generated frames blank in both.

-fgenerated-source-dir=<dir> writes the code there, one file per translation unit named after it, and names the chunks after those files so the line table points at them. It behaves the same however the compiler was invoked: nothing is inferred from the driver's output path, which is a temporary it deletes when compiling and linking in one step, and nothing is ever written next to anyone's source.

Asking for -g is asking to debug, so it should not be on the user to find out why generated frames are empty. When debug information is on and neither way of reaching the code is in place, clad says so once and names the flag that fits: the embedded source is offered only when the debugger being tuned for can read it, which by
CodeGenOptions::getDebuggerTuning is lldb and not gdb.