### PR TITLE
Index a derivative's printed text by a position in that text.

### DIFF
--- a/lib/Differentiator/DerivativePrinter.cpp
+++ b/lib/Differentiator/DerivativePrinter.cpp
@@ -10,6 +10,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -89,22 +90,36 @@ DerivativePrinter::print(const FunctionDecl* FD) {
   return m_Printed.insert({FD, std::move(R)}).first->second;
 }
 
+/// Where \p S starts in \p Text, past the indentation the printer put in
+/// front of it, or nothing if \p Offsets does not have \p S. A free function
+/// so that the header need not name std::optional: whether that is reachable
+/// there depends on the standard library, and on some it is not.
+static std::optional<unsigned>
+textOffsetOf(const llvm::DenseMap<const Stmt*, unsigned>& Offsets,
+             llvm::StringRef Text, const Stmt* S) {
+  auto Found = Offsets.find(S);
+  if (Found == Offsets.end())
+    return std::nullopt;
+  // The printer announces a statement before the indentation in front of it,
+  // so the recorded offset can sit at the start of the line. Both callers
+  // want the statement itself: a caret belongs on its first character, and so
+  // does the text reported beside a position.
+  unsigned Offset = Found->second;
+  while (Offset < Text.size() && (Text[Offset] == ' ' || Text[Offset] == '\t'))
+    ++Offset;
+  return Offset;
+}
+
 SourceLocation DerivativePrinter::locationOf(const FunctionDecl* FD,
                                              const Stmt* S) {
   const Printout& R = print(FD);
   if (!R.At)
     return {};
-  auto Found = R.Offsets.find(S);
-  if (Found == R.Offsets.end())
+  std::optional<unsigned> Offset =
+      textOffsetOf(R.Offsets, m_Locs.textAt(R.At, R.Size), S);
+  if (!Offset)
     return {};
-  // The printer announces a statement before the indentation in front of it,
-  // so the recorded offset can sit at the start of the line. A caret belongs
-  // on the first character of the statement itself.
-  llvm::StringRef Text = m_Locs.textAt(R.At, R.Size);
-  unsigned Offset = Found->second;
-  while (Offset < Text.size() && (Text[Offset] == ' ' || Text[Offset] == '\t'))
-    ++Offset;
-  return R.At.Loc.getLocWithOffset(static_cast<int>(Offset));
+  return R.At.Loc.getLocWithOffset(static_cast<int>(*Offset));
 }
 
 unsigned DerivativePrinter::lineOf(const FunctionDecl* FD, const Stmt* S) {
@@ -147,6 +162,11 @@ SourceRange DerivativePrinter::rangeOf(const FunctionDecl* FD, const Stmt* S) {
     return Begin;
   // A range's end names the last character, not one past it.
   return {Begin, Begin.getLocWithOffset(static_cast<int>(Text.size()) - 1)};
+}
+
+unsigned DerivativePrinter::offsetOf(const FunctionDecl* FD, const Stmt* S) {
+  const Printout& R = print(FD);
+  return textOffsetOf(R.Offsets, m_Locs.textAt(R.At, R.Size), S).value_or(0);
 }
 
 SourceLocation DerivativePrinter::startOf(const FunctionDecl* FD) {

--- a/lib/Differentiator/DerivativePrinter.h
+++ b/lib/Differentiator/DerivativePrinter.h
@@ -54,6 +54,11 @@ public:
   /// went into.
   clang::SourceLocation startOf(const clang::FunctionDecl* FD);
 
+  /// Where \p S starts in the printed text of \p FD. Not the same as the
+  /// distance from the start of the buffer: a buffer holds the text of every
+  /// derivative printed into it, and only the first of them starts at zero.
+  unsigned offsetOf(const clang::FunctionDecl* FD, const clang::Stmt* S);
+
   /// The printed text of \p FD, for a caller that wants to show it rather than
   /// point into it.
   llvm::StringRef textOf(const clang::FunctionDecl* FD);

--- a/test/Misc/GeneratedSourceLocations.C
+++ b/test/Misc/GeneratedSourceLocations.C
@@ -37,9 +37,27 @@ double f(double x) {
 // The reverse sweep restores what the forward one saved.
 // CHECK: {{[0-9]+}}:9-{{[0-9]+}}: t = _t0;
 
+// One buffer holds every derivative in the unit, so only the first of them
+// starts where the buffer does. A second one is where a position into the
+// buffer and a position into the text stop agreeing, and reporting the text
+// by the wrong one of the two prints nothing at all.
+// CHECK: generated-source: g_grad
+// CHECK: {{[0-9]+}}:5-{{[0-9]+}}: double _d_u = 0.;
+// CHECK-NEXT: {{[0-9]+}}:5-{{[0-9]+}}: double u = y * y;
+
+// A second function, so that a second derivative is printed into the same
+// buffer after the first.
+double g(double y) {
+  double u = y * y;
+  u = u * u;
+  return u;
+}
+
 int main() {
-  auto g = clad::gradient(f);
+  auto gf = clad::gradient(f);
+  auto gg = clad::gradient(g);
   double d = 0;
-  g.execute(2, &d);
+  gf.execute(2, &d);
+  gg.execute(2, &d);
   return 0;
 }

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -402,8 +402,11 @@ void InitTimers();
       llvm::SmallVector<const clang::Stmt*, 32> Ordered;
       collectStmts(FD->getBody(), getDerivativePrinter(), FD, Ordered);
       clang::SourceManager& SM = m_CI.getSourceManager();
+      // Into the printed text, not into the buffer it sits in: every
+      // derivative printed after the first starts part-way through its buffer,
+      // and indexing its text by a buffer offset runs off the end of it.
       auto offsetOf = [&](const clang::Stmt* S) {
-        return SM.getFileOffset(getDerivativePrinter().locationOf(FD, S));
+        return getDerivativePrinter().offsetOf(FD, S);
       };
       llvm::stable_sort(Ordered,
                         [&](const clang::Stmt* A, const clang::Stmt* B) {


### PR DESCRIPTION
-fdump-generated-source prints, for each statement of a derivative, the position it occupies and the text sitting at it. The position comes from the statement's location, which is an offset into the buffer the derivative was printed into, and the text is then indexed with that same offset. One buffer holds every derivative in the translation unit, so the two only agree for the first one printed into it.

For every derivative after that the offset runs past the end of its own text. Without assertions the reported text comes out empty -- correct positions, nothing beside them -- and with assertions StringRef::drop_front fires and the compiler dies. Only the first derivative of a unit was ever reported.

Ask the printer where a statement begins in the text it printed, and index by that. The positions do not change; the text beside them becomes the statement's own. The dump test grows a second function, which is all it takes to tell the two positions apart.