### PR TITLE
Vary what a pointer writes through, not only the pointer.

### DIFF
--- a/lib/Differentiator/ActivityAnalyzer.cpp
+++ b/lib/Differentiator/ActivityAnalyzer.cpp
@@ -10,6 +10,7 @@
 #include "clang/AST/Type.h"
 #include "clang/Basic/LLVM.h"
 
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 
@@ -109,6 +110,27 @@ void VariedAnalyzer::AnalyzeCFGBlock(const CFGBlock& block) {
       if (merge(succData.get(), m_BlockData[block.getBlockID()].get()))
         m_CFGQueue.insert(succ->getBlockID());
     }
+  }
+}
+
+void VariedAnalyzer::addVariedDeclWithAliases(const VarDecl* VD) {
+  llvm::SmallVector<const VarDecl*, 4> worklist{VD};
+  // What has been queued already. Two pointers initialised from the same
+  // variable reconverge on it, so a declaration can be reached by more than
+  // one path; admitting each one once is what bounds the walk.
+  llvm::SmallPtrSet<const VarDecl*, 4> seen{VD};
+  while (!worklist.empty()) {
+    const VarDecl* cur = worklist.pop_back_val();
+    m_DiffReq.addVariedDecl(cur);
+    // setIsRequired already walks a REF_TYPE's targets to set their varied
+    // bit; this walks the same edges to reach the request's varied-decl set,
+    // which is what decides whether a declaration is given an adjoint.
+    const VarData* data = getVarDataFromDecl(cur);
+    if (data && data->m_Type == VarData::REF_TYPE)
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+      for (const VarDecl* target : *data->m_Val.m_RefData)
+        if (target && seen.insert(target).second)
+          worklist.push_back(target);
   }
 }
 
