### PR TITLE
[ci] Ask clang-tidy for clad's own check list again.

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -58,6 +58,11 @@ jobs:
           apt_packages: libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev,libthrust-dev,libbenchmark-dev,libomp-21-dev,libopenblas-dev
           exclude: "test/*,unittests/*"
           split_workflow: true
+          # Load-bearing empty: the action passes --checks only when this is
+          # non-empty, and its default list carries none of the negations in
+          # clad's .clang-tidy. Empty, and with no config_file pinning one
+          # file, clang-tidy looks a config up beside each source instead.
+          clang_tidy_checks: ''
 
       - name: Upload artifacts
         uses: ZedThree/clang-tidy-review/upload@v0.23.1


### PR DESCRIPTION
Dropping config_file so a directory's .clang-tidy could apply also dropped the check list. The action passes --checks whenever clang_tidy_checks is non-empty, and its default -- readability-*, cppcoreguidelines-* and the rest with no negations -- overrides whatever a config file says. So the review started reporting the checks clad switched off on purpose, readability-identifier-length among them, which fires on every two-letter name in the tree.

Set clang_tidy_checks to empty. With neither it nor config_file given the action passes no flag at all, and clang-tidy looks a config up beside each source: the root list for lib/, and the root list less two checks for benchmark/, which is what dropping config_file was for.