### PR TITLE
Carry a type alias into the derivative instead of refusing it.

### DIFF
--- a/include/clad/Differentiator/VisitorBase.h
+++ b/include/clad/Differentiator/VisitorBase.h
@@ -657,6 +657,12 @@ namespace clad {
     /// m_Sema.PopDeclContextIsUsed.
     clang::NamespaceDecl* BuildNamespaceDecl(clang::IdentifierInfo* II,
                                              bool isInline);
+    /// Re-declares \p TND in the derivative and makes it findable there by
+    /// name, so the statements that follow can go on naming the type as they
+    /// did.
+    clang::TypedefNameDecl*
+    BuildTypedefNameDecl(const clang::TypedefNameDecl* TND);
+
     /// Wraps a declaration in DeclStmt.
     /// \n Variable declaration cannot be added to code directly, instead we
     /// have to build a declaration staement.

--- a/lib/Differentiator/BaseForwardModeVisitor.cpp
+++ b/lib/Differentiator/BaseForwardModeVisitor.cpp
@@ -1888,6 +1888,10 @@ StmtDiff BaseForwardModeVisitor::VisitDeclStmt(const DeclStmt* DS) {
       decls.push_back(VDDiff.getDecl());
       if (VDDiff.getDecl_dx())
         declsDiff.push_back(VDDiff.getDecl_dx());
+    } else if (const auto* TND = dyn_cast<TypedefNameDecl>(D)) {
+      // An alias carries no value and so no derivative, but the statements
+      // after it go on naming the type by it.
+      decls.push_back(BuildTypedefNameDecl(TND));
     } else if (auto* SAD = dyn_cast<StaticAssertDecl>(D)) {
       DeclDiff<StaticAssertDecl> SADDiff = DifferentiateStaticAssertDecl(SAD);
       if (SADDiff.getDecl())

--- a/lib/Differentiator/ReverseModeVisitor.cpp
+++ b/lib/Differentiator/ReverseModeVisitor.cpp
@@ -4007,6 +4007,13 @@ Expr* ReverseModeVisitor::getStdInitListSizeExpr(const Expr* E) {
               }
           }
         }
