### PR TITLE
Prove what range of a pointer parameter a function writes.

### DIFF
--- a/include/clad/Differentiator/Analyses.def
+++ b/include/clad/Differentiator/Analyses.def
@@ -25,5 +25,8 @@ CLAD_ANALYSIS(Varied, "activity", "va", false,
               "skips the adjoint of a value no input can vary")
 CLAD_ANALYSIS(Useful, "useful", "ua", false,
               "skips the adjoint of a value no output depends on")
+CLAD_ANALYSIS(Loop, "loop", "loop", true,
+              "reads a function's counted loops to bound the range of a "
+              "pointer parameter it writes")
 
 #undef CLAD_ANALYSIS

--- a/include/clad/Differentiator/Differentiator.h
+++ b/include/clad/Differentiator/Differentiator.h
@@ -215,6 +215,38 @@ CUDA_HOST_DEVICE auto back(TapeType& of) -> decltype(of.back()) {
   return of.back();
 }
 
+/// Record `n` elements starting at `p`, so the reverse sweep can put them back
+/// with peek_range. Used where clad can prove how much of a buffer a call
+/// overwrites: recording the range once is cheaper than snapshotting each
+/// element into a restore_tracker, and the pair needs no addresses.
+// A run of a raw buffer is the thing these three exist to walk.
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+template <typename TapeType, typename T>
+CUDA_HOST_DEVICE void record_range(TapeType& to, const T* p, std::size_t n) {
+  for (std::size_t i = 0; i < n; ++i)
+    to.emplace_back(p[i]);
+}
+
+/// Write the most recently recorded run back to `p` without consuming it. A
+/// call's reverse sweep replays it twice -- once so the pullback starts from
+/// pre-call state, and once after, because the pullback's own replay mutates
+/// what the first replay put back.
+template <typename TapeType, typename T>
+CUDA_HOST_DEVICE void peek_range(TapeType& from, T* p, std::size_t n) {
+  for (std::size_t i = 0; i < n; ++i)
+    p[n - 1 - i] = from.peek_back(i);
+}
+
+/// Drop the most recently recorded run, once its call has been swept. Keeps
+/// the tape's LIFO order in step with the sweep, which is what lets one tape
+/// serve every instance of a call inside a loop.
+template <typename TapeType>
+CUDA_HOST_DEVICE void drop_range(TapeType& from, std::size_t n) {
+  for (std::size_t i = 0; i < n; ++i)
+    from.pop_back();
+}
+// NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+
 /// Reset values in an already-constructed adjoint (or its iterable elements)
 /// to zero in place. This is the primitive used by the default zero_like
 /// implementation. Provide an overload when the default recursive or

--- a/include/clad/Differentiator/Tape.h
+++ b/include/clad/Differentiator/Tape.h
@@ -724,6 +724,27 @@ public:
     return *(m_tail->elements() + index);
   }
 
