### PR TITLE
Preserve reverse-forward results used by return statements

### DIFF
--- a/lib/Differentiator/CladUtils.cpp
+++ b/lib/Differentiator/CladUtils.cpp
@@ -1925,6 +1925,10 @@ namespace clad {
         // If the parent is a Stmt but not an Expr, then the result is not used.
         if (!S)
           return false;
+        // A call returned directly is still consumed by the enclosing
+        // function, including its value and adjoint in reverse_forw mode.
+        if (isa<ReturnStmt>(S))
+          return false;
         E = dyn_cast<Expr>(S);
         if (!E)
           return true;

--- a/test/Gradient/ReturnedCallAdjoint.C
+++ b/test/Gradient/ReturnedCallAdjoint.C
@@ -1,0 +1,45 @@
+// RUN: %cladclang %s -I%S/../../include -o %t 2>&1 | %filecheck %s
+// RUN: %t | %filecheck_exec %s
+
+#include "clad/Differentiator/Differentiator.h"
+
+#include <cstdio>
+
+struct Result {
+  double value;
+  double* storage;
+};
+
+Result make_result(double x) { return {x * x, nullptr}; }
+
+namespace clad::custom_derivatives {
+
+clad::ValueAndAdjoint<Result, Result> make_result_reverse_forw(double x,
+                                                               double /*d_x*/) {
+  return {make_result(x), {0, nullptr}};
+}
+
+void make_result_pullback(double x, Result d_result, double* d_x) {
+  *d_x += 2 * x * d_result.value;
+}
+
+} // namespace clad::custom_derivatives
+
+Result helper(double x) { return make_result(x); }
+
+double loss(double x) {
+  auto result = helper(x);
+  return result.value;
+}
+
+// CHECK: clad::ValueAndAdjoint<Result, Result> helper_reverse_forw(
+// CHECK: make_result_reverse_forw(
+// CHECK: return {{.*}}.value{{.*}}.adjoint{{.*}};
+
+int main() {
+  auto gradient = clad::gradient(loss);
+  double dx = 0;
+  gradient.execute(3, &dx);
+  std::printf("%.1f\n", dx);
+  // CHECK-EXEC: 6.0
+}


### PR DESCRIPTION
`hasUnusedReturnValue` treats a non-expression parent as evidence that a call’s result is unused. However, `ReturnStmt` consumes that result. This misclassification can cause reverse-forward generation to omit the value/adjoint pair needed to build the enclosing function’s return statement.
Treat `ReturnStmt` as a use of the call result, allowing the existing reverse-forward handling to preserve both components.
Add a standalone regression test that checks the generated return statement and verifies the gradient through a record-returning helper.