### PR TITLE
Recompute a counted loop's trip count instead of counting it.

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/StringRef.h"
 
 #include <cassert>
+#include <set>
 #include <string>
 
 namespace clang {
@@ -544,6 +545,15 @@ namespace clad {
     /// like threadIdx, blockIdx, blockDim, or gridDim.
     bool isCUDABuiltinVariable(const clang::Expr* E,
                                const clang::ASTContext& Context);
+
+    /// Adds to \p Written every variable \p S may write. "Write" is meant
+    /// broadly, as anything that can change a value: an assignment, an
+    /// increment, a taken address, or a bind to a non-const reference.
+    /// Over-approximates on purpose -- callers ask whether a variable is
+    /// provably left alone, and a name that only might be written is no use
+    /// to them.
+    void collectWrittenVars(clang::Stmt* S,
+                            std::set<const clang::VarDecl*>& Written);
     } // namespace utils
     } // namespace clad
 

--- a/include/clad/Differentiator/DiffPlanner.h
+++ b/include/clad/Differentiator/DiffPlanner.h
@@ -32,16 +32,19 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <unordered_map>
 
 namespace clang {
 class CallExpr;
 class CompilerInstance;
 class DeclGroupRef;
 class Expr;
+class ForStmt;
 class FunctionDecl;
 class ParmVarDecl;
 class Sema;
 class Type;
+class VarDecl;
 } // namespace clang
 
 namespace clad {
@@ -49,6 +52,26 @@ using OwnedAnalysisContexts =
     llvm::SmallVector<std::unique_ptr<clang::AnalysisDeclContext>, 4>;
 using ParamSet = std::set<const clang::ParmVarDecl*>;
 using ParamInfo = std::map<const clang::FunctionDecl*, ParamSet>;
+
+/// What one walk of the primal found out about a `for` loop, in terms of the
+/// loop's own expressions rather than anything built from them.
+struct CountedLoopFacts {
+  /// The variable the loop steps, or null when the loop is not counted.
+  const clang::VarDecl* IndVar = nullptr;
+  /// The loop's own start and bound, and whether the comparison includes the
+  /// bound.
+  const clang::Expr* Init = nullptr;
+  const clang::Expr* Bound = nullptr;
+  bool Inclusive = false;
+  /// Whether the loop declares its index, so no statement after the loop can
+  /// read what it left there.
+  bool OwnsIndVar = false;
+  /// Whether Init and Bound read in the reverse sweep as they did in the
+  /// forward one, which is what makes a trip count worth building from them.
+  bool BoundsAreStable = false;
+
+  explicit operator bool() const { return IndVar != nullptr; }
+};
 /// A read-only, AD-oriented view over the primal being differentiated: it
 /// wraps the primal FunctionDecl and surfaces the AD-relevant facts the
 /// FunctionDecl itself does not. Recording such facts here, rather than
@@ -173,6 +196,21 @@ private:
     bool HasAnalysisRun = false;
   } m_NullTangentInfo;
 
+  /// The primal's local variables and parameters it may write. A property of
+  /// the Function, so worked out once and kept.
+  mutable struct WrittenVarInfo {
+    std::set<const clang::VarDecl*> Written;
+    bool HasAnalysisRun = false;
+  } m_WrittenVarInfo;
+
+  /// What each `for` in the primal is. Decided here rather than per loop in a
+  /// visitor because it needs the chain of loops a statement sits in, which
+  /// one walk has and a visit of a single loop does not.
+  mutable struct CountedLoopInfo {
+    std::unordered_map<const clang::ForStmt*, CountedLoopFacts> Loops;
+    bool HasAnalysisRun = false;
+  } m_CountedLoopInfo;
+
 public:
   /// The primal body's tail-position return -- the one an early-return encoder
   /// lets control fall through to, as opposed to an early return that needs a
@@ -199,6 +237,24 @@ public:
   /// is therefore never null. Answers false for a non-pointer, and for a
   /// variable belonging to a function other than this request's.
   bool mayHaveNullTangent(const clang::VarDecl* VD) const;
+
+  /// Whether the primal may write the local variable or parameter \p VD.
+  /// "Write" is meant broadly, as anything that can change the value between
+  /// two points of the body: an assignment, an increment, a taken address, or
+  /// a bind to a non-const reference. A variable this answers false for holds
+  /// the same value throughout the call, so the reverse sweep may read it and
+  /// see what the forward sweep saw -- which is what lets a loop's iteration
+  /// count be recomputed from its bounds rather than counted.
+  ///
+  /// Answers true, conservatively, for anything it cannot see through: a
+  /// variable with static or external storage (a callee may write it), and one
+  /// belonging to a function other than this request's.
+  bool writesVariable(const clang::VarDecl* VD) const;
+
+  /// What is known about \p FS as a counted loop, or a default-constructed
+  /// result when it is not one. Reading the facts does not build anything: a
+  /// caller that wants a trip-count expression builds it from Init and Bound.
+  const CountedLoopFacts& countedLoop(const clang::ForStmt* FS) const;
 
   /// Function to be differentiated.
   const clang::FunctionDecl* Function = nullptr;

--- a/include/clad/Differentiator/ReverseModeVisitor.h
+++ b/include/clad/Differentiator/ReverseModeVisitor.h
@@ -10,6 +10,7 @@
 #include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/Compatibility.h"
 #include "clad/Differentiator/DerivativeBuilder.h"
+#include "clad/Differentiator/DiffPlanner.h"
 #include "clad/Differentiator/ParseDiffArgsTypes.h"
 #include "clad/Differentiator/ReverseModeVisitorDirectionKinds.h"
 #include "clad/Differentiator/VisitorBase.h"
@@ -19,6 +20,7 @@
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/OpenMPClause.h"
+#include "clang/AST/OperationKinds.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtOpenMP.h"
 #include "clang/AST/StmtVisitor.h"
@@ -657,15 +659,33 @@ namespace clad {
     /// If we are currently inside a loop, then a clad tape object is created
     /// to be used as the counter; otherwise, a temporary global variable (in
     /// function scope) is created to be used as the counter.
+    ///
+    /// When the caller can prove the iteration count from the loop's own
+    /// bounds (see DiffRequest::countedLoop), it passes that count here and
+    /// the forward sweep stops counting altogether: no reset, no per-iteration
+    /// increment, and -- for a nested loop -- no tape. The reverse loop then
+    /// assigns the count to a plain function-scope variable on entry.
     class LoopCounter {
       clang::Expr *m_Ref = nullptr;
       clang::Expr *m_Pop = nullptr;
       clang::Expr *m_Push = nullptr;
       ReverseModeVisitor& m_RMV;
       clang::VarDecl* m_numRevIterations = nullptr;
+      clang::Expr* m_TripCount = nullptr;
 
     public:
-      LoopCounter(ReverseModeVisitor& RMV);
+      LoopCounter(ReverseModeVisitor& RMV, clang::Expr* tripCount = nullptr);
+
+      /// Returns true if the reverse sweep computes the iteration count from
+      /// the loop bounds instead of reading a count the forward sweep kept.
+      [[nodiscard]] bool isRecomputed() const { return m_TripCount; }
+
+      /// Returns `counter = <trip count>`, the init of the reverse loop.
+      /// Only valid when isRecomputed().
+      [[nodiscard]] clang::Expr* getCounterInit() const {
+        return m_RMV.BuildOp(clang::BinaryOperatorKind::BO_Assign, cloneRef(),
+                             m_TripCount);
+      }
       /// Returns `clad::push(_t, 0UL)` expression if clad tape is used
       /// for counter; otherwise, returns nullptr.
       clang::Expr* getPush() const { return m_Push; }
@@ -683,8 +703,11 @@ namespace clad {
         return m_RMV.CloneNode(m_Ref);
       }
 
-      /// Returns counter post-increment expression (`counter++`).
+      /// Returns counter post-increment expression (`counter++`), or nullptr
+      /// when the count is recomputed and the forward sweep must not count.
       clang::Expr* getCounterIncrement() {
+        if (isRecomputed())
+          return nullptr;
         return m_RMV.BuildOp(clang::UnaryOperatorKind::UO_PostInc, cloneRef());
       }
 
@@ -918,6 +941,29 @@ namespace clad {
 
     /// A flag indicating if the Stmt is contained in a checkpointed loop.
     bool m_IsInsideCheckpointedLoop = false;
+
+    /// The two expressions a counted loop's reverse sweep needs. What the
+    /// loop *is* -- its index, its bounds, whether they hold still -- belongs
+    /// to the request, not here; this is only what had to be built from it.
+    struct CountedLoopCode {
+      /// The iterations the loop performs, as an expression the reverse sweep
+      /// can evaluate on entry. Null when that could not be proven, in which
+      /// case the forward sweep has to count them.
+      clang::Expr* TripCount = nullptr;
+      /// What the induction variable holds once the loop has exited.
+      clang::Expr* IndVarEnd = nullptr;
+    };
+
+    /// Recognises the counted loop -- an integer variable stepped by one from
+    /// a stable initial value while it stays below a stable bound, with no
+    /// early exit -- and nothing else.
+    CountedLoopCode BuildCountedLoop(const CountedLoopFacts& F);
+
+    /// The loop index whose value the forward sweep need not save before
+    /// overwriting it. A member because the statement that would save it is
+    /// differentiated several calls down, with no parameter of its own to
+    /// carry this; set only while that one statement is being visited.
+    const clang::VarDecl* m_UnsavedLoopIndex = nullptr;
   };
 } // end namespace clad
 

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -15,6 +15,7 @@
 #include "clang/AST/ParentMapContext.h"
 #include "clang/AST/QualTypeNames.h"
 #include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Stmt.h"
 #include "clang/AST/TemplateName.h"
 #include "clang/AST/Type.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
@@ -30,10 +31,12 @@
 
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 
 #include <memory>
+#include <set>
 #include <vector>
 
 using namespace clang;
@@ -1980,6 +1983,78 @@ namespace clad {
     bool ShouldRecompute(const Expr* E, const ASTContext& C) {
       return !(utils::ContainsFunctionCalls(E) || E->HasSideEffects(C)) ||
              isCUDABuiltInIndex(E);
+    }
+
+    void collectWrittenVars(Stmt* S, std::set<const VarDecl*>& Written) {
+      class WrittenVarCollector
+          : public RecursiveASTVisitor<WrittenVarCollector> {
+        std::set<const VarDecl*>* m_Written;
+
+        void mark(const Expr* E) {
+          if (const auto* DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts()))
+            if (const auto* VD = dyn_cast<VarDecl>(DRE->getDecl()))
+              m_Written->insert(VD);
+        }
+
+        /// Marks the arguments \p Callee may write. A parameter type is what
+        /// says so, and where there is none to consult -- an indirect call --
+        /// every argument counts as written.
+        void markByRefArgs(const FunctionDecl* Callee,
+                           llvm::ArrayRef<Expr*> Args) {
+          for (unsigned i = 0, e = Args.size(); i != e; ++i) {
+            if (Callee) {
+              // Past the last parameter the argument is a variadic one, and
+              // `...` takes its arguments by value, so printf("%d", i) leaves
+              // i alone. Passing it for writing reads as printf("%d", &i),
+              // where the address is what the callee gets and taking it is
+              // already a write.
+              if (i >= Callee->getNumParams())
+                continue;
+              QualType T = Callee->getParamDecl(i)->getType();
+              if (!T->isLValueReferenceType() ||
+                  T.getNonReferenceType().isConstQualified())
+                continue;
+            }
+            mark(Args[i]);
+          }
+        }
+
+      public:
+        explicit WrittenVarCollector(std::set<const VarDecl*>& Written)
+            : m_Written(&Written) {}
+
+        bool VisitBinaryOperator(BinaryOperator* BO) {
+          if (BO->isAssignmentOp())
+            mark(BO->getLHS());
+          return true;
+        }
+
+        bool VisitUnaryOperator(UnaryOperator* UO) {
+          // A taken address is a write that can happen anywhere later.
+          if (UO->isIncrementDecrementOp() || UO->getOpcode() == UO_AddrOf)
+            mark(UO->getSubExpr());
+          return true;
+        }
+
+        bool VisitCallExpr(CallExpr* CE) {
+          const FunctionDecl* FD = CE->getDirectCallee();
+          // An overloaded operator passes its object as argument zero, so the
+          // arguments sit one ahead of the parameters when it is a member.
+          unsigned Offset = isa<CXXOperatorCallExpr>(CE) &&
+                            isa_and_nonnull<CXXMethodDecl>(FD);
+          llvm::ArrayRef<Expr*> Args(CE->getArgs(), CE->getNumArgs());
+          markByRefArgs(FD, Args.drop_front(Offset));
+          return true;
+        }
+
+        bool VisitCXXConstructExpr(CXXConstructExpr* CE) {
+          markByRefArgs(CE->getConstructor(),
+                        llvm::ArrayRef<Expr*>(CE->getArgs(), CE->getNumArgs()));
+          return true;
+        }
+      };
+      WrittenVarCollector Collector(Written);
+      Collector.TraverseStmt(S);
     }
   } // namespace utils
 } // namespace clad