+  /// Access the value `i` positions from the end (0 being the last) without
+  /// removing it, so a recorded run can be read more than once. Walks back
+  /// from the tail rather than forward from the head, which keeps a read near
+  /// the end cheap however long the tape has grown.
+  CUDA_HOST_DEVICE reference peek_back(std::size_t i) {
+    assert(i < m_size);
+    std::size_t index = m_size - 1 - i;
+    if (index < SBO_SIZE)
+      return *(sbo_elements() + index);
+    std::size_t base =
+        SBO_SIZE + (((m_size - 1 - SBO_SIZE) / SLAB_SIZE) * SLAB_SIZE);
+    Slab* slab = m_tail;
+    while (index < base) {
+      slab = slab->prev;
+      base -= SLAB_SIZE;
+    }
+    if (DiskOffload || GpuOffload)
+      ensure_loaded(slab);
+    return *(slab->elements() + (index - base));
+  }
+
   CUDA_HOST_DEVICE const_reference back() const {
     assert(m_size);
     std::size_t index = m_size - 1;

--- a/lib/Differentiator/CMakeLists.txt
+++ b/lib/Differentiator/CMakeLists.txt
@@ -70,6 +70,7 @@ llvm_add_library(cladDifferentiator
   VectorPushForwardModeVisitor.cpp
   Version.cpp
   VisitorBase.cpp
+  LoopAnalyzer.cpp
   ${version_inc}
   )
 

--- a/lib/Differentiator/LoopAnalyzer.cpp
+++ b/lib/Differentiator/LoopAnalyzer.cpp
@@ -1,0 +1,446 @@
+#include "LoopAnalyzer.h"
+
+#include "clad/Differentiator/CladUtils.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
+#include "clang/AST/OperationKinds.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Stmt.h"
+#include "clang/Basic/LLVM.h"
+#include "clang/Basic/SourceLocation.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace clang;
+
+namespace clad {
+
+/// Whether \p E steps \p VD by exactly one. The increment may carry
+/// unrelated work alongside, as `for (...; ...; ++i, ++p)` does.
+static bool stepsByOne(const Expr* E, const VarDecl* VD) {
+  if (!E)
+    return false;
+  E = E->IgnoreParenImpCasts();
+  if (const auto* UO = dyn_cast<UnaryOperator>(E)) {
+    if (UO->getOpcode() != UO_PostInc && UO->getOpcode() != UO_PreInc)
+      return false;
+    const auto* DRE =
+        dyn_cast<DeclRefExpr>(UO->getSubExpr()->IgnoreParenImpCasts());
+    return DRE && DRE->getDecl() == VD;
+  }
+  if (const auto* BO = dyn_cast<BinaryOperator>(E))
+    if (BO->getOpcode() == BO_Comma)
+      return stepsByOne(BO->getLHS(), VD) || stepsByOne(BO->getRHS(), VD);
+  return false;
+}
+
+CountedForLoop recogniseCountedForLoop(const ForStmt* FS) {
+  CountedForLoop L;
+  if (!FS)
+    return L;
+
+  // `v < bound` or `v <= bound`, naming the variable on the left.
+  const auto* Cond = dyn_cast_or_null<BinaryOperator>(FS->getCond());
+  if (!Cond)
+    return L;
+  bool Inclusive = Cond->getOpcode() == BO_LE;
+  if (!Inclusive && Cond->getOpcode() != BO_LT)
+    return L;
+  const auto* CondLHS =
+      dyn_cast<DeclRefExpr>(Cond->getLHS()->IgnoreParenImpCasts());
+  if (!CondLHS)
+    return L;
+  const auto* IndVar = dyn_cast<VarDecl>(CondLHS->getDecl());
+  // Integer only: a floating induction variable makes the iteration count
+  // depend on rounding.
+  if (!IndVar || !IndVar->getType()->isIntegerType())
+    return L;
+
+  // `T v = init` or `v = init`, naming that same variable.
+  const Expr* Init = nullptr;
+  if (const auto* DS = dyn_cast_or_null<DeclStmt>(FS->getInit())) {
+    if (DS->isSingleDecl() && DS->getSingleDecl() == IndVar)
+      Init = IndVar->getInit();
+  } else if (const auto* BO = dyn_cast_or_null<BinaryOperator>(FS->getInit())) {
+    const auto* LHS =
+        dyn_cast<DeclRefExpr>(BO->getLHS()->IgnoreParenImpCasts());
+    if (BO->getOpcode() == BO_Assign && LHS && LHS->getDecl() == IndVar)
+      Init = BO->getRHS();
+  }
+  if (!Init)
+    return L;
+
+  if (!stepsByOne(FS->getInc(), IndVar))
+    return L;
+
+  L.IndVar = IndVar;
+  L.Init = Init->IgnoreParenImpCasts();
+  L.Bound = Cond->getRHS()->IgnoreParenImpCasts();
+  L.Inclusive = Inclusive;
+  return L;
+}
+bool CountedLoopStack::isNonNegative(const Expr* E) const {
+  if (!E)
+    return false;
+  E = E->IgnoreParenImpCasts();
+  if (const auto* IL = dyn_cast<IntegerLiteral>(E))
+    return !IL->getValue().isNegative();
+  // A loop index already on the stack is non-negative if its own start was.
+  if (const auto* DRE = dyn_cast<DeclRefExpr>(E)) {
+    const CountedForLoop* L = steppedBy(dyn_cast<VarDecl>(DRE->getDecl()));
+    return L && L->InitIsNonNegative;
+  }
+  if (const auto* BO = dyn_cast<BinaryOperator>(E))
+    if (BO->getOpcode() == BO_Add)
+      return isNonNegative(BO->getLHS()) && isNonNegative(BO->getRHS());
+  return false;
+}
+
+bool CountedLoopStack::enter(const ForStmt* FS) {
+  CountedForLoop L = recogniseCountedForLoop(FS);
+  if (!L)
+    return false;
+  // Computed here rather than at recognition: it depends on the loops this
+  // one sits inside, which only the stack knows.
+  L.InitIsNonNegative = isNonNegative(L.Init);
+  m_Loops.push_back(L);
+  return true;
+}
+
+namespace {
+
+/// Whether a loop's body changes what its header promised: assigning to the
+/// induction variable or the bound, stepping either itself, or taking an
+/// address through which something else could.
+///
+/// recogniseCountedForLoop reads the header alone, deliberately, and leaves
+/// this to whoever acts on the result. An extent has to add it twice over: an
+/// index the body moves need not stay under the bound, and a bound the body
+/// raises is not the value a caller substituting its argument would get.
+class LoopShapeBreaker : public RecursiveASTVisitor<LoopShapeBreaker> {
+  const VarDecl* m_IndVar;
+  const VarDecl* m_Bound;
+  bool m_Broken = false;
+
+  bool isWatched(const Expr* E) const {
+    const auto* DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts());
+    const auto* VD = DRE ? dyn_cast<VarDecl>(DRE->getDecl()) : nullptr;
+    return VD && (VD == m_IndVar || VD == m_Bound);
+  }
+
+public:
+  LoopShapeBreaker(const VarDecl* IndVar, const VarDecl* Bound)
+      : m_IndVar(IndVar), m_Bound(Bound) {}
+  [[nodiscard]] bool broken() const { return m_Broken; }
+
+  bool VisitBinaryOperator(BinaryOperator* BO) {
+    if (BO->isAssignmentOp() && isWatched(BO->getLHS()))
+      m_Broken = true;
+    return true;
+  }
+  bool VisitUnaryOperator(UnaryOperator* UO) {
+    if ((UO->isIncrementDecrementOp() || UO->getOpcode() == UO_AddrOf) &&
+        isWatched(UO->getSubExpr()))
+      m_Broken = true;
+    return true;
+  }
+};
+
+class ExtentVisitor : public RecursiveASTVisitor<ExtentVisitor> {
+  llvm::SmallVectorImpl<WrittenExtent>& m_Extents;
+  llvm::DenseMap<const ParmVarDecl*, unsigned> m_ParamIdx;
+  CountedLoopStack m_Loops;
+  bool m_Opaque = false;
+  /// The first write this analysis could not attribute; the later ones say
+  /// nothing more, since every parameter is already reported unbounded.
+  clang::SourceLocation m_OpaqueAt;
+  const Stmt* m_FnBody;
+  const ASTContext& m_Context;
+
+public:
+  ExtentVisitor(const FunctionDecl* FD,
+                llvm::SmallVectorImpl<WrittenExtent>& Extents)
+      : m_Extents(Extents), m_FnBody(FD->getBody()),
+        m_Context(FD->getASTContext()) {
+    for (unsigned i = 0, e = FD->getNumParams(); i != e; ++i)
+      m_ParamIdx[FD->getParamDecl(i)] = i;
+  }
+
+  bool TraverseForStmt(ForStmt* FS) {
+    bool Entered = !breaksShape(FS) && m_Loops.enter(FS);
+    bool res = RecursiveASTVisitor::TraverseForStmt(FS);
+    m_Loops.leave(Entered);
+    return res;
+  }
+
+  bool VisitBinaryOperator(BinaryOperator* BO) {
+    if (BO->isAssignmentOp())
+      recordWrite(BO->getLHS());
+    return true;
+  }
+
+  bool VisitUnaryOperator(UnaryOperator* UO) {
+    if (UO->isIncrementDecrementOp())
+      recordWrite(UO->getSubExpr());
+    return true;
+  }
+
+  /// A callee can write through anything it is handed by pointer or by
+  /// non-const reference -- its object included -- and its body is not
+  /// examined here. Such an argument therefore defeats the analysis, unless it
+  /// demonstrably designates this function's own local storage, which no
+  /// parameter can alias.
+  bool VisitCallExpr(CallExpr* CE) {
+    // A member call does not carry its object among its arguments, but a
+    // non-const method writes through it just the same.
+    if (const auto* MCE = dyn_cast<CXXMemberCallExpr>(CE)) {
+      const CXXMethodDecl* MD = MCE->getMethodDecl();
+      const Expr* Obj = MCE->getImplicitObjectArgument();
+      if (Obj && (!MD || !MD->isConst()) &&
+          !utils::designatesLocallyOwnedStorage(
+              Obj, /*asPointerValue=*/Obj->getType()->isPointerType())) {
+        m_Opaque = true;
+        if (m_OpaqueAt.isInvalid())
+          m_OpaqueAt = Obj->getBeginLoc();
+        return true;
+      }
+    }
+    const FunctionDecl* Callee = CE->getDirectCallee();
+    // An overloaded operator passes its object as argument zero, so the
+    // arguments sit one ahead of the parameters when it is a member.
+    unsigned Offset =
+        isa<CXXOperatorCallExpr>(CE) && isa_and_nonnull<CXXMethodDecl>(Callee);
+    for (unsigned i = Offset, e = CE->getNumArgs(); i != e; ++i) {
+      const Expr* Arg = CE->getArg(i);
+      QualType ArgTy = Arg->getType();
+      // The parameter says whether the callee may write, not the argument: an
+      // argument bound to a `double&` is still spelled `double` here. Where
+      // there is no parameter to consult -- an indirect call, or the variadic
+      // tail -- every argument counts as written.
+      unsigned P = i - Offset;
+      if (Callee && P < Callee->getNumParams())
+        ArgTy = Callee->getParamDecl(P)->getType();
+      bool MayWrite = !Callee || P >= Callee->getNumParams() ||
+                      (ArgTy->isPointerType() &&
+                       !ArgTy->getPointeeType().isConstQualified()) ||
+                      (ArgTy->isLValueReferenceType() &&
+                       !ArgTy.getNonReferenceType().isConstQualified());
+      if (MayWrite && !utils::designatesLocallyOwnedStorage(
+                          Arg, /*asPointerValue=*/ArgTy->isPointerType())) {
+        m_Opaque = true;
+        if (m_OpaqueAt.isInvalid())
+          m_OpaqueAt = Arg->getBeginLoc();
+        return true;
+      }
+    }
+    return true;
+  }
+
+  /// Whether acting on \p FS's recognised shape would be unsound here.
+  ///
+  /// The index and the bound are watched over different reaches. The index
+  /// only has to hold still while the loop runs. The bound has to hold still
+  /// for the whole call, because a call site works the range out from the
+  /// argument it passed and reads it much later.
+  [[nodiscard]] bool breaksShape(const ForStmt* FS) const {
+    CountedForLoop L = recogniseCountedForLoop(FS);
+    if (!L)
+      return false; // Not recognised anyway; nothing to break.
+    LoopShapeBreaker InLoop(L.IndVar, /*Bound=*/nullptr);
+    InLoop.TraverseStmt(const_cast<Stmt*>(cast<Stmt>(FS->getBody())));
+    if (InLoop.broken())
+      return true;
+    const auto* BoundDRE = dyn_cast<DeclRefExpr>(L.Bound);
+    const auto* BoundVD =
+        BoundDRE ? dyn_cast<VarDecl>(BoundDRE->getDecl()) : nullptr;
+    if (!BoundVD)
+      return false;
+    LoopShapeBreaker InFn(/*IndVar=*/nullptr, BoundVD);
+    InFn.TraverseStmt(const_cast<Stmt*>(m_FnBody));
+    return InFn.broken();
+  }
+
+  [[nodiscard]] bool sawOpaqueWrite() const { return m_Opaque; }
+  [[nodiscard]] clang::SourceLocation opaqueWriteLoc() const {
+    return m_OpaqueAt;
+  }
+
+private:
+  /// Records `[0, Bound)` in \p E when a call site can work Bound out for
+  /// itself -- when it folds to a constant, or names a by-value parameter it
+  /// passed. Marks \p E BoundNotReadable otherwise, leaving it Unknown.
+  void classifyBound(const Expr* B, WrittenExtent& E) const {
+    E.Why = WrittenExtent::Refusal::BoundNotUsable;
+    B = B->IgnoreParenImpCasts();
+    // Folded, not matched against a literal: a dimension is usually written
+    // as a constexpr variable, an enumerator or a template argument, and all
+    // of those are as readable at a call site as the number itself.
+    Expr::EvalResult R;
+    if (B->EvaluateAsInt(R, m_Context)) {
+      const llvm::APSInt& V = R.Val.getInt();
+      // Zero-extending a negative bound would name almost all of memory, and
+      // the loop it describes never runs anyway.
+      if (V.isNegative())
+        return;
+      E.K = WrittenExtent::Kind::Range;
+      E.Why = WrittenExtent::Refusal::None;
+      E.BoundIsParam = false;
+      E.BoundConst = V.getZExtValue();
+      return;
+    }
+    if (const auto* DRE = dyn_cast<DeclRefExpr>(B))
+      if (const auto* PVD = dyn_cast<ParmVarDecl>(DRE->getDecl())) {
+        auto it = m_ParamIdx.find(PVD);
+        // A reference parameter names storage a callee can change under us.
+        if (it == m_ParamIdx.end() || PVD->getType()->isReferenceType())
+          return;
+        E.K = WrittenExtent::Kind::Range;
+        E.Why = WrittenExtent::Refusal::None;
+        E.BoundIsParam = true;
+        E.BoundParamIdx = it->second;
+      }
+  }
+
+  /// Widens the recorded extent for `Idx` so it also covers `New`. Two
+  /// descriptions that are not identical widen to Unknown rather than to a
+  /// guessed union: a wrong union would under-record.
+  void widen(unsigned Idx, const WrittenExtent& New) {
+    WrittenExtent& Cur = m_Extents[Idx];
+    if (Cur.K == WrittenExtent::Kind::None) {
+      Cur = New;
+      return;
+    }
+    if (Cur.K == WrittenExtent::Kind::Unknown ||
+        New.K == WrittenExtent::Kind::Unknown) {
+      // Keep the refusal that was already recorded: the first thing the
+      // analysis could not bound is the one worth reporting.
+      if (Cur.K != WrittenExtent::Kind::Unknown) {
+        Cur.Why = New.Why;
+        Cur.RefusedAt = New.RefusedAt;
+      }
+      Cur.K = WrittenExtent::Kind::Unknown;
+      return;
+    }
+    // A single element inside an already-recorded range adds nothing, and a
+    // range subsumes a single element only when the element is provably
+    // inside it -- which needs the bound's value, so do not assume it.
+    bool same =
+        Cur.K == New.K && (Cur.K == WrittenExtent::Kind::Element
+                               ? Cur.Offset == New.Offset
+                               : Cur.BoundIsParam == New.BoundIsParam &&
+                                     Cur.BoundParamIdx == New.BoundParamIdx &&
+                                     Cur.BoundConst == New.BoundConst);
+    if (!same) {
+      Cur.K = WrittenExtent::Kind::Unknown;
+      Cur.Why = WrittenExtent::Refusal::WritesDisagree;
+      Cur.RefusedAt = New.RefusedAt;
+    }
+  }
+
+  /// Attributes a write to a parameter and classifies the range it covers.
+  void recordWrite(const Expr* LHS) {
+    LHS = LHS->IgnoreParenImpCasts();
+    const Expr* Base = nullptr;
+    WrittenExtent E;
+    // Every write carries where it is, not just the ones that give up: a
+    // disagreement is discovered at the second write and has to point there.
+    E.RefusedAt = LHS->getBeginLoc();
+
+    if (const auto* ASE = dyn_cast<ArraySubscriptExpr>(LHS)) {
+      Base = ASE->getBase();
+      const Expr* Idx = ASE->getIdx()->IgnoreParenImpCasts();
+      if (const auto* IL = dyn_cast<IntegerLiteral>(Idx)) {
+        E.K = WrittenExtent::Kind::Element;
+        E.Offset = IL->getValue().getZExtValue();
+      } else if (const auto* DRE = dyn_cast<DeclRefExpr>(Idx)) {
+        const auto* VD = dyn_cast<VarDecl>(DRE->getDecl());
+        E.K = WrittenExtent::Kind::Unknown;
+        E.Why = WrittenExtent::Refusal::IndexNotCounted;
+        E.RefusedAt = Idx->getBeginLoc();
+        const CountedForLoop* L = m_Loops.steppedBy(VD);
+        // A subscript by the loop variable falls inside [0, Bound) only if
+        // the loop starts at or above zero and a call site can read Bound.
+        // Not Inclusive: `i <= d` reaches out[d], which [0, d) excludes.
+        if (L && L->InitIsNonNegative && !L->Inclusive)
+          classifyBound(L->Bound, E);
+      } else {
+        E.K = WrittenExtent::Kind::Unknown;
+        E.Why = WrittenExtent::Refusal::IndexNotUnderstood;
+        E.RefusedAt = Idx->getBeginLoc();
+      }
+    } else if (const auto* UO = dyn_cast<UnaryOperator>(LHS)) {
+      if (UO->getOpcode() != UO_Deref)
+        return;
+      Base = UO->getSubExpr();
+      E.K = WrittenExtent::Kind::Element;
+      E.Offset = 0;
+    } else {
+      // A write to something that is not reached through a pointer -- a local
+      // scalar, a member -- cannot land in a parameter's buffer.
+      return;
+    }
+
+    // Reached through a pointer, but not one of this function's parameters:
+    // it may alias any of them, and nothing here rules that out.
+    const auto* DRE = dyn_cast<DeclRefExpr>(Base->IgnoreParenImpCasts());
+    const auto* PVD = DRE ? dyn_cast<ParmVarDecl>(DRE->getDecl()) : nullptr;
+    auto it = PVD ? m_ParamIdx.find(PVD) : m_ParamIdx.end();
+    if (it == m_ParamIdx.end()) {
+      if (Base->getType()->isPointerType()) {
+        m_Opaque = true;
+        if (m_OpaqueAt.isInvalid())
+          m_OpaqueAt = LHS->getBeginLoc();
+      }
+      return;
+    }
+    widen(it->second, E);
+  }
+};
+
+} // namespace
+
+/// Whether a caller could see a write through this parameter at all: a
+/// pointer or reference to something not const.
+static bool parameterMayBeWritten(QualType T) {
+  return (T->isPointerType() && !T->getPointeeType().isConstQualified()) ||
+         (T->isLValueReferenceType() &&
+          !T.getNonReferenceType().isConstQualified());
+}
+
+void computeWrittenExtents(const FunctionDecl* FD,
+                           llvm::SmallVectorImpl<WrittenExtent>& Extents) {
+  Extents.clear();
+  Extents.resize(FD->getNumParams());
+  // No body to inspect. None would read as "writes nothing", which is the one
+  // thing this analysis must never say without having looked -- an extern may
+  // write all of a buffer it is handed.
+  if (!FD->doesThisDeclarationHaveABody()) {
+    for (unsigned i = 0, e = FD->getNumParams(); i != e; ++i)
+      if (parameterMayBeWritten(FD->getParamDecl(i)->getType())) {
+        Extents[i].K = WrittenExtent::Kind::Unknown;
+        Extents[i].Why = WrittenExtent::Refusal::NoDefinition;
+        Extents[i].RefusedAt = FD->getLocation();
+      }
+    return;
+  }
+  ExtentVisitor V(FD, Extents);
+  V.TraverseStmt(FD->getBody());
+  // Something in the body could write through a parameter without this
+  // analysis seeing which one. Report every parameter it could have been as
+  // unbounded rather than as untouched, so a caller that gates on isProven()
+  // does not mistake silence for proof.
+  if (V.sawOpaqueWrite())
+    for (unsigned i = 0, e = FD->getNumParams(); i != e; ++i) {
+      if (parameterMayBeWritten(FD->getParamDecl(i)->getType())) {
+        Extents[i].K = WrittenExtent::Kind::Unknown;
+        Extents[i].Why = WrittenExtent::Refusal::OpaqueWrite;
+        Extents[i].RefusedAt = V.opaqueWriteLoc();
+      }
+    }
+}
+
+} // namespace clad