+      } else if (const auto* TND = dyn_cast<TypedefNameDecl>(D)) {
+        // An alias carries no value and so no derivative, but the statements
+        // after it go on naming the type by it. It lands at the top of the
+        // derivative rather than where it stood, because the declarations that
+        // use it are promoted there too, and an alias reads no variable that
+        // would keep it from moving.
+        AddToGlobalBlock(BuildDeclStmt(BuildTypedefNameDecl(TND)));
       } else if (auto* SAD = dyn_cast<StaticAssertDecl>(D)) {
         DeclDiff<StaticAssertDecl> SADDiff = DifferentiateStaticAssertDecl(SAD);
         if (SADDiff.getDecl())

--- a/lib/Differentiator/VisitorBase.cpp
+++ b/lib/Differentiator/VisitorBase.cpp
@@ -176,6 +176,17 @@ namespace clad {
     return VD;
   }
 
+  TypedefNameDecl*
+  VisitorBase::BuildTypedefNameDecl(const TypedefNameDecl* TND) {
+    SourceLocation Loc = GenLoc();
+    TypedefNameDecl* Clone = utils::BuildTypedefNameDecl(
+        m_Context, m_Sema.CurContext, Loc, Loc, TND);
+    // The derivative's own statements look the name up, so registering it is
+    // what makes the alias usable rather than merely present.
+    m_Sema.PushOnScopeChains(Clone, getCurrentScope());
+    return Clone;
+  }
+
   void VisitorBase::updateReferencesOf(Stmt* InSubtree) {
     utils::ReferencesUpdater up(m_Sema, getCurrentScope(), m_DiffReq.Function,
                                 m_DeclReplacements);

--- a/test/Misc/TypeAliases.C
+++ b/test/Misc/TypeAliases.C
@@ -1,0 +1,95 @@
+// RUN: %cladclang %s -I%S/../../include -oTypeAliases.out 2>&1 | %filecheck %s
+// RUN: ./TypeAliases.out | %filecheck_exec %s
+// RUN: %cladclang -Xclang -plugin-arg-clad -Xclang -disable-tbr %s \
+// RUN:   -I%S/../../include -oTypeAliases.out
+// RUN: ./TypeAliases.out | %filecheck_exec %s
+
+// An alias is where portable code picks a type -- a precision, a width, an
+// index -- and the code around it is written in those terms. clad carries the
+// alias into the derivative and keeps it as written, so the derivative stays
+// portable in the same way the primal was.
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+template <typename T> struct Traits {
+  using value_type = T;
+  typedef unsigned long index_type;
+};
+
+// Reverse mode promotes the declarations it derives to function scope, so an
+// alias they are written in terms of has to move there with them.
+template <typename T> T weighted(const T* x, int n) {
+  using elem = typename Traits<T>::value_type;
+  typedef typename Traits<T>::index_type index;
+  elem s = 0;
+  for (index i = 0; i < (index)n; ++i) {
+    elem t = x[i] * x[i];
+    s += t;
+  }
+  return s;
+}
+// CHECK: void weighted_grad_0(const double *x, int n, double *_d_x) {
+// CHECK-NEXT: int _d_n = 0;
+// CHECK-NEXT: using elem = typename Traits<double>::value_type;
+// CHECK-NEXT: typedef typename Traits<double>::index_type index;
+// CHECK-NEXT: index _d_i = 0UL;
+// CHECK-NEXT: index i = 0UL;
+// CHECK-NEXT: elem _d_t = 0.;
+// CHECK-NEXT: elem t = 0.;
+// CHECK-NEXT: elem _d_s = 0.;
+// CHECK-NEXT: elem s = 0;
+
+// The alias sits in the loop the promoted declarations come out of, so it has
+// to leave with them rather than stay behind.
+double innerAlias(const double* x, int n) {
+  double s = 0;
+  for (int i = 0; i < n; ++i) {
+    using elem = double;
+    elem t = x[i] * x[i];
+    s += t;
+  }
+  return s;
+}
+// CHECK: void innerAlias_grad_0(const double *x, int n, double *_d_x) {
+// CHECK: using elem = double;
+// CHECK-NEXT: elem _d_t = 0.;
+// CHECK-NEXT: elem t = 0.;
+
+// Forward mode leaves declarations where it finds them, and an alias built on
+// an earlier alias still reads.
+double pointerAlias(double x) {
+  typedef double real;
+  using ptr = const real*;
+  real y = x * x;
+  ptr p = &y;
+  return *p * x;
+}
+// CHECK: double pointerAlias_darg0(double x) {
+// CHECK-NEXT: double _d_x = 1;
+// CHECK-NEXT: typedef double real;
+// CHECK-NEXT: using ptr = const real *;
+// CHECK-NEXT: real _d_y = _d_x * x + x * _d_x;
+// CHECK-NEXT: real y = x * x;
+
+int main() {
+  double x[4] = {1, 2, 3, 4};
+  double dx[4] = {0, 0, 0, 0};
+
+  auto gw = clad::gradient(weighted<double>, "x");
+  gw.execute(x, 4, dx);
+  printf("weighted: {%.2f, %.2f, %.2f, %.2f}\n", dx[0], dx[1], dx[2], dx[3]);
+  // CHECK-EXEC: weighted: {2.00, 4.00, 6.00, 8.00}
+
+  for (int i = 0; i < 4; ++i)
+    dx[i] = 0;
+  auto gi = clad::gradient(innerAlias, "x");
+  gi.execute(x, 4, dx);
+  printf("innerAlias: {%.2f, %.2f, %.2f, %.2f}\n", dx[0], dx[1], dx[2], dx[3]);
+  // CHECK-EXEC: innerAlias: {2.00, 4.00, 6.00, 8.00}
+
+  auto dp = clad::differentiate(pointerAlias, "x");
+  printf("pointerAlias: %.2f\n", dp.execute(3));
+  // CHECK-EXEC: pointerAlias: 27.00
+}


### PR DESCRIPTION
A `using` or `typedef` in the body of a differentiated function was reported as an unsupported declaration kind and dropped, while the statements around it went on naming the type by it. That rules out the way performance-portable
code is written: the alias is where the precision, the width or the index type is chosen once, and every declaration below it is spelled in those terms.

Both modes now re-declare the alias in the derivative with the type it was written with, rather than the type it resolves to, so a derivative of a template still names the type that template chose. Reverse mode puts it at the top of the derivative, because the declarations that use it are promoted to function scope too and an alias reads no variable that would keep it from moving there.

A local class stays unsupported: it has members to derive, which an alias does not.