--- a/lib/Differentiator/DiffPlanner.cpp
+++ b/lib/Differentiator/DiffPlanner.cpp
@@ -6,7 +6,9 @@
 #include "TBRAnalyzer.h"
 #include "UsefulAnalyzer.h"
 
+#include "LoopAnalyzer.h"
 #include "clad/Differentiator/CladConfig.h"
+
 #include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/Compatibility.h"
 #include "clad/Differentiator/DerivativeBuilder.h"
@@ -50,10 +52,12 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <optional>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 using namespace clang;
@@ -477,6 +481,35 @@ static QualType GetDerivedFunctionType(const CallExpr* CE) {
     F.TraverseStmt(Def->getBody());
     m_EarlyReturnInfo = {F.Found, /*HasAnalysisRun=*/true};
     return F.Found;
+  }
+
+  const CountedLoopFacts& DiffRequest::countedLoop(const ForStmt* FS) const {
+    static const CountedLoopFacts None;
+    const FunctionDecl* Def = Function ? Function->getDefinition() : nullptr;
+    if (!Def || !Def->hasBody())
+      return None;
+    if (!m_CountedLoopInfo.HasAnalysisRun) {
+      collectCountedLoops(*this, m_CountedLoopInfo.Loops);
+      m_CountedLoopInfo.HasAnalysisRun = true;
+    }
+    auto it = m_CountedLoopInfo.Loops.find(FS);
+    return it == m_CountedLoopInfo.Loops.end() ? None : it->second;
+  }
+
+  bool DiffRequest::writesVariable(const VarDecl* VD) const {
+    // A reference names storage this walk does not follow, and static or
+    // external storage is reachable from inside a callee. Neither can be
+    // ruled out by looking at the body alone.
+    if (VD->getType()->isReferenceType() || !VD->hasLocalStorage())
+      return true;
+    const FunctionDecl* Def = Function ? Function->getDefinition() : nullptr;
+    if (!Def || !Def->hasBody())
+      return true;
+    if (!m_WrittenVarInfo.HasAnalysisRun) {
+      utils::collectWrittenVars(Def->getBody(), m_WrittenVarInfo.Written);
+      m_WrittenVarInfo.HasAnalysisRun = true;
+    }
+    return m_WrittenVarInfo.Written.count(VD) != 0;
   }
 
   namespace {

--- a/lib/Differentiator/LoopAnalyzer.cpp
+++ b/lib/Differentiator/LoopAnalyzer.cpp
@@ -1,6 +1,7 @@
 #include "LoopAnalyzer.h"
 
 #include "clad/Differentiator/CladUtils.h"
+#include "clad/Differentiator/DiffPlanner.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
@@ -13,7 +14,11 @@
 #include "clang/Basic/SourceLocation.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+
+#include <set>
+#include <unordered_map>
 
 using namespace clang;
 
@@ -36,6 +41,119 @@ static bool stepsByOne(const Expr* E, const VarDecl* VD) {
     if (BO->getOpcode() == BO_Comma)
       return stepsByOne(BO->getLHS(), VD) || stepsByOne(BO->getRHS(), VD);
   return false;
+}
+
+namespace {
+/// Fills in what each `for` in a body is, in one walk.
+///
+/// The chain of loops a statement sits in is what makes a nested loop's
+/// bounds readable: `for (j = i + 1; ...)` is stable only because the
+/// reverse sweep steps `i` back before entering the reverse of anything
+/// inside `i`'s loop. A walk has that chain; a visit of one loop does not,
+/// which is why this is decided here rather than where the trip count is
+/// built.
+class CountedLoopCollector : public RecursiveASTVisitor<CountedLoopCollector> {
+  const DiffRequest& m_Request;
+  ASTContext& m_Context;
+  std::unordered_map<const ForStmt*, CountedLoopFacts>& m_Out;
+  llvm::SmallVector<const VarDecl*, 4> m_EnclosingIndVars;
+
+  /// Whether \p E reads in the reverse sweep as it did in the forward one:
+  /// it combines arithmetically only constants, variables the primal never
+  /// writes, and the induction variables of the loops around it.
+  bool isStable(const Expr* E) const {
+    E = E->IgnoreParenImpCasts();
+    // A constant is stable however it is spelled -- a literal, a constexpr
+    // variable, an enumerator or a template argument all bound a loop, and
+    // the last three are the usual way a dimension is written.
+    if (E->getIntegerConstantExpr(m_Context))
+      return true;
+    if (const auto* UO = dyn_cast<UnaryOperator>(E)) {
+      UnaryOperatorKind op = UO->getOpcode();
+      return (op == UO_Plus || op == UO_Minus) && isStable(UO->getSubExpr());
+    }
+    if (const auto* BO = dyn_cast<BinaryOperator>(E)) {
+      BinaryOperatorKind op = BO->getOpcode();
+      if (op != BO_Add && op != BO_Sub && op != BO_Mul)
+        return false;
+      return isStable(BO->getLHS()) && isStable(BO->getRHS());
+    }
+    const auto* DRE = dyn_cast<DeclRefExpr>(E);
+    if (!DRE)
+      return false;
+    const auto* VD = dyn_cast<VarDecl>(DRE->getDecl());
+    // Integer only: the count this bounds is arithmetic, and a floating
+    // bound would make it depend on rounding.
+    if (!VD || !VD->getType()->isIntegerType() ||
+        VD->getType().isVolatileQualified())
+      return false;
+    // An enclosing loop's induction variable is written -- by its own
+    // increment -- yet still reads correctly here, because the reverse sweep
+    // steps it back before entering the reverse of this loop.
+    if (llvm::is_contained(m_EnclosingIndVars, VD))
+      return true;
+    return !m_Request.writesVariable(VD);
+  }
+
+public:
+  CountedLoopCollector(
+      const DiffRequest& R, ASTContext& C,
+      std::unordered_map<const ForStmt*, CountedLoopFacts>& Out)
+      : m_Request(R), m_Context(C), m_Out(Out) {}
+
+  bool TraverseForStmt(ForStmt* FS) {
+    CountedLoopFacts F;
+    CountedForLoop L = recogniseCountedForLoop(FS);
+    // An early return can skip the forward loop while the master reverse
+    // sweep still runs, so a recomputed count would be the full one for a
+    // loop that never ran.
+    if (L && !m_Request.hasEarlyReturns() && !mayExitEarly(FS->getBody())) {
+      // The increment is the only thing allowed to move the induction
+      // variable; a body that also writes it -- directly, or by handing it
+      // to a callee as a non-const reference -- runs a number of times the
+      // bounds do not say.
+      std::set<const VarDecl*> writtenInBody;
+      utils::collectWrittenVars(FS->getBody(), writtenInBody);
+      if (!writtenInBody.count(L.IndVar)) {
+        F.IndVar = L.IndVar;
+        F.Init = L.Init;
+        F.Bound = L.Bound;
+        F.Inclusive = L.Inclusive;
+        F.OwnsIndVar = isa<DeclStmt>(FS->getInit());
+        F.BoundsAreStable = isStable(L.Init) && isStable(L.Bound);
+      }
+    }
+    m_Out[FS] = F;
+    // A loop counted at all offers its index to the loops inside it, even
+    // when its own bounds are not stable: its reverse still steps that index
+    // back one per iteration.
+    if (F.IndVar)
+      m_EnclosingIndVars.push_back(F.IndVar);
+    bool res = RecursiveASTVisitor::TraverseForStmt(FS);
+    if (F.IndVar)
+      m_EnclosingIndVars.pop_back();
+    return res;
+  }
+};
+} // namespace
+
+void collectCountedLoops(
+    const DiffRequest& R,
+    std::unordered_map<const ForStmt*, CountedLoopFacts>& Out) {
+  // DiffRequest::countedLoop, the only caller, resolved this definition to
+  // decide it had a body worth walking.
+  const FunctionDecl* Def = R.Function->getDefinition();
+  CountedLoopCollector C(R, Def->getASTContext(), Out);
+  C.TraverseStmt(Def->getBody());
+}
+
+bool mayExitEarly(const Stmt* S) {
+  if (!S)
+    return false;
+  if (isa<BreakStmt>(S) || isa<ContinueStmt>(S) || isa<ReturnStmt>(S) ||
+      isa<GotoStmt>(S) || isa<IndirectGotoStmt>(S) || isa<LabelStmt>(S))
+    return true;
+  return llvm::any_of(S->children(), mayExitEarly);
 }
 
 CountedForLoop recogniseCountedForLoop(const ForStmt* FS) {

--- a/lib/Differentiator/LoopAnalyzer.h
+++ b/lib/Differentiator/LoopAnalyzer.h
@@ -1,6 +1,8 @@
 #ifndef CLAD_DIFFERENTIATOR_LOOPANALYZER_H
 #define CLAD_DIFFERENTIATOR_LOOPANALYZER_H
 
+#include "clad/Differentiator/DiffPlanner.h"
+
 #include "clang/AST/Stmt.h"
 #include "clang/Basic/SourceLocation.h"
 
@@ -8,6 +10,7 @@
 #include "llvm/ADT/SmallVector.h"
 
 #include <cstdint>
+#include <unordered_map>
 
 namespace clang {
 class Expr;
@@ -54,6 +57,23 @@ struct CountedForLoop {
 /// moves the induction variable itself -- so each caller adds the
 /// conditions its own use needs.
 CountedForLoop recogniseCountedForLoop(const clang::ForStmt* FS);
+
+/// Fills \p Out with what every `for` in \p R's primal is. One walk, because
+/// deciding it needs the chain of loops a statement sits in, which a visit of a
+/// single loop does not have.
+void collectCountedLoops(
+    const DiffRequest& R,
+    std::unordered_map<const clang::ForStmt*, CountedLoopFacts>& Out);
+
+/// Whether \p S can leave the loop it belongs to before that loop's condition
+/// says so. Nested loops and switches are searched too -- a `break` of their
+/// own is theirs to keep, but rejecting the outer loop as well is cheaper than
+/// tracking which construct each one binds to, and costs only coverage.
+///
+/// Syntax, like recogniseCountedForLoop, and separate from it because what an
+/// early exit rules out differs per caller: a trip count worked out from the
+/// bounds would be wrong, while a written extent stays an over-approximation.
+bool mayExitEarly(const clang::Stmt* S);
 
 /// The counted loops enclosing whatever a visitor is currently looking at.
 ///

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -66,9 +66,11 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -1221,9 +1223,112 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
             utils::unwrapIfSingleStmt(Reverse)};
   }
 
+  ReverseModeVisitor::CountedLoopCode
+  ReverseModeVisitor::BuildCountedLoop(const CountedLoopFacts& F) {
+    // Nothing is decided here: whether the loop is counted, and whether its
+    // bounds hold still across the sweeps, was settled once for the whole
+    // primal. What is left is building the count, which needs Sema and the
+    // scope this visitor is standing in.
+    CountedLoopCode CL;
+    if (!F || !F.BoundsAreStable)
+      return CL;
+    const VarDecl* indVar = F.IndVar;
+    const Expr* init = F.Init;
+    const Expr* bound = F.Bound;
+    const bool inclusive = F.Inclusive;
+
+    // The count is `bound - init`, one more when the bound is inclusive, and
+    // zero when the loop body never runs. Guarding on the same comparison the
+    // loop itself uses keeps the two in step; without it an empty loop would
+    // wrap the subtraction around and iterate the reverse sweep forever.
+    QualType sizeTy = clad_compat::getSizeType(m_Context);
+    // clang returned llvm::Optional here before 16, and the two spell the
+    // same thing differently.
+    clad_compat::llvm_Optional<llvm::APSInt> initVal =
+        init->getIntegerConstantExpr(m_Context);
+    clad_compat::llvm_Optional<llvm::APSInt> boundVal =
+        bound->getIntegerConstantExpr(m_Context);
+
+    // A loop written with constant bounds -- the common `i < 3` -- has a count
+    // known here, and spelling it out beats emitting arithmetic over literals.
+    // Both are widened to int64_t and subtracted, so each has to leave room
+    // for the difference and for the inclusive bound's extra iteration. Half
+    // the positive range apiece is plenty for a loop count and needs no case
+    // analysis at the ends.
+    static constexpr unsigned MaxCountBits = 62;
+    if (initVal && boundVal && initVal->isNonNegative() &&
+        boundVal->isNonNegative() && initVal->getActiveBits() <= MaxCountBits &&
+        boundVal->getActiveBits() <= MaxCountBits) {
+      int64_t count = static_cast<int64_t>(boundVal->getZExtValue()) -
+                      static_cast<int64_t>(initVal->getZExtValue()) +
+                      (inclusive ? 1 : 0);
+      CL.TripCount = ConstantFolder::synthesizeLiteral(sizeTy, m_Context,
+                                                       count > 0 ? count : 0);
+      int64_t end = static_cast<int64_t>(initVal->getZExtValue()) +
+                    (count > 0 ? count : 0);
+      CL.IndVarEnd =
+          ConstantFolder::synthesizeLiteral(indVar->getType(), m_Context, end);
+      return CL;
+    }
+
+    auto toSize = [&](const Expr* E) {
+      // A cast binds tighter than the arithmetic it may contain, so a compound
+      // operand needs parentheses to print back as what it is.
+      Expr* operand = Clone(E);
+      if (!isa<DeclRefExpr>(operand) && !isa<ParenExpr>(operand) &&
+          !isa<IntegerLiteral>(operand))
+        operand = BuildParens(operand);
+      return m_Sema
+          .BuildCStyleCastExpr(
+              noLoc, m_Context.getTrivialTypeSourceInfo(sizeTy), noLoc, operand)
+          .get();
+    };
+    // Casting both sides before subtracting keeps a negative init exact: the
+    // wrapped values differ by the same amount the originals do.
+    Expr* count = toSize(bound);
+    if (initVal && initVal->isNonNegative() &&
+        initVal->getActiveBits() <= MaxCountBits) {
+      // A constant start folds into the inclusive bound's extra iteration,
+      // rather than emitting the two of them as `- 1 + 1`.
+      int64_t offset =
+          static_cast<int64_t>(initVal->getZExtValue()) - (inclusive ? 1 : 0);
+      if (offset)
+        count = BuildOp(
+            offset > 0 ? BO_Sub : BO_Add, count,
+            ConstantFolder::synthesizeLiteral(
+                sizeTy, m_Context, /*val=*/offset > 0 ? offset : -offset));
+    } else {
+      count = BuildOp(BO_Sub, count, toSize(init));
+      if (inclusive)
+        count = BuildOp(BO_Add, count,
+                        ConstantFolder::synthesizeLiteral(sizeTy, m_Context,
+                                                          /*val=*/1));
+    }
+    auto guard = [&](Expr* ran, Expr* didNot) {
+      Expr* runs =
+          BuildOp(inclusive ? BO_GE : BO_GT, Clone(bound), Clone(init));
+      return m_Sema.ActOnConditionalOp(noLoc, noLoc, runs, ran, didNot).get();
+    };
+    CL.TripCount =
+        guard(BuildParens(count),
+              ConstantFolder::synthesizeLiteral(sizeTy, m_Context, /*val=*/0));
+    // Where the index is left: at the bound, one past it when the bound is
+    // inclusive, and untouched when the loop body never ran.
+    Expr* end = Clone(bound);
+    if (inclusive)
+      end = BuildOp(BO_Add, end,
+                    ConstantFolder::synthesizeLiteral(indVar->getType(),
+                                                      m_Context,
+                                                      /*val=*/1));
+    CL.IndVarEnd = guard(end, Clone(init));
+    return CL;
+  }
+
   StmtDiff ReverseModeVisitor::VisitForStmt(const ForStmt* FS) {
     beginBlock(direction::reverse);
-    LoopCounter loopCounter(*this);
+    const CountedLoopFacts& CLF = m_DiffReq.countedLoop(FS);
+    CountedLoopCode CL = BuildCountedLoop(CLF);
+    LoopCounter loopCounter(*this, CL.TripCount);
     ScopeRAII forScope(*this, Scope::DeclScope | Scope::ControlScope |
                                   Scope::BreakScope | Scope::ContinueScope);
     llvm::SaveAndRestore<Expr*> SaveCurrentBreakFlagExpr(
@@ -1232,7 +1337,22 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     const Stmt* init = FS->getInit();
     if (m_ExternalSource)
       m_ExternalSource->ActBeforeDifferentiatingLoopInitStmt();
-    StmtDiff initResult = init ? DifferentiateSingleStmt(init) : StmtDiff{};
+    // Promoting a loop-local declaration to function scope makes the forward
+    // sweep save whatever the name held before, so that the reverse sweep can
+    // put it back. A loop that declares its own index and whose reverse sets
+    // that index on entry needs neither: the value saved is one no statement
+    // can observe. Only a nested loop saves it at all -- an outermost one is
+    // already at function-body level.
+    bool unsavedIndex = CL.TripCount && CLF.OwnsIndVar && isInsideLoop;
+    StmtDiff initResult;
+    {
+      // Read far below in DifferentiateVarDeclStmt, which nothing else can
+      // hand it to; scoped so it cannot outlive the one statement it is about.
+      llvm::SaveAndRestore<const VarDecl*> SaveUnsaved(m_UnsavedLoopIndex);
+      if (unsavedIndex)
+        m_UnsavedLoopIndex = CLF.IndVar;
+      initResult = init ? DifferentiateSingleStmt(init) : StmtDiff{};
+    }
 
     // Save the isInsideLoop value (we may be inside another loop).
     llvm::SaveAndRestore<bool> SaveIsInsideLoop(isInsideLoop);
@@ -1363,9 +1483,23 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
           m_Context, BodyDiff.getStmt_dx(), revPassCondStmts));
     }
 
-    Stmt* revInit = loopCounter.getNumRevIterations()
-                        ? BuildDeclStmt(loopCounter.getNumRevIterations())
-                        : nullptr;
+    Stmt* revInit = nullptr;
+    if (loopCounter.getNumRevIterations())
+      revInit = BuildDeclStmt(loopCounter.getNumRevIterations());
+    else if (loopCounter.isRecomputed()) {
+      Expr* revInitExpr = loopCounter.getCounterInit();
+      if (unsavedIndex) {
+        // Seed the index with what the forward loop left in it, so the
+        // per-iteration step-back below walks it to where the loop started.
+        auto it = m_DeclReplacements.find(CLF.IndVar);
+        assert(it != m_DeclReplacements.end() && "index must be remapped");
+        revInitExpr =
+            BuildOp(BO_Comma,
+                    BuildOp(BO_Assign, BuildDeclRef(it->second), CL.IndVarEnd),
+                    revInitExpr);
+      }
+      revInit = revInitExpr;
+    }
     Stmt* Reverse = nullptr;
     if (BodyDiff.getStmt_dx())
       Reverse = new (m_Context)
@@ -3952,7 +4086,7 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                   BuildArrayAssignment(declRef, init, direction::forward);
             else
               assignment = BuildOp(BO_Assign, declRef, init);
-            if (isInsideLoop) {
+            if (isInsideLoop && VD != m_UnsavedLoopIndex) {
               if (m_DiffReq.shouldBeRecorded(DS)) {
                 auto pushPop = StoreAndRestore(declRef, /*prefix=*/"_t",
                                                /*moveToTape=*/true);
@@ -4662,9 +4796,26 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
                               /*pNeedsUpdate=*/true};
   }
 
-  ReverseModeVisitor::LoopCounter::LoopCounter(ReverseModeVisitor& RMV)
-      : m_RMV(RMV) {
+  ReverseModeVisitor::LoopCounter::LoopCounter(ReverseModeVisitor& RMV,
+                                               Expr* tripCount)
+      : m_RMV(RMV), m_TripCount(tripCount) {
     ASTContext& C = m_RMV.m_Context;
+    if (tripCount) {
+      // The forward sweep never touches this counter, so it needs no reset
+      // and -- unlike a counted one -- no tape when the loop is nested: the
+      // reverse loop assigns it on entry, once per enclosing iteration.
+      VarDecl* VD = m_RMV.BuildGlobalVarDecl(clad_compat::getSizeType(C), "_t");
+      DeclStmt* decl = m_RMV.BuildDeclStmt(VD);
+      // Declare it beside its loop, where a counted one sits. A loop below
+      // function-body level is the exception: the reverse sweep runs in a
+      // sibling block and could not name a declaration left in that one.
+      if (m_RMV.getCurrentScope()->isFunctionScope())
+        m_RMV.addToCurrentBlock(decl, direction::forward);
+      else
+        m_RMV.addToBlock(decl, m_RMV.m_Globals);
+      m_Ref = m_RMV.BuildDeclRef(VD);
+      return;
+    }
     // The counter's reset lives in the forward sweep, which an early return
     // taken before the loop never reaches -- while the master reverse sweep
     // still runs. Zero-init makes the reverse loop a no-op there.
@@ -5164,8 +5315,11 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
     addToCurrentBlock(bodyDiff.getStmt_dx(), direction::reverse);
     bodyDiff = {bodyDiff.getStmt(),
                 utils::unwrapIfSingleStmt(endBlock(direction::reverse))};
-    bodyDiff.updateStmt(utils::PrependAndCreateCompoundStmt(
-        m_Context, bodyDiff.getStmt(), counterIncrement));
+    // Null when the reverse sweep recomputes the iteration count instead of
+    // reading one the forward sweep kept.
+    if (counterIncrement)
+      bodyDiff.updateStmt(utils::PrependAndCreateCompoundStmt(
+          m_Context, bodyDiff.getStmt(), counterIncrement));
     return bodyDiff;
   }
 

--- a/test/Analyses/ActivityReverse.cpp
+++ b/test/Analyses/ActivityReverse.cpp
@@ -278,14 +278,13 @@ double f9(double x, double const *obs)
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0.;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (loopIdx0 = 0; loopIdx0 < 2; loopIdx0++) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, res);
 // CHECK-NEXT:         res += std::lgamma(obs[2 + loopIdx0] + 1) + x;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 2{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         loopIdx0--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             res = clad::pop(_t1);

--- a/test/Analyses/TBR.cpp
+++ b/test/Analyses/TBR.cpp
@@ -18,14 +18,13 @@ double f1(double x) {
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_t = 0.;
 //CHECK-NEXT:     double t = 1;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, t);
 //CHECK-NEXT:         t *= x;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_t += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         t = clad::pop(_t1);
 //CHECK-NEXT:         double _r_d0 = _d_t;
 //CHECK-NEXT:         _d_t = 0.;

--- a/test/Analyses/TBRLoopTapes.C
+++ b/test/Analyses/TBRLoopTapes.C
@@ -16,8 +16,8 @@
 #include <cstdio>
 
 // The pullback of `+` reads neither operand, so no iteration's y is wanted in
-// reverse and the tape holding them goes away. The loop counter that drives
-// the reverse sweep is not the tape's business and stays either way.
+// reverse and the tape holding them goes away. The trip count that drives the
+// reverse sweep is not the tape's business and stays either way.
 double sum(double x) {
   double y = 0;
   for (int i = 0; i < 3; ++i)
@@ -27,12 +27,12 @@ double sum(double x) {
 
 // CHECK-OFF-LABEL: void sum_grad(double x, double *_d_x) {
 // CHECK-OFF: clad::tape<double> _t1 = {};
-// CHECK-OFF: _t0++;
 // CHECK-OFF: clad::push(_t1, y);
+// CHECK-OFF: for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-OFF: y = clad::pop(_t1);
 
 // CHECK-TBR-LABEL: void sum_grad(double x, double *_d_x) {
-// CHECK-TBR: _t0++;
+// CHECK-TBR: for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-TBR-NOT: clad::tape<double>
 // CHECK-TBR-NOT: clad::push
 // CHECK-TBR-NOT: clad::pop

--- a/test/Arrays/ArrayInputsReverseMode.C
+++ b/test/Arrays/ArrayInputsReverseMode.C
@@ -18,13 +18,12 @@ double addArr(const double *arr, int n) {
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     double _d_ret = 0.;
 //CHECK-NEXT:     double ret = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         ret += arr[i];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_ret += _d_y;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r_d0 = _d_ret;
@@ -59,15 +58,14 @@ float func(float* a, float* b) {
 //CHECK-NEXT:     clad::tape<float> _t1 = {};
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, a[i]);
 //CHECK-NEXT:         a[i] *= b[i];
 //CHECK-NEXT:         sum += a[i];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             float _r_d1 = _d_sum;
@@ -103,13 +101,12 @@ float func2(float* a) {
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         sum += helper(a[i]);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         float _r_d0 = _d_sum;
 //CHECK-NEXT:         float _r0 = 0.F;
@@ -130,13 +127,12 @@ float func3(float* a, float* b) {
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         sum += (a[i] += b[i]);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         float _r_d0 = _d_sum;
 //CHECK-NEXT:         _d_a[i] += _r_d0;
@@ -161,13 +157,12 @@ double func4(double x) {
 //CHECK-NEXT:     double arr[3] = {x, 2 * x, x * x};
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r_d0 = _d_sum;
 //CHECK-NEXT:             int _r0 = 0;
@@ -209,20 +204,18 @@ double func5(int k) {
 //CHECK-NEXT:     double arr[n];
 //CHECK-NEXT:     double _d_arr[n];
 //CHECK-NEXT:     clad::zero_init(_d_arr, n);
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         arr[i] = k;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t1 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t1;
 //CHECK-NEXT:     for (i0 = 0; i0 < 3; i0++) {
-//CHECK-NEXT:         _t1++;
 //CHECK-NEXT:         sum += addArr(arr, n);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t1; _t1--) {
+//CHECK-NEXT:     for (_t1 = 3{{U|UL|ULL}}; _t1; _t1--) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r_d1 = _d_sum;
 //CHECK-NEXT:             int _r0 = 0;
@@ -230,7 +223,7 @@ double func5(int k) {
 //CHECK-NEXT:             _d_n += _r0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r_d0 = _d_arr[i];
@@ -258,14 +251,13 @@ double func6(double seed) {
 //CHECK-NEXT:     double arr[3] = {0};
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < 3; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, arr) , clad::move({seed, seed * i, seed + i}, arr);
 //CHECK-NEXT:         sum += addArr(arr, 3);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r_d0 = _d_sum;
@@ -314,14 +306,13 @@ double func7(double *params) {
 //CHECK-NEXT:     double paramsPrime[1] = {0};
 //CHECK-NEXT:     double _d_out = 0.;
 //CHECK-NEXT:     double out = 0.;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < 1; ++i) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::move({params[0]}, paramsPrime);
 //CHECK-NEXT:         out = out + inv_square(paramsPrime);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_out += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = 1{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r_d0 = _d_out;
 //CHECK-NEXT:             _d_out = 0.;
@@ -409,9 +400,8 @@ double func9(double i, double j) {
 //CHECK-NEXT:     int idx = 0;
 //CHECK-NEXT:     double _d_arr[5] = {0};
 //CHECK-NEXT:     double arr[5] = {};
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (idx = 0; idx < 5; ++idx) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         modify(arr[idx], i);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
@@ -421,7 +411,7 @@ double func9(double i, double j) {
 // CHECK-NEXT:         _d_arr[3] += 1;
 // CHECK-NEXT:         _d_arr[4] += 1;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 5{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         --idx;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r0 = 0.;
@@ -464,14 +454,13 @@ double func10(double *arr, int n) {
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_res = 0.;
 //CHECK-NEXT:     double res = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, arr[i]);
 // CHECK-NEXT:         res += sq(arr[i]);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         --i;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             double _r_d0 = _d_res;
@@ -500,16 +489,15 @@ double func11(double seed) {
 // CHECK-NEXT:    double arr[3];
 // CHECK-NEXT:    double _d_sum = 0.;
 // CHECK-NEXT:    double sum = 0;
-// CHECK-NEXT:    unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:    unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:    for (i = 0; i < 3; i++) {
-// CHECK-NEXT:        _t0++;
 // CHECK-NEXT:        arr[0] = seed;
 // CHECK-NEXT:        arr[1] = seed * i;
 // CHECK-NEXT:        arr[2] = seed + i;
 // CHECK-NEXT:        sum += addArr(arr, 3);
 // CHECK-NEXT:    }
 // CHECK-NEXT:    _d_sum += 1;
-// CHECK-NEXT:    for (; _t0; _t0--) {
+// CHECK-NEXT:    for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:        i--;
 // CHECK-NEXT:        {
 // CHECK-NEXT:            double _r_d3 = _d_sum;
@@ -550,13 +538,12 @@ double func12(double x[3], double y[3]) {
 //CHECK-NEXT:       int i = 0;
 //CHECK-NEXT:       double _d_prod = 0.;
 //CHECK-NEXT:       double prod = 0;
-//CHECK-NEXT:       unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:       unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:       for (i = 0; i < 3; ++i) {
-//CHECK-NEXT:           _t0++;
 //CHECK-NEXT:           prod += x[i] * y[i];
 //CHECK-NEXT:       }
 //CHECK-NEXT:       _d_prod += 1;
-//CHECK-NEXT:       for (; _t0; _t0--) {
+//CHECK-NEXT:       for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:           --i;
 //CHECK-NEXT:           double _r_d0 = _d_prod;
 //CHECK-NEXT:           _d_x[i] += _r_d0 * y[i];
@@ -581,14 +568,13 @@ double func13(double* x, double y) {
 // CHECK-NEXT:      double arr[4] = {0};
 // CHECK-NEXT:      double _d_prod = 0.;
 // CHECK-NEXT:      double prod = 0;
-// CHECK-NEXT:      unsigned {{int|long}} _t0 = 0;
+// CHECK-NEXT:      unsigned {{int|long}} _t0;
 // CHECK-NEXT:      for (i = 0; i < 2; ++i) {
-// CHECK-NEXT:          _t0++;
 // CHECK-NEXT:          clad::push(_t1, arr) , clad::move({1. + i, 0., y}, arr);
 // CHECK-NEXT:          prod += arr[0] * x[0] + arr[1] * x[1] + arr[2] * x[2] + arr[3] * x[3];
 // CHECK-NEXT:      }
 // CHECK-NEXT:      _d_prod += 1;
-// CHECK-NEXT:      for (; _t0; _t0--) {
+// CHECK-NEXT:      for (_t0 = 2{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:          {
 // CHECK-NEXT:              double _r_d0 = _d_prod;
 // CHECK-NEXT:              _d_arr[0] += _r_d0 * x[0];

--- a/test/CUDA/GradientCuda.cu
+++ b/test/CUDA/GradientCuda.cu
@@ -35,9 +35,8 @@ __device__ __host__ double gauss(const double* x, double* p, double sigma, int d
 //CHECK-NEXT:     int i = 0;
 //CHECK-NEXT:     double _d_t = 0.;
 //CHECK-NEXT:     double t = 0;
-//CHECK-NEXT:     unsigned long _t0 = 0;
+//CHECK-NEXT:     unsigned long _t0;
 //CHECK-NEXT:     for (i = 0; i < dim; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         t += (x[i] - p[i]) * (x[i] - p[i]);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     double _t1 = t;
@@ -68,7 +67,7 @@ __device__ __host__ double gauss(const double* x, double* p, double sigma, int d
 //CHECK-NEXT:         _d_sigma += 2 * _r0 * sigma;
 //CHECK-NEXT:         _d_sigma += 2 * sigma * _r0;
 //CHECK-NEXT:     }
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = dim > 0 ? (unsigned long)dim : 0UL; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         double _r_d0 = _d_t;
 //CHECK-NEXT:         _d_p[i] += -_r_d0 * (x[i] - p[i]);

--- a/test/CUDA/GradientKernels.cu
+++ b/test/CUDA/GradientKernels.cu
@@ -509,15 +509,14 @@ double fn_memory(double *out, double *in) {
 //CHECK-NEXT:    cudaMemcpy(out_host, out, 10 * sizeof(double), cudaMemcpyDeviceToHost);
 //CHECK-NEXT:    double _d_res = 0.;
 //CHECK-NEXT:    double res = 0;
-//CHECK-NEXT:    unsigned long _t0 = 0;
+//CHECK-NEXT:    unsigned long _t0;
 //CHECK-NEXT:    for (i = 0; i < 10; ++i) {
-//CHECK-NEXT:        _t0++;
 //CHECK-NEXT:        printf("Writing result of out[%d]\n", i);
 //CHECK-NEXT:        clad::push(_t1, res);
 //CHECK-NEXT:        res += out_host[i];
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_res += 1;
-//CHECK-NEXT:    for (; _t0; _t0--) {
+//CHECK-NEXT:    for (_t0 = 10UL; _t0; _t0--) {
 //CHECK-NEXT:        --i;
 //CHECK-NEXT:        {
 //CHECK-NEXT:            res = clad::pop(_t1);

--- a/test/CUDA/RunCudaDemos.C
+++ b/test/CUDA/RunCudaDemos.C
@@ -13,7 +13,7 @@
 // CHECK_PARTICLE_SIMULATION: void run_simulation_grad(thrust::device_vector<double> &x, thrust::device_vector<double> &y, const thrust::device_vector<double> &vx, const thrust::device_vector<double> &vy, const thrust::device_vector<double> &dts, thrust::device_vector<double> *_d_x, thrust::device_vector<double> *_d_y, thrust::device_vector<double> *_d_vx, thrust::device_vector<double> *_d_vy, thrust::device_vector<double> *_d_dts)
 // CHECK_PARTICLE_SIMULATION: for (i = 0; i < n_steps; ++i)
 // CHECK_PARTICLE_SIMULATION: clad::custom_derivatives::thrust::reduce_pullback
-// CHECK_PARTICLE_SIMULATION: for (; _t0; _t0--)
+// CHECK_PARTICLE_SIMULATION: for (_t0 = 5UL; _t0; _t0--)
 // CHECK_PARTICLE_SIMULATION: clad::custom_derivatives::thrust::copy_pullback
 // CHECK_PARTICLE_SIMULATION: clad::custom_derivatives::thrust::transform_pullback
 

--- a/test/ErrorEstimation/LoopsAndArrays.C
+++ b/test/ErrorEstimation/LoopsAndArrays.C
@@ -22,14 +22,13 @@ float func(float* p, int n) {
 //CHECK-NEXT:     unsigned {{int|long}} p_size = {{0U|0UL}};
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += p[i];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});
@@ -63,15 +62,14 @@ float func2(float x) {
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float _d_z = 0.F;
 //CHECK-NEXT:     float z;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < 9; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, m) , m = x * x;
 //CHECK-NEXT:         clad::push(_t2, z);
 //CHECK-NEXT:         z = m + m;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_z += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = 9{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_z * z * {{.+}});
@@ -155,16 +153,15 @@ float func4(float x[10], float y[10]) {
 //CHECK-NEXT:     clad::tape<float> _t2 = {};
 //CHECK-NEXT:     float _d_sum = 0.F;
 //CHECK-NEXT:     float sum = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < 10; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, x[i]);
 //CHECK-NEXT:         x[i] += y[i];
 //CHECK-NEXT:         clad::push(_t2, sum);
 //CHECK-NEXT:         sum += x[i];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = 10{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});
@@ -310,14 +307,13 @@ double func6(double x) {
 //CHECK-NEXT:     clad::tape<double> _t1 = {};
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long}} _t0;
 //CHECK-NEXT:     for (i = 1; i < 10; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += fun(x);
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = 9{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         sum = clad::pop(_t1);
 //CHECK-NEXT:         double _r0 = 0.;

--- a/test/ErrorEstimation/LoopsAndArraysExec.C
+++ b/test/ErrorEstimation/LoopsAndArraysExec.C
@@ -21,14 +21,13 @@ double runningSum(float* f, int n) {
 //CHECK-NEXT:     unsigned {{int|long}} f_size = {{0U|0UL}};
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 1; i < n; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += f[i] + f[i - 1];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = n > 1 ? ((unsigned {{int|long|long long}})n - 1{{U|UL|ULL}}) : 0{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});
@@ -58,33 +57,29 @@ double mulSum(float* a, float* b, int n) {
 //CHECK: void mulSum_grad(float *a, float *b, int n, float *_d_a, float *_d_b, int *_d_n, double &_final_error) {
 //CHECK-NEXT:     int _d_i = 0;
 //CHECK-NEXT:     int i = 0;
-//CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
-//CHECK-NEXT:     clad::tape<int> _t2 = {};
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t1;
 //CHECK-NEXT:     int _d_j = 0;
 //CHECK-NEXT:     int j = 0;
-//CHECK-NEXT:     clad::tape<double> _t3 = {};
-//CHECK-NEXT:     unsigned {{int|long}} b_size = {{0U|0UL}};
-//CHECK-NEXT:     unsigned {{int|long}} a_size = {{0U|0UL}};
+//CHECK-NEXT:     clad::tape<double> _t2 = {};
+//CHECK-NEXT:     unsigned {{int|long|long long}} b_size = 0{{U|UL|ULL}};
+//CHECK-NEXT:     unsigned {{int|long|long long}} a_size = 0{{U|UL|ULL}};
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
-//CHECK-NEXT:         clad::push(_t1, 0);
-//CHECK-NEXT:         for (clad::push(_t2, j) , j = 0; j < n; j++) {
-//CHECK-NEXT:             clad::back(_t1)++;
-//CHECK-NEXT:             clad::push(_t3, sum);
+//CHECK-NEXT:         for (j = 0; j < n; j++) {
+//CHECK-NEXT:             clad::push(_t2, sum);
 //CHECK-NEXT:             sum += a[i] * b[j];
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
-//CHECK-NEXT:             for (; clad::back(_t1); clad::back(_t1)--) {
+//CHECK-NEXT:             for (j = n > 0 ? n : 0 , _t1 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t1; _t1--) {
 //CHECK-NEXT:                 j--;
 //CHECK-NEXT:                 _final_error += std::abs(_d_sum * sum * {{.+}});
-//CHECK-NEXT:                 sum = clad::pop(_t3);
+//CHECK-NEXT:                 sum = clad::pop(_t2);
 //CHECK-NEXT:                 double _r_d0 = _d_sum;
 //CHECK-NEXT:                 b_size = std::max(b_size, j);
 //CHECK-NEXT:                 _d_a[i] += _r_d0 * b[j];
@@ -92,11 +87,7 @@ double mulSum(float* a, float* b, int n) {
 //CHECK-NEXT:                 _d_b[j] += a[i] * _r_d0;
 //CHECK-NEXT:                 b_size = std::max(b_size, j);
 //CHECK-NEXT:             }
-//CHECK-NEXT:             {
-//CHECK-NEXT:                 _d_j = 0;
-//CHECK-NEXT:                 j = clad::pop(_t2);
-//CHECK-NEXT:             }
-//CHECK-NEXT:             clad::pop(_t1);
+//CHECK-NEXT:             _d_j = 0;
 //CHECK-NEXT:         }
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _final_error += std::abs(_d_sum * sum * {{.+}});
@@ -124,14 +115,13 @@ double divSum(float* a, float* b, int n) {
 //CHECK-NEXT:     unsigned {{int|long}} a_size = {{0U|0UL}};
 //CHECK-NEXT:     double _d_sum = 0.;
 //CHECK-NEXT:     double sum = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < n; i++) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_t1, sum);
 //CHECK-NEXT:         sum += a[i] / b[i];
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_sum += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         i--;
 //CHECK-NEXT:         {
 //CHECK-NEXT:             _final_error += std::abs(_d_sum * sum * {{.+}});

--- a/test/Gradient/CountedReverseLoops.C
+++ b/test/Gradient/CountedReverseLoops.C
@@ -1,0 +1,491 @@
+// RUN: %cladclang %s -I%S/../../include -oCountedReverseLoops.out 2>&1 \
+// RUN:   | %filecheck %s
+// RUN: ./CountedReverseLoops.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s \
+// RUN:   -I%S/../../include -oCountedReverseLoops.out
+// RUN: ./CountedReverseLoops.out | %filecheck_exec %s
+
+// A loop whose iteration count the reverse sweep can recompute from the loop's
+// own bounds does not need the forward sweep to count for it. The useful half
+// of what follows is the negative half: every loop clad must keep counting,
+// because recomputing there would silently produce a wrong gradient rather
+// than a slow one.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cmath>
+#include <cstdio>
+
+// -- Recomputed ------------------------------------------------------------
+
+// A literal bound is known here, so the count is spelled out.
+double literalBound(const double* x) {
+  double s = 0;
+  for (int i = 0; i < 4; i++)
+    s += x[i] * x[i];
+  return s;
+}
+// CHECK: void literalBound_grad(const double *x, double *_d_x) {
+// CHECK-NOT: _t0++;
+// CHECK: for (_t0 = 4{{U|UL|ULL}}; _t0; _t0--) {
+
+// A constexpr variable, an enumerator or a template argument is as constant as
+// a literal, and is the usual way a dimension is written.
+constexpr int Dim = 3;
+double constexprBound(const double* x) {
+  double s = 0;
+  for (int i = 0; i < Dim; i++)
+    s += x[i] * x[i];
+  return s;
+}
+// CHECK: void constexprBound_grad(const double *x, double *_d_x) {
+// CHECK: for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
+
+// A parameter the primal never writes still reads the same in the reverse
+// sweep. The guard is the loop's own comparison, so a bound of zero or less
+// gives a count of zero rather than an enormous one.
+double paramBound(const double* x, int n) {
+  double s = 0;
+  for (int i = 0; i < n; i++)
+    s += x[i] * x[i];
+  return s;
+}
+// CHECK: void paramBound_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
+
+// An inclusive bound runs once more, and a non-zero start that many fewer.
+double inclusiveBound(const double* x, int n) {
+  double s = 0;
+  for (int i = 1; i <= n; i++)
+    s += x[i] * x[i];
+  return s;
+}
+// CHECK: void inclusiveBound_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: for (_t0 = n >= 1 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
+
+// Nested loops are where counting cost the most: the inner counter used to be
+// a whole clad::tape, pushed once per outer iteration. Recomputed, it is a
+// plain variable the inner reverse loop assigns on entry.
+double nested(const double* x) {
+  double s = 0;
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 2; ++j)
+      s += x[i] * x[j];
+  return s;
+}
+// CHECK: void nested_grad(const double *x, double *_d_x) {
+// CHECK-NOT: clad::tape<unsigned {{int|long|long long}}>
+// CHECK: for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
+// CHECK-NEXT: i--;
+// CHECK-NEXT: for (j = 2 , _t1 = 2{{U|UL|ULL}}; _t1; _t1--) {
+
+// A second index walked alongside the induction variable joins the increment
+// with a comma. That still steps the induction variable by one.
+double commaStep(const double* x) {
+  double s = 0;
+  int p = 0;
+  for (int i = 0; i < 4; i++, p++)
+    s += x[i] * p;
+  return s;
+}
+// CHECK: void commaStep_grad(const double *x, double *_d_x) {
+// CHECK: for (_t0 = 4{{U|UL|ULL}}; _t0; _t0--) {
+
+// The triangular loop -- the shape a packed symmetric matrix is walked with.
+// Its start is not loop-invariant at all: it names the enclosing induction
+// variable. That still reads correctly, because the reverse sweep steps the
+// outer variable back before it enters the inner reverse loop.
+double triangular(const double* x, int n) {
+  double s = 0;
+  for (int i = 0; i < n; i++)
+    for (int j = i + 1; j < n; j++)
+      s += x[i] * x[j];
+  return s;
+}
+// CHECK: void triangular_grad_0(const double *x, int n, double *_d_x) {
+// CHECK-NOT: clad::tape<unsigned {{int|long|long long}}>
+// CHECK: for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
+// CHECK-NEXT: i--;
+// CHECK-NEXT: for (j = n > i + 1 ? n : i + 1 , _t1 = n > i + 1 ? ((unsigned {{int|long|long long}})n - (unsigned {{int|long|long long}})(i + 1)) : 0{{U|UL|ULL}}; _t1; _t1--) {
+
+// A variadic argument travels by value, so a loop that reports its progress
+// still has an index only the increment moves. Handing it over for writing
+// reads as note("i", &i) instead, where taking the address is already a
+// write.
+int note(const char* tag, ...) { return 0; }
+double logsIndex(const double* x, int n) {
+  double s = 0;
+  for (int i = 0; i < n; i++) {
+    note("i", i);
+    s += x[i] * x[i];
+  }
+  return s;
+}
+// CHECK: void logsIndex_grad_0(const double *x, int n, double *_d_x) {
+// CHECK-NOT: _t0++;
+// CHECK: for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
+
+// A start the count has to carry a sign through, which is how a stencil walks
+// the halo either side of its centre.
+double negatedStart(const double* x, int n, int m) {
+  double s = 0;
+  for (int i = -m; i < n; i++)
+    s += x[i + 4] * x[i + 4];
+  return s;
+}
+// CHECK: void negatedStart_grad_0(const double *x, int n, int m, double *_d_x) {
+// CHECK-NOT: _t0++;
+// CHECK: for (_t0 = n > -m ? ((unsigned {{int|long|long long}})n - (unsigned {{int|long|long long}})-m) : 0{{U|UL|ULL}}; _t0; _t0--) {
+
+// An inclusive bound over a start that is not a constant. The start cannot
+// absorb the extra iteration the way a literal one does, so the count carries
+// it as its own term.
+double inclusiveVarStart(const double* x, int n, int lo) {
+  double s = 0;
+  for (int i = lo; i <= n; i++)
+    s += x[i] * x[i];
+  return s;
+}
+// CHECK: void inclusiveVarStart_grad_0(const double *x, int n, int lo, double *_d_x) {
+// CHECK-NOT: _t0++;
+// CHECK: for (_t0 = n >= lo ? ((unsigned {{int|long|long long}})n - (unsigned {{int|long|long long}})lo + 1{{U|UL|ULL}}) : 0{{U|UL|ULL}}; _t0; _t0--) {
+
+// -- Counted ---------------------------------------------------------------
+
+// An outer loop whose own bound it writes cannot have its trip count worked
+// out, so it keeps a counter. It is still a counted loop, so it still steps
+// its index back on the way into anything nested in it, and the inner loop
+// naming that index is recomputed even though the outer one is not.
+double outerUnstable(const double* x, int n) {
+  double s = 0;
+  for (int i = 0; i < n; ++i) {
+    if (i == 1)
+      n = 4;
+    for (int j = i + 1; j < 5; ++j)
+      s += x[j] * x[i];
+  }
+  return s;
+}
+// CHECK: void outerUnstable_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: _t0++;
+// CHECK: for (j = 5 > i + 1 ? 5 : i + 1 , _t1 = 5 > i + 1 ? ((unsigned {{int|long|long long}})5 - (unsigned {{int|long|long long}})(i + 1)) : 0{{U|UL|ULL}}; _t1; _t1--) {
+
+// The same inner loop, but the variable its start names belongs to a while
+// loop. Nothing steps that variable back on the way into the inner reverse
+// loop, so what the start would read there is not what the forward sweep saw.
+double triangularUnderWhile(const double* x, int n) {
+  double s = 0;
+  int i = 0;
+  while (i < n) {
+    for (int j = i + 1; j < n; j++)
+      s += x[i] * x[j];
+    i++;
+  }
+  return s;
+}
+// CHECK: void triangularUnderWhile_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: clad::tape<unsigned {{int|long|long long}}>
+
+// The index of the inner loop is declared outside it, so a statement after the
+// loop can read what the loop left there. Its pre-loop value has to be saved,
+// even though the count itself is still recomputed.
+double sharedIndex(const double* x, int n) {
+  double s = 0;
+  int j = 0;
+  for (int i = 0; i < n; i++)
+    for (j = i + 1; j < n; j++)
+      s += x[i] * x[j];
+  return s + j;
+}
+// CHECK: void sharedIndex_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: clad::tape<int> [[JT:_t[0-9]+]] = {};
+// CHECK: clad::push([[JT]], j);
+// CHECK-NEXT: for (j = i + 1; j < n; j++) {
+// CHECK: j = clad::pop([[JT]]);
+
+
+// The bound is written in the loop, so what it reads in the reverse sweep is
+// not what the forward sweep saw.
+double variableBound(const double* x, int n) {
+  double s = 0;
+  for (int i = 0; i < n; i++) {
+    s += x[i] * x[i];
+    n = n - 1;
+  }
+  return s;
+}
+// CHECK: void variableBound_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: _t0++;
+// CHECK: for (; _t0; _t0--) {
+
+// A `break` stops the loop before its bound says so.
+double earlyBreak(const double* x, int n) {
+  double s = 0;
+  for (int i = 0; i < n; i++) {
+    if (x[i] < 0)
+      break;
+    s += x[i] * x[i];
+  }
+  return s;
+}
+// CHECK: void earlyBreak_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: _t0++;
+
+// The body moves the induction variable itself.
+double skips(const double* x, int n) {
+  double s = 0;
+  for (int i = 0; i < n; i++) {
+    s += x[i] * x[i];
+    if (x[i] > 4)
+      i = i + 1;
+  }
+  return s;
+}
+// CHECK: void skips_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: _t0++;
+// CHECK: for (; _t0; _t0--) {
+
+// A callee moves it, through a non-const reference. Nothing at the loop says
+// so; only the parameter's type does.
+void advance(int& i) { i += 1; }
+double skipsViaCall(const double* x, int n) {
+  double s = 0;
+  for (int i = 0; i < n; i++) {
+    s += x[i] * x[i];
+    advance(i);
+  }
+  return s;
+}
+// CHECK: void skipsViaCall_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: _t0++;
+// CHECK: for (; _t0; _t0--) {
+
+// A bound whose address escapes may be written through the pointer.
+double escapedBound(const double* x, int n) {
+  int* p = &n;
+  double s = 0;
+  for (int i = 0; i < n; i++) {
+    s += x[i] * x[i];
+    *p = *p - 1;
+  }
+  return s;
+}
+// CHECK: void escapedBound_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: _t0++;
+// CHECK: for (; _t0; _t0--) {
+
+// The step is not one.
+double stride2(const double* x, int n) {
+  double s = 0;
+  for (int i = 0; i < n; i += 2)
+    s += x[i] * x[i];
+  return s;
+}
+// CHECK: void stride2_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: _t0++;
+// CHECK: for (; _t0; _t0--) {
+
+// Only `for` is recognised; an equivalent while loop is not.
+double whileLoop(const double* x, int n) {
+  double s = 0;
+  int i = 0;
+  while (i < n) {
+    s += x[i] * x[i];
+    i++;
+  }
+  return s;
+}
+// CHECK: void whileLoop_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: _t0++;
+
+// An early return elsewhere in the function can skip the forward loop while
+// the master reverse sweep still runs. A count recomputed there would be the
+// full one for a loop that never executed.
+double earlyReturn(const double* x, int n) {
+  if (n < 0)
+    return 0;
+  double s = 0;
+  for (int i = 0; i < 4; i++)
+    s += x[i] * x[i];
+  return s;
+}
+// CHECK: void earlyReturn_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: _t0++;
+
+// A bound in static storage is reachable from inside any callee, and a bound
+// reached through a reference names storage this walk does not follow. In
+// neither case does the body say the bound holds still between the sweeps.
+double staticBound(const double* x) {
+  static int sBound = 4;
+  double s = 0;
+  for (int i = 0; i < sBound; i++)
+    s += x[i] * x[i];
+  return s;
+}
+// CHECK: void staticBound_grad(const double *x, double *_d_x) {
+// CHECK: _t0++;
+// CHECK: for (; _t0; _t0--) {
+
+double refBound(const double* x, int& n) {
+  double s = 0;
+  for (int i = 0; i < n; i++)
+    s += x[i] * x[i];
+  return s;
+}
+// CHECK: void refBound_grad_0(const double *x, int &n, double *_d_x) {
+// CHECK: _t0++;
+// CHECK: for (; _t0; _t0--) {
+
+// A bound built with an operator the stability reading does not model. The
+// count would be right here, but `/` is not one of the three it proves
+// anything about, so the loop keeps counting.
+double dividedBound(const double* x, int n) {
+  double s = 0;
+  for (int i = 0; i < n / 2; i++)
+    s += x[i] * x[i];
+  return s;
+}
+// CHECK: void dividedBound_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: _t0++;
+// CHECK: for (; _t0; _t0--) {
+
+// -- Values ----------------------------------------------------------------
+
+#define CHECK_GRAD(NAME, N)                                                    \
+  do {                                                                         \
+    auto g = clad::gradient(NAME, "x");                                        \
+    double dx[8] = {0, 0, 0, 0, 0, 0, 0, 0};                                   \
+    g.execute(x, N, dx);                                                       \
+    bool ok = true;                                                            \
+    for (int k = 0; k < 8; k++) {                                              \
+      double xp[8], xm[8];                                                     \
+      for (int j = 0; j < 8; j++) {                                            \
+        xp[j] = x[j];                                                          \
+        xm[j] = x[j];                                                          \
+      }                                                                        \
+      xp[k] += h;                                                              \
+      xm[k] -= h;                                                              \
+      double fd = (NAME(xp, N) - NAME(xm, N)) / (2 * h);                       \
+      ok = ok && std::abs(dx[k] - fd) <= 1e-5 * std::max(1.0, std::abs(fd));   \
+    }                                                                          \
+    printf("%s(%d): %s\n", #NAME, (int)(N), ok ? "ok" : "MISMATCH");           \
+  } while (0)
+
+int main() {
+  const double h = 1e-5;
+  double x[8] = {0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5};
+
+  // Derivatives are dumped in the order they are first requested, so ask for
+  // them in the order the primals appear above and the checks above read
+  // alongside the code they check.
+  auto gl = clad::gradient(literalBound, "x");
+  auto gc = clad::gradient(constexprBound, "x");
+  clad::gradient(paramBound, "x");
+  clad::gradient(inclusiveBound, "x");
+  auto gn = clad::gradient(nested, "x");
+  auto gs = clad::gradient(commaStep, "x");
+  clad::gradient(triangular, "x");
+  clad::gradient(logsIndex, "x");
+  auto gns = clad::gradient(negatedStart, "x");
+  auto giv = clad::gradient(inclusiveVarStart, "x");
+  clad::gradient(outerUnstable, "x");
+  clad::gradient(triangularUnderWhile, "x");
+  clad::gradient(sharedIndex, "x");
+  clad::gradient(variableBound, "x");
+  clad::gradient(earlyBreak, "x");
+  clad::gradient(skips, "x");
+  clad::gradient(skipsViaCall, "x");
+  clad::gradient(escapedBound, "x");
+  clad::gradient(stride2, "x");
+  clad::gradient(whileLoop, "x");
+  clad::gradient(earlyReturn, "x");
+  auto gsb = clad::gradient(staticBound, "x");
+  auto grb = clad::gradient(refBound, "x");
+  clad::gradient(dividedBound, "x");
+
+  // The recomputed loops, including the counts a wrong recomputation would
+  // get wrong: an empty loop, and one whose bound is negative.
+  CHECK_GRAD(paramBound, 4);
+  CHECK_GRAD(paramBound, 0);
+  CHECK_GRAD(paramBound, -1);
+  CHECK_GRAD(inclusiveBound, 3);
+  CHECK_GRAD(inclusiveBound, 0);
+  // The triangular count depends on the enclosing loop's variable, so an
+  // off-by-one there would show up only as a wrong gradient.
+  CHECK_GRAD(triangular, 6);
+  CHECK_GRAD(triangular, 1);
+  // The inner count names the outer index while the outer loop rewrites its
+  // own bound mid-flight, so a wrong step-back would show up only here.
+  CHECK_GRAD(outerUnstable, 3);
+  CHECK_GRAD(triangularUnderWhile, 6);
+  CHECK_GRAD(sharedIndex, 6);
+  CHECK_GRAD(dividedBound, 7);
+  // CHECK-EXEC: paramBound(4): ok
+  // CHECK-EXEC: paramBound(0): ok
+  // CHECK-EXEC: paramBound(-1): ok
+  // CHECK-EXEC: inclusiveBound(3): ok
+  // CHECK-EXEC: inclusiveBound(0): ok
+  // CHECK-EXEC: triangular(6): ok
+  // CHECK-EXEC: triangular(1): ok
+  // CHECK-EXEC: outerUnstable(3): ok
+  // CHECK-EXEC: triangularUnderWhile(6): ok
+  // CHECK-EXEC: sharedIndex(6): ok
+  // CHECK-EXEC: dividedBound(7): ok
+
+  // The counted ones, where a recomputed count would disagree with the number
+  // of iterations the forward sweep actually ran.
+  CHECK_GRAD(variableBound, 6);
+  CHECK_GRAD(skips, 6);
+  // skipsViaCall is checked above for the code clad emits, but not for its
+  // value: advance_pullback replays `i += 1` without restoring i, so the
+  // reverse sweep indexes one past where the forward sweep was. That is a
+  // separate defect in the pullback of an int taken by non-const reference,
+  // unrelated to how the loop is counted.
+  CHECK_GRAD(escapedBound, 6);
+  CHECK_GRAD(stride2, 7);
+  CHECK_GRAD(whileLoop, 5);
+  CHECK_GRAD(earlyReturn, 2);
+  // CHECK-EXEC: variableBound(6): ok
+  // CHECK-EXEC: skips(6): ok
+  // CHECK-EXEC: escapedBound(6): ok
+  // CHECK-EXEC: stride2(7): ok
+  // CHECK-EXEC: whileLoop(5): ok
+  // CHECK-EXEC: earlyReturn(2): ok
+
+  // The bound-free ones take no count argument.
+  double dl[8] = {0}, dc[8] = {0}, dn[8] = {0}, ds[8] = {0};
+  gl.execute(x, dl);
+  gc.execute(x, dc);
+  gn.execute(x, dn);
+  gs.execute(x, ds);
+  printf("literalBound: %.2f %.2f\n", dl[0], dl[3]);
+  // CHECK-EXEC: literalBound: 1.00 7.00
+  printf("constexprBound: %.2f %.2f\n", dc[0], dc[2]);
+  // CHECK-EXEC: constexprBound: 1.00 5.00
+  // nested() is (x0+x1+x2)*(x0+x1), so d/dx0 = (x0+x1) + (x0+x1+x2) = 6.5 and
+  // d/dx2 = (x0+x1) = 2.
+  printf("nested: %.2f %.2f\n", dn[0], dn[2]);
+  // CHECK-EXEC: nested: 6.50 2.00
+  printf("commaStep: %.2f %.2f\n", ds[0], ds[3]);
+  // CHECK-EXEC: commaStep: 0.00 3.00
+
+  // A sign carried through the count, an inclusive bound over a variable
+  // start, and a bound the loop cannot claim: all three are wrong by a whole
+  // iteration if the count is.
+  double dns[8] = {0}, dvs[8] = {0}, dsb[8] = {0};
+  gns.execute(x, 3, 2, dns);
+  printf("negatedStart: %.2f %.2f\n", dns[2], dns[6]);
+  // CHECK-EXEC: negatedStart: 5.00 13.00
+  giv.execute(x, 3, 1, dvs);
+  printf("inclusiveVarStart: %.2f %.2f\n", dvs[1], dvs[3]);
+  // CHECK-EXEC: inclusiveVarStart: 3.00 7.00
+  gsb.execute(x, dsb);
+  printf("staticBound: %.2f %.2f\n", dsb[0], dsb[3]);
+  // CHECK-EXEC: staticBound: 1.00 7.00
+  double drb[8] = {0};
+  int rn = 4;
+  grb.execute(x, rn, drb);
+  printf("refBound: %.2f %.2f\n", drb[0], drb[3]);
+  // CHECK-EXEC: refBound: 1.00 7.00
+  return 0;
+}

--- a/test/Gradient/FunctionCalls.C
+++ b/test/Gradient/FunctionCalls.C
@@ -149,10 +149,8 @@ float sum(double* arr, int n) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     float _d_res = 0;
 // CHECK-NEXT:     float res = 0;
-// CHECK-NEXT:     _t0 = 0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     for (int i = 0; i < n; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         res += arr[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _tracker0.store(arr[0]);
@@ -165,9 +163,8 @@ float sum(double* arr, int n) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     float _d_res = 0.F;
 // CHECK-NEXT:     float res = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         res += arr[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     arr[0] += 10 * arr[0];
@@ -176,7 +173,7 @@ float sum(double* arr, int n) {
 // CHECK-NEXT:         double _r_d1 = _d_arr[0];
 // CHECK-NEXT:         _d_arr[0] += 10 * _r_d1;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         float _r_d0 = _d_res;
 // CHECK-NEXT:         _d_arr[i] += _r_d0;
@@ -216,15 +213,14 @@ double fn4(double* arr, int n) {
 // CHECK-NEXT:     double res = 0;
 // CHECK-NEXT:     clad::record_range(_rec0, arr, 1UL);
 // CHECK-NEXT:     res += sum(arr, n);
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, arr[i]);
 // CHECK-NEXT:         twice(arr[i]);
 // CHECK-NEXT:         res += arr[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d1 = _d_res;
@@ -576,13 +572,12 @@ double fn13(double* x, const double* w) {
 // CHECK-NEXT:     std::size_t i = {{0U|0UL}};
 // CHECK-NEXT:     double _d_wCopy[2] = {0};
 // CHECK-NEXT:     double wCopy[2];
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 2; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         wCopy[i] = w[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     multiply_pullback(x, wCopy + 1, 1, _d_x, _d_wCopy + 1);
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 2{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = _d_wCopy[i];
@@ -905,10 +900,8 @@ void mult(double* x, double y) {
 
 // CHECK: void mult_reverse_forw(double *x, double y, double *_d_x, double _d_y, clad::restore_tracker &_tracker0) {
 // CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
-// CHECK-NEXT:     _t0 = 0;
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     for (int i = 0; i < 3; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         _tracker0.store(x[i]);
 // CHECK-NEXT:         x[i] *= y;
 // CHECK-NEXT:     }
@@ -918,13 +911,12 @@ void mult(double* x, double y) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 3; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, x[i]);
 // CHECK-NEXT:         x[i] *= y;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             x[i] = clad::pop(_t1);
@@ -1104,13 +1096,12 @@ inline double flexibleInterp(double const *params, const double *high) {
 // CHECK-NEXT:     std::size_t i = {{0U|0UL}};
 // CHECK-NEXT:     double _d_total = 0.;
 // CHECK-NEXT:     double total = 1.;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 1; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         total += params[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_total += _d_y;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 1{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         double _r_d0 = _d_total;
 // CHECK-NEXT:         _d_params[i] += _r_d0;
@@ -1521,13 +1512,12 @@ double fn25_defined_later(double x) {
 // CHECK-NEXT:     std::size_t i = {{0U|0UL}};
 // CHECK-NEXT:     double _d_total = 0.;
 // CHECK-NEXT:     double total = 1.;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 1; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         total += params[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_total += _d_y;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 1{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         double _r_d0 = _d_total;
 // CHECK-NEXT:         _d_params[i] += _r_d0;

--- a/test/Gradient/Gradients.C
+++ b/test/Gradient/Gradients.C
@@ -659,13 +659,12 @@ float running_sum(float* p, int n) {
 // CHECK: void running_sum_grad(float *p, int n, float *_d_p, int *_d_n) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 1; i < n; i++) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         p[i] += p[i - 1];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_p[n - 1] += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = n > 1 ? ((unsigned {{int|long|long long}})n - 1{{U|UL|ULL}}) : 0{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             float _r_d0 = _d_p[i];

--- a/test/Gradient/Loops.C
+++ b/test/Gradient/Loops.C
@@ -23,14 +23,13 @@ double f1(double x) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_t = 0.;
 // CHECK-NEXT:     double t = 1;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 3; i++) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, t);
 // CHECK-NEXT:         t *= x;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         t = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_t;
 // CHECK-NEXT:         _d_t = 0.;
@@ -50,25 +49,22 @@ double f2(double x) {
 // CHECK: void f2_grad(double x, double *_d_x) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     clad::tape<unsigned {{int|long|long long}}> _t1 = {};
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t1;
 // CHECK-NEXT:     int _d_j = 0;
 // CHECK-NEXT:     int j = 0;
 // CHECK-NEXT:     clad::tape<double> _t2 = {};
 // CHECK-NEXT:     double _d_t = 0.;
 // CHECK-NEXT:     double t = 1;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 3; i++) {
-// CHECK-NEXT:         _t0++;
-// CHECK-NEXT:        clad::push(_t1, 0);
 // CHECK-NEXT:         for (j = 0; j < 3; j++) {
-// CHECK-NEXT:             clad::back(_t1)++;
 // CHECK-NEXT:             clad::push(_t2, t);
 // CHECK-NEXT:             t *= x;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_t += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
-// CHECK-NEXT:         for (; clad::back(_t1); clad::back(_t1)--) {
+// CHECK-NEXT:     for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
+// CHECK-NEXT:         for (j = 3 , _t1 = 3{{U|UL|ULL}}; _t1; _t1--) {
 // CHECK-NEXT:             t = clad::pop(_t2);
 // CHECK-NEXT:             double _r_d0 = _d_t;
 // CHECK-NEXT:             _d_t = 0.;
@@ -76,7 +72,6 @@ double f2(double x) {
 // CHECK-NEXT:             *_d_x += t * _r_d0;
 // CHECK-NEXT:         }
 // CHECK-NEXT:         _d_j = 0;
-// CHECK-NEXT:         clad::pop(_t1);
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -167,9 +162,8 @@ double f5(double x){
 // CHECK: void f5_grad(double x, double *_d_x) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 10; i++) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         x++;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_x += 1;
@@ -192,14 +186,13 @@ double f_const_local(double x) {
 // CHECK-NEXT:     double n = 0.;
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 3; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, n) , n = x + i;
 // CHECK-NEXT:         res += x * n;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             *_d_x += _d_res * n;
 // CHECK-NEXT:             _d_n += x * _d_res;
@@ -226,13 +219,12 @@ double f_sum(double *p, int n) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     double _d_s = 0.;
 // CHECK-NEXT:     double s = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < n; i++) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         s += p[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_s += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         double _r_d0 = _d_s;
 // CHECK-NEXT:         _d_p[i] += _r_d0;
@@ -257,13 +249,12 @@ double f_sum_squares(double *p, int n) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     double _d_s = 0.;
 // CHECK-NEXT:     double s = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < n; i++) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         s += sq(p[i]);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_s += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         i--;
 // CHECK-NEXT:         double _r_d0 = _d_s;
 // CHECK-NEXT:         double _r0 = 0.;
@@ -392,16 +383,15 @@ double f6 (double i, double j) {
 // CHECK-NEXT:     double c = 0.;
 // CHECK-NEXT:     double _d_a = 0.;
 // CHECK-NEXT:     double a = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (counter = 0; counter < 3; ++counter) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         b = i * i;
 // CHECK-NEXT:         c = j * j;
 // CHECK-NEXT:         b += j;
 // CHECK-NEXT:         a += b + c + i;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_a += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             _d_b += _d_a;
 // CHECK-NEXT:             _d_c += _d_a;
@@ -1269,16 +1259,15 @@ double fn19(double* arr, int n) {
 // CHECK-NEXT:     double *ref = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         _d_ref = &_d_arr[i];
 // CHECK-NEXT:         clad::push(_t1, _d_ref);
 // CHECK-NEXT:         ref = &arr[i];
 // CHECK-NEXT:         res += *ref;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         _d_ref = clad::pop(_t1);
 // CHECK-NEXT:         {
@@ -1349,13 +1338,12 @@ double fn20(double *arr, int n) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < n; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         res += (arr[i] *= 5);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = _d_res;
@@ -1384,14 +1372,13 @@ double fn21(double x) {
 // CHECK-NEXT:     double arr[3] = {0};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::move({1, x, 2}, arr);
 // CHECK-NEXT:         res += arr[0] + arr[1];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 5{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = _d_res;
 // CHECK-NEXT:             _d_arr[0] += _r_d0;
@@ -1422,14 +1409,13 @@ double fn22(double param) {
 // CHECK-NEXT:     double arr[1] = {0};
 // CHECK-NEXT:     double _d_out = 0.;
 // CHECK-NEXT:     double out = 0.;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 1; i++) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, arr) , clad::move({1.}, arr);
 // CHECK-NEXT:         out += arr[0] * param;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 1{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = _d_out;
 // CHECK-NEXT:             _d_arr[0] += _r_d0 * param;
@@ -2681,14 +2667,13 @@ double fn43(double* x, double y) {
 //CHECK-NEXT:    double t4 = 0.;
 //CHECK-NEXT:    double _d_out = 0.;
 //CHECK-NEXT:    double out = 0.;
-//CHECK-NEXT:    unsigned {{int|long}} _t0 = 0;
+//CHECK-NEXT:    unsigned {{int|long}} _t0;
 //CHECK-NEXT:    for (i = 0; i < 3; i++) {
-//CHECK-NEXT:        _t0++;
 //CHECK-NEXT:        clad::push(_t1, t4) , t4 = x[i];
 //CHECK-NEXT:        out += 1. / t4;
 //CHECK-NEXT:    }
 //CHECK-NEXT:    _d_out += 1;
-//CHECK-NEXT:    for (; _t0; _t0--) {
+//CHECK-NEXT:    for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:        i--;
 //CHECK-NEXT:        {
 //CHECK-NEXT:            double _r0 = _d_out * -(1. / (t4 * t4));
@@ -2761,15 +2746,14 @@ double fn45(double x, double y) {
 // CHECK-NEXT:     double t2 = 0.;
 // CHECK-NEXT:     double _d_sum = 0.;
 // CHECK-NEXT:     double sum = 0;
-// CHECK-NEXT:     unsigned {{int|long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 100; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         t1 = x;
 // CHECK-NEXT:         t2 = y / t1;
 // CHECK-NEXT:         sum += std::pow(t2, 2);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_sum += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 100{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         t1 = x;
 // CHECK-NEXT:         t2 = y / t1;
 // CHECK-NEXT:         sum += std::pow(t2, 2);

--- a/test/Gradient/ReverseForw.C
+++ b/test/Gradient/ReverseForw.C
@@ -183,15 +183,14 @@ double f4(double x) {
 //CHECK-NEXT:     clad::tape<clad::ValueAndAdjoint<double *, double *> > _t1 = {};
 //CHECK-NEXT:     double _d_r = 0.;
 //CHECK-NEXT:     double r = 0;
-//CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+//CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 //CHECK-NEXT:     for (i = 0; i < 2; ++i) {
-//CHECK-NEXT:         _t0++;
 //CHECK-NEXT:         clad::push(_tracker0, clad::restore_tracker());
 //CHECK-NEXT:         clad::push(_t1, mul2_reverse_forw(&x, _d_x, clad::back(_tracker0)));
 //CHECK-NEXT:         r += *clad::back(_t1).value;
 //CHECK-NEXT:     }
 //CHECK-NEXT:     _d_r += 1;
-//CHECK-NEXT:     for (; _t0; _t0--) {
+//CHECK-NEXT:     for (_t0 = 2{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK-NEXT:         *clad::back(_t1).adjoint += _d_r;
 //CHECK-NEXT:         clad::back(_tracker0).restore();
 //CHECK-NEXT:         mul2_pullback(&x, _d_x);

--- a/test/Gradient/STLCustomDerivatives.C
+++ b/test/Gradient/STLCustomDerivatives.C
@@ -605,13 +605,12 @@ int main() {
 // CHECK-NEXT:        {{.*}}fill_reverse_forw(&a, x, &_d_a, *_d_x);
 // CHECK-NEXT:        double _d_res = 0.;
 // CHECK-NEXT:        double res = 0;
-// CHECK-NEXT:        unsigned {{long|int}} _t1 = 0;
+// CHECK-NEXT:        unsigned {{long|int}} _t1;
 // CHECK-NEXT:        for (i = 0; i < a.size(); ++i) {
-// CHECK-NEXT:            _t1++;
 // CHECK-NEXT:            res += a.at(i);
 // CHECK-NEXT:        }
 // CHECK-NEXT:        _d_res += 1;
-// CHECK-NEXT:        for (; _t1; _t1--) {
+// CHECK-NEXT:        for (_t1 = 3{{U|UL|ULL}}; _t1; _t1--) {
 // CHECK-NEXT:            --i;
 // CHECK-NEXT:            {
 // CHECK-NEXT:                double _r_d0 = _d_res;
@@ -731,9 +730,8 @@ int main() {
 // CHECK-NEXT:          size_t i0 = {{0U|0UL|0}};
 // CHECK-NEXT:          {{.*}}vector<double> v;
 // CHECK-NEXT:          {{.*}}vector<double> _d_v;
-// CHECK-NEXT:          {{.*}} _t0 = {{0U|0UL|0}};
+// CHECK-NEXT:          {{.*}} _t0;
 // CHECK-NEXT:          for (i = 0; i < 3; ++i) {
-// CHECK-NEXT:              _t0++;
 // CHECK-NEXT:              {{.*}}push(_t1, v);
 // CHECK-NEXT:              {{.*}}push_back_reverse_forw(&v, x, &_d_v, *_d_x);
 // CHECK-NEXT:          }
@@ -772,7 +770,7 @@ int main() {
 // CHECK-NEXT:                  _d_v.at(i0) += _r_d0;
 // CHECK-NEXT:              }
 // CHECK-NEXT:          }
-// CHECK-NEXT:          for (; _t0; _t0--) {
+// CHECK-NEXT:          for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:              {
 // CHECK-NEXT:                  v = {{.*}}back(_t1);
 // CHECK-NEXT:                  {{.*}}push_back_pullback(&v, x, &_d_v, _d_x);
@@ -863,9 +861,8 @@ int main() {
 // CHECK-NEXT:      clad::tape<{{.*}}value_type> _t4 = {};
 // CHECK-NEXT:      {{.*}}allocator_type alloc;
 // CHECK-NEXT:      {{.*}}allocator_type _d_alloc;
-// CHECK-NEXT:      unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:      unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:      for (i = 0; i < 3; ++i) {
-// CHECK-NEXT:          _t0++;
 // CHECK-NEXT:          clad::push(_t1, std::move(_d_ls));
 // CHECK-NEXT:          clad::push(_t2, std::move(ls)) , ls = {u, v}, alloc;
 // CHECK-NEXT:          _d_ls = {0., 0.}, _d_alloc;
@@ -875,7 +872,7 @@ int main() {
 // CHECK-NEXT:          u = ls[1];
 // CHECK-NEXT:      }
 // CHECK-NEXT:      *_d_u += 1;
-// CHECK-NEXT:      for (; _t0; _t0--) {
+// CHECK-NEXT:      for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:          {
 // CHECK-NEXT:              double _r_d1 = *_d_u;
 // CHECK-NEXT:              *_d_u = 0.;
@@ -968,9 +965,8 @@ int main() {
 // CHECK-NEXT:     std::vector<double> _d_ls{};
 // CHECK-NEXT:     clad::tape<value_type *> _t3 = {};
 // CHECK-NEXT:     clad::tape<value_type> _t4 = {};
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 3; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, std::move(_d_ls));
 // CHECK-NEXT:         clad::push(_t2, std::move(ls)) , ls = {{.*{u, v}.*}};
 // CHECK-NEXT:         _d_ls = {{.*}}{0., 0.}{{.*}};
@@ -980,7 +976,7 @@ int main() {
 // CHECK-NEXT:         u = ls[1];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_u += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d1 = *_d_u;
 // CHECK-NEXT:             *_d_u = 0.;
@@ -1045,20 +1041,18 @@ int main() {
 // CHECK-NEXT:     int _d_id0 = 0;
 // CHECK-NEXT:     int id0 = 0;
 // CHECK-NEXT:     const Session &sess = session[0];
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (id = 0; id < nVals; id++) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         sess.arr[id] = tensor_x[id] * tensor_theory_params[0];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     float _d_out = 0.F;
 // CHECK-NEXT:     float out = 0.;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t1 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t1;
 // CHECK-NEXT:     for (id0 = 0; id0 < nVals; id0++) {
-// CHECK-NEXT:         _t1++;
 // CHECK-NEXT:         out += std::exp(-sess.arr[id0]);
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
-// CHECK-NEXT:     for (; _t1; _t1--) {
+// CHECK-NEXT:     for (_t1 = 2{{U|UL|ULL}}; _t1; _t1--) {
 // CHECK-NEXT:         id0--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             float _r_d0 = _d_out;
@@ -1066,7 +1060,7 @@ int main() {
 // CHECK-NEXT:             _r0 += _r_d0 * clad::custom_derivatives::std::exp_pushforward(-sess.arr[id0], 1.F).pushforward;
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 2{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         id--;
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
@@ -1078,13 +1072,12 @@ int main() {
 // CHECK-NEXT:     float *const &arr = sess.arr;
 // CHECK-NEXT:     float _d_out = 0.F;
 // CHECK-NEXT:     float out = 0.;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (id = 0; id < nVals; id++) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         out += arr[id] * tensor_theory_params[0];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_out += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 2{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         id--;
 // CHECK-NEXT:         {
 // CHECK-NEXT:             float _r_d0 = _d_out;

--- a/test/Gradient/TestTypeConversion.C
+++ b/test/Gradient/TestTypeConversion.C
@@ -20,14 +20,13 @@ void fn_type_conversion_grad(float z, int a, float *_d_z, int *_d_a);
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<float> _t1 = {};
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 1; i < a; i++) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, z);
 // CHECK-NEXT:         z = z * a;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     *_d_z += 1;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = a > 1 ? ((unsigned {{int|long|long long}})a - 1{{U|UL|ULL}}) : 0{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             z = clad::pop(_t1);
 // CHECK-NEXT:             float _r_d0 = *_d_z;

--- a/test/Gradient/UserDefinedTypes.C
+++ b/test/Gradient/UserDefinedTypes.C
@@ -59,13 +59,12 @@ double sum(Tangent& t) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         res += t.data[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += _d_y;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 5{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         double _r_d0 = _d_res;
 // CHECK-NEXT:         (*_d_t).data[i] += _r_d0;
@@ -84,13 +83,12 @@ double sum(double *data) {
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         res += data[i];
 // CHECK-NEXT:     }
 // CHECK-NEXT:     _d_res += _d_y;
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 5{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         double _r_d0 = _d_res;
 // CHECK-NEXT:         _d_data[i] += _r_d0;
@@ -283,13 +281,12 @@ double fn8(Tangent t, dcomplex c) {
 // CHECK-NEXT:     int _d_i = 0;
 // CHECK-NEXT:     int i = 0;
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         clad::push(_t1, this->data[i]);
 // CHECK-NEXT:         this->data[i] = d;
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 5{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         --i;
 // CHECK-NEXT:         this->data[i] = clad::pop(_t1);
 // CHECK-NEXT:         double _r_d0 = _d_this->data[i];
@@ -323,9 +320,8 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:     clad::tape<double> _t1 = {};
 // CHECK-NEXT:     double _d_res = 0.;
 // CHECK-NEXT:     double res = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 5; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         res += c.real() + 2 * clad::push(_t1, c.imag());
 // CHECK-NEXT:     }
 // CHECK-NEXT:     res += sum(t);
@@ -334,7 +330,7 @@ double fn9(Tangent t, dcomplex c) {
 // CHECK-NEXT:         double _r_d1 = _d_res;
 // CHECK-NEXT:         sum_pullback(t, _r_d1, _d_t);
 // CHECK-NEXT:     }
-// CHECK-NEXT:     for (; _t0; _t0--) {
+// CHECK-NEXT:     for (_t0 = 5{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:         {
 // CHECK-NEXT:             double _r_d0 = _d_res;
 // CHECK-NEXT:             c.real_pullback(_r_d0, _d_c);
@@ -1079,27 +1075,25 @@ float fn29(float *input, Session const *session) {
 // CHECK-NEXT:      float buffer[5]{0., 0., 0., 0., 0};
 // CHECK-NEXT:      size_t _d_n = {{0U|0UL|0ULL}};
 // CHECK-NEXT:      const size_t n = 5;
-// CHECK-NEXT:      unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:      unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:      for (id = 0; id < n; id++) {
-// CHECK-NEXT:          _t0++;
 // CHECK-NEXT:          buffer[id] = sess.factors[id] * input[id];
 // CHECK-NEXT:      }
 // CHECK-NEXT:      float _d_out = 0.F;
 // CHECK-NEXT:      float out = 0.;
-// CHECK-NEXT:      unsigned {{int|long|long long}} _t1 = 0;
+// CHECK-NEXT:      unsigned {{int|long|long long}} _t1;
 // CHECK-NEXT:      for (id0 = 0; id0 < n; id0++) {
-// CHECK-NEXT:          _t1++;
 // CHECK-NEXT:          out += input[id0];
 // CHECK-NEXT:      }
 // CHECK-NEXT:      _d_out += 1;
-// CHECK-NEXT:      for (; _t1; _t1--) {
+// CHECK-NEXT:      for (_t1 = 5{{U|UL|ULL}}; _t1; _t1--) {
 // CHECK-NEXT:          id0--;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              float _r_d1 = _d_out;
 // CHECK-NEXT:              _d_input[id0] += _r_d1;
 // CHECK-NEXT:          }
 // CHECK-NEXT:      }
-// CHECK-NEXT:      for (; _t0; _t0--) {
+// CHECK-NEXT:      for (_t0 = 5{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:          id--;
 // CHECK-NEXT:          {
 // CHECK-NEXT:              float _r_d0 = _d_buffer[id];

--- a/test/Hessian/TBR.C
+++ b/test/Hessian/TBR.C
@@ -43,9 +43,7 @@ double linearAndNonlinear(double x, double y) {
 // CHECK-NEXT:     double s = a;
 // CHECK-NEXT:     {
 // CHECK-NEXT:         _d_i = 0;
-// CHECK-NEXT:         _t0 = 0;
 // CHECK-NEXT:         for (i = 0; i < 3; ++i) {
-// CHECK-NEXT:             _t0++;
 // CHECK-NEXT:             _d_s = _d_s + _d_a;
 // CHECK-NEXT:             s = s + a;
 // CHECK-NEXT:             clad::push(_t1, _d_a);
@@ -63,7 +61,7 @@ double linearAndNonlinear(double x, double y) {
 // CHECK-NEXT:         _d_d_a += s * _d_y0.pushforward;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     {
-// CHECK-NEXT:         for (; _t0; _t0--) {
+// CHECK-NEXT:         for (_t0 = 3{{U|UL|ULL}}; _t0; _t0--) {
 // CHECK-NEXT:             {
 // CHECK-NEXT:                 a = clad::pop(_t2);
 // CHECK-NEXT:                 double _r_d3 = _d_a0;

--- a/test/Misc/RunDemos.C
+++ b/test/Misc/RunDemos.C
@@ -108,14 +108,13 @@
 //CHECK_FLOAT_SUM:    clad::tape<float> _t1 = {};
 //CHECK_FLOAT_SUM:    float _d_sum = 0.F;
 //CHECK_FLOAT_SUM:    float sum = 0.;
-//CHECK_FLOAT_SUM:    unsigned {{int|long|long long}} _t0 = 0;
+//CHECK_FLOAT_SUM:    unsigned {{int|long|long long}} _t0;
 //CHECK_FLOAT_SUM:    for (i = 0; i < n; i++) {
-//CHECK_FLOAT_SUM:        _t0++;
 //CHECK_FLOAT_SUM:        clad::push(_t1, sum);
 //CHECK_FLOAT_SUM:        sum = sum + x;
 //CHECK_FLOAT_SUM:    }
 //CHECK_FLOAT_SUM:    _d_sum += 1;
-//CHECK_FLOAT_SUM:    for (; _t0; _t0--) {
+//CHECK_FLOAT_SUM:    for (_t0 = n > 0 ? (unsigned {{int|long|long long}})n : 0{{U|UL|ULL}}; _t0; _t0--) {
 //CHECK_FLOAT_SUM:        i--;
 //CHECK_FLOAT_SUM:        {
 //CHECK_FLOAT_SUM:            _final_error += std::abs(_d_sum * sum * 1.1920928955078125E-7);

--- a/test/Regressions/issue-1283.cpp
+++ b/test/Regressions/issue-1283.cpp
@@ -33,9 +33,8 @@ int main() {
 // CHECK-NEXT:     Struct s = {0.};
 // CHECK-NEXT:     double _d_result = 0.;
 // CHECK-NEXT:     double result = 0;
-// CHECK-NEXT:     unsigned {{int|long|long long}} _t0 = 0;
+// CHECK-NEXT:     unsigned {{int|long|long long}} _t0;
 // CHECK-NEXT:     for (i = 0; i < 3; ++i) {
-// CHECK-NEXT:         _t0++;
 // CHECK-NEXT:         s = {0.};
 // CHECK-NEXT:         s.val = a * (i + 1);
 // CHECK-NEXT:         result += s.val;


### PR DESCRIPTION
clad declared a counter beside every loop, incremented it once per iteration, and drove the reverse loop off it. A nested loop's counter had to be a clad::tape, constructed and destroyed per call. The count is already implied by the loop's own bounds, so the forward sweep was carrying a value it could have worked out.

Where the loop is counted -- an integer stepped by one from a stable start while it stays below a stable bound, with no early exit -- the reverse sweep now works the count out for itself and the forward sweep stops carrying it. That shape is the one LoopAnalyzer already recognises for the written-extent analysis, so read it from there rather than matching it a second time, and add the conditions this caller needs on top.

Those conditions are where the soundness lives. An early return can skip the forward loop while the master reverse sweep still runs, so a recomputed count would be the full one for a loop that never ran. The bound has to be stable rather than merely loop-invariant, because the reverse sweep reads it long after the forward one did, so anything the primal writes anywhere disqualifies it. The induction variable must not be written by the body, including through a callee taking it by non-const reference. Answering "does this body write that variable" is easy to get wrong one case at a time -- an assignment or an increment, but equally a taken address, a bind to a non-const reference, an asm operand or a lambda capture -- so utils::collectWrittenVars answers it in one place, over- approximating on purpose, and the request caches the per-function answer.

A nested loop may name an enclosing loop's index in its bounds, which is what makes the triangular `for (j = i + 1; j < d; ++j)` work: the reverse sweep steps the outer index back before entering the reverse of anything nested in it. Only loops recognised as counted contribute one.

Measured on benchmark/ReplayFreePullbacks.cpp as it stands, d=8, k=4, n=512, built for arm64 so the figures are native rather than emulated, with the rail's own check holding the two gradients to 1e-10 of each other: 309 us per gradient down to 86, a factor of 3.6, leaving clad 1.76x off the hand-written replay-free reference. Scaled up to the shape the GMM papers use, d=10, k=25, n=1000, it is 7.24 ms down to 1.69, a factor of 4.3 and 1.63x off that reference.

It is worth that much only now that the range records removed the other tape -- a loop with any tape left in it does not vectorise, so neither removal pays on its own.