--- a/lib/Differentiator/LoopAnalyzer.h
+++ b/lib/Differentiator/LoopAnalyzer.h
@@ -1,0 +1,169 @@
+#ifndef CLAD_DIFFERENTIATOR_LOOPANALYZER_H
+#define CLAD_DIFFERENTIATOR_LOOPANALYZER_H
+
+#include "clang/AST/Stmt.h"
+#include "clang/Basic/SourceLocation.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <cstdint>
+
+namespace clang {
+class Expr;
+class ForStmt;
+class FunctionDecl;
+class VarDecl;
+} // namespace clang
+
+namespace clad {
+
+/// A `for` loop that steps one integer variable by one, from an initial
+/// value, while it compares below a bound.
+///
+/// Several parts of clad need this same shape for different reasons: what
+/// range of a buffer the body writes, how many times a reverse sweep must
+/// run, how to invert the loop. Recognising it once keeps those answers
+/// from drifting apart.
+struct CountedForLoop {
+  /// The variable the loop steps. Null when the loop is not of this shape.
+  const clang::VarDecl* IndVar = nullptr;
+  /// What it starts at, and what it is compared against. Both are the
+  /// loop's own expressions, not copies.
+  const clang::Expr* Init = nullptr;
+  const clang::Expr* Bound = nullptr;
+  /// Whether the comparison is `<=` rather than `<`, so the bound is the
+  /// last value taken rather than the first not taken.
+  bool Inclusive = false;
+  /// Whether the variable starts at or above zero. Together with the bound
+  /// this is what puts a subscript by the variable inside [0, Bound).
+  ///
+  /// Only CountedLoopStack fills this in: a start like `i + 1` is
+  /// non-negative because `i` is an enclosing loop's index, so answering it
+  /// needs the loops around this one, which recognition alone does not see.
+  bool InitIsNonNegative = false;
+
+  explicit operator bool() const { return IndVar != nullptr; }
+};
+
+/// Recognises the shape above in \p FS, or returns an empty result.
+///
+/// This is syntax only. Whether a caller may act on it depends on facts
+/// this does not look at -- whether the bound still holds the same value
+/// when the caller reads it, whether the body leaves the loop early or
+/// moves the induction variable itself -- so each caller adds the
+/// conditions its own use needs.
+CountedForLoop recogniseCountedForLoop(const clang::ForStmt* FS);
+
+/// The counted loops enclosing whatever a visitor is currently looking at.
+///
+/// A visitor calls enter() on the way into a `for` statement and leave() on
+/// the way out. Both the written-extent analysis and reverse mode need to ask
+/// the same question of the result -- which enclosing loop, if any, steps a
+/// given variable -- and each was keeping its own stack to answer it.
+class CountedLoopStack {
+  llvm::SmallVector<CountedForLoop, 4> m_Loops;
+
+public:
+  /// Recognises \p FS and pushes it. Returns whether it was pushed, which the
+  /// caller must hand back to leave() so the two stay paired.
+  bool enter(const clang::ForStmt* FS);
+  void leave(bool Entered) {
+    if (Entered)
+      m_Loops.pop_back();
+  }
+
+  /// The innermost enclosing loop that steps \p V, or null if none does.
+  const CountedForLoop* steppedBy(const clang::VarDecl* V) const {
+    for (const CountedForLoop& L : llvm::reverse(m_Loops))
+      if (L.IndVar == V)
+        return &L;
+    return nullptr;
+  }
+
+private:
+  /// Whether \p E is provably at or above zero, given the loops already on
+  /// the stack -- which is what makes `i + 1` non-negative inside a loop over
+  /// `i` that starts at zero.
+  bool isNonNegative(const clang::Expr* E) const;
+};
+
+/// The range of one pointer parameter that a function writes, described in
+/// terms of that function's own parameters so a call site can evaluate it by
+/// substituting arguments.
+///
+/// The description over-approximates: it names a range that contains every
+/// write, never one that misses any. A caller may therefore record more than
+/// the callee strictly touches, but never less.
+struct WrittenExtent {
+  enum class Kind : std::uint8_t {
+    /// The function does not write through this parameter. Nothing to record.
+    None,
+    /// Exactly one element, at a constant offset.
+    Element,
+    /// Elements [0, Bound), where Bound is a parameter or a constant.
+    Range,
+    /// The function writes through this parameter but the range could not be
+    /// bounded. Callers must assume nothing and keep the conservative
+    /// protocol.
+    Unknown
+  };
+
+  /// Why a write could not be bounded, recorded where the analysis gives up.
+  /// A caller that only knows an extent is Unknown can say that it declined;
+  /// one that knows why can say what to change. Re-deriving the reason at the
+  /// reporting site instead is how the two drift apart.
+  enum class Refusal : std::uint8_t {
+    /// Not refused -- the extent is proven.
+    None,
+    /// The subscript is a variable no counted loop steps, so nothing bounds
+    /// it: the loop is not counted, counts down, or steps by more than one.
+    IndexNotCounted,
+    /// The subscript is neither a constant nor a variable.
+    IndexNotUnderstood,
+    /// Two writes that do not describe one range.
+    WritesDisagree,
+    /// A counted loop does step the subscript, but a call site cannot use its
+    /// bound: it is neither a by-value parameter nor a usable constant.
+    BoundNotUsable,
+    /// A write through a pointer that could not be attributed to a parameter,
+    /// so it may have been through any of them.
+    OpaqueWrite,
+    /// The function has no body here, so nothing about it could be proven.
+    NoDefinition
+  };
+
+  Kind K = Kind::None;
+  Refusal Why = Refusal::None;
+  /// The write, or the part of it, a refusal is about -- for a diagnostic to
+  /// point at. Set on every write, since a disagreement between two of them
+  /// is only discovered at the second.
+  clang::SourceLocation RefusedAt;
+  /// For Kind::Element: the constant offset written.
+  std::uint64_t Offset = 0;
+  /// For Kind::Range: whether Bound names a parameter or is a constant.
+  bool BoundIsParam = false;
+  /// For Kind::Range with BoundIsParam: index of the bounding parameter.
+  unsigned BoundParamIdx = 0;
+  /// For Kind::Range without BoundIsParam: the constant bound.
+  std::uint64_t BoundConst = 0;
+
+  [[nodiscard]] bool isProven() const { return K != Kind::Unknown; }
+};
+
+/// Fills \p Extents with the extent each parameter of \p FD is written over,
+/// one entry per parameter, in parameter order. Anything already there is
+/// replaced.
+///
+/// This is deliberately a small whitelist of shapes that can be proven by
+/// inspection -- a constant subscript, a dereference, and a subscript by the
+/// induction variable of an enclosing counted loop. Everything else, including
+/// every write clad cannot attribute to a parameter, yields Kind::Unknown, so
+/// a caller that gates on isProven() stays conservative as the whitelist
+/// grows.
+void computeWrittenExtents(const clang::FunctionDecl* FD,
+                           llvm::SmallVectorImpl<WrittenExtent>& Extents);
+
+} // namespace clad
+
+#endif // CLAD_DIFFERENTIATOR_LOOPANALYZER_H

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -8,6 +8,7 @@
 #include "ASTIntegrity.h"
 #include "ConstantFolder.h"
 
+#include "LoopAnalyzer.h"
 #include "TBRAnalyzer.h"
 #include "clad/Differentiator/DerivativeBuilder.h"
 #include "clad/Differentiator/DiffPlanner.h"
@@ -2595,6 +2596,71 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     bool recordsAreDead =
         usingRestoreTracker && m_RestoreTracker && mutatesOnlyOwnLocals;
 
