### PR TITLE
Check the arguments before calling a derivative found by lookup

### DIFF
--- a/lib/Differentiator/DerivativeBuilder.cpp
+++ b/lib/Differentiator/DerivativeBuilder.cpp
@@ -35,6 +35,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
+#include "clang/AST/DeclAccessPair.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/OperationKinds.h"
 #include "clang/AST/TemplateBase.h"
@@ -257,9 +258,23 @@ static void registerDerivative(Decl* D, Sema& S, const DiffRequest& R) {
     if (!isa<DeclRefExpr>(UnresolvedLookup))
       return false;
 
-    const auto* DRE = cast<DeclRefExpr>(UnresolvedLookup);
-    if (const auto* FD = dyn_cast<FunctionDecl>(DRE->getDecl()))
-      return NeedsMoreArgs(FD, ARargs.size());
+    auto* DRE = cast<DeclRefExpr>(UnresolvedLookup);
+    if (auto* FD = dyn_cast<FunctionDecl>(DRE->getDecl())) {
+      if (NeedsMoreArgs(FD, ARargs.size()))
+        return true;
+      // With a single candidate Sema builds a plain reference and never
+      // reconsiders it. It can be the wrong function: two instantiations of
+      // one template ask for the same derivative name, so the second lookup
+      // finds the first's derivative. Calling it makes the mismatch a hard
+      // error instead of a signal to derive the overload that fits.
+      OverloadCandidateSet CandidateSet(SourceLocation(),
+                                        OverloadCandidateSet::CSK_Normal);
+      m_Sema.AddOverloadCandidate(FD, DeclAccessPair::make(FD, AS_public),
+                                  ARargs, CandidateSet);
+      OverloadCandidateSet::iterator Best = nullptr;
+      return CandidateSet.BestViableFunction(m_Sema, SourceLocation(), Best) !=
+             OR_Success;
+    }
 
     return false;
   }

