### PR TITLE
[ci] Let a directory's .clang-tidy apply to the files under it.

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -58,7 +58,6 @@ jobs:
           apt_packages: libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libthrust-dev,libbenchmark-dev,libomp-21-dev,libopenblas-dev
           exclude: "test/*,unittests/*"
           split_workflow: true
-          config_file: .clang-tidy
 
       - name: Upload artifacts
         uses: ZedThree/clang-tidy-review/upload@v0.23.1

--- a/benchmark/.clang-tidy
+++ b/benchmark/.clang-tidy
@@ -1,3 +1,6 @@
+# The root list, less what a benchmark does on purpose: it keeps mutable
+# globals for the harness to read, and reports through printf.
+InheritParentConfig: true
 Checks: >
   -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-pro-type-vararg


### PR DESCRIPTION
The review job passes config_file: .clang-tidy, which pins every source to the root list and stops clang-tidy looking for a config beside the file. benchmark/.clang-tidy has therefore never applied: the cppcoreguidelines-pro-type-vararg it was added to turn off still reaches CI, on Multithreading.cpp:54, the very file it shipped with. Locally the error runs the other way -- that file has no InheritParentConfig, so it replaces the root list rather than adding to it, and a run inside benchmark/ enables no cppcoreguidelines, readability or misc check at all. Neither side does what the file says.

Drop the pin and let the directory file inherit. A benchmark source then sees the root list less the two checks a benchmark turns off on purpose: mutable globals the harness reads, and reporting through printf. Counted with --list-checks, a file in benchmark/ goes from 0 of those checks to 255, against 257 for a file in lib/, which is unchanged.

Only two .clang-tidy files exist in the tree, so this activates exactly one directory config, and it can only narrow what the review posts.