@@ -427,7 +449,7 @@ bool VariedAnalyzer::TraverseDeclRefExpr(DeclRefExpr* DRE) {
 
   if (m_Varied && m_Marking) {
     setVaried(DRE);
-    m_DiffReq.addVariedDecl(VD);
+    addVariedDeclWithAliases(VD);
     markExpr(DRE);
   } else if (m_Marking)
     setVaried(DRE, false);

--- a/lib/Differentiator/ActivityAnalyzer.h
+++ b/lib/Differentiator/ActivityAnalyzer.h
@@ -37,6 +37,12 @@ class VariedAnalyzer : public clang::RecursiveASTVisitor<VariedAnalyzer>,
   std::set<const clang::Stmt*>& m_ResSet;
   void markExpr(const clang::Stmt* S) { m_ResSet.insert(S); }
   void setVaried(const clang::Expr* E, bool isVaried = true);
+  /// Records \p VD as varied, and with it every declaration \p VD may alias.
+  /// A write reaching a pointer or reference varies what it refers to, not
+  /// only the pointer itself, so the pointee needs an adjoint just as much.
+  /// The alias targets are the ones TraverseDeclStmt recorded in the REF_TYPE
+  /// dependency set, followed transitively for a pointer bound to a pointer.
+  void addVariedDeclWithAliases(const clang::VarDecl* VD);
   void AnalyzeCFGBlock(const clang::CFGBlock& block);
   void TraverseAllStmtInsideBlock(const clang::CFGBlock& block);
 

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -3981,9 +3981,17 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           else {
             VarDecl* VDDerived = VDDiff.getDecl_dx();
             declsDiff.push_back(VDDerived);
-            if (Stmt* memsetCall = CheckAndBuildCallToMemset(
-                    BuildDeclRef(VDDerived),
-                    VDDerived->getInit()->IgnoreCasts()))
+            // Without an initializer the adjoint is left for the reverse
+            // sweep to read uninitialized, which is a wrong gradient rather
+            // than a missing one. Refuse instead of answering.
+            if (!VDDerived->getInit())
+              diag(DiagnosticsEngine::Error, VD->getLocation(),
+                   "derivative of the initializer of '%0' is not available; "
+                   "the computed gradient would be incorrect")
+                  << VD->getName();
+            else if (Stmt* memsetCall = CheckAndBuildCallToMemset(
+                         BuildDeclRef(VDDerived),
+                         VDDerived->getInit()->IgnoreCasts()))
               memsetCalls.push_back(memsetCall);
             // Track this pointer's allocation size in bytes so an in-place
             // realloc of it can be undone in the reverse sweep. The shadow is

--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -608,6 +608,35 @@ double f15(double x) { return f15_1(x, pick); }
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
+// A write reaching a variable through a pointer varies that variable, not
+// only the pointer holding its address. Leaving the pointee passive used to
+// deny it an adjoint, which both crashed the reverse mode on the adjoint's
+// missing initializer and dropped the dependency `return y` carries.
+double f16(double x) {
+  double y = 0;
+  double* p = &y;
+  *p = x * x;
+  return y;
+}
+
+// The same through an array element and one more level of indirection, so a
+// pointee reached transitively is not left behind either.
+double f17(double x) {
+  double y[2] = {0, 0};
+  double* p = &y[1];
+  double** q = &p;
+  **q = x * x * x;
+  return y[1];
+}
+
+// A reference binding takes the same path through the dependency set.
+double f18(double x) {
+  double y = 0;
+  double& r = y;
+  r = x * x;
+  return y;
+}
+
 int main(){
     double arr[] = {1,2,3,4,5};
     double darr[] = {0,0,0,0,0};
@@ -634,4 +663,7 @@ int main(){
     printf("{%.2f}\n", dx); // CHECK-EXEC: {0.00}
     TEST1(f14, 3);// CHECK-EXEC: {1.00}
     TEST1(f15, 3);// CHECK-EXEC: {6.00}
+    TEST1(f16, 3);// CHECK-EXEC: {6.00}
+    TEST1(f17, 3);// CHECK-EXEC: {27.00}
+    TEST1(f18, 3);// CHECK-EXEC: {6.00}
 }

--- a/test/Diagnostics/VariedAdjointInitializer.C
+++ b/test/Diagnostics/VariedAdjointInitializer.C
@@ -1,0 +1,24 @@
+// RUN: %cladclang %s -I%S/../../include -fsyntax-only -Xclang -verify
+
+#include "clad/Differentiator/Differentiator.h"
+
+// An adjoint whose initializer has no derivative would be left uninitialized
+// for the reverse sweep to read, which answers with a wrong gradient rather
+// than a missing one, so the declaration is refused instead.
+//
+// A conditional yielding a pointer to a pointer is one way to reach that: the
+// adjoint of `r` needs the derivative of `c ? &p : &q`, which clad does not
+// build. This is a limitation of its own, unrelated to which declarations the
+// activity analysis calls varied -- the same happens with the analysis off.
+double f(double x) {
+  double y = 0;
+  double* p = &y;
+  double* q = &y;
+  int c = 1;
+  // expected-error@+1 {{derivative of the initializer of 'r' is not available; the computed gradient would be incorrect}}
+  double** r = c ? &p : &q;
+  **r = x * x;
+  return y;
+}
+
+int main() { auto g = clad::gradient(f, "x"); }


### PR DESCRIPTION
Fixes: #1873

## The crash

Under `-enable-va`, differentiating a function that writes to a variable through a pointer alias crashes clang with a null `Expr*` dereference in `ReverseModeVisitor::VisitDeclStmt`:

```cpp
double f(double x) {
  double y = 0;
  double* p = &y;
  *p = x * x;
  return y;
}
```

## Root cause

The alias information the analysis needed was already being collected, but never reached the decision that consumes it.

`VariedAnalyzer::TraverseDeclStmt` gives `double* p = &y` a `REF_TYPE` `VarData` whose dependency set is `{y}`, and `AnalysisBase::setIsRequired` walks those edges to set the pointee's varied bit. But whether a declaration is given an adjoint is decided by `DiffRequest::shouldHaveAdjoint`, which reads the request's varied-decl set — and only `addVariedDecl` fills that. `TraverseDeclRefExpr` called it on the syntactic declaration, `p`, and stopped.

So `p` came out varied and `y` did not. `y` was denied an adjoint, differentiating `&y` produced nothing for `_d_p` to be initialised with, and `VisitDeclStmt` dereferenced that null initialiser.

## Why the null guard alone is not the fix

Guarding the dereference stops the crash and produces a **silently wrong gradient**: with `y` still passive, the dependency `return y` carries is gone along with its adjoint. Measured on the reproducer above at `x = 3` (expected `6.00`):

| Build | Result |
|---|---|
| master `e871c9f2` | crash — `Expr::IgnoreCasts()` in `VisitDeclStmt` |
| null guard only | compiles, returns `0.00` |
| this PR | `6.00` |

## The change

- **`ActivityAnalyzer`** — `addVariedDeclWithAliases` walks the same `REF_TYPE` edges into the varied-decl set, transitively and cycle-safe, so everything a varied pointer may alias is given an adjoint.
- **`ReverseModeVisitor`** — guard the adjoint's initialiser before dereferencing it. It holds whatever differentiating the primal's initialiser produced, and nothing promises that is non-null. (`AllocCallInfo::recognize` was already null-safe, so the guard belongs at the caller.)

## Tests

Three cases in `test/Analyses/ActivityReverse.cpp`: a write through a pointer, through an array element reached by two levels of indirection, and through a reference binding. They assert the gradient value rather than only that the compiler survives, which is what distinguishes the crash from the silently-wrong-answer failure.

That file compiles the same source with and without `-enable-va` and exec-checks both, and `TEST1` uses `clad::gradient<clad::opts::enable_va>`, so the new cases exercise the analysis in both RUN lines. Verified load-bearing: with the fix reverted the test fails with three crash signatures.

## Scope

This is deliberately the conservative direction. `getDependencySet` is not a points-to analysis, so handing an adjoint to everything a varied pointer *may* alias gives up some pruning. That seemed the right trade against a wrong derivative, but I am happy to narrow it if you would rather the analysis bail only where it cannot resolve an alias.

The same gap should in principle affect a field reached through a pointer and a pointer passed to a callee; those are not addressed here.

## Testing done

`ninja check-clad` on LLVM/Clang 18.1.3, Ubuntu 24.04: **217 passed, 0 failed**, 30 unsupported (CUDA, Enzyme, OpenMP, 32-bit, clang-repl — toolchains absent locally). `git clang-format-18` reports no changes.

Only LLVM 18 was available to me, so the other supported versions rest on CI.