--- a/test/Hessian/MixedInstantiations.C
+++ b/test/Hessian/MixedInstantiations.C
@@ -1,0 +1,103 @@
+// RUN: %cladclang %s -I%S/../../include -oMixedInstantiations.out 2>&1 | %filecheck %s
+// RUN: ./MixedInstantiations.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s -I%S/../../include -oMixedInstantiations.out
+// RUN: ./MixedInstantiations.out | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cmath>
+#include <cstdio>
+
+// A derivative is named after the function it differentiates, so the two
+// instantiations below ask for derivatives of the same name. The one built
+// first must not be called for the second: its parameter types do not match.
+template <typename T> double scale(double x, T n) { return x * x * n; }
+
+double sumOfScales(double x) { return scale(x, 2.) + scale(x, 3); }
+
+// CHECK: inline clad::ValueAndPushforward<double, double> scale_pushforward(double x, double n, double _d_x, double _d_n) {
+// CHECK-NEXT:     double _t0 = x * x;
+// CHECK-NEXT:     return {_t0 * n, (_d_x * x + x * _d_x) * n + _t0 * _d_n};
+// CHECK-NEXT: }
+
+// CHECK: inline clad::ValueAndPushforward<double, double> scale_pushforward(double x, int n, double _d_x, int _d_n) {
+// CHECK-NEXT:     double _t0 = x * x;
+// CHECK-NEXT:     return {_t0 * n, (_d_x * x + x * _d_x) * n + _t0 * _d_n};
+// CHECK-NEXT: }
+
+// CHECK: inline void scale_pushforward_pullback(double x, double n, double _d_x, double _d_n, clad::ValueAndPushforward<double, double> _d_y, double *_d_x0, double *_d_n0, double *_d_d_x, double *_d_d_n);
+// CHECK-NEXT: inline void scale_pushforward_pullback(double x, int n, double _d_x, int _d_n, clad::ValueAndPushforward<double, double> _d_y, double *_d_x0, int *_d_n0, double *_d_d_x, int *_d_d_n);
+
+// CHECK: inline void sumOfScales_pushforward_pullback(double x, double _d_x, clad::ValueAndPushforward<double, double> _d_y, double *_d_x0) {
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_t0 = {0., 0.};
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t00 = scale_pushforward(x, 2., _d_x, 0.);
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _d_t1 = {0., 0.};
+// CHECK-NEXT:     clad::ValueAndPushforward<double, double> _t10 = scale_pushforward(x, 3, _d_x, 0);
+// CHECK-NEXT:     {
+// CHECK-NEXT:         _d_t0.value += _d_y.value;
+// CHECK-NEXT:         _d_t1.value += _d_y.value;
+// CHECK-NEXT:         _d_t0.pushforward += _d_y.pushforward;
+// CHECK-NEXT:         _d_t1.pushforward += _d_y.pushforward;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r4 = 0.;
+// CHECK-NEXT:         int _r5 = 0;
+// CHECK-NEXT:         double _r6 = 0.;
+// CHECK-NEXT:         int _r7 = 0;
+// CHECK-NEXT:         scale_pushforward_pullback(x, 3, _d_x, 0, _d_t1, &_r4, &_r5, &_r6, &_r7);
+// CHECK-NEXT:         *_d_x0 += _r4;
+// CHECK-NEXT:     }
+// CHECK-NEXT:     {
+// CHECK-NEXT:         double _r0 = 0.;
+// CHECK-NEXT:         double _r1 = 0.;
+// CHECK-NEXT:         double _r2 = 0.;
+// CHECK-NEXT:         double _r3 = 0.;
+// CHECK-NEXT:         scale_pushforward_pullback(x, 2., _d_x, 0., _d_t0, &_r0, &_r1, &_r2, &_r3);
+// CHECK-NEXT:         *_d_x0 += _r0;
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// A static member function reaches the same lookup through its class rather
+// than a namespace, and it too has to see both overloads.
+struct Scaler {
+  template <typename T> static double scale(double x, T n) { return x * x * n; }
+};
+
+double sumOfStaticScales(double x) {
+  return Scaler::scale(x, 2.) + Scaler::scale(x, 3);
+}
+
+// CHECK: static inline void scale_pushforward_pullback(double x, double n, double _d_x, double _d_n, clad::ValueAndPushforward<double, double> _d_y, double *_d_x0, double *_d_n0, double *_d_d_x, double *_d_d_n);
+// CHECK-NEXT: static inline void scale_pushforward_pullback(double x, int n, double _d_x, int _d_n, clad::ValueAndPushforward<double, double> _d_y, double *_d_x0, int *_d_n0, double *_d_d_x, int *_d_d_n);
+
+// The same clash reached clad through std::pow: an integral exponent and a
+// floating-point one are two instantiations sharing the name pow_pushforward.
+// This is the shape of RooFit's Bernstein integral, whose Hessian it broke.
+double poly(double x, double y) {
+  double res = 0;
+  for (int j = 0; j < 3; ++j)
+    for (int i = 0; i <= j; ++i) {
+      double powDiff = std::pow(x, j + 1.) - std::pow(y, j + 1.);
+      res += std::pow(-1., j - i) * powDiff;
+    }
+  return res;
+}
+
+int main() {
+  auto scalesHess = clad::hessian(sumOfScales);
+  double scalesMatrix[1] = {0};
+  scalesHess.execute(1.5, scalesMatrix);
+  printf("[%.2f]\n", scalesMatrix[0]); // CHECK-EXEC: [10.00]
+
+  double staticMatrix[1] = {0};
+  clad::hessian(sumOfStaticScales).execute(1.5, staticMatrix);
+  printf("[%.2f]\n", staticMatrix[0]); // CHECK-EXEC: [10.00]
+
+  // poly(x, y) = (x - y) + (x^3 - y^3), so the Hessian is diag(6x, -6y).
+  auto polyHess = clad::hessian(poly);
+  double polyMatrix[4] = {0};
+  polyHess.execute(2, 3, polyMatrix);
+  printf("[%.2f, %.2f, %.2f, %.2f]\n", polyMatrix[0], polyMatrix[1],
+         polyMatrix[2], polyMatrix[3]);
+  // CHECK-EXEC: [12.00, 0.00, 0.00, -18.00]
+}


### PR DESCRIPTION
Two instantiations of one template ask for the same derivative name, so the lookup for the second finds the derivative built for the first:

  template <typename T> double scale(double x, T n) { return x * x * n; }
  double sumOfScales(double x) { return scale(x, 2.) + scale(x, 3); }

clad::hessian builds scale_pushforward_pullback for T = double and injects it into the enclosing namespace. The T = int call finds only that overload. With one candidate Sema builds a plain DeclRefExpr instead of an overload set, and noOverloadExists compared only the argument count, so the call was built anyway:

  error: cannot initialize a parameter of type 'double *' with an rvalue
         of type 'int *'
  note: passing argument to parameter '_d_n' here

<cmath> reaches the same state, where a floating-point and an integral exponent are two instantiations of pow_pushforward. That broke the Hessian of every RooFit likelihood containing a RooBernstein, whose integral mixes std::pow(x, j + 1.) with std::pow(-1., j - i) (root-project/root#21622).

Run the single candidate through overload resolution and report no overload when the arguments are not viable, so the caller derives the one that fits.