+    // Where the extent of every buffer the callee writes is known, recording
+    // those ranges replaces the tracker: one copy per buffer instead of an
+    // address and a scan per element. Only where the tracker's records are the
+    // sole reason to route through the reverse_forw, since the primal is then
+    // equivalent.
+    struct RecordedRange {
+      Expr* Buffer;  // the argument whose range is recorded
+      Expr* Bound;   // how many elements, evaluated at this call site
+      QualType Elem; // what the tape holds
+    };
+    llvm::SmallVector<RecordedRange, 4> recordedRanges;
+    bool useRangeRecords = false;
+    if (usingRestoreTracker && !m_RestoreTracker && hasStoredParams &&
+        !needsForwPass && pullbackStateType.isNull() && !isMethodOperatorCall) {
+      llvm::SmallVector<WrittenExtent, 8> extents;
+      computeWrittenExtents(FD, extents);
+      useRangeRecords = true;
+      for (std::size_t i = 0, e = FD->getNumParams(); i != e && useRangeRecords;
+           ++i) {
+        const WrittenExtent& W = extents[i];
+        if (W.K == WrittenExtent::Kind::None)
+          continue;
+        QualType parTy = FD->getParamDecl(i)->getType();
+        if (i >= CE->getNumArgs() || !parTy->isPointerType() ||
+            parTy->getPointeeType().isConstQualified()) {
+          useRangeRecords = false;
+          break;
+        }
+        Expr* bound = nullptr;
+        if (W.K == WrittenExtent::Kind::Element && W.Offset == 0) {
+          bound = ConstantFolder::synthesizeLiteral(m_Context.UnsignedLongTy,
+                                                    m_Context, /*val=*/1);
+        } else if (W.K == WrittenExtent::Kind::Range) {
+          if (W.BoundIsParam && W.BoundParamIdx < CE->getNumArgs()) {
+            const Expr* arg = CE->getArg(W.BoundParamIdx);
+            // The extent is spelled out four times below. An argument spelled
+            // as a call would run at each of them, and one whose value changed
+            // in between would leave the record and its replays disagreeing
+            // about how many elements there are. Read it once instead; inside
+            // a loop that tapes it, so each iteration replays its own extent.
+            // A constant needs none of this.
+            if (auto val = arg->getIntegerConstantExpr(m_Context))
+              bound = ConstantFolder::synthesizeLiteral(
+                  m_Context.UnsignedLongTy, m_Context, val->getZExtValue());
+            else
+              bound = GlobalStoreAndRef(Clone(arg), m_Context.UnsignedLongTy,
+                                        "_recn", /*force=*/true);
+          } else if (!W.BoundIsParam)
+            bound = ConstantFolder::synthesizeLiteral(m_Context.UnsignedLongTy,
+                                                      m_Context, W.BoundConst);
+        }
+        if (!bound) {
+          useRangeRecords = false;
+          break;
+        }
+        recordedRanges.push_back(
+            {Clone(CE->getArg(i)), bound,
+             parTy->getPointeeType().getUnqualifiedType()});
+      }
+      // Nothing to record means the tracker was not carrying anything either;
+      // leave that case to the existing paths rather than growing a third.
+      if (recordedRanges.empty())
+        useRangeRecords = false;
+    }
+
     // A reverse_forw that carries pullback_state is mandatory even when clad
     // could otherwise call the primal directly: the pullback consumes state
     // only the reverse_forw produces, so eliding it would leave the carrier
@@ -2605,7 +2671,46 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     // relies on. The missing slot is filled with a null-pointer or zero
     // literal, which is why this is restricted to calls whose returned
     // ValueAndAdjoint is unused: those bodies only replay the primal.
