### PR TITLE
[NFC][UA] Rebase UsefulAnalyzer onto the AnalysisBase lattice

### DIFF
--- a/lib/Differentiator/AnalysisBase.cpp
+++ b/lib/Differentiator/AnalysisBase.cpp
@@ -287,7 +287,7 @@ bool AnalysisBase::merge(VarData& targetData, VarData& mergeData) {
     for (auto& pair : *mergeData.m_Val.m_ArrData) {
       auto it = targetData.m_Val.m_ArrData->find(pair.first);
       if (it == targetData.m_Val.m_ArrData->end())
-        (*targetData.m_Val.m_ArrData)[pair.first] = pair.second.copy();
+        isMod = merge(*targetData[pair.first], pair.second) || isMod;
     }
     return isMod;
   }
@@ -455,8 +455,10 @@ bool AnalysisBase::merge(VarsData* targetData, VarsData* mergeData) {
     if (found) {
       if (merge(*found, *pair.second))
         isModified = true;
-    } else
+    } else {
       (*targetData)[pair.first] = pair.second->copy();
+      isModified = true;
+    }
   }
 
   // For every variable in collected targetData predecessors, search it inside
@@ -474,8 +476,11 @@ bool AnalysisBase::merge(VarsData* targetData, VarsData* mergeData) {
         while (branch) {
           auto it = branch->find(pair.first);
           if (it != branch->end()) {
-            (*targetData)[pair.first] = pair.second->copy();
-            merge((*targetData)[pair.first], it->second);
+            // Preserve local state; copying inherited state is not a change.
+            if (targetData->find(pair.first) == targetData->end())
+              (*targetData)[pair.first] = pair.second->copy();
+            isModified =
+                merge((*targetData)[pair.first], it->second) || isModified;
             break;
           }
           branch = branch->m_Prev;
@@ -494,6 +499,8 @@ bool AnalysisBase::merge(VarsData* targetData, VarsData* mergeData) {
       while (branch) {
         auto it = branch->find(pair.first);
         if (it != branch->end()) {
+          // Refresh the local state, but do not report this as worklist
+          // growth: block traversal may immediately clear it again.
           merge(pair.second, it->second);
           break;
         }

--- a/lib/Differentiator/UsefulAnalyzer.cpp
+++ b/lib/Differentiator/UsefulAnalyzer.cpp
@@ -1,20 +1,23 @@
 #include "UsefulAnalyzer.h"
 
+#include "AnalysisBase.h"
+
 #include "clang/AST/Stmt.h"
+
+#include <memory>
 
 using namespace clang;
 
 namespace clad {
 
 void UsefulAnalyzer::Analyze(const FunctionDecl* FD) {
-  // Build the CFG (control-flow graph) of FD.
+  m_Function = FD;
   m_BlockData.resize(m_AnalysisDC->getCFG()->size());
-  m_LoopMem.resize(m_AnalysisDC->getCFG()->size());
-  // Set current block ID to the ID of entry the block.
+  // Useful analysis starts at the exit and propagates to predecessors.
   CFGBlock& exit = m_AnalysisDC->getCFG()->getExit();
   m_CurBlockID = exit.getBlockID();
-  m_BlockData[m_CurBlockID] = createNewVarsData({});
-  // Add the entry block to the queue.
+  m_BlockData[m_CurBlockID] = std::make_unique<VarsData>();
+  // Add the exit block to the queue.
   m_CFGQueue.insert(m_CurBlockID);
 
   // Visit CFG blocks in the queue until it's empty.
@@ -22,30 +25,20 @@ void UsefulAnalyzer::Analyze(const FunctionDecl* FD) {
     auto IDIter = m_CFGQueue.begin();
     m_CurBlockID = *IDIter;
     m_CFGQueue.erase(IDIter);
-    CFGBlock& nextBlock = *getCFGBlockByID(m_CurBlockID);
+    CFGBlock& nextBlock = *getCFGBlockByID(m_AnalysisDC, m_CurBlockID);
     AnalyzeCFGBlock(nextBlock);
   }
 }
 
-CFGBlock* UsefulAnalyzer::getCFGBlockByID(unsigned ID) {
-  return *(m_AnalysisDC->getCFG()->begin() + ID);
+bool UsefulAnalyzer::isUseful(const VarDecl* VD) {
+  return getVarDataFromDecl(VD) != nullptr;
 }
 
-bool UsefulAnalyzer::isUseful(const VarDecl* VD) const {
-  const VarsData& curBranch = getCurBlockVarsData();
-  return curBranch.find(VD) != curBranch.end();
-}
-
-void UsefulAnalyzer::copyVarToCurBlock(const clang::VarDecl* VD) {
-  VarsData& curBranch = getCurBlockVarsData();
-  curBranch.insert(VD);
-}
-
-static void mergeVarsData(std::set<const clang::VarDecl*>* targetData,
-                          std::set<const clang::VarDecl*>* mergeData) {
-  for (const clang::VarDecl* i : *mergeData)
-    targetData->insert(i);
-  *mergeData = *targetData;
+void UsefulAnalyzer::markUseful(const clang::VarDecl* VD) {
+  // A useful declaration needs one leaf, not its field or pointee state.
+  if (!getVarDataFromDecl(VD))
+    getCurBlockVarsData()[VD] = VarData(m_AnalysisDC->getASTContext().BoolTy);
+  m_UsefulDecls.insert(VD);
 }
 
 void UsefulAnalyzer::AnalyzeCFGBlock(const CFGBlock& block) {
@@ -63,24 +56,16 @@ void UsefulAnalyzer::AnalyzeCFGBlock(const CFGBlock& block) {
     if (!pred)
       continue;
     auto& predData = m_BlockData[pred->getBlockID()];
-    if (!predData)
-      predData = createNewVarsData(*m_BlockData[block.getBlockID()]);
-
-    bool shouldPushPred = true;
-    if (pred->getBlockID() < block.getBlockID()) {
-      if (m_LoopMem[block.getBlockID()] == *m_BlockData[block.getBlockID()])
-        shouldPushPred = false;
-      m_LoopMem[block.getBlockID()] = *m_BlockData[block.getBlockID()];
+    auto* currentData = m_BlockData[block.getBlockID()].get();
+    if (!predData) {
+      predData = std::make_unique<VarsData>();
+      predData->m_Prev = currentData;
     }
 
-    if (shouldPushPred)
+    // Discovery links form a forest. Other edges require a growing merge.
+    if (predData->m_Prev == currentData || merge(predData.get(), currentData))
       m_CFGQueue.insert(pred->getBlockID());
-
-    mergeVarsData(predData.get(), m_BlockData[block.getBlockID()].get());
   }
-
-  for (const VarDecl* i : *m_BlockData[block.getBlockID()])
-    m_UsefulDecls.insert(i);
 }
 
 bool UsefulAnalyzer::VisitBinaryOperator(BinaryOperator* BinOp) {
@@ -137,7 +122,7 @@ bool UsefulAnalyzer::VisitDeclRefExpr(DeclRefExpr* DRE) {
     m_Useful = true;
 
   if (m_Useful && m_Marking)
-    copyVarToCurBlock(VD);
+    markUseful(VD);
 
   return true;
 }

--- a/lib/Differentiator/UsefulAnalyzer.h
+++ b/lib/Differentiator/UsefulAnalyzer.h
@@ -1,65 +1,39 @@
 #ifndef CLAD_DIFFERENTIATOR_USEFULANALYZER_H
 #define CLAD_DIFFERENTIATOR_USEFULANALYZER_H
+
+#include "AnalysisBase.h"
+
 #include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/Analysis/AnalysisDeclContext.h"
-#include "clang/Analysis/CFG.h"
 
-#include "clad/Differentiator/CladUtils.h"
-#include "clad/Differentiator/Compatibility.h"
-
-#include <algorithm>
-#include <memory>
-#include <stack>
+#include <set>
 
 namespace clad {
 
-class UsefulAnalyzer : public clang::RecursiveASTVisitor<UsefulAnalyzer> {
-
+/// Backward usefulness analysis. An entry marks a whole variable useful;
+/// every entry is a scalar leaf, independent of the declaration's type.
+class UsefulAnalyzer : public clang::RecursiveASTVisitor<UsefulAnalyzer>,
+                       public AnalysisBase {
   bool m_Useful = false;
   bool m_Marking = false;
-
   std::set<const clang::VarDecl*>& m_UsefulDecls;
-  // std::set<const clang::VarDecl*>& m_VariedDecls;
-  using VarsData = std::set<const clang::VarDecl*>;
-  /// A helper method to allocate VarsData
-  /// \param toAssign - Parameter to initialize new VarsData with.
-  /// \return Unique pointer to a new object of type Varsdata.
-  static std::unique_ptr<VarsData> createNewVarsData(VarsData toAssign) {
-    return std::unique_ptr<VarsData>(new VarsData(std::move(toAssign)));
-  }
-  std::vector<VarsData> m_LoopMem;
-  clang::CFGBlock* getCFGBlockByID(unsigned ID);
 
-  clang::AnalysisDeclContext* m_AnalysisDC;
-  std::unique_ptr<clang::CFG> m_CFG;
-  std::vector<std::unique_ptr<VarsData>> m_BlockData;
-  unsigned m_CurBlockID{};
-  std::set<unsigned> m_CFGQueue;
-  bool isUseful(const clang::VarDecl* VD) const;
-  void copyVarToCurBlock(const clang::VarDecl* VD);
-  VarsData& getCurBlockVarsData() { return *m_BlockData[m_CurBlockID]; }
-  [[nodiscard]] const VarsData& getCurBlockVarsData() const {
-    return const_cast<UsefulAnalyzer*>(this)->getCurBlockVarsData();
-  }
+  bool isUseful(const clang::VarDecl* VD);
+  void markUseful(const clang::VarDecl* VD);
   void AnalyzeCFGBlock(const clang::CFGBlock& block);
 
 public:
-  /// Constructor
   UsefulAnalyzer(clang::AnalysisDeclContext* AnalysisDC,
                  std::set<const clang::VarDecl*>& Decls)
-      : m_UsefulDecls(Decls), m_AnalysisDC(AnalysisDC) {}
+      : AnalysisBase(AnalysisDC), m_UsefulDecls(Decls) {}
 
-  /// Destructor
   ~UsefulAnalyzer() = default;
 
-  /// Delete copy/move operators and constructors.
   UsefulAnalyzer(const UsefulAnalyzer&) = delete;
   UsefulAnalyzer& operator=(const UsefulAnalyzer&) = delete;
   UsefulAnalyzer(const UsefulAnalyzer&&) = delete;
   UsefulAnalyzer& operator=(const UsefulAnalyzer&&) = delete;
 
-  /// Runs Varied analysis.
-  /// \param FD Function to run the analysis on.
+  /// Runs useful analysis on FD.
   void Analyze(const clang::FunctionDecl* FD);
   bool VisitReturnStmt(clang::ReturnStmt* RS);
   bool VisitDeclRefExpr(clang::DeclRefExpr* DRE);

--- a/unittests/Analyses/AnalysisBaseTest.cpp
+++ b/unittests/Analyses/AnalysisBaseTest.cpp
@@ -1,0 +1,195 @@
+#include "AnalysisBase.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+class MergeAccess : public clad::AnalysisBase {
+public:
+  MergeAccess() : AnalysisBase(nullptr) {}
+  using AnalysisBase::merge;
+};
+
+class AnalysisBaseMergeTest : public testing::Test {
+protected:
+  MergeAccess Analysis;
+  // merge treats declaration keys as opaque; nullptr is a supported key.
+  static constexpr const clang::VarDecl* Key = nullptr;
+
+  clad::VarData bit(bool Value) {
+    clad::VarData Data;
+    Data.m_Type = clad::VarData::FUND_TYPE;
+    Data.m_Val.m_FundData = Value;
+    return Data;
+  }
+
+  void put(clad::VarsData& Data, bool Value) { Data[Key] = bit(Value); }
+  bool value(clad::VarsData& Data) { return Data[Key].m_Val.m_FundData; }
+
+  // 0 = absent, 1 = present/false, 2 = present/true.
+  int visible(clad::VarsData* Data) {
+    for (; Data; Data = Data->m_Prev) {
+      auto Found = Data->find(Key);
+      if (Found != Data->end())
+        return Found->second.m_Val.m_FundData ? 2 : 1;
+    }
+    return 0;
+  }
+};
+
+TEST_F(AnalysisBaseMergeTest, ReportsMissingArrayElement) {
+  clad::VarData Target, Source;
+  Target.m_Type = Source.m_Type = clad::VarData::ARR_TYPE;
+  Target.m_Val.m_ArrData = std::make_unique<clad::ArrMap>();
+  Source.m_Val.m_ArrData = std::make_unique<clad::ArrMap>();
+  clad::ProfileID Default, Index;
+  Index.AddInteger(1);
+  (*Target.m_Val.m_ArrData)[Default] = bit(false);
+  (*Source.m_Val.m_ArrData)[Default] = bit(false);
+  (*Source.m_Val.m_ArrData)[Index] = bit(true);
+
+  EXPECT_TRUE(Analysis.merge(Target, Source));
+  EXPECT_TRUE(Target[Index]->m_Val.m_FundData);
+  EXPECT_FALSE(Analysis.merge(Target, Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, PreservesArrayDefaultForMissingElement) {
+  clad::VarData Target, Source;
+  Target.m_Type = Source.m_Type = clad::VarData::ARR_TYPE;
+  Target.m_Val.m_ArrData = std::make_unique<clad::ArrMap>();
+  Source.m_Val.m_ArrData = std::make_unique<clad::ArrMap>();
+  clad::ProfileID Default, Index;
+  Index.AddInteger(1);
+  (*Target.m_Val.m_ArrData)[Default] = bit(true);
+  (*Source.m_Val.m_ArrData)[Default] = bit(false);
+  (*Source.m_Val.m_ArrData)[Index] = bit(false);
+
+  EXPECT_FALSE(Analysis.merge(Target, Source));
+  EXPECT_TRUE(Target[Index]->m_Val.m_FundData);
+  EXPECT_FALSE(Analysis.merge(Target, Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, ReportsNewVariableEvenWithFalseBit) {
+  clad::VarsData Root, Target, Source;
+  Target.m_Prev = Source.m_Prev = &Root;
+  put(Source, false);
+  EXPECT_TRUE(Analysis.merge(&Target, &Source));
+  EXPECT_EQ(visible(&Target), 1);
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, AncestorRefreshDoesNotSignalWorklistGrowth) {
+  clad::VarsData Root, Target, Source;
+  Target.m_Prev = Source.m_Prev = &Root;
+  put(Root, true);
+  put(Target, false);
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+  EXPECT_TRUE(value(Target));
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, ReportsAncestorBitMergedIntoInherited) {
+  clad::VarsData Root, Parent, Target, Source;
+  Parent.m_Prev = Source.m_Prev = &Root;
+  Target.m_Prev = &Parent;
+  put(Root, true);
+  put(Parent, false);
+  EXPECT_TRUE(Analysis.merge(&Target, &Source));
+  EXPECT_TRUE(value(Target));
+  EXPECT_FALSE(value(Parent));
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, LocalTrueShadowsInheritedFalse) {
+  clad::VarsData Root, Parent, Target, Source;
+  Parent.m_Prev = Source.m_Prev = &Root;
+  Target.m_Prev = &Parent;
+  put(Root, false);
+  put(Parent, false);
+  put(Target, true);
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+  EXPECT_TRUE(value(Target));
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+  EXPECT_TRUE(value(Target));
+}
+
+TEST_F(AnalysisBaseMergeTest, LocalFalseShadowsInheritedTrue) {
+  clad::VarsData Root, Parent, Target, Source;
+  Parent.m_Prev = Source.m_Prev = &Root;
+  Target.m_Prev = &Parent;
+  put(Root, false);
+  put(Parent, true);
+  put(Target, false);
+
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+  EXPECT_FALSE(value(Target));
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+  EXPECT_FALSE(value(Target));
+}
+
+TEST_F(AnalysisBaseMergeTest, CopyDownAloneIsNotAChange) {
+  clad::VarsData Root, Parent, Target, Source;
+  Parent.m_Prev = Source.m_Prev = &Root;
+  Target.m_Prev = &Parent;
+  put(Root, false);
+  put(Parent, false);
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+  EXPECT_EQ(visible(&Target), 1);
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, MergeDoesNotMutateSourceOrAncestor) {
+  clad::VarsData Root, Target, Source;
+  Target.m_Prev = Source.m_Prev = &Root;
+  put(Root, false);
+  put(Source, true);
+  EXPECT_TRUE(Analysis.merge(&Target, &Source));
+  EXPECT_TRUE(value(Target));
+  EXPECT_TRUE(value(Source));
+  EXPECT_FALSE(value(Root));
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, SelfMergeIsUnchanged) {
+  clad::VarsData Target;
+  put(Target, true);
+  EXPECT_FALSE(Analysis.merge(&Target, &Target));
+  EXPECT_TRUE(value(Target));
+}
+
+TEST_F(AnalysisBaseMergeTest, ScalarForksJoinAndThenStabilize) {
+  for (int Code = 0; Code < 243; ++Code) {
+    SCOPED_TRACE(Code);
+    clad::VarsData Root, Left, Right, Target, Source;
+    Left.m_Prev = Right.m_Prev = &Root;
+    Target.m_Prev = &Left;
+    Source.m_Prev = &Right;
+    int States = Code;
+    int InState[5];
+    int Idx = 0;
+    for (auto* Data : {&Root, &Left, &Right, &Target, &Source}) {
+      int State = States % 3;
+      States /= 3;
+      InState[Idx++] = State;
+      if (State)
+        put(*Data, State == 2);
+    }
+    int Before = visible(&Target);
+    int Incoming = visible(&Source);
+    int Expected =
+        Before == 2 || Incoming == 2 ? 2 : (Before || Incoming ? 1 : 0);
+    // Phase 3 refreshes local state without reporting worklist growth. This
+    // occurs when Target's local false is refreshed from Root's true while
+    // Left, Right, and Source introduce no branch-specific state.
+    bool IsAncestorRefreshOnly =
+        (InState[0] == 2 && InState[1] == 0 && InState[2] == 0 &&
+         InState[3] == 1 && InState[4] == 0);
+    bool ExpectedChangeReported =
+        (Expected != Before) && !IsAncestorRefreshOnly;
+    EXPECT_EQ(Analysis.merge(&Target, &Source), ExpectedChangeReported);
+    EXPECT_EQ(visible(&Target), Expected);
+    EXPECT_EQ(visible(&Source), Incoming);
+    EXPECT_FALSE(Analysis.merge(&Target, &Source));
+    EXPECT_EQ(visible(&Target), Expected);
+  }
+}
+} // namespace

--- a/unittests/Analyses/CMakeLists.txt
+++ b/unittests/Analyses/CMakeLists.txt
@@ -1,0 +1,44 @@
+add_clad_unittest(AnalysisTests AnalysisBaseTest.cpp)
+
+target_include_directories(AnalysisTests PRIVATE
+  ${CLAD_SOURCE_DIR}/lib/Differentiator)
+
+# Recipe installations can export clang-cpp without clangTooling.
+if (TARGET clang-cpp)
+  target_link_libraries(AnalysisTests PRIVATE cladDifferentiator clang-cpp)
+elseif (TARGET clangTooling)
+  target_link_libraries(AnalysisTests PRIVATE cladDifferentiator clangTooling)
+else()
+  message(FATAL_ERROR
+    "AnalysisTests requires the clang-cpp or clangTooling CMake target")
+endif()
+
+if (CLAD_CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  # These tests link instrumented clad objects, unlike plugin-only tests.
+  # LINK_FLAGS also works with the project's older CMake minimum.
+  set_property(TARGET AnalysisTests APPEND_STRING PROPERTY LINK_FLAGS
+    " --coverage")
+
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # The root build switches the test driver to Clang. Use the coverage
+    # runtime belonging to the GCC that compiled cladDifferentiator.
+    if (NOT stored_cxx_compiler)
+      message(FATAL_ERROR
+        "Cannot identify the GCC compiler used for cladDifferentiator")
+    endif()
+    execute_process(
+      COMMAND "${stored_cxx_compiler}" -print-file-name=libgcov.a
+      RESULT_VARIABLE _clad_gcov_result
+      OUTPUT_VARIABLE _clad_gcov_library
+      ERROR_VARIABLE _clad_gcov_error
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (NOT _clad_gcov_result EQUAL 0 OR
+        NOT IS_ABSOLUTE "${_clad_gcov_library}" OR
+        NOT EXISTS "${_clad_gcov_library}")
+      message(FATAL_ERROR
+        "Cannot locate GCC coverage runtime: ${_clad_gcov_error} "
+        "${_clad_gcov_library}")
+    endif()
+    target_link_libraries(AnalysisTests PRIVATE "${_clad_gcov_library}")
+  endif()
+endif()

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -66,5 +66,6 @@ if (NOT EMSCRIPTEN)
     add_subdirectory(Kokkos)
   endif(Kokkos_FOUND)
 
+  add_subdirectory(Analyses)
   add_subdirectory(Misc)
 endif()


### PR DESCRIPTION
[NFC][UA] Rebase UsefulAnalyzer onto the AnalysisBase lattice

Replace UsefulAnalyzer's duplicated state storage and traversal machinery with the copy-on-write VarsData lattice from AnalysisBase.
Link blocks through first-discovery m_Prev chains. Direct continuations are reprocessed when their parent is visited; other edges are re-enqueued only when merging introduces a new variable.
Represent whole-variable usefulness through scalar presence markers, independent of field, pointee, or declaration types. The payload bits remain false; UsefulAnalyzer queries key presence rather than payload values.
This is a no-functional-change port. Existing -enable-ua coverage in UsefulForward.cpp and UsefulNonTermination.cpp exercises the analyzer's generated-code behavior. Prerequisite PR #2060 additionally pins the default-versus-enable-ua difference in UsefulLattice.cpp.
Inherit the AnalysisTests linking repair from prerequisite PR #2058.
Local validation with Clang/LLVM 18 passes the inherited 11 AnalysisBase unit tests and the complete check-clad regression suite with 230 passed, 30 unsupported, and no failures.

Depends on: #2058, #2060