### PR TITLE
[VA] Preserve accumulated state and report lattice merge changes

### DIFF
--- a/lib/Differentiator/AnalysisBase.cpp
+++ b/lib/Differentiator/AnalysisBase.cpp
@@ -287,7 +287,7 @@ bool AnalysisBase::merge(VarData& targetData, VarData& mergeData) {
     for (auto& pair : *mergeData.m_Val.m_ArrData) {
       auto it = targetData.m_Val.m_ArrData->find(pair.first);
       if (it == targetData.m_Val.m_ArrData->end())
-        (*targetData.m_Val.m_ArrData)[pair.first] = pair.second.copy();
+        isMod = merge(*targetData[pair.first], pair.second) || isMod;
     }
     return isMod;
   }
@@ -455,8 +455,10 @@ bool AnalysisBase::merge(VarsData* targetData, VarsData* mergeData) {
     if (found) {
       if (merge(*found, *pair.second))
         isModified = true;
-    } else
+    } else {
       (*targetData)[pair.first] = pair.second->copy();
+      isModified = true;
+    }
   }
 
   // For every variable in collected targetData predecessors, search it inside
@@ -474,8 +476,11 @@ bool AnalysisBase::merge(VarsData* targetData, VarsData* mergeData) {
         while (branch) {
           auto it = branch->find(pair.first);
           if (it != branch->end()) {
-            (*targetData)[pair.first] = pair.second->copy();
-            merge((*targetData)[pair.first], it->second);
+            // Preserve local state; copying inherited state is not a change.
+            if (targetData->find(pair.first) == targetData->end())
+              (*targetData)[pair.first] = pair.second->copy();
+            isModified =
+                merge((*targetData)[pair.first], it->second) || isModified;
             break;
           }
           branch = branch->m_Prev;
@@ -494,6 +499,8 @@ bool AnalysisBase::merge(VarsData* targetData, VarsData* mergeData) {
       while (branch) {
         auto it = branch->find(pair.first);
         if (it != branch->end()) {
+          // Refresh the local state, but do not report this as worklist
+          // growth: block traversal may immediately clear it again.
           merge(pair.second, it->second);
           break;
         }

--- a/unittests/Analyses/AnalysisBaseTest.cpp
+++ b/unittests/Analyses/AnalysisBaseTest.cpp
@@ -1,0 +1,195 @@
+#include "AnalysisBase.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+class MergeAccess : public clad::AnalysisBase {
+public:
+  MergeAccess() : AnalysisBase(nullptr) {}
+  using AnalysisBase::merge;
+};
+
+class AnalysisBaseMergeTest : public testing::Test {
+protected:
+  MergeAccess Analysis;
+  // merge treats declaration keys as opaque; nullptr is a supported key.
+  static constexpr const clang::VarDecl* Key = nullptr;
+
+  clad::VarData bit(bool Value) {
+    clad::VarData Data;
+    Data.m_Type = clad::VarData::FUND_TYPE;
+    Data.m_Val.m_FundData = Value;
+    return Data;
+  }
+
+  void put(clad::VarsData& Data, bool Value) { Data[Key] = bit(Value); }
+  bool value(clad::VarsData& Data) { return Data[Key].m_Val.m_FundData; }
+
+  // 0 = absent, 1 = present/false, 2 = present/true.
+  int visible(clad::VarsData* Data) {
+    for (; Data; Data = Data->m_Prev) {
+      auto Found = Data->find(Key);
+      if (Found != Data->end())
+        return Found->second.m_Val.m_FundData ? 2 : 1;
+    }
+    return 0;
+  }
+};
+
+TEST_F(AnalysisBaseMergeTest, ReportsMissingArrayElement) {
+  clad::VarData Target, Source;
+  Target.m_Type = Source.m_Type = clad::VarData::ARR_TYPE;
+  Target.m_Val.m_ArrData = std::make_unique<clad::ArrMap>();
+  Source.m_Val.m_ArrData = std::make_unique<clad::ArrMap>();
+  clad::ProfileID Default, Index;
+  Index.AddInteger(1);
+  (*Target.m_Val.m_ArrData)[Default] = bit(false);
+  (*Source.m_Val.m_ArrData)[Default] = bit(false);
+  (*Source.m_Val.m_ArrData)[Index] = bit(true);
+
+  EXPECT_TRUE(Analysis.merge(Target, Source));
+  EXPECT_TRUE(Target[Index]->m_Val.m_FundData);
+  EXPECT_FALSE(Analysis.merge(Target, Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, PreservesArrayDefaultForMissingElement) {
+  clad::VarData Target, Source;
+  Target.m_Type = Source.m_Type = clad::VarData::ARR_TYPE;
+  Target.m_Val.m_ArrData = std::make_unique<clad::ArrMap>();
+  Source.m_Val.m_ArrData = std::make_unique<clad::ArrMap>();
+  clad::ProfileID Default, Index;
+  Index.AddInteger(1);
+  (*Target.m_Val.m_ArrData)[Default] = bit(true);
+  (*Source.m_Val.m_ArrData)[Default] = bit(false);
+  (*Source.m_Val.m_ArrData)[Index] = bit(false);
+
+  EXPECT_FALSE(Analysis.merge(Target, Source));
+  EXPECT_TRUE(Target[Index]->m_Val.m_FundData);
+  EXPECT_FALSE(Analysis.merge(Target, Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, ReportsNewVariableEvenWithFalseBit) {
+  clad::VarsData Root, Target, Source;
+  Target.m_Prev = Source.m_Prev = &Root;
+  put(Source, false);
+  EXPECT_TRUE(Analysis.merge(&Target, &Source));
+  EXPECT_EQ(visible(&Target), 1);
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, AncestorRefreshDoesNotSignalWorklistGrowth) {
+  clad::VarsData Root, Target, Source;
+  Target.m_Prev = Source.m_Prev = &Root;
+  put(Root, true);
+  put(Target, false);
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+  EXPECT_TRUE(value(Target));
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, ReportsAncestorBitMergedIntoInherited) {
+  clad::VarsData Root, Parent, Target, Source;
+  Parent.m_Prev = Source.m_Prev = &Root;
+  Target.m_Prev = &Parent;
+  put(Root, true);
+  put(Parent, false);
+  EXPECT_TRUE(Analysis.merge(&Target, &Source));
+  EXPECT_TRUE(value(Target));
+  EXPECT_FALSE(value(Parent));
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, LocalTrueShadowsInheritedFalse) {
+  clad::VarsData Root, Parent, Target, Source;
+  Parent.m_Prev = Source.m_Prev = &Root;
+  Target.m_Prev = &Parent;
+  put(Root, false);
+  put(Parent, false);
+  put(Target, true);
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+  EXPECT_TRUE(value(Target));
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+  EXPECT_TRUE(value(Target));
+}
+
+TEST_F(AnalysisBaseMergeTest, LocalFalseShadowsInheritedTrue) {
+  clad::VarsData Root, Parent, Target, Source;
+  Parent.m_Prev = Source.m_Prev = &Root;
+  Target.m_Prev = &Parent;
+  put(Root, false);
+  put(Parent, true);
+  put(Target, false);
+
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+  EXPECT_FALSE(value(Target));
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+  EXPECT_FALSE(value(Target));
+}
+
+TEST_F(AnalysisBaseMergeTest, CopyDownAloneIsNotAChange) {
+  clad::VarsData Root, Parent, Target, Source;
+  Parent.m_Prev = Source.m_Prev = &Root;
+  Target.m_Prev = &Parent;
+  put(Root, false);
+  put(Parent, false);
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+  EXPECT_EQ(visible(&Target), 1);
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, MergeDoesNotMutateSourceOrAncestor) {
+  clad::VarsData Root, Target, Source;
+  Target.m_Prev = Source.m_Prev = &Root;
+  put(Root, false);
+  put(Source, true);
+  EXPECT_TRUE(Analysis.merge(&Target, &Source));
+  EXPECT_TRUE(value(Target));
+  EXPECT_TRUE(value(Source));
+  EXPECT_FALSE(value(Root));
+  EXPECT_FALSE(Analysis.merge(&Target, &Source));
+}
+
+TEST_F(AnalysisBaseMergeTest, SelfMergeIsUnchanged) {
+  clad::VarsData Target;
+  put(Target, true);
+  EXPECT_FALSE(Analysis.merge(&Target, &Target));
+  EXPECT_TRUE(value(Target));
+}
+
+TEST_F(AnalysisBaseMergeTest, ScalarForksJoinAndThenStabilize) {
+  for (int Code = 0; Code < 243; ++Code) {
+    SCOPED_TRACE(Code);
+    clad::VarsData Root, Left, Right, Target, Source;
+    Left.m_Prev = Right.m_Prev = &Root;
+    Target.m_Prev = &Left;
+    Source.m_Prev = &Right;
+    int States = Code;
+    int InState[5];
+    int Idx = 0;
+    for (auto* Data : {&Root, &Left, &Right, &Target, &Source}) {
+      int State = States % 3;
+      States /= 3;
+      InState[Idx++] = State;
+      if (State)
+        put(*Data, State == 2);
+    }
+    int Before = visible(&Target);
+    int Incoming = visible(&Source);
+    int Expected =
+        Before == 2 || Incoming == 2 ? 2 : (Before || Incoming ? 1 : 0);
+    // Phase 3 refreshes local state without reporting worklist growth. This
+    // occurs when Target's local false is refreshed from Root's true while
+    // Left, Right, and Source introduce no branch-specific state.
+    bool IsAncestorRefreshOnly =
+        (InState[0] == 2 && InState[1] == 0 && InState[2] == 0 &&
+         InState[3] == 1 && InState[4] == 0);
+    bool ExpectedChangeReported =
+        (Expected != Before) && !IsAncestorRefreshOnly;
+    EXPECT_EQ(Analysis.merge(&Target, &Source), ExpectedChangeReported);
+    EXPECT_EQ(visible(&Target), Expected);
+    EXPECT_EQ(visible(&Source), Incoming);
+    EXPECT_FALSE(Analysis.merge(&Target, &Source));
+    EXPECT_EQ(visible(&Target), Expected);
+  }
+}
+} // namespace

--- a/unittests/Analyses/CMakeLists.txt
+++ b/unittests/Analyses/CMakeLists.txt
@@ -1,0 +1,44 @@
+add_clad_unittest(AnalysisTests AnalysisBaseTest.cpp)
+
+target_include_directories(AnalysisTests PRIVATE
+  ${CLAD_SOURCE_DIR}/lib/Differentiator)
+
+# Recipe installations can export clang-cpp without clangTooling.
+if (TARGET clang-cpp)
+  target_link_libraries(AnalysisTests PRIVATE cladDifferentiator clang-cpp)
+elseif (TARGET clangTooling)
+  target_link_libraries(AnalysisTests PRIVATE cladDifferentiator clangTooling)
+else()
+  message(FATAL_ERROR
+    "AnalysisTests requires the clang-cpp or clangTooling CMake target")
+endif()
+
+if (CLAD_CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  # These tests link instrumented clad objects, unlike plugin-only tests.
+  # LINK_FLAGS also works with the project's older CMake minimum.
+  set_property(TARGET AnalysisTests APPEND_STRING PROPERTY LINK_FLAGS
+    " --coverage")
+
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # The root build switches the test driver to Clang. Use the coverage
+    # runtime belonging to the GCC that compiled cladDifferentiator.
+    if (NOT stored_cxx_compiler)
+      message(FATAL_ERROR
+        "Cannot identify the GCC compiler used for cladDifferentiator")
+    endif()
+    execute_process(
+      COMMAND "${stored_cxx_compiler}" -print-file-name=libgcov.a
+      RESULT_VARIABLE _clad_gcov_result
+      OUTPUT_VARIABLE _clad_gcov_library
+      ERROR_VARIABLE _clad_gcov_error
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (NOT _clad_gcov_result EQUAL 0 OR
+        NOT IS_ABSOLUTE "${_clad_gcov_library}" OR
+        NOT EXISTS "${_clad_gcov_library}")
+      message(FATAL_ERROR
+        "Cannot locate GCC coverage runtime: ${_clad_gcov_error} "
+        "${_clad_gcov_library}")
+    endif()
+    target_link_libraries(AnalysisTests PRIVATE "${_clad_gcov_library}")
+  endif()
+endif()

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -66,5 +66,6 @@ if (NOT EMSCRIPTEN)
     add_subdirectory(Kokkos)
   endif(Kokkos_FOUND)
 
+  add_subdirectory(Analyses)
   add_subdirectory(Misc)
 endif()


### PR DESCRIPTION
[VA] Preserve accumulated state and report lattice merge changes

Make AnalysisBase merges report newly introduced stable state while preserving locally accumulated values during ancestor reconciliation.

VariedAnalyzer uses the returned change flag to drive re-analysis. TBRAnalyzer ignores that flag but consumes the merged state, so preserving local state is relevant to both consumers.

Lattice and Merge Semantics:

- Missing array elements are materialized from the target default element through VarData::operator[] and recursively merged, preserving the conservative default safety floor.
- Local entries in VarsData shadow ancestors along the m_Prev chain. Both shadowing directions have explicit named tests: LocalTrueShadowsInheritedFalse and LocalFalseShadowsInheritedTrue.
- The exhaustive 243-configuration sweep in ScalarForksJoinAndThenStabilize remains.
- Phase 3 refreshes local state from LCA predecessors but deliberately does not report transient worklist growth because block traversal may immediately clear the refreshed state.

Testing and Validation:

- Unit tests: 11/11 AnalysisBaseMergeTest cases pass.
- Regression suite: check-clad passes with 230 passed, 30 unsupported, and 0 failures under Clang/LLVM 18 Release mode.
- A temporary restack with PR [UA] Rebase UsefulAnalyzer onto the AnalysisBase lattice #2057 passes all 13 AnalysisTests and check-clad with 232 passed, 30 unsupported, and 0 failures.
- The 24-case UsefulAnalyzer differential comparison passes with zero differences.
- A bounded exploratory CFG corpus terminates without oscillation. No universal CFG termination proof or fixed worklist pass bound is claimed.