-    if (calleeFnForwPassFD && (!hasDynamicNonDiffParams || !needsForwPass) &&
+    // Recording the ranges replaces what the reverse_forw was carrying, so the
+    // primal is enough here too.
+    if (useRangeRecords) {
+      llvm::SmallVector<Stmt*, 4> peeksBefore;
+      llvm::SmallVector<Stmt*, 8> peeksAfter;
+      for (const RecordedRange& R : recordedRanges) {
+        QualType tapeTy = GetCladTapeOfType(R.Elem);
+        Expr* tape =
+            BuildDeclRef(GlobalStoreImpl(tapeTy, "_rec", getZeroInit(tapeTy)));
+        auto call = [&](const char* name, llvm::SmallVector<Expr*, 3> args) {
+          return GetFunctionCall(name, "clad", args);
+        };
+        addToCurrentBlock(
+            call("record_range",
+                 {CloneNode(tape), CloneNode(R.Buffer), CloneNode(R.Bound)}),
+            direction::forward);
+        peeksBefore.push_back(
+            call("peek_range",
+                 {CloneNode(tape), CloneNode(R.Buffer), CloneNode(R.Bound)}));
+        // The pullback's own replay mutates what the first peek put back, so
+        // the pre-call state has to be replayed again before the sweep moves
+        // on to statements that precede this call.
+        peeksAfter.push_back(
+            call("peek_range",
+                 {CloneNode(tape), CloneNode(R.Buffer), CloneNode(R.Bound)}));
+        peeksAfter.push_back(
+            call("drop_range", {CloneNode(tape), CloneNode(R.Bound)}));
+      }
+      Stmts& block = getCurrentBlock(direction::reverse);
+      auto* it = std::begin(block) + insertionPoint;
+      block.insert(it, peeksBefore.begin(), peeksBefore.end());
+      std::size_t postPullback = insertionPoint + peeksBefore.size() +
+                                 PreCallStmts.size() +
+                                 (OverloadedDerivedFn ? 1 : 0);
+      it = std::begin(block) + postPullback;
+      block.insert(it, peeksAfter.begin(), peeksAfter.end());
+    }
+
+    if (!useRangeRecords && calleeFnForwPassFD &&
+        (!hasDynamicNonDiffParams || !needsForwPass) &&
         ((hasStoredParams && !recordsAreDead) || needsForwPass ||
          !pullbackStateType.isNull())) {
       if (const auto* CD = dyn_cast<CXXConversionDecl>(FD))

--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -322,18 +322,20 @@ double f10(double x){
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
+// f10_1 writes one element of t, so the range recorded is one element wide.
 // CHECK-NEXT: void f10_grad(double x, double *_d_x) {
-// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     clad::tape<double> _rec0 = {};
 // CHECK-NEXT:     double _d_t[3] = {0};
 // CHECK-NEXT:     double t[3];
-// CHECK-NEXT:     _tracker0.clear();
-// CHECK-NEXT:     f10_1_reverse_forw(x, t, 0., _d_t, _tracker0);
+// CHECK-NEXT:     clad::record_range(_rec0, t, 1UL);
+// CHECK-NEXT:     f10_1(x, t);
 // CHECK-NEXT:     _d_t[0] += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _tracker0.restore();
+// CHECK-NEXT:         clad::peek_range(_rec0, t, 1UL);
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         f10_1_pullback(x, t, &_r0, _d_t);
-// CHECK-NEXT:         _tracker0.restore();
+// CHECK-NEXT:         clad::peek_range(_rec0, t, 1UL);
+// CHECK-NEXT:         clad::drop_range(_rec0, 1UL);
 // CHECK-NEXT:         *_d_x += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Analyses/RecordRangeExtent.C
+++ b/test/Analyses/RecordRangeExtent.C
@@ -1,0 +1,56 @@
+// RUN: %cladclang %s -I%S/../../include -oRecordRangeExtent.out 2>&1 | %filecheck %s
+// RUN: ./RecordRangeExtent.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s \
+// RUN:   -I%S/../../include -oRecordRangeExtent.out
+// RUN: ./RecordRangeExtent.out | %filecheck_exec %s
+
+// A recorded range's extent appears at four places -- the record, the two
+// replays around the pullback, and the drop. Spelling the call's argument out
+// at each of them would evaluate it four times, and an argument whose value
+// changed in between would leave the record and its replays disagreeing about
+// how many elements there are. It is read once instead.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+int g_calls = 0;
+int howMany() {
+  ++g_calls;
+  return 2;
+}
+
+// Nonlinear in its own output, so its pullback needs the pre-call values and
+// the caller has to capture them.
+void squarer(int n, double* out) {
+  for (int i = 0; i < n; i++)
+    out[i] = out[i] * out[i];
+}
+
+double f(const double* x) {
+  double b[4] = {x[0], x[1], 0, 0};
+  squarer(howMany(), b);
+  return b[0] + b[1];
+}
+
+// CHECK: void f_grad(const double *x, double *_d_x) {
+// CHECK: {{(unsigned long|std::size_t)}} _recn0 = howMany();
+// CHECK: clad::record_range(_rec0, b, _recn0);
+// CHECK: clad::peek_range(_rec0, b, _recn0);
+// CHECK: clad::peek_range(_rec0, b, _recn0);
+// CHECK-NEXT: clad::drop_range(_rec0, _recn0);
+
+int main() {
+  auto g = clad::gradient(f, "x");
+  double x[4] = {1, 2, 3, 4};
+  double dx[4] = {0, 0, 0, 0};
+  g_calls = 0;
+  g.execute(x, dx);
+  // The extent is read once here. clad separately repeats the call's own
+  // arguments in the pullback call, which is why this is not 1.
+  printf("extent reads: %d\n", g_calls);
+  // CHECK-EXEC: extent reads: 3
+  printf("dx={%.2f, %.2f}\n", dx[0], dx[1]);
+  // CHECK-EXEC: dx={2.00, 4.00}
+  return 0;
+}

--- a/test/Analyses/TBRCalls.C
+++ b/test/Analyses/TBRCalls.C
@@ -149,24 +149,33 @@ double t7(const double* x) {
   return buf[0] + buf[1];
 }
 
+// clad proves how much of `buf` squarer overwrites, so the pre-call state is
+// captured as a range rather than through a tracker, and the primal is called
+// directly. The range is replayed twice, as the tracker was: once before the
+// pullback, once after its own replay re-mutates the buffer.
 // CHECK: void t1_grad(const double *x, double *_d_x) {
-// CHECK: squarer_reverse_forw(2, &{{.*}}, 0, &{{.*}}, _tracker0);
-// CHECK: _tracker0.restore();
+// CHECK: clad::record_range(_rec1, &buf[0], 2UL);
+// CHECK: squarer(2, &{{.*}});
+// CHECK: clad::peek_range(_rec1, &buf[0], 2UL);
 // CHECK: squarer_pullback(2, &{{.*}});
+// CHECK: clad::peek_range(_rec1, &buf[0], 2UL);
+// CHECK-NEXT: clad::drop_range(_rec1, 2UL);
 
 // CHECK: void t7_grad(const double *x, double *_d_x) {
 // CHECK-NOT: _tracker
 // CHECK-NOT: clad::push
 // CHECK: fillfrom_pullback(2, x, &buf[0]
 
-// In a loop each iteration gets its own tracker snapshot through a tape.
+// In a loop each iteration still gets its own snapshot, but one tape of values
+// serves them all -- where a tape of trackers had to hold an address as well
+// as a value for every element, and a whole tracker object per iteration.
 // CHECK: void t9_grad(const double *x, const double *m, double *_d_x, double *_d_m) {
-// CHECK: clad::tape<clad::restore_tracker> _tracker0 = {};
-// CHECK: clad::push(_tracker0, clad::restore_tracker());
-// CHECK: clad::back(_tracker0).restore();
+// CHECK: clad::tape<double> _rec0 = {};
+// CHECK: clad::record_range(_rec0, &buf[0], 2UL);
+// CHECK: clad::peek_range(_rec0, &buf[0], 2UL);
 // CHECK: diffem_pullback(2, x, m + 2 * k, &
-// CHECK-NEXT: clad::back(_tracker0).restore();
-// CHECK-NEXT: clad::pop(_tracker0);
+// CHECK-NEXT: clad::peek_range(_rec0, &buf[0], 2UL);
+// CHECK-NEXT: clad::drop_range(_rec0, 2UL);
 
 int main() {
   double x[2] = {1, 2};

--- a/test/Analyses/TBRChainedCalls.C
+++ b/test/Analyses/TBRChainedCalls.C
@@ -18,8 +18,12 @@
 
 #include <cstdio>
 
+// The first call's buffer must be captured per iteration. clad proves how
+// much of it `sub` writes, so it records that range rather than routing
+// through sub_reverse_forw for a tracker snapshot; either way the values are
+// there, which is what the executed gradients below check.
 // CHECK: void chained_grad_0_1(
-// CHECK: sub_reverse_forw(
+// CHECK: clad::record_range(
 
 void sub(int d, const double* x, const double* y, double* out) {
   for (int i = 0; i < d; i++)

--- a/test/Analyses/TBRComposition.C
+++ b/test/Analyses/TBRComposition.C
@@ -18,10 +18,16 @@
 #include <cstdio>
 
 // Both mutating calls must record their pre-call state, including the one
-// whose data pointer carries no adjoint.
+// whose data pointer carries no adjoint. clad proves how much of each buffer
+// they overwrite, so each records that range instead of routing through a
+// reverse_forw for a tracker snapshot.
+// The extent `d` is read once and taped, so each iteration replays its own --
+// spelling it out at each of the four sites would re-evaluate the argument.
 // CHECK: void objective_pullback(
-// CHECK: center_reverse_forw(
-// CHECK: scale_reverse_forw(
+// CHECK: clad::push(_recn0, d);
+// CHECK-NEXT: clad::record_range(_rec0, &centered[0], clad::back(_recn0));
+// CHECK: clad::push(_recn1, d);
+// CHECK-NEXT: clad::record_range(_rec1, &scaled[0], clad::back(_recn1));
 
 // out[i] = x[i] - m[i]: overwrites caller storage through a pointer, with a
 // non-differentiated data pointer as one input.

--- a/test/Analyses/WrittenExtents.C
+++ b/test/Analyses/WrittenExtents.C
@@ -1,0 +1,323 @@
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fdump-analysis=loop %s \
+// RUN:   -I%S/../../include -oWrittenExtents.out 2>&1 | %filecheck %s
+// RUN: ./WrittenExtents.out
+
+// What a callee writes through each pointer parameter, proven from its body
+// and expressed in its own parameters so a call site can evaluate it. The
+// whitelist is deliberately narrow; the useful half of the report is what
+// comes back `unknown`, because that is what a caller must stay conservative
+// about. Widening the whitelist may turn an `unknown` below into a range, but
+// must never turn a range into a different range.
+
+#include "clad/Differentiator/Differentiator.h"
+
+// The canonical shape: a counted loop over a parameter bound.
+void subtract(int d, const double* x, const double* y, double* out) {
+  for (int i = 0; i < d; i++)
+    out[i] = x[i] - y[i];
+}
+// CHECK: written-extent: subtract: d = none
+// CHECK-NEXT: written-extent: subtract: x = none
+// CHECK-NEXT: written-extent: subtract: y = none
+// CHECK-NEXT: written-extent: subtract: out = [0, d)
+
+// Two loops write `out`, the second from `i + 1` rather than zero. Both stay
+// inside [0, d), so the two records agree and the parameter is still proven.
+void qtimesx(int d, const double* Qd, const double* x, double* out) {
+  for (int i = 0; i < d; i++)
+    out[i] = Qd[i] * x[i];
+  for (int i = 0; i < d; i++)
+    for (int j = i + 1; j < d; j++)
+      out[j] = out[j] + x[i];
+}
+// CHECK: written-extent: qtimesx: d = none
+// CHECK-NEXT: written-extent: qtimesx: Qd = none
+// CHECK-NEXT: written-extent: qtimesx: x = none
+// CHECK-NEXT: written-extent: qtimesx: out = [0, d)
+
+// Two different constant offsets do not describe one range, so they widen to
+// unknown rather than to a guessed hull.
+void constIdx(double* v) {
+  v[0] = 1.0;
+  v[2] = 3.0;
+}
+// CHECK: written-extent: constIdx: v = unknown (writes do not describe one range at line [[@LINE-2]])
+
+// A constant bound is as usable as a parameter one.
+void fixedLoop(double* v) {
+  for (int i = 0; i < 5; ++i)
+    v[i] = v[i] * 2;
+}
+// CHECK: written-extent: fixedLoop: v = [0, 5)
+
+// The index is not an induction variable, so nothing bounds the write.
+void dataDependent(int n, const double* x, double* out) {
+  for (int i = 0; i < n; i++)
+    out[(int)x[i]] = x[i];
+}
+// CHECK: written-extent: dataDependent: n = none
+// CHECK-NEXT: written-extent: dataDependent: x = none
+// CHECK-NEXT: written-extent: dataDependent: out = unknown (index is neither a constant nor a variable at line [[@LINE-4]])
+
+// Only a loop stepping by one is recognised, and only when it is spelled with
+// ++. The rest report unknown, which is the safe answer, and these cases pin
+// it: a step of two writes every other element, so [0, d) would merely be
+// wasteful, but a loop counting down writes none of [init, bound) at all, and
+// an extent that claims a range the loop never touches is a wrong gradient.
+// Widening the recogniser means deciding what each of these writes first.
+void plusEqualOne(int d, double* out) {
+  for (int i = 0; i < d; i += 1)
+    out[i] = 1;
+}
+// CHECK: written-extent: plusEqualOne: out = unknown (index not stepped by a counted loop at line [[@LINE-2]])
+
+void stepsByTwo(int d, double* out) {
+  for (int i = 0; i < d; i += 2)
+    out[i] = 1;
+}
+// CHECK: written-extent: stepsByTwo: out = unknown (index not stepped by a counted loop at line [[@LINE-2]])
+
+void stepsByParameter(int d, int k, double* out) {
+  for (int i = 0; i < d; i += k)
+    out[i] = 1;
+}
+// CHECK: written-extent: stepsByParameter: out = unknown (index not stepped by a counted loop at line [[@LINE-2]])
+
+void countsDown(int d, double* out) {
+  for (int i = d - 1; i > 0; --i)
+    out[i] = 1;
+}
+// CHECK: written-extent: countsDown: out = unknown (index not stepped by a counted loop at line [[@LINE-2]])
+
+// The header alone is not enough: a body that changes the index or the bound
+// breaks what the header promised, and an inclusive bound reaches one past the
+// range [0, Bound) can describe. Each would otherwise report [0, d) while
+// writing outside it -- an under-approximation, the one error a caller cannot
+// survive. (The bodies stay inside the buffer because this test also runs
+// them; what the analysis reacts to is the assignment, not its value.)
+void inclusiveBound(int d, double* out) {
+  for (int i = 0; i <= d; ++i)
+    out[i] = 1;
+}
+// CHECK: written-extent: inclusiveBound: out = unknown (index not stepped by a counted loop at line [[@LINE-2]])
+
+void movesIndex(int d, double* out) {
+  for (int i = 0; i < d; ++i) {
+    i += 2;
+    out[i] = 1;
+  }
+}
+// CHECK: written-extent: movesIndex: out = unknown (index not stepped by a counted loop at line [[@LINE-3]])
+
+void raisesBound(int d, double* out) {
+  for (int i = 0; i < d; ++i) {
+    out[i] = 1;
+    d = 3;
+  }
+}
+// CHECK: written-extent: raisesBound: out = unknown (index not stepped by a counted loop at line [[@LINE-4]])
+
+// Taking the index's address hands it to anything: the loop no longer owns it.
+void escapesIndex(int d, double* out) {
+  for (int i = 0; i < d; ++i) {
+    int* p = &i;
+    out[i] = *p;
+  }
+}
+// CHECK: written-extent: escapesIndex: out = unknown (index not stepped by a counted loop at line [[@LINE-3]])
+
+// The bound has to hold still for the whole call, not only inside the loop: a
+// caller works the range out from the argument it passed. This one writes
+// [0, 2d) while a caller substituting its own d would record [0, d).
+void raisesBoundBefore(int d, double* out) {
+  d = d * 2;
+  for (int i = 0; i < d; ++i)
+    out[i] = 1;
+}
+// CHECK: written-extent: raisesBoundBefore: out = unknown (index not stepped by a counted loop at line [[@LINE-2]])
+
+// A bound taken by reference names storage a callee can change under us, so
+// the value a call site reads is not the value the loop will compare against.
+void referenceBound(int& d, double* out) {
+  for (int i = 0; i < d; ++i)
+    out[i] = 1;
+}
+// CHECK: written-extent: referenceBound: out = unknown (the loop's bound is not one a call site can use at line [[@LINE-2]])
+
+// Only `for` is recognised; an equivalent while loop is not.
+void whileLoop(int n, double* out) {
+  int i = 0;
+  while (i < n) {
+    out[i] = out[i] * 2;
+    i++;
+  }
+}
+// CHECK: written-extent: whileLoop: n = none
+// CHECK-NEXT: written-extent: whileLoop: out = unknown (index not stepped by a counted loop at line [[@LINE-5]])
+
+// A second index walked alongside the induction variable joins the increment
+// with a comma. That still steps the induction variable by one.
+void commaStep(int d, const double* w, double* out) {
+  int p = 0;
+  for (int i = 0; i < d; i++, p++)
+    out[i] = w[p];
+}
+// CHECK: written-extent: commaStep: d = none
+// CHECK-NEXT: written-extent: commaStep: w = none
+// CHECK-NEXT: written-extent: commaStep: out = [0, d)
+
+// A bound does not have to be spelled as a literal to be one. A dimension is
+// usually a constexpr variable, an enumerator or a template argument, and a
+// call site can work any of those out as readily as the number.
+constexpr int Dim = 6;
+enum { EnumDim = 5 };
+void constexprBound(double* v) {
+  for (int i = 0; i < Dim; i++)
+    v[i] = v[i] * 2;
+}
+// CHECK: written-extent: constexprBound: v = [0, 6)
+
+void enumBound(double* v) {
+  for (int i = 0; i < EnumDim; i++)
+    v[i] = v[i] * 2;
+}
+// CHECK: written-extent: enumBound: v = [0, 5)
+
+// The loop is counted, but its bound is a local no call site can work out, so
+// the range cannot be put in terms of this function's parameters.
+void localBound(int d, double* out) {
+  int n = d * 2;
+  for (int i = 0; i < n; i++)
+    out[i] = 1;
+}
+// CHECK: written-extent: localBound: d = none
+// CHECK-NEXT: written-extent: localBound: out = unknown (the loop's bound is not one a call site can use at line [[@LINE-3]])
+
+// A start below zero reaches out[-1], which [0, d) does not describe.
+void negativeStart(int d, double* out) {
+  for (int i = -1; i < d; ++i)
+    out[i] = 1;
+}
+// CHECK: written-extent: negativeStart: out = unknown
+
+// A bound that folds below zero is refused rather than zero-extended into
+// almost the whole address space.
+void negativeBound(double* out) {
+  for (int i = 0; i < -1; ++i)
+    out[i] = 1;
+}
+// CHECK: written-extent: negativeBound: out = unknown
+
+// Two loops over the same buffer with different bounds do not describe one
+// range, and the hull of the two is not something either loop proved.
+void twoBounds(int d, int k, double* out) {
+  for (int i = 0; i < d; ++i)
+    out[i] = 1;
+  for (int i = 0; i < k; ++i)
+    out[i] = 2;
+}
+// CHECK: written-extent: twoBounds: out = unknown (writes do not describe one range at line [[@LINE-2]])
+
+// The index may be declared outside the loop and only assigned in the header.
+// That is the shape clad's own reverse sweeps are emitted in, so it has to be
+// recognised as readily as the declaring form.
+void assignedIndex(int d, double* out) {
+  int i = 0;
+  for (i = 0; i < d; ++i)
+    out[i] = 1;
+}
+// CHECK: written-extent: assignedIndex: out = [0, d)
+
+// A range already proven, then a write nothing bounds. The hull of the two is
+// not something either write proved, so the parameter goes back to unknown.
+void provenThenLoose(int d, double* out) {
+  for (int i = 0; i < d; ++i)
+    out[i] = 1;
+  out[d + 1] = 2;
+}
+// CHECK: written-extent: provenThenLoose: out = unknown
+
+// Shapes the recogniser declines, each still leaving the constant subscript
+// in the body provable. A floating induction variable makes the iteration
+// count depend on rounding.
+void floatIndex(double* out) {
+  for (double x = 0; x < 3; ++x)
+    out[0] = out[0] + x;
+}
+// CHECK: written-extent: floatIndex: out = [0, 1)
+
+// No condition at all bounds nothing.
+void noCondition(double* out) {
+  for (;;) {
+    out[0] = 1;
+    break;
+  }
+}
+// CHECK: written-extent: noCondition: out = [0, 1)
+
+// The condition compares an expression rather than the variable itself.
+void computedCondition(int d, double* out) {
+  for (int i = 0; i - d < 0; ++i)
+    out[0] = 1;
+}
+// CHECK: written-extent: computedCondition: out = [0, 1)
+
+// A header with no initialiser leaves the start value unknown.
+void noInit(int d, double* out) {
+  int i = 0;
+  for (; i < d; ++i)
+    out[0] = 1;
+}
+// CHECK: written-extent: noInit: out = [0, 1)
+
+// A scalar written through a dereference is a single element.
+void scalarOut(double a, double* err) { *err = a * a; }
+// CHECK: written-extent: scalarOut: a = none
+// CHECK-NEXT: written-extent: scalarOut: err = [0, 1)
+
+double f(double a) {
+  double x[4] = {a, a, a, a};
+  double y[4] = {a, a, a, a};
+  double o[4] = {0, 0, 0, 0};
+  double o2[4] = {0, 0, 0, 0};
+  subtract(4, x, y, o);
+  qtimesx(4, x, y, o2);
+  constIdx(o);
+  fixedLoop(o);
+  dataDependent(4, x, o);
+  plusEqualOne(4, o);
+  stepsByTwo(4, o);
+  stepsByParameter(4, 2, o);
+  countsDown(4, o);
+  inclusiveBound(2, o);
+  movesIndex(2, o);
+  raisesBound(2, o);
+  escapesIndex(2, o);
+  raisesBoundBefore(2, o);
+  int rd = 4;
+  referenceBound(rd, o);
+  whileLoop(4, o);
+  commaStep(4, y, o2);
+  constexprBound(o2);
+  enumBound(o2);
+  localBound(2, o);
+  negativeStart(2, o);
+  negativeBound(o);
+  twoBounds(2, 3, o);
+  assignedIndex(2, o);
+  provenThenLoose(2, o);
+  floatIndex(o);
+  noCondition(o);
+  computedCondition(2, o);
+  noInit(2, o);
+  double e = 0;
+  scalarOut(a, &e);
+  return o[0] + o2[0] + e;
+}
+
+int main() {
+  auto g = clad::gradient(f);
+  double da = 0;
+  g.execute(1.0, &da);
+  return 0;
+}

--- a/test/Analyses/WrittenExtentsNoDefinition.C
+++ b/test/Analyses/WrittenExtentsNoDefinition.C
@@ -1,0 +1,34 @@
+// A function declared but not defined here writes nothing this analysis can
+// see -- which is not the same as writing nothing. Reporting `none` would be a
+// proof drawn from never having looked, and an extern is free to fill the
+// whole buffer it is handed. That clad separately declines to differentiate
+// such a call, and warns, says nothing about what the call does to memory.
+//
+// -verify consumes those warnings, so this checks only the report. Syntax-only
+// because there is deliberately no definition to link against.
+//
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fdump-analysis=loop \
+// RUN:   -Xclang -verify -fsyntax-only %s -I%S/../../include 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+void declaredOnly(int n, double* out);
+
+// Only parameters it could write through are affected: an int by value cannot
+// carry a write back to the caller, so it stays `none`.
+// CHECK: written-extent: declaredOnly: n = none
+// CHECK-NEXT: written-extent: declaredOnly: out = unknown (the function has no definition here at line [[@LINE-5]])
+
+double f(double a) {
+  double o[4] = {0, 0, 0, 0};
+  // Differentiated once for the pullback and once for the forward pass, so
+  // each diagnostic is seen twice.
+  declaredOnly(4, o); // expected-warning 2{{attempted differentiation of function 'declaredOnly' without definition and no suitable overload was found in namespace 'custom_derivatives'}} expected-note 2{{numerical differentiation is not viable for 'declaredOnly'; considering 'declaredOnly' as 0}}
+  return o[0] * a;
+}
+
+int main() {
+  auto g = clad::gradient(f);
+  return 0;
+}

--- a/test/Analyses/WrittenExtentsOpaque.C
+++ b/test/Analyses/WrittenExtentsOpaque.C
@@ -1,0 +1,96 @@
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -fdump-analysis=loop %s \
+// RUN:   -I%S/../../include -oWrittenExtentsOpaque.out 2>&1 | %filecheck %s
+// RUN: ./WrittenExtentsOpaque.out | %filecheck_exec %s
+
+// A function that writes a parameter only through a call it makes must not be
+// reported as leaving that parameter untouched: a caller gating on the extent
+// would then record nothing and the gradient would be silently wrong. The
+// analysis has to distinguish "provably not written" from "no write seen".
+//
+// The distinction is which storage the argument designates. Handing a callee a
+// pointer into this function's own locals says nothing about its parameters;
+// handing it a parameter does.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+void inner(int n, double* out) {
+  for (int i = 0; i < n; i++)
+    out[i] = out[i] * 2;
+}
+// CHECK: written-extent: inner: n = none
+// CHECK-NEXT: written-extent: inner: out = [0, n)
+
+// `out` is written only inside inner, so its extent is not visible here.
+void viaCall(int n, const double* x, double* out) {
+  for (int i = 0; i < n; i++)
+    out[i] = x[i];
+  inner(n, out);
+}
+// CHECK: written-extent: viaCall: n = none
+// CHECK-NEXT: written-extent: viaCall: x = none
+// CHECK-NEXT: written-extent: viaCall: out = unknown (a write could not be attributed to a parameter at line [[@LINE-4]])
+
+// The same call shape, but the buffer handed over belongs to this function, so
+// nothing the callee does to it can reach `out`. `out` is nonetheless reported
+// unknown: designatesLocallyOwnedStorage does not see through a local array
+// decaying to a pointer, only through accessors and subscripts. Conservative
+// in the safe direction -- a caller keeps the tracker where it need not have.
+// Widening that helper would turn this line into `[0, n)`.
+void viaLocal(int n, const double* x, double* out) {
+  double scratch[8];
+  for (int i = 0; i < n; i++)
+    scratch[i] = x[i];
+  inner(n, scratch);
+  for (int i = 0; i < n; i++)
+    out[i] = scratch[i];
+}
+// CHECK: written-extent: viaLocal: n = none
+// CHECK-NEXT: written-extent: viaLocal: x = none
+// CHECK-NEXT: written-extent: viaLocal: out = unknown (a write could not be attributed to a parameter at line [[@LINE-7]])
+
+// A member call keeps its object out of the argument list, so the write below
+// is invisible to a walk over the arguments alone.
+struct Box {
+  double v[3];
+  void twice() {
+    for (int i = 0; i < 3; i++)
+      v[i] = v[i] * 2;
+  }
+};
+void viaMemberCall(Box* b) { b->twice(); }
+// CHECK: written-extent: viaMemberCall: b = unknown (a write could not be attributed to a parameter at line [[@LINE-1]])
+
+// A non-const reference is as good as a pointer for writing through, and the
+// callee's body is no more visible here.
+void bump(double& r) { r = r + 1; }
+void viaReference(double* out) { bump(out[0]); }
+// CHECK: written-extent: viaReference: out = unknown (a write could not be attributed to a parameter at line [[@LINE-1]])
+
+double f(const double* x) {
+  double a[3] = {0, 0, 0};
+  double b[3] = {0, 0, 0};
+  viaCall(3, x, a);
+  viaLocal(3, x, b);
+  Box box;
+  for (int i = 0; i < 3; i++)
+    box.v[i] = x[i];
+  viaMemberCall(&box);
+  viaReference(a);
+  return a[0] * a[0] + a[1] * a[1] + a[2] * a[2] + b[0] + b[1] + b[2] +
+         box.v[0];
+}
+
+int main() {
+  auto g = clad::gradient(f, "x");
+  double x[3] = {1, 2, 3};
+  double dx[3] = {0, 0, 0};
+  g.execute(x, dx);
+  // a_i = 2 x_i, and viaReference adds one to a_0, so d(a_0^2)/dx_0 is
+  // 8 x_0 + 4 and the rest 8 x_i; b_i = 2 x_i contributes 2, and
+  // box.v[0] = 2 x_0 contributes 2 more to the first.
+  printf("%.2f %.2f %.2f\n", dx[0], dx[1], dx[2]);
+  // CHECK-EXEC: 16.00 18.00 26.00
+  return 0;
+}

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -206,15 +206,16 @@ double fn4(double* arr, int n) {
   return res;
 }
 
+// sum writes only arr[0], so one element is recorded and the primal is called.
 // CHECK: void fn4_grad(double *arr, int n, double *_d_arr, int *_d_n) {
-// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// CHECK-NEXT:     clad::tape<double> _rec0 = {};
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     _tracker0.clear();
-// CHECK-NEXT:     res += sum_reverse_forw(arr, n, _d_arr, 0, _tracker0);
+// CHECK-NEXT:     clad::record_range(_rec0, arr, 1UL);
+// CHECK-NEXT:     res += sum(arr, n);
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
 // CHECK-NEXT:         _t0++;
@@ -236,10 +237,11 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
 // CHECK-NEXT:         double _r_d0 = _d_res;
-// CHECK-NEXT:         _tracker0.restore();
+// CHECK-NEXT:         clad::peek_range(_rec0, arr, 1UL);
 // CHECK-NEXT:         int _r0 = 0;
 // CHECK-NEXT:         sum_pullback(arr, n, _r_d0, _d_arr, &_r0);
-// CHECK-NEXT:         _tracker0.restore();
+// CHECK-NEXT:         clad::peek_range(_rec0, arr, 1UL);
+// CHECK-NEXT:         clad::drop_range(_rec0, 1UL);
 // CHECK-NEXT:         *_d_n += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -270,16 +272,18 @@ double fn5(double* arr, int n) {
     return arr[0];
 }
 
+// modify2 writes arr[0] and reads arr[1]; only the written element is recorded.
 // CHECK: void fn5_grad(double *arr, int n, double *_d_arr, int *_d_n) {
-// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
-// CHECK-NEXT:     _tracker0.clear();
+// CHECK-NEXT:     clad::tape<double> _rec0 = {};
+// CHECK-NEXT:     clad::record_range(_rec0, arr, 1UL);
 // CHECK-NEXT:     double _d_temp = 0.;
-// CHECK-NEXT:     double temp = modify2_reverse_forw(arr, _d_arr, _tracker0);
+// CHECK-NEXT:     double temp = modify2(arr);
 // CHECK-NEXT:     _d_arr[0] += 1;
 // CHECK-NEXT:     {
-// CHECK-NEXT:       _tracker0.restore();
-// CHECK-NEXT:       modify2_pullback(arr, _d_temp, _d_arr);
-// CHECK-NEXT:       _tracker0.restore();
+// CHECK-NEXT:         clad::peek_range(_rec0, arr, 1UL);
+// CHECK-NEXT:         modify2_pullback(arr, _d_temp, _d_arr);
+// CHECK-NEXT:         clad::peek_range(_rec0, arr, 1UL);
+// CHECK-NEXT:         clad::drop_range(_rec0, 1UL);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -940,22 +944,24 @@ double fn27(double u, double v) {
 } // u * v + u
 
 // CHECK-NEXT: void fn27_grad(double u, double v, double *_d_u, double *_d_v) {
-// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
+// mult writes x[0..3), so the whole buffer is recorded once.
+// CHECK-NEXT:     clad::tape<double> _rec0 = {};
 // CHECK-NEXT:     double _d_arr[3] = {0};
 // CHECK-NEXT:     double arr[3] = {u, v, 1};
 // CHECK-NEXT:     double _d_sum = 0.;
 // CHECK-NEXT:     double sum0 = arr[0] * arr[1] * arr[2];
-// CHECK-NEXT:     _tracker0.clear();
-// CHECK-NEXT:     mult_reverse_forw(arr, u, _d_arr, 0., _tracker0);
+// CHECK-NEXT:     clad::record_range(_rec0, arr, 3UL);
+// CHECK-NEXT:     mult(arr, u);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_sum += 1;
 // CHECK-NEXT:         _d_arr[2] += 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _tracker0.restore();
+// CHECK-NEXT:         clad::peek_range(_rec0, arr, 3UL);
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         mult_pullback(arr, u, _d_arr, &_r0);
-// CHECK-NEXT:         _tracker0.restore();
+// CHECK-NEXT:         clad::peek_range(_rec0, arr, 3UL);
+// CHECK-NEXT:         clad::drop_range(_rec0, 3UL);
 // CHECK-NEXT:         *_d_u += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -981,24 +987,29 @@ double& nested(double* x, double y) {
 // CHECK-NEXT:     return {x[1], _d_x[1]};
 // CHECK-NEXT: }
 
+// Two calls to the same provable callee get a record each; nested itself is
+// not provable -- it writes x only through those calls -- so its own callers
+// keep the tracker.
 // CHECK-NEXT: void nested_pullback(double *x, double y, double *_d_x, double *_d_y) {
-// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
-// CHECK-NEXT:     clad::restore_tracker _tracker1 = {};
-// CHECK-NEXT:     _tracker0.clear();
-// CHECK-NEXT:     mult_reverse_forw(x, y, _d_x, 0., _tracker0);
-// CHECK-NEXT:     _tracker1.clear();
-// CHECK-NEXT:     mult_reverse_forw(x, 3, _d_x, 0, _tracker1);
+// CHECK-NEXT:     clad::tape<double> _rec0 = {};
+// CHECK-NEXT:     clad::tape<double> _rec1 = {};
+// CHECK-NEXT:     clad::record_range(_rec0, x, 3UL);
+// CHECK-NEXT:     mult(x, y);
+// CHECK-NEXT:     clad::record_range(_rec1, x, 3UL);
+// CHECK-NEXT:     mult(x, 3);
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _tracker1.restore();
+// CHECK-NEXT:         clad::peek_range(_rec1, x, 3UL);
 // CHECK-NEXT:         double _r1 = 0.;
 // CHECK-NEXT:         mult_pullback(x, 3, _d_x, &_r1);
-// CHECK-NEXT:         _tracker1.restore();
+// CHECK-NEXT:         clad::peek_range(_rec1, x, 3UL);
+// CHECK-NEXT:         clad::drop_range(_rec1, 3UL);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _tracker0.restore();
+// CHECK-NEXT:         clad::peek_range(_rec0, x, 3UL);
 // CHECK-NEXT:         double _r0 = 0.;
 // CHECK-NEXT:         mult_pullback(x, y, _d_x, &_r0);
-// CHECK-NEXT:         _tracker0.restore();
+// CHECK-NEXT:         clad::peek_range(_rec0, x, 3UL);
+// CHECK-NEXT:         clad::drop_range(_rec0, 3UL);
 // CHECK-NEXT:         *_d_y += _r0;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -1065,17 +1076,18 @@ double fn29(double *x) {
 }
 
 // CHECK: void fn29_grad(double *x, double *_d_x) {
-// CHECK-NEXT:     clad::restore_tracker _tracker0 = {};
-// CHECK-NEXT:     _tracker0.clear();
-// CHECK-NEXT:     foo_reverse_forw(x, _d_x, _tracker0);
+// CHECK-NEXT:     clad::tape<double> _rec0 = {};
+// CHECK-NEXT:     clad::record_range(_rec0, x, 1UL);
+// CHECK-NEXT:     foo(x);
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_x[0] += 1 * x[1];
 // CHECK-NEXT:         _d_x[1] += x[0] * 1;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         _tracker0.restore();
+// CHECK-NEXT:         clad::peek_range(_rec0, x, 1UL);
 // CHECK-NEXT:         foo_pullback(x, _d_x);
-// CHECK-NEXT:         _tracker0.restore();
+// CHECK-NEXT:         clad::peek_range(_rec0, x, 1UL);
+// CHECK-NEXT:         clad::drop_range(_rec0, 1UL);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Misc/Args.C
+++ b/test/Misc/Args.C
@@ -7,6 +7,7 @@
 // CHECK_HELP-NEXT: -fdump-generated-source
 // CHECK_HELP-NEXT: -Rclad-analysis=<name>
 // CHECK_HELP-NEXT: -fgenerated-source-dir=<dir>
+// CHECK_HELP-NEXT: -fdump-analysis=<name>
 // CHECK_HELP-NEXT: -fgenerate-source-file
 // CHECK_HELP-NEXT: -fno-validate-clang-version
 // CHECK_HELP-NEXT: -fcustom-estimation-model
@@ -17,6 +18,7 @@
 // CHECK_HELP-NEXT: -enable-tbr / -disable-tbr {{.*}} Default: on.
 // CHECK_HELP-NEXT: -enable-va / -disable-va {{.*}} Default: off.
 // CHECK_HELP-NEXT: -enable-ua / -disable-ua {{.*}} Default: off.
+// CHECK_HELP-NEXT: -enable-loop / -disable-loop {{.*}} Default: on.
 // CHECK_HELP-NEXT: -help
 
 // RUN: clang -fsyntax-only -fplugin=%cladlib -Xclang -plugin-arg-clad\
@@ -47,6 +49,11 @@
 // RUN: clang -fsyntax-only -fplugin=%cladlib -Xclang -plugin-arg-clad \
 // RUN:  -Xclang -fdisable-analysis=nosuch %s 2>&1 | FileCheck --check-prefix=CHECK_NO_SUCH %s
 // CHECK_NO_SUCH: unknown analysis 'nosuch'; known: tbr activity useful
+
+// The same holds for the flag that asks an analysis to report itself.
+// RUN: clang -fsyntax-only -fplugin=%cladlib -Xclang -plugin-arg-clad \
+// RUN:  -Xclang -fdump-analysis=nosuch %s 2>&1 | FileCheck --check-prefix=CHECK_NO_DUMP %s
+// CHECK_NO_DUMP: unknown analysis 'nosuch'
 
 // 'all' asks for the conservative derivative, so it only makes sense as
 // something to turn off.

--- a/test/Misc/RecordRange.C
+++ b/test/Misc/RecordRange.C
@@ -1,0 +1,96 @@
+// RUN: %cladclang %s -I%S/../../include -oRecordRange.out
+// RUN: ./RecordRange.out | %filecheck_exec %s
+
+// clad::record_range / peek_range / drop_range are how a call site puts back a
+// range a callee overwrote, in place of a restore_tracker's address-keyed log.
+// peek_range must be non-destructive and must be replayable twice, because a
+// call's reverse sweep restores once before the pullback and again after --
+// the pullback's own replay mutates what the first restore put back.
+//
+// The sizes below straddle the tape's inline capacity and its slab size, which
+// is where peek_back's index arithmetic has to walk back through slabs rather
+// than index the tail directly.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+#include <vector>
+
+int main() {
+  const std::size_t totals[] = {5, 64, 65, 1000, 1024, 1089, 5000};
+  const std::size_t runs[] = {1, 3, 64, 100, 1500};
+
+  for (std::size_t total : totals) {
+    for (std::size_t n : runs) {
+      if (n > total)
+        continue;
+      clad::tape<double> t = {};
+      for (std::size_t i = 0; i < total; i++)
+        clad::push(t, (double)i);
+
+      std::vector<double> got(n, -1);
+      clad::peek_range(t, got.data(), n);
+      for (std::size_t i = 0; i < n; i++)
+        if (got[i] != (double)(total - n + i)) {
+          printf("FAIL value total=%zu n=%zu\n", total, n);
+          return 1;
+        }
+      if (t.size() != total) {
+        printf("FAIL peek consumed total=%zu n=%zu\n", total, n);
+        return 1;
+      }
+
+      // Replaying the same run again must give the same values.
+      std::vector<double> again(n, -1);
+      clad::peek_range(t, again.data(), n);
+      for (std::size_t i = 0; i < n; i++)
+        if (again[i] != got[i]) {
+          printf("FAIL second peek total=%zu n=%zu\n", total, n);
+          return 1;
+        }
+
+      clad::drop_range(t, n);
+      if (t.size() != total - n) {
+        printf("FAIL drop total=%zu n=%zu\n", total, n);
+        return 1;
+      }
+      if (total - n > 0 && clad::back(t) != (double)(total - n - 1)) {
+        printf("FAIL back after drop total=%zu n=%zu\n", total, n);
+        return 1;
+      }
+
+      // Two runs on one tape, dropped in the order the reverse sweep drops
+      // them. This is what lets a call inside a loop record every iteration
+      // onto the same tape: the inner run has to read back before the outer
+      // one becomes reachable again.
+      clad::tape<double> nested = {};
+      for (std::size_t i = 0; i < n; i++)
+        clad::push(nested, (double)i);
+      for (std::size_t i = 0; i < n; i++)
+        clad::push(nested, (double)(100 + i));
+      std::vector<double> inner(n, -1);
+      std::vector<double> outer(n, -1);
+      clad::peek_range(nested, inner.data(), n);
+      clad::drop_range(nested, n);
+      clad::peek_range(nested, outer.data(), n);
+      for (std::size_t i = 0; i < n; i++)
+        if (inner[i] != (double)(100 + i) || outer[i] != (double)i) {
+          printf("FAIL nested total=%zu n=%zu\n", total, n);
+          return 1;
+        }
+    }
+  }
+
+  // record_range is the producer the three above consume.
+  double src[4] = {1, 2, 3, 4};
+  clad::tape<double> t = {};
+  clad::record_range(t, src, 4);
+  double dst[4] = {0, 0, 0, 0};
+  clad::peek_range(t, dst, 4);
+  printf("%.0f %.0f %.0f %.0f\n", dst[0], dst[1], dst[2], dst[3]);
+  // CHECK-EXEC: 1 2 3 4
+
+  printf("record_range OK\n");
+  // CHECK-EXEC: record_range OK
+  return 0;
+}

--- a/tools/ClangPlugin.cpp
+++ b/tools/ClangPlugin.cpp
@@ -13,6 +13,7 @@
 #include "clad/Differentiator/Version.h"
 #include "../lib/Differentiator/DerivativePrinter.h"
 #include "../lib/Differentiator/GeneratedCode.h"
+#include "../lib/Differentiator/LoopAnalyzer.h"
 #include "../lib/Differentiator/TBRAnalyzer.h"
 
 #include "clang/AST/ASTConsumer.h"
@@ -563,6 +564,75 @@ void InitTimers();
       }
     }
 
