### PR TITLE
Copy a type alias when copying a lambda's body, do not drop it.

### DIFF
--- a/include/clad/Differentiator/CladUtils.h
+++ b/include/clad/Differentiator/CladUtils.h
@@ -534,6 +534,15 @@ namespace clad {
     /// variable and replace E's further usage by a reference to that variable
     /// to avoid recomputation.
     bool UsefulToStore(const clang::Expr* E);
+    /// Re-declares \p TND in \p DC, keeping the type as it was written rather
+    /// than what it resolves to. An alias is where portable code picks a
+    /// precision, a width or an index type, so resolving it would pin the copy
+    /// to the answer one platform gave.
+    clang::TypedefNameDecl*
+    BuildTypedefNameDecl(clang::ASTContext& C, clang::DeclContext* DC,
+                         clang::SourceLocation StartLoc,
+                         clang::SourceLocation IdLoc,
+                         const clang::TypedefNameDecl* TND);
     /// Builds a reference to one of Enzyme's activity markers, the globals it
     /// matches by name to decide which arguments are differentiated.
     /// They are declared in EnzymeBuiltins.h, which Differentiator.h

--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1965,6 +1965,18 @@ namespace clad {
       return false;
     }
 
+    TypedefNameDecl* BuildTypedefNameDecl(ASTContext& C, DeclContext* DC,
+                                          SourceLocation StartLoc,
+                                          SourceLocation IdLoc,
+                                          const TypedefNameDecl* TND) {
+      TypeSourceInfo* TSI = TND->getTypeSourceInfo();
+      if (isa<TypeAliasDecl>(TND))
+        return TypeAliasDecl::Create(C, DC, StartLoc, IdLoc,
+                                     TND->getIdentifier(), TSI);
+      return TypedefDecl::Create(C, DC, StartLoc, IdLoc, TND->getIdentifier(),
+                                 TSI);
+    }
+
     Expr* BuildEnzymeActivityMarkerRef(Sema& semaRef, llvm::StringRef name) {
       ASTContext& C = semaRef.getASTContext();
       DeclarationName DN = &C.Idents.get(name);

--- a/lib/Differentiator/StmtClone.cpp
+++ b/lib/Differentiator/StmtClone.cpp
@@ -6,8 +6,10 @@
 // File originates from the Scout project (http://scout.zih.tu-dresden.de/)
 
 #include "clad/Differentiator/StmtClone.h"
+#include "clad/Differentiator/CladUtils.h"
 #include "clad/Differentiator/Compatibility.h"
 
+#include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/Stmt.h"
@@ -633,6 +635,12 @@ Decl* StmtClone::CloneDecl(Decl* Node)  {
     // cloned_Decl->setDeclaredInCondition(VD->isDeclaredInCondition());
     return cloned_Decl;
   }
+  // An alias declares no storage and holds no initializer to remap, so a
+  // re-declaration of the same written type is a complete copy.
+  if (auto* TND = dyn_cast<TypedefNameDecl>(Node))
+    return utils::BuildTypedefNameDecl(Ctx, TND->getDeclContext(),
+                                       TND->getBeginLoc(), TND->getLocation(),
+                                       TND);
   assert(0 && "other decl clones aren't supported");
   return 0;
 }

--- a/test/Regressions/lambda-local-typedef.cpp
+++ b/test/Regressions/lambda-local-typedef.cpp
@@ -1,0 +1,30 @@
+// RUN: %cladclang -I%S/../../include %s -o %t
+// RUN: %t | %filecheck_exec %s
+// UNSUPPORTED: clang-11, clang-12, clang-13, clang-14, clang-15, clang-16
+
+// Reverse mode copies a lambda's body to build the primal, and the copy of a
+// declaration was written for variables alone: anything else came back null
+// and left a declaration statement with nothing in it, which crashed clang the
+// next time the body was printed.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+double square(double x) {
+  auto f = [](double v) {
+    using real = double;
+    typedef real elem;
+    elem w = v * v;
+    return w;
+  };
+  return f(x) * x;
+}
+
+int main() {
+  auto g = clad::gradient(square);
+  double dx = 0;
+  g.execute(3, &dx);
+  printf("square: %.2f\n", dx);
+  // CHECK-EXEC: square: 27.00
+}


### PR DESCRIPTION
Reverse mode builds the primal copy of a lambda by copying its body statement by statement, and the copy of a declaration was written for variables alone. Anything else fell through to an assertion that a release build does not run, leaving a declaration statement holding a null declaration. Differentiating a function whose lambda declares a typedef therefore crashed clang the next time that body was printed.

An alias declares no storage and holds no initializer to remap, so re-declaring it with the type it was written with is a complete copy. That spelling is the point: an alias is where portable code picks a precision, a width or an index type, and resolving it would pin the copy to the answer one platform gave.