+    /// Reports, per parameter, the range of it the function was proven to
+    /// write. A parameter that prints `unknown` is one a caller cannot record
+    /// from, so it is the interesting half of the report.
+    static void printWrittenExtents(const clang::FunctionDecl* FD) {
+      llvm::SmallVector<WrittenExtent, 8> Extents;
+      computeWrittenExtents(FD, Extents);
+      for (unsigned i = 0, e = FD->getNumParams(); i != e; ++i) {
+        llvm::outs() << "written-extent: " << FD->getNameAsString() << ": "
+                     << FD->getParamDecl(i)->getNameAsString() << " = ";
+        const WrittenExtent& W = Extents[i];
+        switch (W.K) {
+        case WrittenExtent::Kind::None:
+          llvm::outs() << "none";
+          break;
+        case WrittenExtent::Kind::Element:
+          llvm::outs() << "[" << W.Offset << ", " << (W.Offset + 1) << ")";
+          break;
+        case WrittenExtent::Kind::Range:
+          llvm::outs() << "[0, ";
+          if (W.BoundIsParam)
+            llvm::outs()
+                << FD->getParamDecl(W.BoundParamIdx)->getNameAsString();
+          else
+            llvm::outs() << W.BoundConst;
+          llvm::outs() << ")";
+          break;
+        case WrittenExtent::Kind::Unknown:
+          // Report why, not just that: which refusal it was is what tells a
+          // reader whether the code or the analysis is the thing to change.
+          llvm::outs() << "unknown (";
+          switch (W.Why) {
+          case WrittenExtent::Refusal::None:
+            llvm::outs() << "no reason recorded";
+            break;
+          case WrittenExtent::Refusal::IndexNotCounted:
+            llvm::outs() << "index not stepped by a counted loop";
+            break;
+          case WrittenExtent::Refusal::IndexNotUnderstood:
+            llvm::outs() << "index is neither a constant nor a variable";
+            break;
+          case WrittenExtent::Refusal::WritesDisagree:
+            llvm::outs() << "writes do not describe one range";
+            break;
+          case WrittenExtent::Refusal::BoundNotUsable:
+            llvm::outs() << "the loop's bound is not one a call site can use";
+            break;
+          case WrittenExtent::Refusal::OpaqueWrite:
+            llvm::outs() << "a write could not be attributed to a parameter";
+            break;
+          case WrittenExtent::Refusal::NoDefinition:
+            llvm::outs() << "the function has no definition here";
+            break;
+          }
+          // The line the refusal is about, so a reader can go look at it
+          // rather than re-find it. Printing it also keeps the recorded
+          // location honest -- nothing else reads it yet.
+          if (W.RefusedAt.isValid()) {
+            const clang::SourceManager& SM =
+                FD->getASTContext().getSourceManager();
+            llvm::outs() << " at line "
+                         << SM.getPresumedLoc(W.RefusedAt).getLine();
+          }
+          llvm::outs() << ")";
+          break;
+        }
+        llvm::outs() << "\n";
+      }
+    }
+
     static void printDerivative(clang::Decl* D, bool DeclarationOnly,
                                 const DifferentiationOptions& DO) {
       clang::LangOptions LangOpts;
@@ -710,6 +780,10 @@ void InitTimers();
       // if enabled, print ASTs of the original functions
       if (m_DO.DumpSourceFnAST)
         FD->dumpColor();
+
+      // if enabled, report what each parameter's writes were proven to cover
+      if (m_DO.DumpLoopAnalysis)
+        printWrittenExtents(FD);
 
       // If enabled, set the proper fields in derivative builder.
       if (m_DO.PrintNumDiffErrorInfo) {

--- a/tools/ClangPlugin.h
+++ b/tools/ClangPlugin.h
@@ -69,6 +69,10 @@ struct DifferentiationOptions {
 #define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
   bool Remark##Id##Analysis = false;
 #include "clad/Differentiator/Analyses.def"
+  /// Whether -fdump-analysis named each analysis; see Analyses.def.
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
+  bool Dump##Id##Analysis = false;
+#include "clad/Differentiator/Analyses.def"
   bool GenerateSourceFile = false;
   bool DumpGeneratedSource = false;
   /// Where to write the generated code so a debugger can open it, and
@@ -160,6 +164,26 @@ inline AnalysisFlagResult remarkAnalysisByName(DifferentiationOptions& DO,
 #define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
   if (Arg == (Name)) {                                                         \
     DO.Remark##Id##Analysis = true;                                            \
+    return AnalysisFlagResult::Ok;                                             \
+  }
+#include "clad/Differentiator/Analyses.def"
+  llvm::errs() << "clad: Error: unknown analysis '" << Arg << "'; known:";
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc) llvm::errs() << " " Name;
+#include "clad/Differentiator/Analyses.def"
+  llvm::errs() << ".\n";
+  return AnalysisFlagResult::Error;
+}
+
+/// Match -fdump-analysis=<name>, asking the named analysis to report what it
+/// concluded. One flag naming an analysis rather than a flag per analysis:
+/// clad has several and will grow more.
+inline AnalysisFlagResult dumpAnalysisByName(DifferentiationOptions& DO,
+                                             llvm::StringRef Arg) {
+  if (!Arg.consume_front("-fdump-analysis="))
+    return AnalysisFlagResult::NotMine;
+#define CLAD_ANALYSIS(Id, Name, Legacy, Default, Desc)                         \
+  if (Arg == (Name)) {                                                         \
+    DO.Dump##Id##Analysis = true;                                              \
     return AnalysisFlagResult::Ok;                                             \
   }
 #include "clad/Differentiator/Analyses.def"
@@ -468,6 +492,10 @@ inline AnalysisFlagResult remarkAnalysisByName(DifferentiationOptions& DO,
                      R != AnalysisFlagResult::NotMine) {
             if (R == AnalysisFlagResult::Error)
               return false;
+          } else if (AnalysisFlagResult R = dumpAnalysisByName(m_DO, args[i]);
+                     R != AnalysisFlagResult::NotMine) {
+            if (R == AnalysisFlagResult::Error)
+              return false;
           } else if (args[i] == "-fgenerate-source-file") {
             m_DO.GenerateSourceFile = true;
           } else if (args[i] == "-fno-validate-clang-version") {
@@ -514,6 +542,9 @@ inline AnalysisFlagResult remarkAnalysisByName(DifferentiationOptions& DO,
                    "that file instead. Given with no directory, nothing is "
                    "written and clad stops advising that nothing can be "
                    "read.\n"
+                << "-fdump-analysis=<name> - Prints what the named analysis "
+                   "concluded, for each function differentiated. The names are "
+                   "those listed below.\n"
                 << "-fgenerate-source-file - Produces a file containing the "
                    "derivatives.\n"
                 << "-fno-validate-clang-version - Disables the validation of "


### PR DESCRIPTION
A caller that wants to record a callee's output rather than snapshot the buffer and restore it afterwards has to know how much to record. The answer has to come from the callee, be expressed in the callee's own parameters so a call site can evaluate it, and be an over-approximation: recording more than the callee touches is merely wasteful, recording less is a wrong gradient.

Add that analysis. Every extent worth having comes from a counted loop -- a subscript by the induction variable covers the loop's range -- so it rests on a recogniser for the one loop shape clad keeps asking about: a loop stepping one integer by one, from some initial value, while comparing below a bound. Several parts of clad ask that same question and would drift if each matched it separately. The recogniser reports only what is syntactically true and leaves to each caller whether acting on it is safe, since that differs per caller. The shapes that do not come from a loop -- a dereference, a constant subscript -- are single elements, and everything else is reported as unknown, including two writes that do not describe one range.

What this caller adds on top is watched over two different reaches. The index only has to hold still while the loop runs. The bound has to hold still for the whole call, because the range is worked out at the call site from the argument passed there and read much later: a statement anywhere in the function that raises the bound, or a bound bound by reference, leaves a caller recording less than the callee writes. A write handed to another function is unattributable the same way, its object included -- a member call does not carry that object among its arguments, but a non-const method writes through it just the same.

It registers in Analyses.def like the analyses already there, so it takes a switch and is covered by -fdisable-analysis=all without further work, and -fdump-analysis=loop reports what it concluded. Nothing consumes the extents yet.